### PR TITLE
Fix crash when running local exploit suggester

### DIFF
--- a/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
+++ b/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
@@ -206,8 +206,7 @@ class MetasploitModule < Msf::Exploit::Local
   # WinRM is running, it returns 2. And if both are running, it returns
   # BITS + WINRM = 3.
   def check_bits_and_winrm
-    check_command = 'powershell.exe Get-Service -Name BITS,WinRM'
-    result = cmd_exec(check_command)
+    result = cmd_exec('cmd.exe', '/c echo . | powershell.exe Get-Service -Name BITS,WinRM')
     vprint_status('Checking if BITS and WinRM are stopped...')
 
     if result.include?('~~')


### PR DESCRIPTION
Improves https://github.com/rapid7/metasploit-framework/issues/17498

Fixes a crash when running local exploit suggester against older Windows targets

Context: The local exploit suggester currently crashes against older windows targets:

```
[msf](Jobs:0 Agents:1) post(multi/recon/local_exploit_suggester) >> run

[*] 10.129.23.11 - Collecting local exploits for x64/windows...
[*] 10.129.23.11 - 176 exploit checks are being tried...
[-] 10.129.23.11 - Post interrupted by the console user
[*] Post module execution completed
```

This was tracked down to the `bits_ntlm_token_impersonation` module when it's checking the bits/winrm version via powershell: 

https://github.com/rapid7/metasploit-framework/blob/eb12cfec0523df548bab650c7706b9d356d7dc1f/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb#L209-L210

I've applied the previous work arounds from:

- Fixing powershell command for Python https://github.com/rapid7/metasploit-framework/pull/8056/files
- Fixing powershell command for older OS versions https://github.com/rapid7/metasploit-framework/pull/3390/files

Examples with sessions:
1. Windows 10
2. Windows 7

Example windows 10; the prompt immediately returns:
```
meterpreter > execute -f powershell.exe -c -i -a 'whoami'
Process 7924 created.
Channel 7 created.
nt authority\system
meterpreter > 
```

Example windows 7; keeps the channel remains open until pressing enter:

```
meterpreter > execute -f powershell.exe -c -i -a 'whoami'
Process 2720 created.
Channel 21 created.
nt authority\system
```

It also turns out that with windows 10 you can enter into a working powershell session without the meterpreter powershell extension:

```
msf6 exploit(windows/local/bits_ntlm_token_impersonation) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > execute -f powershell.exe -c -i
Process 5680 created.
Channel 9 created.
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Try the new cross-platform PowerShell https://aka.ms/pscore6

PS C:\WINDOWS\system32> whoami
whoami
```

Whilst Windows 7 hangs:

```
msf6 exploit(windows/local/bits_ntlm_token_impersonation) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > execute -f powershell.exe -c -i
Process 2988 created.
Channel 23 created.
Windows PowerShell 
Copyright (C) 2009 Microsoft Corporation. All rights reserved.

```

Running `powershell.exe` directly times out:

```
msf6 > sessions -c 'powershell.exe whoami'
[*] Running 'powershell.exe whoami' on meterpreter session 1 (192.168.123.164)
nt authority\system
[*] Running 'powershell.exe whoami' on meterpreter session 2 (192.168.123.132)
[-] Operation timed out
```

Whilst the workaround works on older versions and newer versions of Windows:

```
msf6 exploit(windows/local/bits_ntlm_token_impersonation) > sessions -c 'cmd.exe /c echo . | powershell.exe whoami'
[*] Running 'cmd.exe /c echo . | powershell.exe whoami' on meterpreter session 1 (192.168.123.164)
nt authority\system            
[*] Running 'cmd.exe /c echo . | powershell.exe whoami' on meterpreter session 2 (192.168.123.132)
nt authority\system  
```

@bwatters-r7 Was able to verify the fix pattern worked across multiple windows boxes too:

<details>
<summary>Test lab output</summary>

