### PR TITLE
Update ftp login connect timeout option name

### DIFF
--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -30,7 +30,10 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '1999-0502'] # Weak password
         ],
-      'License'     => MSF_LICENSE
+      'License'     => MSF_LICENSE,
+      'DefaultOptions' => {
+        'ConnectTimeout' => 30
+      }
     )
 
     register_options(
@@ -43,7 +46,6 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         OptBool.new('SINGLE_SESSION', [ false, 'Disconnect after every login attempt', false]),
-        OptInt.new('CONNECTION_TIMEOUT', [true, 'Connection timeout for the FTP login scanner', 30])
       ]
     )
 
@@ -70,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
-        connection_timeout: datastore['CONNECTION_TIMEOUT'],
+        connection_timeout: datastore['ConnectTimeout'],
         ftp_timeout: datastore['FTPTimeout'],
         framework: framework,
         framework_module: self,


### PR DESCRIPTION
Updates https://github.com/rapid7/metasploit-framework/pull/17873 to use the existing `ConnectTimeout` naming convention instead of `CONNECTION_TIMEOUT`

## Verification

Steps are the same as https://github.com/rapid7/metasploit-framework/pull/17873

But you should be able to see that with the `show advanced` command that the `ConnectTimeout` datastore option already exists, and now has a default value of 30 as per the previous module behavior:


```
msf6 auxiliary(scanner/ftp/ftp_login) > advanced

Module advanced options (auxiliary/scanner/ftp/ftp_login):

   Name                     Current Setting  Required  Description
   ----                     ---------------  --------  -----------
   CHOST                                     no        The local client address
   CPORT                                     no        The local client port
   vvvvvvvvvvvvvv
   ConnectTimeout           30               yes       Maximum number of seconds to establish a TCP connection
   ^^^^^^^^^^^^^^
```