### PR TITLE
Update document normalizer to support all references

### DIFF
--- a/lib/msf/util/document_generator/document_normalizer.rb
+++ b/lib/msf/util/document_generator/document_normalizer.rb
@@ -201,6 +201,16 @@ module Msf
             case ref.ctx_id
             when 'MSB'
               normalized << "* [#{ref.ctx_val}](#{ref.site})"
+            when 'BID'
+              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
+            when 'EDB'
+              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
+            when 'ZDI'
+              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
+            when 'WPVDB'
+              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
+            when 'PACKETSTORM'
+              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
             when 'URL'
               normalized << "* [#{ref.site}](#{ref.site})"
             when 'OSVDB'

--- a/lib/msf/util/document_generator/document_normalizer.rb
+++ b/lib/msf/util/document_generator/document_normalizer.rb
@@ -201,16 +201,6 @@ module Msf
             case ref.ctx_id
             when 'MSB'
               normalized << "* [#{ref.ctx_val}](#{ref.site})"
-            when 'BID'
-              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
-            when 'EDB'
-              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
-            when 'ZDI'
-              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
-            when 'WPVDB'
-              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
-            when 'PACKETSTORM'
-              normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
             when 'URL'
               normalized << "* [#{ref.site}](#{ref.site})"
             when 'OSVDB'

--- a/spec/lib/msf/util/document_generator/normalizer_spec.rb
+++ b/spec/lib/msf/util/document_generator/normalizer_spec.rb
@@ -157,6 +157,16 @@ RSpec.describe Msf::Util::DocumentGenerator::DocumentNormalizer do
       it 'returns the reference list in HTML' do
         expect(subject.send(:normalize_references, msf_mod.references)).to include('* [http://')
       end
+
+      it 'returns the references list with packetstorm URL' do
+        refs = [Msf::Module::SiteReference.new('PACKETSTORM', '171208')]
+        expect(subject.send(:normalize_references, refs)).to include('* [PACKETSTORM-171208]')
+      end
+
+      it 'returns the references list with 51030 URL' do
+        refs = [Msf::Module::SiteReference.new('EDB', '51030')]
+        expect(subject.send(:normalize_references, refs)).to include('* [EDB-51030]')
+      end
     end
   end
 


### PR DESCRIPTION
This updates document normalizer to support all references from `/lib/msf/core/module/reference.rb`. Currently document normalizer doesn't support all of them. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/webexec`
- [ ] `info -d`
- [ ] **Verify** that you can see references section and another way to verify is to edit a existing module and add more references related to `BID` or `EDB` etc. which we were not supporting before and verify if you can see the references to it in the html.

## Test screenshots
Following screenshot displays examples of how references related to `BID` or `EDB` or `PACKETSTORM` etc. would look like.
![image](https://user-images.githubusercontent.com/104774338/222283393-9326878f-60b6-4ec1-96a8-0d72580d0e5c.png)
