### PR TITLE
Updates the msfdb default prompts for webservice

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -78,7 +78,7 @@ require 'msfenv'
     retry_max: 10,
     retry_delay: 5.0,
     ws_user: nil,
-    add_data_service: true,
+    add_data_service: false,
     data_service_name: nil,
     use_defaults: false,
     delete_existing_data: true
@@ -921,6 +921,7 @@ def parse_args(args)
       if !n
         @options[:add_data_service] = false
       else
+        @options[:add_data_service] = true
         @options[:data_service_name] = n
       end
     }
@@ -987,8 +988,7 @@ def prompt_for_component(command)
     return :database
   end
 
-  enable_webservice = ask_yn("Would you like to #{command} the webservice? (Not Required)", default: 'no')
-  if enable_webservice
+  if @options[:add_data_service] == true
     :all
   else
     :database


### PR DESCRIPTION
Fixes #17986

This PR updates the `msfdb` commands to no longer call the web services as default. The web service will now be called with the web service flag: `--msf-data-service <NAME>` e.g.
```Bash
bundle exec ruby ./msfdb init --msf-data-service test
```

## Before 
When using `bundle exec ruby ./msfdb init --use-defaults` the user would still be prompted if the webservice should be initialised.
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/96fb556a-65c8-4e6b-8140-2b96aa590b24)

## After 
Users are no longer prompted if the webservice should be initialised.
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/278e3fce-af43-4210-a8fc-add1b229b70c)

## Verification

List the steps needed to make sure this thing works

- [x] **Verify** code changes are sane
- [x] Run `msfdb` with it's various commands to ensure no functionality has been broken
- [x] Run `bundle exec ruby ./msfdb init --use-defaults` and ensure you are no longer prompted for the webservice