### PR TITLE
Fix time command bug when running complex commands

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -405,7 +405,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
     begin
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      command = args.join(' ')
+      command = Shellwords.shelljoin(args)
 
       case profiler
       when '--cpu'


### PR DESCRIPTION
Fix bug when running the `time` command in msfconsole with complex commands


The original use case was repeating the time it takes to run the reg query command against the last opened session

### Before

The command parsing is wrong, and cmd.exe opens

```
msf6> repeat -n 10 time sessions -i -1 -c 'cmd.exe /c reg query "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\.NET CLR Data\Linkage" /v "Export"'
...
[*] Running 'cmd.exe' on meterpreter session -1 (127.0.0.1)
Microsoft Windows [Version 10.0.14393]
(c) 2016 Microsoft Corporation. All rights reserved.

c:\metasploit-framework>
```

### After

Command parsing is right, and the reg query runs successfully

```
msf6> repeat -n 10 time sessions -i -1 -c 'cmd.exe /c reg query "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\.NET CLR Data\Linkage" /v "Export"'
...

HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\.NET CLR Data\Linkage
    Export    REG_MULTI_SZ    .NET CLR Data

...
```

## Verification

The above steps work