### PR TITLE
Consider Windows 10 Revision number in version module

### DIFF
--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -33,7 +33,7 @@ module Msf::Post::Windows::Version
 
   def get_version_info_fallback_impl
     build_num_raw = cmd_exec('cmd.exe /c ver')
-    groups = build_num_raw.match(/.*Version\s+(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?/)
+    groups = build_num_raw.match(/Version\s+(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?/)
     if groups.nil?
       return nil
     end

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -53,8 +53,12 @@ module Msf::Post::Windows::Version
       service_pack = os_version_info_ex[6]
       product_type = os_version_info_ex[9]
     
-      session.sys.registry.open_key(HKEY_LOCAL_MACHINE, 'SOFTWARE\Microsoft\Windows NT\CurrentVersion', KEY_READ)
-      Msf::WindowsVersion.new(major, minor, build, service_pack, product_type)
+      revision = 0
+      if (major >= 10)
+        revision = registry_getvaldata('HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', 'UBR', Msf::Post::Windows::Registry::REGISTRY_VIEW_NATIVE)
+      end
+
+      Msf::WindowsVersion.new(major, minor, build, service_pack, revision, product_type)
     else
       # Command shell - we'll try reg commands, and fall back to `ver`
       build_str = shell_registry_getvaldata('HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', 'CurrentBuildNumber', Msf::Post::Windows::Registry::REGISTRY_VIEW_NATIVE)

--- a/lib/msf/core/post/windows/version.rb
+++ b/lib/msf/core/post/windows/version.rb
@@ -32,15 +32,15 @@ module Msf::Post::Windows::Version
   end
 
   def get_version_info_fallback_impl
-    build_num_raw = cmd_exec('ver')
+    build_num_raw = cmd_exec('cmd.exe /c ver')
     groups = build_num_raw.match(/.*Version\s+(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?/)
     if groups.nil?
       return nil
     end
 
-    major, minor, build, _revision = groups.captures
+    major, minor, build, revision = groups.captures
     # Default to workstation, since it'll likely be an older OS - pre Server editions
-    return Msf::WindowsVersion.new(major.to_i, minor.to_i, build.to_i, 0, Msf::WindowsVersion::VER_NT_WORKSTATION)
+    return Msf::WindowsVersion.new(major.to_i, minor.to_i, build.to_i, 0, revision, Msf::WindowsVersion::VER_NT_WORKSTATION)
   end
 
   def get_version_info_impl
@@ -52,7 +52,8 @@ module Msf::Post::Windows::Version
       build = os_version_info_ex[3]
       service_pack = os_version_info_ex[6]
       product_type = os_version_info_ex[9]
-
+    
+      session.sys.registry.open_key(HKEY_LOCAL_MACHINE, 'SOFTWARE\Microsoft\Windows NT\CurrentVersion', KEY_READ)
       Msf::WindowsVersion.new(major, minor, build, service_pack, product_type)
     else
       # Command shell - we'll try reg commands, and fall back to `ver`
@@ -92,11 +93,12 @@ module Msf::Post::Windows::Version
         # This is Windows 10+ - the version numbering is calculated differently
         major = shell_registry_getvaldata('HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', 'CurrentMajorVersionNumber', Msf::Post::Windows::Registry::REGISTRY_VIEW_NATIVE)
         minor = shell_registry_getvaldata('HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', 'CurrentMinorVersionNumber', Msf::Post::Windows::Registry::REGISTRY_VIEW_NATIVE)
-        if major.nil? || minor.nil?
+        ubr = shell_registry_getvaldata('HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', 'UBR', Msf::Post::Windows::Registry::REGISTRY_VIEW_NATIVE)
+        if major.nil? || minor.nil? || ubr.nil?
           return get_version_info_fallback_impl
         end
 
-        Msf::WindowsVersion.new(major, minor, build_num, 0, product_type)
+        Msf::WindowsVersion.new(major, minor, build_num, 0, ubr, product_type)
       else
         # Pre-Windows 10
         service_pack_raw = shell_registry_getvaldata('HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', 'CSDVersion', Msf::Post::Windows::Registry::REGISTRY_VIEW_NATIVE)
@@ -112,7 +114,7 @@ module Msf::Post::Windows::Version
           end
         end
 
-        Msf::WindowsVersion.new(major, minor, build_num, service_pack, product_type)
+        Msf::WindowsVersion.new(major, minor, build_num, service_pack, 0, product_type)
       end
     end
   end

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -69,12 +69,19 @@ module Msf
       Server2016Plus = 'Windows Server 2016+'.freeze
     end
 
-    def initialize(major, minor, build, service_pack, product_type)
+    def initialize(major, minor, build, service_pack, revision, product_type)
       self._major = major
       self._minor = minor
       self._build = build
       self._service_pack = service_pack
+      self._revision = revision
       self.product_type = product_type
+    end
+
+    # The specific revision number of this version
+    # This is mainly going to be present on Windows 10+, wherein it's easy to get it from the registry.
+    def revision_number
+      _revision
     end
 
     # The specific build number of this version (major.minor.build.service_pack)
@@ -132,7 +139,7 @@ module Msf
 
     private
 
-    attr_accessor :_major, :_minor, :_build, :_service_pack, :product_type
+    attr_accessor :_major, :_minor, :_build, :_service_pack, :_revision, :product_type
 
     # The major release within which this build fits
     def major_release_name

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -21,6 +21,7 @@ module Msf
     Vista_SP0 = Server2008_SP0 = Rex::Version.new('6.0.6000.0')
     Vista_SP1 = Server2008_SP1 = Rex::Version.new('6.0.6001.1')
     Vista_SP2 = Server2008_SP2 = Rex::Version.new('6.0.6002.2')
+    Server2008_SP2_Update = Rex::Version.new('6.0.6003.2') # https://support.microsoft.com/en-us/topic/build-number-changing-to-6003-in-windows-server-2008-1335e4d4-c155-52eb-4a45-b85bd1909ca8
     Win7_SP0 = Server2008_R2_SP0 = Rex::Version.new('6.1.7600.0')
     Win7_SP1 = Server2008_R2_SP1 = Rex::Version.new('6.1.7601.1')
     Win8 = Server2012 = Rex::Version.new('6.2.9200.0')

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Version
   include Msf::Exploit::EXE # Needed for generate_payload_dll
   include Msf::Post::Windows::FileSystem
   include Msf::Post::Windows::Process
@@ -94,55 +95,43 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Target is not a Windows system, so it is not affected by this vulnerability!')
     end
 
-    # XXX Using session.shell_command_token over cmd_exec() here as @wvu-r7 noticed cmd_exec() was broken under some situations.
-    build_num_raw = session.shell_command_token('cmd.exe /c ver')
-    build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)
-    if build_num.nil?
-      print_error("Couldn't retrieve the target's build number!")
-    else
-      build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)[0]
-      print_status("Target's build number: #{build_num}")
-    end
-
     # see https://docs.microsoft.com/en-us/windows/release-information/
     version = get_version_info
-    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_1909)
+    unless version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Win10_1909)
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
-    build_num_gemversion = Rex::Version.new(build_num)
-
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2020-03-10/microsoft/
-    if (build_num_gemversion >= Rex::Version.new('10.0.18363.0')) && (build_num_gemversion < Rex::Version.new('10.0.18363.719')) # Windows 10 v1909
+    if version.build_number == Msf::WindowsVersion::Win10_1909 && version.build_number.revision_number.between?(0, 718)
       return CheckCode::Appears('Vulnerable Windows 10 v1909 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18362.0')) && (build_num_gemversion < Rex::Version.new('10.0.18362.719')) # Windows 10 v1903
