### PR TITLE
Improve check_host return code handling

### DIFF
--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -162,11 +162,19 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     begin
-      if check_host(ip) == Exploit::CheckCode::Safe
-        print_error("Target is not vulnerable")
+      vuln_status = check_host(ip)
+      case vuln_status
+      when Exploit::CheckCode::Safe
+        print_error('Target is not vulnerable')
         return
+      when Exploit::CheckCode::Unknown
+        print_error('An unknown error occurred when trying to check the target! Observe the traffic with HTTPTrace turned on and try to debug.')
+        return
+      when Exploit::CheckCode::Vulnerable
+        print_good('Target is vulnerable!')
       else
-        print_good("Target may be vulnerable...")
+        print_error('An unknown status code was returned from check_host!')
+        return
       end
 
       content_length = get_file_size

--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -165,13 +165,13 @@ class MetasploitModule < Msf::Auxiliary
       vuln_status = check_host(ip)
       case vuln_status
       when Exploit::CheckCode::Safe
-        print_error('Target is not vulnerable')
+        print_error('The target is not exploitable.')
         return
       when Exploit::CheckCode::Unknown
-        print_error('An unknown error occurred when trying to check the target! Observe the traffic with HTTPTrace turned on and try to debug.')
+        print_error('Cannot reliably check exploitability! Observe the traffic with HTTPTrace turned on and try to debug.')
         return
       when Exploit::CheckCode::Vulnerable
-        print_good('Target is vulnerable!')
+        print_good('The target is vulnerable.')
       else
         print_error('An unknown status code was returned from check_host!')
         return


### PR DESCRIPTION
## Summary
```
print_good("Target may be vulnerable...")
```

this code is not clear the target is vulnerable or not.
It can cause confusion to users.
It is also unnecessary code because it is verified in the code that follows.

In conclusion, I think it's better to delete it.

