### PR TITLE
Fix python meterpreter subprocess deadlock and file descriptor leak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.137)
+      metasploit-payloads (= 2.0.138)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -258,7 +258,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.137)
+    metasploit-payloads (2.0.138)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.137'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.138'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Fix python meterpreter subprocess deadlock and file descriptor leak caused by the stdout/stderr file descriptors not being closed

https://github.com/rapid7/metasploit-payloads/pull/653

## Verification

- Verify the commands work as expected and there isn't a file descriptor leak present in this scenario - https://github.com/rapid7/metasploit-payloads/pull/653