### PR TITLE
Update reload_lib command to catch script errors

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -21,8 +21,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
   def initialize(driver)
     super
-    output, is_success = modified_files
-    @modified_files = is_success ? output : []
+    @modified_files = modified_file_paths(print_errors: false)
   end
 
   def name
@@ -79,20 +78,21 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     load full_path
   end
 
-  def reload_changed_files
+  # @return [Array<String>] The list of modified file paths since startup
+  def modified_file_paths(print_errors: true)
     files, is_success = modified_files
 
     unless is_success
-      print_error("Git is not available")
-      return
+      print_error("Git is not available") if print_errors
+      files = []
     end
 
-    @modified_files |= files
-    @modified_files.each do |file|
+    @modified_files ||= []
+    @modified_files |= files.map do |file|
       next if file.end_with?('_spec.rb') || file.end_with?("spec_helper.rb")
-      f = File.join(Msf::Config.install_root, file)
-      reload_file(f, print_errors: false)
+      File.join(Msf::Config.install_root, file)
     end
+    @modified_files
   end
 
   def cmd_irb_help
@@ -260,6 +260,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   # Reload Ruby library files from specified paths
   #
   def cmd_reload_lib(*args)
+    files = []
     options = OptionParser.new do |opts|
       opts.banner = 'Usage: reload_lib lib/to/reload.rb [...]'
       opts.separator ''
@@ -272,16 +273,21 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
       opts.on '-a', '--all', 'Reload all* changed files in your current Git working tree.
                                      *Excludes modules and non-Ruby files.' do
-        return reload_changed_files
+        files.concat(modified_file_paths)
       end
     end
 
     # The remaining unparsed arguments are files
-    files = options.order(args)
+    files.concat(options.order(args))
+    files.uniq!
 
     return print(options.help) if files.empty?
 
-    files.each { |file| reload_file(file) }
+    files.each do |file|
+      reload_file(file)
+    rescue ScriptError, StandardError => e
+      print_error("Error while reloading file #{file}: #{e}")
+    end
   end
 
   #


### PR DESCRIPTION
Updates the reload_lib command to continue reloading the remaining files if a single file fails to load

## Verification

Introduce syntax errors into different library files and run `reload_lib -a`; All files will attempted to be loaded rather breaking after the first.

### Before

Fails on the first file:

```
msf6 payload(windows/meterpreter/reverse_tcp) > reload_lib -a
[*] Reloading /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/session.rb
[-] Error while running command reload_lib: /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/session.rb:23: syntax error, unexpected ':', expecting constant
  :::
    ^
```

### After

All files are attempted to be loaded:
```
msf6 payload(windows/meterpreter/reverse_tcp) > reload_lib -a
[+] Attempting to load files ["/Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/session.rb", "/Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/kerberos/model/pre_auth_pk_as_rep.rb"]
[*] Reloading /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/session.rb
[-] Error while reloading file /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/session.rb: /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/session.rb:23: syntax error, unexpected ':', expecting constant
  :::
    ^

[*] Reloading /Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/kerberos/model/pre_auth_pk_as_rep.rb
[-] Error while reloading file /Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/kerberos/model/pre_auth_pk_as_rep.rb: /Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/kerberos/model/pre_auth_pk_as_rep.rb:11: syntax error, unexpected '<'
          <foo>
          ^
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/kerberos/model/pre_auth_pk_as_rep.rb:12: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
          sequence :pre_auth_pk_as_rep, explicit:...
                   ^
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/proto/kerberos/model/pre_auth_pk_as_rep.rb:12: Can't assign to true
... explicit: 0, constructed: true,
...                           ^~~~


```