### PR TITLE
Fixes incorrect usage of pack/unpack directives

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -300,7 +300,7 @@ module Msf
             def build_pa_for_user(opts = {})
               auth_package = 'Kerberos'.b
 
-              checksum_data = [Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL].pack('<I')
+              checksum_data = [Rex::Proto::Kerberos::Model::NameType::NT_PRINCIPAL].pack('I<')
               checksum_data << opts[:username].b
               checksum_data << opts[:realm].b
               checksum_data << auth_package

--- a/lib/msf/core/exploit/remote/rdp.rb
+++ b/lib/msf/core/exploit/remote/rdp.rb
@@ -230,8 +230,8 @@ module Exploit::Remote::RDP
       [self.rdp_user_id, chan_id].pack('S>S>'), # MCS send data request structure, choice 25
       "\x70", # Wut (security header)
       per_data(
-        [data_length].pack('<L'),
-        [flags].pack('<L'),
+        [data_length].pack('L<'),
+        [flags].pack('L<'),
         data
       )
     ].join('')
@@ -584,7 +584,7 @@ module Exploit::Remote::RDP
 
     sha1 << mac_salt_key
     sha1 << pad1
-    sha1 << [data_content.length].pack('<L')
+    sha1 << [data_content.length].pack('L<')
     sha1 << data_content
 
     md5 << mac_salt_key
@@ -1247,10 +1247,10 @@ protected
     flags: RDPConstants::REDIRECTION_SUPPORTED | RDPConstants::REDIRECTION_VERSION3,
     session_id: 0
   )
-    body = [flags, session_id].pack('<L<L')
+    body = [flags, session_id].pack('L<L<')
 
     result = [
-      [0xc004, body.length + 4].pack('<S<S'),
+      [0xc004, body.length + 4].pack('S<S<'),
       body
     ].join('')
 
@@ -1261,10 +1261,10 @@ protected
     encryption_methods: RDPConstants::ENCRYPTION_40BIT | RDPConstants::ENCRYPTION_128BIT,
     ext_encryption_methods: 0
   )
-    body = [encryption_methods, ext_encryption_methods].pack('<L<L')
+    body = [encryption_methods, ext_encryption_methods].pack('L<L<')
 
     result = [
-      [0xc002, body.length + 4].pack('<S<S'),
+      [0xc002, body.length + 4].pack('S<S<'),
       body
     ].join('')
 
@@ -1273,7 +1273,7 @@ protected
 
   def cs_network_data(channels)
     chan_data = channels.map{ |c|
-      [c[0].encode('ASCII')].pack('a8*') + [c[1]].pack('L')
+      [c[0].encode('ASCII')].pack('a8') + [c[1]].pack('L')
     }.join('')
 
     body = [
@@ -1282,13 +1282,14 @@ protected
     ].join('')
 
     result = [
-      [0xc003, body.length + 4].pack('<S<S'),
+      [0xc003, body.length + 4].pack('S<S<'),
       body
     ].join('')
 
     result
   end
 
