### PR TITLE
Fix #17629  #query_ldap issues

### DIFF
--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -180,12 +180,10 @@ module Msf
         def query_ldap(session_handle, base, scope, filter, fields)
           vprint_status('Searching LDAP directory')
           search = wldap32.ldap_search_sA(session_handle, base, scope, filter, nil, 0, 4)
-          vprint_status("search: #{search}")
-
           if search['return'] == LDAP_SIZELIMIT_EXCEEDED
             print_error('LDAP_SIZELIMIT_EXCEEDED, parsing what we retrieved, try increasing the MAX_SEARCH value [0:LDAP_NO_LIMIT]')
           elsif search['return'] != Error::SUCCESS
-            print_error('No results')
+            print_error("Search returned LDAP error #{search['return']} (#{ERROR_CODE_TO_CONSTANT.fetch(search['return'], 'Unknown')})")
             wldap32.ldap_msgfree(search['res'])
             return
           end
@@ -198,10 +196,7 @@ module Msf
             return
           end
 
-          print_status("Entries retrieved: #{search_count}")
-
-          pEntries = []
-          entry_results = []
+          vprint_status("Entries retrieved: #{search_count}")
 
           if datastore['MAX_SEARCH'] == 0
             max_search = search_count
@@ -209,136 +204,40 @@ module Msf
             max_search = [datastore['MAX_SEARCH'], search_count].min
           end
 
-          0.upto(max_search - 1) do |i|
-            if (i == 0)
-              pEntries[0] = wldap32.ldap_first_entry(session_handle, search['res'])['return']
-            end
+          entry = wldap32.ldap_first_entry(session_handle, search['res'])['return']
 
-            if (pEntries[i] == 0)
-              print_error('Failed to get entry')
-              wldap32.ldap_msgfree(search['res'])
-              return
-            end
-
-            vprint_status("Entry #{i}: 0x#{pEntries[i].to_s(16)}")
-
-            entry = get_entry(pEntries[i])
-
-            # Entries are a linked list...
-            if client.arch == ARCH_X64
-              pEntries[i + 1] = entry[4]
-            else
-              pEntries[i + 1] = entry[3]
-            end
-
-            ber = get_ber(entry)
-
+          entry_results = []
+          while entry != 0 && (entry_results.length < max_search)
             field_results = []
             fields.each do |field|
-              vprint_status("Field: #{field}")
-
-              values = get_values_from_ber(ber, field)
-
               values_result = ''
-              values_result = values.join(',') if values
-              vprint_status("Values #{values}")
+              values = wldap32.ldap_get_values(session_handle, entry, field)
+              if values['return'] != 0
+                count_values = wldap32.ldap_count_values(values['return'])
+                if count_values['return'] != 0
+                  if client.native_arch == ARCH_X64
+                    value_pointers = client.railgun.memread(values['return'], 8 * count_values['return']).unpack('Q*')
+                  else
+                    value_pointers = client.railgun.memread(values['return'], 4 * count_values['return']).unpack('V*')
+                  end
+                  values_result = value_pointers.map { |ptr| client.railgun.util.read_string(ptr) }.join(',')
+                end
+                wldap32.ldap_value_free(values['return'])
+              end
 
               field_results << { type: 'unknown', value: values_result }
             end
 
             entry_results << field_results
+            entry = wldap32.ldap_next_entry(session_handle, entry)['return']
           end
+
+          wldap32.ldap_msgfree(search['res'])
 
           return {
             fields: fields,
             results: entry_results
           }
