### PR TITLE
Fix typo in psexec.rb

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/remote/smb/client/psexec.rb
@@ -26,7 +26,7 @@ module Exploit::Remote::SMB::Client::Psexec
       [
         OptString.new('SERVICE_NAME', [ false, 'The service name', nil]),
         OptString.new('SERVICE_DISPLAY_NAME', [ false, 'The service display name', nil]),
-        OptString.new('SERVICE_DESCRIPTION', [false, "Service description to to be used on target for pretty listing",nil])
+        OptString.new('SERVICE_DESCRIPTION', [false, "Service description to be used on target for pretty listing",nil])
       ], self.class)
 
     register_advanced_options(


### PR DESCRIPTION
Found via `proselint` in documentation of Metasploit itself.