### PR TITLE
DBManager: Import: Add Nuclei JSON database import

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -32,6 +32,7 @@ module Msf::DBManager::Import
   autoload :Nexpose, 'msf/core/db_manager/import/nexpose'
   autoload :Nikto, 'msf/core/db_manager/import/nikto'
   autoload :Nmap, 'msf/core/db_manager/import/nmap'
+  autoload :Nuclei, 'msf/core/db_manager/import/nuclei'
   autoload :OpenVAS, 'msf/core/db_manager/import/open_vas'
   autoload :Outpost24, 'msf/core/db_manager/import/outpost24'
   autoload :Qualys, 'msf/core/db_manager/import/qualys'
@@ -59,6 +60,7 @@ module Msf::DBManager::Import
   include Msf::DBManager::Import::Nexpose
   include Msf::DBManager::Import::Nikto
   include Msf::DBManager::Import::Nmap
+  include Msf::DBManager::Import::Nuclei
   include Msf::DBManager::Import::OpenVAS
   include Msf::DBManager::Import::Outpost24
   include Msf::DBManager::Import::Qualys
@@ -353,6 +355,12 @@ module Msf::DBManager::Import
     elsif (firstline.index("<NessusClientData>"))
       @import_filedata[:type] = "Nessus XML (v1)"
       return :nessus_xml
+    elsif firstline.starts_with?('{"template":')
+      @import_filedata[:type] = "Nuclei JSONL"
+      return :nuclei_jsonl
+    elsif firstline.starts_with?('[{"template":')
+      @import_filedata[:type] = "Nuclei JSON"
+      return :nuclei_json
     elsif (firstline.index("<SecScan ID="))
       @import_filedata[:type] = "Microsoft Baseline Security Analyzer"
       return :mbsa_xml

--- a/lib/msf/core/db_manager/import/nuclei.rb
+++ b/lib/msf/core/db_manager/import/nuclei.rb
@@ -1,0 +1,151 @@
+module Msf::DBManager::Import::Nuclei
+  #
+  # Imports Nuclei scan results in JSON format.
+  #
+  def import_nuclei_json(args = {}, &block)
+    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
+
+    JSON.parse(args[:data]).each do |data|
+      next if data.blank?
+
+      ip = data['ip']
+
+      next if ip.blank?
+      next if bl.include?(ip)
+
+      yield(:address, ip) if block
+
+      matched_at = data['matched-at']
+      uri = URI.parse(matched_at.include?('://') ? matched_at : "tcp://#{matched_at}")
+      vhost = uri.host
+      port = uri.port.to_i
+      service = uri.scheme
+
+      template_id = data['template-id']
+      matcher_name = data['matcher-name']
+
+      info = data['info']
+      name = info['name']
+      description = info['description'].to_s.strip
+      severity = info['severity']
+
+      desc_text = [template_id, name, matcher_name, description].join("\n").strip
+
+      note = {
+        workspace: wspace,
+        host: ip,
+        vhost: vhost,
+        port: port,
+        proto: 'tcp',
+        sname: service,
+        type: 'host.nuclei.scan',
+        data: desc_text,
+        update: :unique_data,
+        task: args[:task]
+      }
+
+      report_note(note)
+
+      next unless %w[low medium high critical].include?(severity)
+
+      references = info['reference'] || []
+      curl_command = data['curl-command']
+      extracted_results = data['extracted-results']
+      proof = [curl_command, extracted_results].join("\n\n")
+
+      vuln = {
+        workspace: wspace,
+        host: ip,
+        vhost: vhost,
+        port: port,
+        proto: 'tcp',
+        sname: service,
+        name: name,
+        info: desc_text,
+        proof: proof,
+        refs: references,
+        task: args[:task]
+      }
+
+      report_vuln(vuln)
+    end
+  end
+
+  #
+  # Imports Nuclei scan results in JSON Lines (JSONL) format.
+  #
+  def import_nuclei_jsonl(args = {}, &block)
+    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
+
+    args[:data].each_line do |line|
+      next if line.strip.blank?
+
+      data = JSON.parse(line)
+
+      next if data.blank?
+
+      ip = data['ip']
+
+      next if ip.blank?
+      next if bl.include?(ip)
+
+      yield(:address, ip) if block
+
+      matched_at = data['matched-at']
+      uri = URI.parse(matched_at.include?('://') ? matched_at : "tcp://#{matched_at}")
+      vhost = uri.host
+      port = uri.port.to_i
+      service = uri.scheme
+
+      template_id = data['template-id']
+      matcher_name = data['matcher-name']
+
+      info = data['info']
+      name = info['name']
+      description = info['description'].to_s.strip
+      severity = info['severity']
+
+      desc_text = [template_id, name, matcher_name, description].join("\n").strip
+
+      note = {
+        workspace: wspace,
+        host: ip,
+        vhost: vhost,
+        port: port,
+        proto: 'tcp',
+        sname: service,
+        type: 'host.nuclei.scan',
+        data: desc_text,
+        update: :unique_data,
+        task: args[:task]
+      }
+
+      report_note(note)
+
+      next unless %w[low medium high critical].include?(severity)
+
+      references = info['reference'] || []
+      curl_command = data['curl-command']
+      extracted_results = data['extracted-results']
+      proof = [curl_command, extracted_results].join("\n\n")
+
+      vuln = {
+        workspace: wspace,
+        host: ip,
+        vhost: vhost,
+        port: port,
+        proto: 'tcp',
+        sname: service,
+        name: name,
+        info: desc_text,
+        proof: proof,
+        refs: references,
+        task: args[:task]
+      }
+
+      report_vuln(vuln)
+    end
+  end
+end


