### PR TITLE
Add in missing EDB reference to pfsense_pfblockerng_webshell

### DIFF
--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'CVE', '2022-31814' ],
-          [ 'URL', 'https://www.ihteam.net/advisory/pfblockerng-unauth-rce-vulnerability/']
+          [ 'URL', 'https://www.ihteam.net/advisory/pfblockerng-unauth-rce-vulnerability/'],
+          [ 'EDB', '51032' ]
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'unix',


### PR DESCRIPTION
Fixes #17732 by adding in the missing EDB reference to the exploit.

## Verification

List the steps needed to make sure this thing works

- [ ] Check that the added reference looks correct.
- [ ] Verify that Metasploit still loads and that you can run `info` and display the information of the module in the console correctly.
