### PR TITLE
Bump payloads to 2.0.127

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.126)
+      metasploit-payloads (= 2.0.127)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -254,7 +254,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.126)
+    metasploit-payloads (2.0.127)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.126'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.127'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps payloads to take in the fix here: https://github.com/rapid7/metasploit-payloads/pull/630

Testing
- [ ] Let automated tests run
- [ ] Verify sanity tests pass