### PR TITLE
Modify command stagers to not go over 100%

### DIFF
--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -93,14 +93,16 @@ module Exploit::CmdStager
 
       sent = 0
       total_bytes = 0
-      cmd_list.each { |cmd| total_bytes += cmd.length }
+      cmd_list.each { |cmd| total_bytes += cmd.bytesize }
 
       delay = opts[:delay]
       delay ||= 0.25
 
       cmd_list.each do |cmd|
+        # calculate string beforehand length in case exploit mutates string
+        command_length = cmd.bytesize
         execute_command(cmd, opts)
-        sent += cmd.length
+        sent += command_length
 
         # In cases where a server has multiple threads, we want to be sure that
         # commands we execute happen in the correct (serial) order.


### PR DESCRIPTION
Fixes #9693

Resolves bug in https://github.com/rapid7/metasploit-framework/issues/9693 where the command stagers for some modules would go over 100%.

## Verification

Start `msfconsole`

```
use exploit/multi/ftp/pureftpd_bash_env_exec
set payload linux/x86/meterpreter/reverse_tcp
set lhost 127.0.0.1
set lport 5555
set rhost 127.0.0.1
```

in a separate terminal tab: `ncat -k -l 21`

on original tab: `exploit`

before:
```
[*] 127.0.0.1:21 - Command Stager progress -  60.48% done (499/825 bytes)
[*] 127.0.0.1:21 - Command Stager progress - 100.61% done (830/825 bytes)
```

after:
```
[*] Started reverse TCP handler on 127.0.0.1:5555
[*] 127.0.0.1:21 - Command Stager progress -  60.48% done (499/825 bytes)
[*] 127.0.0.1:21 - Command Stager progress - 100.00% done (825/825 bytes)
[*] Exploit completed, but no session was created.
```

note: if exploit is taking a long time, switch to netcat server tab and spam "200 ok" a few times to move it along