### PR TITLE
Fix rex-text crashes when running ruby 3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.50)
+    rex-text (0.2.52)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.5)


### PR DESCRIPTION
Fix rex-text crashes when running ruby 3.3 - pulled in from https://github.com/rapid7/rex-text/pull/62