### PR TITLE
Fix kerberos datastore name typo in winrm docs

### DIFF
--- a/docs/metasploit-framework.wiki/Metasploit-Guide-WinRM.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-WinRM.md
@@ -147,7 +147,7 @@ Open a WinRM session:
 
 ```msf
 msf6 > use auxiliary/scanner/winrm/winrm_login
-msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd win::rmauth=kerberos domaincontrollerrhost=192.168.123.13 winrm::rhostname=dc3.demo.local domain=demo.local
+msf6 auxiliary(scanner/winrm/winrm_login) > run rhost=192.168.123.13 username=Administrator password=p4$$w0rd winrm::auth=kerberos domaincontrollerrhost=192.168.123.13 winrm::rhostname=dc3.demo.local domain=demo.local
 
 [+] 192.168.123.13:88 - Received a valid TGT-Response
 [*] 192.168.123.13:5985   - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20230118120604_default_192.168.123.13_mit.kerberos.cca_451736.bin


### PR DESCRIPTION
Fixes a Kerberos datastore name typo in the WinRM docs