### PR TITLE
Improve UX of module explorer on docs.metasploit.com

### DIFF
--- a/docs/_includes/js/custom.js
+++ b/docs/_includes/js/custom.js
@@ -1,19 +1,60 @@
 // Handle opening/closing module overview list items
 jtd.onReady(function(ready) {
-    var moduleStructures = document.querySelectorAll('.module-structure');
-    for (var i = 0; i < moduleStructures.length; i++) {
-        jtd.addEvent(moduleStructures[i], 'click', function (e) {
+    var forEach = function (list, callback) {
+        for (var i = 0; i < list.length; i++) {
+            callback(list[i])
+        }
+    };
+
+    // Bind listeners for expand all / collapse all functionality
+    var bindToggleAll = function (selector, options) {
+        var isOpen = options.open;
+        var expandAllButtons = document.querySelectorAll(selector);
+        forEach(expandAllButtons, function (button) {
+            jtd.addEvent(button, 'click', function (e) {
+                var originalTarget = e.target || e.srcElement || e.originalTarget;
+                if (originalTarget.tagName !== 'A') { return; }
+
+                var moduleList = originalTarget.closest('.module-list');
+                forEach(moduleList.querySelectorAll('.folder > ul'), function (list) {
+                    if (isOpen) {
+                        list.classList.add('open');
+                    } else {
+                        list.classList.remove('open');
+                    }
+                })
+
+                e.preventDefault();
+            });
+        });
+    };
+    bindToggleAll('.module-list [data-expand-all]', { open: true })
+    bindToggleAll('.module-list [data-collapse-all]', { open: false })
+
+    // Bind listeners for collapsing module navigation items
+    var moduleStructureElements = document.querySelectorAll('.module-structure');
+    forEach(moduleStructureElements, function (moduleStructure) {
+        jtd.addEvent(moduleStructure, 'click', function (e) {
             var originalTarget = e.target || e.srcElement || e.originalTarget;
             if (originalTarget.tagName !== 'A') { return; }
 
             var parentListItem = originalTarget.closest('li');
             if (parentListItem.className.indexOf('folder') === -1) { return; }
 
-            var childList = parentListItem.querySelector('ul');
-            if (childList) {
-                childList.classList.toggle('open');
-            }
+            toggleChildModuleList(parentListItem)
             e.preventDefault();
         });
+    })
+
+    var toggleChildModuleList = function (parent) {
+        var list = parent.querySelector('ul');
+        if (!list) {
+            return;
+        }
+        list.classList.toggle('open');
+        // Recursively automatically open any nested lists of size 1
+        if (list.children.length === 1) {
+            toggleChildModuleList(list.children[0])
+        }
     }
 });

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -45,14 +45,32 @@
     width: 90%;
 }
 
+.module-controls {
+    line-height: 0;
+    border-bottom: 1px solid #ddd;
+}
+
+.module-controls a {
+    line-height: 1;
+    padding: 0.5rem;
+    display: inline-block;
+}
+
+.module-controls span {
+    display: inline-block;
+}
+
 .module-structure a, .module-structure a:hover {
     background-image: none;
 }
 
-.module-structure a:hover .target {
+.module-structure a .target {
     pointer-events: none;
     display: inline-block;
     text-decoration: none;
+}
+
+.module-structure a:hover .target {
     background-image: linear-gradient(rgba(114, 83, 237, 0.45) 0%, rgba(114, 83, 237, 0.45) 100%);
     background-repeat: repeat-x;
     background-position: 0 100%;
@@ -68,6 +86,11 @@
     margin-left: 7px !important;
     padding-left: 20px !important;
     border-left: 1px dashed #d1d7de;
+}
+
+/* Never allow the top-most files/folders to be collapsed */
+.module-structure > li.folder > ul {
+    display: block;
 }
 
 .module-structure li p {

--- a/docs/metasploit-framework.wiki/Modules.md
+++ b/docs/metasploit-framework.wiki/Modules.md
@@ -2,7 +2,7 @@
 
 There are currently {{ site.metasploit_total_module_count }} Metasploit modules:
 
-{{ site.metasploit_nested_module_counts | module_tree }}
+{{ site.metasploit_nested_module_counts | module_tree: "All Modules", true }}
 
 ## Module types
 


### PR DESCRIPTION
Improves the UX of the docs.metasploit.com module explorer. Adds 'expand all' and 'collapse all' buttons to the module explorer. Adds support for automatically opening descendant folders that only contain 1 item. Adds an additional parent folder to make it clearer to the user that the folders are clickable.

### Before

<img width="1146" alt="image" src="https://user-images.githubusercontent.com/60357436/220339646-5ccd13f3-7f0e-415a-9814-8655afafb9cd.png">

### After

<img width="1294" alt="image" src="https://user-images.githubusercontent.com/60357436/220339563-85db6c40-c878-4dc1-b2e0-fa4bd5837b6c.png">


## Verification

- Build the site locally `docs/README.md`
- Verify the behavior