### PR TITLE
Update ssh_login_pubkey.rb to include new variables from login_scanner.

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -51,7 +51,9 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('SSH_DEBUG', [false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
         OptString.new('SSH_KEYFILE_B64', [false, 'Raw data of an unencrypted SSH public key. This should be used by programmatic interfaces to this module only.', '']),
         OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
-        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true])
+        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true]),
+        OptInt.new('MaxErrorCount', [true, "Total errors allowed while connecting", 10]),
+        OptInt.new('MaxConsecutiveErrorCount', [true, "Maximum consecutive errors allowed while connecting", 3])
       ]
     )
 
@@ -161,7 +163,9 @@ class MetasploitModule < Msf::Auxiliary
       connection_timeout: datastore['SSH_TIMEOUT'],
       framework: framework,
       framework_module: self,
-      skip_gather_proof: !datastore['GatherProof']
+      skip_gather_proof: !datastore['GatherProof'],
+      max_consecutive_error_count: datastore['MaxConsecutiveErrorCount'],
+      max_error_count: datastore['MaxErrorCount']
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']


### PR DESCRIPTION
Fixes #17762

Update to ssh_login_pubkey to include new variables introduced in login_scanner for error options.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
