### PR TITLE
Fix module spec test failing on local machine

### DIFF
--- a/lib/rex/proto/http/web_socket.rb
+++ b/lib/rex/proto/http/web_socket.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'bindata'
+require 'rex/post/channel'
 
 module Rex::Proto::Http::WebSocket
   class WebSocketError < StandardError


### PR DESCRIPTION
Fix module spec test failing on local machine

```
$ bundle exec rspec ./spec/modules_spec.rb  
.... etc...
  1) modules it should behave like all modules with module type can be instantiated auxiliary gather/grandstream_ucm62xx_sql_account_guess can be instantiated
     Failure/Error: raise error
     
     Msf::Modules::Error:
       Failed to load module (gather/grandstream_ucm62xx_sql_account_guess from /Users/user/Documents/code/metasploit-framework/modules/auxiliary/gather/grandstream_ucm62xx_sql_account_guess.rb) ... etc ...
     # ------------------
     # --- Caused by: ---
     # NameError:
     #   uninitialized constant Rex::Post::Channel
     #   ./lib/rex/proto/http/web_socket.rb:26:in `<class:Channel>'
```

## Verification

Ensure CI passes