### PR TITLE
Update inspect ticket tests to use the local timezone

### DIFF
--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -82,10 +82,10 @@ module Rex::Proto::Kerberos::CredentialCache
       end
 
       output << 'Times:'
-      output << "Auth time: #{cred.authtime}".indent(2)
-      output << "Start time: #{cred.starttime}".indent(2)
-      output << "End time: #{cred.endtime}".indent(2)
-      output << "Renew Till: #{cred.renew_till}".indent(2)
+      output << "Auth time: #{present_time(cred.authtime)}".indent(2)
+      output << "Start time: #{present_time(cred.starttime)}".indent(2)
+      output << "End time: #{present_time(cred.endtime)}".indent(2)
+      output << "Renew Till: #{present_time(cred.renew_till)}".indent(2)
 
       output << 'Ticket:'
       output << "Ticket Version Number: #{ticket.tkt_vno}".indent(2)
@@ -113,12 +113,12 @@ module Rex::Proto::Kerberos::CredentialCache
       output = []
       output << 'Validation Info:'
 
-      output << "Logon Time: #{present_time(validation_info.logon_time)}".indent(2)
-      output << "Logoff Time: #{present_time(validation_info.logoff_time)}".indent(2)
-      output << "Kick Off Time: #{present_time(validation_info.kick_off_time)}".indent(2)
-      output << "Password Last Set: #{present_time(validation_info.password_last_set)}".indent(2)
-      output << "Password Can Change: #{present_time(validation_info.password_can_change)}".indent(2)
-      output << "Password Must Change: #{present_time(validation_info.password_must_change)}".indent(2)
+      output << "Logon Time: #{present_ndr_file_time(validation_info.logon_time)}".indent(2)
+      output << "Logoff Time: #{present_ndr_file_time(validation_info.logoff_time)}".indent(2)
+      output << "Kick Off Time: #{present_ndr_file_time(validation_info.kick_off_time)}".indent(2)
+      output << "Password Last Set: #{present_ndr_file_time(validation_info.password_last_set)}".indent(2)
+      output << "Password Can Change: #{present_ndr_file_time(validation_info.password_can_change)}".indent(2)
+      output << "Password Must Change: #{present_ndr_file_time(validation_info.password_must_change)}".indent(2)
 
       output << "Logon Count: #{validation_info.logon_count}".indent(2)
       output << "Bad Password Count: #{validation_info.bad_password_count}".indent(2)
@@ -129,8 +129,8 @@ module Rex::Proto::Kerberos::CredentialCache
       output << "User Account Control: #{validation_info.user_account_control}".indent(2)
       output << "Sub Auth Status: #{validation_info.sub_auth_status}".indent(2)
 
-      output << "Last Successful Interactive Logon: #{present_time(validation_info.last_successful_i_logon)}".indent(2)
-      output << "Last Failed Interactive Logon: #{present_time(validation_info.last_failed_i_logon)}".indent(2)
+      output << "Last Successful Interactive Logon: #{present_ndr_file_time(validation_info.last_successful_i_logon)}".indent(2)
+      output << "Last Failed Interactive Logon: #{present_ndr_file_time(validation_info.last_failed_i_logon)}".indent(2)
       output << "Failed Interactive Logon Count: #{validation_info.failed_i_logon_count}".indent(2)
 
       output << "SID Count: #{validation_info.sid_count}".indent(2)
@@ -160,7 +160,7 @@ module Rex::Proto::Kerberos::CredentialCache
       output = []
       output << 'Client Info:'
       output << "Name: '#{client_info.name.encode('utf-8')}'".indent(2)
-      output << "Client ID: #{present_time(client_info.client_id)}".indent(2)
+      output << "Client ID: #{present_ndr_file_time(client_info.client_id)}".indent(2)
       output.join("\n")
     end
 
@@ -231,10 +231,10 @@ module Rex::Proto::Kerberos::CredentialCache
       ticket_enc_part = Rex::Proto::Kerberos::Model::TicketEncPart.decode(decrypted_part)
       output = []
       output << 'Times:'
