### PR TITLE
Improves flag formatting for kerberos ticket presenter

### DIFF
--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -30,6 +30,13 @@ module Rex::Proto::Kerberos::CredentialCache
     }.freeze
     private_constant :AD_TYPE_MAP
 
+    # Tracks the currently supported BinData types that can be formatted by the
+    # Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter#print_bindata_model method.
+    BIT_LENGTHS = {
+      ::BinData::Bit1 => 1
+    }.freeze
+    private_constant :BIT_LENGTHS
+
     # @param [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache] ccache
     def initialize(ccache)
       @ccache = ccache
@@ -106,6 +113,92 @@ module Rex::Proto::Kerberos::CredentialCache
       output.join("\n")
     end
 
+    # This method takes a BinData object and parses it to create a formatted output
+    # that help users visualise what each flag means as well as if it is set or not
+    #
+    # Note: For now we only support bit1 flags from BinData, this could be extended in the future
+    #
+    # Example output
+    # .... .... .... .... .... .... .... .0.. Flag 29: The flag 29 is NOT SET
+    # .... .... .... .... .... .... .... ..1. Flag 30: The flag 30 is SET
+    # .... .... .... .... .... .... .... ...1 Flag 31: The flag 31 is SET
+    #
+    # @param model The BinData object
+    # @param [Integer] bit_length The length of desired byte output - number of dots in example above
+    # @return [String] Formatted output
+    def print_bindata_model(model, bit_length: nil)
+      rows = []
+      model_keys = []
+      model_values = []
+
+      bit_length ||= model.num_bytes * 8
+      fields_and_values = model.to_enum(:each_pair).to_a
+
+      # For now we only support bit1 flags from BinData, this could be extended in the future
+      fields_and_values.each do |field, value|
+        model_keys << field
+        model_values << value
+        unless BIT_LENGTHS.keys.include?(value.class)
+          raise TypeError, "Unsupported field type #{value.class} - expected #{BIT_LENGTHS.keys.join(',')}"
+        end
+      end
+
+      if bit_length < model_keys.length
+        raise ArgumentError, "Bit length(#{bit_length}) should not be less that the number of flags(#{model_keys.length}) within the BinData model"
+      end
+
+      padding = Array.new(bit_length - model_keys.length, :_reserved_)
+      flag_keys = padding + model_keys
+      binary_value = model_values.join
+
+      bit_length.times do |i|
+        next if flag_keys[i].start_with?('_reserved_')
+
+        dot_formatting = Array.new(bit_length, '.')
+        dot_formatting[(i - 1) - (bit_length - 1)] = binary_value[i]
+        buckets = dot_formatting.in_groups_of(4) # Issue if we don't received a multiple of 4
+        dot_formatting = buckets.map(&:join).join(' ')
+
+        human_readable_flag_name = flag_keys[i].to_s.split('_').map(&:capitalize).join(' ')
+        description = "#{human_readable_flag_name}: The #{flag_keys[i].to_s.upcase} bit is #{binary_value.chars[i] == '1' ? 'SET' : 'NOT SET'}"
+        rows << "#{dot_formatting} #{description}"
+      end
+
+      rows.join("\n")
+    end
+
+    # @param [RubySMB::Dcerpc::Samr::PgroupMembershipArray] group_memberships
+    # @return [Array] Formatted human readable representation of the group memberships
+    def print_group_memberships(group_memberships)
+      output = []
+      if group_memberships.any?
+        group_memberships.map do |group|
+          group_attributes = Rex::Proto::Kerberos::Pac::GroupAttributes.read([group.attributes].pack('N'))
+          output << "Relative ID: #{group.relative_id}\nAttributes: #{group.attributes}".indent(4)
+          output << print_bindata_model(group_attributes, bit_length: 32).to_s.indent(6)
+        end
+        output
+      end
+    end
+
+    # @param [RubySMB::Dcerpc::Ndr::NdrUint32] user_flags
+    # @return [Array] Formatted human readable representation of the user flags
+    def print_user_flags(user_flags)
+      output = []
+      user_attributes = Rex::Proto::Kerberos::Pac::UserFlagAttributes.read([user_flags].pack('N'))
+      output << "User Flags: #{user_flags}".indent(2)
+      output << print_bindata_model(user_attributes, bit_length: 32).to_s.indent(4)
+    end
+
+    # @param [RubySMB::Dcerpc::Ndr::NdrUint32] user_account_flags
+    # @return [Array] Formatted human readable representation of the user account flags
+    def print_user_account_flags(user_account_flags)
+      output = []
+      user_account_attributes = Rex::Proto::Kerberos::Pac::UserAccountAttributes.read([user_account_flags].pack('N'))
+      output << "User Account Control: #{user_account_flags}".indent(2)
+      output << print_bindata_model(user_account_attributes, bit_length: 32).to_s.indent(4)
+    end
+
     # @param [Rex::Proto::Kerberos::Pac::Krb5LogonInformation] logon_info
     # @return [String] A human readable representation of a Logon Information
     def present_logon_info(logon_info)
@@ -124,9 +217,9 @@ module Rex::Proto::Kerberos::CredentialCache
       output << "Bad Password Count: #{validation_info.bad_password_count}".indent(2)
       output << "User ID: #{validation_info.user_id}".indent(2)
       output << "Primary Group ID: #{validation_info.primary_group_id}".indent(2)
-      output << "User Flags: #{validation_info.user_flags}".indent(2)
+      output << print_user_flags(validation_info.user_flags)
       output << "User Session Key: #{present_user_session_key(validation_info.user_session_key)}".indent(2)
-      output << "User Account Control: #{validation_info.user_account_control}".indent(2)
+      output << print_user_account_flags(validation_info.user_account_control)
       output << "Sub Auth Status: #{validation_info.sub_auth_status}".indent(2)
 
       output << "Last Successful Interactive Logon: #{present_ndr_file_time(validation_info.last_successful_i_logon)}".indent(2)
@@ -139,7 +232,7 @@ module Rex::Proto::Kerberos::CredentialCache
 
       output << "Group Count: #{validation_info.group_count}".indent(2)
       output << 'Group IDs:'.indent(2)
-      output << validation_info.group_memberships.map { |group| "Relative ID: #{group.relative_id}, Attributes: #{group.attributes}".indent(4) } if validation_info.group_memberships.any?
+      output << print_group_memberships(validation_info.group_memberships)
 
       output << "Logon Domain ID: #{validation_info.logon_domain_id}".indent(2)
 
@@ -219,6 +312,8 @@ module Rex::Proto::Kerberos::CredentialCache
       output << "DNS Domain Name: #{upn_and_dns_info.dns_domain_name.encode('utf-8')}".indent(2)
 
       output << "Flags: #{upn_and_dns_info.flags}".indent(2)
+      upn_and_dns_info_attributes = Rex::Proto::Kerberos::Pac::UpnDnsInfoAttributes.read([upn_and_dns_info.flags].pack('N'))
+      output << print_bindata_model(upn_and_dns_info_attributes, bit_length: 32).to_s.indent(4)
 
       if upn_and_dns_info.has_s_flag?
         output << "SAM Name: #{upn_and_dns_info.sam_name.encode('utf-8')}".indent(2)

