### PR TITLE
Performance regression eager load

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module Metasploit
       when "test"
         config.eager_load = false
       when "production"
-        config.eager_load = true
+        config.eager_load = false
       end
 
       if ActiveRecord.respond_to?(:legacy_connection_handling=)

--- a/lib/msf/core/web_services/http_db_manager_service.rb
+++ b/lib/msf/core/web_services/http_db_manager_service.rb
@@ -61,43 +61,31 @@ class Msf::WebServices::HttpDBManagerService
     Rails.application.require_environment!
   end
 
-  # def init_servlets(http_server)
-  #   servlet_path = File.dirname(__FILE__) + '/servlet/*'
-  #   Dir.glob(servlet_path).collect{|file_path|
-  #     servlet_class = File.basename(file_path, '.rb').classify
-  #     require file_path
-  #     servlet_class_constant = servlet_class.constantize
-  #     http_server.mount servlet_class_constant.api_path, servlet_class_constant
-  #   }
-  # end
-
-
-
-end
-
-
-def print_line(msg)
-  $console_printer.print_line(msg)
-end
-
-def print_warning(msg)
-  $console_printer.print_warning(msg)
-end
-
-def print_good(msg)
-  $console_printer.print_good(msg)
-end
-
-def print_error(msg, exception = nil)
-  unless exception.nil?
-    msg += "\n    Call Stack:"
-    exception.backtrace.each {|line|
-      msg += "\n"
-      msg += "\t #{line}"
-    }
+  def print_line(msg)
+    $console_printer.print_line(msg)
   end
 
-  $console_printer.print_error(msg)
+  def print_warning(msg)
+    $console_printer.print_warning(msg)
+  end
+
+  def print_good(msg)
+    $console_printer.print_good(msg)
+  end
+
+  def print_error(msg, exception = nil)
+    unless exception.nil?
+      msg += "\n    Call Stack:"
+      exception.backtrace.each {|line|
+        msg += "\n"
+        msg += "\t #{line}"
+      }
+    end
+
+    $console_printer.print_error(msg)
+  end
+
+
 end
 
 $console_printer = Rex::Ui::Text::Output::Stdio.new

--- a/lib/msfenv.rb
+++ b/lib/msfenv.rb
@@ -41,3 +41,44 @@ if defined?(::ErrorHighlight)
 end
 
 MsfAutoload.instance
+
+def _warn_deprecation_message(method)
+  stack_size = 3
+  warning_message = "[DEPRECATION] The global method #{method.inspect} is deprecated, please raise a Github issue with this output. Called from: #{caller(1, stack_size).to_a}"
+  warn(warning_message)
+  # Additionally write to ~/.msf4/logs/framework.log - as this gets attached to Github issues etc
+  elog(warning_message)
+end
+
+# @deprecated In most scenarios you should delegate to either a framework module object, or Rex::Ui::Text::DispatcherShell etc
+def print_line(msg)
+  _warn_deprecation_message __method__
+  $stdout.puts(msg)
+end
+
+# @deprecated In most scenarios you should delegate to either a framework module object, or Rex::Ui::Text::DispatcherShell etc
+def print_warning(msg)
+  _warn_deprecation_message __method__
+  $stderr.puts(msg)
+end
+
+# @deprecated In most scenarios you should delegate to either a framework module object, or Rex::Ui::Text::DispatcherShell etc
+def print_good(msg)
+  _warn_deprecation_message __method__
+  $stdout.puts(msg)
+end
+
+# @deprecated In most scenarios you should delegate to either a framework module object, or Rex::Ui::Text::DispatcherShell etc
+def print_error(msg, exception = nil)
+  _warn_deprecation_message __method__
+
+  unless exception.nil?
+    msg += "\n    Call Stack:"
+    exception.backtrace.each {|line|
+      msg += "\n"
+      msg += "\t #{line}"
+    }
+  end
+
+  $stderr.puts(msg)
+end

--- a/spec/zeitwerk_compliance_spec.rb
+++ b/spec/zeitwerk_compliance_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# https://github.com/rails/rails/blob/0fec9536ca43e209064e60f48b0def6bfe539fe2/guides/source/classic_to_zeitwerk_howto.md#rspec
+RSpec.describe 'ZeitwerkCompliance' do
+  it 'loads all files without errors' do
+    expect do
+      # Ensure we've configured zeitwerk
+      require 'msfenv'
+      Zeitwerk::Loader.eager_load_all
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
Small PR, just removes the eager loading from framework to speed up boot times, there was a regression when we moved to Rails 7 that enabled eager loading with zeitwerk so it's just reverting that

This should have no effect on Pro since it has eager loading set to [true](https://github.com/rapid7/pro/blob/a261dc5094cd394e33332d45e0a8f1264c717781/ui/config/environments/production.rb#L53) which the docs say will also eager load all gems with zeitwerk https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#eager-loading

I also did boot up pro with eager loading turned off on framework and I didn't run into any issues

I'm also namespacing some `print_*` methods in `lib/msf/core/web_services/http_db_manager_service.rb` when eager loading these were available globally and accidentally being called, now that it's no longer being eagerly loaded I namespaced it's `print_*` methods and ran through all the modules to ensure they still had access to the various `print_*` methods and I didn't find any issues there either

Added some global `print_*` methods to capture any incorrect printing and warn the user, looks something like this
```
[DEPRECATION] The global print_good is deprecated.
Called from: ["/Users/dwelch/dev/metasploit-framework/lib/msfenv.rb:64:in `print_good'", "/Users/dwelch/dev/metasploit-framework/lib/test_thing.rb:5:in `call_print_good'"]
hello I shouldn't be doing this
```
It shows the location of the caller, which of the prints was called and prints out the original message

# Verification Steps
- [ ] On master `time ./msfconsole -qx 'exit'`
- [ ] On this PR `time ./msfconsole -qx 'exit'`
- [ ] There should be a noticeable time save
- [ ] CI tests pass

Using multitime for multiple runs I got these results
<img width="568" alt="image" src="https://user-images.githubusercontent.com/19910435/225611917-9043a5e0-554c-47e3-a710-3ea032ca0481.png">
On master:
```
$ multitime -n 5 ./msfconsole -qx 'exit'                                                    
===> multitime results
1: ./msfconsole -qx exit
            Mean        Std.Dev.    Min         Median      Max
real        14.743      3.060       11.354      14.879      19.399
user        9.216       0.897       8.406       9.075       10.892
sys         3.346       0.271       3.046       3.344       3.805
```

On this PR:
```
$ multitime -n 5 ./msfconsole -qx 'exit'                                                    
===> multitime results
1: ./msfconsole -qx exit
            Mean        Std.Dev.    Min         Median      Max
real        9.067       0.438       8.731       8.892       9.934
user        6.544       0.055       6.448       6.553       6.618
sys         2.375       0.020       2.337       2.379       2.396
```