### PR TITLE
fix always vulnerable in Auxiliary module s40_traversal

### DIFF
--- a/modules/auxiliary/scanner/http/s40_traversal.rb
+++ b/modules/auxiliary/scanner/http/s40_traversal.rb
@@ -55,10 +55,8 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if not res
-      vprint_error("Server timed out")
-    elsif res and res.body =~ /Error 404 requested page cannot be found/
-      vprint_error("Either the file doesn't exist, or you don't have the permission to get it")
-    else
+      print_error("Server timed out")
+    elsif res.code == 200
       # We don't save the body by default, because there's also other junk in it.
       # But we still have a SAVE option just in case
       print_good("#{datastore['FILE']} retrieved")
@@ -74,6 +72,8 @@ class MetasploitModule < Msf::Auxiliary
         )
         print_good("File saved as: #{p}")
       end
+    else
+      print_error("Either the file doesn't exist, or you don't have the permission to get it")
     end
   end
 end

--- a/modules/auxiliary/scanner/http/s40_traversal.rb
+++ b/modules/auxiliary/scanner/http/s40_traversal.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
         print_good("File saved as: #{p}")
       end
     else
-      print_error("Either the file doesn't exist, or you don't have the permission to get it")
+      vprint_error("Either the file doesn't exist, or you don't have the permission to get it")
     end
   end
 end

--- a/modules/auxiliary/scanner/http/s40_traversal.rb
+++ b/modules/auxiliary/scanner/http/s40_traversal.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if not res
-      print_error("Server timed out")
+      vprint_error("Server timed out")
     elsif res.code == 200
       # We don't save the body by default, because there's also other junk in it.
       # But we still have a SAVE option just in case


### PR DESCRIPTION
## Summary
when i use this module it prints always vulnerable and try to retrieve file like this.

```
msf6 auxiliary(scanner/http/s40_traversal) > set RHOSTS 192.168.138.130
RHOSTS => 192.168.138.130
msf6 auxiliary(scanner/http/s40_traversal) > run

[+] /etc/passwd retrieved
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

I don't know much about this vulnerability, but I know it's a path traversal vulnerability.

So I think it should come out as vulnerable when http code 200 response comes.

i fixed that point.