+  # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/00f1da4a-ee9c-421a-852f-c19f92343d73
   def cs_core_data(
     version: 0x80004,
     width: 800,
@@ -1309,18 +1310,18 @@ protected
     client_dig_product_id = Rex::Text.to_unicode(client_dig_product_id[0..32], 'utf-16le')
 
     body = [
-      [version, width, height].pack('<L<S<S'),
+      [version, width, height].pack('L<S<S<'),
       "\x01\xca", # colour depth (8BPP)
       "\x03\xaa", # SASSequence
-      [keyboard, client_build, client_name, keyboard_type].pack('<L<La32*'),
-      [keyboard_type, keyboard_subtype, keyboard_func_key].pack('<L<L<L'),
+      [keyboard, client_build, client_name].pack('L<L<a32'),
+      [keyboard_type, keyboard_subtype, keyboard_func_key].pack('L<L<L<'),
       "\x00" * 64, # imeFileName
       "\x01\xca", # postBeta2ColorDepth (8BPP)
-      [client_product_id, serial_num].pack('<S<L'),
+      [client_product_id, serial_num].pack('S<L<'),
       "\x18\x00", # highColorDepth: 24 bpp
       "\x07\x00", # supportedColorDepths: flag (24 bpp | 16 bpp | 15 bpp )
       "\x01\x00", # earlyCapabilityFlags: 1 (RNS_UD_CS_SUPPORT_ERRINFO_PDU)
-      [client_dig_product_id].pack('a64*'),
+      [client_dig_product_id].pack('a64'),
       "\x00", # connectionType: 0
       "\x00", # pad1octet
       # serverSelectedProtocol - After negotiating TLS or CredSSP this value must
@@ -1330,7 +1331,7 @@ protected
     ].join('')
 
     result = [
-      [0xc001, body.length + 4].pack('<S<S'),
+      [0xc001, body.length + 4].pack('S<S<'),
       body
     ].join('')
 
@@ -1400,7 +1401,7 @@ protected
         if pkt[7] == "\x68"
           chan_user_id = pkt[8..9].unpack('S>')[0]
           chan_id = pkt[10..11].unpack('S>')[0]
-          flags = pkt[18..21].unpack('<L')[0]
+          flags = pkt[18..21].unpack('L<')[0]
           data = pkt[22..pkt.length]
           rdp_on_channel_receive(pkt, chan_user_id, chan_id, flags, data)
         end

--- a/lib/msf/util/windows_crypto_helpers.rb
+++ b/lib/msf/util/windows_crypto_helpers.rb
@@ -426,4 +426,3 @@ module WindowsCryptoHelpers
 end
 end
 end
-

--- a/lib/msf/util/windows_registry/registry_parser.rb
+++ b/lib/msf/util/windows_registry/registry_parser.rb
@@ -332,7 +332,7 @@ module WindowsRegistry
           return hash_rec.offset_nk
         end
       when LH_MAGIC
-        if hash_rec.key_name.unpack('<L').first == get_lh_hash(key)
+        if hash_rec.key_name.unpack('L<').first == get_lh_hash(key)
           return hash_rec.offset_nk
         end
       when RI_MAGIC
@@ -368,7 +368,7 @@ module WindowsRegistry
       value_list = []
       res = []
       count.times do |i|
-        value_list << @hive_data[4096+offset+i*4, 4].unpack('<l').first
+        value_list << @hive_data[4096+offset+i*4, 4].unpack('l<').first
       end
       value_list.each do |value_offset|
         if value_offset > 0

--- a/lib/msf/util/windows_registry/security.rb
+++ b/lib/msf/util/windows_registry/security.rb
@@ -141,10 +141,10 @@ module WindowsRegistry
 
         if @lsa_vista_style
           decrypted = decrypt_lsa_data(encrypted_secret, lsa_key)
-          secret_size = decrypted[0, 4].unpack('<L').first
+          secret_size = decrypted[0, 4].unpack('L<').first
           secret = decrypted[16, secret_size]
         else
-          encrypted_secret_size = encrypted_secret[0, 4].unpack('<L').first
+          encrypted_secret_size = encrypted_secret[0, 4].unpack('L<').first
           secret = decrypt_secret_data(encrypted_secret[(encrypted_secret.size - encrypted_secret_size)..-1], lsa_key)
         end
         lsa_secrets[key] = secret
@@ -164,7 +164,7 @@ module WindowsRegistry
       if @lsa_vista_style
         nlkm_dec = decrypt_lsa_data(value_data, lsa_key)
       else
-        value_data_size = value_data[0, 4].unpack('<L').first
+        value_data_size = value_data[0, 4].unpack('L<').first
         nlkm_dec = decrypt_secret_data(value_data[(value_data.size - value_data_size)..-1], lsa_key)
       end
 

--- a/lib/rex/post/meterpreter/extensions/bofloader/bofloader.rb
+++ b/lib/rex/post/meterpreter/extensions/bofloader/bofloader.rb
@@ -45,18 +45,18 @@ module Rex
               binary = binary.bytes if binary.is_a? String
               b_length = binary.length
               binary = [b_length] + binary
-              buf = binary.pack("<Ic#{b_length}")
+              buf = binary.pack("I<c#{b_length}")
               @size += buf.length
               @buffer << buf
             end
 
             def add_int(dint)
-              @buffer << [dint.to_i].pack('<I')
+              @buffer << [dint.to_i].pack('I<')
               @size += 4
             end
 
             def add_short(short)
-              @buffer << [short.to_i].pack('<s')
+              @buffer << [short.to_i].pack('s<')
               @size += 2
             end
 
@@ -65,7 +65,7 @@ module Rex
               str << 0x00 # Null terminated strings...
               s_length = str.length
               str = [s_length] + str
-              buf = str.pack("<Ic#{s_length}")
+              buf = str.pack("I<c#{s_length}")
               @size += buf.length
               @buffer << buf
             end
@@ -75,13 +75,13 @@ module Rex
               wstr << 0x00 << 0x00 # Null terminated wide string
               s_length = wstr.length
               wstr = [s_length] + wstr
-              buf = wstr.pack("<Ic#{s_length}")
+              buf = wstr.pack("I<c#{s_length}")
               @size += buf.length
               @buffer << buf
             end
 
             def finalize_buffer
-              output = [@size].pack('<I') + @buffer
+              output = [@size].pack('I<') + @buffer
               reset
               output
             end

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -688,7 +688,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Decrypting hash for user: #{user_record.pmsg_out.msg_getchg.p_nc.string_name.to_ary[0..].join.encode('utf-8')}")
 
     entinf_struct = user_record.pmsg_out.msg_getchg.p_objects.entinf
-    rid = entinf_struct.p_name.sid[-4..].unpack('<L').first
+    rid = entinf_struct.p_name.sid[-4..].unpack('L<').first
     dn = user_record.pmsg_out.msg_getchg.p_nc.string_name.to_ary[0..].join.encode('utf-8')
 
     result = {

--- a/modules/exploits/windows/backupexec/ssl_uaf.rb
+++ b/modules/exploits/windows/backupexec/ssl_uaf.rb
@@ -931,9 +931,9 @@ class MetasploitModule < Msf::Exploit::Remote
           0x631017ff, # pop ebp; ret
           0x631213e6, # add esp, 0x20; ret
           0x63137a3c, # pushal; ret
-          'KERN'.unpack('<L')[0],
-          'EL32'.unpack('<L')[0],
-          '.dll'.unpack('<L')[0],
+          'KERN'.unpack('L<')[0],
+          'EL32'.unpack('L<')[0],
+          '.dll'.unpack('L<')[0],
           0,
           0x63117dfa, # pop edi; ret
           0x6311de4c, # pop edi; pop ebp; ret
@@ -943,10 +943,10 @@ class MetasploitModule < Msf::Exploit::Remote
           0x63116cc9, # pop esi; ret
           0x631213e6, # add esp, 0x20; ret
           0x63137a3c, # pushal; ret
-          'Virt'.unpack('<L')[0],
-          'ualP'.unpack('<L')[0],
-          'rote'.unpack('<L')[0],
-          "ct\0\0".unpack('<L')[0],
+          'Virt'.unpack('L<')[0],
+          'ualP'.unpack('L<')[0],
+          'rote'.unpack('L<')[0],
+          "ct\0\0".unpack('L<')[0],
           0x6314de45, # xchg eax, edi; ret
           0x6311db46, # push esp; pop esi; ret
           0x6311a398, # xchg eax, esi; ret
@@ -974,9 +974,9 @@ class MetasploitModule < Msf::Exploit::Remote
           0x6310184f, # pop ebp; ret
           0x6313937d, # add esp, 0x20; ret
           0x6311c618, # pushal; ret
-          'KERN'.unpack('<L')[0],
-          'EL32'.unpack('<L')[0],
-          '.dll'.unpack('<L')[0],
+          'KERN'.unpack('L<')[0],
+          'EL32'.unpack('L<')[0],
+          '.dll'.unpack('L<')[0],
           0,
           0x63198d07, # xchg eax, ebp; mov edi, 0xc483fff9; or al, 0x5e; ret
           0x6311e378, # pop edi; ret
@@ -984,10 +984,10 @@ class MetasploitModule < Msf::Exploit::Remote
           0x631289b9, # pop esi; ret
           0x6313937d, # add esp, 0x20; ret
           0x6311c618, # pushal; ret
-          'Virt'.unpack('<L')[0],
-          'ualP'.unpack('<L')[0],
-          'rote'.unpack('<L')[0],
-          "ct\0\0".unpack('<L')[0],
+          'Virt'.unpack('L<')[0],
+          'ualP'.unpack('L<')[0],
+          'rote'.unpack('L<')[0],
+          "ct\0\0".unpack('L<')[0],
           0x631289b9, # pop esi; ret
           0x631018aa, # pop eax; ret
           0x63198446, # mov edi, eax; call esi
@@ -1017,9 +1017,9 @@ class MetasploitModule < Msf::Exploit::Remote
           0x6310184f, # pop ebp; ret
           0x631394ad, # add esp, 0x20; ret
           0x6311c69c, # pushal; ret
-          'KERN'.unpack('<L')[0],
-          'EL32'.unpack('<L')[0],
-          '.dll'.unpack('<L')[0],
+          'KERN'.unpack('L<')[0],
+          'EL32'.unpack('L<')[0],
+          '.dll'.unpack('L<')[0],
           0,
           0x6311e3c0, # pop edi; ret
           0x631018aa, # pop eax; ret
@@ -1029,10 +1029,10 @@ class MetasploitModule < Msf::Exploit::Remote
           0x63128a39, # pop esi; ret
           0x631394ad, # add esp, 0x20; ret
           0x6311c69c, # pushal; ret
-          'Virt'.unpack('<L')[0],
-          'ualP'.unpack('<L')[0],
-          'rote'.unpack('<L')[0],
-          "ct\0\0".unpack('<L')[0],
+          'Virt'.unpack('L<')[0],
+          'ualP'.unpack('L<')[0],
+          'rote'.unpack('L<')[0],
+          "ct\0\0".unpack('L<')[0],
           0x63128a39, # pop esi; ret
           0x631018aa, # pop eax; ret
           0x631993e6, # mov edi, eax; call esi

--- a/modules/exploits/windows/fileformat/homm3_h3m.rb
+++ b/modules/exploits/windows/fileformat/homm3_h3m.rb
@@ -310,11 +310,11 @@ class MetasploitModule < Msf::Exploit::Remote
     bkd_crc = wanted_crc ^ 0xffffffff
 
     # deduce the 4 bytes we need to insert
-    [fwd_crc].pack('<L').each_byte.reverse_each do |c|
+    [fwd_crc].pack('L<').each_byte.reverse_each do |c|
       bkd_crc = ((bkd_crc << 8) & 0xffffffff) ^ crc32_reverse[bkd_crc >> 24] ^ c
     end
 
-    res = data + [bkd_crc].pack('<L')
+    res = data + [bkd_crc].pack('L<')
     res
   end
 end

--- a/modules/exploits/windows/fileformat/vlc_mkv.rb
+++ b/modules/exploits/windows/fileformat/vlc_mkv.rb
@@ -130,14 +130,14 @@ class MetasploitModule < Msf::Exploit
     block_size = 0x1000
 
     if target.arch.first == ARCH_X64
-      target_address_packed = [target.ret].pack("<Q")
-      rop_chain = target['RopChain'].map { |qword| [qword].pack("<Q") }.join
+      target_address_packed = [target.ret].pack("Q<")
+      rop_chain = target['RopChain'].map { |qword| [qword].pack("Q<") }.join
 
       if size == 0x180
         uaf_object = "\x41" * size
         uaf_object[0x30, 8] = target_address_packed
-        uaf_object[0x38, 8] = [target.ret + 0x10000].pack("<Q")
-        uaf_object[0x168, 8] = [target.ret + 0x3c0].pack("<Q")
+        uaf_object[0x38, 8] = [target.ret + 0x10000].pack("Q<")
+        uaf_object[0x168, 8] = [target.ret + 0x3c0].pack("Q<")
         uaf_object[0x170, 8] = target_address_packed
         return uaf_object
       else
@@ -146,46 +146,46 @@ class MetasploitModule < Msf::Exploit
         block[0x8, target_address_packed.length] = target_address_packed
         block[0x10, target_address_packed.length] = target_address_packed
 
-        block[0x40, 8] = [0x1].pack("<Q")
-        block[0x58, 8] = [target.ret + 0x3a8].pack("<Q")
-        block[0xE4, 8] = [0x1].pack("<Q")
+        block[0x40, 8] = [0x1].pack("Q<")
+        block[0x58, 8] = [target.ret + 0x3a8].pack("Q<")
+        block[0xE4, 8] = [0x1].pack("Q<")
 
-        block[0x1b8, 8] = [target.ret + 0x80].pack("<Q")
+        block[0x1b8, 8] = [target.ret + 0x80].pack("Q<")
         block[0x3b8, rop_chain.length] = rop_chain
 
-        block[0x6d8, 8] = [target.ret + 0x10].pack("<Q")
+        block[0x6d8, 8] = [target.ret + 0x10].pack("Q<")
         block[0x700, payload.encoded.length] = payload.encoded
 
         block *= size / block.length + 1
       end
       return block[0, size]
     elsif target.arch.first == ARCH_X86
-      target_address_packed = [target.ret].pack("<I")
-      rop_chain = target['RopChain'].map { |dword| [dword].pack("<I") }.join
+      target_address_packed = [target.ret].pack("I<")
+      rop_chain = target['RopChain'].map { |dword| [dword].pack("I<") }.join
 
       if size == 0x100
         uaf_object = "\x41" * size
         uaf_object[0x28, 4] = target_address_packed
-        uaf_object[0x2c, 4] = [target.ret + 0x10000].pack("<I")
-        uaf_object[0xf4, 4] = [target.ret + 0x2bc].pack("<I")
+        uaf_object[0x2c, 4] = [target.ret + 0x10000].pack("I<")
+        uaf_object[0xf4, 4] = [target.ret + 0x2bc].pack("I<")
         uaf_object[0xf8, 4] = target_address_packed
         return uaf_object
       else
         block = "\x00" * block_size
-        block[0x0, 4] = [0x22000040].pack("<I")
+        block[0x0, 4] = [0x22000040].pack("I<")
         block[0x4, target_address_packed.length] = target_address_packed
         block[0x8, target_address_packed.length] = target_address_packed
 
-        block[0x10, 4] = [0xc85].pack("<I")
-        block[0x30, 4] = [0x1].pack("<I")
-        block[0xc0, 4] = [0x1].pack("<I")
+        block[0x10, 4] = [0xc85].pack("I<")
+        block[0x30, 4] = [0x1].pack("I<")
+        block[0xc0, 4] = [0x1].pack("I<")
 
-        block[0x194, 4] = [0x2200031c].pack("<I")
-        block[0x2c0, 4] = [0x220002e4].pack("<I")
-        block[0x2f4, 4] = [0x22000310].pack("<I")
+        block[0x194, 4] = [0x2200031c].pack("I<")
+        block[0x2c0, 4] = [0x220002e4].pack("I<")
+        block[0x2f4, 4] = [0x22000310].pack("I<")
 
         block[0x2f8, rop_chain.length] = rop_chain
-        block[0x564, 4] = [0x22000588].pack("<I")
+        block[0x564, 4] = [0x22000588].pack("I<")
         block[0x5e0, payload.encoded.length] = payload.encoded
 
         block *= size / block.length + 1

--- a/modules/exploits/windows/misc/plugx.rb
+++ b/modules/exploits/windows/misc/plugx.rb
@@ -114,9 +114,9 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status(data.inspect)
       return false
     end
-    key = data[0..4].unpack('<I')[0]
+    key = data[0..4].unpack('I<')[0]
     hdr = xor_wrap(key, data[0..16])
-    _x, _flags, _cmd, comp_size, _uncomp_size, _xx = hdr.unpack('<ISSSSI')
+    _x, _flags, _cmd, comp_size, _uncomp_size, _xx = hdr.unpack('I<S<S<S<S<I<')
     if (comp_size + 16) == data.size
       raw = xor_wrap(key, data[16..-1])
       print_status(raw.inspect)
@@ -128,9 +128,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
     key = rand(0xFFFFFFFF)
-    hh = [key, 0, 0, 0, 0, 0].pack('<ISSSSI')
+    hh = [key, 0, 0, 0, 0, 0].pack('I<S<S<S<S<I<')
     hdr = xor_wrap(key, hh)
-    sock.put([key].pack('<I') + hdr[4..-1])
+    sock.put([key].pack('I<') + hdr[4..-1])
     if validate_response(sock.get_once || '')
       return Exploit::CheckCode::Appears
     end
@@ -138,8 +138,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def decode_packet(data)
-    key = data[0..4].unpack('<I')
-    _x, flags, _cmd, _comp_size, _uncomp_size, _xx = xorstream2(key, data[0..16]).unpack('<ISSSSI')
+    key = data[0..4].unpack('I<')
+    _x, flags, _cmd, _comp_size, _uncomp_size, _xx = xorstream2(key, data[0..16]).unpack('I<S<S<S<S<I<')
 
     buf = xor_stream(key, data[16..-1])
     buf = decompress(buf)
@@ -153,11 +153,11 @@ class MetasploitModule < Msf::Exploit::Remote
     pad = 0x18
     a = 0x004045c4
     pktlen = l + pad + 9
-    jmp = "\xe9" + [-pktlen].pack('<I')
+    jmp = "\xe9" + [-pktlen].pack('I<')
     key = rand(0xFFFFFFFF)
-    hh = [key, 0, 0, pktlen, pktlen, 0].pack('<ISSSSI')
+    hh = [key, 0, 0, pktlen, pktlen, 0].pack('I<S<S<S<S<I<')
     hdr = xor_wrap(key, hh)
-    pkt = [key].pack('<I') + hdr[4..-1] + payload.encoded + 'A' * (l - payload.encoded.size) + [a].pack('<I') + 'x' * pad + jmp
+    pkt = [key].pack('I<') + hdr[4..-1] + payload.encoded + 'A' * (l - payload.encoded.size) + [a].pack('I<') + 'x' * pad + jmp
 
     connect
     sock.put(pkt)

--- a/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
+++ b/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     offset = rand_text_alphanumeric(1000)
     offset += "\x0f" * 33
 
-    heap_flip = [target.ret].pack('<Q*')
+    heap_flip = [target.ret].pack('Q<*')
 
     alignment = rand_text_alphanumeric(7) # Adjustment for the initial chain
     rop_chain = generate_rsp_chain # Stage1: Stack alignment
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
       0x0000000140025dab
     ] # add esp, edi ; adc byte [rax], al ; add rsp, 0x0000000000000278 ; ret
 
-    return rop_gadgets.pack('<Q*')
+    return rop_gadgets.pack('Q<*')
   end
 
   # generate_rop_chain: This chain will craft function calls to GetModuleHandleA, GetProcAddressStub,
@@ -311,7 +311,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rop_gadgets += [0x00000001400a9747] # jmp rax
     rop_gadgets += [0x0000000140018c42] * 20 # ret (do not remove)
 
-    return rop_gadgets.pack('<Q*')
+    return rop_gadgets.pack('Q<*')
   end
 
   # parse_listing: once the directory_list probe is sent we're returned a directory listing

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -352,7 +352,7 @@ private
         [
           pool_address + HEADER_SIZE + 0x10, # indirect call gadget, over this pointer + egg
           p
-        ].pack('<Qa*').ljust(CHUNK_SIZE - HEADER_SIZE, "\x00")
+        ].pack('Q<a*').ljust(CHUNK_SIZE - HEADER_SIZE, "\x00")
       }
     rescue => ex
       print_error("#{ex.backtrace.join("\n")}: #{ex.message} (#{ex.class})")