```
Windows 7
=======================

msf6 payload(windows/meterpreter/reverse_tcp) > sessions -l

Active sessions
===============

  Id  Name  Type                     Information                        Connection
  --  ----  ----                     -----------                        ----------
  11        meterpreter x86/windows  WIN7X64-SP0\msfuser @ WIN7X64-SP0  10.5.135.201:4444 -> 10.5.134.178:49166 (10.5.134.178)
  12        meterpreter x86/windows  WIN7X64-SP1\msfuser @ WIN7X64-SP1  10.5.135.201:4444 -> 10.5.134.161:49173 (10.5.134.161)
  13        meterpreter x86/windows  WIN7X86-SP0\msfuser @ WIN7X86-SP0  10.5.135.201:4444 -> 10.5.134.134:49171 (10.5.134.134)
  14        meterpreter x86/windows  WIN7X86-SP1\msfuser @ WIN7X86-SP1  10.5.135.201:4444 -> 10.5.134.166:49172 (10.5.134.166)

msf6 payload(windows/meterpreter/reverse_tcp) > sessions -C sysinfo
[*] Running 'sysinfo' on meterpreter session 11 (10.5.134.178)
Computer        : WIN7X64-SP0
OS              : Windows 7 (6.1 Build 7600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
[*] Running 'sysinfo' on meterpreter session 12 (10.5.134.161)
Computer        : WIN7X64-SP1
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
[*] Running 'sysinfo' on meterpreter session 13 (10.5.134.134)
Computer        : WIN7X86-SP0
OS              : Windows 7 (6.1 Build 7600).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
[*] Running 'sysinfo' on meterpreter session 14 (10.5.134.166)
Computer        : WIN7X86-SP1
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
msf6 payload(windows/meterpreter/reverse_tcp) > sessions -c 'powershell.exe whoami'
[*] Running 'powershell.exe whoami' on meterpreter session 11 (10.5.134.178)
[-] Operation timed out
[*] Running 'powershell.exe whoami' on meterpreter session 12 (10.5.134.161)
[-] Operation timed out
[*] Running 'powershell.exe whoami' on meterpreter session 13 (10.5.134.134)
[-] Operation timed out
[*] Running 'powershell.exe whoami' on meterpreter session 14 (10.5.134.166)
[-] Operation timed out
msf6 payload(windows/meterpreter/reverse_tcp) > sessions -c 'cmd.exe /c echo . | powershell.exe whoami'
[*] Running 'cmd.exe /c echo . | powershell.exe whoami' on meterpreter session 11 (10.5.134.178)
win7x64-sp0\msfuser
[*] Running 'cmd.exe /c echo . | powershell.exe whoami' on meterpreter session 12 (10.5.134.161)
win7x64-sp1\msfuser
[*] Running 'cmd.exe /c echo . | powershell.exe whoami' on meterpreter session 13 (10.5.134.134)
win7x86-sp0\msfuser
[*] Running 'cmd.exe /c echo . | powershell.exe whoami' on meterpreter session 14 (10.5.134.166)
win7x86-sp1\msfuser
msf6 payload(windows/meterpreter/reverse_tcp) > 
```
</details>

And https://github.com/rapid7/metasploit-framework/pull/3390#issuecomment-44133851 confirmed that it worked with other tested versions too:

> The platforms I tested - PowerShell 2.0 on Windows 2003, Windows 7, Windows 2008 R2 as well as PowerShell 4.0 on Windows 2012 R2.

## Verification

Running against a 2008 R2 target should replicate this issue with the local exploit suggester; but the underlying issue impacts other operating systems such as windows 7 (shown above)

### Before

The module times out:

```
msf6 exploit(windows/local/bits_ntlm_token_impersonation) > rerun session=-1 verbose=true
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] Target session has either SeImpersonatePrivilege or SeAssignPrimaryTokenPrivilege.
[-] Exploit failed [user-interrupt]: Rex::TimeoutError Send timed out
[-] rerun: Interrupted
```

### After

The module runs:

```
msf6 exploit(windows/local/bits_ntlm_token_impersonation) > rerun session=-1 verbose=true
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] Target session has either SeImpersonatePrivilege or SeAssignPrimaryTokenPrivilege.
[*] Checking if BITS and WinRM are stopped...
[!] WinRM is currently running. It must be down for the exploit to succeed.
[-] WinRM is running. Target is not exploitable.
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
```