--- a/lib/rex/proto/kerberos/pac.rb
+++ b/lib/rex/proto/kerberos/pac.rb
@@ -6,10 +6,20 @@ module Rex
       module Pac
         VERSION = 0
         NETLOGON_FLAG = 0x20000
-        SE_GROUP_MANDATORY = 1
-        SE_GROUP_ENABLED_BY_DEFAULT = 2
-        SE_GROUP_ENABLED = 4
+
+        # Kerberos:
+        # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/311aab27-ebdf-47f7-b939-13dc99b15341
+        # Reference with details on flags:
+        # https://learn.microsoft.com/en-gb/windows/win32/api/winnt/ns-winnt-token_groups?redirectedfrom=MSDN#members
+        SE_GROUP_MANDATORY = 0x00000001
+        SE_GROUP_ENABLED_BY_DEFAULT = 0x00000002
+        SE_GROUP_ENABLED = 0x00000004
+        SE_GROUP_OWNER = 0x00000008
+        SE_GROUP_RESOURCE = 0x20000000
+
+        # XXX: Does not include some of the newer SE_GROUP_* flags
         SE_GROUP_ALL = SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_ENABLED
+
         USER_NORMAL_ACCOUNT = 0x00000010
         USER_DONT_EXPIRE_PASSWORD = 0x00000200
         PAC_LOGON_INFO = 1

--- a/lib/rex/proto/kerberos/pac/krb5_pac.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac.rb
@@ -40,6 +40,8 @@ module Rex::Proto::Kerberos::Pac
   end
 
   # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/311aab27-ebdf-47f7-b939-13dc99b15341
+  #
+  # [SIDATT] https://learn.microsoft.com/en-gb/windows/win32/api/winnt/ns-winnt-token_groups?redirectedfrom=MSDN
   class GroupAttributes < BinData::Record
     endian :big
 
@@ -47,15 +49,28 @@ module Rex::Proto::Kerberos::Pac
       bit1 :"_reserved_#{self.fields.length}"
     end
 
+    # @!attribute [rw] resource
+    #   @return [BinData::Bit1] This setting means that the group is a domain-local or resource group. Corresponds to SE_GROUP_RESOURCE. For more information, see [SIDATT].
     bit1 :resource
 
     25.times do
       bit1 :"_reserved_#{self.fields.length}"
     end
 
+    # @!attribute [rw] owner
+    #   @return [BinData::Bit1] This setting means that the group can be assigned as an owner of a resource. Corresponds to SE_GROUP_OWNER. For more information, see [SIDATT].
     bit1 :owner
+
+    # @!attribute [rw] enabled
+    #   @return [BinData::Bit1] This setting means that the group is enabled for use. Corresponds to SE_GROUP_ENABLED. For more information, see [SIDATT].
     bit1 :enabled
+
+    # @!attribute [rw] enabled_by_default
+    #   @return [BinData::Bit1] This setting means that the group is marked as enabled by default. Corresponds to SE_GROUP_ENABLED_BY_DEFAULT. For more information, see [SIDATT].
     bit1 :enabled_by_default
+
+    # @!attribute [rw] mandatory
+    #   @return [BinData::Bit1] This setting means that the group is mandatory for the user and cannot be disabled. Corresponds to SE_GROUP_MANDATORY. For more information, see [SIDATT].
     bit1 :mandatory
   end
 
@@ -67,27 +82,69 @@ module Rex::Proto::Kerberos::Pac
       bit1 :"_reserved_#{self.fields.length}"
     end
 
+    # @!attribute [rw] used_lmv2_auth_and_ntlmv2_session_key
+    #   @return [BinData::Bit1] The LMv2 response from the LmChallengeResponseFields ([MS-NLMP] section 2.2.1.3) was used for authentication and the NTLMv2 response from the NtChallengeResponseFields ([MS-NLMP] section 2.2.1.3) was used session key generation.
     bit1 :used_lmv2_auth_and_ntlmv2_session_key
+
+    # @!attribute [rw] used_lmv2_auth_and_session_key
+    #   @return [BinData::Bit1] The LMv2 response from the LmChallengeResponseFields ([MS-NLMP] section 2.2.1.3) was used for authentication and session key generation.
     bit1 :used_lmv2_auth_and_session_key
 
+    # @!attribute [rw] used_ntlmv2_auth_and_session_key
+    #   @return [BinData::Bit1] The NTLMv2 response from the NtChallengeResponseFields ([MS-NLMP] section 2.2.1.3) was used for authentication and session key generation.
     bit1 :used_ntlmv2_auth_and_session_key
+
+    # @!attribute [rw] profile_path_populated
+    #   @return [BinData::Bit1] Indicates that ProfilePath is populated.
     bit1 :profile_path_populated
+
+    # @!attribute [rw] resource_group_ids
+    #   @return [BinData::Bit1] Indicates that the ResourceGroupIds field is populated.
     bit1 :resource_group_ids
+
+    # @!attribute [rw] accepts_ntlmv2
+    #   @return [BinData::Bit1] Indicates that the domain controller understands NTLMv2.
     bit1 :accepts_ntlmv2
 
+    # @!attribute [rw] machine_account
+    #   @return [BinData::Bit1] Indicates that the account is a machine account.
     bit1 :machine_account
-    bit1 :sub_authentication
-    bit1 :extra_sids
-    bit1 :_reserved_27
 
+    # @!attribute [rw] sub_authentication
+    #   @return [BinData::Bit1] Sub-authentication used; session key came from the sub-authentication package.
+    bit1 :sub_authentication
+
+    # @!attribute [rw] extra_sids
+    #   @return [BinData::Bit1] Indicates that the ExtraSids field is populated and contains additional SIDs.
+    bit1 :extra_sids
+
+    1.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    # @!attribute [rw] lan_manager
+    #   @return [BinData::Bit1] LAN Manager key was used for authentication.
     bit1 :lan_manager
-    bit1 :_reserved_29
+
+    1.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    # @!attribute [rw] no_encryption
+    #   @return [BinData::Bit1] No encryption is available.
     bit1 :no_encryption
+
+    # @!attribute [rw] guest
+    #   @return [BinData::Bit1] Authentication was done via the GUEST account; no password was used
     bit1 :guest
   end
 
-  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/4df07fab-1bbc-452f-8e92-7853a3c7e380
-  # Protocol revision 45.0 contains USER_ACCOUNT Codes in section 2.2.1.12
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/b10cfda1-f24f-441b-8f43-80cb93e786ec
+  #
+  # [RFC4120] https://www.rfc-editor.org/rfc/rfc4120
+  # [RFC3961] https://www.ietf.org/rfc/rfc3961.txt
+  # [MS-KILE] https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/2a32282e-dd48-4ad9-a542-609804b02cc9
+  # [MS-LSAD] https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/1b5471ef-4c33-4a91-b079-dfcbb82f05cc
   class UserAccountAttributes < BinData::Record
     endian :big
 
@@ -95,36 +152,98 @@ module Rex::Proto::Kerberos::Pac
       bit1 :"_reserved_#{self.fields.length}"
     end
 