+    elsif version.build_number == Msf::WindowsVersion::Win10_1903 && version.build_number.revision_number.between?(0, 718)
       return CheckCode::Appears('Vulnerable Windows 10 v1903 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17763.0')) && (build_num_gemversion < Rex::Version.new('10.0.17763.1098')) # Windows 10 v1809
+    elsif version.build_number == Msf::WindowsVersion::Win10_1809 && version.build_number.revision_number.between?(0, 1097)
       return CheckCode::Appears('Vulnerable Windows 10 v1809 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17134.0')) && (build_num_gemversion < Rex::Version.new('10.0.17134.1365')) # Windows 10 v1803
+    elsif version.build_number == Msf::WindowsVersion::Win10_1803 && version.build_number.revision_number.between?(0, 1364)
       return CheckCode::Appears('Vulnerable Windows 10 v1803 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.16299.0')) && (build_num_gemversion < Rex::Version.new('10.0.16299.1747')) # Windows 10 v1709
+    elsif version.build_number == Msf::WindowsVersion::Win10_1709 && version.build_number.revision_number.between?(0, 1746)
       return CheckCode::Appears('Vulnerable Windows 10 v1709 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.15063.0')) && (build_num_gemversion < Rex::Version.new('10.0.15063.2313')) # Windows 10 v1703
+    elsif version.build_number == Msf::WindowsVersion::Win10_1703 && version.build_number.revision_number.between?(0, 2312)
       return CheckCode::Appears('Vulnerable Windows 10 v1703 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.14393.0')) && (build_num_gemversion < Rex::Version.new('10.0.14393.3564')) # Windows 10 v1607
+    elsif version.build_number == Msf::WindowsVersion::Win10_1607 && version.build_number.revision_number.between?(0, 3563)
       return CheckCode::Appears('Vulnerable Windows 10 v1607 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.10586.0')) && (build_num_gemversion < Rex::Version.new('10.0.10586.9999999')) # Windows 10 v1511
