### PR TITLE
Fix number of OSX nightly installers we retain and fix typo

### DIFF
--- a/docs/metasploit-framework.wiki/Nightly-Installers.md
+++ b/docs/metasploit-framework.wiki/Nightly-Installers.md
@@ -20,7 +20,7 @@ Linux packages are built nightly for .deb (i386, amd64, armhf, arm64) and .rpm (
 
 ### macOS manual installation
 
-The latest OS X installer package can also be downloaded directly here: <https://osx.metasploit.com/metasploitframework-latest.pkg>, with the last 10 builds archived at <https://osx.metasploit.com/>. Simply download and launch the installer to install Metaploit Framework with all of its dependencies.
+The latest OS X installer package can also be downloaded directly here: <https://osx.metasploit.com/metasploitframework-latest.pkg>, with the last 8 builds archived at <https://osx.metasploit.com/>. Simply download and launch the installer to install Metasploit Framework with all of its dependencies.
 
 ## Installing Metasploit on Windows
 


### PR DESCRIPTION
Fixes #16126

We no longer retain 10 installs of OSX nightly builds, but rather the last 8. We should update our documentation to fix this and to also spell Metasploit correctly.

## Verification

List the steps needed to make sure this thing works

- [ ] Verify there are no concerns with updating this to accurately reflect the number of previous installers we have.
- [ ] Verify that [osx.metasploit.com](https://osx.metasploit.com/) holds the last 8 nightly installers and their associated signature files.
- [ ] Verify the typo in Metasploit has now been fixed.