+    # @!attribute [rw] use_aes_keys
+    #   @return [BinData::Bit1] This bit is ignored by clients and servers.
     bit1 :use_aes_keys
+
+    # @!attribute [rw] partial_secrets_account
+    #   @return [BinData::Bit1] Specifies that the object is a read-only domain controller (RODC).
     bit1 :partial_secrets_account
 
+    # @!attribute [rw] no_auth_data_required
+    #   @return [BinData::Bit1] This bit is used by the Kerberos protocol. It indicates that when the key distribution center (KDC) is issuing a service ticket for this account, the privilege attribute certificate (PAC) is not to be included. For more information, see [RFC4120].
     bit1 :no_auth_data_required
+
+    # @!attribute [rw] trusted_to_authenticate_for_delegation
+    #   @return [BinData::Bit1] This bit is used by the Kerberos protocol, as specified in [MS-KILE] section 3.3.1.1.
     bit1 :trusted_to_authenticate_for_delegation
+
+    # @!attribute [rw] password_expired
+    #   @return [BinData::Bit1] Specifies that the password age on the user has exceeded the maximum password age policy.
     bit1 :password_expired
+
+    # @!attribute [rw] dont_require_preauth
+    #   @return [BinData::Bit1] This bit is used by the Kerberos protocol. It indicates that the account is not required to present valid preauthentication data, as described in [RFC4120] section 7.5.2.
     bit1 :dont_require_preauth
 
+    # @!attribute [rw] use_des_key_only
+    #   @return [BinData::Bit1] This bit is used by the Kerberos protocol. It indicates that only des-cbc-md5 or des-cbc-crc keys (as defined in [RFC3961]) are used in the Kerberos protocol for this account.
     bit1 :use_des_key_only
+
+    # @!attribute [rw] not_delegated
+    #   @return [BinData::Bit1] This bit is used by the Kerberos protocol. It indicates that the ticket-granting tickets (TGTs) of this account and the service tickets obtained by this account are not marked as forwardable or proxiable when the forwardable or proxiable ticket flags are requestedFor more information, see [RFC4120].
     bit1 :not_delegated
+
+    # @!attribute [rw] trusted_for_delegation
+    #   @return [BinData::Bit1] This bit is used by the Kerberos protocol. It indicates that the "OK as Delegate" ticket flag (described in[RFC4120] section 2.8) is to be set.
     bit1 :trusted_for_delegation
+
+    # @!attribute [rw] smartcard_required
+    #   @return [BinData::Bit1] Specifies that the user can authenticate only with a smart card.
     bit1 :smartcard_required
 
+    # @!attribute [rw] encrypted_test_password_allowed
+    #   @return [BinData::Bit1] Specifies that the cleartext password is to be persisted.
     bit1 :encrypted_test_password_allowed
+
+    # @!attribute [rw] account_auto_lock
+    #   @return [BinData::Bit1] Specifies that the account has been locked out.
     bit1 :account_auto_lock
+
+    # @!attribute [rw] dont_expire_password
+    #   @return [BinData::Bit1] Specifies that the maximum-password-age policy does not apply to this user.
     bit1 :dont_expire_password
+
+    # @!attribute [rw] server_trust_account
+    #   @return [BinData::Bit1] Specifies that the object is a DC.
     bit1 :server_trust_account
 
+    # @!attribute [rw] workstation_trust_account
+    #   @return [BinData::Bit1] Specifies that the object is a member workstation or server.
     bit1 :workstation_trust_account
+
+    # @!attribute [rw] interdomain_trust_account
+    #   @return [BinData::Bit1] Specifies that the object represents a trust object. For more information about trust objects, see [MS-LSAD].
     bit1 :interdomain_trust_account
+
+    # @!attribute [rw] mns_logon_account
+    #   @return [BinData::Bit1] This bit is ignored by clients and servers.
     bit1 :mns_logon_account
+
+    # @!attribute [rw] normal_account
+    #   @return [BinData::Bit1] Specifies that the user is not a computer object.
     bit1 :normal_account
 
+    # @!attribute [rw] temp_duplicate_account
+    #   @return [BinData::Bit1] This bit is ignored by clients and servers.
     bit1 :temp_duplicate_account
+
+    # @!attribute [rw] password_not_required
+    #   @return [BinData::Bit1] Specifies that the password-length policy does not apply to this user.
     bit1 :password_not_required
+
+    # @!attribute [rw] home_directory_required
+    #   @return [BinData::Bit1] Specifies that the homeDirectory attribute is required.
     bit1 :home_directory_required
+
+    # @!attribute [rw] account_disabled
+    #   @return [BinData::Bit1] Specifies that the account is not enabled for authentication.
     bit1 :account_disabled
   end
 
   # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/1c0d6e11-6443-4846-b744-f9f810a504eb
+  #
+  # [MS-ADA3] https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ada3/4517e835-3ee6-44d4-bb95-a94b6966bfb0
   class UpnDnsInfoAttributes < BinData::Record
     endian :big
 
@@ -132,7 +251,12 @@ module Rex::Proto::Kerberos::Pac
       bit1 :"_reserved_#{self.fields.length}"
     end
 
+    # @!attribute [rw] sam_name_and_sid
+    #   @return [BinData::Bit1] The UPN_DNS_INFO structure has been extended with the user account’s SAM Name and SID.
     bit1 :sam_name_and_sid
+
+    # @!attribute [rw] upn_name_constructed
+    #   @return [BinData::Bit1] The user account object does not have the userPrincipalName attribute ([MS-ADA3] section 2.349) set. A UPN constructed by concatenating the user name with the DNS domain name of the account domain is provided.
     bit1 :upn_name_constructed
   end
 

