### PR TITLE
Update brocade tests to pass locally

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -123,7 +123,7 @@ class Msf::DBManager
 
   def initialize(framework, opts = {})
     self.framework = framework
-    self.migrated  = false
+    self.migrated  = nil
     self.modules_cached  = false
     self.modules_caching = false
 

--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -1,6 +1,12 @@
 module Msf::DBManager::Connection
   # Returns true if we are ready to load/store data
   def active
+    # In some scenarios we may have a connection established already, and we need to manually check if migration is required
+    # This check normally happens in after_establish_connection, but that might not always get called - for instance during RSpec tests
+    if migrated.nil? && usable && connection_established?
+      self.migrated = !needs_migration?
+    end
+
     # usable and migrated a just Boolean attributes, so check those first because they don't actually contact the
     # database.
     usable && migrated && connection_established?
@@ -11,8 +17,6 @@ module Msf::DBManager::Connection
   #
   # @return [void]
   def after_establish_connection(opts={})
-    self.migrated = false
-
     begin
       # Migrate the database, if needed
       migrate(opts)
@@ -32,7 +36,6 @@ module Msf::DBManager::Connection
   # Connects this instance to a database
   #
   def connect(opts={})
-
     return false if not @usable
 
     nopts = opts.dup
@@ -47,8 +50,6 @@ module Msf::DBManager::Connection
     nopts['wait_timeout'] ||= 300
 
     begin
-      self.migrated = false
-
       # Check ApplicationRecord was already connected by Rails::Application.initialize! or some other API.
       unless connection_established?
         create_db(nopts)
@@ -129,7 +130,7 @@ module Msf::DBManager::Connection
   def disconnect
     begin
       ApplicationRecord.remove_connection
-      self.migrated = false
+      self.migrated = nil
       self.modules_cached = false
     rescue ::Exception => e
       self.error = e

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -171,7 +171,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
         begin
           unserialized_body = Base64.urlsafe_decode64(unserialized_body).b
         rescue ArgumentError => e
-          print_error("Data format suggests response body is not encoded: #{e}")
+          elog("Data format suggests response body is not encoded", e)
         end
       end
 

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -122,7 +122,7 @@ module Msf::DBManager::ModuleCache
   #
   # @return [void]
   def purge_all_module_details
-    return if not self.migrated
+    return unless self.migrated
     return if self.modules_caching
 
     ::ApplicationRecord.connection_pool.with_connection do


### PR DESCRIPTION
Currently the brocade tests fail locally due to a regression introduced by https://github.com/rapid7/metasploit-framework/pull/16817

```
Currently these tests fail locally when run manually:

F

  1) Msf::Auxiliary::Brocade#brocade_config_eater deals with user hidden passwords
     Failure/Error: expect(aux_brocade).to receive(:myworkspace).at_least(:once).and_return(workspace)
     
       (#<DummyBrocadeClass:0x00007f92620ce508>).myworkspace(*(any args))
           expected: at least 1 time with any arguments
           received: 0 times with any arguments
```

### Context

There were multiple issues spotted as part of fixing this:

1. When we create a new instance of a framework object in our test suite:

```
  let(:framework) do
    Msf::Simple::Framework.create(
        'ConfigDirectory' => framework_config_pathname.to_s,
        # don't load any module paths so we can just load the module under test and save time
        'DeferModuleLoads' => true
    )
  end
```

Ends up globally setting values in Msf::Config - which causes other unintended side effects:

https://github.com/rapid7/metasploit-framework/blame/d9c5a3debf36657c11b10bc94bead2cc7af6ff5f/lib/msf/base/simple/framework.rb#L104-L107

This mutation on the global `Msf::Config` object effect meant swapping that from `Msf::Config.get_config_root` to `Msf::Config.config_directory` as part of https://github.com/rapid7/metasploit-framework/pull/16817 broke things

2. If `framework.db` isn't explicitly configured with a database yaml file, which is the case when you create a test framework object with `'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,`, no connection is established to the database to detect if a migration is required. However, the `framework.db` object will also reuse an existing ActiveRecord DB connection if one is available - which is the case during RSpec test runs. Therefore the logic to test if a migration is required needs to be updated to handle this scenario.

3. The brocade tests assume they will have a connection to the local test database, but due to the config being set to `'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,`. This means that on CI when REMOTE_DB=1 is set, the test never runs against the REMOTE_DB. The test also won't work correctly with the `REMOTE_DB=1` flag set, as it incorrectly talks to the test database, and relies on FactoryBot - which doesn't work with `REMOTE_DB=1` as FactoryBot interacts with the local_database and not the Remote HTTP webservice database

## Verification

### Before

Multiple tests fail on master for dev environments:

```
bundle exec rspec spec/lib/msf/core/auxiliary/brocade_spec.rb
```

### After

All tests pass