### PR TITLE
Update metasploit-payloads gem to 2.0.130

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.127)
+      metasploit-payloads (= 2.0.130)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -254,7 +254,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.127)
+    metasploit-payloads (2.0.130)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -74,7 +74,7 @@ metasploit-concern, 5.0.1, "New BSD"
 metasploit-credential, 6.0.4, "New BSD"
 metasploit-framework, 6.3.15, "New BSD"
 metasploit-model, 5.0.1, "New BSD"
-metasploit-payloads, 2.0.127, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.130, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.2, "New BSD"
 metasploit_payloads-mettle, 1.0.20, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.127'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.130'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/17776

Includes changes from:
* rapid7/metasploit-payloads#631
* rapid7/metasploit-payloads#639
* rapid7/metasploit-payloads#634
