### PR TITLE
Add an AMQP-Version Scanner Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/amqp/amqp_version.md
+++ b/documentation/modules/auxiliary/scanner/amqp/amqp_version.md
@@ -1,0 +1,55 @@
+## Description
+
+This module displays the version information about Advanced Message Queuing Protocol (AMQP) 0-9-1 servers. Per the
+specification, the "server-properties":
+
+> ... SHOULD contain at least these fields: "host", specifying the server host name or address, "product", giving the
+> name of the server product, "version", giving the name of the server version, "platform", giving the name of the
+> operating system, "copyright", if appropriate, and "information", giving other general information.
+
+*See: https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.start.server-properties*
+
+## Verification Steps
+
+1. Do: `use auxiliary/scanner/amqp/amqp_version`
+2. Do: `set RHOSTS [IP]`
+3. Do: `set RPORT [PORT]`
+4. Do: `run`
+
+## Scenarios
+
+**Running the scanner**
+
+```
+msf6 > use auxiliary/scanner/amqp/amqp_version
+msf6 auxiliary(scanner/amqp/amqp_version) > set RHOSTS 192.168.159.0/24
+RHOSTS => 192.168.159.0/24
+msf6 auxiliary(scanner/amqp/amqp_version) > run
+
+[*] 192.168.159.17:5671 - AMQP Detected (version:RabbitMQ 3.8.16) (cluster:rabbit@WIN-KHPRSGSRF30) (platform:Erlang/OTP 23.3) (authentication:AMQPLAIN, PLAIN)
+[*] 192.168.159.0/24:5671 - Scanned  51 of 256 hosts (19% complete)
+[*] 192.168.159.0/24:5671 - Scanned  53 of 256 hosts (20% complete)
+[*] 192.168.159.0/24:5671 - Scanned  98 of 256 hosts (38% complete)
+[*] 192.168.159.128:5671 - AMQP Detected (version:RabbitMQ 3.11.10) (cluster:rabbit@my-rabbit) (platform:Erlang/OTP 25.3) (authentication:PLAIN, AMQPLAIN)
+[*] 192.168.159.0/24:5671 - Scanned 104 of 256 hosts (40% complete)
+[*] 192.168.159.0/24:5671 - Scanned 150 of 256 hosts (58% complete)
+[*] 192.168.159.0/24:5671 - Scanned 154 of 256 hosts (60% complete)
+[*] 192.168.159.0/24:5671 - Scanned 199 of 256 hosts (77% complete)
+[*] 192.168.159.0/24:5671 - Scanned 216 of 256 hosts (84% complete)
+[*] 192.168.159.0/24:5671 - Scanned 233 of 256 hosts (91% complete)
+[*] 192.168.159.0/24:5671 - Scanned 256 of 256 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/amqp/amqp_version) > services 
+Services
+========
+
+host             port  proto  name   state  info
+----             ----  -----  ----   -----  ----
+192.168.159.17   5671  tcp    amqps  open   AMQP Detected (version:RabbitMQ 3.8.16) (cluster:rabbit@WIN-KHPRSGSRF30) (platform:Erlang/OTP 23.3) (authentication:AMQPLAIN, PL
+                                            AIN)
+192.168.159.128  5671  tcp    amqps  open   AMQP Detected (version:RabbitMQ 3.11.10) (cluster:rabbit@my-rabbit) (platform:Erlang/OTP 25.3) (authentication:PLAIN, AMQPLAIN)
+
+msf6 auxiliary(scanner/amqp/amqp_version) 
+```
+
+[1]: https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.start.server-properties

--- a/lib/rex/proto/amqp/version_0_9_1/client.rb
+++ b/lib/rex/proto/amqp/version_0_9_1/client.rb
@@ -1,5 +1,6 @@
 class Rex::Proto::Amqp::Version091::Client
 
+  require 'rex/stopwatch'
   require 'rex/proto/amqp/error'
   require 'rex/proto/amqp/version_0_9_1/frames'
   require 'rex/proto/amqp/version_0_9_1/client/channel'

--- a/modules/auxiliary/scanner/amqp/amqp_version.rb
+++ b/modules/auxiliary/scanner/amqp/amqp_version.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name' => 'AMQP 0-9-1 Version Scanner',
+      'Description' => 'Detect AMQP version information.',
+      'Author' => 'Spencer McIntyre',
+      'License' => MSF_LICENSE,
+      'References' => [
+        [ 'URL', 'https://www.rabbitmq.com/amqp-0-9-1-reference.html' ]
+      ]
+    )
+
+    register_options([
+      Opt::RPORT(5671)
+    ])
+
+    register_advanced_options(
+      [
+        OptBool.new('SSL', [ true, 'Negotiate SSL/TLS for outgoing connections', true ]),
+        Opt::SSLVersion
+      ]
+    )
+  end
+
+  def peer
+    rhost = datastore['RHOST']
+    rport = datastore['RPORT']
+    if Rex::Socket.is_ipv6?(rhost)
+      "[#{rhost}]:#{rport}"
+    else
+      "#{rhost}:#{rport}"
+    end
+  end
+
+  def print_prefix
+    peer.ljust(21) + ' - '
+  end
+
+  def run_host(target_host)
+    amqp_client = Rex::Proto::Amqp::Version091::Client.new(
+      target_host,
+      port: datastore['RPORT'],
+      context: { 'Msf' => framework, 'MsfExploit' => self },
+      ssl: datastore['SSL'],
+      ssl_version: datastore['SSLVersion']
+    )
+
+    amqp_client.connect
+    amqp_client.send_protocol_header
+    amqp_client.recv_connection_start
+    server_info = amqp_client.server_info
+
+    info_line = 'AMQP Detected'
+    unless server_info[:properties]['product'].blank? || server_info[:properties]['version'].blank?
+      info_line << " (version:#{server_info[:properties]['product']} #{server_info[:properties]['version']})"
+    end
+    unless server_info[:properties]['cluster_name'].blank?
+      info_line << " (cluster:#{server_info[:properties]['cluster_name']})"
+    end
+    unless server_info[:properties]['platform'].blank?
+      info_line << " (platform:#{server_info[:properties]['platform']})"
+    end
+    info_line << " (authentication:#{server_info[:security_mechanisms].join(', ')})"
+    print_status(info_line)
+    report_service(
+      host: target_host,
+      port: datastore['RPORT'],
+      name: "amqp#{datastore['SSL'] ? 's' : ''}",
+      info: info_line
+    )
+  rescue Rex::Proto::Amqp::Error::UnexpectedReplyError => e
+    fail_with(Failure::UnexpectedReply, e.message)
+  rescue Rex::Proto::Amqp::Error::AmqpError => e
+    fail_with(Failure::Unknown, e.message)
+  ensure
+    amqp_client.close
+  end
+end


### PR DESCRIPTION
This adds a version scanner module for AMQP servers such as RabbitMQ. It extracts information from the [ConnectionStart.server_properties](https://www.rabbitmq.com/amqp-0-9-1-reference.html#connection.start.server-properties*) and displays it to the user as well as logs it to the services.

## Verification

You can start a RabbitMQ server using Docker by running: `docker run --rm -it --hostname "$(hostname)" -p 15672:15672 -p 5672:5672 rabbitmq:3-management`.

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/amqp/amqp_version`
- [ ] Set the RHOSTS, RPORT and SSL options appropriate
- [ ] Run the module, and see a service was identified