-      output << "Auth time: #{ticket_enc_part.authtime}".indent(2)
-      output << "Start time: #{ticket_enc_part.starttime}".indent(2)
-      output << "End time: #{ticket_enc_part.endtime}".indent(2)
-      output << "Renew Till: #{ticket_enc_part.renew_till}".indent(2)
+      output << "Auth time: #{present_time(ticket_enc_part.authtime)}".indent(2)
+      output << "Start time: #{present_time(ticket_enc_part.starttime)}".indent(2)
+      output << "End time: #{present_time(ticket_enc_part.endtime)}".indent(2)
+      output << "Renew Till: #{present_time(ticket_enc_part.renew_till)}".indent(2)
 
       output << "Client Addresses: #{ticket_enc_part.caddr.to_a.length}"
       unless ticket_enc_part.caddr.to_a.empty?
@@ -281,14 +281,21 @@ module Rex::Proto::Kerberos::CredentialCache
 
     # @param [RubySMB::Dcerpc::Ndr::NdrFileTime] time
     # @return [String] A human readable representation of the time
-    def present_time(time)
+    def present_ndr_file_time(time)
       if time.get == Rex::Proto::Kerberos::Pac::NEVER_EXPIRE
         'Never Expires (inf)'
       elsif time.get == 0
         'No Time Set (0)'
       else
-        time.to_time.to_s
+        present_time(time.to_time)
       end
+    end
+
+
+    # @param [Time] time
+    # @return [String] A human readable representation of the time in the users timezone
+    def present_time(time)
+      time.localtime.to_s
     end
   end
 end

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -124,10 +124,10 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: 2022-11-28 15:51:29 +0000
-            Start time: 2022-11-28 15:51:29 +0000
-            End time: 2032-11-25 15:51:29 +0000
-            Renew Till: 2032-11-25 15:51:29 +0000
+            Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+            Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+            End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+            Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -157,10 +157,10 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: 2022-11-28 15:51:29 +0000
-            Start time: 2022-11-28 15:51:29 +0000
-            End time: 2032-11-25 15:51:29 +0000
-            Renew Till: 2032-11-25 15:51:29 +0000
+            Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+            Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+            End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+            Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -170,10 +170,10 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
               Key Version Number: 2
               Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
-                  Auth time: 2022-11-28 15:51:29 UTC
-                  Start time: 2022-11-28 15:51:29 UTC
-                  End time: 2032-11-25 15:51:29 UTC
-                  Renew Till: 2032-11-25 15:51:29 UTC
+                  Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+                  Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+                  End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+                  Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'

--- a/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe 'kerberos inspect ticket' do
 
   let(:expected_decrypted_aes_output) do
     expected_output = ["#{file_format} File:#{ticket_path}"]
-    expected_output << <<~'EOF'.chomp # Single quote removes interpolation for the hex results
+    expected_output << <<~EOF.chomp
       Primary Principal: Administrator@WINDOMAIN.LOCAL
       Ccache version: 4
 
@@ -475,10 +475,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: 2023-01-13 14:31:25 +0000
-            Start time: 2023-01-13 14:31:25 +0000
-            End time: 2033-01-10 14:31:25 +0000
-            Renew Till: 2033-01-10 14:31:25 +0000
+            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+            End time: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -488,10 +488,10 @@ RSpec.describe 'kerberos inspect ticket' do
               Key Version Number: 2
               Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
-                  Auth time: 2023-01-13 14:31:25 UTC
-                  Start time: 2023-01-13 14:31:25 UTC
-                  End time: 2033-01-10 14:31:25 UTC
-                  Renew Till: 2033-01-10 14:31:25 UTC
+                  Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+                  Start time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+                  End time: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
+                  Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -501,7 +501,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: 2023-01-13 14:31:25 +0000
+                    Logon Time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -538,7 +538,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: 2023-01-13 14:31:25 +0000
+                    Client ID: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
                   Pac Server Checksum:
                     Signature: 81a20da731b3b9bdd2e756dc
                   Pac Privilege Server Checksum:
