### PR TITLE
Fix issue that falsely caused empty file reads on meterpreter

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -831,7 +831,8 @@ protected
   def _read_file_meterpreter(file_name)
     fd = session.fs.file.new(file_name, 'rb')
 
-    data = fd.read
+    data = ''.b
+    data << fd.read
     data << fd.read until fd.eof?
 
     data

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -837,7 +837,7 @@ protected
     data
   rescue EOFError
     # Sometimes fd isn't marked EOF in time?
-    ''
+    data
   rescue ::Rex::Post::Meterpreter::RequestError => e
     print_error("Failed to open file: #{file_name}: #{e}")
     return nil


### PR DESCRIPTION
Fix issue that falsely caused empty file reads on Meterpreter

This issue in particular happened frequently with the Java Meterpreter. When running the post [`test/file` module](https://github.com/rapid7/metasploit-framework/blob/966dec5b03a4c5a8edb5891a6c9f67b1f0687f1f/test/modules/post/test/file.rb#L241-L248) - file reads would end up as an empty string instead of the intended data

```
    # [read] [+] should delete binary files
    # [read] [*] [should append binary data] Got eof reading file meterpreter EOFError
    # [read] [*] [should append binary data] expected: [222, 173, 190, 239] - ASCII-8BIT
    # [read] [*] [should append binary data] actual: [] - ASCII-8BIT
    # [read] [-] FAILED: should append binary data
```

## Verification

This only happens occasionally; I verified the solution as a fix on CI after a few hundred runs