### PR TITLE
Add additional logging to post test file

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Post
       f = read_file(datastore['BaseFileName'])
       ret = (f == 'foo')
       unless ret
-        print_error("Didn't read what we wrote, actual file on target: |#{f}|")
+        vprint_status("Didn't read what we wrote, actual file on target: |#{f.inspect}| - #{f.bytes.inspect}")
       end
 
       ret
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Post
       final_contents = read_file(datastore['BaseFileName'])
       ret &&= final_contents == 'foobarbaz'
       unless ret
-        print_error("Didn't read what we wrote, actual file on target: #{final_contents}")
+        vprint_status("Didn't read what we wrote, actual file on target: |#{file_contents.inspect}| - #{file_contents.bytes.inspect}")
       end
 
       ret


### PR DESCRIPTION
Adds additional logging to the `test/file` module. This module is useful for developers contributing enhancements or new functionality to Meterpreter and other payloads. It is available after running `loadpath test/modules`

## Verification

Review the code changes
Verify the test module works and outputs the log information when `verbose=true`