### PR TITLE
Correct incorrect log format

### DIFF
--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
           print_good(f)
         end
       else
-        print_good('No File(s) found')
+        print_error('No File(s) found')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
           print_good(f)
         end
       else
-        print_good('No File(s) found')
+        print_error('No File(s) found')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE


### PR DESCRIPTION
## Summary

i correct these two module's incorrect log format.

```
auxiliary/admin/http/trendmicro_dlp_traversal
auxiliary/admin/http/tomcat_utf8_traversal
```

in above module, when they found no files, it use print_good like this.
```
msf6 auxiliary(admin/http/trendmicro_dlp_traversal) > run

[*] Attempting to connect to 192.168.138.130:8443
[+] No File(s) found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

But I don't think print_good is right in this situation. Because they failed to find the file.
Users can be confused by they are success.

so i fixed it from "print_good" to "print_error".
