### PR TITLE
Update the exported keytab table entries to sort by db insert id

### DIFF
--- a/modules/auxiliary/admin/kerberos/keytab.rb
+++ b/modules/auxiliary/admin/kerberos/keytab.rb
@@ -89,43 +89,49 @@ class MetasploitModule < Msf::Auxiliary
     # Kerberos encryption keys, most likely extracted from running secrets dump
     kerberos_key_creds = framework.db.creds(type: 'Metasploit::Credential::KrbEncKey')
     keytab_entries = kerberos_key_creds.map do |cred|
-      {
-        realm: cred.realm.value,
-        components: cred.public.username.split('/'),
-        name_type: Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL,
-        timestamp: Time.at(0).utc,
-        vno8: datastore['KVNO'],
-        vno: datastore['KVNO'],
-        keyblock: {
-          enctype: cred.private.enctype,
-          data: cred.private.key
+      [
+        cred.id,
+        {
+          realm: cred.realm.value,
+          components: cred.public.username.split('/'),
+          name_type: Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL,
+          timestamp: Time.at(0).utc,
+          vno8: datastore['KVNO'],
+          vno: datastore['KVNO'],
+          keyblock: {
+            enctype: cred.private.enctype,
+            data: cred.private.key
+          }
         }
-      }
+      ]
     end
 
     # Additionally append NTHASH values, which don't require a salt
     nthash_creds = framework.db.creds(type: 'Metasploit::Credential::NTLMHash')
     keytab_entries += nthash_creds.map do |cred|
       nthash = cred.private.to_s.split(':').last
-      {
-        realm: cred.realm&.value.to_s,
-        components: cred.public.username.split('/'),
-        name_type: Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL,
-        timestamp: Time.at(0).utc,
-        vno8: datastore['KVNO'],
-        vno: datastore['KVNO'],
-        keyblock: {
-          enctype: Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC,
-          data: [nthash].pack('H*')
+      [
+        cred.id,
+        {
+          realm: cred.realm&.value.to_s,
+          components: cred.public.username.split('/'),
+          name_type: Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL,
+          timestamp: Time.at(0).utc,
+          vno8: datastore['KVNO'],
+          vno: datastore['KVNO'],
+          keyblock: {
+            enctype: Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC,
+            data: [nthash].pack('H*')
+          }
         }
-      }
+      ]
     end
 
     if keytab_entries.empty?
       print_status('No entries to export')
     end
 
-    keytab.key_entries.concat(keytab_entries)
+    keytab.key_entries.concat(keytab_entries.sort_by { |id, _entry| id }.to_h.values)
     write_keytab(keytab_path, keytab)
   end
 

--- a/spec/modules/auxiliary/admin/kerberos/keytab_spec.rb
+++ b/spec/modules/auxiliary/admin/kerberos/keytab_spec.rb
@@ -295,9 +295,9 @@ RSpec.describe 'kerberos keytab' do
             
              kvno  type           principal                      hash                                                                                                                              date
              ----  ----           ---------                      ----                                                                                                                              ----
-             1     18 (AES256)    user_with_krbkey@demo.local    63346133663331643634616661363438613664303864303737363536336531323338623937366430623930663739656130373231393433363832393465393239  #{Time.parse('1970-01-01 01:00:00 +0100').to_time}
              1     23 (RC4_HMAC)  user_without_realm@            e02bc503339d51f71d913c245d35b50b                                                                                                  #{Time.parse('1970-01-01 01:00:00 +0100').to_time}
              1     23 (RC4_HMAC)  user_with_realm@example.local  32ede47af254546a82b1743953cc4950                                                                                                  #{Time.parse('1970-01-01 01:00:00 +0100').to_time}
+             1     18 (AES256)    user_with_krbkey@demo.local    63346133663331643634616661363438613664303864303737363536336531323338623937366430623930663739656130373231393433363832393465393239  #{Time.parse('1970-01-01 01:00:00 +0100').to_time}
 
           TABLE
         end


### PR DESCRIPTION
Updates the `modules/auxiliary/admin/kerberos/keytab` module to sort new keytab table entries by the db insert id when running the `EXPORT` action

## Verification

Verify CI passes
Verify the previous steps from https://github.com/rapid7/metasploit-framework/pull/17749