--- a/lib/rex/proto/kerberos/pac/krb5_pac.rb
+++ b/lib/rex/proto/kerberos/pac/krb5_pac.rb
@@ -39,6 +39,103 @@ module Rex::Proto::Kerberos::Pac
     ndr_uint32 :attributes
   end
 
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/311aab27-ebdf-47f7-b939-13dc99b15341
+  class GroupAttributes < BinData::Record
+    endian :big
+
+    2.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    bit1 :resource
+
+    25.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    bit1 :owner
+    bit1 :enabled
+    bit1 :enabled_by_default
+    bit1 :mandatory
+  end
+
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/69e86ccc-85e3-41b9-b514-7d969cd0ed73
+  class UserFlagAttributes < BinData::Record
+    endian :big
+
+    18.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    bit1 :used_lmv2_auth_and_ntlmv2_session_key
+    bit1 :used_lmv2_auth_and_session_key
+
+    bit1 :used_ntlmv2_auth_and_session_key
+    bit1 :profile_path_populated
+    bit1 :resource_group_ids
+    bit1 :accepts_ntlmv2
+
+    bit1 :machine_account
+    bit1 :sub_authentication
+    bit1 :extra_sids
+    bit1 :_reserved_27
+
+    bit1 :lan_manager
+    bit1 :_reserved_29
+    bit1 :no_encryption
+    bit1 :guest
+  end
+
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/4df07fab-1bbc-452f-8e92-7853a3c7e380
+  # Protocol revision 45.0 contains USER_ACCOUNT Codes in section 2.2.1.12
+  class UserAccountAttributes < BinData::Record
+    endian :big
+
+    10.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    bit1 :use_aes_keys
+    bit1 :partial_secrets_account
+
+    bit1 :no_auth_data_required
+    bit1 :trusted_to_authenticate_for_delegation
+    bit1 :password_expired
+    bit1 :dont_require_preauth
+
+    bit1 :use_des_key_only
+    bit1 :not_delegated
+    bit1 :trusted_for_delegation
+    bit1 :smartcard_required
+
+    bit1 :encrypted_test_password_allowed
+    bit1 :account_auto_lock
+    bit1 :dont_expire_password
+    bit1 :server_trust_account
+
+    bit1 :workstation_trust_account
+    bit1 :interdomain_trust_account
+    bit1 :mns_logon_account
+    bit1 :normal_account
+
+    bit1 :temp_duplicate_account
+    bit1 :password_not_required
+    bit1 :home_directory_required
+    bit1 :account_disabled
+  end
+
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/1c0d6e11-6443-4846-b744-f9f810a504eb
+  class UpnDnsInfoAttributes < BinData::Record
+    endian :big
+
+    30.times do
+      bit1 :"_reserved_#{self.fields.length}"
+    end
+
+    bit1 :sam_name_and_sid
+    bit1 :upn_name_constructed
+  end
+
   class Krb5SidAndAttributesPtr < RubySMB::Dcerpc::Ndr::NdrConfArray
     default_parameters byte_align: 1, type: :krb5_sid_and_attributes
 

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# Dummy BinData model
+class DummyAttributes < BinData::Record
+  endian :little
+
+  bit1 :foo
+  bit2 :bar
+
+  bit3 :owner
+  bit2 :mandatory
+end
+
 RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
   subject do
     described_class.new(ccache)
@@ -194,8 +205,42 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     User ID: 500
                     Primary Group ID: 513
                     User Flags: 0
+                      .... .... .... .... ..0. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is NOT SET
+                      .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                      .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                      .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+                      .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+                      .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+                      .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+                      .... .... .... .... .... .... ..0. .... Extra Sids: The EXTRA_SIDS bit is NOT SET
+                      .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+                      .... .... .... .... .... .... .... ..0. No Encryption: The NO_ENCRYPTION bit is NOT SET
+                      .... .... .... .... .... .... .... ...0 Guest: The GUEST bit is NOT SET
                     User Session Key: 00000000000000000000000000000000
                     User Account Control: 528
+                      .... .... ..0. .... .... .... .... .... Use Aes Keys: The USE_AES_KEYS bit is NOT SET
+                      .... .... ...0 .... .... .... .... .... Partial Secrets Account: The PARTIAL_SECRETS_ACCOUNT bit is NOT SET
+                      .... .... .... 0... .... .... .... .... No Auth Data Required: The NO_AUTH_DATA_REQUIRED bit is NOT SET
+                      .... .... .... .0.. .... .... .... .... Trusted To Authenticate For Delegation: The TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION bit is NOT SET
+                      .... .... .... ..0. .... .... .... .... Password Expired: The PASSWORD_EXPIRED bit is NOT SET
+                      .... .... .... ...0 .... .... .... .... Dont Require Preauth: The DONT_REQUIRE_PREAUTH bit is NOT SET
+                      .... .... .... .... 0... .... .... .... Use Des Key Only: The USE_DES_KEY_ONLY bit is NOT SET
+                      .... .... .... .... .0.. .... .... .... Not Delegated: The NOT_DELEGATED bit is NOT SET
+                      .... .... .... .... ..0. .... .... .... Trusted For Delegation: The TRUSTED_FOR_DELEGATION bit is NOT SET
+                      .... .... .... .... ...0 .... .... .... Smartcard Required: The SMARTCARD_REQUIRED bit is NOT SET
+                      .... .... .... .... .... 0... .... .... Encrypted Test Password Allowed: The ENCRYPTED_TEST_PASSWORD_ALLOWED bit is NOT SET
+                      .... .... .... .... .... .0.. .... .... Account Auto Lock: The ACCOUNT_AUTO_LOCK bit is NOT SET
+                      .... .... .... .... .... ..1. .... .... Dont Expire Password: The DONT_EXPIRE_PASSWORD bit is SET
+                      .... .... .... .... .... ...0 .... .... Server Trust Account: The SERVER_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... 0... .... Workstation Trust Account: The WORKSTATION_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .0.. .... Interdomain Trust Account: The INTERDOMAIN_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... ..0. .... Mns Logon Account: The MNS_LOGON_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... ...1 .... Normal Account: The NORMAL_ACCOUNT bit is SET
+                      .... .... .... .... .... .... .... 0... Temp Duplicate Account: The TEMP_DUPLICATE_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .... .0.. Password Not Required: The PASSWORD_NOT_REQUIRED bit is NOT SET
+                      .... .... .... .... .... .... .... ..0. Home Directory Required: The HOME_DIRECTORY_REQUIRED bit is NOT SET
+                      .... .... .... .... .... .... .... ...0 Account Disabled: The ACCOUNT_DISABLED bit is NOT SET
                     Sub Auth Status: 0
                     Last Successful Interactive Logon: No Time Set (0)
                     Last Failed Interactive Logon: No Time Set (0)
@@ -204,11 +249,41 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     Resource Group Count: 0
                     Group Count: 5
                     Group IDs:
-                      Relative ID: 513, Attributes: 7
-                      Relative ID: 512, Attributes: 7
-                      Relative ID: 520, Attributes: 7
-                      Relative ID: 518, Attributes: 7
-                      Relative ID: 519, Attributes: 7
+                      Relative ID: 513
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 512
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 520
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 518
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 519
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
                     Logon Domain ID: S-1-5-21-3541430928-2051711210-1391384369
                     Effective Name: 'Administrator'
                     Full Name: ''
@@ -271,6 +346,8 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
             UPN: test@windomain.local
             DNS Domain Name: WINDOMAIN.LOCAL
             Flags: 1
+              .... .... .... .... .... .... .... ..0. Sam Name And Sid: The SAM_NAME_AND_SID bit is NOT SET
+              .... .... .... .... .... .... .... ...1 Upn Name Constructed: The UPN_NAME_CONSTRUCTED bit is SET
         EOF
       end
     end
@@ -288,9 +365,205 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
             UPN: test@windomain.local
             DNS Domain Name: WINDOMAIN.LOCAL
             Flags: 3
+              .... .... .... .... .... .... .... ..1. Sam Name And Sid: The SAM_NAME_AND_SID bit is SET
+              .... .... .... .... .... .... .... ...1 Upn Name Constructed: The UPN_NAME_CONSTRUCTED bit is SET
             SAM Name: test
             SID: S-1-5-32-544
         EOF
