### PR TITLE
Add bootsnap for bootup performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       aws-sdk-s3
       bcrypt
       bcrypt_pbkdf
+      bootsnap
       bson
       chunky_png
       dnsruby
@@ -152,6 +153,8 @@ GEM
     bcrypt (3.1.18)
     bcrypt_pbkdf (1.1.0)
     bindata (2.4.15)
+    bootsnap (1.16.0)
+      msgpack (~> 1.2)
     bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -38,3 +38,64 @@ lib_path = root.join('lib').to_path
 unless $LOAD_PATH.include? lib_path
   $LOAD_PATH.unshift lib_path
 end
+
+require 'digest'
+require 'metasploit/framework/version'
+require 'msf/base/config'
+
+# Invalidate and delete the bootsnap cache if required. For instance if the metasploit-framework version has changed.
+#
+# @param [Hash] bootsnap_config See https://github.com/Shopify/bootsnap/blob/95e8d170aea99a831fd484ce09ad2f195644e740/lib/bootsnap.rb#L38
+# @return [void]
+def invalidate_bootsnap_cache!(bootsnap_config)
+  expected_cache_metadata = {
+    'metasploit_framework_version' => Metasploit::Framework::Version::VERSION,
+    'ruby_description' => RUBY_DESCRIPTION,
+    'bundler_lockfile_hash' => Digest::MD5.hexdigest(Bundler.read_file(Bundler.default_lockfile)),
+    'bootsnap_config' => {
+      'load_path_cache' => bootsnap_config[:load_path_cache],
+      'compile_cache_iseq' => bootsnap_config[:compile_cache_iseq],
+      'compile_cache_yaml' => bootsnap_config[:compile_cache_yaml],
+    }
+  }
+
+  cache_metadata_path = File.join(bootsnap_config[:cache_dir], "metadata.yaml")
+  if File.exist?(cache_metadata_path)
+    cache_metadata = YAML.safe_load(File.binread(cache_metadata_path))
+    if cache_metadata != expected_cache_metadata
+      FileUtils.rm_rf(bootsnap_config[:cache_dir], secure: true)
+    end
+  end
+
+  FileUtils.mkdir_p(bootsnap_config[:cache_dir])
+  File.binwrite(cache_metadata_path, expected_cache_metadata.to_yaml)
+
+  nil
+end
+
+# Attempt to use bootsnap caching for improved startup time
+begin
+  require 'bootsnap'
+  env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']
+  development_mode = ['', nil, 'development'].include?(env)
+
+  cache_dir = ::File.join(Msf::Config.config_directory, "bootsnap_cache")
+  bootsnap_config = {
+    cache_dir: cache_dir,
+    ignore_directories: [],
+    development_mode: development_mode,
+    load_path_cache: true, # Optimize the LOAD_PATH with a cache
+    compile_cache_iseq: false, # Don't compile Ruby code into ISeq cache, breaks coverage reporting.
+    compile_cache_yaml: false, # Don't compile YAML into a cache
+    readonly: false, # Update caches - https://github.com/Shopify/bootsnap/commit/b51397f96c33aa421fd5c29484fb9574df9eb451
+  }
+  invalidate_bootsnap_cache!(bootsnap_config)
+  Bootsnap.setup(**bootsnap_config)
+rescue
+  $stderr.puts 'Warning: Failed bootsnap cache setup'
+  begin
+    FileUtils.rm_rf(cache_dir, secure: true)
+  rescue
+    $stderr.puts 'Warning: Failed deleting bootsnap cache'
+  end
+end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -54,6 +54,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'actionpack', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
+  # Improves bootup performance by caching expensive computations
+  spec.add_runtime_dependency 'bootsnap'
   # Needed for Javascript obfuscation
   spec.add_runtime_dependency 'jsobfu'
   # Needed for some admin modules (scrutinizer_add_user.rb)


### PR DESCRIPTION
Adds caching to Ruby's load path to improve the bootup performance of msfconsole on startup on macOS from ~13 seconds to ~9.7 seconds

### Context

I noticed when running `strace` to dump out the Linux system calls on msfconsole bootup, that when msfconsole attempts to load a Ruby file such as with `require 'foo'` you can see Ruby attempting to find the source code on disk in multiple places:

```
openat(... gem1/foo.rb ...) ENOENT (No such file or directory)
openat(... gem2/foo.rb ...) ENOENT (No such file or directory)
openat(... gem3/foo.rb ...) ENOENT (No such file or directory)
openat(... gem4/foo.rb ...) ENOENT (No such file or directory)
... etc ...
```

Kali example:

![image](https://user-images.githubusercontent.com/60357436/227206047-a4a3bc9b-9cbd-48f9-9ccf-a62648d224d4.png)

Specifically Ruby is checking the global `$LOAD_PATH` array which tracks the location of all the loaded gems/libraries that Metasploit depends on to find the required Ruby file. Since Metasploit's $LOAD_PATH is pretty big from the amount of gems we have, attempting to load a single Ruby file involves a lot of expensive trial and error until it finds the right file on disk:

```
>> $LOAD_PATH.length
=> 236
```

Example values of $LOAD_PATH
```
>> $LOAD_PATH
=> 
["/Users/user/Documents/code/metasploit-framework/lib",
 "/Users/user/Documents/code/metasploit-framework/app/models",
 "/Users/user/Documents/code/metasploit-framework/app/concerns",
 "/Users/user/Documents/code/metasploit-framework/app/validators",
 "/Users/user/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/metasploit-credential-6.0.2/app/concerns",
  ... etc ...
]
```

Bootsnap can be used to optimize this look up by performing [Path Pre-Scanning](https://github.com/Shopify/bootsnap#path-pre-scanning) - i.e. `Kernel#require` and `Kernel#load` are modified to eliminate $LOAD_PATH scans

## Verification

- Code review
- Confirm the before/after time for:
  - [ ] mac - Before: ~13, after ~9.7
  - [ ] windows - Before:  28.287, After: 26.2
  - [ ] kali - Before: 11.23, after: 9.359
  - [ ] pro -
- Confirm there's no issues the readline `$LOAD_PATH` hack here: https://github.com/rapid7/metasploit-framework/blob/192af217b6a05d99379dd3905968a5fcf597a6eb/lib/msf/ui/console/driver.rb#L661-L675
   - Both `bundle exec ruby ./msfconsole -q --real-readline` and `bundle exec ruby ./msfconsole -q --no-readline` appear to work as expected