### PR TITLE
Remove active database check for module cache rebuild

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -160,7 +160,7 @@ class Driver < Msf::Ui::Driver
       self.framework.init_module_paths(module_paths: opts['ModulePath'])
     end
 
-    if framework.db && framework.db.active && framework.db.is_local? && !opts['DeferModuleLoads']
+    unless opts['DeferModuleLoads']
       framework.threads.spawn("ModuleCacheRebuild", true) do
         framework.modules.refresh_cache_from_module_files
       end


### PR DESCRIPTION
The module metadata cache used to use the database so this check made sense, the cache has since been moved to a json file so no longer needs the db so a check for a database is no longer needed

I don't expect this to impact pro, while it does have a database based cache it uses a different mechanism here: https://github.com/rapid7/metasploit-framework/blob/90d4b660f7ca664b5a6cfb49961fcb88f8255ae3/lib/msf/core/db_manager/module_cache.rb#L255-L323

# Verification steps
- [ ] Shut down your db
- [ ] Run `msfconsole` 
- [ ] Check your cache to see if it rebuilt
- [ ] Verify against pro (just to be sure)