### PR TITLE
Add check metadata to rpc module info

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -224,6 +224,7 @@ class RPC_Module < RPC_Base
     res['platform'] = m.platform.platforms.map { |x| x.to_s }
     res['authors'] = m.author.map { |a| a.to_s }
     res['privileged'] = m.privileged?
+    res['check'] = m.has_check?
 
     res['references'] = []
     m.references.each do |r|
@@ -722,6 +723,10 @@ class RPC_Module < RPC_Base
 
 private
 
+  # @param [String] mtype The module type
+  # @param [String] mname The module name
+  # @return [Msf::Module] The module if found
+  # @raise [Msf::RPC::Exception] An exception is raised if the module is not found
   def _find_module(mtype,mname)
 
     if mname !~ /^(exploit|payload|nop|encoder|auxiliary|post|evasion)\//


### PR DESCRIPTION
Updates the Metasploit RPC `module.info` command response to include whether or not the module supports a check method, i.e. `rpc.call('module.info', 'exploit', 'multi/http/gitlab_file_read_rce')` will return `'check': true`

Closes https://github.com/rapid7/metasploit-framework/issues/17829

## Verification

Create the server:
```
bundle exec ruby ./msfrpcd -P password -S -a 127.0.0.1 -f
```

Create the client and verify the check metadata is available:

```
bundle exec ruby ./msfrpc -P password -a 127.0.0.1 -S
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>> rpc.call('module.info', 'exploit', 'multi/http/gitlab_file_read_rce')
=> 
{"type"=>"exploit",                       
 "name"=>"GitLab File Read Remote Code Execution",
 "fullname"=>"exploit/multi/http/gitlab_file_read_rce",
...
 "check"=>true, <-----------
...
```