### PR TITLE
Fix external module crash for att open proxy scanner

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -5,11 +5,6 @@ module Msf::Module::External
 
   def execute_module(path, method: :run, args: datastore, fail_on_exit: true)
     mod = Msf::Modules::External.new(path, framework: framework)
-    if args.is_a?(Msf::DataStore) || args.is_a?(Msf::DataStoreWithFallbacks)
-      datastore_to_h = args.to_h
-      datastore_to_h['rhost'] = args['RHOSTS'] if args['RHOSTS'] && datastore_to_h['rhost'].to_s.empty?
-      args = datastore_to_h
-    end
     success = mod.exec(method: method, args: args) do |m|
       begin
         case m.method

--- a/lib/msf/core/modules/external/templates/multi_scanner.erb
+++ b/lib/msf/core/modules/external/templates/multi_scanner.erb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_batch(ips)
     datastore.delete('RHOSTS')
+    datastore.remove_option('RHOSTS') if self.datastore.is_a?(Msf::DataStoreWithFallbacks)
     datastore['rhosts'] = ips
 
     execute_module(<%= meta[:path] %>)

--- a/lib/msf/core/modules/external/templates/single_host_login_scanner.erb
+++ b/lib/msf/core/modules/external/templates/single_host_login_scanner.erb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     print_status("Running for #{ip}...")
     rhost = datastore.delete('RHOST')
+    datastore.remove_option('RHOST') if self.datastore.is_a?(Msf::DataStoreWithFallbacks)
     datastore['rhost'] = rhost
     datastore['userpass'] ||= build_credentials_array
     datastore['sleep_interval'] ||= userpass_interval

--- a/lib/msf/core/modules/external/templates/single_scanner.erb
+++ b/lib/msf/core/modules/external/templates/single_scanner.erb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     print_status("Running for #{ip}...")
     rhost = datastore.delete('RHOST')
+    datastore.remove_option('RHOST') if self.datastore.is_a?(Msf::DataStoreWithFallbacks)
     datastore['rhost'] = rhost
     execute_module(<%= meta[:path] %>)
   end


### PR DESCRIPTION
Fix external module crash for when running the `auxiliary/scanner/wproxy/att_open_proxy` module

## Verification

### Before

The att_open_proxy module iterated over an RHOST string, instead of an array of RHOST ips

```
msf6 auxiliary(scanner/wproxy/att_open_proxy) > run 127.0.0.1

[-] .:49152 - Error connecting: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
[-] .:49152 - Error connecting: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
[-] 1:49152 - Error connecting: [Errno 65] No route to host
[-] 7:49152 - Error connecting: [Errno 65] No route to host
[-] 2:49152 - Error connecting: [Errno 65] No route to host
[-] .:49152 - Error connecting: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
[-] 1:49152 - Error connecting: [Errno 65] No route to host
[-] [:49152 - Error connecting: [Errno 8] nodename nor servname provided, or not known
[-] ":49152 - Error connecting: [Errno 8] nodename nor servname provided, or not known
[-] ]:49152 - Error connecting: [Errno 8] nodename nor servname provided, or not known
[-] 0:49152 - Error connecting: [Errno 61] Connect call failed ('0.0.0.0', 49152)
[-] 0:49152 - Error connecting: [Errno 61] Connect call failed ('0.0.0.0', 49152)
[-] ":49152 - Error connecting: [Errno 8] nodename nor servname provided, or not known
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After

Verifying the at&t open proxy scanner now works:

```
# Create a fake listener in a tab
print -n "\x2a\xce..." | ncat -lnvp 49152 

# Run the module - no longer crashes, and you can see the ncat client has connected
msf6 auxiliary(scanner/wproxy/att_open_proxy) > run

[+] 127.0.0.1:49152 - Matches
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Also verifying get user spns still works - which was originally updated to work in https://github.com/rapid7/metasploit-framework/pull/17490

```
msf6 auxiliary(gather/get_user_spns) > run rhost=192.168.123.13 domain=adf3.local user=Administrator PASS=p4$$w0rd4

[*] Running for 192.168.123.13...
[+] ServicePrincipalName                    Name            MemberOf  PasswordLastSet             LastLogon                   Delegation    
[+] --------------------------------------  --------------  --------  --------------------------  --------------------------  -------------
[+] fake_msql/dc3.adf3.local:1433           fake_mysql                2022-02-10 10:57:13.356981  <never>                     unconstrained 
[+] fake_msql/dc3.adf3.local                fake_mysql                2022-02-10 10:57:13.356981  <never>                     unconstrained 
[+] adf3.local/kerberoastable_service       kerberoastable            2022-06-27 20:03:33.970786  2022-06-30 14:49:29.019696                
[+] adf3.local/kerberoastable_service:1337  kerberoastable            2022-06-27 20:03:33.970786  2022-06-30 14:49:29.019696                
[+] $krb5tgs$23$*fake_mysql$ADF3.LOCAL$adf3.local/fake_mysql*$8ecdb0028c2afe5fe22....
```