### PR TITLE
Fix remaining hardcoded timezones in tests

### DIFF
--- a/spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
           TABLE
         end
       end
@@ -223,7 +223,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host       principal                      sname                                   issued                     status  path
             --    ----       ---------                      -----                                   ------                     ------  ----
-            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active  #{valid_ccache_path}
+            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active  #{valid_ccache_path}
           TABLE
         end
       end
@@ -270,10 +270,10 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
                   Addresses: 0
                   Authdatas: 0
                   Times:
-                    Auth time: 2022-11-28 15:51:29 +0000
-                    Start time: 2022-11-28 15:51:29 +0000
-                    End time: 2032-11-25 15:51:29 +0000
-                    Renew Till: 2032-11-25 15:51:29 +0000
+                    Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+                    Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+                    End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+                    Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
                   Ticket:
                     Ticket Version Number: 5
                     Realm: WINDOMAIN.LOCAL
@@ -298,8 +298,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{old_valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{old_expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{old_valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{old_expired_ccache_path}
             Deleted 2 entries
           TABLE
           expect(kerberos_ticket_storage.tickets.length).to eq(0)
@@ -314,7 +314,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host       principal                      sname                                   issued                     status  path
             --    ----       ---------                      -----                                   ------                     ------  ----
-            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active  #{valid_ccache_path}
+            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active  #{valid_ccache_path}
           TABLE
         end
       end
@@ -327,8 +327,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
           TABLE
         end
       end
@@ -341,8 +341,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
           TABLE
         end
       end
@@ -355,8 +355,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
           TABLE
         end
       end
@@ -369,8 +369,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
           TABLE
         end
       end
@@ -420,8 +420,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host        principal                      sname                                   issued                     status       path
             --    ----        ---------                      -----                                   ------                     ------       ----
-            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  inactive     #{valid_ccache_path}
-            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+            [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  inactive     #{valid_ccache_path}
+            [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
             Deactivated 2 entries
           TABLE
         end
@@ -441,8 +441,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
               ==============
               id    host        principal                      sname                                   issued                     status       path
               --    ----        ---------                      -----                                   ------                     ------       ----
-              [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active       #{valid_ccache_path}
-              [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            2022-12-16 12:05:05 +0000  >>expired<<  #{expired_ccache_path}
+              [id]  192.0.2.2   Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active       #{valid_ccache_path}
+              [id]  192.0.2.24  Administrator@ADF3.LOCAL       krbtgt/ADF3.LOCAL@ADF3.LOCAL            #{Time.parse('2022-12-16 12:05:05 +0000').to_time}  >>expired<<  #{expired_ccache_path}
               Activated 2 entries
             TABLE
           end
@@ -459,7 +459,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host       principal                      sname                                   issued                     status  path
             --    ----       ---------                      -----                                   ------                     ------  ----
-            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  active  #{old_valid_ccache_path}
+            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  active  #{old_valid_ccache_path}
             Deleted 1 entry
           TABLE
           expect(kerberos_ticket_storage.tickets.length).to eq(1)
@@ -474,7 +474,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
             ==============
             id    host       principal                      sname                                   issued                     status    path
             --    ----       ---------                      -----                                   ------                     ------    ----
-            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  2022-11-28 15:51:29 +0000  inactive  #{valid_ccache_path}
+            [id]  192.0.2.2  Administrator@WINDOMAIN.LOCAL  krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL  #{Time.parse('2022-11-28 15:51:29 +0000').to_time}  inactive  #{valid_ccache_path}
             Deactivated 1 entry
           TABLE
         end

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                 Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: 2022-11-28 15:51:29 +0000
+                    Logon Time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -220,7 +220,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: 2022-11-28 15:51:29 +0000
+                    Client ID: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
                   Pac Server Checksum:
                     Signature: 5eb9400bcab42babcd598210
                   Pac Privilege Server Checksum:


### PR DESCRIPTION
Follow on from #17690 where I apparently missed a couple tests while fixing up the timezone issues we had

# Verification steps
- [ ] Run the inspect ticket specs `bundle exec rspec spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb`
- [ ] Run the klist specs `bundle exec rspec spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb`
- [ ] Run the keytab specs `bundle exec rspec spec/modules/auxiliary/admin/kerberos/keytab_spec.rb`
- [ ] Run the ccaceh presenter specs `bundle exec spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb`
- [ ] Change your timezone to something else
- [ ] Run the inspect ticket specs `bundle exec rspec spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb`
- [ ] Run the klist specs `bundle exec rspec spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb`
- [ ] Run the keytab specs `bundle exec rspec spec/modules/auxiliary/admin/kerberos/keytab_spec.rb`
- [ ] Run the ccaceh presenter specs `bundle exec spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb`