### PR TITLE
Update rubocop rule for module length limits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -175,12 +175,13 @@ Lint/DeprecatedGemVersion:
   Exclude:
     - 'metasploit-framework.gemspec'
 
-Metrics/ClassLength:
+Metrics/ModuleLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'
-  Enabled: true
-  Exclude:
-    - 'modules/**/*'
-    - 'test/modules/**/*'
+  Enabled: false
+
+Metrics/ClassLength:
+  Description: 'Most Metasploit classes are quite large. This is ok.'
+  Enabled: false
 
 Style/ClassAndModuleChildren:
   Enabled: false


### PR DESCRIPTION
Update rubocop rule for module length limits

Originally hit by @bwatters-r7 in https://github.com/rapid7/metasploit-framework/pull/17782


## Verification

- Verify CI passes
- Confirm we're okay with the change