### PR TITLE
fix broken module references

### DIFF
--- a/modules/auxiliary/scanner/smb/impacket/secretsdump.py
+++ b/modules/auxiliary/scanner/smb/impacket/secretsdump.py
@@ -47,7 +47,7 @@ metadata = {
         {'type': 'url', 'ref': 'http://www.quarkslab.com/en-blog+read+13'},
         {'type': 'url', 'ref': 'https://code.google.com/p/creddump/'},
         {'type': 'url', 'ref': 'http://lab.mediaservice.net/code/cachedump.rb'},
-        {'type': 'url', 'ref': 'http://insecurety.net/?p=768'},
+        {'type': 'url', 'ref': 'https://web.archive.org/web/20140207114722/http://insecurety.net/?p=768'},
         {'type': 'url', 'ref': 'http://www.beginningtoseethelight.org/ntsecurity/index.htm'},
         {'type': 'url', 'ref': 'http://www.ntdsxtract.com/downloads/ActiveDirectoryOfflineHashDumpAndForensics.pdf'},
         {'type': 'url', 'ref': 'http://www.passcape.com/index.php?section=blog&cmd=details&id=15'},

--- a/modules/exploits/multi/http/zemra_panel_rce.rb
+++ b/modules/exploits/multi/http/zemra_panel_rce.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'http://0day.today/exploit/19259'],
-          ['URL', 'http://insecurety.net/?p=144'], #leaked source code and backdoor intro
+          ['URL', 'https://web.archive.org/web/20140207114942/http://insecurety.net/?p=144'], #leaked source code and backdoor intro
           ['URL', 'http://www.symantec.com/connect/blogs/ddos-attacks-zemra-bot']
         ],
       'Privileged'     => false,

--- a/modules/post/windows/gather/credentials/skype.rb
+++ b/modules/post/windows/gather/credentials/skype.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           ['URL', 'http://www.recon.cx/en/f/vskype-part2.pdf'],
-          ['URL', 'http://insecurety.net/?p=427'],
+          ['URL', 'https://web.archive.org/web/20140207115406/http://insecurety.net/?p=427'],
           ['URL', 'https://github.com/skypeopensource/tools']
         ],
         'Compat' => {


### PR DESCRIPTION
doing these "by domain" now, piecemeal-ish

I was going to submit one PR per module changed, but lets be real, there are like a thousand or so dead links in the MSF codebase and I don't think R7 employees want to review 1000 PR's that each contain like, a one line change.

this PR fixes all broken references to the "insecurety.net" website, which is long dead and won't be coming back, as the writers lost the domain.

the archiving of references will continue.