### PR TITLE
Fix crash when running a module through socks 4a proxy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.49)
+    rex-socket (0.1.51)
       rex-core
     rex-sslscan (0.1.9)
       rex-core


### PR DESCRIPTION
Fix crash when running socks proxy4a comm.

Fix from: https://github.com/rapid7/rex-socket/pull/60

## Verification

Replication steps: https://github.com/rapid7/rex-socket/pull/60