### PR TITLE
Ensure identify hashes helper is accessible to modules

### DIFF
--- a/lib/msf/core/auxiliary/arista.rb
+++ b/lib/msf/core/auxiliary/arista.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'metasploit/framework/hashes'
-
 module Msf
   ###
   #
@@ -129,7 +127,7 @@ module Msf
           cred[:username] = name
           cred[:private_data] = hash
 
-          if framework.db.active          
+          if framework.db.active
             create_credential_and_login(cred)
           end
           print_good(output)

--- a/lib/msf/core/auxiliary/f5.rb
+++ b/lib/msf/core/auxiliary/f5.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'metasploit/framework/hashes'
-
 module Msf
   ###
   #

--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'metasploit/framework/hashes'
-
 module Msf
   ###
   #

--- a/lib/msf/core/auxiliary/vyos.rb
+++ b/lib/msf/core/auxiliary/vyos.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'metasploit/framework/hashes'
-
 module Msf
   ###
   #

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -297,7 +297,7 @@ class MsfAutoload
   def config_paths
     [
       { path: "#{__dir__}/msf/", namespace: Msf },
-      { path: "#{__dir__}/rex/", namespace: Rex },
+      { path: "#{__dir__}/rex/", namespace: Rex }
     ]
   end
 
@@ -333,3 +333,6 @@ autoload :BinData, 'bindata'
 autoload :RubySMB, 'ruby_smb'
 
 require 'rexml/document'
+
+# XXX: Should be removed once the `lib/metasploit` folder is loaded by Zeitwerk
+require 'metasploit/framework/hashes'

--- a/modules/auxiliary/gather/ldap_hashdump.rb
+++ b/modules/auxiliary/gather/ldap_hashdump.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::LDAP
@@ -212,7 +210,7 @@ class MetasploitModule < Msf::Auxiliary
     ltype.gsub!(/ /, '_')
     ltype.gsub!(/,/, '.')
     ltype.gsub!(/(ou=|fn=|cn=|o=|dc=|c=)/i, '')
-    ltype.gsub!(/[^a-z0-9._\-]+/i, '')
+    ltype.gsub!(/[^a-z0-9._-]+/i, '')
     ltype = ltype.last(16)
 
     ldif_filename = store_loot(

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::LDAP

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
 require 'ruby_smb/dcerpc/client'
 
 class MetasploitModule < Msf::Auxiliary

--- a/modules/auxiliary/gather/xymon_info.rb
+++ b/modules/auxiliary/gather/xymon_info.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.rb
+++ b/modules/auxiliary/scanner/http/wp_bulletproofsecurity_backups.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'rex/zip'
-require 'metasploit/framework/hashes'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HTTP::Wordpress

--- a/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_modern_events_calendar_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_modern_events_calendar_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_paid_membership_pro_code_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_paid_membership_pro_code_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_registrationmagic_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_secure_copy_content_protection_sqli.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/http/wp_total_upkeep_downloader.rb
+++ b/modules/auxiliary/scanner/http/wp_total_upkeep_downloader.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::TcpServer
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/server/capture/vnc.rb
+++ b/modules/auxiliary/server/capture/vnc.rb
@@ -1,4 +1,3 @@
-require 'metasploit/framework/hashes'
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 

--- a/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
+++ b/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 

--- a/modules/post/bsd/gather/hashdump.rb
+++ b/modules/post/bsd/gather/hashdump.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::Priv

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::Priv

--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'unix_crypt'
-require 'metasploit/framework/hashes'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Linux::Priv

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'metasploit/framework/credential_collection'
-require 'metasploit/framework/hashes'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Common

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasploit/framework/hashes'
-
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Solaris::Priv

--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -2,7 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require 'metasploit/framework/hashes'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::NetAPI

--- a/spec/lib/metasploit/framework/hashes/identify_spec.rb
+++ b/spec/lib/metasploit/framework/hashes/identify_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'metasploit/framework/hashes'
 require 'bcrypt'
 
 =begin


### PR DESCRIPTION
Fixes a crash when modules relied on a hash identifying method that wasn't always available. This method is now available as expected and modules will no longer crash.

```
>> Metasploit::Framework::Hashes.identify_hash('$2a$05$LhayLxezLhK1LhWvKxCyLOj0j1u.Kj0jZ0pEmm134uzrQlFvQJLF6')
(irb):1:in `<main>': uninitialized constant Metasploit::Framework::Hashes (NameError)
```

Spotted as part of https://github.com/rapid7/metasploit-framework/pull/17353#issuecomment-1505058937

## Verification

Ensure the hashes helper is available from within Metasploit console:

```
msf6 exploit(multi/handler) > irb
[*] Starting IRB shell...
[*] You are in exploit/multi/handler
>> Metasploit::Framework::Hashes.identify_hash('$2a$05$LhayLxezLhK1LhWvKxCyLOj0j1u.Kj0jZ0pEmm134uzrQlFvQJLF6')
=> "bf"
```