### PR TITLE
Fix paths for directory checks

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -156,7 +156,7 @@ module Msf::Post::File
       if session.platform == 'windows'
         f = cmd_exec("cmd.exe /C IF exist \"#{path}\\*\" ( echo true )")
       else
-        f = session.shell_command_token("test -d \"#{path}\" && echo true")
+        f = session.shell_command_token("test -d '#{path}' && echo true")
       end
       return false if f.nil? || f.empty?
       return false unless f =~ /true/

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Post
         'Description' => %q{ This module will test Post::File API methods },
         'License' => MSF_LICENSE,
         'Author' => [ 'egypt' ],
-        'Platform' => [ 'windows', 'linux', 'java' ],
+        'Platform' => [ 'windows', 'linux', 'unix', 'java' ],
         'SessionTypes' => [ 'meterpreter', 'shell' ]
       )
     )


### PR DESCRIPTION
The path C:\ ends with a trailing backslash which will cause bash to wait for more input when used with [`#directory?` ](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/post/file.rb#L159)because it escapes the trailing `"`. Switching the string to be in single quotes instead of double quotes eliminates this problem and is how other *nix arguments are escaped in commands.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a shell session on a Linux host (use `cmd/unix/reverse_bash` or something similar)
- [ ] Run `loadpath test/modules` to load the test modules
- [ ] Run the `post/test/file` module
- [ ] See that it works

## After this patch

```
msf6 post(test/file) > set SESSION -1
SESSION => -1
msf6 post(test/file) > run

[*] Running against session -1
[*] Session type is shell and platform is unix
[+] should test for directory existence
[+] should create directories
[+] should list the directory we just made
[+] should recursively delete the directory we just made
[+] should delete a symbolic link target
[+] should not recurse into symbolic link directories
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should expand home
[+] should not expand non-isolated tilde
[+] should not expand mid-string tilde
[+] should not expand env vars with invalid naming
[+] should expand multiple variables
[*] Passed: 21; Failed: 0
[*] Post module execution completed
msf6 post(test/file) > 
```

## Before this patch
```
msf6 post(test/file) > rerun
[*] Reloading module...

[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: unix
[*] Running against session -1
[*] Session type is shell and platform is unix
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[-] FAILED: should test for directory existence
[-] FAILED: should create directories
[-] FAILED: should list the directory we just made
[-] Exception: NoMethodError: undefined method `split' for nil:NilClass
[+] should recursively delete the directory we just made
[!] skipping link related checks because the target is incompatible
[-] FAILED: should write binary data
[-] Exception: RuntimeError: Can't find command on the victim for writing binary data
[-] FAILED: should read the binary data we just wrote
[-] Exception: NoMethodError: undefined method `length' for nil:NilClass
[+] should delete binary files
[-] FAILED: should append binary data
[-] Exception: RuntimeError: Can't find command on the victim for writing binary data
...
```
Everything times out after the directory check for `C:\`.