+    elsif version.build_number == Msf::WindowsVersion::Win10_1511
       return CheckCode::Appears('Vulnerable Windows 10 v1511 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.10240.0')) && (build_num_gemversion < Rex::Version.new('10.0.10240.18519')) # Windows 10 v1507
+    elsif version.build_number == Msf::WindowsVersion::Win10_1507 && version.build_number.revision_number.between?(0, 18518)
       return CheckCode::Appears('Vulnerable Windows 10 v1507 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.3.9600.0')) && (build_num_gemversion < Rex::Version.new('6.3.9600.19665')) # Windows 8.1/Windows Server 2012 R2
+    elsif version.build_number == Msf::WindowsVersion::Win81 # Includes Server 2012 R2
       target_not_presently_supported
-      return CheckCode::Appears('Vulnerable Windows 8.1/Windows Server 2012 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.2.9200.0')) && (build_num_gemversion < Rex::Version.new('6.2.9200.23009')) # Windows 8/Windows Server 2012
+      return CheckCode::Detected('Vulnerable Windows 8.1/Windows Server 2012 R2 build detected!')
+    elsif version.build_number == Msf::WindowsVersion::Win8 # Includes Server 2012
       target_not_presently_supported
-      return CheckCode::AppearsAppears('Vulnerable Windows 8/Windows Server 2012 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24549')) # Windows 7/Windows Server 2008 R2
+      return CheckCode::Detected('Vulnerable Windows 8/Windows Server 2012 build detected!')
+    elsif version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) # Includes Server 2008 R2
       target_not_presently_supported
-      return CheckCode::Appears('Vulnerable Windows 7/Windows Server 2008 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.0.6001.0')) && (build_num_gemversion < Rex::Version.new('6.0.6003.20749')) # Windows Server 2008/Windows Server 2008 SP2
+      return CheckCode::Detected('Vulnerable Windows 7/Windows Server 2008 R2 build detected!')
+    elsif version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2008_SP2_Update) # Includes Server 2008
       target_not_presently_supported
-      return CheckCode::Appears('Windows Server 2008/Windows Server 2008 SP2 build detected!')
+      return CheckCode::Detected('Windows Windows Server 2008 build detected!')
     else
       return CheckCode::Safe('The build number of the target machine does not appear to be a vulnerable version!')
     end

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Exploit::EXE
   include Msf::Post::File
   include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Version
   include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
   include Msf::Post::Windows::Dotnet
@@ -117,29 +118,21 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Target is not a Windows system, so it is not affected by this vulnerability!')
     end
 
-    build_num_raw = cmd_exec('cmd.exe /c ver')
-    build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)
-    if build_num.nil?
-      return CheckCode::Unknown("Couldn't retrieve the target's build number!")
-    else
-      build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)[0]
-      vprint_status("Target's build number: #{build_num}")
-    end
+    version = get_version_info
 
-    build_num_gemversion = Rex::Version.new(build_num)
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2020-03-10/microsoft/
-    if (build_num_gemversion >= Rex::Version.new('10.0.19042.0')) && (build_num_gemversion < Rex::Version.new('10.0.19042.685')) # Windows 10 20H2
+    if version.build_number == Msf::WindowsVersion::Win10_20H2 && version.build_number.revision_number.between?(0, 684)
       return CheckCode::Appears('A vulnerable Windows 10 20H2 build was detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19041.0')) && (build_num_gemversion < Rex::Version.new('10.0.19041.685')) # Windows 10 v2004 aka 20H1
+    elsif version.build_number == Msf::WindowsVersion::Win10_2004 && version.build_number.revision_number.between?(0, 684)
       return CheckCode::Appears('A vulnerable Windows 10 20H1 build was detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18363.0')) && (build_num_gemversion < Rex::Version.new('10.0.18363.1256')) # Windows 10 v1909
+    elsif version.build_number == Msf::WindowsVersion::Win10_1909 && version.build_number.revision_number.between?(0, 1255)
       return CheckCode::Appears('A vulnerable Windows 10 v1909 build was detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18362.0')) && (build_num_gemversion < Rex::Version.new('10.0.18362.1256')) # Windows 10 v1903
+    elsif version.build_number == Msf::WindowsVersion::Win10_1903 && version.build_number.revision_number.between?(0, 1255)
       return CheckCode::Appears('A vulnerable Windows 10 v1903 build was detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17763.0')) && (build_num_gemversion < Rex::Version.new('10.0.17763.1637')) # Windows 10 v1809
+    elsif version.build_number == Msf::WindowsVersion::Win10_1809 && version.build_number.revision_number.between?(0, 1636)
       return CheckCode::Appears('A vulnerable Windows 10 v1809 build was detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17134.0')) && (build_num_gemversion < Rex::Version.new('10.0.17134.1902')) # Windows 10 v1803
