### PR TITLE
AWS EC2 enum: implement reporting

### DIFF
--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Auxiliary
           'Aaron Soto <aaron.soto@rapid7.com>',
           'RageLtMan <rageltman[at]sempervictus>'
         ],
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'SideEffects' => [IOC_IN_LOGS],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -40,14 +40,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def handle_aws_errors(err)
-    if err.class.module_parents.include?(Aws)
-      fail_with(Failure::UnexpectedReply, err.message)
-    else
-      raise err
-    end
-  end
-
   def enumerate_regions
     return [datastore['REGION']] if datastore['REGION']
 
@@ -147,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
   rescue Seahorse::Client::NetworkingError => e
     print_error e.message
     print_error 'Confirm region name (eg. us-west-2) is valid or blank before retrying'
-  rescue ::Exception => e
-    handle_aws_errors(e)
+  rescue Aws::EC2::Errors::ServiceError => e
+    fail_with(Failure::UnexpectedReply, e.message)
   end
 end

--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -41,8 +41,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enumerate_regions
-    return [datastore['REGION']] if datastore['REGION']
-
     regions = []
 
     ec2 = Aws::EC2::Resource.new(
@@ -125,7 +123,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    regions = enumerate_regions
+    all_regions = enumerate_regions
+    if datastore['REGION'].blank?
+      regions = all_regions
+    elsif !all_regions.include?(datastore['REGION'])
+      fail_with(Failure::BadConfig, "Invalid AWS region: #{datastore['REGION']}")
+    else
+      regions = [datastore['REGION']]
+    end
 
     regions.uniq.each do |region|
       vprint_status "Checking #{region}..."

--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Auxiliary
         secret_access_key: datastore['SECRET_ACCESS_KEY']
       )
 
-      instances = datastore['LIMIT'] ? ec2.instances : ec2.instances.limit(datastore['LIMIT'])
+      instances = datastore['LIMIT'] ? ec2.instances.limit(datastore['LIMIT']) : ec2.instances
       print_status "Found #{ec2.instances.count} instances in #{region}"
 
       instances.each do |i|


### PR DESCRIPTION
Implement reporting for EC2 enumeration module

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use cloud/aws/enum_ec2`
- [ ] set options
- [ ] **Verify** enumerated hosts (and notes) appear in the workspace
