### PR TITLE
Fix unitialized constant error when meterpreter registry key reads timeout

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -668,7 +668,7 @@ protected
 
     begin
       check = session.sys.registry.check_key_exists(root_key, base_key)
-    rescue Rex::Post::Meterpreter::RequestError, TimesoutError
+    rescue Rex::Post::Meterpreter::RequestError, Rex::TimeoutError
       return false
     end
 


### PR DESCRIPTION
Fixes the following error:

```
[-] Exception: NameError : uninitialized constant Msf::Post::Windows::Registry::TimesoutError
```

## Verification

Verify the new constant is valid