### PR TITLE
apache nifi version scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/apache_nifi_version.md
+++ b/documentation/modules/auxiliary/scanner/http/apache_nifi_version.md
@@ -10,7 +10,7 @@ Also works against NiFi <= 1.13.0, but the module needs to be adjusted:
 
 ### Docker Install
 
-Apache manages Docker installs for nifi with version numbers, simply select the version number you wish to install. Examples:
+Apache manages Docker installs for NiFi with version numbers, simply select the version number you wish to install. Examples:
 
 ```
 docker run -p 8443:8443 -d apache/nifi:1.21.0
@@ -34,7 +34,7 @@ docker run -p 8080:8080 -d apache/nifi:1.11.0
 1. Do: `use auxiliary/scanner/http/apache_nifi_version`
 1. Do: `set rhosts [ip]`
 1. Do: `run`
-1. You should get back the version number of the nifi instance
+1. You should get back the version number of the NiFi instance
 
 ## Options
 

--- a/documentation/modules/auxiliary/scanner/http/apache_nifi_version.md
+++ b/documentation/modules/auxiliary/scanner/http/apache_nifi_version.md
@@ -1,0 +1,76 @@
+## Vulnerable Application
+
+This module identifies Apache NiFi websites and reports their version number.
+
+Tested against NiFi major releases 1.14.0 - 1.21.0, and 1.11.0-1.13.0.
+
+Also works against NiFi <= 1.13.0, but the module needs to be adjusted:
+ - set SSL false
+ - set rport 8080
+
+### Docker Install
+
+Apache manages Docker installs for nifi with version numbers, simply select the version number you wish to install. Examples:
+
+```
+docker run -p 8443:8443 -d apache/nifi:1.21.0
+docker run -p 8443:8443 -d apache/nifi:1.20.0
+docker run -p 8443:8443 -d apache/nifi:1.19.0
+docker run -p 8443:8443 -d apache/nifi:1.18.0
+docker run -p 8443:8443 -d apache/nifi:1.17.0
+docker run -p 8443:8443 -d apache/nifi:1.16.0
+docker run -p 8443:8443 -d apache/nifi:1.15.0
+docker run -p 8443:8443 -d apache/nifi:1.14.0
+docker run -p 8080:8080 -d apache/nifi:1.13.0
+docker run -p 8080:8080 -d apache/nifi:1.13.0
+docker run -p 8080:8080 -d apache/nifi:1.12.0
+docker run -p 8080:8080 -d apache/nifi:1.11.0
+```
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/apache_nifi_version`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should get back the version number of the nifi instance
+
+## Options
+
+## Scenarios
+
+### Docker image 1.21.0 and 1.11.0
+
+```
+└─$ docker run -p 8443:8443 -d apache/nifi:1.21.0
+1df39f1d1dc0a4abde9e2daedf8b3dc66d37fb53126e491b7050da618e971dfd
+└─$ ./msfconsole -q
+msf6 > use auxiliary/scanner/http/apache_nifi_version
+msf6 auxiliary(scanner/http/apache_nifi_version) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/apache_nifi_version) > run
+
+[+] Apache NiFi 1.21.0 found on 127.0.0.1
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+```
+└─$ docker run -p 8080:8080 -d apache/nifi:1.11.0
+089f1b164853df8b088a3e80d25d7f886b1934a654ed7807433e3eef46a5973f
+└─$ ./msfconsole -q
+msf6 > use auxiliary/scanner/http/apache_nifi_version
+msf6 auxiliary(scanner/http/apache_nifi_version) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/apache_nifi_version) > set ssl false
+[!] Changing the SSL option's value may require changing RPORT!
+ssl => false
+msf6 auxiliary(scanner/http/apache_nifi_version) > set rport 8080
+rport => 8080
+msf6 auxiliary(scanner/http/apache_nifi_version) > run
+
+[+] Apache NiFi 1.11.0 found on 127.0.0.1
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/apache_nifi_version.rb
+++ b/modules/auxiliary/scanner/http/apache_nifi_version.rb
@@ -1,0 +1,62 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache NiFi Version Scanner',
+        'Description' => %q{
+          This module identifies Apache NiFi websites and reports their version number.
+
+          Tested against NiFi major releases 1.14.0 - 1.21.0, and 1.11.0-1.13.0
+          Also works against NiFi <= 1.13.0, but the module needs to be adjusted:
+          set SSL false
+          set rport 8080
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die',
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(8443),
+        OptString.new('TARGETURI', [ true, 'The URI of the Apache NiFi Application', '/nifi/login'])
+      ]
+    )
+    register_advanced_options([
+      OptBool.new('SSL', [true, 'Negotiate SSL connection', true])
+    ])
+  end
+
+  def run_host(ip)
+    vprint_status("Checking #{ip}")
+    res = send_request_cgi!(
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected Respones Code (response code: #{res.code})") unless res.code == 200
+
+    if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]*)">}
+      print_good("Apache NiFi #{Regexp.last_match(1)} found on #{ip}")
+    else
+      print_bad("Apache NiFi not detected on #{ip}")
+    end
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+  end
+end

--- a/modules/auxiliary/scanner/http/apache_nifi_version.rb
+++ b/modules/auxiliary/scanner/http/apache_nifi_version.rb
@@ -56,7 +56,5 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_bad("Apache NiFi not detected on #{ip}")
     end
-  rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 end


### PR DESCRIPTION
This PR adds a version scanner for Apache NiFi.  It should work on 1.11.0-1.21.0 (what I tested against, may be more).  I tried 1.10.0, but the docker image crashes, so I didn't bother going back any further.

## Verification

- [ ] Start one of the docker iamges
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/apache_nifi_version`
- [ ] `set rhosts [ip]`
- [ ] **Verify** it identifies the server
- [ ] **Document** looks good

