### PR TITLE
Add missing fields when reading metadata cache

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -36,7 +36,7 @@ class Obj
   attr_reader :autofilter_ports
   # @return [Array<String>]
   attr_reader :autofilter_services
-  # @return [Array<String>]
+  # @return [Array<String>, nil]
   attr_reader :targets
   # @return [Time]
   attr_reader :mod_time
@@ -174,7 +174,7 @@ class Obj
     @name                = obj_hash['name']
     @fullname            = obj_hash['fullname']
     @aliases             = obj_hash['aliases'] || []
-    @disclosure_date     = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
+    @disclosure_date     = obj_hash['disclosure_date'].nil? ? nil : Date.parse(obj_hash['disclosure_date'])
     @rank                = obj_hash['rank']
     @type                = obj_hash['type']
     @description         = obj_hash['description']

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -171,30 +171,31 @@ class Obj
   #######
 
   def init_from_hash(obj_hash)
-    @name               = obj_hash['name']
-    @fullname           = obj_hash['fullname']
-    @aliases            = obj_hash['aliases'] || []
-    @disclosure_date    = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
-    @rank               = obj_hash['rank']
-    @type               = obj_hash['type']
-    @description        = obj_hash['description']
-    @author             = obj_hash['author'].nil? ? [] : obj_hash['author']
-    @references         = obj_hash['references']
-    @platform           = obj_hash['platform']
-    @arch               = obj_hash['arch']
-    @rport              = obj_hash['rport']
-    @mod_time           = Time.parse(obj_hash['mod_time'])
-    @ref_name           = obj_hash['ref_name']
-    @path               = obj_hash['path']
-    @is_install_path    = obj_hash['is_install_path']
-    @targets            = obj_hash['targets'].nil? ? [] : obj_hash['targets']
-    @check              = obj_hash['check'] ? true : false
-    @post_auth          = obj_hash['post_auth']
-    @default_credential = obj_hash['default_credential']
-    @notes              = obj_hash['notes'].nil? ? {} : obj_hash['notes']
-    @needs_cleanup      = obj_hash['needs_cleanup']
-    @session_types      = obj_hash['session_types']
-
+    @name                = obj_hash['name']
+    @fullname            = obj_hash['fullname']
+    @aliases             = obj_hash['aliases'] || []
+    @disclosure_date     = obj_hash['disclosure_date'].nil? ? nil : Time.parse(obj_hash['disclosure_date'])
+    @rank                = obj_hash['rank']
+    @type                = obj_hash['type']
+    @description         = obj_hash['description']
+    @author              = obj_hash['author'].nil? ? [] : obj_hash['author']
+    @references          = obj_hash['references']
+    @platform            = obj_hash['platform']
+    @arch                = obj_hash['arch']
+    @rport               = obj_hash['rport']
+    @mod_time            = Time.parse(obj_hash['mod_time'])
+    @ref_name            = obj_hash['ref_name']
+    @path                = obj_hash['path']
+    @is_install_path     = obj_hash['is_install_path']
+    @targets             = obj_hash['targets']
+    @check               = obj_hash['check'] ? true : false
+    @post_auth           = obj_hash['post_auth']
+    @default_credential  = obj_hash['default_credential']
+    @notes               = obj_hash['notes'].nil? ? {} : obj_hash['notes']
+    @needs_cleanup       = obj_hash['needs_cleanup']
+    @session_types       = obj_hash['session_types']
+    @autofilter_ports    = obj_hash['autofilter_ports']
+    @autofilter_services = obj_hash['autofilter_services']
   end
 
   def sort_platform_string


### PR DESCRIPTION
Recommend viewing this one with whitespace differences off

Spotted some weird inconsistencies when comparing my local module metadata cache to the base metadata cache that comes from framework
<img width="658" alt="image" src="https://user-images.githubusercontent.com/19910435/232626754-cde2bdb5-34c0-4860-ba45-581a643e1f2c.png">

You can see the missing fields `autofilter_ports` and `autofilter_services` turns out they were never being read correctly from the cache in the first place so this PR adds them in
I also noticed that when the target was `null` it was flipping it to an empty array, I made the local cache consistent with what is currently in `db/modules_metadata_base.json` but I'm happy to make them both empty arrays instead of both being null

# Verification steps
- [ ] run `msfconsole` 
- [ ] run `git diff db/modules_metadata_base.json ~/.msf4/store/modules_metadata.json`
- [ ] the only differences you should see are the updates to the `mod_time` 
