### PR TITLE
Update post/multi/gather/aws_keys to run against linux sessions

### DIFF
--- a/modules/post/multi/gather/aws_keys.rb
+++ b/modules/post/multi/gather/aws_keys.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        'Platform' => ['linux', 'osx', 'unix', 'solaris', 'bsd'],
         'SessionTypes' => %w[shell meterpreter],
         'References' => [
           [ 'URL', 'http://s3tools.org/kb/item14.htm' ],


### PR DESCRIPTION
Updates `/post/multi/gather/aws_keys.rb` gather aws keys to run against linux

When testing the new SSM session type:

```
msf6 auxiliary(cloud/aws/enum_ssm) > sessions

Active sessions
===============

  Id  Name  Type                       Information                                Connection
  --  ----  ----                       -----------                                ----------
  3         shell linux                AWS SSM EC2Instance (i-xxxx)                x.x.x.x:49292 -> x.x.x.x:0 (x.x.x.x)
```


This post module wasn't auto-suggested by the Pro UI:

```
>> m = self.framework.post.create('multi/gather/aws_keys').session_incompatibility_reasons(3)
=> ["incompatible session platform: linux"]
>> 
```
