### PR TITLE
Fix exception handling in `gitlab_github_import_rce_cve_2022_2992` module

### DIFF
--- a/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
@@ -7,13 +7,15 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Form::Authenticate
   # @param username [String] Username
   # @param password [String] Password
   # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
+  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError] if the request timed out
+  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError] if the authenticaiton failed
+  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError] if it was not possible to extract the CSRF token
   def gitlab_sign_in(username, password)
     sign_in_path = '/users/sign_in'
     csrf_token = gitlab_helper_extract_csrf_token(
       path: sign_in_path,
       regex: %r{action="/users/sign_in".*name="authenticity_token"\s+value="([^"]+)"}
     )
-    raise Msf::Exploit::Remote::HTTP::GitLab::Error::CsrfError unless csrf_token
 
     res = send_request_cgi({
       'method' => 'POST',

--- a/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
@@ -23,6 +23,13 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Helpers
     post_data
   end
 
+  # Extract the CSRF token at the given URI using the provided regex
+  #
+  # @param path [String] the URI to retrive the CSRF token from
+  # @param regex [String] the regex used to extract the CSRF token from the HTML response
+  # @return [String] the CSRF token
+  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError] if the request timed out
+  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError] if it was not possible to extract the CSRF token
   def gitlab_helper_extract_csrf_token(path:, regex:)
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
+++ b/modules/exploits/multi/http/gitlab_github_import_rce_cve_2022_2992.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Appears("Detected GitLab version #{version} which is vulnerable.")
   rescue Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError
     return CheckCode::Detected('Could not detect the version because authentication failed.')
-  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error => e
+  rescue Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError => e
     return CheckCode::Unknown("#{e.class} - #{e.message}")
   end
 


### PR DESCRIPTION
This is a straightforward fix for wrong exception handling in the `exploits/multi/http/gitlab_github_import_rce_cve_2022_2992` module. The exception handler was not rescuing the correct class.

Also, I removed a unnecessary check in the GitLab authentication mixin. First this code had a typo (`GitLab` -> `Gitlab`) and since `gitlab_helper_extract_csrf_token` always return a string or raise an exception, `csrf_token` cannot be `nil`.
```ruby
    csrf_token = gitlab_helper_extract_csrf_token(
      path: sign_in_path,
      regex: %r{action="/users/sign_in".*name="authenticity_token"\s+value="([^"]+)"}
    )
    raise Msf::Exploit::Remote::HTTP::GitLab::Error::CsrfError unless csrf_token
```

Finally I added some documentation around these helpers.

## Test
On way to test this would be to run the module's `check` method against a GitLab [instance](https://about.gitlab.com/install/) and modify the code to create an error during authentication:
```
sed -i '' 's/name="authenticity_token"/FAIL/' lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
```
### Before
```
msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > check rhosts=192.168.100.119 lhost=192.168.100.1 username=root password=1234

[-] Exploit failed: Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError Could not successfully extract CSRF token using the regex (?-mix:action="\/users\/sign_in".*name="FAIL"\s+value="([^"]+)")
[-] 192.168.100.119:80 - Check failed: The state could not be determined.
```
### After
```
msf6 exploit(multi/http/gitlab_github_import_rce_cve_2022_2992) > check rhosts=192.168.100.119 lhost=192.168.100.1 username=root password=1234
[*] 192.168.100.119:80 - Cannot reliably check exploitability. Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError - Could not successfully extract CSRF token using the regex (?-mix:action="\/users\/sign_in".*FAIL\s+value="([^"]+)")
```
