### PR TITLE
feedback_assistant_root: Check if OSX version is blank in check method

### DIFF
--- a/modules/exploits/osx/local/feedback_assistant_root.rb
+++ b/modules/exploits/osx/local/feedback_assistant_root.rb
@@ -54,12 +54,17 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = Rex::Version.new(get_system_version)
+    version = get_system_version
+
+    return CheckCode::Unknown('Could not retrieve OSX version') if version.blank?
+
+    version = Rex::Version.new(version)
+
     if version >= Rex::Version.new('10.14.4')
-      CheckCode::Safe
-    else
-      CheckCode::Appears
+      return CheckCode::Safe("OSX version #{version} is not vulnerable.")
     end
+
+    CheckCode::Appears("OSX version #{version} appears vulnerable.")
   end
 
   def exploit


### PR DESCRIPTION
Untested. Fixes #17943
