### PR TITLE
Add namespaced test module logging

### DIFF
--- a/test/lib/module_test.rb
+++ b/test/lib/module_test.rb
@@ -35,17 +35,20 @@ module Msf
     end
 
     def it(msg = "", &block)
+      @current_it_msg = msg
       @tests += 1
       begin
         result = block.call
         unless result
-          print_error("FAILED: #{msg}")
-          print_error("FAILED: #{error}") if error
           @failures += 1
+          print_error("FAILED: #{error}") if error
+          @current_it_msg = nil
+          print_error("FAILED: #{msg}")
           return
         end
       rescue SkipTestError => e
         @skipped += 1
+        @current_it_msg = nil
         print_status("SKIPPED: #{msg} (#{e.message})")
       rescue ::Exception => e
         @failures += 1
@@ -54,6 +57,8 @@ module Msf
         dlog("Exception in testing - #{msg}")
         dlog("Call stack: #{e.backtrace.join("\n")}")
         return
+      ensure
+        @current_it_msg = nil
       end
 
       print_good("#{msg}")
@@ -66,6 +71,22 @@ module Msf
     # @return [Integer] The number of tests that have passed
     def passed
       @tests - @failures
+    end
+
+    # When printing to console, additionally prepend the current test name
+    [
+      :print,
+      :print_line,
+      :print_status,
+      :print_good,
+
+      :print_warning,
+      :print_error,
+      :print_bad,
+    ].each do |method|
+      define_method(method) do |msg|
+        super(@current_it_msg ? "[#{@current_it_msg}] #{msg}" : msg)
+      end
     end
   end
 


### PR DESCRIPTION
When running test modules that have been loaded by `loadpath test/modules`, any verbose printing logic generated will now be prefixed by the current test that is being run

<img width="765" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/b9ed7e51-eb95-4a0d-a881-1961ce645535">

## Verification

Verify `test/all` works with `verbose=true`, and that the logging works as expected