### PR TITLE
Update broken secunia references

### DIFF
--- a/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           ['OSVDB', '52048'],
           ['CVE', '2009-0815'],
-          ['URL', 'http://secunia.com/advisories/33829/'],
+          ['URL', 'http://web.archive.org/web/20090212165636/http://secunia.com:80/advisories/33829/'],
           ['EDB', '8038'],
           ['URL', 'http://typo3.org/teams/security/security-bulletins/typo3-sa-2009-002/'],
         ],

--- a/modules/exploits/linux/mysql/mysql_yassl_getname.rb
+++ b/modules/exploits/linux/mysql/mysql_yassl_getname.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '37943' ],
           [ 'BID', '37974' ],
           [ 'OSVDB', '61956' ],
-          [ 'URL', 'http://secunia.com/advisories/38344/' ]
+          [ 'URL', 'http://web.archive.org/web/20100129041727/http://secunia.com:80/advisories/38344/' ]
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['OSVDB', '83199'],
-          ['URL', 'http://secunia.com/advisories/49103/']
+          ['URL', 'http://web.archive.org/web/20121014000855/http://secunia.com/advisories/49103/']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2011-0518' ],
           [ 'OSVDB', '75095' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2011-21/' ]
+          [ 'URL', 'http://web.archive.org/web/20110322161808/http://secunia.com:80/secunia_research/2011-21' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2012-0261'],
           ['OSVDB', '78064'],
-          ['URL', 'http://secunia.com/advisories/47417/'],
+          ['URL', 'http://web.archive.org/web/20140724161718/http://secunia.com/advisories/47417/'],
         ],
       'Privileged' => true,
       'Payload'    =>

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2012-0262'],
           ['OSVDB', '78065'],
-          ['URL', 'http://secunia.com/advisories/47417/'],
+          ['URL', 'http://web.archive.org/web/20120114164329/http://secunia.com:80/advisories/47417'],
         ],
       'Privileged' => true,
       'Payload'    =>

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2011-3833'],
           ['OSVDB', '76999'],
           ['OSVDB', '77003'],
-          ['URL', 'http://secunia.com/secunia_research/2011-75/'],
-          ['URL', 'http://secunia.com/secunia_research/2011-79/'],
+          ['URL', 'http://web.archive.org/web/20111202001019/http://secunia.com:80/secunia_research/2011-75'],
+          ['URL', 'http://web.archive.org/web/20120105104613/http://secunia.com/secunia_research/2011-79/'],
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/multi/misc/indesign_server_soap.rb
+++ b/modules/exploits/multi/misc/indesign_server_soap.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'OSVDB', '87548'],
-          [ 'URL', 'http://secunia.com/advisories/48572/' ]
+          [ 'URL', 'http://web.archive.org/web/20130119134644/http://secunia.com/advisories/48572/' ]
         ],
       'Targets'        =>
         [

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
             ['CVE', '2014-5073'],
             ['OSVDB', '109572'],
-            ['URL', 'http://secunia.com/secunia_research/2014-8/']
+            ['URL', 'http://web.archive.org/web/20140905004331/http://secunia.com:80/secunia_research/2014-8/']
         ],
       'DisclosureDate' => '2014-06-25',
       'Privileged'     => false,

--- a/modules/exploits/unix/webapp/mybb_backdoor.rb
+++ b/modules/exploits/unix/webapp/mybb_backdoor.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'OSVDB', '76111' ],
           [ 'BID', '49993' ],
-          [ 'SECUNIA', '46300' ],
+          [ 'URL', 'http://web.archive.org/web/20121010011259/http://secunia.com/advisories/46300/' ],
           [ 'URL', 'http://blog.mybb.com/2011/10/06/1-6-4-security-vulnerabilit/' ]
         ],
       'Privileged'     => false,

--- a/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2006-4602'],
           ['OSVDB', '28456'],
           ['BID', '19819'],
