### PR TITLE
Add CVE-1999-0554 to nfsmount module

### DIFF
--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -18,6 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author'	=> ['<tebo[at]attackresearch.com>'],
       'References' => [
         ['CVE', '1999-0170'],
+        ['CVE', '1999-0554'],
         ['URL', 'https://www.ietf.org/rfc/rfc1094.txt']
       ],
       'License'	=> MSF_LICENSE


### PR DESCRIPTION
Adds a NFS related CVE to the nfsmount module.  https://nvd.nist.gov/vuln/detail/CVE-1999-0554 is related to finding sensitive files on an NFS mount. This also helps with circular references as Nessus already refers to this module as the exploit to the cve: https://www.tenable.com/plugins/nessus/11356