### PR TITLE
Masm support

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -103,6 +103,8 @@ module Buffer
         buf = Rex::Text.to_psh_comment(buf)
       when 'go','golang'
         buf = Rex::Text.to_golang_comment(buf)
+      when 'masm','ml64'
+        buf = Rex::Text.to_masm_comment(buf)
       when 'nim','nimlang'
         buf = Rex::Text.to_nim_comment(buf)
       when 'rust', 'rustlang'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -63,6 +63,8 @@ module Buffer
         buf = Rex::Text.encode_base64(buf)
       when 'go','golang'
         buf = Rex::Text.to_golang(buf)
+      when 'masm'
+        buf = Rex::Text.to_masm(buf)
       when 'nim','nimlang'
         buf = Rex::Text.to_nim(buf)
       when 'rust', 'rustlang'
@@ -130,6 +132,7 @@ module Buffer
       'java',
       'js_be',
       'js_le',
+      'masm',
       'nim',
       'nimlang',
       'num',


### PR DESCRIPTION
PR to rex-text tp add the functions to_masm() and to_masm_comment(): **OK**

add code to call those functions from buffer.rb: **OK**

It is now easy to get shellcode from msfvenom in masm output format:

```
msfvenom -p windows/x64/messagebox -a x64 --platform windows -f masm
```