### PR TITLE
bump metasploit credential to 6.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.4)
+    metasploit-credential (6.0.5)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 5.0.0)


### PR DESCRIPTION
This bumps the `metasploit-credential` gem to version 6.0.5 in order to fix a bug with credential imports.

## Verification

-Import a credential of type NTLMHash, PostgresMD5, or KrbEncKey, where the key has uppercase values
-Delete that credential core
-Import the credential again
Previously, this will give an error on import. This should now yield successful imports on the version bump