### PR TITLE
missing adapter for python Windows

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_socat_sctp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_sctp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 70
+  CachedSize = 71
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_socat_sctp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_sctp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 87
+  CachedSize = 88
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/stagers/linux/x64/reverse_sctp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_sctp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 130
+  CachedSize = 136
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseSctp_x64

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1162,6 +1162,14 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/windows/powershell_reverse_tcp_ssl'
   end
 
+  context 'cmd/windows/python' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/windows/python'
+                          ],
+                          reference_name: 'cmd/windows/python'
+  end
+
   context 'cmd/windows/reverse_lua' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -638,6 +638,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/unix/bind_nodejs'
   end
 
+  context 'cmd/unix/bind_socat_sctp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/unix/bind_socat_sctp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/bind_socat_sctp'
+  end
+
   context 'cmd/unix/bind_socat_udp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -894,6 +904,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_openssl'
+  end
+
+  context 'cmd/unix/reverse_socat_sctp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/unix/reverse_socat_sctp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/reverse_socat_sctp'
   end
 
   context 'cmd/unix/reverse_socat_udp' do
@@ -1720,6 +1740,17 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell/bind_tcp'
+  end
+
+  context 'linux/x64/shell/reverse_sctp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'stagers/linux/x64/reverse_sctp',
+                            'stages/linux/x64/shell'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/x64/shell/reverse_sctp'
   end
 
   context 'linux/x64/shell/reverse_tcp' do
@@ -2762,6 +2793,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp'
+  end
+
+  context 'python/shell_reverse_sctp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/python/shell_reverse_sctp'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'python/shell_reverse_sctp'
   end
 
   context 'python/shell_reverse_tcp_ssl' do


### PR DESCRIPTION
Add a missing adapter to automation tests

## Verification

List the steps needed to make sure this thing works

- [x] **Verify** payload tests automation no longer warns of missing payloads.
