### PR TITLE
Revert "Added new Datastore options to ssh_login"

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -45,20 +45,6 @@ module Metasploit
           # @!attribute bruteforce_speed
           #   @return [Integer] The desired speed, with 5 being 'fast' and 0 being 'slow.'
           attr_accessor :bruteforce_speed
-          # @!attribute max_consecutive_error_count
-          #   @return [Integer] Maximum consecutive errors allowed
-          attr_accessor :max_consecutive_error_count
-          # @!attribute max_error_count
-          #   @return [Integer] Maximum errors allowed
-          attr_accessor :max_error_count
-
-          validates :max_consecutive_error_count,
-                    presence: true,
-                    numericality: {
-                      only_integer:             true,
-                      greater_than_or_equal_to: 1,
-                      less_than_or_equal_to:    :max_error_count
-                    }
 
           validates :connection_timeout,
                     presence: true,
@@ -261,8 +247,8 @@ module Metasploit
                 if result.status == Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
                   consecutive_error_count += 1
                   total_error_count += 1
-                  break if consecutive_error_count >= max_consecutive_error_count
-                  break if total_error_count >= max_error_count
+                  break if consecutive_error_count >= 3
+                  break if total_error_count >= 10
                 end
               end
             end
@@ -311,8 +297,6 @@ module Metasploit
           # @return [void]
           def set_sane_defaults
             self.connection_timeout = 30 if self.connection_timeout.nil?
-            self.max_consecutive_error_count = 3 if self.max_consecutive_error_count.nil?
-            self.max_error_count = 10 if self.max_error_count.nil?
           end
 
           # This method validates that the credentials supplied

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -44,9 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::Proxies,
         OptBool.new('SSH_DEBUG', [false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
         OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
-        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true]),
-        OptInt.new('MaxErrorCount', [true, "Total errors allowed while connecting", 10]),
-        OptInt.new('MaxConsecutiveErrorCount', [true, "Maximum consecutive errors allowed while connecting", 3])
+        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true])
       ]
     )
 
@@ -110,9 +108,7 @@ class MetasploitModule < Msf::Auxiliary
       connection_timeout: datastore['SSH_TIMEOUT'],
       framework: framework,
       framework_module: self,
-      skip_gather_proof: !datastore['GatherProof'],
-      max_consecutive_error_count: datastore['MaxConsecutiveErrorCount'],
-      max_error_count: datastore['MaxErrorCount']
+      skip_gather_proof: !datastore['GatherProof']
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/17762

Reverts rapid7/metasploit-framework#17727

This will make it so that we don't have the error mentioned at https://github.com/rapid7/metasploit-framework/issues/17762 doesn't occur any more. Seems some of these commits ended up breaking our code so we will need a better solution.