### PR TITLE
Change exploit template comment header from http to https for Msftidy

### DIFF
--- a/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
+++ b/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
@@ -35,7 +35,7 @@ But of course, to begin, you most likely need a template to work with, and here 
 
 ```ruby
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/docs/metasploit-framework.wiki/How-to-get-started-with-writing-an-auxiliary-module.md
+++ b/docs/metasploit-framework.wiki/How-to-get-started-with-writing-an-auxiliary-module.md
@@ -49,7 +49,7 @@ Here's the most basic example of an auxiliary module. We'll explain a bit more a
 
 ```ruby
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -86,7 +86,7 @@ Because the ```Msf::Auxiliary::Scanner``` mixin is so popular, we figured you wa
 
 ```ruby
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/docs/metasploit-framework.wiki/How-to-write-a-browser-exploit-using-HttpServer.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-browser-exploit-using-HttpServer.md
@@ -74,7 +74,7 @@ To get things started, you can always use the following template to start develo
 
 ```ruby
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/docs/metasploit-framework.wiki/How-to-write-a-module-using-HttpServer-and-HttpClient.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-module-using-HttpServer-and-HttpClient.md
@@ -8,7 +8,7 @@ Here is how you can set it up:
 
 ```ruby
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
+++ b/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
@@ -216,7 +216,7 @@ We're excited to see your upcoming contributions of new modules, documentation, 
 
 Finally, we welcome your feedback on this guide, so feel free to reach out to us on [Slack] or open a [new issue].  For their significant contributions to this guide, we would like to thank [@kernelsmith], [@corelanc0d3r], and [@ffmike].
 
-[commercial-installer]:http://metasploit.com/download
+[commercial-installer]:https://metasploit.com/download
 [kali-user-instructions]:https://docs.kali.org/general-use/starting-metasploit-framework-in-kali
 [parrot-user-instructions]:https://parrotsec.org/docs/installation.html
 [CONTRIBUTING.md]:https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Msftidy complains about Line 2 of the exploit template comment having `http://` protocol instead of `https://` protocol.

Reference in PR [#18170](https://github.com/rapid7/metasploit-framework/pull/18170), commit hash ad0d3e79, where Msftidy lint test fails to pass, but in the next commit 591fee18, the test passes.

- Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

No issue number, but I noticed this while copying and pasting the template code to write a new exploit.