### PR TITLE
Update setting missing datastore values to a warning instead of an error

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1935,8 +1935,7 @@ class Core
       message = "Unknown datastore option: #{name}."
       suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
       message << " Did you mean #{suggestion}?" if suggestion
-      print_error(message)
-      return false
+      print_warning(message)
     end
 
     # If the driver indicates that the value is not valid, bust out.


### PR DESCRIPTION
Removes 'return false' to ensure that we don't break automation scripts, or the multi/handler workflow that might set a payload last, i.e. set PAYLOAD_OPTION ....; set payload ....

Fix based on this [conversation](https://github.com/rapid7/metasploit-framework/issues/17886#issuecomment-1510002329), which provides some more context.

## Verification

List the steps needed to make sure this thing works

- [ ] Verify code changes are sane