### PR TITLE
Add lazy loading for payloads on startup

### DIFF
--- a/lib/msf/base/simple/framework/module_paths.rb
+++ b/lib/msf/base/simple/framework/module_paths.rb
@@ -48,7 +48,7 @@ module Msf
 
           # Load each of the module paths
           allowed_module_paths.each do |path|
-            self.modules.add_module_path(path, opts)
+            self.modules.add_module_path(path, opts, recalculate: false)
           end
 
           @module_paths_inited = true

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -83,6 +83,19 @@ module Msf
       # The path from which the module was loaded.
       #
       attr_accessor :file_path
+
+      # @return [String, nil] Reference name of the payload being adapted
+      attr_accessor :adapted_refname
+
+      # @return [String, nil] Reference name of the payloads adapter
+      attr_accessor :adapter_refname
+
+      # @return [String, nil] Reference name of the payload stage
+      attr_accessor :stage_refname
+
+      # @return [String, nil] Reference name of the payloads stager
+      attr_accessor :stager_refname
+
     end
 
     #
@@ -205,6 +218,26 @@ module Msf
     #
     def file_path
       self.class.file_path
+    end
+
+    # @return [String, nil] Reference name of the payload being adapted
+    def adapted_refname
+      self.class.adapted_refname
+    end
+
+    # @return [String, nil] Reference name of the payloads adapter
+    def adapter_refname
+      self.class.adapter_refname
+    end
+
+    # @return [String, nil] Reference name of the payload stage
+    def stage_refname
+      self.class.stage_refname
+    end
+
+    # @return [String, nil] Reference name of the payloads stager
+    def stager_refname
+      self.class.stager_refname
     end
 
     #

--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -83,7 +83,7 @@ module Msf::Module::ModuleInfo
   #
   def merge_check_key(info, name, val)
     if (self.respond_to?("merge_info_#{name.downcase}", true))
-      eval("merge_info_#{name.downcase}(info, val)")
+      self.send("merge_info_#{name.downcase}", info, val)
     else
       # If the info hash already has an entry for this name
       if (info[name])

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -161,7 +161,7 @@ module Msf::ModuleManager::Loading
   # @option options [Array] :modules An array of regex patterns to search for specific modules
   # @return [Hash{String => Integer}] Maps module type to number of modules loaded
   def load_modules(path, options={})
-    options.assert_valid_keys(:force, :whitelist)
+    options.assert_valid_keys(:force, :whitelist, :recalculate)
 
     count_by_type = {}
 

--- a/lib/msf/core/module_manager/module_paths.rb
+++ b/lib/msf/core/module_manager/module_paths.rb
@@ -16,7 +16,7 @@ module Msf::ModuleManager::ModulePaths
   # @param [Hash] opts
   # @option opts [Array] whitelist An array of regex patterns to search for specific modules
   # @return (see Msf::Modules::Loader::Base#load_modules)
-  def add_module_path(path, opts={})
+  def add_module_path(path, opts={}, recalculate: true)
     nested_paths = []
 
     # remove trailing file separator
@@ -38,7 +38,7 @@ module Msf::ModuleManager::ModulePaths
     # Load all of the modules from the nested paths
     count_by_type = {}
     nested_paths.each { |path|
-      path_count_by_type = load_modules(path, opts.merge({:force => false}))
+      path_count_by_type = load_modules(path, opts.merge({:force => false, recalculate: recalculate}))
 
       # merge hashes
       path_count_by_type.each do |type, path_count|

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -34,17 +34,12 @@ class Msf::ModuleSet < Hash
   # @param reference_name [String] The module reference name.
   # @return [Msf::Module,nil] Instance of the named module or nil if it
   #   could not be created.
-  def create(reference_name)
+  def create(reference_name, cache_type: Msf::ModuleManager::Cache::FILESYSTEM)
     klass = fetch(reference_name, nil)
     instance = nil
-
-    # If there is no module associated with this class, then try to demand
-    # load it.
+    # If there is no module associated with this class, then try to demand load it.
     if klass.nil? or klass == Msf::SymbolicModule
-      if framework.modules.load_cached_module(module_type, reference_name) || empty?
-        recalculate
-      end
-
+      framework.modules.load_cached_module(module_type, reference_name, cache_type: cache_type)
       klass = fetch(reference_name, nil)
     end
 

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -107,12 +107,17 @@ class Msf::Modules::Loader::Base
   #
   # @see #read_module_content
   # @see Msf::ModuleManager::Loading#file_changed?
-  def load_module(parent_path, type, module_reference_name, options={})
-    options.assert_valid_keys(:count_by_type, :force, :recalculate_by_type, :reload)
+  def load_module(parent_path, type, module_reference_name, options = {})
+    options.assert_valid_keys(:count_by_type, :force, :recalculate_by_type, :reload, :cached_metadata)
     force = options[:force] || false
     reload = options[:reload] || false
 
-    module_path = self.module_path(parent_path, type, module_reference_name)
+    if options[:cached_metadata]
+      module_path = options[:cached_metadata].path
+    else
+      module_path = self.module_path(parent_path, type, module_reference_name)
+    end
+
     file_changed = module_manager.file_changed?(module_path)
 
     unless force or file_changed
@@ -123,7 +128,7 @@ class Msf::Modules::Loader::Base
 
     reload ||= force || file_changed
 
-    module_content = read_module_content(parent_path, type, module_reference_name)
+    module_content = read_module_content_from_path(module_path)
 
     if module_content.empty?
       # read_module_content is responsible for calling {#load_error}, so just return here.
@@ -207,7 +212,8 @@ class Msf::Modules::Loader::Base
             'paths' => [
                 module_reference_name
             ],
-            'type' => type
+            'type' => type,
+            'cached_metadata' => options[:cached_metadata]
         }
     )
 
