### PR TITLE
Fixes `couchdb_login`'s login logic

### DIFF
--- a/documentation/modules/auxiliary/scanner/couchdb/couchdb_login.md
+++ b/documentation/modules/auxiliary/scanner/couchdb/couchdb_login.md
@@ -2,7 +2,35 @@
 
 Apache CouchDB is a nosql database server which communicates over HTTP.  This module will enumerate the server and databases hosted on it.
 
-The following was done on Ubuntu 16.04, and is largely base on [1and1.com](https://www.1and1.com/cloud-community/learn/database/couchdb/install-and-use-couchdb-on-ubuntu-1604/):
+### Docker setup
+  1. `docker run -p 5984:5984 --env COUCHDB_USER=admin --env COUCHDB_PASSWORD=password apache/couchdb:3.3.1`
+     After running this command you will see the server is returning errors, to resolve this we must run some cURL commands.
+
+  2. In another window, after startup, run the following three cURL commands:
+   ```
+   $ curl localhost:5984
+   {"couchdb":"Welcome","version":"2.1.1","features":["scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
+   ```
+   ```
+   $ curl -X PUT http://admin:password@localhost:5984/_users
+   {"ok":true}
+   ```
+   ```
+   $ curl -X PUT http://admin:password@localhost:5984/_replicator
+   {"ok":true}
+   ```
+   ```
+   $ curl -X PUT http://admin:password@localhost:5984/_global_changes
+   {"ok":true}
+   ```
+
+  After running these commands you should get the following response when accessing http://localhost:5984/.
+   ```
+  {"couchdb":"Welcome","version":"3.3.1","git_sha":"1fd50b82a","uuid":"bb8a05afa55cd9407a9532d05de65736","features":["access-ready","partitioned","pluggable-storage-engines","reshard","scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
+  ```
+
+### Ubuntu 16.04 Setup
+The following was done on Ubuntu 16.04, and is largely based on [1and1.com](https://www.1and1.com/cloud-community/learn/database/couchdb/install-and-use-couchdb-on-ubuntu-1604/):
   
   1. `sudo apt install software-properties-common`
   2. `sudo add-apt-repository ppa:couchdb/stable`


### PR DESCRIPTION
Fixes #17865

The linked issue had a diff from @bcoles with a potential fix but wasn't tested against a CouchDB environment. I patched in the diff and got a CouchDB environment setup and adding those setup steps to the `couchdb_login.md` docs. 

## Tests

### couchdb with a login present on the wordlist:
![image](https://user-images.githubusercontent.com/69522014/233325229-5e735303-76e9-4fcd-b171-89ae2fe930dc.png)

### couchdb without a login present on the wordlist
![image](https://user-images.githubusercontent.com/69522014/233325412-f99999b9-1a3c-4b6c-bc15-71d779e3f73c.png)

### no connection to couchdb
![image](https://user-images.githubusercontent.com/69522014/233325546-10eb6d37-f26d-47ab-85c5-618b2f97af3c.png)


## Verification

List the steps needed to make sure this thing works

- [ ] Get a couchdb docker container running - see new docs as part of this PR
- [ ] run `use auxiliary/scanner/couchdb/couchdb_login`
- [ ] run `set rhosts 127.0.0.1`
- [ ] complete the same tests outlined in above `tests` section