### PR TITLE
Fixes validation for `to_handler` command for Evasion and Payload modules

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -153,7 +153,8 @@ module Exploit
       raise $!
     rescue ::Msf::OptionValidateError => e
       exploit.error = e
-      ::Msf::Ui::Formatter::OptionValidateError.print_error(oexploit, e)
+      ::Msf::Ui::Formatter::OptionValidateError.print_error(exploit, e)
+      return false
     rescue ::Exception => e
       exploit.error = e
       exploit.print_error("Exploit failed: #{e}")
@@ -248,4 +249,3 @@ end
 
 end
 end
-

--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -91,10 +91,22 @@ class Evasion
     }
 
     handler.share_datastore(mod.datastore)
-    handler.exploit_simple(handler_opts)
-    job_id = handler.job_id
 
-    print_status "Payload Handler Started as Job #{job_id}"
+    replicant_handler = nil
+    handler.exploit_simple(handler_opts) do |yielded_replicant_handler|
+      replicant_handler = yielded_replicant_handler
+    end
+
+    if replicant_handler.nil?
+      print_error('Failed to run module')
+      return
+    end
+
+    if replicant_handler.error.nil?
+      job_id = handler.job_id
+
+      print_status "Payload Handler Started as Job #{job_id}"
+    end
   end
 end
 end

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -59,10 +59,22 @@ module Msf
             }
 
             handler.share_datastore(mod.datastore)
-            handler.exploit_simple(handler_opts)
-            job_id = handler.job_id
 
-            print_status "Payload Handler Started as Job #{job_id}"
+            replicant_handler = nil
+            handler.exploit_simple(handler_opts) do |yielded_replicant_handler|
+              replicant_handler = yielded_replicant_handler
+            end
+
+            if replicant_handler.nil?
+              print_error('Failed to run module')
+              return
+            end
+
+            if replicant_handler.error.nil?
+              job_id = handler.job_id
+
+              print_status "Payload Handler Started as Job #{job_id}"
+            end
           end
 
           alias cmd_exploit cmd_to_handler


### PR DESCRIPTION
Fixes #17935

This PR fixes a validation issue that was present in the `to_handler` methods for both Payload and Evasion modules. More information can be found in the linked issue.

## Before
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/d57a12cc-d0eb-4242-8552-34c4be93aaa8)

## After
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/83e0c186-5337-4d44-bb5b-b81227c8a69e)


## Verification
- [ ] Start `msfconsole`
- [ ] Use any payload e.g. `use linux/x64/meterpreter/reverse_tcp`
- [ ] Run `to_handler` while having no value set for `LHOST`
- [ ] **Verify** a suitable error is now returned
- [ ] Repeat the steps above for an Evasion module.