### PR TITLE
Update formatting logic for info command

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -317,9 +317,7 @@ class ReadableText
     end
 
     # Description
-    output << "Description:\n"
-    output << word_wrap(Rex::Text.compress(mod.description))
-    output << "\n"
+    output << dump_description(mod, indent)
 
     # References
     output << dump_references(mod, indent)
@@ -373,9 +371,7 @@ class ReadableText
     end
 
     # Description
-    output << "Description:\n"
-    output << word_wrap(Rex::Text.compress(mod.description))
-    output << "\n"
+    output << dump_description(mod, indent)
 
     # References
     output << dump_references(mod, indent)
@@ -433,9 +429,7 @@ class ReadableText
     end
 
     # Description
-    output << "Description:\n"
-    output << word_wrap(Rex::Text.compress(mod.description))
-    output << "\n"
+    output << dump_description(mod, indent)
 
     # References
     output << dump_references(mod, indent)
@@ -482,9 +476,7 @@ class ReadableText
     end
 
     # Description
-    output << "Description:\n"
-    output << word_wrap(Rex::Text.compress(mod.description))
-    output << "\n"
+    output << dump_description(mod, indent)
 
     # References
     output << dump_references(mod, indent)
@@ -524,9 +516,8 @@ class ReadableText
     end
 
     # Description
-    output << "Description:\n"
-    output << word_wrap(Rex::Text.compress(mod.description))
-    output << "\n\n"
+    output << dump_description(mod, indent)
+    output << "\n"
 
     return output
   end
@@ -556,9 +547,7 @@ class ReadableText
     output << dump_traits(mod)
 
     # Description
-    output << "Description:\n"
-    output << word_wrap(Rex::Text.compress(mod.description))
-    output << "\n"
+    output << dump_description(mod, indent)
 
     output << dump_references(mod, indent)
 
@@ -1141,17 +1130,44 @@ class ReadableText
     return framework.jobs.keys.length > 0 ? tbl.to_s : "#{tbl.header_to_s}No active jobs.\n"
   end
 
-  # Jacked from Ernest Ellingson <erne [at] powernav.com>, modified
-  # a bit to add indention
+  # Dumps the module description
   #
-  # @param str [String] the string to wrap.
-  # @param indent [Integer] the indentation amount.
-  # @param col [Integer] the column wrap width.
-  # @return [String] the wrapped string.
-  def self.word_wrap(str, indent = DefaultIndent, col = DefaultColumnWrap)
-    return Rex::Text.wordwrap(str, indent, col)
+  # @param mod [Msf::Module] the module.
+  # @param indent [String] the indentation string
+  # @return [String] the string description
+  def self.dump_description(mod, indent)
+    description = mod.description
+
+    output = "Description:\n"
+    output << word_wrap_description(description, indent)
+    output << "\n\n"
   end
 
+  # @param str [String] the string to wrap.
+  # @param indent [String] the indentation string
+  # @return [String] the wrapped string.
+  def self.word_wrap_description(str, indent = '')
+    return '' if str.blank?
+
+    str_lines = str.strip.lines(chomp: true)
+    # Calculate the preceding whitespace length of each line
+    smallest_preceding_whitespace = nil
+    str_lines[1..].to_a.each do |line|
+      preceding_whitespace = line[/^\s+/]
+      if preceding_whitespace && (smallest_preceding_whitespace.nil? || preceding_whitespace.length < smallest_preceding_whitespace)
+        smallest_preceding_whitespace = preceding_whitespace.length
+      end
+    end
+
+    # Normalize any existing left-most whitespace on each line; Ignoring the first line which won't have any preceding whitespace
+    result = str_lines.map.with_index do |line, index|
+      next if line.blank?
+
+      "#{indent}#{index == 0 || smallest_preceding_whitespace.nil? ? line : line[smallest_preceding_whitespace..]}"
+    end.join("\n")
+
+    result
+  end
 end
 
 end end

--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -150,7 +150,15 @@ module Msf::Module::ModuleInfo
   # Merges the module description.
   #
   def merge_info_description(info, val)
-    merge_info_string(info, 'Description', val, ". ", true)
+    key = 'Description'
+    unless info[key]
+      info[key] = val
+      return
+    end
+
+    current_value = Msf::Serializer::ReadableText.word_wrap_description(info[key])
+    new_value = Msf::Serializer::ReadableText.word_wrap_description(val)
+    info[key] = current_value.end_with?('.') ? "#{current_value}\n#{val}" : "#{current_value}.\n\n#{new_value}"
   end
 
   #

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -206,4 +206,150 @@ RSpec.describe Msf::Serializer::ReadableText do
       end
     end
   end
