### PR TITLE
Fix argument validation for the route command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -310,13 +310,18 @@ class Console::CommandDispatcher::Stdapi::Net
 
       when 'add'
         # Satisfy check to see that formatting is correct
-        unless Rex::Socket::RangeWalker.new(args[0]).length == 1
-          print_error "Invalid IP Address"
+        unless Rex::Socket.is_ip_addr?(args[0])
+          print_error "Invalid subnet: #{args[0]}"
           return false
         end
 
-        unless Rex::Socket::RangeWalker.new(args[1]).length == 1
-          print_error 'Invalid Subnet mask'
+        unless Rex::Socket.is_ip_addr?(args[1])
+          print_error "Invalid subnet mask: #{args[1]}"
+          return false
+        end
+
+        unless Rex::Socket.is_ip_addr?(args[2])
+          print_error "Invalid gateway address: #{args[2]}"
           return false
         end
 
@@ -325,13 +330,18 @@ class Console::CommandDispatcher::Stdapi::Net
         client.net.config.add_route(*args)
       when 'delete'
         # Satisfy check to see that formatting is correct
-        unless Rex::Socket::RangeWalker.new(args[0]).length == 1
-          print_error 'Invalid IP Address'
+        unless Rex::Socket.is_ip_addr?(args[0])
+          print_error "Invalid subnet: #{args[0]}"
           return false
         end
 
-        unless Rex::Socket::RangeWalker.new(args[1]).length == 1
-          print_error 'Invalid Subnet mask'
+        unless Rex::Socket.is_ip_addr?(args[1])
+          print_error "Invalid subnet mask: #{args[1]}"
+          return false
+        end
+
+        unless Rex::Socket.is_ip_addr?(args[2])
+          print_error "Invalid gateway address: #{args[2]}"
           return false
         end
 


### PR DESCRIPTION
This fixes the argument validation for the Meterpreter `route` command. The command has subcommands for add and delete, both of which take three arguments. The arguments are the subnet, subnet mask and gateway for the route that should be added or deleted. All three of these values are more or less IP addresses, e.g. `192.168.150.0`, `255.255.255.0`, `192.168.149.2` respectively.

Prior to these changes there were two issues with the validation:

1. `Rex::Socket::RangeWalker#length` does not properly validate that an argument is a single IP address. For example, it'll return length 1 for a hostname that resolves to a single IP address. Switched this to use `Rex::Socket.is_ip_addr?` which is much more explicit and less likely to be fooled.
2. A community member reported having issues with mistaking the Meterpreter route command for the Metasploit route command. Both of which take a subnet and a subnet mask as the first two arguments. The third argument, however for Metasploit is the session number while for Meterpreter, it was the gateway. By validating the gateway argument, users are much less likely to mistakenly add a Metasploit route to their Meterpreter session through something like `route add 0.0.0.0 0.0.0.0 1`. This example would route all traffic through session one when used as a Metasploit command, or it would route all traffic using `0.0.0.1` as the default gateway when used as a Meterpreter command, which would likely result in the session dying.


There's another unrelated issue already tracked in https://github.com/rapid7/metasploit-payloads/issues/613 for the Windows Meterpreter throwing errors with it's route command. The improved validation here can still be tested independently of that issue.

## Testing

- [x] Open a Meterpreter session
- [x] Run the `route add` command with invalid values for each of the three arguments
- [x] See that each time, Metasploit throws an error when appropriate