### PR TITLE
Improve accuracy of msfconsole performance profiling

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -15,11 +15,11 @@ begin
 
   # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
-  require 'msfenv'
   require 'metasploit/framework/profiler'
-  require 'metasploit/framework/command/console'
-
   Metasploit::Framework::Profiler.start
+
+  require 'msfenv'
+  require 'metasploit/framework/command/console'
   Metasploit::Framework::Command::Console.start
 rescue Interrupt
   puts "\nAborting..."


### PR DESCRIPTION
Improves the accuracy of msfconsole performance profiling

## Verification

Verify profiling reports still work as expected:

```
METASPLOIT_CPU_PROFILE=true ./msfconsole -x 'exit'
METASPLOIT_MEMORY_PROFILE=true ./msfconsole -x 'exit'
```