### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -76,7 +76,7 @@ module ResponseDataHelper
     begin
       # If we are running the data service on the same box this will ensure we only write
       # the file if it is somehow not there already.
-      unless File.exists?(save_path) && File.read(save_path, mode: 'rb') == decoded_file
+      unless File.exist?(save_path) && File.read(save_path, mode: 'rb') == decoded_file
         File.write(save_path, decoded_file, mode: 'wb')
       end
     rescue => e

--- a/lib/msf/core/auxiliary/manage_engine_xnode/config.rb
+++ b/lib/msf/core/auxiliary/manage_engine_xnode/config.rb
@@ -12,7 +12,7 @@ module Msf::Auxiliary::ManageEngineXnode::Config
   # @return [Hash, Integer] Hash containing the data repositories (tables) and their fields (columns) to dump if reading the config file succeeded, error code otherwise
   def grab_config(config_file)
     # get the specified data repositories (tables) and fields (columns) to dump from the config file
-    return CONFIG_FILE_DOES_NOT_EXIST unless File.exists? config_file
+    return CONFIG_FILE_DOES_NOT_EXIST unless File.exist?(config_file)
 
     begin
       config_contents = File.read(config_file)

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -115,7 +115,7 @@ module Msf::DBManager::Loot
 
       # If the user updates the path attribute (or filename) we need to update the file
       # on disk to reflect that.
-      if opts[:path] && File.exists?(loot.path)
+      if opts[:path] && File.exist?(loot.path)
         File.rename(loot.path, opts[:path])
       end
 

--- a/lib/msf/core/web_services/servlet/loot_servlet.rb
+++ b/lib/msf/core/web_services/servlet/loot_servlet.rb
@@ -67,7 +67,7 @@ module Msf::WebServices::LootServlet
         # Give the file a unique name to prevent accidental overwrites. Only do this if there is actually a file
         # on disk. If there is not a file on disk we assume that this DB record is for tracking a file outside
         # of metasploit, so we don't want to assign them a unique file name and overwrite that.
-        if opts[:path] && File.exists?(db_record.path)
+        if opts[:path] && File.exist?(db_record.path)
           filename = File.basename(opts[:path])
           opts[:path] = File.join(Msf::Config.loot_directory, "#{SecureRandom.hex(10)}-#{filename}")
         end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1162,7 +1162,7 @@ module Msf
             readable = false
             contents = ''
 
-            if File.exists?(favs_file)
+            if File.exist?(favs_file)
               exists = true
             end
 
@@ -1419,7 +1419,7 @@ module Msf
           def show_favorites # :nodoc:
             favs_file = Msf::Config.fav_modules_file
 
-            unless File.exists?(favs_file)
+            unless File.exist?(favs_file)
               print_error("The favorite modules file does not exist")
               return
             end

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -33,9 +33,9 @@ module Msf
         user_path = File.join(PullRequestFinder::USER_MANUAL_BASE_PATH, "#{mod.fullname}.md")
         global_path = File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md")
 
-        if File.exists?(user_path)
+        if File.exist?(user_path)
           kb_path = user_path
-        elsif File.exists?(global_path)
+        elsif File.exist?(global_path)
           kb_path = global_path
         end
 

--- a/modules/evasion/windows/windows_defender_js_hta.rb
+++ b/modules/evasion/windows/windows_defender_js_hta.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Evasion
     file_payload = Rex::Text.encode_base64(payload.encoded)
     evasion_shellcode_path = File.join(Msf::Config.data_directory, 'exploits', 'evasion_shellcode.js')
     jsnet_code = File.read(evasion_shellcode_path)
-    fail_with(Failure::NotFound, 'The JScript.NET file was not found.') unless File.exists?(evasion_shellcode_path)
+    fail_with(Failure::NotFound, 'The JScript.NET file was not found.') unless File.exist?(evasion_shellcode_path)
     js_file = ERB.new(jsnet_code).result(binding())
     jsnet_encoded = Rex::Text.encode_base64(js_file)
     # This is used in the ERB template
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Evasion
     arch = ["x86", "x64"].include?(payload.arch.first) ? payload.arch.first : "anycpu"
     hta_path = File.join(Msf::Config.data_directory, 'exploits', 'hta_evasion.hta')
     hta = File.read(hta_path)
-    fail_with(Failure::NotFound, 'The HTA file was not found.') unless File.exists?(hta_path)
+    fail_with(Failure::NotFound, 'The HTA file was not found.') unless File.exist?(hta_path)
     hta_file = ERB.new(hta).result(binding())
     file_create(hta_file)
   end

--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -353,7 +353,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
         wrapper_path = ::File.join(template_base, "samba-root-#{template_type}-#{t_plat}-#{t_arch}.so.gz")
-        next unless ::File.exists?(wrapper_path)
+        next unless ::File.exist?(wrapper_path)
 
         data = ''
         ::File.open(wrapper_path, "rb") do |fd|


### PR DESCRIPTION
File.exists? was deprecated in Ruby 2.1.0 and has been removed in the Ruby 3.2.0.

