### PR TITLE
Add notes section to exploit template

### DIFF
--- a/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
+++ b/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
@@ -1,3 +1,12 @@
+---
+layout: "default"
+title: "Writing an exploit"
+parent: "Guides"
+warning: "Do not modify this file directly. Please modify metasploit-framework/docs/metasploit-framework.wiki instead"
+old_path: "metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md"
+has_content: "true"
+---
+
 ## On this page
 * [Plan your module](#plan-your-module)
 * [Ranking](#ranking)
@@ -9,7 +18,7 @@ The real kung-fu behind exploit development isn't actually about which language 
 
 ## Plan your module
 
-First, ask yourself will exploiting this vulnerability result in executing a payload? If not, then despite exploiting a vulnerability, for Metasploit's purposes the module would fall into the [[auxiliary|How-to-get-started-with-writing-an-auxiliary-module]] category.
+First, ask yourself will exploiting this vulnerability result in executing a payload? If not, then despite exploiting a vulnerability, for Metasploit's purposes the module would fall into the [auxiliary]({% link docs/development/developing-modules/guides/how-to-get-started-with-writing-an-auxiliary-module.md %}) category.
 
 Unlike writing a proof-of-concept, when you write a Metasploit module, you need to think about how users might use it in the real world. Stealth is usually an important element to think about. Can your exploit achieve code execution without dropping a file? Can the input look more random, so it's more difficult to detect? How about obfuscation? Is it generating unnecessary traffic? Can it be more stable without crashing the system?
 
@@ -69,7 +78,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Privileged' => false,
         'DisclosureDate' => '',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        },
       )
     )
   end
@@ -99,7 +113,13 @@ end
 
 * **Payloads** - The Payloads field specifies how the payload should be encoded and generated. You can specify: `Space`, `SaveRegisters`, `Prepend`, `PrependEncoder`, `BadChars`, `Append`, `AppendEncoder`, `MaxNops`, `MinNops`, `Encoder`, `Nop`, `EncoderType`, `EncoderOptions`, `ExtendedOptions`, `EncoderDontFallThrough`.
 
-**DisclosureDate** - The DisclosureDate is about when the vulnerability was disclosed in public, in the format of: "M D Y". For example: "Apr 04 2014"
+* **DisclosureDate** - The DisclosureDate is about when the vulnerability was disclosed in public, in the format of: "M D Y". For example: "Apr 04 2014"
+
+* **Notes** - The Notes field is a hash always containing three keys. The value of each key is an array of constants. The list of available constants can be found in the [Definition of Module Reliability Side Effects and Stability](https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html). The key should be present even if the array is empty.
+    * **Stability** - The Stability field describes how the exploit affects the system it's being run on, ex: `CRASH_SAFE`, `CRASH_OS_DOWN`
+    * **Reliability** - The Reliability field describes how reliable the session is that gets returned by the exploit, ex: `REPEATABLE_SESSION`, `UNRELIABLE_SESSION`
+    * **SideEffects** - The SideEffects field describes the side effects cause by the exploit that the user should be aware of, ex: `ARTIFACTS_ON_DISK`, `IOC_IN_LOGS`, `ACCOUNT_LOCKOUTS`.
+
 
 Your exploit should also have a `check` method to support the check command, but this is optional in case it's not possible.
 

--- a/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
+++ b/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
@@ -106,7 +106,8 @@ end
 
 * **DisclosureDate** - The DisclosureDate is about when the vulnerability was disclosed in public, in the format of: "M D Y". For example: "Apr 04 2014"
 
-* **Notes** - The Notes field is a hash always containing three keys. The value of each key is an array of constants. The list of available constants can be found in the [Definition of Module Reliability Side Effects and Stability](https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html). The key should be present even if the array is empty.
+* **Notes** - The Notes field is a hash always containing three keys. The value of each key is an array of constants. The list of available constants can be found in the [[Definition of Module Reliability Side Effects and Stability|./Definition-of-Module-Reliability-Side-Effects-and-Stability.md]]. The key should be present even if the array is empty.
+
     * **Stability** - The Stability field describes how the exploit affects the system it's being run on, ex: `CRASH_SAFE`, `CRASH_OS_DOWN`
     * **Reliability** - The Reliability field describes how reliable the session is that gets returned by the exploit, ex: `REPEATABLE_SESSION`, `UNRELIABLE_SESSION`
     * **SideEffects** - The SideEffects field describes the side effects cause by the exploit that the user should be aware of, ex: `ARTIFACTS_ON_DISK`, `IOC_IN_LOGS`, `ACCOUNT_LOCKOUTS`.

--- a/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
+++ b/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
@@ -1,12 +1,3 @@
----
-layout: "default"
-title: "Writing an exploit"
-parent: "Guides"
-warning: "Do not modify this file directly. Please modify metasploit-framework/docs/metasploit-framework.wiki instead"
-old_path: "metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md"
-has_content: "true"
----
-
 ## On this page
 * [Plan your module](#plan-your-module)
 * [Ranking](#ranking)
@@ -18,7 +9,7 @@ The real kung-fu behind exploit development isn't actually about which language 
 
 ## Plan your module
 
-First, ask yourself will exploiting this vulnerability result in executing a payload? If not, then despite exploiting a vulnerability, for Metasploit's purposes the module would fall into the [auxiliary]({% link docs/development/developing-modules/guides/how-to-get-started-with-writing-an-auxiliary-module.md %}) category.
+First, ask yourself will exploiting this vulnerability result in executing a payload? If not, then despite exploiting a vulnerability, for Metasploit's purposes the module would fall into the [[auxiliary|How-to-get-started-with-writing-an-auxiliary-module]] category.
 
 Unlike writing a proof-of-concept, when you write a Metasploit module, you need to think about how users might use it in the real world. Stealth is usually an important element to think about. Can your exploit achieve code execution without dropping a file? Can the input look more random, so it's more difficult to detect? How about obfuscation? Is it generating unnecessary traffic? Can it be more stable without crashing the system?
 


### PR DESCRIPTION
I noticed the notes section was missing from this exploit template. I know sometimes contributors miss this section. Hopefully this helps. 