@@ -242,7 +248,7 @@ class Msf::Modules::Loader::Base
   # @return [Hash{String => Integer}] Maps module type to number of
   #   modules loaded
   def load_modules(path, options={})
-    options.assert_valid_keys(:force)
+    options.assert_valid_keys(:force, :recalculate)
 
     force = options[:force]
     count_by_type = {}
@@ -258,11 +264,12 @@ class Msf::Modules::Loader::Base
           :force => force
       )
     end
-
-    recalculate_by_type.each do |type, recalculate|
-      if recalculate
-        module_set = module_manager.module_set(type)
-        module_set.recalculate
+    if options[:recalculate]
+      recalculate_by_type.each do |type, recalculate|
+        if recalculate
+          module_set = module_manager.module_set(type)
+          module_set.recalculate
+        end
       end
     end
 
@@ -578,6 +585,16 @@ class Msf::Modules::Loader::Base
   # @param module_reference_name (see #load_module)
   # @return [String] module content that can be module_evaled into the {#create_namespace_module}
   def read_module_content(parent_path, type, module_reference_name)
+    raise ::NotImplementedError
+  end
+
+  # Read the content of a module
+  #
+  # @abstract Override to read the module content based on the method of the loader subclass and return a string.
+  #
+  # @param full_path Path to the module to be read
+  # @return [String] module content that can be module_evaled into the {#create_namespace_module}
+  def read_module_content_from_path(full_path)
     raise ::NotImplementedError
   end
 

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -73,6 +73,14 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   def read_module_content(parent_path, type, module_reference_name)
     full_path = module_path(parent_path, type, module_reference_name)
 
+    read_module_content_from_path(full_path)
+  end
+
+  # Loads the module content from the on disk file.
+  #
+  # @param (see Msf::Modules::Loader::Base#read_module_content_from_path)
+  # @return (see Msf::Modules::Loader::Base#read_module_content_from_path)
+  def read_module_content_from_path(full_path)
     module_content = ''
 
     begin

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -81,6 +81,15 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
   # @return (see Msf::Modules::Loader::Base#read_module_content)
   def read_module_content(parent_path, type, module_reference_name)
     full_path = module_path(parent_path, type, module_reference_name)
+
+    read_module_content_from_path(full_path)
+  end
+
+  # Loads the module content from the on disk file.
+  #
+  # @param (see Msf::Modules::Loader::Base#read_module_content_from_path)
+  # @return (see Msf::Modules::Loader::Base#read_module_content_from_path)
+  def read_module_content_from_path(full_path)
     unless File.executable?(full_path)
       load_error(full_path, Errno::ENOENT.new)
       return ''

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -34,6 +34,12 @@ class Cache
     }
   end
 
+  def get_module_reference(type:, reference_name:)
+    @mutex.synchronize do
+      wait_for_load
+      @module_metadata_cache["#{type}_#{reference_name}"]
+    end
+  end
   #
   # Checks for modules loaded that are not a part of the cache and updates the underlying store
   # if there are changes.
@@ -49,7 +55,7 @@ class Cache
           next if unchanged_reference_name_set.include? mn
 
           begin
-            module_instance = mt[1].create(mn)
+            module_instance = mt[1].create(mn, cache_type: Msf::ModuleManager::Cache::MEMORY)
           rescue Exception => e
             elog "Unable to create module: #{mn}. #{e.message}"
           end

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -56,6 +56,18 @@ class Obj
   attr_reader :notes
   # @return [Array<String>]
   attr_reader :session_types
+  # @return [Integer] The type of payload, e.g. Single, Stager, Adapter
+  attr_reader :payload_type
+  # @return [String, nil] Name of the adapter if applicable
+  attr_reader :adapter_refname
+  # @return [String, nil] Name of the adapted payload if applicable
+  attr_reader :adapted_refname
+  # @return [Boolean] Whether or not the payload is staged
+  attr_reader :staged
+  # @return [String, nil] Name of the stage if applicable
+  attr_reader :stage_refname
+  # @return [String, nil] Name of the stager if applicable
+  attr_reader :stager_refname
 
   def initialize(module_instance, obj_hash = nil)
     unless obj_hash.nil?
@@ -110,6 +122,19 @@ class Obj
 
     @session_types = module_instance.respond_to?(:session_types) && module_instance.session_types
 
