### PR TITLE
Remote::JndiInjection: handle LDAP UnbindRequest

### DIFF
--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -60,9 +60,12 @@ module Exploit::Remote::JndiInjection
                else
                  service.encode_ldap_response(pdu.message_i, 50, '', 'Not authenticated', Net::LDAP::PDU::SearchResult)
                end
+             when Net::LDAP::PDU::UnbindRequest
+               vprint_status("Client sent unbind request")
+               nil # close client, no response can be sent over unbound comm
              else
                vprint_status("Client sent unexpected request #{pdu.app_tag}")
-               client.close
+               nil # close client, can't handle the unknown
              end
       resp.nil? ? client.close : on_send_response(client, resp)
     rescue StandardError => e

--- a/lib/rex/proto/ldap/server.rb
+++ b/lib/rex/proto/ldap/server.rb
@@ -182,6 +182,8 @@ module Rex
                      else
                        service.encode_ldap_response(pdu.message_id, 50, '', 'Not authenticated', Net::LDAP::PDU::SearchResult)
                      end
+                   when Net::LDAP::PDU::UnbindRequest
+                     nil # close client, no response can be sent over unbound comm
                    else
                      service.encode_ldap_response(
                        pdu.message_id,


### PR DESCRIPTION
@ErikWynter showed me this output during his effort to pwn APC servers:
![image](https://github.com/rapid7/metasploit-framework/assets/1331084/1ac5d899-8b79-42d2-8efc-50c50db91016)

The `unexpected request 2` bit is misleading - thats the LDAP component not handling the session termination in the catch-all. This takes developers down the wrong debug path, and is easy to remedy.
Resolve by explicitly adding a case for the `UnbindRequest` type.

Ping @smcintyre-r7 - requesting eyes-on in case i broke something (its kinda late). :smile: 