### PR TITLE
Update debug command to correctly output datastore values

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -91,7 +91,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     @modified_files |= files.map do |file|
       next if file.end_with?('_spec.rb') || file.end_with?("spec_helper.rb")
       File.join(Msf::Config.install_root, file)
-    end
+    end.compact
     @modified_files
   end
 
@@ -286,7 +286,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     files.each do |file|
       reload_file(file)
     rescue ScriptError, StandardError => e
-      print_error("Error while reloading file #{file}: #{e}")
+      print_error("Error while reloading file #{file.inspect}: #{e}:\n#{e.backtrace.to_a.map { |line| "  #{line}" }.join("\n")}")
     end
   end
 

--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -122,11 +122,11 @@ module Msf
         end
 
         # Retrieve and add more up to date information
-        add_hash_to_ini_group(ini, framework.datastore, driver.get_config_core)
+        add_hash_to_ini_group(ini, framework.datastore.to_h, driver.get_config_core)
         add_hash_to_ini_group(ini, driver.get_config, driver.get_config_group)
 
         if driver.active_module
-          add_hash_to_ini_group(ini, driver.active_module.datastore.dup, driver.active_module.refname)
+          add_hash_to_ini_group(ini, driver.active_module.datastore.to_h, driver.active_module.refname)
         end
 
         # Filter credentials

--- a/spec/lib/msf/debug_spec.rb
+++ b/spec/lib/msf/debug_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Msf::Ui::Debug do
 
     framework = instance_double(
       ::Msf::Framework,
-      datastore: {}
+      datastore: Msf::DataStore.new
     )
 
     driver = instance_double(
@@ -374,13 +374,17 @@ RSpec.describe Msf::Ui::Debug do
   it 'correctly retrieves and parses a populated global datastore' do
     allow(::Msf::Config).to receive(:config_file).and_return(File.join(file_fixtures_path, 'config_files', 'empty.ini'))
 
-    framework = instance_double(
-      ::Msf::Framework,
-      datastore: {
+    framework_datastore = Msf::DataStore.new
+    framework_datastore.merge!(
+      {
         'key1' => 'val1',
         'key2' => 'val2',
         'key3' => 'val3'
       }
+    )
+    framework = instance_double(
+      ::Msf::Framework,
+      datastore: framework_datastore
     )
 
     driver = instance_double(
@@ -416,13 +420,17 @@ RSpec.describe Msf::Ui::Debug do
   it 'correctly retrieves and parses a populated global datastore and current module' do
     allow(::Msf::Config).to receive(:config_file).and_return(File.join(file_fixtures_path, 'config_files', 'empty.ini'))
 
-    framework = instance_double(
-      ::Msf::Framework,
-      datastore: {
+    datastore = Msf::DataStore.new
+    datastore.merge!(
+      {
         'key1' => 'val1',
         'key2' => 'val2',
         'key3' => 'val3'
       }
+    )
+    framework = instance_double(
+      ::Msf::Framework,
+      datastore: datastore
     )
 
     driver = instance_double(
@@ -467,18 +475,23 @@ RSpec.describe Msf::Ui::Debug do
   it 'correctly retrieves and parses active module variables' do
     allow(::Msf::Config).to receive(:config_file).and_return(File.join(file_fixtures_path, 'config_files', 'empty.ini'))
 
+    framework_datastore = Msf::DataStore.new
     framework = instance_double(
       ::Msf::Framework,
-      datastore: {}
+      datastore: framework_datastore
     )
 
-    active_module = instance_double(
-      Msf::Module,
-      datastore: {
+    module_datastore = Msf::ModuleDataStore.new(framework_datastore)
+    module_datastore.merge!(
+      {
         'key7' => 'val7',
         'key8' => 'default_val8',
         'key9' => 'val9'
-      },
+      }
+    )
+    active_module = instance_double(
+      Msf::Module,
+      datastore: module_datastore,
       refname: 'active/module/variables'
     )
 
@@ -515,13 +528,17 @@ RSpec.describe Msf::Ui::Debug do
   it 'preferences the framework datastore values over config stored values' do
     allow(::Msf::Config).to receive(:config_file).and_return(File.join(file_fixtures_path, 'config_files', 'module.ini'))
 
-    framework = instance_double(
-      ::Msf::Framework,
-      datastore: {
+    framework_datastore = Msf::DataStore.new
+    framework_datastore.merge!(
+      {
         'key1' => 'val1',
         'key2' => 'val2',
         'key3' => 'val3'
       }
+    )
+    framework = instance_double(
+      ::Msf::Framework,
+      datastore: framework_datastore
     )
 
     driver = instance_double(
@@ -566,9 +583,10 @@ RSpec.describe Msf::Ui::Debug do
   it 'correctly retrieves and parses Database information' do
     allow(::Msf::Config).to receive(:config_file).and_return(File.join(file_fixtures_path, 'config_files', 'db.ini'))
 
+    framework_datastore = Msf::DataStore.new
     framework = instance_double(
       ::Msf::Framework,
-      datastore: {}
+      datastore: framework_datastore
     )
 
     driver = instance_double(


### PR DESCRIPTION
Update debug command to correctly output datastore values

## Verification

### Before

The datastore is not output correctly:

```
msf6 payload(windows/meterpreter/reverse_tcp) > debug --datastore
Please provide the below information in any Github issues you open. New issues can be opened here https://github.com/rapid7/metasploit-framework/issues/new/choose
ENSURE YOU HAVE REMOVED ANY SENSITIVE INFORMATION BEFORE SUBMITTING!

===8<=== CUT AND PASTE EVERYTHING BELOW THIS LINE ===8<===


##  Module/Datastore

An error occurred when trying to build this section:
<details>
<summary>Collapse</summary>

Failed to extract Datastore: NoMethodError - undefined method `empty?' for #<Msf::DataStoreWithFallbacks:0x00007fea52371600 @options={}, @aliases={}, @defaults={}, @user_defined={"loglevel"=>"3", "lhost"=>"192.168.123.1", "sessiontlvlogging"=>"false", "rhosts"=>"127.0.0.1"}> 
 Call stack:
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/debug.rb:349:in `add_hash_to_ini_group'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/debug.rb:125:in `datastore'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:358:in `block in cmd_debug'
/Users/user/Documents/code/metasploit-framework/lib/rex/parser/arguments.rb:87:in `block in parse'
/Users/user/Documents/code/metasploit-framework/lib/rex/parser/arguments.rb:53:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/parser/arguments.rb:53:in `each_with_index'
/Users/user/Documents/code/metasploit-framework/lib/rex/parser/arguments.rb:53:in `parse'
/Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:355:in `cmd_debug'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:168:in `run'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'

</details>
```

### After

The datastore is output:

```
debug --datastore
Please provide the below information in any Github issues you open. New issues can be opened here https://github.com/rapid7/metasploit-framework/issues/new/choose
ENSURE YOU HAVE REMOVED ANY SENSITIVE INFORMATION BEFORE SUBMITTING!

===8<=== CUT AND PASTE EVERYTHING BELOW THIS LINE ===8<===


##  Module/Datastore

The following global/module datastore, and database setup was configured before the issue occurred:
<details>
<summary>Collapse</summary>

[framework/core]
loglevel=3
lhost=192.168.123.1
sessiontlvlogging=false
rhosts=127.0.0.1

[framework/database]

[framework/database/7xxC1BOU]
url=[Filtered]

... etc ...
```