### PR TITLE
Minor fix in vsftpd_232.md docs

### DIFF
--- a/documentation/modules/auxiliary/dos/ftp/vsftpd_232.md
+++ b/documentation/modules/auxiliary/dos/ftp/vsftpd_232.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This is an auxiliary for DOSing a VSFTPD server from version 2.3.3 and below. The
+This is an auxiliary for DOSing a VSFTPD server from version 2.3.2 and below. The
 vulnerability has been directly tested on versions 2.3.0, 2.3.1, and 2.3.2 and have
 shown success.
 


### PR DESCRIPTION
I missed this and realized right after I landed the PR. Slighty incorrect wording with regards to affected versions. Version 2.3.3 is the fixed version and is not affected:
> The vsf_filename_passes_filter function in ls.c in vsftpd before 2.3.3 allows remote authenticated users to cause a denial of service