### PR TITLE
Update zimbra_slapper_priv_esc.rb

### DIFF
--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged' => true,
         'References' => [
           [ 'CVE', '2022-37393' ],
-          [ 'URL', 'https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
+          [ 'URL', 'https://web.archive.org/web/20221002011602/https://darrenmartyn.ie/2021/10/27/zimbra-zmslapd-local-root-exploit/' ],
         ],
         'Targets' => [
           [ 'Auto', {} ],


### PR DESCRIPTION
fixing reference to use an archive.org link as the site referenced is down and probably won't be coming back up anytime soon.

as an aside, I might do this for other modules with dead reference links. Is there a preferred way to do this? Or just ad-hoc PR's?