### PR TITLE
Added new Datastore options to ssh_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -45,6 +45,20 @@ module Metasploit
           # @!attribute bruteforce_speed
           #   @return [Integer] The desired speed, with 5 being 'fast' and 0 being 'slow.'
           attr_accessor :bruteforce_speed
+          # @!attribute maxconsecutiveerrors
+          #   @return [Integer] Maximum consecutive errors allowed
+          attr_accessor :maxconsecutiveerrors
+          # @!attribute maxerrorcount
+          #   @return [Integer] Maximum Errors allowed
+          attr_accessor :maxerrorcount
+
+          validates :maxconsecutiveerrors,
+                    presence: true,
+                    numericality: {
+                      only_integer:             true,
+                      greater_than_or_equal_to: 1,
+                      less_than_or_equal_to:    :maxerrorcount
+                    }
 
           validates :connection_timeout,
                     presence: true,
@@ -247,8 +261,8 @@ module Metasploit
                 if result.status == Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
                   consecutive_error_count += 1
                   total_error_count += 1
-                  break if consecutive_error_count >= 3
-                  break if total_error_count >= 10
+                  break if consecutive_error_count >= maxconsecutiveerrors
+                  break if total_error_count >= maxerrorcount
                 end
               end
             end

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -45,14 +45,14 @@ module Metasploit
           # @!attribute bruteforce_speed
           #   @return [Integer] The desired speed, with 5 being 'fast' and 0 being 'slow.'
           attr_accessor :bruteforce_speed
-          # @!attribute max_consecutive_errors
+          # @!attribute max_consecutive_error_count
           #   @return [Integer] Maximum consecutive errors allowed
-          attr_accessor :max_consecutive_errors
+          attr_accessor :max_consecutive_error_count
           # @!attribute max_error_count
-          #   @return [Integer] Maximum Errors allowed
+          #   @return [Integer] Maximum errors allowed
           attr_accessor :max_error_count
 
-          validates :max_consecutive_errors,
+          validates :max_consecutive_error_count,
                     presence: true,
                     numericality: {
                       only_integer:             true,
@@ -261,7 +261,7 @@ module Metasploit
                 if result.status == Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
                   consecutive_error_count += 1
                   total_error_count += 1
-                  break if consecutive_error_count >= max_consecutive_errors
+                  break if consecutive_error_count >= max_consecutive_error_count
                   break if total_error_count >= max_error_count
                 end
               end
@@ -311,7 +311,7 @@ module Metasploit
           # @return [void]
           def set_sane_defaults
             self.connection_timeout = 30 if self.connection_timeout.nil?
-            self.max_consecutive_errors = 3 if self.max_consecutive_errors.nil?
+            self.max_consecutive_error_count = 3 if self.max_consecutive_error_count.nil?
             self.max_error_count = 10 if self.max_error_count.nil?
           end
 

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -311,6 +311,8 @@ module Metasploit
           # @return [void]
           def set_sane_defaults
             self.connection_timeout = 30 if self.connection_timeout.nil?
+            self.max_consecutive_errors = 3 if self.max_consecutive_errors.nil?
+            self.max_error_count = 10 if self.max_error_count.nil?
           end
 
           # This method validates that the credentials supplied

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -45,19 +45,19 @@ module Metasploit
           # @!attribute bruteforce_speed
           #   @return [Integer] The desired speed, with 5 being 'fast' and 0 being 'slow.'
           attr_accessor :bruteforce_speed
-          # @!attribute maxconsecutiveerrors
+          # @!attribute max_consecutive_errors
           #   @return [Integer] Maximum consecutive errors allowed
-          attr_accessor :maxconsecutiveerrors
-          # @!attribute maxerrorcount
+          attr_accessor :max_consecutive_errors
+          # @!attribute max_error_count
           #   @return [Integer] Maximum Errors allowed
-          attr_accessor :maxerrorcount
+          attr_accessor :max_error_count
 
-          validates :maxconsecutiveerrors,
+          validates :max_consecutive_errors,
                     presence: true,
                     numericality: {
                       only_integer:             true,
                       greater_than_or_equal_to: 1,
-                      less_than_or_equal_to:    :maxerrorcount
+                      less_than_or_equal_to:    :max_error_count
                     }
 
           validates :connection_timeout,
@@ -261,8 +261,8 @@ module Metasploit
                 if result.status == Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
                   consecutive_error_count += 1
                   total_error_count += 1
-                  break if consecutive_error_count >= maxconsecutiveerrors
-                  break if total_error_count >= maxerrorcount
+                  break if consecutive_error_count >= max_consecutive_errors
+                  break if total_error_count >= max_error_count
                 end
               end
             end

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
         OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true]),
         OptInt.new('MaxErrorCount', [true, "Total errors allowed while connecting", 10]),
-        OptInt.new('MaxConsecutiveErrors', [true, "Max Consicutive errors allowed while connecting", 3])
+        OptInt.new('MaxConsecutiveErrorCount', [true, "Maximum consecutive errors allowed while connecting", 3])
       ]
     )
 
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Auxiliary
       framework: framework,
       framework_module: self,
       skip_gather_proof: !datastore['GatherProof'],
-      max_consecutive_errors: datastore['MaxConsecutiveErrors'],
+      max_consecutive_error_count: datastore['MaxConsecutiveErrorCount'],
       max_error_count: datastore['MaxErrorCount']
     )
 

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -111,8 +111,8 @@ class MetasploitModule < Msf::Auxiliary
       framework: framework,
       framework_module: self,
       skip_gather_proof: !datastore['GatherProof'],
-      maxconsecutiveerrors: datastore['MaxConsecutiveErrors'],
-      maxerrorcount: datastore['MaxErrorCount']
+      max_consecutive_errors: datastore['MaxConsecutiveErrors'],
+      max_error_count: datastore['MaxErrorCount']
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -44,7 +44,9 @@ class MetasploitModule < Msf::Auxiliary
         Opt::Proxies,
         OptBool.new('SSH_DEBUG', [false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
         OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
-        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true])
+        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true]),
+        OptInt.new('MaxErrorCount', [true, "Total errors allowed while connecting", 10]),
+        OptInt.new('MaxConsecutiveErrors', [true, "Max Consicutive errors allowed while connecting", 3])
       ]
     )
 
@@ -108,7 +110,9 @@ class MetasploitModule < Msf::Auxiliary
       connection_timeout: datastore['SSH_TIMEOUT'],
       framework: framework,
       framework_module: self,
-      skip_gather_proof: !datastore['GatherProof']
+      skip_gather_proof: !datastore['GatherProof'],
+      maxconsecutiveerrors: datastore['MaxConsecutiveErrors'],
+      maxerrorcount: datastore['MaxErrorCount']
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']


### PR DESCRIPTION
Addressed feature suggestion in issue #17178 
added `MaxErrorCount` and `MaxConsecutiveErrors` to datastore.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use scanner/ssh/ssh_login`
- [ ] `show advanced options`
