### PR TITLE
Add appropriate skips to post test modules

### DIFF
--- a/test/modules/post/test/extapi.rb
+++ b/test/modules/post/test/extapi.rb
@@ -30,8 +30,8 @@ class MetasploitModule < Msf::Post
       vprint_status("Loading extapi extension...")
       begin
         session.core.use("extapi")
-      rescue Errno::ENOENT
-        print_error("This module is only available in a windows meterpreter session.")
+      rescue Errno::ENOENT, Rex::Post::Meterpreter::ExtensionLoadError
+        print_status("This module is only available in a windows meterpreter session.")
         return
       end
     end
@@ -40,174 +40,160 @@ class MetasploitModule < Msf::Post
   end
 
   def test_clipboard_management
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     vprint_status("Starting clipboard management tests")
-    services = nil
 
-    if session.commands.include? "extapi_clipboard_get_data"
+    it "should return an array of clipboard data" do
+      return skip('session does not support COMMAND_ID_EXTAPI_CLIPBOARD_GET_DATA') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_CLIPBOARD_GET_DATA)
+
       ret = false
-      it "should return an array of clipboard data" do
+      clipboard = session.extapi.clipboard.get_data(false)
+
+      if clipboard && clipboard.any? && clipboard.first[:type]
+        vprint_status("Clipboard: #{clipboard}")
+        ret = true
+      end
+
+      ret
+    end
+
+    it "should return clipboard jpg dimensions" do
+      return skip("Session doesn't implement railgun.user32, skipping jpg test") unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API) && session.railgun.user32
+
+      # VK_PRINTSCREEN 154 Maybe needed on XP?
+      # VK_SNAPSHOT 44
+      session.railgun.user32.keybd_event(44, 0, 0, 0)
+      session.railgun.user32.keybd_event(44, 0, 'KEYEVENTF_KEYUP', 0)
+
+      clipboard = session.extapi.clipboard.get_data(false)
+      ret = clipboard && clipboard.first && (clipboard.first[:type] == :jpg) && clipboard.first[:width]
+      ret
+    end
+
+    it "should set clipboard text" do
+      return skip('session does not support COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA)
+
+      text = Rex::Text.rand_text_alphanumeric(1024)
+      ret = session.extapi.clipboard.set_text(text)
+
+      if ret
         clipboard = session.extapi.clipboard.get_data(false)
-
-        if clipboard && clipboard.any? && clipboard.first[:type]
-          vprint_status("Clipboard: #{clipboard}")
-          ret = true
-        end
-
-        ret
-      end
-
-      if session.railgun.user32
-        it "should return clipboard jpg dimensions" do
-          ret = false
-
-          # VK_PRINTSCREEN 154 Maybe needed on XP?
-          # VK_SNAPSHOT 44
-          session.railgun.user32.keybd_event(44, 0, 0, 0)
-          session.railgun.user32.keybd_event(44, 0, 'KEYEVENTF_KEYUP', 0)
-
-          clipboard = session.extapi.clipboard.get_data(false)
-          ret = clipboard && clipboard.first && (clipboard.first[:type] == :jpg) && clipboard.first[:width]
-        end
-      else
-        print_status("Session doesn't implement railgun.user32, skipping jpg test")
-      end
-
-      if session.commands.include? "extapi_clipboard_set_data"
-        ret = false
-
-        it "should set clipboard text" do
-          ret = false
-          text = Rex::Text.rand_text_alphanumeric(1024)
-          ret = session.extapi.clipboard.set_text(text)
-
-          if ret
-            clipboard = session.extapi.clipboard.get_data(false)
-            ret = clipboard && clipboard.first && (clipboard.first[:type] == :text) && (clipboard.first[:data] == text)
-          end
-
-          ret
-        end
-      else
-        vprint_status("Session doesn't implement extapi_clipboard_set_data, skipping test")
-      end
-
-      it "should download clipboard text data" do
-        ret = false
-        text = Rex::Text.rand_text_alphanumeric(1024)
-        ret = session.extapi.clipboard.set_text(text)
-        clipboard = session.extapi.clipboard.get_data(true)
         ret = clipboard && clipboard.first && (clipboard.first[:type] == :text) && (clipboard.first[:data] == text)
       end
 
-      if session.railgun.user32
-        it "should download clipboard jpg data" do
-          ret = false
+      ret
+    end
 
-          # VK_PRINTSCREEN 154 Maybe needed on XP?
-          # VK_SNAPSHOT 44
-          session.railgun.user32.keybd_event(44, 0, 0, 0)
-          session.railgun.user32.keybd_event(44, 0, 'KEYEVENTF_KEYUP', 0)
+    it "should download clipboard text data" do
+      return skip('session does not support COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA)
 
-          clipboard = session.extapi.clipboard.get_data(true)
-          if clipboard && clipboard.first && (clipboard.first[:type] == :jpg) && !(clipboard.first[:data].empty?)
-            # JPG Magic Bytes
-            ret = (clipboard.first[:data][0, 2] == "\xFF\xD8")
-          end
+      text = Rex::Text.rand_text_alphanumeric(1024)
+      ret = session.extapi.clipboard.set_text(text)
+      clipboard = session.extapi.clipboard.get_data(true)
+      ret = clipboard && clipboard.first && (clipboard.first[:type] == :text) && (clipboard.first[:data] == text)
+      ret
+    end
 
-          ret
-        end
-      else
-        print_status("Session doesn't implement railgun.user32, skipping download_jpg test")
+    it "should download clipboard jpg data" do
+      return skip("Session doesn't implement railgun.user32, skipping download_jpg test") unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API) && session.railgun.user32
+
+      ret = false
+
+      # VK_PRINTSCREEN 154 Maybe needed on XP?
+      # VK_SNAPSHOT 44
+      session.railgun.user32.keybd_event(44, 0, 0, 0)
+      session.railgun.user32.keybd_event(44, 0, 'KEYEVENTF_KEYUP', 0)
+
+      clipboard = session.extapi.clipboard.get_data(true)
+      if clipboard && clipboard.first && (clipboard.first[:type] == :jpg) && !(clipboard.first[:data].empty?)
+        # JPG Magic Bytes
+        ret = (clipboard.first[:data][0, 2] == "\xFF\xD8")
       end
-    else
-      print_status("Session doesn't implement extapi_clipboard_get_data, skipping test")
+
+      ret
     end
   end
 
   def test_service_management
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     vprint_status("Starting service management tests")
     services = nil
 
-    if session.commands.include? "extapi_service_enum"
-      ret = false
-      it "should return an array of services" do
-        services = session.extapi.service.enumerate
+    it "should return an array of services" do
+      return skip('session does not support COMMAND_ID_EXTAPI_SERVICE_ENUM') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_SERVICE_ENUM)
 