-          ['URL', 'http://secunia.com/advisories/21733/'],
+          ['URL', 'http://web.archive.org/web/20061013183145/http://secunia.com:80/advisories/21733/'],
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['OSVDB', '87353'],
-          ['URL', 'http://secunia.com/advisories/51037/'],
+          ['URL', 'http://web.archive.org/web/20121223025326/http://secunia.com:80/advisories/51037'],
           ['WPVDB', '6103']
         ],
       'Privileged'     => false,

--- a/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
+++ b/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2012-4915'],
           ['OSVDB', '88891'],
-          ['URL', 'http://secunia.com/advisories/50832'],
+          ['URL', 'http://web.archive.org/web/20130119141940/http://secunia.com/advisories/50832/'],
           ['WPVDB', '6073']
         ],
       'Privileged'     => false,

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://blogs.technet.com/b/mmpc/archive/2011/04/12/analysis-of-the-cve-2011-0611-adobe-flash-player-vulnerability-exploitation.aspx' ],
           [ 'URL', 'http://contagiodump.blogspot.com/2011/04/apr-8-cve-2011-0611-flash-player-zero.html' ],
           [ 'URL', 'http://bugix-security.blogspot.com/2011/04/cve-2011-0611-adobe-flash-zero-day.html' ],
-          [ 'URL', 'http://secunia.com/blog/210' ],
+          [ 'URL', 'http://web.archive.org/web/20110417154057/http://secunia.com:80/blog/210/' ],
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-1799' ],
           [ 'OSVDB', '66636'],
           [ 'BID', '41962' ],
