### PR TITLE
Fix dead reference links in rpc_cmsd_opcode21.rb

### DIFF
--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -31,8 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2009-3699' ],
           [ 'OSVDB', '58726' ],
           [ 'BID', '36615' ],
-          [ 'URL', 'http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=825' ],
-          [ 'URL', 'http://aix.software.ibm.com/aix/efixes/security/cmsd_advisory.asc' ]
+          [ 'URL', 'https://web.archive.org/web/20091013155835/http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=825' ],
+          [ 'URL', 'https://web.archive.org/web/20221204155746/http://aix.software.ibm.com/aix/efixes/security/cmsd_advisory.asc' ]
         ],
       'Platform'       => [ 'aix' ],
       'Payload'        =>


### PR DESCRIPTION
Both the reference links in this module are dead, replacing with archive.org links.

Much like https://github.com/rapid7/metasploit-framework/pull/17825, I'll be doing these ad-hoc for a little bit until I figure out a reliable way to do a load of them in one batch.