-      return CheckCode::Appears('A vulnerable Windows 10 v1809 build was detected!')
+    elsif version.build_number == Msf::WindowsVersion::Win10_1803 && version.build_number.revision_number.between?(0, 1901)
+      return CheckCode::Appears('A vulnerable Windows 10 v1803 build was detected!')
     else
       return CheckCode::Safe('The build number of the target machine does not appear to be a vulnerable version!')
     end

--- a/modules/exploits/windows/local/cve_2021_40449.rb
+++ b/modules/exploits/windows/local/cve_2021_40449.rb
@@ -79,63 +79,52 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Target is not a Windows system, so it is not affected by this vulnerability!')
     end
 
-    version_info = get_version_info
-    unless version_info.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H1) ||
-           version_info.build_number == Msf::WindowsVersion::Server2022 ||
-           version_info.build_number == Msf::WindowsVersion::Win11_21H1
+    version = get_version_info
+    unless version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Win10_21H1) ||
+           version.build_number == Msf::WindowsVersion::Server2022 ||
+           version.build_number == Msf::WindowsVersion::Win11_21H2
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
-    build_num_raw = cmd_exec('cmd.exe /c ver')
-    build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)
-    if build_num.nil?
-      print_error("Couldn't retrieve the target's build number!")
-    else
-      build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)[0]
-      print_status("Target's build number: #{build_num}")
-    end
-
-    build_num_gemversion = Rex::Version.new(build_num)
-
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2021-10-12/microsoft/
-    if (build_num_gemversion >= Rex::Version.new('10.0.22000.0')) && (build_num_gemversion < Rex::Version.new('10.0.22000.258')) # Windows 11
+    if version.build_number == Msf::WindowsVersion::Win11_21H2 && version.build_number.revision_number.between?(0, 257)
       return CheckCode::Appears('Vulnerable Windows 11 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.20348.0')) && (build_num_gemversion < Rex::Version.new('10.0.20348.288')) # Windows Server 2022
+    elsif version.build_number == Msf::WindowsVersion::Server2022 && version.build_number.revision_number.between?(0, 287)
       return CheckCode::Appears('Vulnerable Windows Server 2022 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19044.0')) && (build_num_gemversion < Rex::Version.new('10.0.19044.1319')) # Windows 10 21H2
+    elsif version.build_number == Msf::WindowsVersion::Win10_21H2 && version.build_number.revision_number.between?(0, 1318)
       return CheckCode::Appears('Vulnerable Windows 10 21H2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19043.0')) && (build_num_gemversion < Rex::Version.new('10.0.19043.1288')) # Windows 10 21H1
+    elsif version.build_number == Msf::WindowsVersion::Win10_21H1 && version.build_number.revision_number.between?(0, 1287)
       return CheckCode::Appears('Vulnerable Windows 10 21H1 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19042.0')) && (build_num_gemversion < Rex::Version.new('10.0.19042.1288')) # Windows 10 20H2
+    elsif version.build_number == Msf::WindowsVersion::Win10_20H2 && version.build_number.revision_number.between?(0, 1287)
       return CheckCode::Appears('Vulnerable Windows 10 20H2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19041.0')) && (build_num_gemversion < Rex::Version.new('10.0.19041.1288')) # Windows 10 20H1
+    elsif version.build_number == Msf::WindowsVersion::Win10_2004 && version.build_number.revision_number.between?(0, 1287)
       return CheckCode::Appears('Vulnerable Windows 10 20H1 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18363.0')) && (build_num_gemversion < Rex::Version.new('10.0.18363.1854')) # Windows 10 v1909
+    elsif version.build_number == Msf::WindowsVersion::Win10_1909 && version.build_number.revision_number.between?(0, 1853)
       return CheckCode::Appears('Vulnerable Windows 10 v1909 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18362.0')) && (build_num_gemversion < Rex::Version.new('10.0.18362.9999999')) # Windows 10 v1903
+    elsif version.build_number == Msf::WindowsVersion::Win10_1903
       return CheckCode::Appears('Vulnerable Windows 10 v1903 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17763.0')) && (build_num_gemversion < Rex::Version.new('10.0.17763.2237')) # Windows 10 v1809
+    elsif version.build_number == Msf::WindowsVersion::Win10_1809 && version.build_number.revision_number.between?(0, 2236)
       return CheckCode::Appears('Vulnerable Windows 10 v1809 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17134.0')) && (build_num_gemversion < Rex::Version.new('10.0.17134.999999')) # Windows 10 v1803
+    elsif version.build_number == Msf::WindowsVersion::Win10_1803
       return CheckCode::Appears('Vulnerable Windows 10 v1803 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.16299.0')) && (build_num_gemversion < Rex::Version.new('10.0.16299.999999')) # Windows 10 v1709
