### PR TITLE
Fix undefined method word_wrap error on msfconsole boot

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -261,8 +261,8 @@ class Core
     banner << ("+ -- --=[ %-#{padding}s]\n" % eva)
 
     banner << "\n"
-    banner << Msf::Serializer::ReadableText.word_wrap("Metasploit tip: #{Tip.sample}\n", indent = 0, cols = 60)
-    banner << Msf::Serializer::ReadableText.word_wrap('Metasploit Documentation: https://docs.metasploit.com/', indent = 0, cols = 60)
+    banner << Rex::Text.wordwrap("Metasploit tip: #{Tip.sample}\n", indent = 0, cols = 60)
+    banner << Rex::Text.wordwrap('Metasploit Documentation: https://docs.metasploit.com/', indent = 0, cols = 60)
 
     # Display the banner
     print_line(banner)

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -380,7 +380,7 @@ class Driver < Msf::Ui::Driver
                 "then restore the removed files from quarantine or reinstall the framework.\e[0m"\
                 "\n\n"
 
-      $stderr.puts(Msf::Serializer::ReadableText.word_wrap(avdwarn, 0, 80))
+      $stderr.puts(Rex::Text.wordwrap(avdwarn, 0, 80))
   end
 
   #


### PR DESCRIPTION
Fix undefined method word_wrap error on msfconsole boot

## Verification

### Master

Console generates warning:

```
$ bundle exec ruby ./msfconsole -x 'exit'                                                                 
                                                  
[-] Error while running command banner: undefined method `word_wrap' for Msf::Serializer::ReadableText:Class

Call stack:
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:264:in `cmd_banner'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/driver.rb:365:in `on_startup'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/driver.rb:173:in `initialize'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `new'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:60:in `driver'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

### This branch

No warnings
