### PR TITLE
Add ensure disconnect to ftp login module, ftp timeout configuration

### DIFF
--- a/lib/metasploit/framework/login_scanner/ftp.rb
+++ b/lib/metasploit/framework/login_scanner/ftp.rb
@@ -44,8 +44,9 @@ module Metasploit
           rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             success = false
+          ensure
+            disconnect
           end
-
 
           if success
             result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -42,7 +42,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptBool.new('SINGLE_SESSION', [ false, 'Disconnect after every login attempt', false])
+        OptBool.new('SINGLE_SESSION', [ false, 'Disconnect after every login attempt', false]),
+        OptInt.new('CONNECTION_TIMEOUT', [true, 'Connection timeout for the FTP login scanner', 30])
       ]
     )
 
@@ -69,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
-        connection_timeout: 30,
+        connection_timeout: datastore['CONNECTION_TIMEOUT'],
         ftp_timeout: datastore['FTPTimeout'],
         framework: framework,
         framework_module: self,

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -70,6 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
         connection_timeout: 30,
+        ftp_timeout: datastore['FTPTimeout'],
         framework: framework,
         framework_module: self,
         ssl: datastore['SSL'],


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/17791

Paired with @adfoster-r7 

Ensures that sockets are being closed when using `ftp_login` module.
Additionally, adds ability to set `ftp_timeout` for this module in options prior to run.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] run against either netcat or a real server
- [ ] ensure that the server's connection closes after run (via `lsof`, etc)

For debugging we ran against a ncat server:

```
metasploit-framework % ncat -lnvp 2000
\Ncat: Version 7.93 ( https://nmap.org/ncat )
Ncat: Listening on :::2000
Ncat: Listening on 0.0.0.0:2000
```

Run the metasploit module:


```
msf6 auxiliary(scanner/ftp/ftp_login) > time run rhosts=127.0.0.1 rport=2000 username=zgoldman password=pass ftptimeout=3

[*] 127.0.0.1:2000        - 127.0.0.1:2000 - Starting FTP login sweep
[!] 127.0.0.1:2000        - No active DB -- Credential data will not be saved!
[-] 127.0.0.1:2000        - 127.0.0.1:2000 - LOGIN FAILED: zgoldman:pass (Incorrect: )
[*] 127.0.0.1:2000        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
[+] Command "run rhosts=127.0.0.1 rport=2000 username=zgoldman password=pass ftptimeout=3" completed in 6.047376000002259 seconds
```

You can see Metasploit connected to the ncat bind, and attempted to authenticate:

```
metasploit-framework % ncat -lnvp 2000
\Ncat: Version 7.93 ( https://nmap.org/ncat )
Ncat: Listening on :::2000
Ncat: Listening on 0.0.0.0:2000
Ncat: Connection from 127.0.0.1.
Ncat: Connection from 127.0.0.1:49475.
USER zgoldman
```

### Before

The file descriptors are not closed after the module completes:

```
zgoldman@AUS-MBP-10311 metasploit-framework % lsof -i :2000
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ruby    32353 zgoldman   15u  IPv4 0xd34de6bc98106953      0t0  TCP localhost:65320->localhost:callbook (ESTABLISHED)
ncat    41191 zgoldman    5u  IPv4 0xd34de6bc973cc643      0t0  TCP localhost:callbook->localhost:65320 (ESTABLISHED)
```

###  After

The file descriptors are now closed correctly:

```
zgoldman@AUS-MBP-10311 metasploit-framework % lsof -i :2000
zgoldman@AUS-MBP-10311 metasploit-framework % 
```