### PR TITLE
Fix Windows7 Meterpreter crash when in debug mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.125)
+      metasploit-payloads (= 2.0.126)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -254,7 +254,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.125)
+    metasploit-payloads (2.0.126)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/docs/metasploit-framework.wiki/Meterpreter-Debugging-Meterpreter-Sessions.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Debugging-Meterpreter-Sessions.md
@@ -83,7 +83,7 @@ php shell_http.php
 
 ```
 use windows/x64/meterpreter_reverse_tcp
-generate -f exe -o shell.exe MeterpreterDebugBuild=true MeterpreterDebugLogging='rpath:C:/test/foo.txt'
+generate -f exe -o shell.exe MeterpreterDebugBuild=true MeterpreterDebugLogging='rpath:C:/Windows/Temp/foo.txt'
 
 to_handler
 ```

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.125'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.126'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Landing the work of https://github.com/rapid7/metasploit-payloads/pull/636

Fixes a crash when running Meterpreter with debug logging on Windows 7

## Verification

Build a debug build:
```
use windows/x64/meterpreter_reverse_tcp
generate -f exe -o shell.exe MeterpreterDebugBuild=true MeterpreterDebugLogging='rpath:C:/Windows/Temp/foo.txt'
```

Run the handler:
```
to_handler
```

Open on Windows 7 and Windows 10, verify that the logging works:

```
C:\WINDOWS\system32>type C:\Windows\Temp\foo.txt | more
[21d0] [METSRV] Getting ready to init with config 0000000140048200
[21d0] [SERVER] Initializing from configuration: 0x0000000140048200
[21d0] [SESSION] Comms handle: 0
[21d0] [SESSION] Expiry: 604800
[21d0] [SERVER] UUID: 7c3bd7532a48f27f4889498b2cc94486
[21d0] [SERVER] Session GUID: 00000000-0000-0000-0000-000000000000
[21d0] [SERVER] main server thread: handle=0x0000017C id=0x000021D0 sigterm=0x00542E80
[21d0] [REMOTE] remote created 0000000000542420
[21d0] [DISPATCH] Session going for 604800 seconds from 1681919014 to 1682523814
... etc ...
```