### PR TITLE
Add in SCHANNEL support for LDAP

### DIFF
--- a/lib/msf/core/exploit/remote/auth_option.rb
+++ b/lib/msf/core/exploit/remote/auth_option.rb
@@ -17,6 +17,9 @@ module Msf::Exploit::Remote::AuthOption
   # plaintext authentication is used
   PLAINTEXT = 'plaintext'
 
+  # SCHANNEL authentication is used.
+  SCHANNEL = 'schannel'
+
   # Do not authenticate with the service
   NONE = 'none'
 
@@ -41,6 +44,7 @@ module Msf::Exploit::Remote::AuthOption
     AUTO,
     NTLM,
     KERBEROS,
+    SCHANNEL,
     PLAINTEXT,
     NONE
   ]

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -99,7 +99,7 @@ module Msf
         begin
           pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
         rescue => e
-          fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Couldn't open the certificate file or the file doesn't exist. Error was #{e}")
+          fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Failed to load the PFX file (#{e})")
         end
 
         connect_opts[:auth] = {

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -31,6 +31,7 @@ module Msf
         Msf::OptString.new('DOMAIN', [false, 'The domain to authenticate to']),
         Msf::OptString.new('USERNAME', [false, 'The username to authenticate with'], aliases: ['BIND_DN']),
         Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW']),
+        Msf::OptString.new('PFX_PATH', [false, 'The path to the PFX file on disk to authenticate with', ''])
       ])
 
       register_advanced_options(
@@ -78,7 +79,7 @@ module Msf
 
       if datastore['SSL']
         connect_opts[:encryption] = {
-          method: :start_tls,
+          method: :simple_tls,
           tls_options: {
             verify_mode: OpenSSL::SSL::VERIFY_NONE
           }
@@ -86,6 +87,25 @@ module Msf
       end
 
       case datastore['LDAP::Auth']
+      when Msf::Exploit::Remote::AuthOption::SCHANNEL
+        pfx_path = datastore['PFX_PATH']
+        raise StandardError, 'SCHANNEL authentication specified but no PFX_PATH set' if pfx_path.blank?
+
+        pkcs = OpenSSL::PKCS12.new(File.read(pfx_path), '')
+        connect_opts[:auth] = {
+          method: :sasl,
+          mechanism: 'EXTERNAL',
+          initial_credential: '',
+          challenge_response: true
+        }
+        connect_opts[:encryption] = {
+          method: :start_tls,
+          tls_options: {
+            verify_mode: OpenSSL::SSL::VERIFY_NONE,
+            cert: pkcs.certificate,
+            key: pkcs.key
+          }
+        }
       when Msf::Exploit::Remote::AuthOption::KERBEROS
         fail_with(Msf::Exploit::Failure::BadConfig, 'The Ldap::Rhostname option is required when using Kerberos authentication.') if datastore['Ldap::Rhostname'].blank?
         fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
@@ -264,8 +284,8 @@ module Msf
       end
 
       # NOTE: Find the first entry that starts with `DC=` as this will likely be the base DN.
-      naming_contexts.select! {|context| context =~ /^(DC=[A-Za-z0-9-]+,?)+$/}
-      naming_contexts.reject! {|context| context =~ /(Configuration)|(Schema)|(ForestDnsZones)/}
+      naming_contexts.select! { |context| context =~ /^(DC=[A-Za-z0-9-]+,?)+$/ }
+      naming_contexts.reject! { |context| context =~ /(Configuration)|(Schema)|(ForestDnsZones)/ }
       if naming_contexts.blank?
         print_error("#{peer} A base DN matching the expected format could not be found!")
         return
@@ -287,26 +307,26 @@ module Msf
     #   bind request failed.
     # @return [Nil] This function does not return any data.
     def validate_bind_success!(ldap)
-      bind_result = ldap.as_json['result']['ldap_result']
+      bind_result = ldap.get_operation_result.table
 
       # Codes taken from https://ldap.com/ldap-result-code-reference-core-ldapv3-result-codes
-      case bind_result['resultCode']
+      case bind_result[:code]
       when 0
         vprint_good('Successfully bound to the LDAP server!')
       when 1
-        fail_with(Msf::Module::Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result[:error_message].strip}")
       when 7
         fail_with(Msf::Module::Failure::NoTarget, 'Target does not support the simple authentication mechanism!')
       when 8
-        fail_with(Msf::Module::Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::NoTarget, "Server requires a stronger form of authentication than we can provide! The error was: #{bind_result[:error_message].strip}")
       when 14
-        fail_with(Msf::Module::Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::NoTarget, "Server requires additional information to complete the bind. Error was: #{bind_result[:error_message].strip}")
       when 48
         fail_with(Msf::Module::Failure::NoAccess, "Target doesn't support the requested authentication type we sent. Try binding to the same user without a password, or providing credentials if you were doing anonymous authentication.")
       when 49
         fail_with(Msf::Module::Failure::NoAccess, 'Invalid credentials provided!')
       else
-        fail_with(Msf::Module::Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result[:error_message].strip}")
       end
     end
 
@@ -314,9 +334,11 @@ module Msf
     # Fail with an appropriate error code if the query failed.
     #
     # @param query_result [Hash] A hash containing the results of the query
-    #   as a 'resultCode' with an integer representing the result code,
-    #   'errorMessage' containing an optional error message, and
-    #   'matchedDN' containing the matched DN.
+    #   as a 'extended_response' representing the extended response,
+    #   a 'code' with an integer representing the result code,
+    #   a 'error_message' containing an optional error message as a Net::BER::BerIdentifiedString,
+    #   a 'matched_dn' containing the matched DN,
+    #   and a 'message' containing the query result message.
     # @param filter [Net::LDAP::Filter]  A Net::LDAP::Filter to use to
     #   filter the results of the query.
     #
@@ -326,19 +348,19 @@ module Msf
     # @return [Nil] This function does not return any data.
     def validate_query_result!(query_result, filter)
       if query_result.class != Hash
-        raise ArgumentError.new('Parameter to "validate_query_result!" function was not a Hash!')
+        raise ArgumentError, 'Parameter to "validate_query_result!" function was not a Hash!'
       end
 
       # Codes taken from https://ldap.com/ldap-result-code-reference-core-ldapv3-result-codes
-      case query_result['resultCode']
+      case query_result[:code]
       when 0
         vprint_status("Successfully queried #{filter}.")
       when 1
         # This is unknown as whilst we could fail on lack of authorization, this is not guaranteed with this error code.
         # The user will need to inspect the error message to determine the root cause of the issue.
-        fail_with(Msf::Module::Failure::Unknown, "An LDAP operational error occurred on #{filter}. It is likely the client requires authorization! The error was: #{query_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::Unknown, "An LDAP operational error occurred on #{filter}. It is likely the client requires authorization! The error was: #{query_result[:error_message].strip}")
       when 2
-        fail_with(Msf::Module::Failure::BadConfig, "The LDAP protocol being used by Metasploit isn't supported. The error was #{query_result['errorMessage'].strip}")
+        fail_with(Msf::Module::Failure::BadConfig, "The LDAP protocol being used by Metasploit isn't supported. The error was #{query_result[:error_message].strip}")
       when 3
         fail_with(Msf::Module::Failure::TimeoutExpired, "The LDAP server returned a timeout response to the query #{filter}.")
       when 4
@@ -368,10 +390,10 @@ module Msf
       when 65
         fail_with(Msf::Module::Failure::Unknown, "The LDAP operation failed due to an object class violation when using #{filter}.")
       else
-        if query_result['errorMessage'].blank?
+        if query_result[:error_message].blank?
           fail_with(Msf::Module::Failure::Unknown, "Query #{filter} failed but no error message was returned!")
         else
-          fail_with(Msf::Module::Failure::Unknown, "Query #{filter} failed with error: #{query_result['errorMessage'].strip}")
+          fail_with(Msf::Module::Failure::Unknown, "Query #{filter} failed with error: #{query_result[:error_message].strip}")
         end
       end
     end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -89,7 +89,8 @@ module Msf
       case datastore['LDAP::Auth']
       when Msf::Exploit::Remote::AuthOption::SCHANNEL
         pfx_path = datastore['PFX_PATH']
-        raise StandardError, 'SCHANNEL authentication specified but no PFX_PATH set' if pfx_path.blank?
+        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'SCHANNEL authentication specified but no PFX_PATH set') if pfx_path.blank?
+        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'SCHANNEL authentication requires an SSL connection!') if datastore['SSL'] != true
 
         pkcs = OpenSSL::PKCS12.new(File.read(pfx_path), '')
         connect_opts[:auth] = {

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -92,8 +92,12 @@ module Msf
         fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The LDAP::CertFile option is required when using SCHANNEL authentication.') if pfx_path.blank?
         fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The SSL option must be enabled when using SCHANNEL authentication.') if datastore['SSL'] != true
 
+        unless ::File.file?(pfx_path) and ::File.readable?(pfx_path)
+          fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'Failed to load the PFX certificate file. The path was not a readable file.')
+        end
+
         begin
-          pkcs = OpenSSL::PKCS12.new(File.read(pfx_path), '')
+          pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
         rescue => e
           fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Couldn't open the certificate file or the file doesn't exist. Error was #{e}")
         end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -30,14 +30,14 @@ module Msf
         OptBool.new('SSL', [false, 'Enable SSL on the LDAP connection', false]),
         Msf::OptString.new('DOMAIN', [false, 'The domain to authenticate to']),
         Msf::OptString.new('USERNAME', [false, 'The username to authenticate with'], aliases: ['BIND_DN']),
-        Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW']),
-        Msf::OptString.new('PFX_PATH', [false, 'The path to the PFX file on disk to authenticate with', ''])
+        Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW'])
       ])
 
       register_advanced_options(
         [
           *kerberos_storage_options(protocol: 'LDAP'),
           *kerberos_auth_options(protocol: 'LDAP', auth_methods: Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS),
+          Msf::OptPath.new('LDAP::CertFile', [false, 'The path to the PKCS12 (.pfx) certificate file to authenticate with'], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL]),
           OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
         ]
       )
