### PR TITLE
Update test post modules to always have a clean writable file system directory

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -9,6 +9,7 @@ require 'module_test'
 class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
+  include Msf::ModuleTest::PostTestFileSystem
   include Msf::Post::Common
   include Msf::Post::File
 
@@ -24,13 +25,6 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter', 'shell', 'powershell' ]
       )
     )
-
-    register_options(
-      [
-        OptString.new('BaseDirectoryName', [true, 'Directory name to create', 'test-dir']),
-        OptString.new('BaseFileName', [true, 'File name to create', 'test-file'])
-      ], self.class
-    )
   end
 
   #
@@ -39,11 +33,12 @@ class MetasploitModule < Msf::Post
   # The +cleanup+ method will change it back
   #
   def setup
-    @old_pwd = pwd
-    tmp = directory?('/tmp') ? '/tmp' : '%TEMP%'
-    vprint_status("Setup: changing working directory to #{tmp}")
-    cd(tmp)
+    push_test_directory
+    super
+  end
 
+  def cleanup
+    pop_test_directory
     super
   end
 
@@ -282,12 +277,6 @@ class MetasploitModule < Msf::Post
         result == expected
       end
     end
-  end
-
-  def cleanup
-    vprint_status("Cleanup: changing working directory back to #{@old_pwd}")
-    cd(@old_pwd)
-    super
   end
 
   def make_symlink(target, symlink)


### PR DESCRIPTION
Update test post modules to always have a clean, writable, and consistent test file system directory when running modules under the `loadpath test/modules` directory

## Verification

Verify the `test/all` module works on an osx/linux/windows host