### PR TITLE
Fix an edge case in .to_win32pe

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -306,8 +306,8 @@ require 'digest/sha1'
     block = blocks.first
 
     # TODO: Allow the entry point in a different block
-    if payload.length + 256 > block[1]
-      raise RuntimeError, "The largest block in .text does not have enough contiguous space (need:#{payload.length+256} found:#{block[1]})"
+    if payload.length + 256 >= block[1]
+      raise RuntimeError, "The largest block in .text does not have enough contiguous space (need:#{payload.length+257} found:#{block[1]})"
     end
 
     # Make a copy of the entire .text section
@@ -328,8 +328,8 @@ require 'digest/sha1'
       poff += 256
       eidx = rand(poff-(entry.length + 5))
     else          # place the entry pointer after the payload
-      poff -= 256
-      eidx = rand(block[1] - (poff + payload.length)) + poff + payload.length
+      poff -= [256, poff].min
+      eidx = rand(block[1] - (poff + payload.length + 256)) + poff + payload.length
     end
 
     # Relative jump from the end of the nops to the payload


### PR DESCRIPTION
When the entry point is after the payload, there would occasionally be cases where `poff` and `eidx` to be invalid, causing `entry` to be truncated. `poff` should never be negative and `eidx` should reserve the 256 bytes that `entry` may occupy.


## Testing
- [ ] Generate multiple x86 payload EXEs and ensure they always work
    * Alternatively you can modify the `rand()` calls to initialize `eloc` to 1 and `poff` to 100. This would have triggered the bug every time.