-        if services && services.any? && services.first[:name]
-          vprint_status("First service: #{services.first}")
-          ret = true
-        end
+      services = session.extapi.service.enumerate
 
-        ret
+      if services && services.any? && services.first[:name]
+        vprint_status("First service: #{services.first}")
+        ret = true
       end
 
-      if session.commands.include? "extapi_service_query"
-        ret = false
+      ret
+    end
 
-        it "should return service information" do
-          service = session.extapi.service.query(services.first[:name])
-          vprint_status("Service info: #{service}")
-          if service && service[:starttype]
-            ret = true
-          end
+    it "should return service information" do
+      return skip('session does not support COMMAND_ID_EXTAPI_SERVICE_QUERY') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_SERVICE_QUERY)
 
-          ret
-        end
-      else
-        print_status("Session doesn't implement extapi_service_query, skipping test")
+      service = session.extapi.service.query(services.first[:name])
+      vprint_status("Service info: #{service}")
+      if service && service[:starttype]
+        ret = true
       end
-    else
-      print_status("Session doesn't implement extapi_service_enum, skipping test")
+
+      ret
     end
   end
 
   def test_desktop_windows_management
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     vprint_status("Starting desktop windows management tests")
     windows = nil
 
-    if session.commands.include? "extapi_window_enum"
+    it "should return an array of windows" do
+      return skip('session does not support COMMAND_ID_EXTAPI_WINDOW_ENUM') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_WINDOW_ENUM)
+
+      windows = session.extapi.window.enumerate(false, nil)
+
+      if windows && windows.any? && windows.first[:handle]
+        vprint_status("First window: #{windows.first}")
+        ret = true
+      end
+
+      ret
+    end
+
+    it "should return an array including unknown windows" do
+      return skip('session does not support COMMAND_ID_EXTAPI_WINDOW_ENUM') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_WINDOW_ENUM)
+
       ret = false
