### PR TITLE
add support to masm formatting

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -63,6 +63,8 @@ module Buffer
         buf = Rex::Text.encode_base64(buf)
       when 'go','golang'
         buf = Rex::Text.to_golang(buf)
+      when 'masm'
+        buf = Rex::Text.to_masm(buf)
       when 'nim','nimlang'
         buf = Rex::Text.to_nim(buf)
       when 'rust', 'rustlang'
@@ -130,6 +132,7 @@ module Buffer
       'java',
       'js_be',
       'js_le',
+      'masm',
       'nim',
       'nimlang',
       'num',


### PR DESCRIPTION
Add support to masm. Usefull when the shellcode loader is written in asm x64 using masm.


- [ ] git pull Rex-text in order to get the function to_masm() working
- [ ] use msfvenom to generate a shellcode using the option -f masm

```
(shellchocolat)➜ ➜ ~ cat nop.bin | msfvenom -p - -a x64 --platform windows -e x64/xor -f masm
Attempting to read payload from STDIN...
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x64/xor
x64/xor succeeded with size 55 (iteration=0)
x64/xor chosen with final size 55
Payload size: 55 bytes
Final size of masm file: 277 bytes
shellcode DB 48h,31h,0c9h,48h,81h,0e9h,0feh,0ffh
DB 0ffh,0ffh,48h,8dh,05h,0efh,0ffh,0ffh
DB 0ffh,48h,0bbh,0adh,70h,0efh,27h,0cfh
DB 0cbh,91h,2ah,48h,31h,58h,27h,48h
DB 2dh,0f8h,0ffh,0ffh,0ffh,0e2h,0f4h,3dh
DB 0e0h,7fh,0b7h,5fh,5bh,01h,0bah,3dh
DB 0e0h,7fh,0b7h,5fh,0cbh,91h,2ah
```