@@ -550,7 +550,7 @@ RSpec.describe 'kerberos inspect ticket' do
   let(:expected_encrypted_aes_output) do
     expected_output = ['No decryption key provided proceeding without decryption.']
     expected_output << "#{file_format} File:#{ticket_path}"
-    expected_output << <<~'EOF'.chomp # Single quote removes interpolation for the hex results
+    expected_output << <<~EOF.chomp
       Primary Principal: Administrator@WINDOMAIN.LOCAL
       Ccache version: 4
 
@@ -566,10 +566,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: 2023-01-13 14:31:25 +0000
-            Start time: 2023-01-13 14:31:25 +0000
-            End time: 2033-01-10 14:31:25 +0000
-            Renew Till: 2033-01-10 14:31:25 +0000
+            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+            End time: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -585,7 +585,7 @@ RSpec.describe 'kerberos inspect ticket' do
 
   let(:expected_decrypted_nthash_output) do
     expected_output = ["#{file_format} File:#{ticket_path}"]
-    expected_output << <<~'EOF'.chomp # Single quote removes interpolation for the hex results
+    expected_output << <<~EOF.chomp
       Primary Principal: Administrator@WINDOMAIN.LOCAL
       Ccache version: 4
 
@@ -601,10 +601,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: 2023-01-13 14:36:39 +0000
-            Start time: 2023-01-13 14:36:39 +0000
-            End time: 2033-01-10 14:36:39 +0000
-            Renew Till: 2033-01-10 14:36:39 +0000
+            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+            End time: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -614,10 +614,10 @@ RSpec.describe 'kerberos inspect ticket' do
               Key Version Number: 2
               Decrypted (with key: 88e4d9fabaecf3dec18dd80905521b29):
                 Times:
-                  Auth time: 2023-01-13 14:36:39 UTC
-                  Start time: 2023-01-13 14:36:39 UTC
-                  End time: 2033-01-10 14:36:39 UTC
-                  Renew Till: 2033-01-10 14:36:39 UTC
+                  Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+                  Start time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+                  End time: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
+                  Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -627,7 +627,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: 2023-01-13 14:36:39 +0000
+                    Logon Time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -664,7 +664,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: 2023-01-13 14:36:39 +0000
+                    Client ID: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
                   Pac Server Checksum:
                     Signature: 1a038d8dd257a7d9b875280259ab0e4a
                   Pac Privilege Server Checksum:
@@ -676,7 +676,7 @@ RSpec.describe 'kerberos inspect ticket' do
   let(:expected_encrypted_nthash_output) do
     expected_output = ['No decryption key provided proceeding without decryption.']
     expected_output << "#{file_format} File:#{ticket_path}"
-    expected_output << <<~'EOF'.chomp # Single quote removes interpolation for the hex results
+    expected_output << <<~EOF.chomp
       Primary Principal: Administrator@WINDOMAIN.LOCAL
       Ccache version: 4
 
@@ -692,10 +692,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: 2023-01-13 14:36:39 +0000
-            Start time: 2023-01-13 14:36:39 +0000
-            End time: 2033-01-10 14:36:39 +0000
-            Renew Till: 2033-01-10 14:36:39 +0000
+            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+            End time: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL

--- a/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
@@ -475,10 +475,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
-            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
-            End time: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
-            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
+            Auth time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
+            Start time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
+            End time: #{Time.parse('2033-01-10 14:31:25 UTC').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:31:25 UTC').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -488,10 +488,10 @@ RSpec.describe 'kerberos inspect ticket' do
               Key Version Number: 2
               Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
-                  Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
-                  Start time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
-                  End time: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
-                  Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
+                  Auth time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
+                  Start time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
+                  End time: #{Time.parse('2033-01-10 14:31:25 UTC').to_time}
+                  Renew Till: #{Time.parse('2033-01-10 14:31:25 UTC').to_time}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -501,7 +501,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+                    Logon Time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -538,7 +538,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+                    Client ID: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
                   Pac Server Checksum:
                     Signature: 81a20da731b3b9bdd2e756dc
                   Pac Privilege Server Checksum:
