### PR TITLE
Softing Secure Integration Server login module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/softing_sis_login.md
+++ b/documentation/modules/auxiliary/scanner/http/softing_sis_login.md
@@ -1,0 +1,66 @@
+## Description
+
+This module allows you to authenticate to Softing Secure Integration Server.
+
+By default:
+* Credentials are `admin:admin`.
+* HTTP is TCP/8099 and HTTPS is TCP/443. Either one can be used, but the module defaults to TCP/8099.
+
+## Vulnerable Application
+
+This module was tested against version 1.22, installed on Windows Server 2019 Standard x64.
+
+*1.22 Download*
+
+https://industrial.softing.com/products/opc-opc-ua-software-platform/integration-platform/secure-integration-server.html
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/http/softing_sis_login`
+3. Do: `set RHOST <target_ip>`
+4. Do: Optional: `set SSL true` if necessary
+5. Do: Optional: `set RPORT 443` if SSL is set
+6. Do: `set USERNAME <username>` if necessary. Default is `admin`
+7. Do: `set PASSWORD <password>` if necessary. Default is `admin`
+8. Do: `run`
+
+## Scenarios
+### Default
+
+In this scenario, the default options were used.
+
+```
+msf6 > use auxiliary/scanner/http/softing_sis_login 
+msf6 auxiliary(scanner/http/softing_sis_login) > set RHOSTS 192.168.50.119
+RHOSTS => 192.168.50.119
+msf6 auxiliary(scanner/http/softing_sis_login) > run
+
+[+] 192.168.50.119:8099 - Success: 'admin:admin'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/softing_sis_login) > 
+```
+
+### Different admin password, SSL in use
+
+In this scenario, the default password for the `admin` user has been changed, and SSL was used.
+
+```
+msf6 > use auxiliary/scanner/http/softing_sis_login 
+msf6 auxiliary(scanner/http/softing_sis_login) > set RHOSTS 192.168.50.119
+RHOSTS => 192.168.50.119
+msf6 auxiliary(scanner/http/softing_sis_login) > set PASSWORD admin123
+PASSWORD => admin123
+msf6 auxiliary(scanner/http/softing_sis_login) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 auxiliary(scanner/http/softing_sis_login) > set RPORT 443
+RPORT => 443
+msf6 auxiliary(scanner/http/softing_sis_login) > run
+
+[+] 192.168.50.119:443 - Success: 'admin:admin123'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/softing_sis_login) > 
+```

--- a/documentation/modules/auxiliary/scanner/http/softing_sis_login.md
+++ b/documentation/modules/auxiliary/scanner/http/softing_sis_login.md
@@ -42,6 +42,20 @@ msf6 auxiliary(scanner/http/softing_sis_login) > run
 msf6 auxiliary(scanner/http/softing_sis_login) > 
 ```
 
+`creds` output:
+
+```
+msf6 auxiliary(scanner/http/softing_sis_login) > creds
+Credentials
+===========
+
+host            origin          service          public  private  realm  private_type  JtR Format
+----            ------          -------          ------  -------  -----  ------------  ----------
+192.168.50.119  192.168.50.119  8099/tcp (http)  admin   admin           Password      
+
+msf6 auxiliary(scanner/http/softing_sis_login) > 
+```
+
 ### Different admin password, SSL in use
 
 In this scenario, the default password for the `admin` user has been changed, and SSL was used.
