### PR TITLE
Updates `jenkins_gather` module to work with newer version of Jenkins

### DIFF
--- a/documentation/modules/post/multi/gather/jenkins_gather.md
+++ b/documentation/modules/post/multi/gather/jenkins_gather.md
@@ -8,6 +8,14 @@ This module has been verified against:
   1. Jenkins 2.67 on Ubuntu 16.04 in Docker
   1. Jenkins 2.67 on Windows 7 SP 1
   1. Jenkins 2.60.1
+  1. Jenkins 2.411 Docker image
+  1. Jenkins 2.410 Windows 10
+  1. Jenkins 2.410 Docker image
+  1. Jenkins 2.409 Docker image
+  1. Jenkins 2.401.1 Docker image
+  1. Jenkins 2.346.3 Docker image
+  1. Jenkins 2.103 Docker image
+  1. Jenkins 1.565 Docker image
   1. Jenkins 1.56
 
 ## Verification Steps


### PR DESCRIPTION
This PR updates the `jenkins_gather` module to work with newer versions of Jenkins. 

Changes the logic from group loot to now check for each specific file individually, allowing for more flexibility across Jenkins version where files these loot file are created at different times of setup.

This PR also adds support for `initialAdminPassword` to now be stored as loot. Newer version off Jenkins have this value when you skip the account setup and continue as admin. Thought it may be useful for a user to have.

![image](https://github.com/rapid7/metasploit-framework/assets/69522014/139d4a16-f1d0-43c7-a7a8-42fe4d053b0b)

Tested against Jenkins versions:
- 2.411 🟢
- 2.410 🟢
- 2.409 🟢
- 2.401.1 🟢
- 2.346.3 🟢
-  2.103 🟢
- 1.565 🟢


## Before
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/a709b3ba-2b68-408e-81cd-a61382fd01a9)

## After
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/b09d1ff9-5ba0-433a-ac15-31433915dd97)

## initialAdminPassword
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/7a4b1ed4-d052-49df-bc80-66bd1faeafb5)

## initialAdminPassword loot
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/905b39e6-cf01-4e63-b1f1-578fdbbeaf2d)

## Verification

- [ ] Run a target docker container: `docker run -p 8080:8080 jenkins/jenkins:latest`
- [ ] Start `msfconsole`
- [ ] Get a session I used `exploit/multi/http/jenkins_script_console`
- [ ] Set the session and run
- [ ] I tested this by run the gather before creating any credentials on the Jenkins client, then tested again after adding some creds.