### PR TITLE
 Add datastore option for Jenkins home directory

### DIFF
--- a/documentation/modules/post/multi/gather/jenkins_gather.md
+++ b/documentation/modules/post/multi/gather/jenkins_gather.md
@@ -80,7 +80,7 @@ Provided by:
 Basic options:
   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
-  JENKINS_HOME                 no        Set to the home directory of Jenkins. Linux versions default to /var/lib/jenkins, but C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins on Windows.
+  JENKINS_HOME                 no        Set to the home directory of Jenkins. Linux versions default to /var/lib/jenkins, but C:\ProgramData\Jenkins\.jenkins on Windows.
   SEARCH_JOBS true             no        Search through job history logs for interesting keywords. Increases runtime.
   SESSION     17               yes       The session to run this module on.
   STORE_LOOT  true             no        Store files in loot (will simply output file to console if set to false).

--- a/documentation/modules/post/multi/gather/jenkins_gather.md
+++ b/documentation/modules/post/multi/gather/jenkins_gather.md
@@ -45,6 +45,10 @@ keywords but obviously increases runtime on larger instances.
   This option saves interesting files and loot to disk. If set to
 false will simply output data to console.
 
+  **JENKINS_HOME**
+  This option can be set if we want to specify where the Jenkins
+data resides.
+
 ## Scenarios
 
 **Jenkins on Windows**
@@ -76,6 +80,7 @@ Provided by:
 Basic options:
   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
+  JENKINS_HOME                 no        Set to the home directory of Jenkins. Linux versions default to /var/lib/jenkins, but C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins on Windows.
   SEARCH_JOBS true             no        Search through job history logs for interesting keywords. Increases runtime.
   SESSION     17               yes       The session to run this module on.
   STORE_LOOT  true             no        Store files in loot (will simply output file to console if set to false).

--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
     )
     register_options(
       [
-        OptString.new('JENKINS_HOME', [ false, 'Set to the home directory of Jenkins. The Linux versions default to /var/lib/jenkins, but C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins on Windows.', ]),
+        OptString.new('JENKINS_HOME', [ false, 'Set to the home directory of Jenkins. The Linux versions default to /var/lib/jenkins, but C:\\ProgramData\\Jenkins\\.jenkins on Windows.', ]),
         OptBool.new('STORE_LOOT', [false, 'Store files in loot (will simply output file to console if set to false).', true]),
         OptBool.new('SEARCH_JOBS', [false, 'Search through job history logs for interesting keywords. Increases runtime.', false])
       ]
@@ -330,8 +330,8 @@ class MetasploitModule < Msf::Post
     print_status('Searching for Jenkins directory... This could take some time...')
     case platform
     when 'windows'
-      if exists?('C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins\\secret.key.not-so-secret')
-        home = 'C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins\\'
+      if exists?('C:\\ProgramData\\Jenkins\\.jenkins\\secret.key.not-so-secret')
+        home = 'C:\\ProgramData\\Jenkins\\.jenkins\\'
       else
         case session.type
         when 'meterpreter'

--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
     )
     register_options(
       [
-        OptString.new('JENKINS_HOME', [ false, 'Set to the home directory of Jenkins. The Linux versions default to /var/lib/jenkins, but C:\\ProgramData\\Jenkins\\.jenkins on Windows.', ]),
+        OptString.new('JENKINS_HOME', [ false, 'Set to the home directory of Jenkins. The Linux versions default to /var/lib/jenkins, but C:\\\\ProgramData\\\\Jenkins\\\\.jenkins on Windows.', ]),
         OptBool.new('STORE_LOOT', [false, 'Store files in loot (will simply output file to console if set to false).', true]),
         OptBool.new('SEARCH_JOBS', [false, 'Search through job history logs for interesting keywords. Increases runtime.', false])
       ]

--- a/modules/post/multi/gather/jenkins_gather.rb
+++ b/modules/post/multi/gather/jenkins_gather.rb
@@ -33,6 +33,7 @@ class MetasploitModule < Msf::Post
     )
     register_options(
       [
+        OptString.new('JENKINS_HOME', [ false, 'Set to the home directory of Jenkins. The Linux versions default to /var/lib/jenkins, but C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins on Windows.', ]),
         OptBool.new('STORE_LOOT', [false, 'Store files in loot (will simply output file to console if set to false).', true]),
         OptBool.new('SEARCH_JOBS', [false, 'Search through job history logs for interesting keywords. Increases runtime.', false])
       ]
@@ -319,17 +320,32 @@ class MetasploitModule < Msf::Post
   end
 
   def find_home(platform)
+    if datastore['JENKINS_HOME']
+      if exist?(datastore['JENKINS_HOME'] + '/secret.key.not-so-secret')
+        return datastore['JENKINS_HOME']
+      end
+      print_status(datastore['JENKINS_HOME'] + ' does not seem to contain secrets.')
+    end
+
     print_status('Searching for Jenkins directory... This could take some time...')
     case platform
     when 'windows'
-      case session.type
-      when 'meterpreter'
-        home = session.fs.file.search(nil, 'secret.key.not-so-secret')[0]['path']
+      if exists?('C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins\\secret.key.not-so-secret')
+        home = 'C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Jenkins.jenkins\\'
       else
-        home = cmd_exec('cmd.exe', "/c dir /b /s c:\*secret.key.not-so-secret", timeout = 120).split('\\')[0..-2].join('\\').strip
+        case session.type
+        when 'meterpreter'
+          home = session.fs.file.search(nil, 'secret.key.not-so-secret')[0]['path']
+        else
+          home = cmd_exec('cmd.exe', "/c dir /b /s c:\*secret.key.not-so-secret", 120).split('\\')[0..-2].join('\\').strip
+        end
       end
     when 'nix'
-      home = cmd_exec('find', "/ -name 'secret.key.not-so-secret' 2>/dev/null", timeout = 120).split('/')[0..-2].join('/').strip
+      if exists?('/var/lib/jenkins/secret.key.not-so-secret')
+        home = '/var/lib/jenkins/'
+      else
+        home = cmd_exec('find', "/ -name 'secret.key.not-so-secret' 2>/dev/null", 120).split('/')[0..-2].join('/').strip
+      end
     end
     fail_with(Failure::NotFound, 'No Jenkins installation found or readable, exiting...') if !exist?(home)
     print_status("Found Jenkins installation at #{home}")


### PR DESCRIPTION
This patch adds a new option to the jenkins_gather.rb script, allowing a
user to specify the "jenkins home" directory, instead of running a potentially
time-and-resource-consuming "find /" command. Default directories are 
now also included.

This patch is inspired by an environment where the "find /" command was
taking too long, and there was no way to set a configuration, despite
the correct directory being known. This patch also now allows for
alternative Jenkins directories to be gathered, not just the first one
found by `find'.