-        end
-
-        # Gets the LDAP Entry
-        #
-        # @param pEntry [Integer] Pointer to the Entry
-        # @return [Array] Entry data structure
-        def get_entry(pEntry)
-          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            raise "Session doesn't support Railgun!"
-          end
-
-          return client.railgun.memread(pEntry, 41).unpack('VVVVVVVVVvCCC')
-        end
-
-        # Get BER Element data structure from LDAPMessage
-        #
-        # @param msg [String] The LDAP Message from the server
-        # @return [String] The BER data structure
-        def get_ber(msg)
-          unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
-            raise "Session doesn't support Railgun!"
-          end
-
-          ber = client.railgun.memread(msg[2], 60).unpack('V*')
-
-          # BER Pointer is different between x86 and x64
-          if client.arch == ARCH_X64
-            ber_data = client.railgun.memread(ber[4], ber[0])
-          else
-            ber_data = client.railgun.memread(ber[3], ber[0])
-          end
-
-          return ber_data
-        end
-
-        # Search through the BER data structure for our Attribute.
-        # This doesn't attempt to parse the BER structure correctly
-        # instead it finds the first occurance of our field name
-        # tries to check the length of that value.
-        #
-        # @param ber_data [String] BER data structure
-        # @param field [String] Attribute name
-        # @return [Array] Values for the given +field+
-        def get_values_from_ber(ber_data, field)
-          field_offset = ber_data.index(field)
-
-          unless field_offset
-            vprint_status("Field not found in BER: #{field}")
-            return nil
-          end
-
-          # Value starts after our field string
-          values_offset = field_offset + field.length
-          values_start_offset = values_offset + 8
-          values_len_offset = values_offset + 5
-          curr_len_offset = values_offset + 7
-
-          values_length = ber_data[values_len_offset].unpack('C')[0]
-          values_end_offset = values_start_offset + values_length
-
-          curr_length = ber_data[curr_len_offset].unpack('C')[0]
-          curr_start_offset = values_start_offset
-
-          if (curr_length >= 127)
-            curr_length = ber_data[curr_len_offset + 1, 4].unpack('N')[0]
-            curr_start_offset += 4
-          end
-
-          curr_end_offset = curr_start_offset + curr_length
-
-          values = []
-          while (curr_end_offset < values_end_offset)
-            values << ber_data[curr_start_offset..curr_end_offset]
-
-            break unless ber_data[curr_end_offset] == "\x04"
-
-            curr_len_offset = curr_end_offset + 1
-            curr_length = ber_data[curr_len_offset].unpack('C')[0]
-            curr_start_offset = curr_end_offset + 2
-            curr_end_offset = curr_end_offset + curr_length + 2
-          end
-
-          # Strip trailing 0 or \x04 which is used to delimit values
-          values.map! { |x| x[0..x.length - 2] }
-
-          return values
         end
 
         # Shortcut to the WLDAP32 Railgun Object
@@ -365,9 +264,9 @@ module Msf
             raise "Unable to initialize ldap server: #{init_result['ErrorMessage']}"
           end
 
-          vprint_status("LDAP Handle: #{session_handle}")
+          vprint_status("LDAP Handle: 0x#{session_handle.to_s(16)}")
 
-          vprint_status('Setting Sizelimit Option')
+          vprint_status('Setting the size limit option')
           wldap32.ldap_set_option(session_handle, LDAP_OPT_SIZELIMIT, [size_limit].pack('V'))
 
           vprint_status('Binding to LDAP server')

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/railgun.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/railgun.rb
@@ -133,7 +133,7 @@ class Railgun
   #
   def util
     if @util.nil?
-      @util = Util.new(self, client.arch)
+      @util = Util.new(self, client.native_arch)
     end
 
     return @util

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Post
     inner_filter << '(!(lockoutTime>=1))' if datastore['EXCLUDE_LOCKED']
     inner_filter << '(!(userAccountControl:1.2.840.113556.1.4.803:=2))' if datastore['EXCLUDE_DISABLED']
     inner_filter << "(memberof:1.2.840.113556.1.4.1941:=#{datastore['GROUP_MEMBER']})" if datastore['GROUP_MEMBER']
