### PR TITLE
Msf::Post::Windows::Accounts.resolve_sid: Support PowerShell sessions

### DIFF
--- a/modules/post/windows/gather/resolve_sid.rb
+++ b/modules/post/windows/gather/resolve_sid.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'chao-mu'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => ['meterpreter'],
+        'SessionTypes' => %w[meterpreter powershell],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],


### PR DESCRIPTION
Support resolving account SID to username and domain on PowerShell sessions.

With a couple of caveats (described below), this change brings 7 modules one step closer to working on non-Meterpreter sessions. The most common use case for this method is to resolve a SID to username+domain.

Although querying remote servers is not supported, this functionality is not something we ever use in Framework, with the exception of the `resolve_sid` module (when the non-default `SYSTEM_NAME` option is used).

```
# grep -rn resolve_sid modules/ lib/
modules/exploits/windows/local/mqac_write.rb:75:    local_sys = resolve_sid('S-1-5-18')
modules/exploits/windows/local/ms11_080_afdjoinleaf.rb:107:    local_sys = resolve_sid('S-1-5-18')
modules/post/windows/escalate/golden_ticket.rb:101:        user = resolve_sid("#{domain_sid}-#{id}")[:name]
modules/post/windows/escalate/golden_ticket.rb:104:        user = resolve_sid("#{domain_sid}-500")[:name]
modules/post/windows/gather/resolve_sid.rb:39:    info = resolve_sid(sid, target_system || nil)
modules/post/windows/gather/smart_hashdump.rb:390:    local_sys = resolve_sid('S-1-5-18')
modules/post/windows/gather/enum_logged_on_users.rb:90:      info = resolve_sid(maybe_sid)
modules/post/windows/manage/enable_rdp.rb:129:      rdu_sid = resolve_sid('S-1-5-32-555')
modules/post/windows/manage/enable_rdp.rb:130:      admin_sid = resolve_sid('S-1-5-32-544')
lib/msf/core/post/windows/accounts.rb:238:        def resolve_sid(sid, system_name = nil)
lib/msf/core/post/windows/accounts.rb:243:            return _powershell_resolve_sid(sid, system_name)
lib/msf/core/post/windows/accounts.rb:250:          _meterpreter_resolve_sid(sid, system_name)
lib/msf/core/post/windows/accounts.rb:256:        # see #resolve_sid
lib/msf/core/post/windows/accounts.rb:261:        def _powershell_resolve_sid(sid, system_name = nil)
lib/msf/core/post/windows/accounts.rb:280:        # see #resolve_sid
lib/msf/core/post/windows/accounts.rb:282:        def _meterpreter_resolve_sid(sid, system_name = nil)
lib/msf/core/post/windows/user_profiles.rb:79:    sidinf = resolve_sid(hive['SID'].to_s)
```

Although the result `:type` is hard-coded as `:unknown`, again this is something we never use with the exception of the `resolve_sid` module.

```
# grep -rn resolve_sid modules/ lib/ -A 10 | grep :type
modules/post/windows/gather/resolve_sid.rb-43-    sid_type = info[:type]
```
