### PR TITLE
update reference format for entry in rapid7.com

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           %w(OSVDB 49243),
           %w(MSB MS08-067),
           # If this vulnerability is found, ms08-67 is exposed as well
-          ['URL', 'http://www.rapid7.com/vulndb/lookup/dcerpc-ms-netapi-netpathcanonicalize-dos']
+          ['URL', 'https://www.rapid7.com/db/vulnerabilities/dcerpc-ms-netapi-netpathcanonicalize-dos/']
         ],
       'DefaultOptions' =>
         {


### PR DESCRIPTION
Updates a reference on `exploit/windows/smb/ms08_067_netapi` to the new URL format for a https://www.rapid7.com/db/ direct link.