### PR TITLE
Extract rspec wait for expect helper

### DIFF
--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Metasploit's json-rpc" do
   include_context 'Msf::DBManager'
   include_context 'Metasploit::Framework::Spec::Constants cleaner'
   include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
+  include_context 'wait_for_expect'
 
   let(:health_check_url) { '/api/v1/health' }
   let(:rpc_url) { '/api/v1/json-rpc' }
@@ -119,28 +120,6 @@ RSpec.describe "Metasploit's json-rpc" do
         mock_rack_env_value
       else
         original_env[key]
-      end
-    end
-  end
-
-  # Waits until the given expectations are all true. This function executes the given block,
-  # and if a failure occurs it will be retried `retry_count` times before finally failing.
-  # This is useful to expect against asynchronous/eventually consistent systems.
-  #
-  # @param retry_count [Integer] The total amount of times to retry the given expectation
-  # @param sleep_duration [Integer] The total amount of time to sleep before trying again
-  def wait_for_expect(retry_count = 20, sleep_duration = 0.5)
-    failure_count = 0
-
-    begin
-      yield
-    rescue RSpec::Expectations::ExpectationNotMetError
-      failure_count += 1
-      if failure_count < retry_count
-        sleep sleep_duration
-        retry
-      else
-        raise
       end
     end
   end

--- a/spec/support/shared/contexts/wait_for_expect.rb
+++ b/spec/support/shared/contexts/wait_for_expect.rb
@@ -1,0 +1,23 @@
+RSpec.shared_context "wait_for_expect" do
+  # Waits until the given expectations are all true. This function executes the given block,
+  # and if a failure occurs it will be retried `retry_count` times before finally failing.
+  # This is useful to expect against asynchronous/eventually consistent systems.
+  #
+  # @param retry_count [Integer] The total amount of times to retry the given expectation
+  # @param sleep_duration [Integer] The total amount of time to sleep before trying again
+  def wait_for_expect(retry_count = 40, sleep_duration = 0.5)
+    failure_count = 0
+
+    begin
+      yield
+    rescue RSpec::Expectations::ExpectationNotMetError
+      failure_count += 1
+      if failure_count < retry_count
+        sleep sleep_duration
+        retry
+      else
+        raise
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracting the rspec wait-for-expect helper, as prep work for a future PR that will make use of it

## Verification

Verify CI passes