### PR TITLE
Fix symlink test bug when running python meterpreter on windows

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -292,7 +292,7 @@ class MetasploitModule < Msf::Post
 
   def make_symlink(target, symlink)
     if session.platform == 'windows'
-      cmd_exec("cmd.exe /c mklink #{directory?(target) ? '/D ' : ''}#{symlink} #{target}")
+      cmd_exec("cmd.exe", "/c mklink #{directory?(target) ? '/D ' : ''}#{symlink} #{target}")
     else
       cmd_exec("ln -s $(pwd)/#{target} $(pwd)/#{symlink}")
     end


### PR DESCRIPTION
Fix symlink test bug when running python Meterpreter on windows with the `test/file` module, available after running `loadpath test/modules`

## Verification

Verify that `test/file` works on a windows python Meterpreter session

Before - test failure:

```
msf6 > use python/meterpreter/reverse_tcp
msf6 payload(python/meterpreter/reverse_tcp) > generate -f raw -o shell.py lhost=127.0.0.1
[*] Writing 428 bytes to shell.py...
msf6 payload(python/meterpreter/reverse_tcp) > to_handler
...
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:50555) at 2023-06-14 12:17:22 -0700
...
msf6 payload(python/meterpreter/reverse_tcp) > loadpath test/modules
Loaded 39 modules:
    14 auxiliary modules
    13 exploit modules
    12 post modules
...
msf6 post(test/file) > run session=-1

[!] SESSION may not be compatible with this module:
[!]  * missing Meterpreter features: stdapi_fs_chmod
[*] Running against session -1
[*] Session type is meterpreter and platform is windows
[+] should test for directory existence
[+] should create directories
[+] should list the directory we just made
[+] should recursively delete the directory we just made
[-] FAILED: should delete a symbolic link target
[-] Exception: Rex::Post::Meterpreter::RequestError: stdapi_sys_process_execute: Operation failed: Python exception: FileNotFoundError
[-] FAILED: should not recurse into symbolic link directories
[-] Exception: Rex::Post::Meterpreter::RequestError: stdapi_sys_process_execute: Operation failed: Python exception: FileNotFoundError
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[-] Passed: 14; Failed: 2; Skipped: 0
[*] Post module execution completed
```

After - all green:

``` 
[*] Running against session -1
[*] Session type is meterpreter and platform is windows
[+] should test for directory existence
[+] should create directories
[+] should list the directory we just made
[+] should recursively delete the directory we just made
[+] should delete a symbolic link target
[+] should not recurse into symbolic link directories
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[+] should test for file existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[*] Passed: 16; Failed: 0; Skipped: 0
[*] Post module execution completed
```