### PR TITLE
Fix Ruby 3.2 crash when running certain tools

### DIFF
--- a/tools/exploit/random_compile_c.rb
+++ b/tools/exploit/random_compile_c.rb
@@ -23,7 +23,7 @@ weight = ARGV.shift
 source_code_path = ARGV.shift
 out_path = ARGV.shift
 
-if source_code_path.nil? || source_code_path.empty? || !File.exists?(source_code_path)
+if source_code_path.nil? || source_code_path.empty? || !File.exist?(source_code_path)
   puts "Please set the source code path"
   exit
 elsif out_path.nil? || out_path.empty?
@@ -33,7 +33,7 @@ end
 
 source_code = File.read(source_code_path)
 Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(out_path, source_code, weight: weight.to_i)
-if File.exists?(out_path)
+if File.exist?(out_path)
   puts "File saved as #{out_path}"
 end
 rescue SignalException => e

--- a/tools/modules/cve_xref.rb
+++ b/tools/modules/cve_xref.rb
@@ -207,7 +207,7 @@ def main
       end
       filter = val
     when "-d"
-      unless File.exists?(val.to_s)
+      unless File.exist?(val.to_s)
         raise RuntimeError, "#{val} not found"
       end
 


### PR DESCRIPTION
Fix Ruby 3.2 crash when running certain tools

Continuation of https://github.com/rapid7/metasploit-framework/pull/17729

## Verification

### Before

Calls to the removed API

```
➜  metasploit-framework git:(upstream-master) rg 'File.exists\?' .        
./tools/modules/cve_xref.rb
210:      unless File.exists?(val.to_s)

./tools/exploit/random_compile_c.rb
26:if source_code_path.nil? || source_code_path.empty? || !File.exists?(source_code_path)
36:if File.exists?(out_path)
```

### After

No results

```
➜  metasploit-framework git:(upstream-master) rg 'File.exists\?' .        
```