+    if module_instance.respond_to?(:payload_type)
+      @payload_type = module_instance.payload_type
+      @staged = module_instance.staged?
+    end
+    if @staged
+      @stage_refname = module_instance.stage_refname
+      @stager_refname = module_instance.stager_refname
+    end
+    if @payload_type == Payload::Type::Adapter
+      @adapter_refname = module_instance.adapter_refname
+      @adapted_refname = module_instance.adapted_refname
+    end
+
     # Due to potentially non-standard ASCII we force UTF-8 to ensure no problem with JSON serialization
     force_encoding(::Encoding::UTF_8)
   end
@@ -118,7 +143,7 @@ class Obj
   # Returns the JSON representation of the module metadata
   #
   def to_json(*args)
-    {
+    data = {
       'name'               => @name,
       'fullname'           => @fullname,
       'aliases'            => @aliases,
@@ -143,8 +168,23 @@ class Obj
       'default_credential' => @default_credential,
       'notes'              => @notes,
       'session_types'      => @session_types,
-      'needs_cleanup'      => @needs_cleanup
-    }.to_json(*args)
+      'needs_cleanup'      => @needs_cleanup,
+    }
+
+    if @payload_type
+      payload_data = {
+        'payload_type'       => @payload_type,
+        'adapter_refname'    => @adapter_refname,
+        'adapted_refname'    => @adapted_refname,
+        'adapted'            => @adapted,
+        'staged'             => @staged,
+        'stage_refname'      => @stage_refname,
+        'stager_refname'     => @stager_refname,
+      }.compact
+      data.merge!(payload_data)
+    end
+
+    data.to_json(*args)
   end
 
   #
@@ -174,7 +214,7 @@ class Obj
     @name                = obj_hash['name']
     @fullname            = obj_hash['fullname']
     @aliases             = obj_hash['aliases'] || []
-    @disclosure_date     = obj_hash['disclosure_date'].nil? ? nil : Date.parse(obj_hash['disclosure_date'])
+    @disclosure_date     = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
     @rank                = obj_hash['rank']
     @type                = obj_hash['type']
     @description         = obj_hash['description']
@@ -196,6 +236,12 @@ class Obj
     @session_types       = obj_hash['session_types']
     @autofilter_ports    = obj_hash['autofilter_ports']
     @autofilter_services = obj_hash['autofilter_services']
+    @payload_type        = obj_hash['payload_type']
+    @adapter_refname     = obj_hash['adapter_refname']
+    @adapted_refname     = obj_hash['adapted_refname']
+    @staged              = obj_hash['staged']
+    @stage_refname       = obj_hash['stage_refname']
+    @stager_refname      = obj_hash['stager_refname']
   end
 
   def sort_platform_string


### PR DESCRIPTION
This PR includes the changes made in #17987 so land that one first

This PR aims to reduce the bootup time when starting up `msfconsole` by removing the need to `recalculate` all payloads.
To accomplish this I have added a handful of extra fields to the module metadata json file with information such as what handler the payload uses and if/what payload is being adapted so we can create these payloads on the fly.


Benchmark on master:
`hyperfine --export-json /dev/stdout  --warmup 3 "bundle exec ruby ./msfconsole -qx 'exit'"`
<img width="655" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/19910435/b7e1f6ce-cbfb-4918-88e5-21387087c263">


Benchmark on this PR:
`hyperfine --export-json /dev/stdout  --warmup 3 "bundle exec ruby ./msfconsole -qx 'exit'"`
<img width="657" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/19910435/774b4bfa-0270-479f-8815-65cf162cc372">


# Verification Steps
- [ ] CI passes
- [ ] you can boot up `msfconsole` 
- [ ] `use exploit/multi/handler` then `show payloads` all compatible payloads should appear (should be identical to master)
- [ ] Follow the previous step for an array of modules checking that only compatible payloads are shown
- [ ] `use payload/windows/x64/meterpreter/reverse_tcp` and then `generate`
- [ ] Follow previous step for multiple other payloads and check they are available and generate correctly
- [ ] Check that generating the same payloads via `msfvenom` also works
- [ ] `loadpath test/modules` or any other path with modules, check all modules are available and working as intended
- [ ] check any payloads added to `~/.msf4/modules/` work as expected
- [ ] run `time unknown_command` and check it's roughy in line with master `[+] Command "unknown_command" completed in 0.006908999988809228 seconds` was my result on master your mileage may vary
- [ ] Run through manual and automated testing for Metasploit Pro

# Known Issues
- `./msfconsole --defer-module-loads` results in some weirdness where you can select `exploit/multi/handler` but are unable to show/select any payloads for it, but currently on master you are just unable to even use `exploit/multi/handler` in the first place so it doesn't feel like a regression to me
![image](https://user-images.githubusercontent.com/19910435/232621084-392c1837-283b-4317-963f-c6ae272c5057.png)
![image](https://user-images.githubusercontent.com/19910435/232621141-4a77336e-ceec-4ee8-9a13-7090996e3c7f.png)
I would like to tackle this issue after this PR lands since deferring module loads will knock the bootup time down even further
