### PR TITLE
Fix missing return in HTTP CmdStagers

### DIFF
--- a/lib/msf/core/exploit/cmd_stager/http.rb
+++ b/lib/msf/core/exploit/cmd_stager/http.rb
@@ -42,7 +42,7 @@ module HTTP
 
     unless user_agent =~ agent_regex
       print_status("Sending 404 to #{client}")
-      send_not_found(cli)
+      return send_not_found(cli)
     end
 
     print_status("Sending payload to #{client}")


### PR DESCRIPTION
Fetch payloads are cooler, but this was missed in https://github.com/rapid7/metasploit-framework/pull/13426. (Edit: Because I'm a big dummy.)

FWIW, the client doesn't actually receive the payload. You can test with `curl -A` or `wget -U` and a `CmdStager` exploit.