### PR TITLE
Use ldap_connect in place of ldap_new to trigger the bind early

### DIFF
--- a/modules/auxiliary/gather/ldap_hashdump.rb
+++ b/modules/auxiliary/gather/ldap_hashdump.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     entries_returned = 0
 
     print_status("#{peer} Connecting...")
-    ldap_new do |ldap|
+    ldap_connect do |ldap|
       if ldap.get_operation_result.code == 0
         vprint_status("#{peer} LDAP connection established")
       else


### PR DESCRIPTION
The auxiliary/gather/ldap_hashdump added in #13906 was using `ldap_new` instead of `ldap_connect` this lead to the logic checking for a valid connection to _always_ claim a connection was established since `ldap.get_operation_result.code` will always be 0 (indicating no errors) before connecting

Simple fix to just replace `ldap_new` with `ldap_connect`

## Before
```
    89:     ldap_new do |ldap|
    90:       require 'pry-byebug'; binding.pry
 => 91:       if ldap.get_operation_result.code == 0
    92:         vprint_status("#{peer} LDAP connection established")
    93:       else
    94:         # Even if we get "Invalid credentials" error, we may proceed with anonymous bind
    95:         print_ldap_error(ldap)
    96:       end


[1] pry(#<Msf::Modules::Auxiliary__Gather__Ldap_hashdump::MetasploitModule>)> ldap.instance_variable_get :@open_connection
=> nil
```

## After
```
    89:     ldap_connect do |ldap|
    90:       require 'pry-byebug'; binding.pry
 => 91:       if ldap.get_operation_result.code == 0
    92:         vprint_status("#{peer} LDAP connection established")
    93:       else
    94:         # Even if we get "Invalid credentials" error, we may proceed with anonymous bind
    95:         print_ldap_error(ldap)
    96:       end

[1] pry(#<Msf::Modules::Auxiliary__Gather__Ldap_hashdump::MetasploitModule>)> ldap.instance_variable_get :@open_connection
=> #<Net::LDAP::Connection:0x00007f91f79da6d0 @conn=#<Socket:fd 13>, @message_queue={1=>[]}, @msgid=1>
```

# Verification Steps
- [ ] Follow the steps listed in the module documentation https://github.com/HynekPetrak/metasploit-framework/blob/aa60b4efc0d6955e537d6650da1fa6b8918e8146/documentation/modules/auxiliary/gather/ldap_hashdump.md#verification-steps