### PR TITLE
adjust check func's problem that always print vulnerable

### DIFF
--- a/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
@@ -69,8 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     get_version
+    return CheckCode::Unknown if @version < 0
     version = Rex::Version.new(@version)
-    return CheckCode::Unknown if version.version.empty?
     vprint_status "Found CouchDB version #{version}"
 
     return CheckCode::Appears if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))


### PR DESCRIPTION

i adopt the suggestion that [bwatters-r7](https://github.com/bwatters-r7) says

please check this issue.
https://github.com/rapid7/metasploit-framework/pull/17712

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
