### PR TITLE
Created mixin to retrieve the architecture of the current shell.

### DIFF
--- a/lib/msf/core/post/architecture.rb
+++ b/lib/msf/core/post/architecture.rb
@@ -17,6 +17,8 @@ module Msf::Post::Architecture
     )
   end
 
+  # Get the architecture of the target's operating system.
+  # @return [String, Nil] Returns a string containing the target OS architecture if known, or Nil if its not known.
   def get_os_architecture
     if session.type == 'meterpreter'
       return sysinfo['Architecture']

--- a/lib/msf/core/post/architecture.rb
+++ b/lib/msf/core/post/architecture.rb
@@ -18,14 +18,6 @@ module Msf::Post::Architecture
   end
 
   def get_os_architecture
-    result = get_os_architecture_impl
-    if result.nil?
-    end
-
-    result
-  end
-
-  def get_os_architecture_impl
     if session.type == 'meterpreter'
       return sysinfo['Architecture']
     else

--- a/lib/msf/core/post/architecture.rb
+++ b/lib/msf/core/post/architecture.rb
@@ -1,0 +1,52 @@
+# -*- coding: binary -*-
+
+module Msf::Post::Architecture
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api
+            ]
+          }
+        }
+      )
+    )
+  end
+
+  def get_os_architecture
+    result = get_os_architecture_impl
+    if result.nil?
+    end
+
+    result
+  end
+
+  def get_os_architecture_impl
+    if session.type == 'meterpreter'
+      return sysinfo['Architecture']
+    else
+      case session.platform
+      when 'windows', 'win'
+        # Check for 32-bit process on 64-bit arch
+        arch = get_env('PROCESSOR_ARCHITEW6432')
+        if arch.strip.empty? or arch =~ /PROCESSOR_ARCHITEW6432/
+          arch = get_env('PROCESSOR_ARCHITECTURE')
+        end
+        if arch =~ /AMD64/m
+          return ARCH_X64
+        elsif arch =~ /86/m
+          return ARCH_X86
+        elsif arch =~ /ARM64/m
+          return ARCH_AARCH64
+        else
+          print_error('Target is running Windows on an unsupported architecture!')
+          return nil
+        end
+      end
+    end
+  end
+end

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -6,6 +6,7 @@ require 'rex/exploitation/cmdstager'
 
 class MetasploitModule < Msf::Post
   include Exploit::Powershell
+  include Post::Architecture
   include Post::Windows::Powershell
 
   def initialize(info = {})
@@ -84,19 +85,19 @@ class MetasploitModule < Msf::Post
     when 'windows', 'win'
       platform = 'windows'
       lplat = [Msf::Platform::Windows]
-      arch = cmd_exec('wmic os get osarchitecture')
-      if arch =~ /64-bit/m
+      arch = get_os_architecture
+      case arch
+      when ARCH_X64
         payload_name = 'windows/x64/meterpreter/reverse_tcp'
-        larch = [ARCH_X64]
         psh_arch = 'x64'
-      elsif arch =~ /32-bit/m
+      when ARCH_X86
         payload_name = 'windows/meterpreter/reverse_tcp'
-        larch = [ARCH_X86]
         psh_arch = 'x86'
       else
         print_error('Target is running Windows on an unsupported architecture such as Windows ARM!')
         return nil
       end
+      larch = [arch]
       vprint_status('Platform: Windows')
     when 'osx'
       platform = 'osx'


### PR DESCRIPTION
Adds a mixin to support retrieving the architecture of the current shell. In meterpreter, this uses the built in behaviour, which calls the appropriate API. In command shells and PowerShell, looks at the appropriate environment variables.

I added this to the `shell_to_meterpreter` module for now.

Currently only supports Windows, tested on Win2000 upwards.

## Verification

To test this, I created a test module, that simply includes the mixin, calls `get_os_architecture` and prints it out.

Tested on:

### Command Shell

- [x] Windows 2000 x86
- [x] Windows XP x86
- [x] Windows 2003 x86
- [x] Windows XP x64
- [x] Windows XP x64 (x86 process)
- [x] Windows Server 2008 x64
- [x] Windows Server 2008 x64 (x86 process)
- [x] Windows Server 2008 R2 x64
- [x] Windows Server 2008 R2 x64 (x86 process)
- [x] Windows Server 2012 x64
- [x] Windows Server 2012 x64 (x86 process)
- [x] Windows 10 x64
- [x] Windows 10 x64 (x86 process)
- [x] Windows Server 2022 x64
- [x] Windows Server 2022 x64 (x86 process)

### Meterpreter

- [x] Windows XP x86
- [x] Windows 2003 x86
- [x] Windows XP x64
- [x] Windows XP x64 (x86 process)
- [x] Windows Server 2008 x64
- [x] Windows Server 2008 x64 (x86 process)
- [x] Windows Server 2008 R2 x64
- [x] Windows Server 2008 R2 x64 (x86 process)
- [x] Windows Server 2012 x64
- [x] Windows Server 2012 x64 (x86 process)
- [x] Windows 10 x64
- [x] Windows 10 x64 (x86 process)
- [x] Windows Server 2022 x64
- [x] Windows Server 2022 x64 (x86 process)

### PowerShell

- [x] Windows Server 2008 R2 x64
- [x] Windows Server 2008 R2 x64 (x86 process)
- [x] Windows Server 2012 x64
- [x] Windows Server 2012 x64 (x86 process)
- [x] Windows 10 x64
- [x] Windows 10 x64 (x86 process)
- [x] Windows Server 2022 x64
- [x] Windows Server 2022 x64 (x86 process)

Python:
- [x] Python-32-bit on Win10 x64
- [x] Python-64-bit on Win10 x64

Java:
- [x] JRE64 on Win10