@@ -88,11 +88,16 @@ module Msf
 
       case datastore['LDAP::Auth']
       when Msf::Exploit::Remote::AuthOption::SCHANNEL
-        pfx_path = datastore['PFX_PATH']
-        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'SCHANNEL authentication specified but no PFX_PATH set') if pfx_path.blank?
-        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'SCHANNEL authentication requires an SSL connection!') if datastore['SSL'] != true
+        pfx_path = datastore['LDAP::CertFile']
+        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The LDAP::CertFile option is required when using SCHANNEL authentication.') if pfx_path.blank?
+        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The SSL option must be enabled when using SCHANNEL authentication.') if datastore['SSL'] != true
 
-        pkcs = OpenSSL::PKCS12.new(File.read(pfx_path), '')
+        begin
+          pkcs = OpenSSL::PKCS12.new(File.read(pfx_path), '')
+        rescue => e
+          fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Couldn't open the certificate file or the file doesn't exist. Error was #{e}")
+        end
+
         connect_opts[:auth] = {
           method: :sasl,
           mechanism: 'EXTERNAL',

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -78,7 +78,7 @@ module Msf
 
       if datastore['SSL']
         connect_opts[:encryption] = {
-          method: :simple_tls,
+          method: :start_tls,
           tls_options: {
             verify_mode: OpenSSL::SSL::VERIFY_NONE
           }

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -65,14 +65,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def fail_with_ldap_error(message)
-    ldap_result = @ldap.as_json['result']['ldap_result']
-    return if ldap_result['resultCode'] == 0
+    ldap_result = @ldap.get_operation_result.table
+    return if ldap_result[:code] == 0
 
     print_error(message)
     # Codes taken from https://ldap.com/ldap-result-code-reference-core-ldapv3-result-codes
-    case ldap_result['resultCode']
+    case ldap_result[:code]
     when 1
-      fail_with(Failure::Unknown, "An LDAP operational error occurred. The error was: #{ldap_result['errorMessage'].strip}")
+      fail_with(Failure::Unknown, "An LDAP operational error occurred. The error was: #{ldap_result[:error_message].strip}")
     when 16
       fail_with(Failure::NotFound, 'The LDAP operation failed because the referenced attribute does not exist.')
     when 50
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::Unknown, 'The LDAP operation failed due to an object class violation.')
     end
 
-    fail_with(Failure::Unknown, "Unknown LDAP error occurred: result: #{ldap_result['resultCode']} message: #{ldap_result['errorMessage'].strip}")
+    fail_with(Failure::Unknown, "Unknown LDAP error occurred: result: #{ldap_result[:code]} message: #{ldap_result[:error_message].strip}")
   end
 
   def get_delegate_from_obj

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -145,9 +145,9 @@ class MetasploitModule < Msf::Auxiliary
       controls << [LDAP_SERVER_SD_FLAGS_OID.to_ber, true.to_ber, control_values].to_ber_sequence
 
       returned_entries = ldap.search(base: full_base_dn, filter: filter, attributes: attributes, controls: controls)
-      query_result = ldap.as_json['result']['ldap_result']
+      query_result_table = ldap.get_operation_result.table
 
-      validate_query_result!(query_result, filter)
+      validate_query_result!(query_result_table, filter)
 
       if returned_entries.blank?
         vprint_error("No results found for #{filter}.")

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -140,9 +140,8 @@ class MetasploitModule < Msf::Auxiliary
     base ||= @base_dn
     scope ||= Net::LDAP::SearchScope_WholeSubtree
     returned_entries = ldap.search(base: base, filter: filter, attributes: attributes, scope: scope)
-    query_result = ldap.as_json['result']['ldap_result']
-
-    validate_query_result!(query_result, filter)
+    query_result_table = ldap.get_operation_result.table
+    validate_query_result!(query_result_table, filter)
 
     if returned_entries.nil? || returned_entries.empty?
       print_error("No results found for #{filter}.")


### PR DESCRIPTION
Its finally here 🥳 SCHANNEL support has now been added in for LDAP so you can now use certificates to authenticate to the server and retrieve sensitive information as the user the certificate is authorized to authenticate as (if the certificate allows certificate authentication).

This should start completing the diagram that Spencer put up at https://gist.github.com/zeroSteiner/47dc724da74e6bd3f7c9b1da319ccb4b by completing the link between `Certificate` and `LDAP` by adding in the SCHANNEL support.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Follow the directions at https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/icpr_cert.html#issue-a-generic-certificate to get a certificate as a given user. Just make sure the certificate template specified has permissions to perform certificate authentication (has the Client Authentication, PKINIT Client Authentication, Smart Card Logon, Any Purpose, or SubCA EKUs enabled and allows enrollment by the user you are enrolling as).
- [ ] `use auxiliary/gather/ldap_query`
- [ ] `set LDAP::Auth schannel`
- [ ] `set RHOST *target host, usually the DC which is running the LDAP server*`
- [ ] `set PFX_PATH *path to the loot file on disk where the PFX data was saved from earlier*`
- [ ] `set SSL true`
- [ ] `run` or `exploit`
- [ ] Verify that you get the expected data.
- [ ] Verify via WireShark that that the traffic is TLS encrypted.

Here is an example run for convenience sake:

```
msf6 > use auxiliary/gather/ldap_query
msf6 auxiliary(gather/ldap_query) > set RHOST 192.168.153.167
RHOST => 192.168.153.167
msf6 auxiliary(gather/ldap_query) > set LDAP::Auth schannel
LDAP::Auth => schannel
msf6 auxiliary(gather/ldap_query) > set SSL true
SSL => true
msf6 auxiliary(gather/ldap_query) > show options

Module options (auxiliary/gather/ldap_query):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   BASE_DN                         no        LDAP base DN if you already have it
   DOMAIN                          no        The domain to authenticate to
   OUTPUT_FORMAT  table            yes       The output format to use (Accepted: csv, table, json)
   PASSWORD                        no        The password to authenticate with
   PFX_PATH                        no        The path to the PFX file on disk to authenticate with
   RHOSTS         192.168.153.167  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT          389              yes       The target port
   SSL            false            no        Enable SSL on the LDAP connection
   USERNAME                        no        The username to authenticate with


   When ACTION is RUN_SINGLE_QUERY:

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   QUERY_ATTRIBUTES                   no        Comma seperated list of attributes to retrieve from the server
   QUERY_FILTER                       no        Filter to send to the target LDAP server to perform the query


   When ACTION is RUN_QUERY_FILE:

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   QUERY_FILE_PATH                   no        Path to the JSON or YAML file to load and run queries from


Auxiliary action:

   Name           Description
   ----           -----------
   ENUM_ACCOUNTS  Dump info about all known user accounts in the domain.



View the full module info with the info, or info -d command.

msf6 auxiliary(gather/ldap_query) > set PFX_PATH /home/gwillcox/.msf4/loot/20230222155929_default_192.168.153.150_windows.ad.cs_830521.pfx
PFX_PATH => /home/gwillcox/.msf4/loot/20230222155929_default_192.168.153.150_windows.ad.cs_830521.pfx
msf6 auxiliary(gather/ldap_query) > exploit
[*] Running module against 192.168.153.167

[*] Discovering base DN automatically
[+] 192.168.153.167:389 Discovered base DN: DC=daforest,DC=com
[+] 192.168.153.167:389 Discovered schema DN: DC=daforest,DC=com
CN=Administrator CN=Users DC=daforest DC=com
============================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-02-24 18:25:30 UTC
 logoncount          97
 memberof            CN=Group Policy Creator Owners,CN=Users,DC=daforest,DC=com || CN=Domain Admins,CN=Users,DC=daforest,DC=com || CN=Enterprise Admins,CN=Users,DC=daforest,DC=com || CN=Schema Admins,CN=Users,DC=daforest,DC=com || CN=Users,CN=Builtin,DC=daforest,DC=com || CN=Administrators,CN=Builtin,DC=daforest,DC=com
 name                Administrator
 objectsid           S-1-5-21-583768849-728913032-1533249101-500
 pwdlastset          133164016158726978
 samaccountname      Administrator
 useraccountcontrol  66048

CN=Guest CN=Users DC=daforest DC=com
====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for guest access to the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 memberof            CN=Guests,CN=Builtin,DC=daforest,DC=com
 name                Guest
 objectsid           S-1-5-21-583768849-728913032-1533249101-501
 pwdlastset          0
 samaccountname      Guest
 useraccountcontrol  66082

CN=WIN-BRSHGJGIDFM OU=Domain Controllers DC=daforest DC=com
===========================================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-02-24 14:47:00 UTC
 logoncount          333
 memberof            CN=Pre-Windows 2000 Compatible Access,CN=Builtin,DC=daforest,DC=com || CN=Cert Publishers,CN=Users,DC=daforest,DC=com
 name                WIN-BRSHGJGIDFM
 objectsid           S-1-5-21-583768849-728913032-1533249101-1000
 pwdlastset          133191500547736948
 samaccountname      WIN-BRSHGJGIDFM$
 useraccountcontrol  532480

CN=krbtgt CN=Users DC=daforest DC=com
=====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Key Distribution Center Service Account
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 memberof            CN=Denied RODC Password Replication Group,CN=Users,DC=daforest,DC=com
 name                krbtgt
 objectsid           S-1-5-21-583768849-728913032-1533249101-502
 pwdlastset          133164161644084399
 samaccountname      krbtgt
 useraccountcontrol  514

CN=CHILD$ CN=Users DC=daforest DC=com
=====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           1601-01-01 00:00:00 UTC
 logoncount          0
 name                CHILD$
 objectsid           S-1-5-21-583768849-728913032-1533249101-1103
 pwdlastset          133189882446424612
 samaccountname      CHILD$
 useraccountcontrol  2080

CN=normal CN=Users DC=daforest DC=com
=====================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 displayname         normal
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-01-25 20:36:46 UTC
 logoncount          2
 name                normal
 objectsid           S-1-5-21-583768849-728913032-1533249101-1107
 pwdlastset          133189972129176212
 samaccountname      normal
 useraccountcontrol  66048
 userprincipalname   normal@daforest.com

[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_query) > 
```