@@ -566,10 +566,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
-            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
-            End time: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
-            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
+            Auth time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
+            Start time: #{Time.parse('2023-01-13 14:31:25 UTC').to_time}
+            End time: #{Time.parse('2033-01-10 14:31:25 UTC').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:31:25 UTC').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -601,10 +601,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
-            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
-            End time: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
-            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
+            Auth time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
+            Start time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
+            End time: #{Time.parse('2033-01-10 14:36:39 UTC').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:36:39 UTC').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -614,10 +614,10 @@ RSpec.describe 'kerberos inspect ticket' do
               Key Version Number: 2
               Decrypted (with key: 88e4d9fabaecf3dec18dd80905521b29):
                 Times:
-                  Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
-                  Start time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
-                  End time: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
-                  Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
+                  Auth time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
+                  Start time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
+                  End time: #{Time.parse('2033-01-10 14:36:39 UTC').to_time}
+                  Renew Till: #{Time.parse('2033-01-10 14:36:39 UTC').to_time}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -627,7 +627,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+                    Logon Time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -664,7 +664,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+                    Client ID: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
                   Pac Server Checksum:
                     Signature: 1a038d8dd257a7d9b875280259ab0e4a
                   Pac Privilege Server Checksum:
@@ -692,10 +692,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
-            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
-            End time: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
-            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
+            Auth time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
+            Start time: #{Time.parse('2023-01-13 14:36:39 UTC').to_time}
+            End time: #{Time.parse('2033-01-10 14:36:39 UTC').to_time}
+            Renew Till: #{Time.parse('2033-01-10 14:36:39 UTC').to_time}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL

--- a/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
@@ -475,10 +475,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
-            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
-            End time: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
-            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
+            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+            End time: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
+            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -488,10 +488,10 @@ RSpec.describe 'kerberos inspect ticket' do
               Key Version Number: 2
               Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
-                  Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
-                  Start time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
-                  End time: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
-                  Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
+                  Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+                  Start time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+                  End time: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
+                  Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -501,7 +501,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+                    Logon Time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -538,7 +538,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
+                    Client ID: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
                   Pac Server Checksum:
                     Signature: 81a20da731b3b9bdd2e756dc
                   Pac Privilege Server Checksum:
@@ -566,10 +566,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
-            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').to_time}
-            End time: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
-            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').to_time}
+            Auth time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+            Start time: #{Time.parse('2023-01-13 14:31:25 +0000').localtime}
+            End time: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
+            Renew Till: #{Time.parse('2033-01-10 14:31:25 +0000').localtime}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -601,10 +601,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
-            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
-            End time: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
-            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
+            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+            End time: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
+            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -614,10 +614,10 @@ RSpec.describe 'kerberos inspect ticket' do
               Key Version Number: 2
               Decrypted (with key: 88e4d9fabaecf3dec18dd80905521b29):
                 Times:
-                  Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
-                  Start time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
-                  End time: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
-                  Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
+                  Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+                  Start time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+                  End time: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
+                  Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -627,7 +627,7 @@ RSpec.describe 'kerberos inspect ticket' do
                 Flags: 0x50a00000 (FORWARDABLE, PROXIABLE, RENEWABLE, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+                    Logon Time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -664,7 +664,7 @@ RSpec.describe 'kerberos inspect ticket' do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
+                    Client ID: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
                   Pac Server Checksum:
                     Signature: 1a038d8dd257a7d9b875280259ab0e4a
                   Pac Privilege Server Checksum:
@@ -692,10 +692,10 @@ RSpec.describe 'kerberos inspect ticket' do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
-            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').to_time}
-            End time: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
-            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').to_time}
+            Auth time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+            Start time: #{Time.parse('2023-01-13 14:36:39 +0000').localtime}
+            End time: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
+            Renew Till: #{Time.parse('2033-01-10 14:36:39 +0000').localtime}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL


### PR DESCRIPTION
Tests for the inspect ticket module were failing if the machine running them was in a timezone other than GMT, this PR updates the test to expect the time to be in the local timezone

# Verification steps
- [ ] Run the inspect ticket tests `bundle exec rspec spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb`
- [ ] Change your timezone to something else
- [ ] Run the inspect ticket tests again `bundle exec rspec spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb`

