### PR TITLE
Replace [System.IO.File]::Exists with Test-Path

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -305,7 +305,7 @@ module Msf::Post::File
       end
       return !!stat
     elsif session.type == 'powershell'
-      return cmd_exec("[System.IO.File]::Exists( \"#{path}\")")&.include?('True')
+      return cmd_exec("Test-Path \"#{path}\"")&.include?('True')
     else
       if session.platform == 'windows'
         f = cmd_exec("cmd.exe /C IF exist \"#{path}\" ( echo true )")


### PR DESCRIPTION
The exists? method in post/file has a different implementation for PSH sessions than other shells which are testing for the existence of a path, not the presence of a file.

Fix this by replacing [System.IO.File]::Exists with Test-Path.

Testing:
```powershell
PS C:\Windows\system32> [System.IO.File]::Exists("C:\")
False
PS C:\Windows\system32>test-path C:\
PS C:\Windows\system32> test-path C:\
True
```
