### PR TITLE
lock nokogiri due to compile issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ PATH
       net-ssh
       network_interface
       nexpose
-      nokogiri
+      nokogiri (~> 1.14.0)
       octokit (~> 4.0)
       openssl-ccm
       openvas-omp
@@ -288,8 +288,8 @@ GEM
     network_interface (0.0.2)
     nexpose (7.3.0)
     nio4r (2.5.9)
-    nokogiri (1.15.2)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.14.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nori (2.6.0)
     octokit (4.25.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     network_interface (0.0.2)
     nexpose (7.3.0)
     nio4r (2.5.9)
-    nokogiri (1.14.3)
+    nokogiri (1.14.5)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nori (2.6.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -83,7 +83,8 @@ Gem::Specification.new do |spec|
   # NTLM authentication
   spec.add_runtime_dependency 'rubyntlm'
   # Needed by anemone crawler
-  spec.add_runtime_dependency 'nokogiri'
+  # Locked until build env can handle newer version due to native compile issue in 1.15.x
+  spec.add_runtime_dependency 'nokogiri', '~> 1.14.0'
   # Needed by db.rb and Msf::Exploit::Capture
   spec.add_runtime_dependency 'packetfu'
   # For sniffer and raw socket modules


### PR DESCRIPTION
Nokogiri 1.15.0 has introduced compiler requirements not available in the metasploit build env, for now lock the version until either the env is updated or the gem code is more compatible.

## Verification

List the steps needed to make sure this thing works

- [x] Build `metasploit-omnibus` rpm in the published container.
