### PR TITLE
Before running tests ensure database is migrated

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,10 @@ if load_metasploit
       require f
     }
   end
+
+  # Fail the test suite if the test environment database has not been migrated
+  migration_manager = Class.new.extend(Msf::DBManager::Migration)
+  fail "Run `RAILS_ENV=test rake db:migrate` before running tests" if migration_manager.needs_migration?
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Adds database migration validation before attempting to run the test suite. Users who have not migrated their local test database will be notified of the steps required to resolve this issue.

### Before

Tests fail due to mysterious reasons

### After

The user is now notified about pending migrations when attempting run the test suite

## Verification

- Roll back the latest migration: `bundle exec rake db:rollback RAILS_ENV=test`
- Verify the error is present:
```
$ bundle exec rspec spec/lib/msf/core/auxiliary/brocade_spec.rb
...
An error occurred while loading spec_helper.
Failure/Error: fail "Run `RAILS_ENV=test rake db:migrate` before running tests" if migration_manager.needs_migration?

RuntimeError:
  Run `RAILS_ENV=test rake db:migrate` before running tests

```
- Migrate to the latest migration: `bundle exec rake db:migrate RAILS_ENV=test`
- Verify the error is not present
```
$ bundle exec rspec spec/lib/msf/core/auxiliary/brocade_spec.rb 
....
Finished in 5.55 seconds (files took 5.71 seconds to load)
8 examples, 0 failures
```