### PR TITLE
cisco_dcnm_auth_bypass: Fix TARGETURI URL normalization

### DIFF
--- a/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'POST',
       'headers' => h,
       'vars_post' => d,
-      'uri' => normalize_uri(target_uri.path + 'fm/fmrest/dbadmin/addUser')
+      'uri' => normalize_uri(target_uri.path, 'fm/fmrest/dbadmin/addUser')
     })
 
     if r && r.body != 'Access denied'


### PR DESCRIPTION
The `bypass_auth` method will break if a user supplies a `TARGETURI` path without a trailing `/`.

https://github.com/rapid7/metasploit-framework/blob/eb12cfec0523df548bab650c7706b9d356d7dc1f/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb#L97

https://github.com/rapid7/metasploit-framework/blob/eb12cfec0523df548bab650c7706b9d356d7dc1f/lib/msf/core/exploit/remote/http_client.rb#L577-L593

```ruby
#!/usr/bin/env ruby

  #
  # Returns a modified version of the URI that:
  # 1. Always has a starting slash
  # 2. Removes all the double slashes
  #
  def normalize_uri(*strs)
    new_str = strs * "/"

    new_str = new_str.gsub!("//", "/") while new_str.index("//")

    # Makes sure there's a starting slash
    unless new_str[0,1] == '/'
      new_str = '/' + new_str
    end

    new_str
  end

puts 'concat:'
puts normalize_uri('' + 'fm/fmrest/dbadmin/addUser')
puts normalize_uri('/' + 'fm/fmrest/dbadmin/addUser')
puts normalize_uri('/asdf' + 'fm/fmrest/dbadmin/addUser')
puts normalize_uri('asdf' + 'fm/fmrest/dbadmin/addUser')

puts

puts '*args:'
puts normalize_uri('', 'fm/fmrest/dbadmin/addUser')
puts normalize_uri('/', 'fm/fmrest/dbadmin/addUser')
puts normalize_uri('/asdf', 'fm/fmrest/dbadmin/addUser')
puts normalize_uri('asdf', 'fm/fmrest/dbadmin/addUser')
```

```
# ./test.rb 
concat:
/fm/fmrest/dbadmin/addUser
/fm/fmrest/dbadmin/addUser
/asdffm/fmrest/dbadmin/addUser # <-- fail
/asdffm/fmrest/dbadmin/addUser # <-- fail

*args:
/fm/fmrest/dbadmin/addUser
/fm/fmrest/dbadmin/addUser
/asdf/fm/fmrest/dbadmin/addUser # <-- success
/asdf/fm/fmrest/dbadmin/addUser # <-- success
```
