### PR TITLE
Standardize NagiosXI Exploit Structure for Authentication Methods 

### DIFF
--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -79,11 +79,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     auth_cookies = extract_auth_cookies(res_array) # if we are here, this cannot be nil since the mixin checks for that already
     return 6, 'Failed to extract authentication cookies' unless auth_cookies.present?
 
-    nsp = get_nsp(res_array[0]) if handle_nsp
+    nsp = get_nsp(res_array[1]) if handle_nsp
     return 6, 'Failed to extract nsp string' if handle_nsp && !nsp.present?
 
     # Obtain the Nagios XI version
-    nagios_version = nagios_xi_version(res_array[0])
+    nagios_version = nagios_xi_version(res_array[1])
     if nagios_version.nil?
       return 7, 'Unable to obtain the Nagios XI version from the dashboard'
     end
@@ -251,10 +251,10 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return [5, [auth_cookies, nsp]]
     end
 
-    # Return the HTTP resonse body and the authentication cookies.
-    # The response body can be used to obtain the version number.
+    # Return the authentication cookies and the HTTP resonse body.
     # The cookies can be used by exploit modules to send authenticated requests.
-    [0, [res_index.body, auth_cookies]]
+    # The response body can be used to obtain the version number.
+    [0, [auth_cookies, res_index.body]]
 
   end
 
@@ -263,7 +263,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # @param res [Rex::Proto::Http::Response] HTTP response
   # @return [String, nil] auth_cookies value, nil if not found
   def extract_auth_cookies(res_array)
-    auth_cookies = res_array[1]
+    auth_cookies = res_array[0]
     return auth_cookies if auth_cookies && /nagiosxi=[a-z0-9]+;/.match(auth_cookies)
   end
 

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Auxiliary
       return rce_check(nagios_version_result, real_target: true)
     end
     
-    # Try to authenticate with nagios_xi_login. Error check with auth_result
+    # Authenticate to ensure we can access the NagiosXI version
     auth_result, err_msg, auth_cookies, version = authenticate(username, password, finish_install)
     case auth_result
     when AUTH_RESULTS[:connection_failed]

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Try to authenticate with nagios_xi_login. Error check with auth_result
+    # Authenticate to ensure we can access the NagiosXI version
     auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
     case auth_result
     when AUTH_RESULTS[:connection_failed]

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -85,8 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+    # Try to authenticate with nagios_xi_login. Error check with auth_result
     auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
     case auth_result
     when AUTH_RESULTS[:connection_failed]

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Try to authenticate with nagios_xi_login. Error check with auth_result
+    # Authenticate to ensure we can access the NagiosXI version
     auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
 
     case auth_result

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -113,8 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+    # Try to authenticate with nagios_xi_login. Error check with auth_result
     auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
 
     case auth_result

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Try to authenticate with nagios_xi_login. Error check with auth_result
+    # Authenticate to ensure we can access the NagiosXI version
     auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
     case auth_result
     when AUTH_RESULTS[:connection_failed]

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -86,8 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+    # Try to authenticate with nagios_xi_login. Error check with auth_result
     auth_result, err_msg, @auth_cookies, @version = authenticate(username, password, finish_install)
     case auth_result
     when AUTH_RESULTS[:connection_failed]

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -87,63 +87,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a GET request to index.php and the session cookies
-    login_result, res_array = nagios_xi_login(username, password, finish_install)
-    case login_result
-    when 1..3 # An error occurred
-      return CheckCode::Unknown(res_array[0])
-    when 4 # Nagios XI is not fully installed
-      install_result = install_nagios_xi(password)
-      if install_result
-        return CheckCode::Unknown(install_result[1])
-      end
-
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..3 # An error occurred
-        return CheckCode::Unknown(res_array[0])
-      when 4 # Nagios XI is still not fully installed
-        return CheckCode::Detected('Failed to install Nagios XI on the target.')
-      end
+    # Try to authenticate with nagios_xi_login. Error check with auth_result
+    auth_result, err_msg, auth_cookies, version = authenticate(username, password, finish_install)
+    case auth_result
+    when AUTH_RESULTS[:connection_failed]
+      return CheckCode::Unknown(err_msg)
+    when AUTH_RESULTS[:unexpected_error], AUTH_RESULTS[:not_fully_installed], AUTH_RESULTS[:failed_to_handle_license_agreement], AUTH_RESULTS[:failed_to_extract_tokens], AUTH_RESULTS[:unable_to_obtain_version]
+      return CheckCode::Detected(err_msg)
+    when AUTH_RESULTS[:not_nagios_application]
+      return CheckCode::Safe(err_msg)
     end
 
-    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
-    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
-    if login_result == 5 # the Nagios XI license agreement has not been signed
-      auth_cookies, nsp = res_array
-      sign_license_result = sign_license_agreement(auth_cookies, nsp)
-      if sign_license_result
-        return CheckCode::Unknown(sign_license_result[1])
-      end
+    print_status("Target is Nagios XI with version #{version}")
 
-      login_result, res_array = login_after_install_or_license(username, password, finish_install)
-      case login_result
-      when 1..3
-        return CheckCode::Unknown(res_array[0])
-      when 5 # the Nagios XI license agreement still has not been signed
-        return CheckCode::Detected('Failed to sign the license agreement.')
-      end
-    end
-
-    print_good('Successfully authenticated to Nagios XI')
-
-    # Obtain the Nagios XI version
-    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
-
-    nagios_version = nagios_xi_version(res_array[0])
-    if nagios_version.nil?
-      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
-    end
-
-    print_status("Target is Nagios XI with version #{nagios_version}")
-
-    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
-      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    if /^\d{4}R\d\.\d/.match(version) || /^\d{4}RC\d/.match(version) || /^\d{4}R\d.\d[A-Ha-h]/.match(version) || version == '5R1.0'
+      version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
     end
 
     # check if the target is actually vulnerable
-    version = Rex::Version.new(nagios_version)
+    version = Rex::Version.new(version)
     if version >= Rex::Version.new('5.5.0') && version <= Rex::Version.new('5.7.3')
       return CheckCode::Appears
     end

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Try to authenticate with nagios_xi_login. Error check with auth_result
+    # Authenticate to ensure we can access the NagiosXI version
     auth_result, err_msg, auth_cookies, version = authenticate(username, password, finish_install)
     case auth_result
     when AUTH_RESULTS[:connection_failed]


### PR DESCRIPTION
### Item 5/5 of #17606 

## Changelog

### `login.rb`: 
 - Change order of cookies and response body in `0` result return to standardize with line 251.
 - Change `authenticate` to use `index=1` because of order change.
 - Change `extract_auth_cookies` to extract from zeroth position because of order change.

### `nagios_xi_scanner.rb` and `nagios_xi_snmptrap_authenticated_rce.rb`:
 - Remove code that performs the same logic as `authenticate` and replace it with a function call.
 - Remove version error checking because it is checked by `when AUTH_RESULTS[:unable_to_obtain_version]` when checking `auth_result`

### Exploits affected:
- [CVE-2020-5791](https://github.com/advisories/GHSA-2j39-6c38-r3mx)
- [CVE-2020-5792](https://github.com/advisories/GHSA-4w5r-xgqv-25rr)
- [CVE-2019-15949](https://github.com/advisories/GHSA-8qv6-943v-r8gm)
- [CVE-2020-35578](https://github.com/advisories/GHSA-gp5w-f9p7-f7f5)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <insert path to each exploit>`
- [ ] `run`
- [ ] **Verify** each exploit runs without failure 
- [ ] **Verify** each exploit does not give unexpected error messages, particularly those concerning Nagios authentication
