### PR TITLE
Change dead links to live links, in documents

### DIFF
--- a/docs/metasploit-framework.wiki/Contributing-to-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Contributing-to-Metasploit.md
@@ -58,7 +58,7 @@ You probably shouldn't run proof of concept exploit code you find on the Interne
 
 Also, please take a peek at our guides on using git and our acceptance guidelines for new modules in case you're not familiar with them.
 
-If you get stuck, try to explain your specific problem as best you can on our [Freenode IRC](https://freenode.net/) channel, #metasploit (joining requires a [registered nick](https://freenode.net/kb/answer/registration)). Someone should be able to lend a hand. Apparently, some of those people never sleep.
+If you get stuck, try to explain your specific problem as best you can on our [Freenode IRC](https://freenode.net/) channel, #metasploit (joining requires a [registered nick](https://freenode.net/view/Nick_Registration)). Someone should be able to lend a hand. Apparently, some of those people never sleep.
 
 # Thank you
 

--- a/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
+++ b/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
@@ -218,7 +218,7 @@ Finally, we welcome your feedback on this guide, so feel free to reach out to us
 
 [commercial-installer]:https://metasploit.com/download
 [kali-user-instructions]:https://docs.kali.org/general-use/starting-metasploit-framework-in-kali
-[parrot-user-instructions]:https://parrotsec.org/docs/installation.html
+[parrot-user-instructions]:https://parrotsec.org/docs/category/installation
 [CONTRIBUTING.md]:https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md
 
 [Ubuntu]:https://www.ubuntu.com/download/desktop

--- a/docs/metasploit-framework.wiki/git/Git-Reference-Sites.md
+++ b/docs/metasploit-framework.wiki/git/Git-Reference-Sites.md
@@ -14,7 +14,7 @@ The following sites are great references for Git padawans and jedi alike:
 * [Git is Easier Than You Think](http://nfarina.com/post/9868516270/git-is-simpler): A nice tutorial that breaks down one Git user's experience switching from Subversion.
 * [PeepCode: Git](http://peepcode.com/products/git): A one-hour (not-free) screencast covering Git basics. Well-made and easy to follow.
 * [GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html): Another great post from Scott Chacon describing a GitHub-based workflow for projects.
-* [Getting Started with GitHub](http://pragprog.com/screencasts/v-scgithub/insider-guide-to-github): Also from GitHub's own Scott Chacon, this two-part screencast (one free and one paid) will walk you through the basics of using GitHub.
+* [Getting Started with GitHub](https://pragprog.com/screencasts/v-scgithub/insider-guide-to-github): Also from GitHub's own Scott Chacon, this two-part screencast (one free and one paid) will walk you through the basics of using GitHub.
 
 
 ## Using Git in Editors


### PR DESCRIPTION
Hi team :D
Some of the [Metasploit Documentation](https://docs.metasploit.com)'s sub-documents have dead links. With this PR, we changed dead link to a valid link. 

In addition, I think it's better to deliver the two below rather than change them directly, so I included them only in the contents.

- https://docs.metasploit.com/docs/development/maintainers/committer-keys.html
  - (404) https://keybase.io/grantwillcox
- https://docs.metasploit.com/docs/development/google-summer-of-code/gsoc-2017-project-ideas.html
  - (404) https://github.com/wvu-r7

> There won't be a security problem, but someone can occupy the page, so I think it needs to be updated or removed.