### PR TITLE
add support for beta and prerelease versions to grafana_plugin_traversal

### DIFF
--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -78,10 +78,10 @@ class MetasploitModule < Msf::Auxiliary
        version.between?(Rex::Version.new('8.1.0'), Rex::Version.new('8.1.8')) ||
        version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.7')) ||
        version.between?(Rex::Version.new('8.3.0'), Rex::Version.new('8.3.1'))
-      print_good("Detected vulnerable Grafina: #{full_version}")
+      print_good("Detected vulnerable Grafana: #{full_version}")
       return Exploit::CheckCode::Appears
     end
-    print_bad("Detected non-vulnerable Grafina: #{full_version}")
+    print_bad("Detected non-vulnerable Grafana: #{full_version}")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -62,10 +62,18 @@ class MetasploitModule < Msf::Auxiliary
     })
     return Exploit::CheckCode::Unknown unless res && res.code == 200
 
-    /"subTitle":"Grafana v(?<version>\d{1,2}.\d{1,2}.\d{1,2}) \([0-9a-f]{10}\)",/ =~ res.body
-    return Exploit::CheckCode::Safe unless version
+    # We need to take into account beta versions, which end with -beta<digit>. See: https://grafana.com/docs/grafana/latest/release-notes/
+    /"subTitle":"Grafana v(?<full_version>\d{1,2}\.\d{1,2}\.\d{1,2}(?:-beta\d)?) \([0-9a-f]{10}\)",/ =~ res.body
+    return Exploit::CheckCode::Safe unless full_version
 
-    version = Rex::Version.new(version)
+    # However, since 8.3.1 does not have a beta, we can safely ignore the -beta suffix when comparing versions
+    # In fact, this is necessary because Rex::Version doesn't correctly handle versions ending with -beta when comparing
+    if /-beta\d$/ =~ full_version
+      version = Rex::Version.new(full_version[0..-7])
+    else
+      version = Rex::Version.new(full_version)
+    end
+
     if version.between?(Rex::Version.new('8.0.0-beta1'), Rex::Version.new('8.0.7')) ||
        version.between?(Rex::Version.new('8.1.0'), Rex::Version.new('8.1.8')) ||
        version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.7')) ||

--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
     return Exploit::CheckCode::Unknown unless res && res.code == 200
 
     # We need to take into account beta versions, which end with -beta<digit>. See: https://grafana.com/docs/grafana/latest/release-notes/
-    # Also take into account preview versions, which end with -preview. See https://grafana.com/grafana/download/10.0.0-preview?edition=oss
+    # Also take into account preview versions, which end with -preview. See https://grafana.com/grafana/download/10.0.0-preview?edition=oss for more info.
     /"subTitle":"Grafana v(?<full_version>\d{1,2}\.\d{1,2}\.\d{1,2}(?:(?:-beta\d)?|(?:-preview)?)) \([0-9a-f]{10}\)",/ =~ res.body
     return Exploit::CheckCode::Safe unless full_version
 

--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -78,10 +78,10 @@ class MetasploitModule < Msf::Auxiliary
        version.between?(Rex::Version.new('8.1.0'), Rex::Version.new('8.1.8')) ||
        version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.7')) ||
        version.between?(Rex::Version.new('8.3.0'), Rex::Version.new('8.3.1'))
-      print_good("Detected vulnerable Grafina: #{version}")
+      print_good("Detected vulnerable Grafina: #{full_version}")
       return Exploit::CheckCode::Appears
     end
-    print_bad("Detected non-vulnerable Grafina: #{version}")
+    print_bad("Detected non-vulnerable Grafina: #{full_version}")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -63,13 +63,16 @@ class MetasploitModule < Msf::Auxiliary
     return Exploit::CheckCode::Unknown unless res && res.code == 200
 
     # We need to take into account beta versions, which end with -beta<digit>. See: https://grafana.com/docs/grafana/latest/release-notes/
-    /"subTitle":"Grafana v(?<full_version>\d{1,2}\.\d{1,2}\.\d{1,2}(?:-beta\d)?) \([0-9a-f]{10}\)",/ =~ res.body
+    # Also take into account preview versions, which end with -preview. See https://grafana.com/grafana/download/10.0.0-preview?edition=oss
+    /"subTitle":"Grafana v(?<full_version>\d{1,2}\.\d{1,2}\.\d{1,2}(?:(?:-beta\d)?|(?:-preview)?)) \([0-9a-f]{10}\)",/ =~ res.body
     return Exploit::CheckCode::Safe unless full_version
 
     # However, since 8.3.1 does not have a beta, we can safely ignore the -beta suffix when comparing versions
     # In fact, this is necessary because Rex::Version doesn't correctly handle versions ending with -beta when comparing
     if /-beta\d$/ =~ full_version
       version = Rex::Version.new(full_version[0..-7])
+    elsif /-preview$/ =~ full_version
+      version = Rex::Version.new(full_version[0..-9])
     else
       version = Rex::Version.new(full_version)
     end


### PR DESCRIPTION
# About
This change improves the `modules/auxiliary/scanner/http/grafana_plugin_traversal.rb` module so that it correctly identifies Grafana beta versions.

Grafana has released serveral beta versions. For all of these, the version name ends with `-beta<digit>`. The full list of versions is available [here](https://grafana.com/docs/grafana/latest/release-notes/) . Currently, the regex used in the module to extract the Grafana version does not take into account that versions can have the suffix mentioned above. As a result, the regex check fails when run against a beta version, causing the module to treat the target as safe. This change improves the regex to take into account the beta suffix. Since `Rex::Version` does not correctly handle beta versions in version comparisons, the suffix is removed for the version comparisons, but the full version, including the suffix, will be printed to the console.

# Example run before bugfix: Grafana 8.1.0-beta3
```
msf6 auxiliary(scanner/http/grafana_plugin_traversal) > run

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/grafana_plugin_traversal)
```
# Example run after bugfix: Grafana 8.1.0-beta3
```
msf6 auxiliary(scanner/http/grafana_plugin_traversal) > run

[+] Detected vulnerable Grafina: 8.1.0-beta3
[*] 10.10.10.11 - Progress   0/40 (0.0%)
[+] alertlist was found and exploited successfully
[+] 10.10.10.11:3000 - File saved in: /root/.msf4/loot/20230605125129_default_10.10.10.11_grafana.loot_406602.ini
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/grafana_plugin_traversal) >
```

