### PR TITLE
Fix #cd for Powershell Sessions

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/remote/smb/client/psexec.rb
@@ -241,7 +241,7 @@ module Exploit::Remote::SMB::Client::Psexec
 
   def execute_command(text, bat, cmd)
     # Try and execute the provided command
-    cmd = cmd.gsub('&', '^&')
+    cmd = Msf::Post::Windows.escape_cmd_literal(cmd, spaces: false)
     execute = "%COMSPEC% /C echo #{cmd} ^> %SYSTEMDRIVE%#{text} > #{bat} & %COMSPEC% /C start %COMSPEC% /C #{bat}"
     vprint_status("Executing the command: #{execute}")
     begin

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -49,7 +49,7 @@ module Msf::Post::File
     if session.type == 'meterpreter'
       session.fs.dir.chdir(e_path)
     elsif session.type == 'powershell'
-      cmd_exec("Set-Location -Path \"#{e_path}\"")
+      cmd_exec("Set-Location -Path \"#{e_path}\";[System.IO.Directory]::SetCurrentDirectory($(Get-Location))")
     else
       session.shell_command_token("cd \"#{e_path}\"")
     end

--- a/lib/msf/core/post/windows.rb
+++ b/lib/msf/core/post/windows.rb
@@ -1,4 +1,18 @@
 # -*- coding: binary -*-
 
 module Msf::Post::Windows
+  # Escape a string literal value to be included as an argument to cmd.exe. The escaped value *should not* be placed
+  # within double quotes as this will alter now it is evaluated (e.g. `echo "^"((^&test) Foo^""` is different than
+  # `echo ^"((^&test) Foo^"`.
+  #
+  # @param [String] string The string to escape for use with cmd.exe.
+  # @param [Boolean] spaces Whether or not to escape spaces. If the string is being passed to echo, set this to false
+  #   otherwise if it's an argument, set it to true.
+  # @return [String] The escaped string.
+  def self.escape_cmd_literal(string, spaces:)
+    string = string.dup
+    %w[ ^ & < > | " ].each { |char| string.gsub!(char, "^#{char}") }
+    string.gsub!(' ', '" "') if spaces
+    string
+  end
 end


### PR DESCRIPTION
Per https://github.com/PowerShell/PowerShell/issues/10278 the .NET working directory is different from the Powershell one. Our Powershell Post API methods use a mix of Powershell and .NET methods. This means that after changing directory, methods that use .NET will fail when given relative paths because the current working directory is different. The proposed solution is to set the .NET working directory at the same time so they stay synchronized. With this in place, 3 tests will start to pass from the `post/test/file` module, leaving just one failure.

Also added is a method to escape Windows command literals that's more robust that what was added [here](https://github.com/rapid7/metasploit-framework/commit/548a2d7ab4a8fbf3c9faff6f589e67349e2c2b64#diff-9b3f3bfdb1ef399361d23cab82715ca0b0fc897a97db09953113b9eb6fede739) which ended up breaking the `cmd/windows/powershell_reverse_tcp` payload when delivered via psexec.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] Set the payload to `cmd/windows/powershell_reverse_tcp`
- [x] Set the necessary options and run the module to open a session
- [x] Run `loadpath test/modules`
- [x] Run the `post/test/file` module with the new session.
- [x] The `should delete a symbolic link target` will fail but the rest will pass
    - [x] `should create directories` passes 🟢 
    - [x] `should list the directory we just made` passes 🟢 
    - [x] `should not recurse into symbolic link directories` passes 🟢 

## New Output

```
msf6 post(test/file) > run

[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: powershell
[*] Running against session -1
[*] Session type is powershell and platform is windows
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[+] should test for directory existence
[+] should create directories
[+] should list the directory we just made
[+] should recursively delete the directory we just made
[-] FAILED: should delete a symbolic link target
[+] should not recurse into symbolic link directories
[-] Passed: 15; Failed: 1
[*] Post module execution completed
```

## Old Output

```
msf6 post(test/file) > run

[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: powershell
[*] Running against session -1
[*] Session type is powershell and platform is windows
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[+] should test for directory existence
[-] FAILED: should create directories
[-] FAILED: should list the directory we just made
[+] should recursively delete the directory we just made
[-] FAILED: should delete a symbolic link target
[-] FAILED: should not recurse into symbolic link directories
[-] Passed: 12; Failed: 4
[*] Post module execution completed
msf6 post(test/file) > 
```