### PR TITLE
Fix windows python meterpreter getuid intermittent crash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.143)
+      metasploit-payloads (= 2.0.145)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -258,7 +258,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.143)
+    metasploit-payloads (2.0.145)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.143'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.145'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Fixes intermittent segfaults/crashes with the Windows Python Meterpreter when the getuid command was executing

Associated PRs 
- https://github.com/rapid7/metasploit-payloads/pull/661
- https://github.com/rapid7/metasploit-payloads/pull/663

## Verification

- Verify a Python meterpreter session opens on a Windows host and the getuid command works