### PR TITLE
rocketmq version lib

### DIFF
--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -71,7 +71,7 @@ module Msf
       # Errors will result in "UNKNOWN_VERSION_ID_<id>" and may be caused by needing to update the version table
       # from https://github.com/apache/rocketmq/blob/develop/common/src/4d82b307ef50f5cba5717d0ebafeb3cabf336873/java/org/apache/rocketmq/common/MQVersion.java
       version_list = JSON.parse(File.read(::File.join(Msf::Config.data_directory, 'rocketmq_versions_list.json'), mode: 'rb'))
-      version_list.fetch(id, "UNKNOWN_VERSION_ID_#{id})")
+      version_list.fetch(id, "UNKNOWN_VERSION_ID_#{id})").gsub('_', '.')
     end
   end
 end

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -1,0 +1,77 @@
+# -*- coding: binary -*-
+
+module Msf
+  ###
+  #
+  # This module provides methods for working with Arista equipment
+  #
+  ###
+  module Auxiliary::Rocketmq
+    def initialize(info = {})
+      super
+      register_options([ Opt::RPORT(9876) ], Msf::Auxiliary::Rocketmq)
+    end
+
+    def send_version_request
+      # sends a version request to the service, and returns the data as a list of hashes. nil on error
+      # https://github.com/Malayke/CVE-2023-33246_RocketMQ_RCE_EXPLOIT/blob/e27693a854a8e3b2863dc366f36002107e3595de/check.py#L68
+      data = '{"code":105,"extFields":{"Signature":"/u5P/wZUbhjanu4LM/UzEdo2u2I=","topic":"TBW102","AccessKey":"rocketmq2"},"flag":0,"language":"JAVA","opaque":1,"serializeTypeCurrentRPC":"JSON","version":401}'
+      data_length = "\x00\x00\x00" + [data.length].pack('C')
+      header = "\x00\x00\x00" + [data.length + data_length.length].pack('C')
+
+      begin
+        connect
+        vprint_status('Sending request')
+        sock.send(header + data_length + data, 0)
+        res = sock.recv(1024)
+      rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+        print_error("Unable to connect: #{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      ensure
+        disconnect
+      end
+
+      if res.nil?
+        vprint_error('No response received')
+        return nil
+      end
+
+      unless res.include?('{')
+        vprint_error('Response contains unusable data')
+        return nil
+      end
+
+      # remove a response header so we have json-ish data
+      res = res[8..]
+
+      # we have 2 json objects appended to eachother, so we now need to split that out and make it usable
+      res = res.split('}{')
+
+      jsonable = []
+      # patch back in the { and }
+      res.each do |r|
+        r += '}' unless r.end_with?('}')
+        r = '{' + r unless r.start_with?('{')
+        jsonable.append(r)
+      end
+
+      result = []
+      jsonable.each do |j|
+        res = JSON.parse(j)
+        result.append(res)
+      rescue JSON::ParserError
+        vprint_error("Unable to parse json data: #{j}")
+        next
+      end
+      result
+    end
+
+    def get_rocketmq_version(id)
+      # This function takes an ID (number) and looks through rocketmq's index of verison numbers to find the real version number
+      # Errors will result in "UNKNOWN_VERSION_ID_<id>" and may be caused by needing to update the version table
+      # from https://github.com/apache/rocketmq/blob/develop/common/src/4d82b307ef50f5cba5717d0ebafeb3cabf336873/java/org/apache/rocketmq/common/MQVersion.java
+      version_list = JSON.parse(File.read(::File.join(Msf::Config.data_directory, 'rocketmq_versions_list.json'), mode: 'rb'))
+      version_list.fetch(id, "UNKNOWN_VERSION_ID_#{id})")
+    end
+  end
+end

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -89,7 +89,7 @@ module Msf
       parsed_data
     end
 
-    def get_broker_port(broker_datas, rhost, default_broker_port)
+    def get_broker_port(broker_datas, rhost, default_broker_port: 10911)
       # Example of brokerData:
       # [{"brokerAddrs"=>{"0"=>"172.16.199.135:10911"}, "brokerName"=>"DESKTOP-8ATHH6O", "cluster"=>"DefaultCluster"}]
       target_port = nil

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -110,7 +110,6 @@ module Msf
     def get_broker_port(broker_datas, rhost, default_broker_port: 10911)
       # Example of brokerData:
       # [{"brokerAddrs"=>{"0"=>"172.16.199.135:10911"}, "brokerName"=>"DESKTOP-8ATHH6O", "cluster"=>"DefaultCluster"}]
-      target_port = nil
 
       broker_datas['brokerDatas'].each do |broker_data|
         broker_data['brokerAddrs'].values.each do |broker_endpoint|

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -71,7 +71,7 @@ module Msf
       # Errors will result in "UNKNOWN_VERSION_ID_<id>" and may be caused by needing to update the version table
       # from https://github.com/apache/rocketmq/blob/develop/common/src/4d82b307ef50f5cba5717d0ebafeb3cabf336873/java/org/apache/rocketmq/common/MQVersion.java
       version_list = JSON.parse(File.read(::File.join(Msf::Config.data_directory, 'rocketmq_versions_list.json'), mode: 'rb'))
-      version_list.fetch(id, "UNKNOWN_VERSION_ID_#{id})").gsub('_', '.')
+      version_list.fetch(id, "UNKNOWN_VERSION_ID_#{id}").gsub('_', '.')
     end
   end
 end

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -89,23 +89,22 @@ module Msf
       parsed_data
     end
 
-    def get_broker_port(brokerDatas, rhost)
+    def get_broker_port(broker_datas, rhost, default_broker_port)
       # Example of brokerData:
       # [{"brokerAddrs"=>{"0"=>"172.16.199.135:10911"}, "brokerName"=>"DESKTOP-8ATHH6O", "cluster"=>"DefaultCluster"}]
       target_port = nil
-      brokerDatas.each do |brokerData|
-        brokerData.each do |key, broker_info|
-          next unless key == 'brokerAddrs'
-          broker_info.each do |_iterator, broker_endpoint|
-            next unless broker_endpoint.include?(rhost)
-            return broker_endpoint.match(/#{rhost}:(\d+)/)[1]
-          end
+
+      broker_datas['brokerDatas'].each do |broker_data|
+        broker_data['brokerAddrs'].values.each do |broker_endpoint|
+          next unless broker_endpoint.start_with?("#{rhost}:")
+          return broker_endpoint.match(/\A#{rhost}:(\d+)\z/)[1].to_i
         end
       end
 
+
       if target_port.nil?
-        print_status('autodetection failed, assuming default port of 10911')
-        target_port = 10911
+        print_status("autodetection failed, assuming default port of #{default_broker_port}")
+        target_port = default_broker_port
       end
       target_port
     end

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -13,9 +13,11 @@ module Msf
       register_options([ Opt::RPORT(9876) ], Msf::Auxiliary::Rocketmq)
     end
 
-    def send_version_request
-      # sends a version request to the service, and returns the data as a list of hashes. nil on error
-      # https://github.com/Malayke/CVE-2023-33246_RocketMQ_RCE_EXPLOIT/blob/e27693a854a8e3b2863dc366f36002107e3595de/check.py#L68
+    # Sends a version request to the service, and returns the data as a list of hashes or nil on error
+    #
+    # @see https://github.com/Malayke/CVE-2023-33246_RocketMQ_RCE_EXPLOIT/blob/e27693a854a8e3b2863dc366f36002107e3595de/check.py#L68
+    # @return [String, nil] The data as a list of hashes or nil on error
+    def send_version_request 
       data = '{"code":105,"extFields":{"Signature":"/u5P/wZUbhjanu4LM/UzEdo2u2I=","topic":"TBW102","AccessKey":"rocketmq2"},"flag":0,"language":"JAVA","opaque":1,"serializeTypeCurrentRPC":"JSON","version":401}'
       data_length = "\x00\x00\x00" + [data.length].pack('C')
       header = "\x00\x00\x00" + [data.length + data_length.length].pack('C')
@@ -45,7 +47,7 @@ module Msf
     end
 
     def get_rocketmq_version(id)
-      # This function takes an ID (number) and looks through rocketmq's index of verison numbers to find the real version number
+      # This function takes an ID (number) and looks through rocketmq's index of version numbers to find the real version number
       # Errors will result in "UNKNOWN_VERSION_ID_<id>" and may be caused by needing to update the version table
       # from https://github.com/apache/rocketmq/blob/develop/common/src/4d82b307ef50f5cba5717d0ebafeb3cabf336873/java/org/apache/rocketmq/common/MQVersion.java
       version_list = JSON.parse(File.read(::File.join(Msf::Config.data_directory, 'rocketmq_versions_list.json'), mode: 'rb'))
@@ -102,11 +104,8 @@ module Msf
       end
 
 
-      if target_port.nil?
-        print_status("autodetection failed, assuming default port of #{default_broker_port}")
-        target_port = default_broker_port
-      end
-      target_port
+      print_status("autodetection failed, assuming default port of #{default_broker_port}")
+      default_broker_port
     end
   end
 end

--- a/modules/auxiliary/scanner/misc/rocketmq_version.rb
+++ b/modules/auxiliary/scanner/misc/rocketmq_version.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
     parsed_data = {}
     # grab some data that we need/want out of the response
     res.each do |j|
-      parsed_data['version'] = get_rocketmq_version(j['version']).gsub('_', '.') if j['version']
+      parsed_data['version'] = get_rocketmq_version(j['version']) if j['version']
       parsed_data['brokerDatas'] = j['brokerDatas'] if j['brokerDatas']
     end
 

--- a/modules/auxiliary/scanner/misc/rocketmq_version.rb
+++ b/modules/auxiliary/scanner/misc/rocketmq_version.rb
@@ -6,6 +6,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Rocketmq
 
   def initialize(info = {})
     super(
@@ -31,74 +32,29 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     )
-    register_options([ Opt::RPORT(9876) ])
-  end
-
-  def get_version(id)
-    # from https://github.com/apache/rocketmq/blob/develop/common/src/4d82b307ef50f5cba5717d0ebafeb3cabf336873/java/org/apache/rocketmq/common/MQVersion.java
-    version_list = JSON.parse(File.read(::File.join(Msf::Config.data_directory, 'rocketmq_versions_list.json'), mode: 'rb'))
-    version_list.fetch(id, "UNKNOWN_VERSION_ID_#{id})")
   end
 
   def run_host(_ip)
-    # https://github.com/Malayke/CVE-2023-33246_RocketMQ_RCE_EXPLOIT/blob/e27693a854a8e3b2863dc366f36002107e3595de/check.py#L68
-    data = '{"code":105,"extFields":{"Signature":"/u5P/wZUbhjanu4LM/UzEdo2u2I=","topic":"TBW102","AccessKey":"rocketmq2"},"flag":0,"language":"JAVA","opaque":1,"serializeTypeCurrentRPC":"JSON","version":401}'
-    data_length = "\x00\x00\x00" + [data.length].pack('C')
-    header = "\x00\x00\x00" + [data.length + data_length.length].pack('C')
-
-    begin
-      connect
-      vprint_status('Sending request')
-      sock.send(header + data_length + data, 0)
-      res = sock.recv(1024)
-    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-      print_error("Unable to connect: #{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-    ensure
-      disconnect
-    end
+    res = send_version_request
 
     if res.nil?
-      vprint_error('No response received')
+      print_error('Invalid or no response received')
       return
-    end
-
-    unless res.include?('{')
-      vprint_error('Response contains unusable data')
-      return
-    end
-
-    # remove a response header so we have json-ish data
-    res = res[8..]
-
-    # we have 2 json objects appended to eachother, so we now need to split that out and make it usable
-    res = res.split('}{')
-
-    jsonable = []
-    # patch back in the { and }
-    res.each do |r|
-      r += '}' unless r.end_with?('}')
-      r = '{' + r unless r.start_with?('{')
-      jsonable.append(r)
     end
 
     parsed_data = {}
     # grab some data that we need/want out of the response
-    jsonable.each do |j|
-      begin
-        res = JSON.parse(j)
-      rescue JSON::ParserError
-        vprint_error("Unable to parse json data: #{j}")
-        next
-      end
-      parsed_data['version'] = get_version(res['version']).gsub('_', '.') if res['version']
-      parsed_data['brokerDatas'] = res['brokerDatas'] if res['brokerDatas']
+    res.each do |j|
+      parsed_data['version'] = get_rocketmq_version(j['version']).gsub('_', '.') if j['version']
+      parsed_data['brokerDatas'] = j['brokerDatas'] if j['brokerDatas']
     end
 
-    if parsed_data == {}
+    if parsed_data == {} || parsed_data['version'].nil?
       vprint_error('Unable to find version or other data within response.')
       return
     end
-    print_good("RocketMQ version #{parsed_data['version']} found with brokers: #{res['brokerDatas']}")
+    output = "RocketMQ version #{parsed_data['version']}"
+    output += " found with brokers: #{parsed_data['brokerDatas']}" if parsed_data['brokerDatas']
+    print_good(output)
   end
 end

--- a/modules/auxiliary/scanner/misc/rocketmq_version.rb
+++ b/modules/auxiliary/scanner/misc/rocketmq_version.rb
@@ -42,17 +42,8 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    parsed_data = {}
+    parsed_data = parse_rocketmq_data(res)
     # grab some data that we need/want out of the response
-    res.each do |j|
-      parsed_data['version'] = get_rocketmq_version(j['version']) if j['version']
-      parsed_data['brokerDatas'] = j['brokerDatas'] if j['brokerDatas']
-    end
-
-    if parsed_data == {} || parsed_data['version'].nil?
-      vprint_error('Unable to find version or other data within response.')
-      return
-    end
     output = "RocketMQ version #{parsed_data['version']}"
     output += " found with brokers: #{parsed_data['brokerDatas']}" if parsed_data['brokerDatas']
     print_good(output)

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -8,7 +8,37 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
     mod
   end
 
-  describe 'get_rocketmq_version' do
+  let(:mock_name_server_response) do
+    "\x00\x00\x00\xC7\x00\x00\x00\xC3{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
+  end
+
+  let(:expected_name_server_response) do
+    "\x00\x00\x01a\x00\x00\x00_{\"code\":0,\"flag\":1,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":403}{\"brokerDatas\":[{\"brokerAddrs\":{\"0\":\"172.16.199.135:10911\"},\"brokerName\":\"DESKTOP-8ATHH6O\",\"cluster\":\"DefaultCluster\"}],\"filterServerTable\":{},\"queueDatas\":[{\"brokerName\":\"DESKTOP-8ATHH6O\",\"perm\":7,\"readQueueNums\":8,\"topicSysFlag\":0,\"writeQueueNums\":8}]}".b
+  end
+
+  let(:expected_parsed_data_response) do
+    {
+      'brokerDatas' => [
+        {
+          'brokerAddrs' => {
+            '0' => '172.16.199.135:10911'
+          },
+          'brokerName' => 'DESKTOP-8ATHH6O',
+          'cluster' => 'DefaultCluster'
+        }
+      ],
+      'version' => 'V4.9.5'
+    }
+  end
+
+  let(:mock_sock) { double :'Rex::Socket::Tcp', send: nil, recv: expected_name_server_response, close: nil, shutdown: nil }
+
+  before(:each) do
+    allow(subject).to receive(:connect).and_return(mock_sock)
+    allow(subject).to receive(:sock).and_return(mock_sock)
+  end
+
+  describe '#get_rocketmq_version' do
     context 'correctly looks up id 401 as V4.9.4' do
       it 'returns that version' do
         expect(subject.get_rocketmq_version(401)).to eql('V4.9.4')
@@ -22,29 +52,9 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
     end
   end
 
-  let(:expected_name_server_request) do
-    "\x00\x00\x00\xC7\x00\x00\x00\xC3{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
-  end
-
-  let(:expected_name_server_response) do
-    "\x00\x00\x01a\x00\x00\x00_{\"code\":0,\"flag\":1,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":403}{\"brokerDatas\":[{\"brokerAddrs\":{\"0\":\"172.16.199.135:10911\"},\"brokerName\":\"DESKTOP-8ATHH6O\",\"cluster\":\"DefaultCluster\"}],\"filterServerTable\":{},\"queueDatas\":[{\"brokerName\":\"DESKTOP-8ATHH6O\",\"perm\":7,\"readQueueNums\":8,\"topicSysFlag\":0,\"writeQueueNums\":8}]}".b
-  end
-
-  let(:expected_parsed_data_response) do
-    {"brokerDatas" => [{"brokerAddrs"=>{"0"=>"172.16.199.135:10911"}, "brokerName"=>"DESKTOP-8ATHH6O", "cluster"=>"DefaultCluster"}],
-    "version" => "V4.9.5"}
-  end
-
-  let(:mock_sock) { double :'Rex::Socket::Tcp', send: expected_name_server_request, recv: expected_name_server_response, close: nil, shutdown: nil }
-
-  before(:each) do
-    allow(subject).to receive(:connect).and_return(mock_sock)
-    allow(subject).to receive(:sock).and_return(mock_sock)
-  end
-
   describe '#send_version_request' do
     it 'returns version info' do
-      expect(mock_sock).to receive(:send).with(expected_name_server_request, 0)
+      expect(mock_sock).to receive(:send).with(mock_name_server_response, 0)
       expect(subject.send_version_request).to eq(expected_name_server_response)
     end
   end
@@ -57,11 +67,11 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
 
   describe '#get_broker_port' do
     it 'returns the broker port associated with the given rport in the name server response ' do
-      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.135')).to eq(10911)
+      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.135', 10911)).to eq(10911)
     end
 
-    it 'returns the default broker port 10911 when rhost is not found in the name server response' do
-      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.1')).to eq(10911)
+    it 'returns the default broker port when rhost is not found in the name server response' do
+      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.1', 10000)).to eq(10000)
     end
   end
 end

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
     end
 
     it 'returns the default broker port when rhost is not found in the name server response' do
-      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.1', 10000)).to eq(10000)
+      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.1', default_broker_port: 10000)).to eq(10000)
     end
   end
 end

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Auxiliary::Rocketmq do
+  subject do
+    mod = Msf::Module.new
+    mod.extend(Msf::Auxiliary::Rocketmq)
+    mod
+  end
+
+  describe 'get_rocketmq_version' do
+    context 'correctly looks up id 401 as V4.9.4' do
+      it 'returns that version' do
+        expect(subject.get_rocketmq_version(401)).to eql('V4.9.4')
+      end
+    end
+
+    context 'correctly looks up id 99999 as UNKNOWN_VERSION_ID_99999' do
+      it 'returns that version' do
+        expect(subject.get_rocketmq_version(99999)).to eql('UNKNOWN_VERSION_ID_99999')
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
 
   describe '#get_broker_port' do
     it 'returns the broker port associated with the given rport in the name server response ' do
-      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.135', 10911)).to eq(10911)
+      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.135')).to eq(10911)
     end
 
     it 'returns the default broker port when rhost is not found in the name server response' do

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Msf::Auxiliary::Rocketmq do
   subject do
-    mod = Msf::Module.new
+    mod = Msf::Auxiliary.new
+    mod.extend(Msf::Exploit::Remote::Tcp)
     mod.extend(Msf::Auxiliary::Rocketmq)
     mod
   end
@@ -18,6 +19,49 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
       it 'returns that version' do
         expect(subject.get_rocketmq_version(99999)).to eql('UNKNOWN.VERSION.ID.99999')
       end
+    end
+  end
+
+  let(:expected_name_server_request) do
+    "\x00\x00\x00\xC7\x00\x00\x00\xC3{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
+  end
+
+  let(:expected_name_server_response) do
+    "\x00\x00\x01a\x00\x00\x00_{\"code\":0,\"flag\":1,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":403}{\"brokerDatas\":[{\"brokerAddrs\":{\"0\":\"172.16.199.135:10911\"},\"brokerName\":\"DESKTOP-8ATHH6O\",\"cluster\":\"DefaultCluster\"}],\"filterServerTable\":{},\"queueDatas\":[{\"brokerName\":\"DESKTOP-8ATHH6O\",\"perm\":7,\"readQueueNums\":8,\"topicSysFlag\":0,\"writeQueueNums\":8}]}".b
+  end
+
+  let(:expected_parsed_data_response) do
+    {"brokerDatas" => [{"brokerAddrs"=>{"0"=>"172.16.199.135:10911"}, "brokerName"=>"DESKTOP-8ATHH6O", "cluster"=>"DefaultCluster"}],
+    "version" => "V4.9.5"}
+  end
+
+  let(:mock_sock) { double :'Rex::Socket::Tcp', send: expected_name_server_request, recv: expected_name_server_response, close: nil, shutdown: nil }
+
+  before(:each) do
+    allow(subject).to receive(:connect).and_return(mock_sock)
+    allow(subject).to receive(:sock).and_return(mock_sock)
+  end
+
+  describe '#send_version_request' do
+    it 'returns version info' do
+      expect(mock_sock).to receive(:send).with(expected_name_server_request, 0)
+      expect(subject.send_version_request).to eq(expected_name_server_response)
+    end
+  end
+
+  describe '#parse_rocketmq_data' do
+    it 'correctly parses the response from the name server into version and brokeDatas info' do
+      expect(subject.parse_rocketmq_data(expected_name_server_response)).to eq(expected_parsed_data_response)
+    end
+  end
+
+  describe '#get_broker_port' do
+    it 'returns the broker port associated with the given rport in the name server response ' do
+      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.135')).to eq(10911)
+    end
+
+    it 'returns the default broker port 10911 when rhost is not found in the name server response' do
+      expect(subject.get_broker_port(expected_parsed_data_response, '172.16.199.1')).to eq(10911)
     end
   end
 end

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
       end
     end
 
-    context 'correctly looks up id 99999 as UNKNOWN_VERSION_ID_99999' do
+    context 'correctly looks up id 99999 as UNKNOWN.VERSION.ID.99999' do
       it 'returns that version' do
-        expect(subject.get_rocketmq_version(99999)).to eql('UNKNOWN_VERSION_ID_99999')
+        expect(subject.get_rocketmq_version(99999)).to eql('UNKNOWN.VERSION.ID.99999')
       end
     end
   end


### PR DESCRIPTION
This PR moves the version detection for rocketmq out of the scanner module, and into a library so it can be shared by #18082 

Unfortunately I wasn't able to get my test DB installed, so the tests here are minimal. However @jheysel-r7 may be able to write a test for `send_version_request` where it'll return back a valid response.

## Verification

- [ ] install docker image
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/misc/rocketmq_version`
- [ ] `set rhosts [ip]`
- [ ] `run`
- [ ] **Verify** it finds the version of rocketmq

