### PR TITLE
Fix ruby 3.1 crashes and resource leaks when garbage collecting meterpreter resources

### DIFF
--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -199,6 +199,8 @@ class Framework
   #
   # @return [Metasploit::Framework::DataService::DataProxy]
   def db
+    return @db if @db
+
     synchronize {
       @db ||= get_db
     }
@@ -209,6 +211,8 @@ class Framework
   #
   # @return [Msf::SessionManager]
   def sessions
+    return @sessions if @sessions
+
     synchronize {
       @sessions ||= Msf::SessionManager.new(self)
     }
@@ -219,6 +223,8 @@ class Framework
   #
   # @return [Msf::ThreadManager]
   def threads
+    return @threads if @threads
+
     synchronize {
       @threads ||= Msf::ThreadManager.new(self)
     }

--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -153,11 +153,16 @@ class Channel
   def self.finalize(client, cid)
     proc {
       unless cid.nil?
-        begin
-          self._close(client, cid)
-        rescue => e
-          elog("finalize method for Channel failed", error: e)
+        deferred_close_proc = proc do
+          begin
+            self._close(client, cid)
+          rescue => e
+            elog("finalize method for Channel failed", error: e)
+          end
         end
+
+        # Schedule the finalizing logic out-of-band; as this logic might be called in the context of a Signal.trap, which can't synchronize mutexes
+        client.framework.sessions.schedule(deferred_close_proc)
       end
     }
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -337,11 +337,16 @@ class Process < Rex::Post::Process
 
   def self.finalize(client, handle)
     proc do
-      begin
-        self.close(client, handle)
-      rescue => e
-        elog("finalize method for Process failed", error: e)
+      deferred_close_proc = proc do
+        begin
+          self.close(client, handle)
+        rescue => e
+          elog("finalize method for Process failed", error: e)
+        end
       end
+
+      # Schedule the finalizing logic out-of-band; as this logic might be called in the context of a Signal.trap, which can't synchronize mutexes
+      client.framework.sessions.schedule(deferred_close_proc)
     end
   end
 
@@ -366,7 +371,7 @@ class Process < Rex::Post::Process
     request = Packet.create_request(COMMAND_ID_STDAPI_SYS_PROCESS_CLOSE)
     request.add_tlv(TLV_TYPE_HANDLE, handle)
     client.send_request(request, nil)
-    handle = nil;
+    handle = nil
     return true
   end
 


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/17593 - `'synchronize': can't be called from trap context (ThreadError)`

### Context:

Meterpreter's API creates temporary Ruby objects representing remote files/registry keys/etc. These define custom finalizer methods, which perform mutex synchronization/network requests etc:

https://github.com/rapid7/metasploit-framework/blob/783a1eb504ae58e2557eff6d2649a05d8cd903fe/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb#L334-L346

Unfortunately operations such as mutex synchronisation are not allowed in a trap context - which happens in msfconsole even when you use the [logging API](https://github.com/rapid7/metasploit-framework/blob/783a1eb504ae58e2557eff6d2649a05d8cd903fe/lib/rex/logging/log_dispatcher.rb#L89-L97); Previous to Ruby 3.1 these errors would silently disappear, but now they're explicitly logged out to console

### Solution:

Queue up the cleaning logic in the dedicated session manager worker threads

### References:

- https://kirshatrov.com/posts/ruby-signal-trap
- https://github.com/ruby/ruby/blob/012faccf040344360801b0fa77e85f9c8a3a4b2c/doc/signals.rdoc
- https://gist.github.com/mvidner/bf12a0b3c662ca6a5784
- https://github.com/rapid7/metasploit-framework/pull/6864
- https://github.com/rapid7/metasploit-framework/pull/17612

## Verification

Ensure you're using Ruby 3.1.2

```
rvm use 3.1.2
bundle
```

### Before

Garbage collected Meterpreter processes raising 

```
msf6 payload(osx/x64/meterpreter/reverse_tcp) > repeat -n 100 sessions -i -1 -C 'execute -f whoami'
...
/Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:998: warning: Exception in finalizer #<Proc:0x000000010f8fcf40 /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:341>
/Users/user/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:90:in `synchronize': can't be called from trap context (ThreadError)
	from /Users/user/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:90:in `log'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:172:in `elog'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:345:in `rescue in block in finalize'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:342:in `block in finalize'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:998:in `chr'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:998:in `block in xor_bytes'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:997:in `each_byte'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:997:in `xor_bytes'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:985:in `from_r'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:569:in `decrypt_inbound_packet'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:328:in `block in monitor_socket'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
/Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:147:in `synchronize': can't be called from trap context (ThreadError)
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:147:in `send_packet'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:220:in `send_packet_wait_response'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:176:in `send_request'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:370:in `close'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb:343:in `block in finalize'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:998:in `chr'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:998:in `block in xor_bytes'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:997:in `each_byte'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:997:in `xor_bytes'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet.rb:985:in `from_r'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:569:in `decrypt_inbound_packet'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:328:in `block in monitor_socket'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
Process 86463 created.
[*] Running 'execute -f whoami' on meterpreter session 1 (192.168.123.1)
```

Garbage collected registry keys crashing:

```
msf6 exploit(windows/smb/psexec) > repeat -n 100 irb -e "$stderr.puts 'opening key'; key = framework.sessions.get(-1).sys.registry.open_key(HKEY_LOCAL_MACHINE, 'Software\Microsoft\Windows', KEY_READ); key = nil"
....
/Users/user/.rvm/gems/ruby-3.1.2/gems/rex-text-0.2.50/lib/rex/text/color.rb:42: warning: Exception in finalizer #<Proc:0x0000000111b349c8 /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb:38>
/Users/user/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:90:in `synchronize': can't be called from trap context (ThreadError)
	from /Users/user/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:90:in `log'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:172:in `elog'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb:42:in `rescue in block in finalize'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb:39:in `block in finalize'
	from /Users/user/.rvm/gems/ruby-3.1.2/gems/rex-text-0.2.50/lib/rex/text/color.rb:42:in `%'
	from /Users/user/.rvm/gems/ruby-3.1.2/gems/rex-text-0.2.50/lib/rex/text/color.rb:42:in `ansi'
	from /Users/user/.rvm/gems/ruby-3.1.2/gems/rex-text-0.2.50/lib/rex/text/color.rb:50:in `colorize'
	from /Users/user/.rvm/gems/ruby-3.1.2/gems/rex-text-0.2.50/lib/rex/text/color.rb:72:in `substitute_colors'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/output.rb:68:in `print'
	from /Users/user/.rvm/gems/ruby-3.1.2/gems/rex-text-0.2.50/lib/rex/text/color.rb:96:in `reset_color'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:519:in `run_single'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2548:in `block (2 levels) in cmd_repeat'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2547:in `each'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2547:in `block in cmd_repeat'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2546:in `times'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2546:in `call'
	from /Users/user/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:2546:in `cmd_repeat'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
	from /Users/user/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:168:in `run'
	from /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
	from /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
	from ./msfconsole:23:in `<main>'
```

### After

No errors