+    elsif version.build_number == Msf::WindowsVersion::Win10_1709
       return CheckCode::Appears('Vulnerable Windows 10 v1709 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.15063.0')) && (build_num_gemversion < Rex::Version.new('10.0.15063.999999')) # Windows 10 v1703
+    elsif version.build_number == Msf::WindowsVersion::Win10_1703
       return CheckCode::Appears('Vulnerable Windows 10 v1703 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.14393.0')) && (build_num_gemversion < Rex::Version.new('10.0.14393.4704')) # Windows 10 v1607
+    elsif version.build_number == Msf::WindowsVersion::Win10_1607 && version.build_number.revision_number.between?(0, 4703)
       return CheckCode::Appears('Vulnerable Windows 10 v1607 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.10586.0')) && (build_num_gemversion < Rex::Version.new('10.0.10586.9999999')) # Windows 10 v1511
+    elsif version.build_number == Msf::WindowsVersion::Win10_1511
       return CheckCode::Appears('Vulnerable Windows 10 v1511 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.10240.0')) && (build_num_gemversion < Rex::Version.new('10.0.10240.19086')) # Windows 10 v1507
+    elsif version.build_number == Msf::WindowsVersion::Win10_1507 && version.build_number.revision_number.between?(0, 19085)
       return CheckCode::Appears('Vulnerable Windows 10 v1507 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.3.9600.0')) && (build_num_gemversion < Rex::Version.new('6.3.9600.20144')) # Windows 8.1/Windows Server 2012 R2
-      return CheckCode::Appears('Vulnerable Windows 8.1/Windows Server 2012 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.2.9200.0')) && (build_num_gemversion < Rex::Version.new('6.2.9200.23489')) # Windows 8/Windows Server 2012
-      return CheckCode::Appears('Vulnerable Windows 8/Windows Server 2012 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.1.7601.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.25740')) # Windows 7/Windows Server 2008 R2
-      return CheckCode::Appears('Vulnerable Windows 7/Windows Server 2008 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.0.6003.0')) && (build_num_gemversion < Rex::Version.new('6.0.6003.21251')) # Windows Server 2008/Windows Server 2008 SP2
-      return CheckCode::Appears('Vulnerable Windows Server 2008/Windows Server 2008 SP2 build detected!')
+    elsif version.build_number == Msf::WindowsVersion::Win81 # Includes Server 2012 R2
+      return CheckCode::Detected('Windows 8.1/Windows Server 2012 R2 build detected!')
+    elsif version.build_number == Msf::WindowsVersion::Win8 # Includes Server 2012
+      return CheckCode::Detected('Windows 8/Windows Server 2012 build detected!')
+    elsif version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) # Includes Server 2008 R2
+      return CheckCode::Detected('Windows 7/Windows Server 2008 R2 build detected!')
+    elsif version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2008_SP2_Update)
+      return CheckCode::Detected('Windows Server 2008/Windows Server 2008 SP2 build detected!')
     else
       return CheckCode::Safe('The build number of the target machine does not appear to be a vulnerable version!')
     end

--- a/modules/exploits/windows/local/cve_2022_26904_superprofile.rb
+++ b/modules/exploits/windows/local/cve_2022_26904_superprofile.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Version
   include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
   include Msf::Exploit::EXE # Needed for generate_payload_dll
@@ -92,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # see https://docs.microsoft.com/en-us/windows/release-information/
     version = get_version_info
-    unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_21H2) ||
+    unless version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Win10_21H2) ||
            version.build_number == Msf::WindowsVersion::Win11_21H2 ||
            version.build_number == Msf::WindowsVersion::Server2022
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
@@ -116,76 +117,63 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Unknown("PromptOnSecureDesktop was not set to a known value, are you sure the target system isn't corrupted?")
     end
 
-    _major, _minor, build, revision, _branch = file_version('C:\\Windows\\System32\\ntdll.dll')
-    major_minor_version = sysinfo_value.match(/\((\d{1,2}\.\d)/)
-    if major_minor_version.nil?
-      return CheckCode::Unknown("Could not retrieve the major n minor version of the target's build number!")
-    end
-
-    major_minor_version = major_minor_version[1]
-    build_num = "#{major_minor_version}.#{build}.#{revision}"
-
-    build_num_gemversion = Rex::Version.new(build_num)
-
-    # Build numbers taken from https://www.gaijin.at/en/infos/windows-version-numbers and from
-    # https://en.wikipedia.org/wiki/Windows_11_version_history and https://en.wikipedia.org/wiki/Windows_10_version_history
-    if (build_num_gemversion >= Rex::Version.new('10.0.22000.0')) # Windows 11
+    # Build numbers taken from https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2022-26904, and associated
+    # security update information (e.g. https://support.microsoft.com/en-us/topic/windows-10-update-history-857b8ccb-71e4-49e5-b3f6-7073197d98fb,
+    # https://support.microsoft.com/en-us/topic/windows-11-version-21h2-update-history-a19cd327-b57f-44b9-84e0-26ced7109ba9)
+    if version.build_number == Msf::WindowsVersion::Win11_21H2 && version.build_number.revision_number.between?(0, 612)
       return CheckCode::Appears('Vulnerable Windows 11 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.20348.0')) # Windows Server 2022
