### PR TITLE
Fix crash in rpc job info command

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_job.rb
+++ b/lib/msf/core/rpc/v10/rpc_job.rb
@@ -61,7 +61,7 @@ class RPC_Job < RPC_Base
         info[:uripath] = obj.ctx[0].get_resource
       end
       if obj.ctx[0].respond_to?(:datastore)
-        info[:datastore] = obj.ctx[0].datastore
+        info[:datastore] = obj.ctx[0].datastore.to_h
       end
     end
 


### PR DESCRIPTION
Fixes a crash in the RPC job info command when running `rpc.call('job.info', '0')` 
Closes https://github.com/rapid7/metasploit-framework/issues/17816

## Verification

From the original issue:

1. Start `msfrpcd`: `msfrpcd -P password -S -a 127.0.0.1 -f`
1. Start client: `msfrpc -P password -a 127.0.0.1 -S` and use following commands:
   1. Verify that it works: `rpc.call('health.check')`
   `=> {"status"=>"UP"}`
   2. List jobs: `rpc.call('job.list')` - empty as expected
    `=> {}`
    3. Create a job `rpc.call('module.execute', 'exploit', 'multi/handler', {'LHOST'=>'127.0.0.1', 'LPORT'=>'8080'})`
    `=> {"job_id"=>0, "uuid"=>"gdmuq623"}`
     4. List jobs again: `rpc.call('job.list')`
     `=> {"0"=>"Exploit: multi/handler"}`
     5. Get job info: `rpc.call('job.info', '0')` - **This should not happen**
```
/usr/share/metasploit-framework/lib/msf/core/rpc/v10/client.rb:162:in `send_rpc_request': nil (RuntimeError)
        from /usr/share/metasploit-framework/lib/msf/core/rpc/v10/client.rb:104:in `call'
        from (irb):5:in `<main>'
        from /usr/share/metasploit-framework/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
        from /usr/share/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `catch'
        from /usr/share/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `run'
        from /usr/bin/msfrpc:91:in `<main>'
>> 
```