@@ -425,7 +425,7 @@ _egg_loop:
       egg_loop,
       USERMODE_EGG,
       payload.raw
-    ].pack('<Qa*<Qa*')
+    ].pack('Q<a*Q<a*')
   end
 
   def kernel_mode_payload
@@ -982,7 +982,7 @@ userland_payload:
     [
       KERNELMODE_EGG,
       assemble_with_fixups(asm)
-    ].pack('<Qa*')
+    ].pack('Q<a*')
   end
 
   def create_free_trigger(chan_user_id, chan_id)
@@ -1021,7 +1021,7 @@ userland_payload:
         0x0, # Reserved2 (PVOID, 8 bytes) x64 only
         magic_value2, # Address (PVOID, 8 bytes)
         0x0, # SpinLock (UINT_PTR, 8 bytes)
-      ].pack('<Q<Q<Q<Q<L<L<L<L<Q<Q<Q'),
+      ].pack('Q<Q<Q<Q<L<L<L<L<Q<Q<Q<'),
       [
         magic_value2, # SystemResourceList (2 pointers, each 8 bytes)
         magic_value2, # --------------------
@@ -1040,7 +1040,7 @@ userland_payload:
         0x0, # Reserved2 (PVOID, 8 bytes) x64 only
         magic_value2, # Address (PVOID, 8 bytes)
         0x0, # SpinLock (UINT_PTR, 8 bytes)
-      ].pack('<Q<Q<Q<S<S<L<Q<Q<Q<Q<L<L<L<L<Q<Q<Q'),
+      ].pack('Q<Q<Q<S<S<L<Q<Q<Q<Q<L<L<L<L<Q<Q<Q<'),
       [
         0x1F, # ClassOffset (DWORD, 4 bytes)
         0x0, # bindStatus (DWORD, 4 bytes)
@@ -1061,7 +1061,7 @@ userland_payload:
         magic_value1, # connResrouce (QWORD, 8 bytes)
         0x65756c62, # lockCount158 (DWORD, 4 bytes)
         0x7065656b, # dword15C (DWORD, 4 bytes)
-      ].pack('<L<L<Q<Q<Q<La*<L<Q<Q<Q<Q<Q<Q<L<L<Q<L<L')
+      ].pack('L<L<Q<Q<Q<L<a*L<Q<Q<Q<Q<Q<Q<L<L<Q<L<L<')
     ].join('')
   end
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -705,7 +705,7 @@ module EternalBlueWin8
     fake_srv_net_buffer_x64 += [0, 0x82e8, 0].pack('QII<') # _, thisNonPagedPoolSize, _
     fake_srv_net_buffer_x64 += "\x00" * 16
     fake_srv_net_buffer_x64 += [0, total_recv_size].pack('QQ<') # offset 0x40
