### PR TITLE
lock msgpack until build resolved

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ PATH
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
-      msgpack
+      msgpack (~> 1.6.0)
       nessus_rest
       net-ldap
       net-smtp
@@ -270,7 +270,7 @@ GEM
     mini_portile2 (2.8.1)
     minitest (5.18.0)
     mqtt (0.6.0)
-    msgpack (1.7.0)
+    msgpack (1.6.1)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -76,7 +76,8 @@ Gem::Specification.new do |spec|
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components
-  spec.add_runtime_dependency 'msgpack'
+  # Locked until build env can handle newer version. See: https://github.com/msgpack/msgpack-ruby/issues/334
+  spec.add_runtime_dependency 'msgpack', '~> 1.6.0'
   # get list of network interfaces, like eth* from OS.
   spec.add_runtime_dependency 'network_interface'
   # NTLM authentication


### PR DESCRIPTION
MessagePack 1.7.0 gem introduced code not compatible with the current build env used for nightly packages. This may be addressed in several ways and has been reported upstream. Lock the version until a path forward is determined.