### PR DESCRIPTION

RFC. I imagine the import format will be debated.

# Design

The import follows similar design to the [Nikto import](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/db_manager/import/nikto.rb). That is, all records are imported as `notes` and potential vulnerabilities are also reported as `vulns`.

The concept of "vulnerability" is vague. I took the simplest approach: any report item with a severity score `severity` of `"low"` or higher (ie, not `info`) is considered a vulnerability.

Some data from the original scan is lost during import. This is in line with existing import functionality for other data formats. The import process extracts and imports only information which is considered useful. An alternative and far simpler approach would be to simply store each entire JSON line as the note (in JSON format). This approach woudl be lazier, make the code easier to read and maintain, and ensure no data is lost, at the expense of making the `notes` output in `msfconsole` effectively unreadable.


# Output

Tested on a few hosts. Output for Metasploitable2 below.

```
msf6 > db_import nuclei-http-192.168.200.142.json
[*] Importing 'Nuclei JSON' data
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Importing host 192.168.200.142
[*] Successfully imported /root/Desktop/metasploit-framework/nuclei-http-192.168.200.142.json
msf6 > hosts

Hosts
=====

address          mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------          ---  ----  -------  ---------  -----  -------  ----  --------
192.168.200.142             Unknown                    device

msf6 > services
Services
========

host             port  proto  name  state  info
----             ----  -----  ----  -----  ----
192.168.200.142  21    tcp    tcp   open
192.168.200.142  22    tcp    tcp   open
192.168.200.142  25    tcp    tcp   open
192.168.200.142  80    tcp    http  open
192.168.200.142  139   tcp    tcp   open
192.168.200.142  5432  tcp    tcp   open
192.168.200.142  5900  tcp    tcp   open
192.168.200.142  6200  tcp    tcp   open
192.168.200.142  8009  tcp    tcp   open

msf6 > vulns

Vulnerabilities
===============

Timestamp                Host             Name                                                          References
---------                ----             ----                                                          ----------
2023-03-26 10:45:47 UTC  192.168.200.142  PHP CGI v5.3.12/5.4.2 Remote Code Execution                   https://github.com/vulhub/vulhub/tree/master/php/cve-2012-18
                                                                                                        23,https://nvd.nist.gov/vuln/detail/cve-2012-1823,https://bu
                                                                                                        gs.php.net/bug.php?id=61910,http://www.php.net/changelog-5.p
                                                                                                        hp#5.4.2
2023-03-26 10:45:48 UTC  192.168.200.142  PHPinfo Page - Detect
2023-03-26 10:45:48 UTC  192.168.200.142  Ghostcat - Apache Tomcat - AJP File Read/Inclusion Vulnerabi  https://www.tenable.com/blog/cve-2020-1938-ghostcat-apache-t
                                          lity                                                          omcat-ajp-file-readinclusion-vulnerability-cnvd-2020-10487,h
                                                                                                        ttps://nvd.nist.gov/vuln/detail/cve-2020-1938,https://lists.
                                                                                                        apache.org/thread.html/r7c6f492fbd39af34a68681dbbba0468490ff
                                                                                                        1a97a1bd79c6a53610ef%40%3cannounce.tomcat.apache.org%3e,http
                                                                                                        s://lists.apache.org/thread.html/r75113652e46c4dee6872365106
                                                                                                        49acfb70d2c63e074152049c3f399d@%3cnotifications.ofbiz.apache
                                                                                                        .org%3e
2023-03-26 10:45:48 UTC  192.168.200.142  FTP Anonymous Login                                           https://tools.ietf.org/html/rfc2577
2023-03-26 10:45:48 UTC  192.168.200.142  VSFTPD 2.3.4 - Backdoor Command Execution                     https://www.rapid7.com/db/modules/exploit/unix/ftp/vsftpd_23
                                                                                                        4_backdoor/
2023-03-26 10:45:48 UTC  192.168.200.142  VSFTPD 2.3.4 - Backdoor Command Execution                     - https://www.rapid7.com/db/modules/exploit/unix/ftp/vsftpd_
                                                                                                        234_backdoor/
- https://www.exploit-db.com/exploits/49757

msf6 > notes

Notes
=====

 Time                   Host             Service  Port  Protocol  Type              Data
 ----                   ----             -------  ----  --------  ----              ----
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "apache-detect\nApache Detection\n\nSome Apache servers have the version on the
 TC                                                                                 response header. The OpenSSL version can be also obtained"
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "php-detect\nPHP Detect"
 TC
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "waf-detect\nWAF Detection\napachegeneric\nA web application firewall was detect
 TC                                                                                 ed."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "tech-detect\nWappalyzer Technology Detection\nphp"
 TC
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "CVE-2012-1823\nPHP CGI v5.3.12/5.4.2 Remote Code Execution\n\nsapi/cgi/cgi_main
 TC                                                                                 .c in PHP before 5.3.12 and 5.4.x before 5.4.2, when configured as a CGI script
                                                                                    (aka php-cgi), does not properly handle query strings that lack an = (equals sig
                                                                                    n) character, which allows remote attackers to execute arbitrary code by placing
                                                                                     command-line options in the query string, related to lack of skipping a certain
                                                                                     php_getopt for the 'd' case."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\ncross-origin-reso
 TC                                                                                 urce-policy\nThis template searches for missing HTTP security headers. The impac
                                                                                    t of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\naccess-control-al
 TC                                                                                 low-origin\nThis template searches for missing HTTP security headers. The impact
                                                                                     of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\naccess-control-ex
 TC                                                                                 pose-headers\nThis template searches for missing HTTP security headers. The impa
                                                                                    ct of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\naccess-control-ma
 TC                                                                                 x-age\nThis template searches for missing HTTP security headers. The impact of t
                                                                                    hese missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\ncontent-security-
 TC                                                                                 policy\nThis template searches for missing HTTP security headers. The impact of
                                                                                    these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\nx-content-type-op
 TC                                                                                 tions\nThis template searches for missing HTTP security headers. The impact of t
                                                                                    hese missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\nx-permitted-cross
 TC                                                                                 -domain-policies\nThis template searches for missing HTTP security headers. The
                                                                                    impact of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\ncross-origin-open
 TC                                                                                 er-policy\nThis template searches for missing HTTP security headers. The impact
                                                                                    of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\naccess-control-al
 TC                                                                                 low-methods\nThis template searches for missing HTTP security headers. The impac
                                                                                    t of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\nstrict-transport-
 TC                                                                                 security\nThis template searches for missing HTTP security headers. The impact o
                                                                                    f these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\nclear-site-data\n
 TC                                                                                 This template searches for missing HTTP security headers. The impact of these mi
                                                                                    ssing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\ncross-origin-embe
 TC                                                                                 dder-policy\nThis template searches for missing HTTP security headers. The impac
                                                                                    t of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\naccess-control-al
 TC                                                                                 low-credentials\nThis template searches for missing HTTP security headers. The i
                                                                                    mpact of these missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\npermissions-polic
 TC                                                                                 y\nThis template searches for missing HTTP security headers. The impact of these
                                                                                     missing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\nreferrer-policy\n
 TC                                                                                 This template searches for missing HTTP security headers. The impact of these mi
                                                                                    ssing headers can vary."
 2023-03-26 10:45:47 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\naccess-control-al
 TC                                                                                 low-headers\nThis template searches for missing HTTP security headers. The impac
                                                                                    t of these missing headers can vary."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      139   tcp       host.nuclei.scan  "samba-detect\nSamba Service Detection\n\nSamba is a free and open-source softwa
 TC                                                                                 re that allows files to be shared across Windows and Linux systems simply and ea
                                                                                    sily."
 2023-03-26 10:45:48 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "phpinfo-files\nPHPinfo Page - Detect\n\nPHPinfo page was detected. The output o
 TC                                                                                 f the phpinfo() command can reveal sensitive and detailed PHP environment inform
                                                                                    ation."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      5900  tcp       host.nuclei.scan  "vnc-service-detect\nVNC Service Detection\n\nA Virtual Network Computing (VNC)
 TC                                                                                 service was detected."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      8009  tcp       host.nuclei.scan  "CVE-2020-1938\nGhostcat - Apache Tomcat - AJP File Read/Inclusion Vulnerability
 TC                                                                                 \n\nWhen using the Apache JServ Protocol (AJP), care must be taken when trusting
                                                                                     incoming connections to Apache Tomcat. Tomcat treats AJP connections as having
                                                                                    higher trust than, for example, a similar HTTP connection. If such connections a
                                                                                    re available to an attacker, they can be exploited in ways that may be surprisin
                                                                                    g. In Apache Tomcat 9.0.0.M1 to 9.0.0.30, 8.5.0 to 8.5.50 and 7.0.0 to 7.0.99, T
                                                                                    omcat shipped with an AJP Connector enabled by default that listened on all conf
                                                                                    igured IP addresses. It was expected (and recommended in the security guide) tha
                                                                                    t this Connector would be disabled if not required. This vulnerability report id
                                                                                    entified a mechanism that allowed - returning arbitrary files from anywhere in t
                                                                                    he web application - processing any file in the web application as a JSP Further
                                                                                    , if the web application allowed file upload and stored those files within the w
                                                                                    eb application (or the attacker was able to control the content of the web appli
                                                                                    cation by some other means) then this, along with the ability to process a file
                                                                                    as a JSP, made remote code execution possible. It is important to note that miti
                                                                                    gation is only required if an AJP port is accessible to untrusted users. Users w
                                                                                    ishing to take a defence-in-depth approach and block the vector that permits ret
                                                                                    urning arbitrary files and execution as JSP may upgrade to Apache Tomcat 9.0.31,
                                                                                     8.5.51 or 7.0.100 or later. A number of changes were made to the default AJP Co
                                                                                    nnector configuration in 9.0.31 to harden the default configuration. It is likel
                                                                                    y that users upgrading to 9.0.31, 8.5.51 or 7.0.100 or later will need to make s
                                                                                    mall changes to their configurations."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      21    tcp       host.nuclei.scan  "ftp-anonymous-login\nFTP Anonymous Login\n\nAnonymous FTP access allows anyone
 TC                                                                                 to access your public_ftp folder, allowing unidentified visitors to download (an
                                                                                    d possibly upload) files on your website. Anonymous FTP creates the potential fo
                                                                                    r a security hole for hackers and is not recommended."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      5432  tcp       host.nuclei.scan  "pgsql-detect\nPostgreSQL Authentication - Detect\n\nPostgreSQL authentication e
 TC                                                                                 rror messages which could reveal information useful in formulating further attac
                                                                                    ks were detected."
 2023-03-26 10:45:48 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "phpmyadmin-panel\nphpMyAdmin Panel - Detect\n\nphpMyAdmin panel was detected."
 TC
 2023-03-26 10:45:48 U  192.168.200.142  tcp      22    tcp       host.nuclei.scan  "openssh-detect\nOpenSSH Service - Detect\n\nOpenSSH service was detected."
 TC
 2023-03-26 10:45:48 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "HTTP-TRACE\nHTTP TRACE method enabled\ntrace-request"
 TC
 2023-03-26 10:45:48 U  192.168.200.142  tcp      21    tcp       host.nuclei.scan  "vsftpd-backdoor\nVSFTPD 2.3.4 - Backdoor Command Execution\n\nVSFTPD 2.3.4 cont
 TC                                                                                 ains a backdoor command execution vulnerability."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      6200  tcp       host.nuclei.scan  "CVE-2011-2523\nVSFTPD 2.3.4 - Backdoor Command Execution\n\nVSFTPD v2.3.4 had a
 TC                                                                                  serious backdoor vulnerability allowing attackers to execute arbitrary commands
                                                                                     on the server with root-level access. The backdoor was triggered by a specific
                                                                                    string of characters in a user login request, which allowed attackers to execute
                                                                                     any command they wanted."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      25    tcp       host.nuclei.scan  "smtp-service-detect\nSMTP Service Detection\n\nSMTP is part of the application
 TC                                                                                 layer of the TCP/IP protocol. Using a process called \u201Cstore and forward,\u2
                                                                                    01D SMTP moves your email on and across networks."
 2023-03-26 10:45:48 U  192.168.200.142  tcp      25    tcp       host.nuclei.scan  "esmtp-detect\nESMTP Detection\n\nESMTP (Extended Simple Mail Transfer Protocol)
 TC                                                                                  specifies extensions to the original protocol for sending e-mail that supports
                                                                                    graphics, audio and video files, and text in various national languages"
 2023-03-26 10:45:48 U  192.168.200.142  http     80    tcp       host.nuclei.scan  "http-missing-security-headers\nHTTP Missing Security Headers\nx-frame-options\n
 TC                                                                                 This template searches for missing HTTP security headers. The impact of these mi
                                                                                    ssing headers can vary."

msf6 > 
```