+      end
+    end
+
+    describe '#print_bindata_model' do
+      context 'when the bindata object has fields that are not 1bit' do
+        it 'should raise an exception' do
+          binary_value = [7].pack('N')
+          dummy_attributes = DummyAttributes.read(binary_value)
+          expect { subject.print_bindata_model(dummy_attributes, bit_length: 32) }.to raise_error TypeError, 'Unsupported field type BinData::Bit2 - expected BinData::Bit1'
+        end
+      end
+
+      context 'when a bit length less than the number of flags is passed' do # better description
+        it 'should raise an exception' do
+          binary_value = [7].pack('N')
+          group_attributes = Rex::Proto::Kerberos::Pac::GroupAttributes.read(binary_value)
+          expect { subject.print_bindata_model(group_attributes, bit_length: 2) }.to raise_error ArgumentError, 'Bit length(2) should not be less that the number of flags(32) within the BinData model'
+        end
+      end
+
+      context 'when passed GroupAttributes' do
+        it 'should return formatted flag descriptions for GROUP_MEMBERSHIP flags with RESOURCE set' do
+          binary_value = [536870912].pack('N')
+          group_attributes = Rex::Proto::Kerberos::Pac::GroupAttributes.read(binary_value)
+          expect(subject.print_bindata_model(group_attributes, bit_length: 32)).to match_table <<~TABLE
+            ..1. .... .... .... .... .... .... .... Resource: The RESOURCE bit is SET
+            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+            .... .... .... .... .... .... .... .0.. Enabled: The ENABLED bit is NOT SET
+            .... .... .... .... .... .... .... ..0. Enabled By Default: The ENABLED_BY_DEFAULT bit is NOT SET
+            .... .... .... .... .... .... .... ...0 Mandatory: The MANDATORY bit is NOT SET
+          TABLE
+        end
+
+        it 'should return formatted flag descriptions for GROUP_MEMBERSHIP flags with ENABLED, ENABLED_BY_DEFAULT and MANDATORY set' do
+          binary_value = [7].pack('N')
+          group_attributes = Rex::Proto::Kerberos::Pac::GroupAttributes.read(binary_value)
+          expect(subject.print_bindata_model(group_attributes, bit_length: 32)).to match_table <<~TABLE
+            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+            .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+            .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+            .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+          TABLE
+        end
+
+        it 'should return formatted flag descriptions for GROUP_MEMBERSHIP flags with OWNER set' do
+          binary_value = [8].pack('N')
+          group_attributes = Rex::Proto::Kerberos::Pac::GroupAttributes.read(binary_value)
+          expect(subject.print_bindata_model(group_attributes, bit_length: 32)).to match_table <<~TABLE
+            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+            .... .... .... .... .... .... .... 1... Owner: The OWNER bit is SET
+            .... .... .... .... .... .... .... .0.. Enabled: The ENABLED bit is NOT SET
+            .... .... .... .... .... .... .... ..0. Enabled By Default: The ENABLED_BY_DEFAULT bit is NOT SET
+            .... .... .... .... .... .... .... ...0 Mandatory: The MANDATORY bit is NOT SET
+          TABLE
+        end
+      end
+
+      context 'when passed UserFlagsAttributes' do
+        it 'should return formatted user descriptions for nothing being set' do
+          binary_value = [0].pack('N')
+          user_attributes = Rex::Proto::Kerberos::Pac::UserFlagAttributes.read(binary_value)
+          expect(subject.print_bindata_model(user_attributes, bit_length: 32)).to match_table <<~TABLE
+            .... .... .... .... ..0. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is NOT SET
+            .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+            .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+            .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+            .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+            .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+            .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+            .... .... .... .... .... .... ..0. .... Extra Sids: The EXTRA_SIDS bit is NOT SET
+            .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+            .... .... .... .... .... .... .... ..0. No Encryption: The NO_ENCRYPTION bit is NOT SET
+            .... .... .... .... .... .... .... ...0 Guest: The GUEST bit is NOT SET
+          TABLE
+        end
+
+        it 'should return formatted user descriptions for MACHINE_ACCOUNT being set' do
+          binary_value = [32].pack('N')
+          user_attributes = Rex::Proto::Kerberos::Pac::UserFlagAttributes.read(binary_value)
+          expect(subject.print_bindata_model(user_attributes, bit_length: 32)).to match_table <<~TABLE
+            .... .... .... .... ..0. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is NOT SET
+            .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+            .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+            .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+            .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+            .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+            .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+            .... .... .... .... .... .... ..1. .... Extra Sids: The EXTRA_SIDS bit is SET
+            .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+            .... .... .... .... .... .... .... ..0. No Encryption: The NO_ENCRYPTION bit is NOT SET
+            .... .... .... .... .... .... .... ...0 Guest: The GUEST bit is NOT SET
+          TABLE
+        end
+
+        it 'should return formatted user descriptions for USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY, NO_ENCRYPTION and GUEST being set' do
+          binary_value = [8195].pack('N')
+          user_attributes = Rex::Proto::Kerberos::Pac::UserFlagAttributes.read(binary_value)
+          expect(subject.print_bindata_model(user_attributes, bit_length: 32)).to match_table <<~TABLE
+            .... .... .... .... ..1. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is SET
+            .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+            .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+            .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+            .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+            .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+            .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+            .... .... .... .... .... .... ..0. .... Extra Sids: The EXTRA_SIDS bit is NOT SET
+            .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+            .... .... .... .... .... .... .... ..1. No Encryption: The NO_ENCRYPTION bit is SET
+            .... .... .... .... .... .... .... ...1 Guest: The GUEST bit is SET
+          TABLE
+        end
+
+        it 'should return formatted user descriptions for every flag being set' do
+          binary_value = [16363].pack('N')
+          user_attributes = Rex::Proto::Kerberos::Pac::UserFlagAttributes.read(binary_value)
+          expect(subject.print_bindata_model(user_attributes, bit_length: 32)).to match_table <<~TABLE
+            .... .... .... .... ..1. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is SET
+            .... .... .... .... ...1 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is SET
+            .... .... .... .... .... 1... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is SET
+            .... .... .... .... .... .1.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is SET
+            .... .... .... .... .... ..1. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is SET
+            .... .... .... .... .... ...1 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is SET
+            .... .... .... .... .... .... 1... .... Machine Account: The MACHINE_ACCOUNT bit is SET
+            .... .... .... .... .... .... .1.. .... Sub Authentication: The SUB_AUTHENTICATION bit is SET
+            .... .... .... .... .... .... ..1. .... Extra Sids: The EXTRA_SIDS bit is SET
+            .... .... .... .... .... .... .... 1... Lan Manager: The LAN_MANAGER bit is SET
+            .... .... .... .... .... .... .... ..1. No Encryption: The NO_ENCRYPTION bit is SET
+            .... .... .... .... .... .... .... ...1 Guest: The GUEST bit is SET
+          TABLE
+        end
+      end
+
+      context 'when passed UserAccountAttributes' do
+        it 'should return formatted user account descriptions for nothing being set' do
+          binary_value = [0].pack('N')
+          useraccount_attributes = Rex::Proto::Kerberos::Pac::UserAccountAttributes.read(binary_value)
+          expect(subject.print_bindata_model(useraccount_attributes, bit_length: 32)).to match_table <<~TABLE
+            .... .... ..0. .... .... .... .... .... Use Aes Keys: The USE_AES_KEYS bit is NOT SET
+            .... .... ...0 .... .... .... .... .... Partial Secrets Account: The PARTIAL_SECRETS_ACCOUNT bit is NOT SET
+            .... .... .... 0... .... .... .... .... No Auth Data Required: The NO_AUTH_DATA_REQUIRED bit is NOT SET
+            .... .... .... .0.. .... .... .... .... Trusted To Authenticate For Delegation: The TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION bit is NOT SET
+            .... .... .... ..0. .... .... .... .... Password Expired: The PASSWORD_EXPIRED bit is NOT SET
+            .... .... .... ...0 .... .... .... .... Dont Require Preauth: The DONT_REQUIRE_PREAUTH bit is NOT SET
+            .... .... .... .... 0... .... .... .... Use Des Key Only: The USE_DES_KEY_ONLY bit is NOT SET
+            .... .... .... .... .0.. .... .... .... Not Delegated: The NOT_DELEGATED bit is NOT SET
+            .... .... .... .... ..0. .... .... .... Trusted For Delegation: The TRUSTED_FOR_DELEGATION bit is NOT SET
+            .... .... .... .... ...0 .... .... .... Smartcard Required: The SMARTCARD_REQUIRED bit is NOT SET
+            .... .... .... .... .... 0... .... .... Encrypted Test Password Allowed: The ENCRYPTED_TEST_PASSWORD_ALLOWED bit is NOT SET
+            .... .... .... .... .... .0.. .... .... Account Auto Lock: The ACCOUNT_AUTO_LOCK bit is NOT SET
+            .... .... .... .... .... ..0. .... .... Dont Expire Password: The DONT_EXPIRE_PASSWORD bit is NOT SET
+            .... .... .... .... .... ...0 .... .... Server Trust Account: The SERVER_TRUST_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... 0... .... Workstation Trust Account: The WORKSTATION_TRUST_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .0.. .... Interdomain Trust Account: The INTERDOMAIN_TRUST_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... ..0. .... Mns Logon Account: The MNS_LOGON_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... ...0 .... Normal Account: The NORMAL_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .... 0... Temp Duplicate Account: The TEMP_DUPLICATE_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .... .0.. Password Not Required: The PASSWORD_NOT_REQUIRED bit is NOT SET
+            .... .... .... .... .... .... .... ..0. Home Directory Required: The HOME_DIRECTORY_REQUIRED bit is NOT SET
+            .... .... .... .... .... .... .... ...0 Account Disabled: The ACCOUNT_DISABLED bit is NOT SET
+          TABLE
+        end
+
+        it 'should return formatted user account descriptions for DONT_EXPIRE_PASSWORD and NORMAL_ACCOUNT being set' do
+          binary_value = [528].pack('N')
+          useraccount_attributes = Rex::Proto::Kerberos::Pac::UserAccountAttributes.read(binary_value)
+          expect(subject.print_bindata_model(useraccount_attributes, bit_length: 32)).to match_table <<~TABLE
+            .... .... ..0. .... .... .... .... .... Use Aes Keys: The USE_AES_KEYS bit is NOT SET
+            .... .... ...0 .... .... .... .... .... Partial Secrets Account: The PARTIAL_SECRETS_ACCOUNT bit is NOT SET
+            .... .... .... 0... .... .... .... .... No Auth Data Required: The NO_AUTH_DATA_REQUIRED bit is NOT SET
+            .... .... .... .0.. .... .... .... .... Trusted To Authenticate For Delegation: The TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION bit is NOT SET
+            .... .... .... ..0. .... .... .... .... Password Expired: The PASSWORD_EXPIRED bit is NOT SET
+            .... .... .... ...0 .... .... .... .... Dont Require Preauth: The DONT_REQUIRE_PREAUTH bit is NOT SET
+            .... .... .... .... 0... .... .... .... Use Des Key Only: The USE_DES_KEY_ONLY bit is NOT SET
+            .... .... .... .... .0.. .... .... .... Not Delegated: The NOT_DELEGATED bit is NOT SET
+            .... .... .... .... ..0. .... .... .... Trusted For Delegation: The TRUSTED_FOR_DELEGATION bit is NOT SET
+            .... .... .... .... ...0 .... .... .... Smartcard Required: The SMARTCARD_REQUIRED bit is NOT SET
+            .... .... .... .... .... 0... .... .... Encrypted Test Password Allowed: The ENCRYPTED_TEST_PASSWORD_ALLOWED bit is NOT SET
+            .... .... .... .... .... .0.. .... .... Account Auto Lock: The ACCOUNT_AUTO_LOCK bit is NOT SET
+            .... .... .... .... .... ..1. .... .... Dont Expire Password: The DONT_EXPIRE_PASSWORD bit is SET
+            .... .... .... .... .... ...0 .... .... Server Trust Account: The SERVER_TRUST_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... 0... .... Workstation Trust Account: The WORKSTATION_TRUST_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .0.. .... Interdomain Trust Account: The INTERDOMAIN_TRUST_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... ..0. .... Mns Logon Account: The MNS_LOGON_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... ...1 .... Normal Account: The NORMAL_ACCOUNT bit is SET
+            .... .... .... .... .... .... .... 0... Temp Duplicate Account: The TEMP_DUPLICATE_ACCOUNT bit is NOT SET
+            .... .... .... .... .... .... .... .0.. Password Not Required: The PASSWORD_NOT_REQUIRED bit is NOT SET
+            .... .... .... .... .... .... .... ..0. Home Directory Required: The HOME_DIRECTORY_REQUIRED bit is NOT SET
+            .... .... .... .... .... .... .... ...0 Account Disabled: The ACCOUNT_DISABLED bit is NOT SET
+          TABLE
+        end
       end
     end
   end