-          [ 'URL', 'http://secunia.com/advisories/40729/' ],
+          [ 'URL', 'http://web.archive.org/web/20100729143247/http://secunia.com:80/advisories/40729' ],
           [ 'URL', 'http://support.apple.com/kb/HT4290' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-0284' ],
           [ 'OSVDB', '84309'],
           [ 'BID', '54588' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2012-25/' ],
+          [ 'URL', 'http://web.archive.org/web/20120808000045/http://secunia.com:80/secunia_research/2012-25/' ],
 
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '89030' ],
           [ 'BID', '57174' ],
           [ 'EDB', '23944' ],
-          [ 'URL', 'http://secunia.com/advisories/51733/' ]
+          [ 'URL', 'http://web.archive.org/web/20130113203143/http://secunia.com/advisories/51733/' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/gom_openurl.rb
+++ b/modules/exploits/windows/browser/gom_openurl.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2007-5779'],
           [ 'OSVDB', '38282'],
-          [ 'URL', 'http://secunia.com/advisories/27418/' ],
+          [ 'URL', 'http://web.archive.org/web/20071030001455/http://secunia.com:80/advisories/27418/' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-5193' ],
           [ 'OSVDB', '78102' ],
           [ 'EDB', '15668' ],
-          [ 'URL', 'http://secunia.com/advisories/42445/' ],
+          [ 'URL', 'http://web.archive.org/web/20101204093821/http://secunia.com:80/advisories/42445' ],
           [ 'URL', 'http://xforce.iss.net/xforce/xfdb/63666' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '72865' ],
           [ 'BID', '47596' ],
           [ 'ZDI', '12-168' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2011-37/' ]
+          [ 'URL', 'http://web.archive.org/web/20110506063846/http://secunia.com:80/secunia_research/2011-37' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/kazaa_altnet_heap.rb
+++ b/modules/exploits/windows/browser/kazaa_altnet_heap.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2007-5217' ],
           [ 'OSVDB', '37785' ],
-          [ 'URL', 'http://secunia.com/advisories/26970/' ],
+          [ 'URL', 'http://web.archive.org/web/20071014051150/http://secunia.com:80/advisories/26970' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/mcafeevisualtrace_tracetarget.rb
+++ b/modules/exploits/windows/browser/mcafeevisualtrace_tracetarget.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2006-6707'],
           [ 'OSVDB', '32399'],
-          [ 'URL', 'http://secunia.com/advisories/23463' ],
+          [ 'URL', 'http://web.archive.org/web/20061223042405/http://secunia.com:80/advisories/23463/' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms06_013_createtextrange.rb
+++ b/modules/exploits/windows/browser/ms06_013_createtextrange.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['MSB', 'MS06-013'],
           ['BID', '17196'],
           ['US-CERT-VU', '876678'],
-          ['URL', 'http://secunia.com/secunia_research/2006-7/advisory/'],
+          ['URL', 'http://web.archive.org/web/20060418044756/http://secunia.com:80/secunia_research/2006-7/advisory/'],
           ['URL', 'https://seclists.org/lists/bugtraq/2006/Mar/0410.html'],
           ['URL', 'https://seclists.org/lists/fulldisclosure/2006/Mar/1439.html']
         ],

--- a/modules/exploits/windows/browser/novelliprint_callbackurl.rb
+++ b/modules/exploits/windows/browser/novelliprint_callbackurl.rb
@@ -23,7 +23,7 @@
 # References:
 #  - CVE-2010-1527
 #  - OSVDB 67411
-#  - http://secunia.com/secunia_research/2010-104/ - Original advisory by Carsten Eiram, Secunia Research
+#  - http://web.archive.org/web/20100824204359/http://secunia.com:80/secunia_research/2010-104 - Original advisory by Carsten Eiram, Secunia Research
 #  - https://www.exploit-db.com/exploits/15042/ - MOAUB #19 exploit
 #  - https://www.exploit-db.com/moaub-19-novell-iprint-client-browser-plugin-call-back-url-stack-overflow/ - MOAUB #14 binary analysis
 #  - http://www.rec-sec.com/2010/09/21/novell-iprint-callbackurl-buffer-overflow-exploit/ - Metasploit exploit by Trancer, Recognize-Security
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2010-1527' ],
           [ 'OSVDB', '67411'],
-          [ 'URL', 'http://secunia.com/secunia_research/2010-104/' ],	# Carsten Eiram, Secunia Research
+          [ 'URL', 'http://web.archive.org/web/20100824204359/http://secunia.com:80/secunia_research/2010-104' ],	# Carsten Eiram, Secunia Research
           [ 'EDB', '15042' ],		# MOAUB #19
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/novelliprint_datetime.rb
+++ b/modules/exploits/windows/browser/novelliprint_datetime.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2009-1569' ],
           [ 'BID', '37242' ],
           [ 'OSVDB', '60804' ],
-          [ 'URL', 'http://secunia.com/advisories/35004/' ]
+          [ 'URL', 'http://web.archive.org/web/20091213033620/http://secunia.com:80/advisories/35004' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2008-2908'],
           [ 'OSVDB', '46194'],
-          [ 'URL', 'http://secunia.com/advisories/30709/' ],
+          [ 'URL', 'http://web.archive.org/web/20081206030916/http://secunia.com:80/advisories/30709/' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/novelliprint_target_frame.rb
+++ b/modules/exploits/windows/browser/novelliprint_target_frame.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2009-1568' ],
           [ 'BID', '37242' ],
           [ 'OSVDB', '60803' ],
-          [ 'URL', 'http://secunia.com/advisories/37169/' ]
+          [ 'URL', 'http://web.archive.org/web/20091213033630/http://secunia.com:80/advisories/37169' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-0266' ],
           [ 'OSVDB', '78252' ],
           [ 'BID', '51374' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2012-1/' ]
+          [ 'URL', 'http://web.archive.org/web/20120514113631/http://secunia.com/secunia_research/2012-1/' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-0267' ],
           [ 'OSVDB', '78253' ],
           [ 'BID', '51374' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2012-2/' ]
+          [ 'URL', 'http://web.archive.org/web/20120122095846/http://secunia.com:80/secunia_research/2012-2' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/realplayer_console.rb
+++ b/modules/exploits/windows/browser/realplayer_console.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2008-1309' ],
           [ 'OSVDB', '42946' ],
           [ 'BID', '28157' ],
-          [ 'URL', 'http://secunia.com/advisories/29315/' ],
+          [ 'URL', 'http://web.archive.org/web/20080313103656/http://secunia.com:80/advisories/29315/' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/symantec_backupexec_pvcalendar.rb
+++ b/modules/exploits/windows/browser/symantec_backupexec_pvcalendar.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2007-6016' ],
           [ 'OSVDB', '42358'],
           [ 'BID', '26904' ],
-          [ 'URL', 'http://secunia.com/advisories/27885/' ],
+          [ 'URL', 'http://web.archive.org/web/20080302192347/http://secunia.com:80/advisories/27885/' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/wmi_admintools.rb
+++ b/modules/exploits/windows/browser/wmi_admintools.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2010-3973' ],
           [ 'BID', '45546' ],
           [ 'URL', 'http://wooyun.org/bug.php?action=view&id=1006' ],
-          [ 'URL', 'http://secunia.com/advisories/42693' ],
+          [ 'URL', 'http://web.archive.org/web/20101228043011/http://secunia.com:80/advisories/42693' ],
           [ 'URL', 'http://www.microsoft.com/downloads/en/details.aspx?FamilyID=6430f853-1120-48db-8cc5-f2abdc3ed314' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/xmplay_asx.rb
+++ b/modules/exploits/windows/browser/xmplay_asx.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2006-6063'],
           [ 'OSVDB', '30537'],
           [ 'BID', '21206'],
-          [ 'URL', 'http://secunia.com/advisories/22999/' ],
+          [ 'URL', 'http://web.archive.org/web/20070502134818/http://secunia.com:80/advisories/22999' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/adobe_libtiff.rb
+++ b/modules/exploits/windows/fileformat/adobe_libtiff.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '38195' ],
           [ 'OSVDB', '62526' ],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-07.html' ],
-          [ 'URL', 'http://secunia.com/blog/76/' ],
+          [ 'URL', 'http://web.archive.org/web/20100223002318/http://secunia.com:80/blog/76' ],
           [ 'URL', 'http://bugix-security.blogspot.com/2010/03/adobe-pdf-libtiff-working-exploitcve.html' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/chasys_draw_ies_bmp_bof.rb
+++ b/modules/exploits/windows/fileformat/chasys_draw_ies_bmp_bof.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2013-3928' ],
           [ 'OSVDB', '95689' ],
           [ 'BID', '61463' ],
-          [ 'URL', 'http://secunia.com/advisories/53773/' ],
+          [ 'URL', 'http://web.archive.org/web/20140326093457/http://secunia.com/advisories/53773/' ],
           [ 'URL', 'http://longinox.blogspot.com/2013/08/explot-stack-based-overflow-bypassing.html' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/corelpdf_fusion_bof.rb
+++ b/modules/exploits/windows/fileformat/corelpdf_fusion_bof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2013-3248' ],
           [ 'OSVDB', '94933' ],
           [ 'BID', '61010' ],
-          [ 'URL', 'http://secunia.com/advisories/52707/' ]
+          [ 'URL', 'http://web.archive.org/web/20130720043800/http://secunia.com:80/advisories/52707/' ]
         ],
       'Platform'       => [ 'win' ],
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/csound_getnum_bof.rb
+++ b/modules/exploits/windows/fileformat/csound_getnum_bof.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2012-0270' ],
           [ 'OSVDB', '79491' ],
           [ 'BID', '52144' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2012-3/' ],
+          [ 'URL', 'http://web.archive.org/web/20120514124556/http://secunia.com/secunia_research/2012-3/' ],
           [ 'URL', 'http://csound.git.sourceforge.net/git/gitweb.cgi?p=csound/csound5.git;a=commit;h=7d617a9551fb6c552ba16874b71266fcd90f3a6f']
         ],
       'Payload' =>

--- a/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
+++ b/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' =>
         [
           [ 'OSVDB', '68178' ],
-          [ 'URL', 'http://secunia.com/advisories/41519/' ],
+          [ 'URL', 'http://web.archive.org/web/20100923154433/http://secunia.com:80/advisories/41519' ],
           [ 'EDB', '15134' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2013-0726' ],
           [ 'OSVDB', '92694' ],
           [ 'BID', '59379' ],
-          [ 'URL', 'http://secunia.com/advisories/51725/' ]
+          [ 'URL', 'http://web.archive.org/web/20130515231047/http://secunia.com/advisories/51725/' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2013-3482' ],
           [ 'OSVDB', '93650' ],
-          [ 'URL', 'http://secunia.com/advisories/53620/' ]
+          [ 'URL', 'http://web.archive.org/web/20130609135637/http://secunia.com:80/advisories/53620' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/fdm_torrent.rb
+++ b/modules/exploits/windows/fileformat/fdm_torrent.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '33555' ],
           [ 'URL', 'http://freedownload.svn.sourceforge.net/viewvc/freedownload/FDM/vmsBtDownloadManager.cpp?r1=11&r2=18' ],
           [ 'URL', 'http://freedownload.svn.sourceforge.net/viewvc/freedownload/FDM/Bittorrent/fdmbtsupp/vmsBtFileImpl.cpp?r1=9&r2=18' ],
-          [ 'URL', 'http://secunia.com/secunia_research/2009-5/' ],
+          [ 'URL', 'http://web.archive.org/web/20090205145829/http://secunia.com:80/secunia_research/2009-5' ],
           [ 'URL', 'http://downloads.securityfocus.com/vulnerabilities/exploits/33555-SkD.pl' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
+++ b/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['OSVDB', '82000'],
           ['BID', '53562'],
-          ['URL', 'http://secunia.com/advisories/48740/']
+          ['URL', 'http://web.archive.org/web/20121014002756/http://secunia.com/advisories/48740/']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/lattice_pac_bof.rb
+++ b/modules/exploits/windows/fileformat/lattice_pac_bof.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '82001'],
           ['EDB', '19006'],
           ['BID', '53566'],
-          ['URL', 'http://secunia.com/advisories/48741']
+          ['URL', 'http://web.archive.org/web/20120523175252/http://secunia.com:80/advisories/48741']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/ftp/cesarftp_mkd.rb
+++ b/modules/exploits/windows/ftp/cesarftp_mkd.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2006-2961'],
           [ 'OSVDB', '26364'],
           [ 'BID', '18586'],
-          [ 'URL', 'http://secunia.com/advisories/20574/' ],
+          [ 'URL', 'http://web.archive.org/web/20060619195555/http://secunia.com:80/advisories/20574/' ],
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2012-5002'],
           ['OSVDB', '79691'],
-          ['URL', 'http://secunia.com/advisories/47912'],
+          ['URL', 'http://web.archive.org/web/20120514112629/http://secunia.com/advisories/47912/'],
           ['URL', 'http://www.inshell.net/2012/03/ricoh-dc-software-dl-10-ftp-server-sr10-exe-remote-buffer-overflow-vulnerability/']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/http/netdecision_http_bof.rb
+++ b/modules/exploits/windows/http/netdecision_http_bof.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2012-1465'],
           ['OSVDB', '79651'],
-          ['URL', 'http://secunia.com/advisories/48168/'],
+          ['URL', 'http://web.archive.org/web/20121024124508/http://secunia.com/advisories/48168/'],
           ['URL', 'http://secpod.org/advisories/SecPod_Netmechanica_NetDecision_HTTP_Server_DoS_Vuln.txt']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/http/rabidhamster_r4_log.rb
+++ b/modules/exploits/windows/http/rabidhamster_r4_log.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['OSVDB', '79007'],
           ['URL', 'http://aluigi.altervista.org/adv/r4_1-adv.txt'],
-          ['URL', 'http://secunia.com/advisories/47901/']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/ldap/imail_thc.rb
+++ b/modules/exploits/windows/ldap/imail_thc.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2004-0297'],
           [ 'OSVDB', '3984'],
           [ 'BID', '9682'],
-          [ 'URL', 'http://secunia.com/advisories/10880/'],
+          [ 'URL', 'http://web.archive.org/web/20060110155821/http://secunia.com:80/advisories/10880/'],
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/windows/misc/avaya_winpmd_unihostrouter.rb
+++ b/modules/exploits/windows/misc/avaya_winpmd_unihostrouter.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['BID', '47947'],
           ['EDB', '18397'],
           ['URL', 'https://downloads.avaya.com/css/P8/documents/100140122'],
-          ['URL', 'http://secunia.com/advisories/44062']
+          ['URL', 'http://web.archive.org/web/20110527165515/http://secunia.com:80/advisories/44062']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/citrix_streamprocess.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'OSVDB', '70597'],
           [ 'ZDI', '11-023' ],
-          [ 'URL', 'http://secunia.com/advisories/42954/' ],
+          [ 'URL', 'http://web.archive.org/web/20110123164820/http://secunia.com:80/advisories/42954/' ],
           [ 'URL', 'http://support.citrix.com/article/CTX127149' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/misc/stream_down_bof.rb
+++ b/modules/exploits/windows/misc/stream_down_bof.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['OSVDB', '78043'],
           ['BID', '51190'],
           ['URL', 'http://www.dark-masters.tk/'],
-          ['URL', 'http://secunia.com/advisories/47343/'],
+          ['URL', 'http://web.archive.org/web/20121024141958/http://secunia.com/advisories/47343'],
           ['EDB', '18283']
         ],
       'Privileged'     => false,

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['CVE', '2012-3951'],
           ['OSVDB', '84317'],
-          ['URL', 'http://secunia.com/advisories/50074/'],
+          ['URL', 'http://web.archive.org/web/20140722224651/http://secunia.com/advisories/50074/'],
           ['URL', 'https://www.trustwave.com/spiderlabs/advisories/TWSL2012-014.txt']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/tftp/quick_tftp_pro_mode.rb
+++ b/modules/exploits/windows/tftp/quick_tftp_pro_mode.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2008-1610'],
           ['OSVDB', '43784'],
           ['BID', '28459'],
-          ['URL', 'http://secunia.com/advisories/29494'],
+          ['URL', 'http://web.archive.org/web/20080330000001/http://secunia.com:80/advisories/29494/'],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/tftp/threectftpsvc_long_mode.rb
+++ b/modules/exploits/windows/tftp/threectftpsvc_long_mode.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2006-6183'],
           ['OSVDB', '30758'],
           ['BID', '21301'],
-          ['URL', 'http://secunia.com/advisories/23113/'],
+          ['URL', 'http://web.archive.org/web/20070521014920/http://secunia.com:80/advisories/23113'],
         ],
       'DefaultOptions' =>
         {


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/17803

The Secunia links are currently dead; I used the wayback machine to grab replacement links from the earliest date possible:

```
curl --silent 'http://archive.org/wayback/available?url=http://secunia.com/advisories/27418/&timestamp=20060101' | jq
{
  "url": "http://secunia.com/secunia_research/2012-1/",
  "archived_snapshots": {
    "closest": {
      "status": "200",
      "available": true,
      "url": "http://web.archive.org/web/20160402185906/http://secunia.com/secunia_research/2012-1/",
      "timestamp": "20160402185906"
    }
  }
}
```

I ran the following one liner to extract and call the API

> $ rg -i SECUNIA | rg secunia.com | grep -v modules_metadata | grep -v archive.org | cut -d: -f2- | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | sort -u | xargs -n 1 -I {} /bin/bash -c "echo -n {}; echo -n ','; curl --silent 'http://archive.org/wayback/available?url={}&timestamp=20060101' | jq -r '.archived_snapshots.closest.url'"

Example output in the format `old_link,new_link`, which I piped through `sed` for find replacing:

```
http://secunia.com/advisories/10880/,http://web.archive.org/web/20060110155821/http://secunia.com:80/advisories/10880/
http://secunia.com/advisories/20574/,http://web.archive.org/web/20060619195555/http://secunia.com:80/advisories/20574/
http://secunia.com/advisories/21733/,http://web.archive.org/web/20061013183145/http://secunia.com:80/advisories/21733/
http://secunia.com/advisories/22999/,http://web.archive.org/web/20070502134818/http://secunia.com:80/advisories/22999
... etc ...
```