### PR TITLE
Fixed Broken Link for Metasploit Goliath in GSOC'23 page.

### DIFF
--- a/docs/metasploit-framework.wiki/GSoC-2023-Project-Ideas.md
+++ b/docs/metasploit-framework.wiki/GSoC-2023-Project-Ideas.md
@@ -51,7 +51,7 @@ Difficulty: 4/5
 
 Enhance existing Metasploit Goliath dashboard that allows observation of an active engagement. Data visualization would include, but not be limited to: host node graph with activity indicators and heat maps. The main idea here is to create a visualization tool that helps users understand data that has been gathered into Metasploit during usage in some useful way. Proposals should note where the service will live, how a user will use the service, and how you will provide a maintainable and extendable consumer for the data that is exposed.
 
-See [Metasploit 'Goliath' Demo (msf-red)](https://www.youtube.com/watch?v=hvuy6A-ie1g&feature=youtu.be&t=176) for a demo video of Goliath in action. You can also read more on Metasploit Goliath at [Metasploit-Data-Service-Enhancements-(Goliath)](https://github.com/rapid7/metasploit-framework/blob/master/docs/metasploit-framework.wiki/Metasploit-Data-Service-Enhancements-Goliath.md)
+See [Metasploit 'Goliath' Demo (msf-red)](https://www.youtube.com/watch?v=hvuy6A-ie1g&feature=youtu.be&t=176) for a demo video of Goliath in action. You can also read more on Metasploit Goliath at [Metasploit-Data-Service-Enhancements-(Goliath)](/docs/development/roadmap/metasploit-data-service-enhancements-goliath.html)
 
 Size: Medium/Large (Depends on proposal)  
 Difficulty 3/5

--- a/docs/metasploit-framework.wiki/GSoC-2023-Project-Ideas.md
+++ b/docs/metasploit-framework.wiki/GSoC-2023-Project-Ideas.md
@@ -51,7 +51,7 @@ Difficulty: 4/5
 
 Enhance existing Metasploit Goliath dashboard that allows observation of an active engagement. Data visualization would include, but not be limited to: host node graph with activity indicators and heat maps. The main idea here is to create a visualization tool that helps users understand data that has been gathered into Metasploit during usage in some useful way. Proposals should note where the service will live, how a user will use the service, and how you will provide a maintainable and extendable consumer for the data that is exposed.
 
-See [Metasploit 'Goliath' Demo (msf-red)](https://www.youtube.com/watch?v=hvuy6A-ie1g&feature=youtu.be&t=176) for a demo video of Goliath in action. You can also read more on Metasploit Goliath at [Metasploit-Data-Service-Enhancements-(Goliath)](./Metasploit-Data-Service-Enhancements-Goliath)
+See [Metasploit 'Goliath' Demo (msf-red)](https://www.youtube.com/watch?v=hvuy6A-ie1g&feature=youtu.be&t=176) for a demo video of Goliath in action. You can also read more on Metasploit Goliath at [Metasploit-Data-Service-Enhancements-(Goliath)](https://github.com/rapid7/metasploit-framework/blob/master/docs/metasploit-framework.wiki/Metasploit-Data-Service-Enhancements-Goliath.md)
 
 Size: Medium/Large (Depends on proposal)  
 Difficulty 3/5

--- a/docs/metasploit-framework.wiki/GSoC-2023-Project-Ideas.md
+++ b/docs/metasploit-framework.wiki/GSoC-2023-Project-Ideas.md
@@ -51,7 +51,7 @@ Difficulty: 4/5
 
 Enhance existing Metasploit Goliath dashboard that allows observation of an active engagement. Data visualization would include, but not be limited to: host node graph with activity indicators and heat maps. The main idea here is to create a visualization tool that helps users understand data that has been gathered into Metasploit during usage in some useful way. Proposals should note where the service will live, how a user will use the service, and how you will provide a maintainable and extendable consumer for the data that is exposed.
 
-See [Metasploit 'Goliath' Demo (msf-red)](https://www.youtube.com/watch?v=hvuy6A-ie1g&feature=youtu.be&t=176) for a demo video of Goliath in action. You can also read more on Metasploit Goliath at [Metasploit-Data-Service-Enhancements-(Goliath)](/docs/development/roadmap/metasploit-data-service-enhancements-goliath.html)
+See [Metasploit 'Goliath' Demo (msf-red)](https://www.youtube.com/watch?v=hvuy6A-ie1g&feature=youtu.be&t=176) for a demo video of Goliath in action. You can also read more on Metasploit Goliath at [[Metasploit-Data-Service-Enhancements-(Goliath)|./Metasploit-Data-Service-Enhancements-Goliath]]
 
 Size: Medium/Large (Depends on proposal)  
 Difficulty 3/5


### PR DESCRIPTION
The link for the Metasploit-Data-Service-Enhancements-Goliath was not working on the website as no such route existed.

![image](https://user-images.githubusercontent.com/64140687/220747054-6c047634-a80d-4153-a0ca-c0b7515e7034.png)
 
Added the github docs link mentioning Goliath.