--- a/spec/modules/auxiliary/admin/kerberos/forge_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/forge_ticket_spec.rb
@@ -92,8 +92,42 @@ RSpec.describe 'kerberos keytab' do
                         User ID: 500
                         Primary Group ID: 513
                         User Flags: 32
+                          .... .... .... .... ..0. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is NOT SET
+                          .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                          .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                          .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+                          .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+                          .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+                          .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+                          .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+                          .... .... .... .... .... .... ..1. .... Extra Sids: The EXTRA_SIDS bit is SET
+                          .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+                          .... .... .... .... .... .... .... ..0. No Encryption: The NO_ENCRYPTION bit is NOT SET
+                          .... .... .... .... .... .... .... ...0 Guest: The GUEST bit is NOT SET
                         User Session Key: 00000000000000000000000000000000
                         User Account Control: 528
+                          .... .... ..0. .... .... .... .... .... Use Aes Keys: The USE_AES_KEYS bit is NOT SET
+                          .... .... ...0 .... .... .... .... .... Partial Secrets Account: The PARTIAL_SECRETS_ACCOUNT bit is NOT SET
+                          .... .... .... 0... .... .... .... .... No Auth Data Required: The NO_AUTH_DATA_REQUIRED bit is NOT SET
+                          .... .... .... .0.. .... .... .... .... Trusted To Authenticate For Delegation: The TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION bit is NOT SET
+                          .... .... .... ..0. .... .... .... .... Password Expired: The PASSWORD_EXPIRED bit is NOT SET
+                          .... .... .... ...0 .... .... .... .... Dont Require Preauth: The DONT_REQUIRE_PREAUTH bit is NOT SET
+                          .... .... .... .... 0... .... .... .... Use Des Key Only: The USE_DES_KEY_ONLY bit is NOT SET
+                          .... .... .... .... .0.. .... .... .... Not Delegated: The NOT_DELEGATED bit is NOT SET
+                          .... .... .... .... ..0. .... .... .... Trusted For Delegation: The TRUSTED_FOR_DELEGATION bit is NOT SET
+                          .... .... .... .... ...0 .... .... .... Smartcard Required: The SMARTCARD_REQUIRED bit is NOT SET
+                          .... .... .... .... .... 0... .... .... Encrypted Test Password Allowed: The ENCRYPTED_TEST_PASSWORD_ALLOWED bit is NOT SET
+                          .... .... .... .... .... .0.. .... .... Account Auto Lock: The ACCOUNT_AUTO_LOCK bit is NOT SET
+                          .... .... .... .... .... ..1. .... .... Dont Expire Password: The DONT_EXPIRE_PASSWORD bit is SET
+                          .... .... .... .... .... ...0 .... .... Server Trust Account: The SERVER_TRUST_ACCOUNT bit is NOT SET
+                          .... .... .... .... .... .... 0... .... Workstation Trust Account: The WORKSTATION_TRUST_ACCOUNT bit is NOT SET
+                          .... .... .... .... .... .... .0.. .... Interdomain Trust Account: The INTERDOMAIN_TRUST_ACCOUNT bit is NOT SET
+                          .... .... .... .... .... .... ..0. .... Mns Logon Account: The MNS_LOGON_ACCOUNT bit is NOT SET
+                          .... .... .... .... .... .... ...1 .... Normal Account: The NORMAL_ACCOUNT bit is SET
+                          .... .... .... .... .... .... .... 0... Temp Duplicate Account: The TEMP_DUPLICATE_ACCOUNT bit is NOT SET
+                          .... .... .... .... .... .... .... .0.. Password Not Required: The PASSWORD_NOT_REQUIRED bit is NOT SET
+                          .... .... .... .... .... .... .... ..0. Home Directory Required: The HOME_DIRECTORY_REQUIRED bit is NOT SET
+                          .... .... .... .... .... .... .... ...0 Account Disabled: The ACCOUNT_DISABLED bit is NOT SET
                         Sub Auth Status: 0
                         Last Successful Interactive Logon: No Time Set (0)
                         Last Failed Interactive Logon: No Time Set (0)
