### PR TITLE
Update FileInfo mixin

### DIFF
--- a/lib/msf/core/post/windows/file_info.rb
+++ b/lib/msf/core/post/windows/file_info.rb
@@ -1,83 +1,189 @@
 # -*- coding: binary -*-
+
 module Msf
-class Post
-module Windows
+  class Post
+    module Windows
+      # Provides helpers to get file and product versions
+      module FileInfo
+        class FileInfoError < StandardError; end
 
-module FileInfo
+        # A VS_FIXEDFILEINFO structure as defined here:
+        # https://learn.microsoft.com/en-us/windows/win32/api/verrsrc/ns-verrsrc-vs_fixedfileinfo
+        class VsFixedFileInfo < BinData::Record
+          endian :little
 
-  def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-              stdapi_railgun_api
-              stdapi_railgun_memread
-            ]
-          }
-        }
-      )
-    )
-  end
+          uint32 :signature, initial_value: 0xfeef04bd, assert: 0xfeef04bd
+          uint32 :struc_version
+          uint32 :file_version_ms
+          uint32 :file_version_ls
+          uint32 :product_version_ms
+          uint32 :product_version_ls
+          uint32 :file_flags_mask
+          uint32 :file_flags
+          uint32 :file_os
+          uint32 :file_type
+          uint32 :file_subtype
+          uint32 :file_date_ms
+          uint32 :file_date_ls
 
-  def hiword(num)
-    (num >> 16) & 0xffff
-  end
+          def file_version_major
+            hiword(file_version_ms)
+          end
 
-  def loword(num)
-    num & 0xffff
-  end
+          def file_version_minor
+            loword(file_version_ms)
+          end
 
-  # Returns the file version information such as: major, minor, build, revision, branch.
-  #
-  # @param filepath [String] The path of the file you are targeting.
-  # @return [String] Returns the file version information of the file.
+          def file_version_build
+            hiword(product_version_ls)
+          end
 
-  def file_version(filepath)
-    file_version_info_size = client.railgun.version.GetFileVersionInfoSizeA(
-      filepath,
-      nil
-    )['return']
+          def file_version_revision
+            loword(product_version_ls)
+          end
 
-    if file_version_info_size == 0
-      # Indicates an error - should not continue
-      return nil
+          def file_version_branch
+            file_version_revision.to_s[0..1].to_i
+          end
+
+          def product_version_major
+            hiword(product_version_ms)
+          end
+
+          def product_version_minor
+            loword(product_version_ms)
+          end
+
+          def product_version_build
+            hiword(product_version_ls)
+          end
+
+          def product_version_revision
+            loword(product_version_ls)
+          end
+
+          def product_version_branch
+            product_version_revision.to_s[0..1].to_i
+          end
+
+          private
+
+          def hiword(num)
+            (num >> 16) & 0xffff
+          end
+
+          def loword(num)
+            num & 0xffff
+          end
+
+        end
+
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_railgun_api
+                    stdapi_railgun_memread
+                  ]
+                }
+              }
+            )
+          )
+        end
+
+        # Returns the file's binary version number.
+        #
+        # Note that, since Windows 8.1, the file version depends on how the file is
+        # manifested. When it is not manifested, it will always return the Windows 8
+        # version value (6.2) for any newer Windows version (Windows 8.1, 10, 11,
+        # etc.). When the application is manifested, it will always return the version
+        # that the application is manifested for.
+        # See https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa
+        #
+        #
+        # @param filepath [String] The path of the file
+        # @return [Array<String>] Returns the file version information of the file as
+        #   an array such as: major, minor, build, revision, branch
+        # @raise [Msf::Post::Windows::FileInfo::FileInfoError]
+        def file_version(filepath)
+          vs_fixed_file_info = get_vs_fixed_file_info(filepath)
+
+          return [
+            vs_fixed_file_info.file_version_major,
+            vs_fixed_file_info.file_version_minor,
+            vs_fixed_file_info.file_version_build,
+            vs_fixed_file_info.file_version_revision,
+            vs_fixed_file_info.file_version_branch
+          ]
+        end
+
+        # Returns the product version number of a file, which is the binary version
+        # number of the product with which this file was distributed.
+        #
+        # @param filepath [String] The path of the file
+        # @return [Array<String>] Returns the product version information of the file
+        #   as an array such as: major, minor, build, revision, branch
+        # @raise [Msf::Post::Windows::FileInfo::FileInfoError]
+        def product_version(filepath)
+          vs_fixed_file_info = get_vs_fixed_file_info(filepath)
+
+          return [
+            vs_fixed_file_info.product_version_major,
+            vs_fixed_file_info.product_version_minor,
+            vs_fixed_file_info.product_version_build,
+            vs_fixed_file_info.product_version_revision,
+            vs_fixed_file_info.product_version_branch
+          ]
+        end
+
+        # Returns a VsFixedFileInfo BinData structure containing information of the file at `filepath`.
+        # see https://learn.microsoft.com/en-us/windows/win32/api/verrsrc/ns-verrsrc-vs_fixedfileinfo
+        #
+        # @param filepath [String] The path of the file
+        # @return [Msf::Post::Windows::FileInfo::VsFixedFileInfo] VS_FIXEDFILEINFO structure
+        # @raise [Msf::Post::Windows::FileInfo::FileInfoError]
+        def get_vs_fixed_file_info(filepath)
+          file_version_info_size = client.railgun.version.GetFileVersionInfoSizeA(
+            filepath,
+            nil
+          )['return']
+
+          if file_version_info_size == 0
+            # Indicates an error - should not continue
+            return nil
+          end
+
+          buffer = session.railgun.kernel32.VirtualAlloc(
+            nil,
+            file_version_info_size,
+            MEM_COMMIT | MEM_RESERVE,
+            PAGE_READWRITE
+          )['return']
+
+          client.railgun.version.GetFileVersionInfoA(
+            filepath,
+            0,
+            file_version_info_size,
+            buffer
+          )
+
+          result = client.railgun.version.VerQueryValueA(buffer, '\\', 4, 4)
+          ffi = client.railgun.memread(result['lplpBuffer'], result['puLen'])
+
+          return VsFixedFileInfo.read(ffi)
+        rescue BinData::ValidityError, IOError => e
+          msg = "Unable to parse the VS_FIXEDFILEINFO structure from filepath #{filepath}: #{e}"
+          elog(msg)
+          raise FileInfoError, msg
+        rescue Rex::TimeoutError, Rex::Post::Meterpreter::RequestError => e
+          msg = "Communication error while getting file information for #{filepath}: #{e}"
+          elog(msg)
+          raise FileInfoError, msg
+        end
+      end
     end