-    inner_filter << "(#{datastore['FILTER']})" if datastore['FILTER'] != ''
+    inner_filter << "(#{datastore['FILTER']})" unless datastore['FILTER'].blank?
     case datastore['UAC']
     when 'ANY'
     when 'NO_PASSWORD'


### PR DESCRIPTION
This fixes the `#query_ldap` post API method. The original would parse the opaque BER data structures manually which lead to issues due to the assumption that everything was 32-bit. Now that #17562 has been landed the native Windows API methods can be used regardless of if the target is 32-bit or 64-bit. 

The old implementation would obtain the `LDAPMessage` structure and then process it manually, going as far as decoding the BER data itself. I can't find any documentation on the structure of the `LDAPMessage` so it would seem that Microsoft doesn't intend for it to be accessed.

The new implementation takes the following steps:

1. Calls [`ldap_first_entry`](https://learn.microsoft.com/en-us/windows/win32/api/winldap/nf-winldap-ldap_first_entry) to obtain the first `LDAPMessage`
2. For each field that was requested, it calls [`ldap_get_values`](https://learn.microsoft.com/en-us/windows/win32/api/winldap/nf-winldap-ldap_get_values)
3. Counts the number of values that were returned
4. Reads that array of pointers with `#memread`, unpacking them based on the architecture
5. Reads the string data from each and joins it all together using a comma
6. Frees the values
7. Iterates through the next entry, going back to step 2
8. Frees the LDAPMessage

Step 5 is incorrect, we should really be returning an array of strings but the original implementation also just concatenated everything together with a comma. The underlying issue is that LDAP values can be nil a single value or an array of multiple values. I left this as is because modules using this API are probably accustomed to the value being a string.

For testing, use a Python Meterpreter because it supports railgun and the existing logic prefers the extapi for the Windows Meterpreter.

- [x] Start a Python Meterpreter session on a domain controller (this is the easiest to get the LDAP connection to just work)
- [x] Run the `post/windows/gather/enum_ad_users` module and see it work
- [x] Run the `post/windows/gather/enum_ad_computers` module and see it work

## Demo (Fixed)

```
meterpreter > sysinfo
Computer        : DC
OS              : Windows 2016 (Build 17763)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > run post/windows/gather/enum_ad_users

[!] SESSION may not be compatible with this module:
[!]  * unloadable Meterpreter extension: extapi
[*] Querying default naming context
Domain Users
============

 sAMAccountName        name                              userPrincipalName                 userAccountControl  lockoutTime  mail                                    primarygroupid  description
 --------------        ----                              -----------------                 ------------------  -----------  ----                                    --------------  -----------
 Administrator         Administrator                                                       66048                                                                    513             Built-in account for administering the computer/domain
 Guest                 Guest                                                               66082                                                                    514             Built-in account for guest access to the computer/domain
 smcintyre             smcintyre                         smcintyre@msflab.local            66048                            smcintyre@msflab.local                  513
 sshd                  sshd                                                                66048                                                                    513
 krbtgt                krbtgt                                                              514                                                                      513             Key Distribution Center Service Account
 aliddle               Alice Liddle                      aliddle@msflab.local              66048                            aliddle@msflab.local                    513
 $MI1000-P4PGUIV8EHR1  Exchange Online-ApplicationAccou  Exchange_Online-ApplicationAccou  546                                                                      513
                       nt                                nt@msflab.local
 SM_05950467e3ea46ed8  SystemMailbox{1f05a927-1c97-4df7  SystemMailbox{1f05a927-1c97-4df7  514                              SystemMailbox{1f05a927-1c97-4df7-ad98-  513
                       -ad98-cab0bb4191db}               -ad98-cab0bb4191db}@msflab.local                                   cab0bb4191db}@msflab.local
 SM_274b5effbbf3459f8  SystemMailbox{bb558c35-97f1-4cb9  SystemMailbox{bb558c35-97f1-4cb9  514                              SystemMailbox{bb558c35-97f1-4cb9-8ff7-  513
                       -8ff7-d53741dc928c}               -8ff7-d53741dc928c}@msflab.local                                   d53741dc928c}@msflab.local
 SM_1ea45a0f5e274d5c9  SystemMailbox{e0dc1c29-89c3-4034  SystemMailbox{e0dc1c29-89c3-4034  514                              SystemMailbox{e0dc1c29-89c3-4034-b678-  513
                       -b678-e6c29d823ed9}               -b678-e6c29d823ed9}@msflab.local                                   e6c29d823ed9}@msflab.local
 SM_1ec2821cf0ea4ec19  DiscoverySearchMailbox {D919BA05  DiscoverySearchMailbox {D919BA05  514                              DiscoverySearchMailbox{D919BA05-46A6-4  513
                       -46A6-415f-80AD-7E09334BB852}     -46A6-415f-80AD-7E09334BB852}@ms                                   15f-80AD-7E09334BB852}@msflab.local
                                                         flab.local
 SM_164251cf2e97458d8  Migration.8f3e7716-2011-43e4-96b  Migration.8f3e7716-2011-43e4-96b  514                              Migration.8f3e7716-2011-43e4-96b1-aba6  513
                       1-aba62d229136                    1-aba62d229136@msflab.local                                        2d229136@msflab.local
 SM_d1601338536f49488  FederatedEmail.4c1f4d8b-8179-414  FederatedEmail.4c1f4d8b-8179-414  514                              FederatedEmail.4c1f4d8b-8179-4148-93bf  513
                       8-93bf-00a95fa1e042               8-93bf-00a95fa1e042@msflab.local                                   -00a95fa1e042@msflab.local
 SM_7d14c5fb0a244bb0b  SystemMailbox{D0E409A0-AF9B-4720  SystemMailbox{D0E409A0-AF9B-4720  514                              SystemMailbox{D0E409A0-AF9B-4720-92FE-  513
                       -92FE-AAC869B0D201}               -92FE-AAC869B0D201}@msflab.local                                   AAC869B0D201}@msflab.local
 SM_9fbfdc9f9da34155b  SystemMailbox{2CE34405-31BE-455D  SystemMailbox{2CE34405-31BE-455D  514                              SystemMailbox{2CE34405-31BE-455D-89D7-  513
                       -89D7-A7C7DA7A0DAA}               -89D7-A7C7DA7A0DAA}@msflab.local                                   A7C7DA7A0DAA}@msflab.local
 SM_c6906a0fc1764b5db  SystemMailbox{8cc370d3-822a-4ab8  SystemMailbox{8cc370d3-822a-4ab8  514                              SystemMailbox{8cc370d3-822a-4ab8-a926-  513
                       -a926-bb94bd0641a9}               -a926-bb94bd0641a9}@msflab.local                                   bb94bd0641a9}@msflab.local
 HealthMailbox21b1853  HealthMailbox21b1853745514961993  HealthMailbox21b1853745514961993  66048                            HealthMailbox21b185374551496199303bc32  513
                       03bc32fee6069                     03bc32fee6069@msflab.local                                         fee6069@msflab.local
 HealthMailboxd46a71f  HealthMailboxd46a71f1e7ae4e4a896  HealthMailboxd46a71f1e7ae4e4a896  66048                            HealthMailboxd46a71f1e7ae4e4a896d9485a  513
                       d9485a0a4bf4c                     d9485a0a4bf4c@msflab.local                                         0a4bf4c@msflab.local
 HealthMailboxf8d9ea7  HealthMailboxf8d9ea752c084e7293a  HealthMailboxf8d9ea752c084e7293a  66048                            HealthMailboxf8d9ea752c084e7293ad6a5d2  513
                       d6a5d20f6f554                     d6a5d20f6f554@msflab.local                                         0f6f554@msflab.local
 HealthMailbox94d093a  HealthMailbox94d093a0f05e48ad811  HealthMailbox94d093a0f05e48ad811  66048                            HealthMailbox94d093a0f05e48ad81124c19b  513
                       24c19bb6fa748                     24c19bb6fa748@msflab.local                                         b6fa748@msflab.local
 HealthMailboxa9a11e7  HealthMailboxa9a11e74426c436aa75  HealthMailboxa9a11e74426c436aa75  66048                            HealthMailboxa9a11e74426c436aa759c6687  513
                       9c6687cc32754                     9c6687cc32754@msflab.local                                         cc32754@msflab.local
 HealthMailbox8d864d2  HealthMailbox8d864d2afc2749feaef  HealthMailbox8d864d2afc2749feaef  66048                            HealthMailbox8d864d2afc2749feaef57bc62  513
                       57bc62d240431                     57bc62d240431@msflab.local                                         d240431@msflab.local
 HealthMailbox9a524ee  HealthMailbox9a524ee043dd4124ad9  HealthMailbox9a524ee043dd4124ad9  66048                            HealthMailbox9a524ee043dd4124ad9ed993c  513
                       ed993c5438561                     ed993c5438561@msflab.local                                         5438561@msflab.local
 HealthMailbox8e506cb  HealthMailbox8e506cb9bed24339bef  HealthMailbox8e506cb9bed24339bef  66048                            HealthMailbox8e506cb9bed24339befd24886  513
                       d248865cb00a4                     d248865cb00a4@msflab.local                                         5cb00a4@msflab.local
 HealthMailboxc1b73ec  HealthMailboxc1b73eca8fbb40ad85c  HealthMailboxc1b73eca8fbb40ad85c  66048                            HealthMailboxc1b73eca8fbb40ad85cec65b4  513
                       ec65b466c864c                     ec65b466c864c@msflab.local                                         66c864c@msflab.local
 HealthMailboxf9f877e  HealthMailboxf9f877e335d24143828  HealthMailboxf9f877e335d24143828  66048                            HealthMailboxf9f877e335d24143828deb0d0  513
                       deb0d0fff7634                     deb0d0fff7634@msflab.local                                         fff7634@msflab.local
 HealthMailboxa56bf05  HealthMailboxa56bf053817b43cca68  HealthMailboxa56bf053817b43cca68  66048                            HealthMailboxa56bf053817b43cca68cfb756  513
                       cfb756f4db097                     cfb756f4db097@msflab.local                                         f4db097@msflab.local
 mhatter               Maddilyn Hatter                   mhatter@msflab.local              16843264                                                                 513

meterpreter > run post/windows/gather/enum_ad_computers

[!] SESSION may not be compatible with this module:
[!]  * unloadable Meterpreter extension: extapi
[*] Querying default naming context
Domain Computers
================

 dNSHostName                distinguishedName                                description  operatingSystem               operatingSystemServicePack
 -----------                -----------------                                -----------  ---------------               --------------------------
 DC.msflab.local            CN=DC,OU=Domain Controllers,DC=msflab,DC=local                Windows Server 2019 Standard
 EXCHANGE2019.msflab.local  CN=EXCHANGE2019,CN=Computers,DC=msflab,DC=local               Windows Server 2019 Standard
 MSSQL.msflab.local         CN=MSSQL,CN=Computers,DC=msflab,DC=local                      Windows Server 2019 Standard

meterpreter > 
```


## Demo (Original issue)

```
meterpreter > sysinfo
Computer        : DC
OS              : Windows 2016 (Build 17763)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > run post/windows/gather/enum_ad_users

[!] SESSION may not be compatible with this module:
[!]  * unloadable Meterpreter extension: extapi
[-] Unable to find the domain to query.
meterpreter > run post/windows/gather/enum_ad_computers

[!] SESSION may not be compatible with this module:
[!]  * unloadable Meterpreter extension: extapi
[-] Unable to find the domain to query.
meterpreter > 
```