-      it "should return an array of windows" do
-        windows = session.extapi.window.enumerate(false, nil)
+      windows = session.extapi.window.enumerate(true, nil)
 
-        if windows && windows.any? && windows.first[:handle]
-          vprint_status("First window: #{windows.first}")
-          ret = true
-        end
-
-        ret
+      if windows && windows.any?
+        unknowns = windows.select { |w| w[:title] == "<unknown>" }
+        ret = !unknowns.empty?
       end
 
-      it "should return an array including unknown windows" do
-        ret = false
-        windows = session.extapi.window.enumerate(true, nil)
+      ret
+    end
 
-        if windows && windows.any?
-          unknowns = windows.select { |w| w[:title] == "<unknown>" }
-          ret = !unknowns.empty?
-        end
+    it "should return an array of a windows children" do
+      return skip('session does not support COMMAND_ID_EXTAPI_WINDOW_ENUM') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Extapi::COMMAND_ID_EXTAPI_WINDOW_ENUM)
 
-        ret
-      end
-
+      windows = session.extapi.window.enumerate(true, nil)
       parent = windows.select { |w| w[:title] =~ /program manager/i }
+      return skip("Unable to find a suitable parent, skipping test") unless parent && parent.first
 
-      if parent && parent.first
-        it "should return an array of a windows children" do
-          ret = false
-          children = session.extapi.window.enumerate(true, parent.first[:handle])
-          if children && children.any?
-            vprint_status("First child: #{children.first}")
-            ret = true
-          end
-
-          ret
-        end
-      else
-        print_status("Unable to find a suitable parent, skipping test")
+      ret = false
+      children = session.extapi.window.enumerate(true, parent.first[:handle])
+      if children && children.any?
+        vprint_status("First child: #{children.first}")
+        ret = true
       end
-    else
-      print_status("Session doesn't implement extapi_window_enum, skipping test")
+      ret
     end
   end
 end

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -111,8 +111,7 @@ class MetasploitModule < Msf::Post
 
   def test_net_config
     unless (session.commands.include? Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_NET_CONFIG_GET_INTERFACES)
-      vprint_status("This meterpreter does not implement get_interfaces, skipping tests")
-      return
+      return skip("This meterpreter does not implement get_interfaces, skipping tests")
     end
 
     vprint_status("Starting networking tests")

--- a/test/modules/post/test/railgun.rb
+++ b/test/modules/post/test/railgun.rb
@@ -23,7 +23,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_api_function_calls_libc
-    return unless session.platform == 'linux' || session.platform == 'osx'
+    return skip('target is not linux or osx') unless session.platform == 'linux' || session.platform == 'osx'
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
 
     buffer = nil
     buffer_size = 128
@@ -91,17 +92,21 @@ class MetasploitModule < Msf::Post
   end
 
   def test_api_function_file_info_windows
-    return unless session.platform == 'windows'
+    return skip('session platform is not windows') unless session.platform == 'windows'
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
 
     it "Should retrieve the win32k file version" do
       path = expand_path('%WINDIR%\\system32\\win32k.sys')
       major, minor, build, revision, brand = file_version(path)
+      # XXX: These values should be asserted - as in this scenario the values are `nil`
+      # https://github.com/rapid7/metasploit-framework/commit/99e576d023cba66fa898d9ce3b52a52201f0f250
       true
     end
   end
 
   def test_api_function_calls_windows