* https://bugs.ruby-lang.org/issues/17391
* https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/

This PR replaces `File.exists?` in the following modules and libraries:

* modules/exploits/linux/samba/is_known_pipename.rb
* modules/evasion/windows/windows_defender_js_hta.rb
* lib/msf/ui/console/command_dispatcher/modules.rb
* lib/msf/util/document_generator.rb
* lib/msf/core/db_manager/loot.rb
* lib/msf/core/auxiliary/manage_engine_xnode/config.rb
* lib/msf/core/web_services/servlet/loot_servlet.rb
* lib/metasploit/framework/data_service/remote/http/response_data_helper.rb

These changes have been implemented via code review and have not been tested. PR #6795 performed similar changes in 2016.

---

Fortunately, but confusingly, the majority of `exists?` within Framework is due to our `exists?` method in the `File` mixin. The following `exists?` were manually reviewed:

```
# fgrep -rni " exists?" modules/ lib/
modules/exploits/osx/local/vmware_fusion_lpe.rb:188:    unless exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}"
modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb:78:    unless exists? path
modules/exploits/windows/local/bypassuac_windows_store_filesys.rb:62:    if sysinfo['OS'] =~ /Windows 10/ && is_uac_enabled? && exists?("C:\\Windows\\System32\\WSReset.exe")
modules/exploits/windows/local/bypassuac_windows_store_filesys.rb:99:    unless exists? exploit_win_dir
modules/exploits/windows/local/bypassuac_windows_store_filesys.rb:103:    unless exists? exploit_dir
modules/exploits/windows/local/bypassuac_windows_store_filesys.rb:107:    unless exists? exploit_file
modules/exploits/windows/local/bypassuac_windows_store_reg.rb:64:    if sysinfo['OS'] =~ /Windows 10/ && is_uac_enabled? && exists?("C:\\Windows\\System32\\WSReset.exe")
modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb:113:    if exists?(pkexec = cmd_exec('which pkexec'))
modules/exploits/linux/local/netfilter_nft_set_elem_init_privesc.rb:129:    if exists?(@executable_path)
modules/exploits/multi/local/vagrant_synced_folder_vagrantfile_breakout.rb:88:      return exists?(datastore['VAGRANTFILE_PATH']) ? datastore['VAGRANTFILE_PATH'] : nil
modules/post/windows/gather/dumplinks.rb:105:  # This is a hack because Meterpreter doesn't support exists?(file)
modules/post/multi/gather/ubiquiti_unifi_backup.rb:150:      next unless exists?(sprop)
modules/post/multi/gather/jenkins_gather.rb:65:    if exists?(file)
modules/post/multi/gather/jenkins_gather.rb:304:    if exists?(master_key_path) && exists?(hudson_secret_key_path)
lib/msf/core/post/file.rb:279:    return false unless exists?(path)
lib/msf/core/post/file.rb:322:  alias exists? exist?
lib/msf/core/feature_manager.rb:86:    def exists?(name)
lib/msfdb_helpers/pg_ctl.rb:75:      if exists?
lib/msfdb_helpers/pg_ctl.rb:123:    def exists?
lib/msfdb_helpers/pg_ctl.rb:128:      if exists?
lib/msfdb_helpers/standalone.rb:46:    def exists?
lib/msfdb_helpers/pg_ctlcluster.rb:35:      if exists?
lib/msfdb_helpers/pg_ctlcluster.rb:74:    def exists?
lib/msfdb_helpers/pg_ctlcluster.rb:79:      if exists?
```

```
# fgrep -rni "File.exists?" modules/ lib/
modules/exploits/linux/samba/is_known_pipename.rb:356:        next unless ::File.exists?(wrapper_path)
modules/evasion/windows/windows_defender_js_hta.rb:45:    fail_with(Failure::NotFound, 'The JScript.NET file was not found.') unless File.exists?(evasion_shellcode_path)
modules/evasion/windows/windows_defender_js_hta.rb:53:    fail_with(Failure::NotFound, 'The HTA file was not found.') unless File.exists?(hta_path)
lib/msf/ui/console/command_dispatcher/modules.rb:1165:            if File.exists?(favs_file)
lib/msf/ui/console/command_dispatcher/modules.rb:1422:            unless File.exists?(favs_file)
lib/msf/util/document_generator.rb:36:        if File.exists?(user_path)
lib/msf/util/document_generator.rb:38:        elsif File.exists?(global_path)
lib/msf/core/db_manager/loot.rb:118:      if opts[:path] && File.exists?(loot.path)
lib/msf/core/auxiliary/manage_engine_xnode/config.rb:15:    return CONFIG_FILE_DOES_NOT_EXIST unless File.exists? config_file
lib/msf/core/web_services/servlet/loot_servlet.rb:70:        if opts[:path] && File.exists?(db_record.path)
lib/metasploit/framework/data_service/remote/http/response_data_helper.rb:79:      unless File.exists?(save_path) && File.read(save_path, mode: 'rb') == decoded_file
```