+
+  describe '.dump_description' do
+    context 'when the module description is nil' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: nil
+        )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+
+        TABLE
+      end
+    end
+
+    context 'when the module description has no whitespace' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: 'this is a module description'
+        )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+           this is a module description
+        TABLE
+      end
+    end
+
+    context 'when the module description is a single line' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: %q{ This is a description; with module details etc. }
+        )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+           This is a description; with module details etc.
+
+        TABLE
+      end
+    end
+
+    context 'when the first line has less preceding whitespace than the subsequent lines' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: 'Listen for a connection. First, the port will need to be knocked from
+                          the IP defined in KHOST. This IP will work as an authentication method
+                          (you can spoof it with tools like hping). After that you could get your
+                          shellcode from any IP. The socket will appear as "closed," thus helping to
+                          hide the shellcode',
+        )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+           Listen for a connection. First, the port will need to be knocked from
+           the IP defined in KHOST. This IP will work as an authentication method
+           (you can spoof it with tools like hping). After that you could get your
+           shellcode from any IP. The socket will appear as "closed," thus helping to
+           hide the shellcode
+        TABLE
+      end
+    end
+
+    context 'when the first line has more whitespace than the subsequent lines' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: %q{
+                             Login credentials to the Motorola WR850G router with
+                    firmware v4.03 can be obtained via a simple GET request
+                    if issued while the administrator is logged in.  A lot
+                    more information is available through this request, but
+                    you can get it all and more after logging in.
+                  },
+          )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+           Login credentials to the Motorola WR850G router with
+           firmware v4.03 can be obtained via a simple GET request
+           if issued while the administrator is logged in.  A lot
+           more information is available through this request, but
+           you can get it all and more after logging in.
+        TABLE
+      end
+    end
+
+    context 'when there are two blank lines in a row' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: "Run a meterpreter server in Android.\n\nTunnel communication over HTTP"
+        )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+           Run a meterpreter server in Android.
+
+           Tunnel communication over HTTP
+        TABLE
+      end
+    end
+
+    context 'when the module description spans multiple lines' do
+      it 'dumps the module description' do
+        mod = instance_double(
+          Msf::Module,
+          description: %q{
+            This is a description; with module details etc.
+
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer quis mattis lacus. Nam nisi diam, commodo id eu.
+
+            This is a list of important items to consider:
+              - Item A
+              - Item B
+              - Item C
+
+          }
+        )
+
+        result = described_class.dump_description(mod, '  ')
+        expect(result).to match_table <<~TABLE
+         Description:
+           This is a description; with module details etc.
+
+           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer quis mattis lacus. Nam nisi diam, commodo id eu.
+
+           This is a list of important items to consider:
+             - Item A
+             - Item B
+             - Item C
+
+        TABLE
+      end
+    end
+  end
 end


### PR DESCRIPTION
Updates the formatting logic for the info command to

### Before

The `info` command removes whitespace from the module description and it is hard to read:

```
Basic options:
  Name           Current Setting  Required  Description
  ----           ---------------  --------  -----------
  RHOSTS         127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
  RPORT          445              yes       The target port (TCP)
  SMBDomain                       no        (Optional) The Windows domain to use for authentication. Only affects Windows Server 2008 R2, Windows 7, Windows Embedded Standard 7 target machines.
  SMBPass                         no        (Optional) The password for the specified username
  SMBUser                         no        (Optional) The username to authenticate as
  VERIFY_ARCH    true             yes       Check if remote architecture matches exploit Target. Only affects Windows Server 2008 R2, Windows 7, Windows Embedded Standard 7 target machines.
  VERIFY_TARGET  true             yes       Check if remote OS matches exploit Target. Only affects Windows Server 2008 R2, Windows 7, Windows Embedded Standard 7 target machines.

Payload information:
  Space: 2000

Description:
  This module is a port of the Equation Group ETERNALBLUE exploit, 
  part of the FuzzBunch toolkit released by Shadow Brokers. There is a 
  buffer overflow memmove operation in Srv!SrvOs2FeaToNt. The size is 
  calculated in Srv!SrvOs2FeaListSizeToNt, with mathematical error 
  where a DWORD is subtracted into a WORD. The kernel pool is groomed 
  so that overflow is well laid-out to overwrite an SMBv1 buffer. 
  Actual RIP hijack is later completed in 
  srvnet!SrvNetWskReceiveComplete. This exploit, like the original may 
  not trigger 100% of the time, and should be run continuously until 
  triggered. It seems like the pool will get hot streaks and need a 
  cool down period before the shells rain in again. The module will 
  attempt to use Anonymous login, by default, to authenticate to 
  perform the exploit. If the user supplies credentials in the 
  SMBUser, SMBPass, and SMBDomain options it will use those instead. 
  On some systems, this module may cause system instability and 
  crashes, such as a BSOD or a reboot. This may be more likely with 
  some payloads.


```