+    elsif version.build_number == Msf::WindowsVersion::Server2022 && version.build_number.revision_number.between?(0, 642)
       return CheckCode::Appears('Vulnerable Windows Server 2022 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19044.0')) # Windows 10 21H2
+    elsif version.build_number == Msf::WindowsVersion::Win10_21H2 && version.build_number.revision_number.between?(0, 1644)
       return CheckCode::Appears('Vulnerable Windows 10 21H2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19043.0')) # Windows 10 21H1
+    elsif version.build_number == Msf::WindowsVersion::Win10_21H1 && version.build_number.revision_number.between?(0, 1644)
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 21H1 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19042.0')) # Windows 10 20H2 / Windows Server, Version 20H2
+    elsif version.build_number == Msf::WindowsVersion::Win10_20H2 && version.build_number.revision_number.between?(0, 1644)
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 20H2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.19041.0')) # Windows 10 v2004 / Windows Server v2004
+    elsif version.build_number == Msf::WindowsVersion::Win10_2004
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v2004 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18363.0')) # Windows 10 v1909 / Windows Server v1909
+    elsif version.build_number == Msf::WindowsVersion::Win10_1909 && version.build_number.revision_number.between?(0, 2211)
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1909 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.18362.0')) # Windows 10 v1903
+    elsif version.build_number == Msf::WindowsVersion::Win10_1903
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1903 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17763.0')) # Windows 10 v1809 / Windows Server 2019 v1809
+    elsif version.build_number == Msf::WindowsVersion::Win10_1809 && version.build_number.revision_number.between?(0, 2802)
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1809 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.17134.0')) # Windows 10 v1803
+    elsif version.build_number == Msf::WindowsVersion::Win10_1803
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1803 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.16299.0')) # Windows 10 v1709
+    elsif version.build_number == Msf::WindowsVersion::Win10_1709
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1709 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.15063.0')) # Windows 10 v1703
+    elsif version.build_number == Msf::WindowsVersion::Win10_1703
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1703 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.14393.0')) # Windows 10 v1607 / Windows Server 2016 v1607
+    elsif version.build_number == Msf::WindowsVersion::Win10_1607 && version.build_number.revision_number.between?(0, 5065)
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1607 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.10586.0')) # Windows 10 v1511
+    elsif version.build_number == Msf::WindowsVersion::Win10_1511
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1511 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('10.0.10240.0')) # Windows 10 v1507
+    elsif version.build_number == Msf::WindowsVersion::Win10_1507
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 10 v1507 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.3.9600.0')) # Windows 8.1/Windows Server 2012 R2
+    elsif version.build_number == Msf::WindowsVersion::Win81 # Includes Server 2012 R2
       target_not_presently_supported
-      return CheckCode::Appears('Vulnerable Windows 8.1/Windows Server 2012 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.2.9200.0')) # Windows 8/Windows Server 2012
+      return CheckCode::Detected('Windows 8.1/Windows Server 2012 R2 build detected!')
+    elsif version.build_number == Msf::WindowsVersion::Win8 # Includes Server 2012
       target_not_presently_supported
-      return CheckCode::Appears('Vulnerable Windows 8/Windows Server 2012 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.1.7601.0')) # Windows 7 SP1/Windows Server 2008 R2 SP1
+      return CheckCode::Detected('Windows 8/Windows Server 2012 build detected!')
+    elsif version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) # Includes Server 2008 R2
       target_not_presently_supported
