### PR TITLE
Fix non-deterministic test module load failures

### DIFF
--- a/test/modules/post/test/extapi.rb
+++ b/test/modules/post/test/extapi.rb
@@ -1,7 +1,7 @@
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -1,4 +1,4 @@
-lib = File.join(Msf::Config.install_root, 'test', 'lib')
+lib = File.join(Msf::Config.install_root, "test", "lib")
 $LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -1,4 +1,4 @@
-lib = File.join(Msf::Config.install_root, "test", "lib")
+lib = File.join(Msf::Config.install_root, 'test', 'lib')
 $LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 

--- a/test/modules/post/test/get_env.rb
+++ b/test/modules/post/test/get_env.rb
@@ -1,4 +1,5 @@
 lib = File.join(Msf::Config.install_root, "test", "lib")
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 # load 'test/lib/module_test.rb'

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -2,7 +2,7 @@ require 'rex/post/meterpreter/extensions/stdapi/command_ids'
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/railgun.rb
+++ b/test/modules/post/test/railgun.rb
@@ -1,4 +1,5 @@
 lib = File.join(Msf::Config.install_root, "test", "lib")
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -6,7 +6,7 @@
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -6,7 +6,7 @@
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/search.rb
+++ b/test/modules/post/test/search.rb
@@ -2,7 +2,7 @@ require 'rex/post/meterpreter/extensions/stdapi/command_ids'
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/services.rb
+++ b/test/modules/post/test/services.rb
@@ -5,7 +5,7 @@
 require 'rex'
 
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 class MetasploitModule < Msf::Post

--- a/test/modules/post/test/unix.rb
+++ b/test/modules/post/test/unix.rb
@@ -1,5 +1,5 @@
 lib = File.join(Msf::Config.install_root, "test", "lib")
-$:.push(lib) unless $:.include?(lib)
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
 require 'module_test'
 
 # load 'test/lib/module_test.rb'


### PR DESCRIPTION
Fixes non-deterministic test module load failures when running the `loadpath test/modules` command

Depending on the order the OS's file system loaded test modules via `loadpath test/modules`,  modules could fail to load:

```
[read] msf6 payload(python/meterpreter/reverse_tcp) > 
[read] 
[read] [!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[read] [*] Started reverse TCP handler on 127.0.0.1:6007 
[read] [*] Sending stage (24824 bytes) to 127.0.0.1
[read] [*] Meterpreter session 7 opened (127.0.0.1:6007 -> 127.0.0.1:49078) at 2023-05-25 01:03:35 +0000
[write] use test/get_env
[read] [-] No results from search
[read] [-] Failed to load module: test/get_env
```

This is because not all modules were manipulating the load path to `require` the `module_test` library correctly

### Verification steps

If the other modules load first, this should work:

```
loadpath test/modules

use test/get_env
```

But in the scenario of `test/get_env` loading first, the module will fail to load. Verify this by deleting the other test modules on disk. Then exit msfconsole, perform the same steps - and the module will fail to load