### PR TITLE
Add railgun reverse lookup tests for osx and linux

### DIFF
--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -37,22 +37,43 @@ class MetasploitModule < Msf::Post
   end
 
   #
-  # Return an array of windows constants names matching +winconst+
+  # Return an array of constants names matching const
   #
-  def select_const_names(winconst, filter_regex = nil)
-    session.railgun.constant_manager.select_const_names(winconst, filter_regex)
+  def select_const_names(const, filter_regex = nil)
+    session.railgun.constant_manager.select_const_names(const, filter_regex)
   end
 
   #
   # Returns an array of windows error code names for a given windows error code matching +err_code+
   #
-  def lookup_error(err_code, filter_regex = nil)
+  def lookup_windows_error(err_code, filter_regex = nil)
     select_const_names(err_code, /^ERROR_/).select do |name|
       name =~ filter_regex
     end
   end
 
-  def test_static
+  def test_osx_static
+    return skip('session platform is not osx') unless session.platform == 'osx'
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+
+    it "should return a constant name given a const and a filter" do
+      results = select_const_names(4, /^PROT/)
+      results == ['PROT_EXEC']
+    end
+  end
+
+  def test_linux_static
+    return skip('session platform is not osx') unless session.platform == 'linux'
+    return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
+
+    it "should return a constant name given a const and a filter" do
+      results = select_const_names(277, /^SOL_I/)
+      results == ['SOL_IUCV']
+    end
+  end
+
+  def test_windows_static
+    return skip('session platform is not windows') unless session.platform == 'windows'
     return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
 
     it "should return a constant name given a const and a filter" do
@@ -76,7 +97,7 @@ class MetasploitModule < Msf::Post
 
     it "should return an error string given an error code" do
       ret = true
-      results = lookup_error(0x420, /^ERROR_SERVICE/)
+      results = lookup_windows_error(0x420, /^ERROR_SERVICE/)
       ret &&= !!(results.kind_of? Array)
       ret &&= !!(results.length == 1)
 
@@ -84,7 +105,8 @@ class MetasploitModule < Msf::Post
     end
   end
 
-  def test_datastore
+  def test_windows_datastore
+    return skip('session platform is not windows') unless session.platform == 'windows'
     return skip('session does not support COMMAND_ID_STDAPI_RAILGUN_API') unless session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_RAILGUN_API)
 
     if (datastore["WIN_CONST"])


### PR DESCRIPTION
Adds additional `test/railgun_reverse_lookup` tests for osx and linux.

## Verification

Verify the tests pass on the OSX and Linux Python Meterpreters