### PR TITLE
Disable Lint/UnusedMethodArgument as it can break YARD definitions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,17 @@ Lint/UnexpectedBlockArity:
 Lint/UnmodifiedReduceAccumulator:
   Enabled: true
 
+Lint/UnusedMethodArgument:
+  Description: >-
+    Disabled on files under the lib/ directory (aka library files)
+    as this can break YARD documentation since YARD doesn't recognize
+    the _ prefix before parameter names and thinks its a different argument.
+    See https://github.com/rapid7/metasploit-framework/pull/17735
+    Also see https://github.com/rubocop/rubocop/pull/11020
+  Enabled: true
+  Exclude:
+    - 'lib/**/*'
+
 Style/ArgumentsForwarding:
   Enabled: true
 


### PR DESCRIPTION
As noted in the discussion at https://github.com/rapid7/metasploit-framework/pull/17735#discussion_r1126205709, at https://github.com/rapid7/metasploit-framework/pull/17735#issuecomment-1479836976, and in https://github.com/rubocop/rubocop/pull/11020, there is an issue with the `Lint/UnusedMethodArgument` lint rule in that it can end up breaking type signature applications.

We already had to fix this as part of https://github.com/rapid7/metasploit-framework/pull/17735, and I imagine this issue will come up again in the future. 

In the interest of preventing this and as per discussions with Alan, I suggest we disable this linting rule for library code (and keep it for module code) since it does us more harm than good. We can keep `Lint/UnusedBlockArgument` though as that doesn't affect these sorts of tools and can still be a useful indicator.

## Verification

- [ ] Verify that the new changes look good
- [ ] Verify that there are no issues with changing this and that we are happy to make this adjustment.