-      return CheckCode::Appears('Vulnerable Windows 7/Windows Server 2008 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) # Windows 7/Windows Server 2008 R2
+      return CheckCode::Detected('Windows 7/Windows Server 2008 R2 build detected!')
+    elsif version.build_number.between?(Msf::WindowsVersion::Server2008_SP0, Msf::WindowsVersion::Server2008_SP2_Update) # Includes Server 2008
       target_not_presently_supported
-      return CheckCode::Appears('Vulnerable Windows 7/Windows Server 2008 R2 build detected!')
-    elsif (build_num_gemversion >= Rex::Version.new('6.0.6002.0')) # Windows Server 2008 SP2
-      target_not_presently_supported
-      return CheckCode::Appears('Windows Server 2008/Windows Server 2008 SP2 build detected!')
+      return CheckCode::Detected('Windows Server 2008/Windows Server 2008 SP2 build detected!')
     else
       return CheckCode::Safe('The build number of the target machine does not appear to be a vulnerable version!')
     end

--- a/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
+++ b/spec/lib/msf/core/post/windows/task_scheduler_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
   describe '#check_compatibility' do
     context 'with Windows XP SP2' do
       before :example do
-        allow(subject).to receive(:get_version_info).and_return(Msf::WindowsVersion.new(5, 1, 2600, 2, Msf::WindowsVersion::VER_NT_WORKSTATION))
+        allow(subject).to receive(:get_version_info).and_return(Msf::WindowsVersion.new(5, 1, 2600, 2, 0, Msf::WindowsVersion::VER_NT_WORKSTATION))
       end
       it 'sets `@old_schtasks` and `@old_os` to true' do
         subject.send(:check_compatibility)
@@ -169,7 +169,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
 
     context 'with Windows Server 2003 SP2' do
       before :example do
-        allow(subject).to receive(:get_version_info).and_return(Msf::WindowsVersion.new(5, 2, 3790, 2, Msf::WindowsVersion::VER_NT_SERVER))
+        allow(subject).to receive(:get_version_info).and_return(Msf::WindowsVersion.new(5, 2, 3790, 2, 0, Msf::WindowsVersion::VER_NT_SERVER))
       end
       it 'sets `@old_schtasks` to false and `@old_os` to true' do
         subject.send(:check_compatibility)
@@ -180,7 +180,7 @@ RSpec.describe Msf::Post::Windows::TaskScheduler do
 
     context 'with Windows Server 2016' do
       before :example do
-        allow(subject).to receive(:get_version_info).and_return(Msf::WindowsVersion.new(10, 0, 14393, 0, Msf::WindowsVersion::VER_NT_SERVER))
+        allow(subject).to receive(:get_version_info).and_return(Msf::WindowsVersion.new(10, 0, 14393, 0, 0, Msf::WindowsVersion::VER_NT_SERVER))
       end
       it 'sets `@old_schtasks` and `@old_os` to false' do
         subject.send(:check_compatibility)

--- a/spec/lib/msf/core/post/windows/version_spec.rb
+++ b/spec/lib/msf/core/post/windows/version_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Msf::Post::Windows::Version do
     'CurrentMajorVersionNumber'
   end
 
+  let(:ubr) do
+    'UBR'
+  end
+
   let(:product_type_key) do
     'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ProductOptions'
   end
@@ -81,10 +85,12 @@ RSpec.describe Msf::Post::Windows::Version do
       respond_to_reg_query(subject, current_version_key, current_version, '6.3', 'REG_SZ')
       respond_to_reg_query(subject, current_version_key, major_version, '0xa', 'REG_DWORD')
       respond_to_reg_query(subject, current_version_key, minor_version, '0x0', 'REG_DWORD')
+      respond_to_reg_query(subject, current_version_key, ubr, '0x100', 'REG_DWORD')
       respond_to_reg_query(subject, product_type_key, product_type, 'WinNT', 'REG_SZ')
       allow(subject).to receive_message_chain('session.type').and_return('shell')
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Win10_22H2)
+      expect(version.revision).to eq(256)
       expect(version.windows_server?).to eq(false)
       expect(version.domain_controller?).to eq(false)
     end
@@ -94,10 +100,12 @@ RSpec.describe Msf::Post::Windows::Version do
       respond_to_reg_query(subject, current_version_key, current_version, '6.3', 'REG_SZ')
       respond_to_reg_query(subject, current_version_key, major_version, '0xa', 'REG_DWORD')
       respond_to_reg_query(subject, current_version_key, minor_version, '0x0', 'REG_DWORD')
+      respond_to_reg_query(subject, current_version_key, ubr, '0x100', 'REG_DWORD')
       respond_to_reg_query(subject, product_type_key, product_type, 'LanmanNT', 'REG_SZ')
       allow(subject).to receive_message_chain('session.type').and_return('shell')
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Server2022)
+      expect(version.revision).to eq(256)
       expect(version.windows_server?).to eq(true)
       expect(version.domain_controller?).to eq(true)
     end

--- a/spec/lib/msf/core/post/windows/version_spec.rb
+++ b/spec/lib/msf/core/post/windows/version_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Msf::Post::Windows::Version do
       allow(subject).to receive_message_chain('session.type').and_return('shell')
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Win10_22H2)
-      expect(version.revision).to eq(256)
+      expect(version.revision_number).to eq(256)
       expect(version.windows_server?).to eq(false)
       expect(version.domain_controller?).to eq(false)
     end
@@ -105,14 +105,14 @@ RSpec.describe Msf::Post::Windows::Version do
       allow(subject).to receive_message_chain('session.type').and_return('shell')
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Server2022)
-      expect(version.revision).to eq(256)
+      expect(version.revision_number).to eq(256)
       expect(version.windows_server?).to eq(true)
       expect(version.domain_controller?).to eq(true)
     end
 
     it "Windows 2000 German" do
       allow(subject).to receive(:cmd_exec).with("cmd.exe /c reg query \"#{current_version_key}\" /v \"#{current_build_number}\"") { "Der Befehl \"reg\" ist entweder falsch geschrieben oder\r\nkonnte nicht gefunden werden." }
