### PR TITLE
Escape braces after all in cmd/brace encoder

### DIFF
--- a/modules/encoders/cmd/brace.rb
+++ b/modules/encoders/cmd/brace.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Encoder
     return buf if state.badchars !~ /\s/
 
     # Perform brace expansion encoding
-    "{#{buf.gsub(',', '\\,').gsub(/\s+/, ',')}}"
+    "{#{buf.gsub(/([{,}])/, '\\\\\1').gsub(/\s+/, ',')}}"
   end
 
 end


### PR DESCRIPTION
Previously escaped only commas.

Test: `echo -n "echo hello, {world}" | ./msfvenom -a cmd --platform unix -e cmd/brace -b " "`

Updates https://github.com/rapid7/metasploit-framework/pull/10516.