### PR TITLE
Fix windows Meterpreter clipboard manipulation access denied errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.145)
+      metasploit-payloads (= 2.0.147)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.20)
       mqtt
@@ -258,7 +258,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.145)
+    metasploit-payloads (2.0.147)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.145'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.147'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.20'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Fixes an intermittent issue with Windows Meterpreter which caused 'Access Denied' errors when Meterpreter attempte to get or set the clipboard data when either the user or another application was also manipulating the clipboard

Pulls in metasploit-payloads:
- Update extapi OpenClipboard to support retrying if acquiring the lock failed - https://github.com/rapid7/metasploit-payloads/pull/666
-  Fix broken readme code snippets - https://github.com/rapid7/metasploit-payloads/pull/664

## Verification

- Verify the same steps as https://github.com/rapid7/metasploit-payloads/pull/666