-      allow(subject).to receive(:cmd_exec).with("ver") { "Microsoft Windows 2000 [Version 5.00.2195]" }
+      allow(subject).to receive(:cmd_exec).with("cmd.exe /c ver") { "Microsoft Windows 2000 [Version 5.00.2195]" }
       allow(subject).to receive_message_chain('session.type').and_return('shell')
       version = subject.get_version_info
       expect(version.build_number).to eq(Msf::WindowsVersion::Win2000)

--- a/spec/lib/msf/core/windows_version_spec.rb
+++ b/spec/lib/msf/core/windows_version_spec.rb
@@ -3,27 +3,27 @@ require 'spec_helper'
 RSpec.describe Msf::WindowsVersion do
 
   it 'Recognisises a major version' do
-    subject = described_class.new(6, 0, 6000, 0, Msf::WindowsVersion::VER_NT_WORKSTATION)
+    subject = described_class.new(6, 0, 6000, 0, 0, Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Windows Vista')
   end
 
   it 'Recognisises Windows Server' do
-    subject = described_class.new(6, 0, 6000, 0, Msf::WindowsVersion::VER_NT_SERVER)
+    subject = described_class.new(6, 0, 6000, 0, 0, Msf::WindowsVersion::VER_NT_SERVER)
     expect(subject.to_s).to eq('Windows Server 2008')
   end
 
   it 'Adds build suffix to Windows 10' do
-    subject = described_class.new(10,0,18362,0,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    subject = described_class.new(10,0,18362,0, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Windows 10+ Build 18362')
   end
 
   it 'Adds service pack suffix' do
-    subject = described_class.new(5,1,2600,2,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    subject = described_class.new(5,1,2600,2, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Windows XP Service Pack 2')
   end
 
   it 'Outputs unknown version' do
-    subject = described_class.new(1,2,3000,0,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    subject = described_class.new(1,2,3000,0, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Unknown Windows version: 1.2.3000')
   end
 end


### PR DESCRIPTION
This adds to the recently merged Windows Version module, to consider the revision number that is available on Windows 10, to provide finer-grained information that can help determine whether an OS is vulnerable.

I've added that information to the `WindowsVersion` class and applied it to the few locations where it was currently used.

One note on the changes: both the CVE-2020-0787 and CVE-2021-40449 modules performed checks on revision numbers, based on information from Qualys advisories. I've used this change to the mixin in these (and two other modules).

However, for pre-Windows-10 builds (which were also vulnerable to these two exploits), the build numbers could not be derived from running `cmd /c ver` as in the module, as they do not show a revision number. So as far as I could tell, this would never have provided the fine-grained details that would be hoped for. In fact, it used to fail entirely because the regex expected `ver` to return a 4-part build number, which would not have been the case on pre-Windows-10:

```
msf6 exploit(windows/local/cve_2020_0787_bits_arbitrary_file_move) > check

[-] Couldn't retrieve the target's build number!
[*] The target is not exploitable. Target is not running a vulnerable version of Windows!

```

I've removed the fine-grained version detection from these modules for these older OSes, and just reported them as `Detected` rather than `Appears`:

```
msf6 exploit(windows/local/cve_2020_0787_bits_arbitrary_file_move) > check

[!] This target is not presently supported by this exploit. Support may be added in the future!
[!] Attempts to exploit this target with this module WILL NOT WORK!
[*] The service is running, but could not be validated. Windows Vista/Windows Server 2008 build detected!
```

I also added proper detection of vulnerable revisions to `cve_2022_26904_superprofile`, based on MSRC data.

## Verification

- [ ] Ensure Win10 correctly detects the revision on both meterp and command shells
- [ ] Ensure older OSes correctly ignore the revision on both meterp and command shells
- [ ] Ensure each of the modified modules still run, and have valid checks for versions

## Results

I created a module to verify the revision detection, and ran it against command shell and Meterpreter on Server 2008 SP2 and Win 10.

```
msf6 post(windows/manage/get_version_info) > run session=1

[+] Build number: 6.0.6002.2
[+] Revision: 0
[*] Post module execution completed

msf6 post(windows/manage/get_version_info) > run session=2

[+] Build number: 6.0.6002.2
[+] Revision: 0
[*] Post module execution completed

msf6 post(windows/manage/get_version_info) > run session=3

[+] Build number: 10.0.19045.0
[+] Revision: 3086
[*] Post module execution completed

msf6 post(windows/manage/get_version_info) > run session=4

[+] Build number: 10.0.19045.0
[+] Revision: 3086
[*] Post module execution completed
```