### PR TITLE
Handle nil error when creating adapted payloads

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -153,7 +153,7 @@ class PayloadSet < ModuleSet
     adapter_mod, _, _adapter_platform, _adapter_arch, adapter_inst, adapted_modinfo = adapter_info
     single_mod, handler, _single_platform, _single_arch, _single_inst, _single_modinfo = single_info
 
-    return nil unless adapter_inst.compatible?(single_payload.new)
+    return nil unless single_payload && adapter_inst.compatible?(single_payload.new)
 
     payload = build_payload(handler, single_mod, adapter_mod)
 
@@ -281,7 +281,7 @@ class PayloadSet < ModuleSet
     stager_mod, handler, _stager_platform, _stager_arch, _stager_inst, _stager_modinfo = stager_info
     adapter_mod, _, _adapter_platform, _adapter_arch, adapter_inst, adapter_modinfo = adapter_info
 
-    return nil unless adapter_inst.compatible?(staged_payload.new)
+    return nil unless staged_payload && adapter_inst.compatible?(staged_payload.new)
 
     payload = build_payload(handler, stager_mod, stage_mod, adapter_mod)
 


### PR DESCRIPTION
Issue introduced as part of #17901

When doing `show payloads` for a module that supports the encrypted payloads on a machine that doesn't have mingw available we try to adapt a `nil` payload, this PR is just adding a check to make sure the payload we want to adapt is actually available

```
msf6 exploit(multi/handler) > show payloads
[-] Error while running command show: undefined method `new' for nil:NilClass

Call stack:
/Users/dwelch/dev/metasploit-framework/lib/msf/core/payload_set.rb:156:in `calculate_adapted_single_payload'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/payload_set.rb:390:in `add_cached_module'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/payload_set.rb:318:in `add_module'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/module_manager/loading.rb:108:in `on_module_load'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/modules/loader/base.rb:202:in `load_module'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/module_manager/cache.rb:101:in `block in load_cached_module'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/module_manager/cache.rb:98:in `each'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/module_manager/cache.rb:98:in `load_cached_module'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/module_set.rb:42:in `create'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/module_set.rb:26:in `[]'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/exploit.rb:705:in `is_payload_compatible?'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/exploit.rb:744:in `block in compatible_payloads'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/exploit.rb:743:in `each'
/Users/dwelch/dev/metasploit-framework/lib/msf/core/exploit.rb:743:in `compatible_payloads'
/Users/dwelch/dev/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:1398:in `show_payloads'
/Users/dwelch/dev/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:590:in `block in cmd_show'
/Users/dwelch/dev/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:571:in `each'
/Users/dwelch/dev/metasploit-framework/lib/msf/ui/console/command_dispatcher/modules.rb:571:in `cmd_show'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:581:in `run_command'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:530:in `block in run_single'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `each'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:524:in `run_single'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:168:in `run'
/Users/dwelch/dev/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/dwelch/dev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

# Verification steps
- [ ] Boot up msfconsole
- [ ] `use exploit/multi/handler`
- [ ] `show payloads`
