### PR TITLE
Msf::Ui::Console::CommandDispatcher::Core: Fix 'help setg' output

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -97,12 +97,12 @@ class Core
     ["-d", "--delete-all"]     => [ false, "Delete saved options for all modules from the config file."                     ])
 
   # set command options
-  @@set_opts = Rex::Parser::Arguments.new(
+  @@setg_opts = Rex::Parser::Arguments.new(
     ["-h", "--help"] => [ false, "Help banner."],
     ["-c", "--clear"] => [ false, "Clear the values, explicitly setting to nil (default)"]
   )
 
-  @@set_opts = Rex::Parser::Arguments.new(
+  @@set_opts = @@setg_opts.merge(
     ["-g", "--global"] => [ false, "Operate on global datastore variables"]
   )
 
@@ -111,7 +111,6 @@ class Core
     ["-h", "--help"] => [ false, "Help banner."],
   )
 
-  # unset command options
   @@unset_opts = @@unsetg_opts.merge(
     ["-g", "--global"] => [ false, "Operate on global datastore variables"]
   )


### PR DESCRIPTION
Fixes #17887.

I presume the intention for `setg` was to mimic the `set` implementation. That is, identical output for `set[g]` as `unset[g]`, with the non-global variants also displaying help for a `-g` flag to set the value the globally (as this would be redundant help when invoking the global variants).


# Before

```
msf6 > help set
Usage: set [options] [name] [value]

Set the given option to value.  If value is omitted, print the current value.
If both are omitted, print options that are currently set.

If run from a module context, this will set the value in the module's
datastore.  Use -g to operate on the global datastore.

If setting a PAYLOAD, this command can take an index from `show payloads'.

OPTIONS:

    -g, --global  Operate on global datastore variables
```

```
msf6 > help setg
Usage: setg [option] [value]

Exactly like set -g, set a value in the global datastore.
[-] Error while running command help: uninitialized class variable @@setg_opts in Msf::Ui::Console::CommandDispatcher::Core
Did you mean?  @@unsetg_opts
               @@set_opts
               @@unset_opts
               @@save_opts

Call stack:
/root/Desktop/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2013:in `cmd_setg_help'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:184:in `block in cmd_help'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:176:in `each'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:176:in `cmd_help'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/root/Desktop/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/root/Desktop/metasploit-framework/lib/rex/ui/text/shell.rb:168:in `run'
/root/Desktop/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/root/Desktop/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```


# After

```
msf6 > help set
Usage: set [options] [name] [value]

Set the given option to value.  If value is omitted, print the current value.
If both are omitted, print options that are currently set.

If run from a module context, this will set the value in the module's
datastore.  Use -g to operate on the global datastore.

If setting a PAYLOAD, this command can take an index from `show payloads'.

OPTIONS:

    -c, --clear   Clear the values, explicitly setting to nil (default)
    -g, --global  Operate on global datastore variables
    -h, --help    Help banner.
```

```
msf6 > help setg
Usage: setg [option] [value]

Exactly like set -g, set a value in the global datastore.

OPTIONS:

    -c, --clear  Clear the values, explicitly setting to nil (default)
    -h, --help   Help banner.
```
