### PR TITLE
Fix deadlock regression when printing multiple lines to console

### DIFF
--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -1,9 +1,9 @@
 module Msf::DBManager::Connection
   # Returns true if we are ready to load/store data
   def active
-    # In some scenarios we may have a connection established already, and we need to manually check if migration is required
+    # In a Rails test scenario there will be a connection established already, and it needs to be checked manually to see if a migration is required
     # This check normally happens in after_establish_connection, but that might not always get called - for instance during RSpec tests
-    if migrated.nil? && usable && connection_established?
+    if Rails.env.test? && migrated.nil? && usable && connection_established?
       self.migrated = !needs_migration?
     end
 


### PR DESCRIPTION
Fix deadlock regression when printing multiple lines to console

Context: Regression introduced by https://github.com/rapid7/metasploit-framework/pull/17778 - which can deadlock when running the `connection_established?` check, due to a deadlock in the pooling.

Spotted as part of testing https://github.com/rapid7/metasploit-payloads/pull/631 - 

```
msf6 exploit(windows/smb/psexec) > repeat -n 50 sessions -C hashdump
....
[*] Running 'hashdump' on meterpreter session 13 (192.168.123.164)

SEND: #<Rex::Post::Meterpreter::Packet type=Request         tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=2007 command=priv_passwd_get_sam_hashes>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="47385250289868525949033636371531">
]>

RECV: #<Rex::Post::Meterpreter::Packet type=Response        tlvs=[
  #<Rex::Post::Meterpreter::Tlv type=COMMAND_ID      meta=INT        value=2007 command=priv_passwd_get_sam_hashes>
  #<Rex::Post::Meterpreter::Tlv type=REQUEST_ID      meta=STRING     value="47385250289868525949033636371531">
  #<Rex::Post::Meterpreter::Tlv type=oneOf(POWERSHELL_SESSIONID,PYTHON_STDOUT,SAM_HASHES) meta=STRING     value="admin:1005:aad3b435b51404eeaad3b435b51404ee:a9fdfa038c4b75ebc76dc855dd74f0da:::\nAdministrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::\nalan:1006:aad3b435b51404eeaad3b435b51404ee:186cb09181e2c2ecaac768c47c729904:::\nAlan David Foster:1000:aad3b435b51404eeaad3b435b51404ee:186cb09181e2c2ecaac768c47c729904:::\nbasic_user:1007:aad3b435b51404eeaad3b435b51404ee:32ede47af254546a82b1743953cc4950:::\nDefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::\nfoo:1003:aad3b435b51404eeaad3b435b51404ee:ac8e657f83df82beea5d43bdaf7800cc:::\nGuest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::\ntest_user:1002:aad3b435b51404eeaad3b435b51404ee:066ddfd4ef0e9cd7c256fe77191ef43c:::\nuser:1004:aad3b435b51404eeaad3b435b51404ee:91ef1073f6ae95f5ea6ace91c09a963a:::\nWDAGUtilityAccount:504:aad3b435b51404eeaad3b435b51404ee:19ce80797959fdfb522f09643d79aa26:::\n">
  #<Rex::Post::Meterpreter::Tlv type=RESULT          meta=INT        value=0>
  #<Rex::Post::Meterpreter::Tlv type=UUID            meta=RAW        value="\x17\x13\xD5\xCD\x80\xF2[g\x01c\x00be!\xE5H">
]>
admin:1005:aad3b435b51404eeaad3b435b51404ee:a9fdfa038c4b75ebc76dc855dd74f0da:::
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
alan:1006:aad3b435b51404eeaad3b435b51404ee:186cb09181e2c2ecaac768c47c729904:::
Alan David Foster:1000:aad3b435b51404eeaad3b435b51404ee:186cb09181e2c2ecaac768c47c729904:::
[msfconsole hangs here]
```

This issue still technically exists if a module called `connection_established?` in a tight loop.

I tracked this down to hanging when calling `connection_established?` which attempts to open a real socket when the database isn't connected, which can lead to deadlock:

```
msf6 > irb -e '100_000.times { |x| $stderr.puts "Checking active #{x}"; begin; ApplicationRecord.connection_pool.with_connection { nil }; rescue ActiveRecord::ConnectionNotEstablished, PG::ConnectionBad => error; end; }'
```

The `pg` line it hangs on is https://github.com/ged/ruby-pg/blob/cae53b2a7ea8880182e08a1b5b691382b8e5375b/lib/pg/connection.rb#L606

## Verification

- Create a new database:
```
bundle exec ruby ./msfdb init
```
- Verify there are no locks with checking the status:
```
msf6 > irb -e '100_000.times { |x| $stderr.puts "Checking active #{x}"; result = framework.db.active }'
...
Checking active 99999
msf6 > 
```
- Stop the database:
```
bundle exec ruby ./msfdb stop
```
- Verify there are no locks with checking the status - this should fail before this code change:
```
msf6 > irb -e '100_000.times { |x| $stderr.puts "Checking active #{x}"; result = framework.db.active }'
...
Checking active 5377
[msfconsole hangs]
```