### After

When running the `info` command the module description honors whitespace:

```
Basic options:
  Name           Current Setting  Required  Description
  ----           ---------------  --------  -----------
  RHOSTS         127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
  RPORT          445              yes       The target port (TCP)
  SMBDomain                       no        (Optional) The Windows domain to use for authentication. Only affects Windows Server 2008 R2, Windows 7, Windows Embedded Standard 7 target machines.
  SMBPass                         no        (Optional) The password for the specified username
  SMBUser                         no        (Optional) The username to authenticate as
  VERIFY_ARCH    true             yes       Check if remote architecture matches exploit Target. Only affects Windows Server 2008 R2, Windows 7, Windows Embedded Standard 7 target machines.
  VERIFY_TARGET  true             yes       Check if remote OS matches exploit Target. Only affects Windows Server 2008 R2, Windows 7, Windows Embedded Standard 7 target machines.

Payload information:
  Space: 2000

Description:
  This module is a port of the Equation Group ETERNALBLUE exploit, part of
  the FuzzBunch toolkit released by Shadow Brokers.

  There is a buffer overflow memmove operation in Srv!SrvOs2FeaToNt. The size
  is calculated in Srv!SrvOs2FeaListSizeToNt, with mathematical error where a
  DWORD is subtracted into a WORD. The kernel pool is groomed so that overflow
  is well laid-out to overwrite an SMBv1 buffer. Actual RIP hijack is later
  completed in srvnet!SrvNetWskReceiveComplete.

  This exploit, like the original may not trigger 100% of the time, and should be
  run continuously until triggered. It seems like the pool will get hot streaks
  and need a cool down period before the shells rain in again.

  The module will attempt to use Anonymous login, by default, to authenticate to perform the
  exploit. If the user supplies credentials in the SMBUser, SMBPass, and SMBDomain options it will use
  those instead.

  On some systems, this module may cause system instability and crashes, such as a BSOD or
  a reboot. This may be more likely with some payloads.
```


```
Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS     127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
  RPORT      8888             yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       The base path of Apache Druid
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host


  When CMDSTAGER::FLAVOR is one of auto,certutil,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT  8080             yes       The local port to listen on.

Payload information:

Description:
  Apache Druid includes the ability to execute user-provided JavaScript code embedded in
  various types of requests; however, that feature is disabled by default.

  In Druid versions prior to `0.20.1`, an authenticated user can send a specially-crafted request
  that both enables the JavaScript code-execution feature and executes the supplied code all
  at once, allowing for code execution on the server with the privileges of the Druid Server process.
  More critically, authentication is not enabled in Apache Druid by default.

  Tested on the following Apache Druid versions:

  * 0.15.1
  * 0.16.0-iap8
  * 0.17.1
  * 0.18.0-iap3
  * 0.19.0-iap7
  * 0.20.0-iap4.1
  * 0.20.0
  * 0.21.0-iap3
```

## Verification

- Verify the `info` command for various modules
- Eyeball all of the module descriptions that are generated - I think there's some edgecases, but for the most part it seems better than that we had before:

```
msf6 exploit(linux/http/apache_druid_js_rce) > irb -e 'framework.modules.each { |name, clazz| puts name; mod = framework.modules.create(name); puts(mod ? Msf::Serializer::ReadableText.dump_description(mod, "  ") : "unloadable") }'
cmd/brace
Description:
  This encoder uses brace expansion in Bash and other shells
  to avoid whitespace without being overly fancy.

cmd/echo
Description:
  This encoder uses echo and backlash escapes to avoid commonly restricted characters.

cmd/generic_sh
Description:
  This encoder uses standard Bourne shell variable substitution
  tricks to avoid commonly restricted characters.

cmd/ifs
Description:
  This encoder uses Bourne ${IFS} substitution to avoid whitespace
  without being overly fancy.

... etc ..
```