@@ -62,5 +76,20 @@ msf6 auxiliary(scanner/http/softing_sis_login) > run
 [+] 192.168.50.119:443 - Success: 'admin:admin123'
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/softing_sis_login) > 
+```
+
+`creds` output:
+
+```
+msf6 auxiliary(scanner/http/softing_sis_login) > creds
+Credentials
+===========
+
+host            origin          service          public  private  realm  private_type  JtR Format
+----            ------          -------          ------  -------  -----  ------------  ----------
+192.168.50.119  192.168.50.119  8099/tcp (http)  admin   admin           Password      
+192.168.50.119  192.168.50.119  443/tcp (https)  admin   admin123        Password      
+
 msf6 auxiliary(scanner/http/softing_sis_login) > 
 ```

--- a/documentation/modules/auxiliary/scanner/http/softing_sis_login.md
+++ b/documentation/modules/auxiliary/scanner/http/softing_sis_login.md
@@ -20,12 +20,19 @@ https://industrial.softing.com/products/opc-opc-ua-software-platform/integration
 
 1. Start `msfconsole`
 2. Do: `use auxiliary/scanner/http/softing_sis_login`
-3. Do: `set RHOST <target_ip>`
+3. Do: `set RHOSTS <target_ip>` OR `set RHOSTS file:/path/to/targets/file` if against several targets
 4. Do: Optional: `set SSL true` if necessary
 5. Do: Optional: `set RPORT 443` if SSL is set
 6. Do: `set USERNAME <username>` if necessary. Default is `admin`
 7. Do: `set PASSWORD <password>` if necessary. Default is `admin`
 8. Do: `run`
+
+If running against several usernames: `set USER_FILE /path/to/usernames_file`
+If using a wordlist (e.g. common passwords): `set PASS_FILE /path/to/passwords_file`
+
+`USER_FILE` and `PASS_FILE` take priority over `USERNAME` and `PASSWORD`.
+
+A `username:password` pair of credentials can be provided by doing `set USERPASS_FILE /path/to/userpass_file`.
 
 ## Scenarios
 ### Default

--- a/lib/metasploit/framework/login_scanner/softing_sis.rb
+++ b/lib/metasploit/framework/login_scanner/softing_sis.rb
@@ -1,0 +1,116 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      class SoftingSIS < HTTP
+
+        DEFAULT_PORT = 8099
+        DEFAULT_SSL_PORT = 443
+        PRIVATE_TYPES = [ :password ]
+        LOGIN_STATUS = Metasploit::Model::Login::Status
+
+        # Return the authentication token to calculate the signature
+        # the authentication token is 32 hexadecimal characters [0-9][a-f]
+        #
+        # @return [String] The authentication token for Secure Integration Server (SIS)
+        def get_auth_token
+          uri = normalize_uri("#{uri}/runtime/core/user/admin/authentication-token")
+
+          res = send_request({
+            'method' => 'GET',
+            'uri' => uri,
+            'cookie' => 'lang=en; user=guest'
+          })
+
+          # extract the authetication token from the JSON response
+          res_json = res.get_json_document
+          res_json['authentication-token']
+        end
+
+        # Check if the target is Softing Secure Integration Server
+        #
+        # @return [Boolean] TrueClass if target is SIS, otherwise FalseClass
+        def check_setup
+          uri = normalize_uri("#{uri}/js/language.js")
+          res = send_request({ 'uri' => uri })
+
+          # "/js/language.js" should contain "Secure Integration Server"
+          if res && res.body.include?('Secure Integration Server')
+            return true
+          end
+
+          false
+        end
+
+        # the actual login method, called by #attempt_login
+        #
+        # @param user [String] The username to try
+        # @param pass [String] The password to try
+        # @return [Hash]
+        #   * status [Metasploit::Model::Login::Status]
+        #   * proof [String] the HTTP response body
+        def do_login(user, pass)
+          # prep the data needed for login
+          protocol = ssl ? 'https' : 'http'
+          auth_token = get_auth_token
+          login_uri = normalize_uri("#{uri}/runtime/core/user/#{user}/authentication")
+          # calculate signature to use when logging in
+          signature = Digest::MD5.hexdigest(auth_token + pass + auth_token + user + auth_token)
+          # GET parameters for login
+          vars_get = {
+            'Signature' => signature,
+            'User' => user
+          }
+
+          # do the login
+          res = send_request({
+            'method' => 'GET',
+            'uri' => login_uri,
+            'cookie' => 'lang=en; user=guest',
+            'headers' => { 'Referer' => "#{protocol}://#{host}:#{port}" },
+            'vars_get' => vars_get
+          })
+
+          unless res
+            return { status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: res.to_s }
+          end
+
+          # the response is in JSON format
+          res_json = res.get_json_document
+          # a successful response will contain {"Message": "Success"}
+          if res.code.to_i == 200 && res_json && res_json['Message'] == 'Success'
+            return { status: LOGIN_STATUS::SUCCESSFUL, proof: res.body }
+          end
+
+          { status: LOGIN_STATUS::INCORRECT, proof: res.body }
+        end
+
+        # Attempts to login to Softing Secure Integration Server
+        #
+        # @param credential [Metasploit::Framework::Credential] The credential object
+        # @return [Result] A Result object indicating success or failure
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+
+          begin
+            result_opts.merge!(do_login(credential.public, credential.private))
+          rescue ::Rex::ConnectionError => e
+            # something went wrong during login
+            result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
+          end
+
+          Result.new(result_opts)
+        end
+
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/softing_sis_login.rb
+++ b/modules/auxiliary/scanner/http/softing_sis_login.rb
@@ -127,6 +127,9 @@ class MetasploitModule < Msf::Auxiliary
       when Metasploit::Model::Login::Status::INCORRECT
         vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::DENIED_ACCESS
+        vprint_brute(level: :verror, ip: ip, msg: "Access denied: '#{result.credential}'")
+        report_bad_cred(ip, rport, result)
       end
     end
   end

--- a/modules/auxiliary/scanner/http/softing_sis_login.rb
+++ b/modules/auxiliary/scanner/http/softing_sis_login.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/login_scanner/softing_sis'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Softing dataFEED Secure Integration Server Login Utility',
+        'Description' => %q{
+          This module will attempt to authenticate to a Softing dataFEED Secure Integration Server.
+        },
+        'Author' => [ 'Imran E. Dawoodjee <imrandawoodjee.infosec[at]gmail.com>' ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
+        'DefaultOptions' => {
+          'RPORT' => 8099,
+          'SSL' => false,
+          'SSLVersion' => 'TLS1'
+        }
+      )
+    )
+
+    deregister_options('PASSWORD_SPRAY')
+
+    # credentials are "admin:admin" by default
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'The username to specify for authentication. Not required if SIGNATURE is set.', 'admin']),
+        OptString.new('PASSWORD', [false, 'The password to specify for authentication. Not required if SIGNATURE is set.', 'admin']),
+        OptString.new('SIGNATURE', [false, 'The signature to use for authentication.', ''])
+      ]
+    )
+  end
+
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = Metasploit::Framework::CredentialCollection.new(
+        blank_passwords: datastore['BLANK_PASSWORDS'],
+        pass_file: datastore['PASS_FILE'],
+        password: datastore['PASSWORD'],
+        user_file: datastore['USER_FILE'],
+        userpass_file: datastore['USERPASS_FILE'],
+        username: datastore['USERNAME'],
+        user_as_pass: datastore['USER_AS_PASS']
+      )
+
+      return Metasploit::Framework::LoginScanner::SoftingSIS.new(
+        configure_http_login_scanner(
+          host: ip,
+          port: datastore['RPORT'],
+          cred_details: cred_collection,
+          stop_on_success: datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          connection_timeout: 5
+        )
+      )
+    }.call
+  end
+
+  def report_good_cred(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: :password,
+      username: result.credential.public
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: result.status,
+      proof: result.proof
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+  def bruteforce(ip)
+    scanner(ip).scan! do |result|
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
+        report_good_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
+        report_bad_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::INCORRECT
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
+        report_bad_cred(ip, rport, result)
+      end
+    end
+  end
+
+  def run_host(ip)
+    unless scanner(ip).check_setup
+      print_brute(level: :error, ip: ip, msg: 'Target is not Softing dataFEED Secure Integration Server')
+      return
+    end
+
+    bruteforce(ip)
+  end
+
+end

--- a/modules/auxiliary/scanner/http/softing_sis_login.rb
+++ b/modules/auxiliary/scanner/http/softing_sis_login.rb
@@ -17,9 +17,9 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Softing dataFEED Secure Integration Server Login Utility',
+        'Name' => 'Softing Secure Integration Server Login Utility',
         'Description' => %q{
-          This module will attempt to authenticate to a Softing dataFEED Secure Integration Server.
+          This module will attempt to authenticate to a Softing Secure Integration Server.
         },
         'Author' => [ 'Imran E. Dawoodjee <imrandawoodjee.infosec[at]gmail.com>' ],
         'License' => MSF_LICENSE,
@@ -42,8 +42,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('USERNAME', [false, 'The username to specify for authentication. Not required if SIGNATURE is set.', 'admin']),
-        OptString.new('PASSWORD', [false, 'The password to specify for authentication. Not required if SIGNATURE is set.', 'admin']),
-        OptString.new('SIGNATURE', [false, 'The signature to use for authentication.', ''])
+        OptString.new('PASSWORD', [false, 'The password to specify for authentication. Not required if SIGNATURE is set.', 'admin'])
       ]
     )
   end
@@ -74,10 +73,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_good_cred(ip, port, result)
+    service_name = datastore['SSL'] ? 'https' : 'http'
+
     service_data = {
       address: ip,
       port: port,
-      service_name: 'http',
+      service_name: service_name,
       protocol: 'tcp',
       workspace_id: myworkspace_id
     }
@@ -132,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless scanner(ip).check_setup
-      print_brute(level: :error, ip: ip, msg: 'Target is not Softing dataFEED Secure Integration Server')
+      print_brute(level: :error, ip: ip, msg: 'Target is not Softing Secure Integration Server')
       return
     end
 


### PR DESCRIPTION
## Description

This module allows you to authenticate to Softing Secure Integration Server.

By default:
* Credentials are `admin:admin`.
* HTTP is TCP/8099 and HTTPS is TCP/443. Either one can be used, but the module defaults to TCP/8099.

## Vulnerable Application

This module was tested against version 1.22, installed on Windows Server 2019 Standard x64.

*1.22 Download*

https://industrial.softing.com/products/opc-opc-ua-software-platform/integration-platform/secure-integration-server.html

## Verification Steps

1. Start `msfconsole`
2. Do: `use auxiliary/scanner/http/softing_sis_login`
3. Do: `set RHOST <target_ip>`
4. Do: Optional: `set SSL true` if necessary
5. Do: Optional: `set RPORT 443` if SSL is set
6. Do: `set USERNAME <username>` if necessary. Default is `admin`
7. Do: `set PASSWORD <password>` if necessary. Default is `admin`
8. Do: `run`