### PR TITLE
Fix incorrect error handling in ibm sametime enumerate users

### DIFF
--- a/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
+++ b/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Auxiliary
         # valid JSON response - valid response for check
         print_good("Response received, continuing to enumeration phase")
       end
-    rescue JSON::ParserError,
+    rescue JSON::ParserError
       print_error("Error parsing JSON: Invalid response from server")
       return
     end


### PR DESCRIPTION
Fix incorrect error handling in ibm sametime enumerate users

Spotted when playing with CodeQL; this exception handling is wrong - the `print_error` is never called during a JSON parsing exception as it's one of the expressions evaluated when catching exceptions - instead of being part of the body

<img width="1636" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/f997ae95-b59a-4a3d-b26e-85a9791b42e0">

Example:

```
class CustomException < Exception
end

def example
  begin
      puts('before')
      raise CustomException
    rescue CustomException,
      puts('exception occurred')
      return
  end
end

example
```

Current output:
```
before
```

Expected output:
```
before
exception occurred
```

Fixed with:

```diff
    rescue CustomException
      puts('exception occurred')
```

Now:

```
before
exception occurred
```