### PR TITLE
Remove dead link

### DIFF
--- a/docs/metasploit-framework.wiki/Using-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Using-Metasploit.md
@@ -2,7 +2,6 @@
 
 Depending on your skill level - if you have no experience with Metasploit, the following resources may be a better starting point:
 
-* <https://tryhackme.com/room/rpmetasploit>
 * <http://www.offensive-security.com/metasploit-unleashed/Main_Page>
 * <https://metasploit.help.rapid7.com/docs/>
 * <https://www.kali.org/docs/tools/starting-metasploit-framework-in-kali/>


### PR DESCRIPTION
Remove dead link from documentation.

I'm trying to get started with Metasploit, and the first link in the `Using Metasploit` wiki isn't public anymore:

<img width="985" alt="Screenshot 2023-05-22 at 9 43 44 AM" src="https://github.com/rapid7/metasploit-framework/assets/2186874/64ff2ea7-81ac-46b8-b5a2-8940c464daec">

Notice that I even have a valid account (that I'm logged in with!) in the image.

I'd _prefer_ if the first documentation link wasn't dead - I think that's a better onboarding experience - so I made a change to fix it.

If there's some process that I need to go through to get access to that room, I'll attempt it and then document my steps so that the next person that tries to use that room to onboard to Metasploit doesn't hit this same issue.