@@ -104,11 +138,41 @@ RSpec.describe 'kerberos keytab' do
                         Resource Group Count: 0
                         Group Count: 5
                         Group IDs:
-                          Relative ID: 513, Attributes: 7
-                          Relative ID: 512, Attributes: 7
-                          Relative ID: 520, Attributes: 7
-                          Relative ID: 518, Attributes: 7
-                          Relative ID: 519, Attributes: 7
+                          Relative ID: 513
+                          Attributes: 7
+                            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                            .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                            .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                            .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                          Relative ID: 512
+                          Attributes: 7
+                            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                            .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                            .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                            .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                          Relative ID: 520
+                          Attributes: 7
+                            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                            .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                            .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                            .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                          Relative ID: 518
+                          Attributes: 7
+                            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                            .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                            .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                            .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                          Relative ID: 519
+                          Attributes: 7
+                            ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                            .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                            .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                            .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                            .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
                         Logon Domain ID: S-1-5-21-1266190811-2419310613-1856291569
                         Effective Name: 'Administrator'
                         Full Name: ''

--- a/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/inspect_ticket_spec.rb
@@ -512,8 +512,42 @@ RSpec.describe 'kerberos inspect ticket' do
                     User ID: 500
                     Primary Group ID: 513
                     User Flags: 0
+                      .... .... .... .... ..0. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is NOT SET
+                      .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                      .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                      .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+                      .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+                      .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+                      .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+                      .... .... .... .... .... .... ..0. .... Extra Sids: The EXTRA_SIDS bit is NOT SET
+                      .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+                      .... .... .... .... .... .... .... ..0. No Encryption: The NO_ENCRYPTION bit is NOT SET
+                      .... .... .... .... .... .... .... ...0 Guest: The GUEST bit is NOT SET
                     User Session Key: 00000000000000000000000000000000
                     User Account Control: 528
+                      .... .... ..0. .... .... .... .... .... Use Aes Keys: The USE_AES_KEYS bit is NOT SET
+                      .... .... ...0 .... .... .... .... .... Partial Secrets Account: The PARTIAL_SECRETS_ACCOUNT bit is NOT SET
+                      .... .... .... 0... .... .... .... .... No Auth Data Required: The NO_AUTH_DATA_REQUIRED bit is NOT SET
+                      .... .... .... .0.. .... .... .... .... Trusted To Authenticate For Delegation: The TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION bit is NOT SET
+                      .... .... .... ..0. .... .... .... .... Password Expired: The PASSWORD_EXPIRED bit is NOT SET
+                      .... .... .... ...0 .... .... .... .... Dont Require Preauth: The DONT_REQUIRE_PREAUTH bit is NOT SET
+                      .... .... .... .... 0... .... .... .... Use Des Key Only: The USE_DES_KEY_ONLY bit is NOT SET
+                      .... .... .... .... .0.. .... .... .... Not Delegated: The NOT_DELEGATED bit is NOT SET
+                      .... .... .... .... ..0. .... .... .... Trusted For Delegation: The TRUSTED_FOR_DELEGATION bit is NOT SET
+                      .... .... .... .... ...0 .... .... .... Smartcard Required: The SMARTCARD_REQUIRED bit is NOT SET
+                      .... .... .... .... .... 0... .... .... Encrypted Test Password Allowed: The ENCRYPTED_TEST_PASSWORD_ALLOWED bit is NOT SET
+                      .... .... .... .... .... .0.. .... .... Account Auto Lock: The ACCOUNT_AUTO_LOCK bit is NOT SET
+                      .... .... .... .... .... ..1. .... .... Dont Expire Password: The DONT_EXPIRE_PASSWORD bit is SET
+                      .... .... .... .... .... ...0 .... .... Server Trust Account: The SERVER_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... 0... .... Workstation Trust Account: The WORKSTATION_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .0.. .... Interdomain Trust Account: The INTERDOMAIN_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... ..0. .... Mns Logon Account: The MNS_LOGON_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... ...1 .... Normal Account: The NORMAL_ACCOUNT bit is SET
+                      .... .... .... .... .... .... .... 0... Temp Duplicate Account: The TEMP_DUPLICATE_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .... .0.. Password Not Required: The PASSWORD_NOT_REQUIRED bit is NOT SET
+                      .... .... .... .... .... .... .... ..0. Home Directory Required: The HOME_DIRECTORY_REQUIRED bit is NOT SET
+                      .... .... .... .... .... .... .... ...0 Account Disabled: The ACCOUNT_DISABLED bit is NOT SET
                     Sub Auth Status: 0
                     Last Successful Interactive Logon: No Time Set (0)
                     Last Failed Interactive Logon: No Time Set (0)
@@ -522,11 +556,41 @@ RSpec.describe 'kerberos inspect ticket' do
                     Resource Group Count: 0
                     Group Count: 5
                     Group IDs:
