### PR TITLE
Fix edgecase crash when running smb_login with Kerberos auth activated

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -2,6 +2,7 @@ require 'metasploit/framework'
 require 'metasploit/framework/tcp/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/kerberos'
 require 'ruby_smb'
 
 module Metasploit


### PR DESCRIPTION
## Verification

Fix edgecase crash when running smb_login with Kerberos auth activated

## Before

```
msf6 auxiliary(scanner/smb/smb_login) > run rhost=192.168.123.13 username=administrator password=p4$$w0rd4 smb::auth=kerberos smb::rhostname=dc3.adf3.local domaincontrollerrhost=192.168.123.13 domain=adf3.local

[*] 192.168.123.13:445    - 192.168.123.13:445 - Starting SMB login bruteforce
[-] 192.168.123.13:445    - Auxiliary failed: NameError uninitialized constant Metasploit::Framework::LoginScanner::Kerberos
[-] 192.168.123.13:445    - Call stack:
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/smb.rb:146:in `rescue in attempt_login'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/smb.rb:140:in `attempt_login'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:231:in `block in scan!'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:154:in `block in each_credential'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/credential_collection.rb:89:in `block in each_filtered'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/credential_collection.rb:233:in `each_unfiltered'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/credential_collection.rb:86:in `each_filtered'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:141:in `each_credential'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:205:in `scan!'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/smb/smb_login.rb:132:in `run_host'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-] 192.168.123.13:445    -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
```

## After

```
msf6 auxiliary(scanner/smb/smb_login) >  run rhost=192.168.123.13 username=administrator password=p4$$w0rd4 smb::auth=kerberos smb::rhostname=dc3.adf3.local domaincontrollerrhost=192.168.123.13 domain=adf3.local

[*] 192.168.123.13:445    - 192.168.123.13:445 - Starting SMB login bruteforce
[+] 192.168.123.13:445    - 192.168.123.13:88 - Received a valid TGT-Response
[*] 192.168.123.13:445    - 192.168.123.13:445    - TGT MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230519161439_default_192.168.123.13_mit.kerberos.cca_090044.bin
[+] 192.168.123.13:445    - 192.168.123.13:88 - Received a valid TGS-Response
[*] 192.168.123.13:445    - 192.168.123.13:445    - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20230519161439_default_192.168.123.13_mit.kerberos.cca_553618.bin
[+] 192.168.123.13:445    - 192.168.123.13:88 - Received a valid delegation TGS-Response
[+] 192.168.123.13:445    - 192.168.123.13:445 - Success: 'adf3.local\administrator:p4$$w0rd4' Administrator
[!] 192.168.123.13:445    - No active DB -- Credential data will not be saved!
[*] 192.168.123.13:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```