-
-    buffer = session.railgun.kernel32.VirtualAlloc(
-      nil,
-      file_version_info_size,
-      MEM_COMMIT|MEM_RESERVE,
-      PAGE_READWRITE
-    )['return']
-
-    client.railgun.version.GetFileVersionInfoA(
-      filepath,
-      0,
-      file_version_info_size,
-      buffer
-    )
-
-    result = client.railgun.version.VerQueryValueA(buffer, "\\", 4, 4)
-    ffi = client.railgun.memread(result['lplpBuffer'], result['puLen'])
-
-    vs_fixed_file_info = ffi.unpack('V13')
-
-    unless vs_fixed_file_info and (vs_fixed_file_info.length == 13)	and
-(vs_fixed_file_info[0] = 0xfeef04bd)
-      return nil
-    end
-
-    major = hiword(vs_fixed_file_info[2])
-    minor = loword(vs_fixed_file_info[2])
-    build = hiword(vs_fixed_file_info[3])
-    revision = loword(vs_fixed_file_info[3])
-    branch = revision.to_s[0..1].to_i
-
-    return major, minor, build, revision, branch
   end
-end # FileInfo
-end # Windows
-end # Post
-end # Msf
+end

--- a/lib/msf/core/post/windows/file_info.rb
+++ b/lib/msf/core/post/windows/file_info.rb
@@ -176,11 +176,11 @@ module Msf
           return VsFixedFileInfo.read(ffi)
         rescue BinData::ValidityError, IOError => e
           msg = "Unable to parse the VS_FIXEDFILEINFO structure from filepath #{filepath}: #{e}"
-          elog(msg)
+          elog(msg, error: e)
           raise FileInfoError, msg
         rescue Rex::TimeoutError, Rex::Post::Meterpreter::RequestError => e
           msg = "Communication error while getting file information for #{filepath}: #{e}"
-          elog(msg)
+          elog(msg, error: e)
           raise FileInfoError, msg
         end
       end

--- a/modules/exploits/windows/local/cve_2023_21768_afd_lpe.rb
+++ b/modules/exploits/windows/local/cve_2023_21768_afd_lpe.rb
@@ -65,13 +65,13 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless session.platform == 'windows'
-      return Exploit::CheckCode::Safe('Only Windows systems are affected')
+      return CheckCode::Safe('Only Windows systems are affected')
     end
 
-    major, minor, build, revision, _branch = file_version('C:\\Windows\\System32\\ntoskrnl.exe')
+    major, minor, build, revision, _branch = product_version('C:\\Windows\\System32\\ntoskrnl.exe')
     vprint_status("Windows Build Number = #{build}.#{revision}")
 
-    unless major == 6 && minor == 2 && build == 22621
+    unless major == 10 && minor == 0 && build == 22621
       return CheckCode::Safe('The exploit only supports Windows 11 22H2')
     end
 
@@ -80,6 +80,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     CheckCode::Appears
+  rescue Msf::Post::Windows::FileInfo::FileInfoError => e
+    CheckCode::Unknown(e)
   end
 
   def exploit


### PR DESCRIPTION
This adds a new `product_version` helper method to the `FileInfo` mixin. It also refactors the mixin to use a BinData structure to implement the [VS_FIXEDFILEINFO](https://learn.microsoft.com/en-us/windows/win32/api/verrsrc/ns-verrsrc-vs_fixedfileinfo) structure.

This was needed to make sure the correct product version is retrieved from the file information structure ([VS_FIXEDFILEINFO](https://learn.microsoft.com/en-us/windows/win32/api/verrsrc/ns-verrsrc-vs_fixedfileinfo)) on non-manifested files. Since Windows 8.1, the file version depends on how the file is manifested. When it is not manifested, it will always return the Windows 8 version value (6.2) for any newer Windows version (Windows 8.1, 10, 11, etc.). When the application is manifested, it will always return the version that the application is manifested for.

See https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa

Using the product version number ensure it returns the binary version number of the product with which this file was distributed and not the default Windows 8 version value.

This also updates the `cve_2023_21768_afd_lpe` module to use this new helper with the correct version numbers.

The existing modules that call the `file_version` helper method should not be affected since this method behaves the same way. The only difference is that now it raises a `Msf::Post::Windows::FileInfo::FileInfoError` exception if something goes wrong when retrieving the file information.


## Verification
Follow the installation and verification steps from the original [PR](https://github.com/rapid7/metasploit-framework/pull/17826). Make sure the `check` method returns the expected result.