-                      Relative ID: 513, Attributes: 7
-                      Relative ID: 512, Attributes: 7
-                      Relative ID: 520, Attributes: 7
-                      Relative ID: 518, Attributes: 7
-                      Relative ID: 519, Attributes: 7
+                      Relative ID: 513
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 512
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 520
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 518
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 519
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
                     Logon Domain ID: S-1-5-21-3541430928-2051711210-1391384369
                     Effective Name: 'Administrator'
                     Full Name: ''
@@ -638,8 +702,42 @@ RSpec.describe 'kerberos inspect ticket' do
                     User ID: 500
                     Primary Group ID: 513
                     User Flags: 0
+                      .... .... .... .... ..0. .... .... .... Used Lmv2 Auth And Ntlmv2 Session Key: The USED_LMV2_AUTH_AND_NTLMV2_SESSION_KEY bit is NOT SET
+                      .... .... .... .... ...0 .... .... .... Used Lmv2 Auth And Session Key: The USED_LMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                      .... .... .... .... .... 0... .... .... Used Ntlmv2 Auth And Session Key: The USED_NTLMV2_AUTH_AND_SESSION_KEY bit is NOT SET
+                      .... .... .... .... .... .0.. .... .... Profile Path Populated: The PROFILE_PATH_POPULATED bit is NOT SET
+                      .... .... .... .... .... ..0. .... .... Resource Group Ids: The RESOURCE_GROUP_IDS bit is NOT SET
+                      .... .... .... .... .... ...0 .... .... Accepts Ntlmv2: The ACCEPTS_NTLMV2 bit is NOT SET
+                      .... .... .... .... .... .... 0... .... Machine Account: The MACHINE_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .0.. .... Sub Authentication: The SUB_AUTHENTICATION bit is NOT SET
+                      .... .... .... .... .... .... ..0. .... Extra Sids: The EXTRA_SIDS bit is NOT SET
+                      .... .... .... .... .... .... .... 0... Lan Manager: The LAN_MANAGER bit is NOT SET
+                      .... .... .... .... .... .... .... ..0. No Encryption: The NO_ENCRYPTION bit is NOT SET
+                      .... .... .... .... .... .... .... ...0 Guest: The GUEST bit is NOT SET
                     User Session Key: 00000000000000000000000000000000
                     User Account Control: 528
+                      .... .... ..0. .... .... .... .... .... Use Aes Keys: The USE_AES_KEYS bit is NOT SET
+                      .... .... ...0 .... .... .... .... .... Partial Secrets Account: The PARTIAL_SECRETS_ACCOUNT bit is NOT SET
+                      .... .... .... 0... .... .... .... .... No Auth Data Required: The NO_AUTH_DATA_REQUIRED bit is NOT SET
+                      .... .... .... .0.. .... .... .... .... Trusted To Authenticate For Delegation: The TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION bit is NOT SET
+                      .... .... .... ..0. .... .... .... .... Password Expired: The PASSWORD_EXPIRED bit is NOT SET
+                      .... .... .... ...0 .... .... .... .... Dont Require Preauth: The DONT_REQUIRE_PREAUTH bit is NOT SET
+                      .... .... .... .... 0... .... .... .... Use Des Key Only: The USE_DES_KEY_ONLY bit is NOT SET
+                      .... .... .... .... .0.. .... .... .... Not Delegated: The NOT_DELEGATED bit is NOT SET
+                      .... .... .... .... ..0. .... .... .... Trusted For Delegation: The TRUSTED_FOR_DELEGATION bit is NOT SET
+                      .... .... .... .... ...0 .... .... .... Smartcard Required: The SMARTCARD_REQUIRED bit is NOT SET
+                      .... .... .... .... .... 0... .... .... Encrypted Test Password Allowed: The ENCRYPTED_TEST_PASSWORD_ALLOWED bit is NOT SET
+                      .... .... .... .... .... .0.. .... .... Account Auto Lock: The ACCOUNT_AUTO_LOCK bit is NOT SET
+                      .... .... .... .... .... ..1. .... .... Dont Expire Password: The DONT_EXPIRE_PASSWORD bit is SET
+                      .... .... .... .... .... ...0 .... .... Server Trust Account: The SERVER_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... 0... .... Workstation Trust Account: The WORKSTATION_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .0.. .... Interdomain Trust Account: The INTERDOMAIN_TRUST_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... ..0. .... Mns Logon Account: The MNS_LOGON_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... ...1 .... Normal Account: The NORMAL_ACCOUNT bit is SET
+                      .... .... .... .... .... .... .... 0... Temp Duplicate Account: The TEMP_DUPLICATE_ACCOUNT bit is NOT SET
+                      .... .... .... .... .... .... .... .0.. Password Not Required: The PASSWORD_NOT_REQUIRED bit is NOT SET
+                      .... .... .... .... .... .... .... ..0. Home Directory Required: The HOME_DIRECTORY_REQUIRED bit is NOT SET
+                      .... .... .... .... .... .... .... ...0 Account Disabled: The ACCOUNT_DISABLED bit is NOT SET
                     Sub Auth Status: 0
                     Last Successful Interactive Logon: No Time Set (0)
                     Last Failed Interactive Logon: No Time Set (0)
@@ -648,11 +746,41 @@ RSpec.describe 'kerberos inspect ticket' do
                     Resource Group Count: 0
                     Group Count: 5
                     Group IDs:
-                      Relative ID: 513, Attributes: 7
-                      Relative ID: 512, Attributes: 7
-                      Relative ID: 520, Attributes: 7
-                      Relative ID: 518, Attributes: 7
-                      Relative ID: 519, Attributes: 7
+                      Relative ID: 513
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 512
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 520
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 518
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
+                      Relative ID: 519
+                      Attributes: 7
+                        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
+                        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
+                        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
+                        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
+                        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
                     Logon Domain ID: S-1-5-21-3541430928-2051711210-1391384369
                     Effective Name: 'Administrator'
                     Full Name: ''


### PR DESCRIPTION
This PR adds support for flag formatting to the Kerberos ticket presenter.

Expand this output to now breakdown what flags are enabled with a breif description of each flag:
```

  Group IDs:
      Relative ID: 513
      Attributes: 7
        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
       .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
       .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
      Relative ID: 512
      Attributes: 7
        ..0. .... .... .... .... .... .... .... Resource: The RESOURCE bit is NOT SET
        .... .... .... .... .... .... .... 0... Owner: The OWNER bit is NOT SET
        .... .... .... .... .... .... .... .1.. Enabled: The ENABLED bit is SET
        .... .... .... .... .... .... .... ..1. Enabled By Default: The ENABLED_BY_DEFAULT bit is SET
        .... .... .... .... .... .... .... ...1 Mandatory: The MANDATORY bit is SET
```

## Before
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/9710a9ab-c915-47c1-ba96-706a0a2fb8c0)

## After
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/e093fe86-77f5-4f2f-8c45-cee44727ff95)


## Verification

- [ ] Create a `.kirbi` file to test against - https://github.com/rapid7/metasploit-framework/pull/17635
- [ ] Start `msfconsole`
- [ ] Run `run ticket_path=./ticket.kirbi NTHASH=<NTHASH>`
