### PR TITLE
Update get_ticket to support using forged golden tickets

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -302,17 +302,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgt_only(options = {})
-    credential = get_cached_credential(
-      options.merge(
-        sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
-          name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-          name_string: [
-            "krbtgt",
-            realm
-          ]
+    if options[:cache_file]
+      credential = load_credential_from_file(options[:cache_file])
+    else
+      credential = get_cached_credential(
+        options.merge(
+          sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
+            name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+            name_string: [
+              "krbtgt",
+              realm
+            ]
+          )
         )
       )
-    )
+    end
+
     if credential
       print_status("#{peer} - Using cached credential for #{credential.server} #{credential.client}")
       return credential


### PR DESCRIPTION
Updates the `auxiliary/admin/kerberos/get_ticket` module to support using forged golden tickets. Users can now provide the `Krb5Ccname` option to supply the Kerberos TGT to use when requesting the service ticket. If unset, the database will be checked

## Verification

- Forge a golden ticket, request a service ticket, psexec into the target - as per the scenario added to the docs