### PR TITLE
Fix broken binary file upload test on windows sessions

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -212,8 +212,9 @@ class MetasploitModule < Msf::Post
 
   def test_binary_files
     # binary_data = ::File.read("/bin/ls")
-    binary_data = ::File.read('/bin/echo')
+    # binary_data = ::File.read('/bin/echo')
     # binary_data = "\xff\x00\xff\xfe\xff\`$(echo blha)\`"
+    binary_data = ((0..255).to_a * 500).shuffle.pack("c*")
     it 'should write binary data' do
       vprint_status "Writing #{binary_data.length} bytes"
       t = Time.now


### PR DESCRIPTION
Fixes a broken binary file upload test on windows sessions

## Verification

Run the test module against a non-unix system

Before: File not found error
After: No longer produces a file not found error