### PR TITLE
Fix the reverse port forward message

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -480,13 +480,12 @@ class Console::CommandDispatcher::Stdapi::Net
               'PeerHost'          => lhost,
               'PeerPort'          => lport,
               'MeterpreterRelay'  => true)
-            rport = relay.opts['LocalPort']
           rescue Exception => e
             print_error("Failed to create relay: #{e.to_s}")
             return false
           end
 
-          print_status("Reverse TCP relay created: (remote) #{netloc(rhost, rport)} -> (local) #{netloc(channel.params.localhost, channel.params.localport)}")
+          print_status("Reverse TCP relay created: (remote) #{netloc(channel.params.localhost, channel.params.localport)} -> (local) #{netloc(lhost, lport)}")
         else
           # Validate parameters
           unless lport && rhost && rport


### PR DESCRIPTION
This fixes a mistake I made in commit 81295e40fa421414606777cdd85d1a49f122e016 where I updated the information with the wrong side of the connection. Since it's a reverse portforward, the "localhost" from the channel is actually where the socket is listening on the remote host.

As it is now, the same information is shown as both the local and remote sides.

## Verification

- [x] Open a Meterpreter session
- [x] Start a reverse port forward with `portfwd add -R -l 8080 -L 127.0.0.1 -p 1234`
- [x] See that the remote host is listening on TCP port 1234
- [x] Start a local service on port 8080, Python works well with `python -m http.server 8080`
- [x] Connect to the compromised host on port 1234 and see that a connection was made to the local service. If you're running an HTTP server, you'll need to make a request.

## Demo

In the following image, 192.168.159.10 is a compromised Windows host. The reverse port forward command above is used to redirect port 1234 on the compromised host to the local system on which Metasploit is running. After the portforward is started, `netstat` is used to confirm that 1234 is listening. After the port has been verified, `curl` is used to make a request to the compromised host, showing that the port is being redirected as indicated by the message.
![image](https://user-images.githubusercontent.com/2058303/221968543-bdc8d847-d48c-4b31-aa9a-0e3ca5e7ec21.png)


Without these changes, the incorrect output would have been displayed:
```
meterpreter > portfwd add -R -l 8080 -L 127.0.0.1 -p 1234
[*] Reverse TCP relay created: (remote) :1234 -> (local) [::]:1234
meterpreter 
```