-    fake_srv_net_buffer_x64 += [TARGET_HAL_HEAP_ADDR, TARGET_HAL_HEAP_ADDR].pack('<QQ') # pmdl2, pointer to fake struct
+    fake_srv_net_buffer_x64 += [TARGET_HAL_HEAP_ADDR, TARGET_HAL_HEAP_ADDR].pack('Q<Q<') # pmdl2, pointer to fake struct
     fake_srv_net_buffer_x64 += [0, 0].pack('QQ<')
     fake_srv_net_buffer_x64 += "\x00" * 16
     fake_srv_net_buffer_x64 += "\x00" * 16


### PR DESCRIPTION
This PR aims to fix the following errors are now raised in ruby 3.3.0:

* Array#pack now raises ArgumentError for unknown directives
* String#unpack now raises ArgumentError for unknown directives
 
Context: https://bugs.ruby-lang.org/issues/19150

### invalid unpack example
Current behavior in Ruby 3.2:
 
```
2.7.2 :001 >  "a\x00\x00\x00".unpack("*V")
 => [97] 
 ```

Ruby 3.3 now raises an error:
 
```
3.3.0-preview1 :006 > "a\x00\x00\x00".unpack("*V")
<internal:pack>:20:in `unpack': unknown unpack directive '*' in '*V' (ArgumentError)
```

### invalid pack example
Ruby 3.2

```
3.0.5 :009 > [0x1].pack('<L')
 => "\x01\x00\x00\x00" 
```

Ruby 3.3

```
3.3.0-preview1 :003 > [0x1].pack('<L')
<internal:pack>:8:in `pack': unknown pack directive '<' in '<L' (ArgumentError)
```


## Verification

- [ ] **Verify** code changes look sane