### PR TITLE
ssh_enumusers.rb: Change default value of 'CHECK_FALSE' to true (closes #17810)

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
                      'found (timing attack only)', 10
                    ]),
         OptBool.new('CHECK_FALSE',
-                    [false, 'Check for false positives (random username)', false])
+                    [false, 'Check for false positives (random username)', true])
       ]
     )
 


### PR DESCRIPTION
 The default action "Malformed Packet" reports all users as found even
 though they don't exist.

 Setting "CHECK_FALSE" to true will make the scanner bail out as it
 realizes the target is patched.

Closes: https://github.com/rapid7/metasploit-framework/issues/17810