### PR TITLE
rescue login scanner attempts

### DIFF
--- a/docs/metasploit-framework.wiki/Creating-Metasploit-Framework-LoginScanners.md
+++ b/docs/metasploit-framework.wiki/Creating-Metasploit-Framework-LoginScanners.md
@@ -156,7 +156,7 @@ def attempt_login(credential)
 
   begin
     success = connect_login(credential.public, credential.private)
-  rescue ::EOFError,  Rex::AddressInUse, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error
+  rescue ::EOFError,  Rex::AddressInUse, Rex::ConnectionError, Rex::ConnectionProxyError, Rex::ConnectionTimeout, Rex::TimeoutError, Errno::ECONNRESET, Errno::EINTR, ::Timeout::Error
     result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
     success = false
   end

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -253,6 +253,8 @@ module Metasploit
               end
             end
             nil
+          rescue => e
+            elog('Attempt may not yield a result', error: e)
           end
 
           # Raise an exception if this scanner's attributes are not valid.

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -251,10 +251,10 @@ module Metasploit
                   break if total_error_count >= 10
                 end
               end
+            rescue => e
+              elog('Attempt may not yield a result', error: e)
             end
             nil
-          rescue => e
-            elog('Attempt may not yield a result', error: e)
           end
 
           # Raise an exception if this scanner's attributes are not valid.

--- a/lib/metasploit/framework/login_scanner/postgres.rb
+++ b/lib/metasploit/framework/login_scanner/postgres.rb
@@ -19,7 +19,7 @@ module Metasploit
         REALM_KEY            = Metasploit::Model::Realm::Key::POSTGRESQL_DATABASE
 
         # This method attempts a single login with a single credential against the target
-        # @param credential [Credential] The credential object to attmpt to login with
+        # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
         def attempt_login(credential)
           result_options = {
@@ -60,7 +60,7 @@ module Metasploit
                     proof: e.message
                 })
             end
-          rescue Rex::ConnectionError, EOFError, Timeout::Error => e
+          rescue Rex::ConnectionError, Rex::ConnectionProxyError, Errno::ECONNRESET, Errno::EINTR, Errno::ENOTCONN, Rex::TimeoutError, EOFError, Timeout::Error => e
             result_options.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           rescue Msf::Db::PostgresPR::AuthenticationMethodMismatch => e
             result_options.merge!({

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -159,10 +159,9 @@ module Metasploit
             yield result if block_given?
           end
 
-          shutdown_socket
           nil
-        rescue => e
-          elog('Attempt may not yield a result', error: e)
+        ensure
+          shutdown_socket
         end
 
         # Queue up and possibly send any requests, based on the queue limit and final flag

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -161,6 +161,8 @@ module Metasploit
 
           shutdown_socket
           nil
+        rescue => e
+          elog('Attempt may not yield a result', error: e)
         end
 
         # Queue up and possibly send any requests, based on the queue limit and final flag


### PR DESCRIPTION
* Improve base login scanner to catch any Exception for an individual credential
* ~Catch any Exception in SNMP scanner that override base method~
* Ensure socket close for SNMP scanner
* Expand connection errors possible in PostgreSQL scanner

## Verification

- [ ] Start `msfconsole`
- [ ] `use` various login scanner module
- [ ] ***Verify*** no change in happy path behavior
- [ ] Introduce various raised exception in scanners `#attempt_login` methods and validate no longer crash the module completely.