-    return unless session.platform == 'windows'
+    return skip('session platform is not windows') unless session.platform == 'windows'
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
 
     it "Should include error information in the results" do
       ret = true

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -53,6 +53,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_static
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+
     it "should return a constant name given a const and a filter" do
       ret = true
       results = select_const_names(4, /^SERVICE/)
@@ -83,6 +85,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_datastore
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+
     if (datastore["WIN_CONST"])
       it "should look up arbitrary constants" do
         ret = true

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -32,6 +32,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_0_registry_read
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should evaluate key existence" do
       k_exists = registry_key_exist?(%q#HKCU\Environment#)
       k_dne = registry_key_exist?(%q#HKLM\\Non\Existent\Key#)
@@ -133,6 +135,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_1_registry_write
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should create keys" do
       ret = registry_createkey(%q#HKCU\test_key#)
     end

--- a/test/modules/post/test/services.rb
+++ b/test/modules/post/test/services.rb
@@ -41,6 +41,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_start
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should start #{datastore["SSERVICE"]}" do
       ret = true
       results = service_start(datastore['SSERVICE'])
@@ -63,6 +65,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_list
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should list services" do
       ret = true
       results = service_list
@@ -76,6 +80,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_info
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should return info on a given service  #{datastore["QSERVICE"]}" do
       ret = true
       results = service_info(datastore['QSERVICE'])
@@ -94,6 +100,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_create
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should create a service  #{datastore["NSERVICE"]}" do
       mode = case datastore["MODE"]
              when "disable"; START_TYPE_DISABLED
@@ -133,6 +141,8 @@ class MetasploitModule < Msf::Post
   end
 
   def test_status
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     it "should return status on a given service #{datastore["QSERVICE"]}" do
       ret = true
       results = service_status(datastore['QSERVICE'])
@@ -148,12 +158,15 @@ class MetasploitModule < Msf::Post
   end
 
   def test_change
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     service_name = "a" << Rex::Text.rand_text_alpha(5)
     display_name = service_name
 
-    it "should modify config on a given service #{service_name}" do
+    it "should modify config on a given service" do
       ret = true
 
+      vprint_status("creating new service #{service_name}")
       results = service_create(service_name,
                                display: display_name,
                                path: datastore['BINPATH'],
@@ -179,11 +192,14 @@ class MetasploitModule < Msf::Post
   end
 
   def test_restart_disabled
+    return skip('session platform is not windows') unless session.platform == 'windows'
+
     service_name = "a" << Rex::Text.rand_text_alpha(5)
     display_name = service_name
 
-    it "should start a disabled service #{service_name}" do
+    it "should start a disabled service" do
       ret = true
+      vprint_status("creating new service #{service_name}")
       results = service_create(service_name,
                                display: display_name,
                                path: datastore['BINPATH'],
@@ -204,6 +220,7 @@ class MetasploitModule < Msf::Post
   end
 
   def test_restart_start
+    return skip('session platform is not windows') unless session.platform == 'windows'
     service_name = datastore['SSERVICE']
 
     it "should restart a started service #{service_name}" do
@@ -221,6 +238,7 @@ class MetasploitModule < Msf::Post
   end
 
   def test_noaccess
+    return skip('session platform is not windows') unless session.platform == 'windows'
     it "should raise a runtime exception if no access to service" do
       ret = false
       begin
@@ -234,6 +252,7 @@ class MetasploitModule < Msf::Post
   end
 
   def test_no_service
+    return skip('session platform is not windows') unless session.platform == 'windows'
     it "should raise a runtime exception if services doesnt exist" do
       ret = false
       begin


### PR DESCRIPTION
Depends on https://github.com/rapid7/metasploit-framework/pull/18050

Adds additional `skip` calls to the `test/post` modules to ensure that only relevant test expectations are run against the specified session without crashes. This change is useful for developers contributing enhancements or new functionality to Meterpreter and other payloads. It is available after running `loadpath test/modules`

## Verification

Same as https://github.com/rapid7/metasploit-framework/pull/18050

Skipped values will be tracked:

<img width="80%" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/65707219-0b58-4152-beef-cdeb7392110a">