# Bugs

There are several (mostly minor) bugs - all of which would be easier to resolve in Nuclei than Metasploit.


## Missing Service Ports

Not shown above is an issue where service ports are missing for some notes (specifically issues related to SSL/TLS ciphers (`self-signed-ssl`, `expired-ssl`, ...). This data is not available in the nuclei output. This seems like an oversight in the Nuclei templates and resulting reporting format.

Here's an example (from a test host not Metasploitable2):

```
 2023-03-26 10:54:18 U  127.0.0.123                          host.nuclei.scan  "self-signed-ssl\nSelf Signed SSL Certificate\n\nself-signed certificates are public
 TC                                                                            key certificates that are not issued by a certificate authority. These self-signed\nc
                                                                               ertificates are easy to make and do not cost money. However, they do not provide any
                                                                               trust value."
 2023-03-26 10:54:18 U  127.0.0.123                          host.nuclei.scan  "expired-ssl\nExpired SSL Certificate\n\nAfter an SSL certificate expires, you will n
 TC                                                                            o longer be able to communicate over a secure, encrypted HTTPS connection."
 2023-03-26 10:54:18 U  127.0.0.123                          host.nuclei.scan  "ssl-issuer\nDetect SSL Certificate Issuer"
 TC
```

## Missing Service Names

The service names are inferred where possible and fall back to `tcp`. There is no JSON property which defines the service type. This seems like an oversight in the Nuclei templates and resulting reporting format.

In instances where the output does not include the service name, we could perform one of two terrible approaches:

* Text matching the template name and description text for known service names
* Iterating through `tags` and matching possible service names.

These approaches are both terrible and I refuse to implement them. This would be much easier to fix on the Nuclei side.

Here's the first example I pulled from the logs at random. There are many. The `type` is listed as `"network"` which is useless to determine the service. The only references to FTP are the software name in the template name; and the `tags` array which contains `ftp` among multiple other tags.

```json
{
  "template": "network/cves/2011/CVE-2011-2523.yaml",
  "template-url": "https://github.com/projectdiscovery/nuclei-templates/blob/master/network/cves/2011/CVE-2011-2523.yaml",
  "template-id": "CVE-2011-2523",
  "info": {
    "name": "VSFTPD 2.3.4 - Backdoor Command Execution",
    "author": [
      "pussycat0x"
    ],
    "tags": [
      "cve",
      "cve2011",
      "network",
      "vsftpd",
      "ftp",
      "backdoor"
    ],
    "description": "VSFTPD v2.3.4 had a serious backdoor vulnerability allowing attackers to execute arbitrary commands on the server with root-level access. The backdoor was triggered by a specific string of characters in a user login request, which allowed attackers to execute any command they wanted.\n",
    "reference": [
      "- https://www.rapid7.com/db/modules/exploit/unix/ftp/vsftpd_234_backdoor/\n- https://www.exploit-db.com/exploits/49757"
    ],
    "severity": "critical",
    "metadata": {
      "verified": "true",
      "shodan-query": "product:\"vsftpd\""
    },
    "classification": {
      "cve-id": [
        "cve-2011-2523"
      ],
      "cwe-id": null
    },
    "remediation": "Update to the latest version of VSFTPD, which does not contain the backdoor.\n"
  },
  "type": "network",
  "host": "192.168.200.142",
  "matched-at": "192.168.200.142:6200",
  "ip": "192.168.200.142",
  "timestamp": "2023-03-25T23:22:16.667765276-04:00",
  "matcher-status": true,
  "matched-line": null
}
```


## Presumed TCP Protocol

The `proto` protocol is always assumed to be TCP. This data is not available in the nuclei output. This seems like an oversight in the Nuclei templates and resulting reporting format.



# Testing

```
nuclei -u 192.168.200.142 -json -o nuclei-192.168.200.142.json
nuclei -u http://192.168.200.142/ -json -o nuclei-http-192.168.200.142.json
```

```
db_import nuclei-192.168.200.142.json
db_import nuclei-http-192.168.200.142.json
```
