### PR TITLE
Adds support for attic label on issues

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -191,6 +191,14 @@ jobs:
                     Closing this issue. If you believe this issue has been closed in error, please provide any relevant output and logs which may be useful in diagnosing the issue.
                   `
                 },
+                attic: {
+                  close: true,
+                  comment: `
+                    Thanks for your contribution to Metasploit Framework! We've looked at this issue, and we agree that it seems like a good issue to resolve - however we do not currently have the bandwidth to prioritize this issue.
+            
+                    We've labeled this as \`attic\` and closed it for now. If you believe this issue has been closed in error, or that it should be prioritized, please comment with additional information.
+                    `
+                }
               }
             };
 


### PR DESCRIPTION
Adds support for attic labels on Metasploit Framework issues.


Tested on a dummy [repo](https://github.com/cgranleese-r7/test-label/issues/1):
![image](https://user-images.githubusercontent.com/69522014/232487748-3eeeb685-224d-4d74-9668-b90789e1586d.png)


## Verification

List the steps needed to make sure this thing works

- [ ] Ensure all goes green
- [ ] Verify code changes are sane

