### PR TITLE
Remove Ruby 2.7 from Github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - '2.7'
+          - '3.0'
 
     name: Ruby ${{ matrix.ruby }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - '2.7'
+          - '3.0'
 
     name: Lint msftidy
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,7 +64,6 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
@@ -73,7 +72,6 @@ jobs:
           - ubuntu-20.04
           - ubuntu-latest
         exclude:
-          - { os: ubuntu-latest, ruby: '2.7' }
           - { os: ubuntu-latest, ruby: '3.0' }
         include:
           - os: ubuntu-latest

--- a/.github/workflows/weekly-dependencies-pr.yml
+++ b/.github/workflows/weekly-dependencies-pr.yml
@@ -40,7 +40,7 @@ jobs:
             const hasPR = await github.rest.pulls.list({
               owner,
               repo,
-              head: owner + ':' + '${{ github.ref_name }}' 
+              head: owner + ':' + '${{ github.ref_name }}'
             });
             console.log('hasPR:');
             console.log(JSON.stringify({ data: hasPR.data, status: hasPR.status }, null, 4));


### PR DESCRIPTION
Removes Ruby 2.7 from Github actions now that it has been EOL'd ~3 months ago

I will be putting up a future PR that requires Ruby `3.x` test libraries, and most likely existing libraries that we depend on will follow suit in the short future.

## Verification

Verify CI passes