### PR TITLE
Ldap login scanner module

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -192,6 +192,11 @@ module Metasploit::Framework
     #   @return [String]
     attr_accessor :userpass_file
 
+    # @!attribute anonymous_login
+    #   Whether to attempt an anonymous login (blank user/pass)
+    #   @return [Boolean]
+    attr_accessor :anonymous_login
+
     # @option opts [Boolean] :blank_passwords See {#blank_passwords}
     # @option opts [String] :pass_file See {#pass_file}
     # @option opts [String] :password See {#password}
@@ -225,6 +230,10 @@ module Metasploit::Framework
       end
 
       prepended_creds.each { |c| yield c }
+
+      if anonymous_login
+        yield Metasploit::Framework::Credential.new(public: '', private: '', realm: realm, private_type: :password)
+      end
 
       if username.present?
         if nil_passwords
@@ -325,7 +334,7 @@ module Metasploit::Framework
     #
     # @return [Boolean]
     def empty?
-      prepended_creds.empty? && !has_users? || (has_users? && !has_privates?)
+      prepended_creds.empty? && !has_users? && !anonymous_login || (has_users? && !has_privates?)
     end
 
     # Returns true when there are any user values set

--- a/lib/metasploit/framework/ldap/client.rb
+++ b/lib/metasploit/framework/ldap/client.rb
@@ -10,7 +10,8 @@ module Metasploit
           connect_opts = {
             host: rhost,
             port: rport,
-            connect_timeout: connect_timout
+            connect_timeout: connect_timout,
+            proxies: opts[:proxies]
           }
 
           if ssl

--- a/lib/metasploit/framework/ldap/client.rb
+++ b/lib/metasploit/framework/ldap/client.rb
@@ -25,17 +25,17 @@ module Metasploit
           case opts[:ldap_auth]
           when Msf::Exploit::Remote::AuthOption::SCHANNEL
             pfx_path = opts[:ldap_cert_file]
-            raise ValidationError, 'The LDAP::CertFile option is required when using SCHANNEL authentication.' if pfx_path.blank?
-            raise ValidationError, 'The SSL option must be enabled when using SCHANNEL authentication.' if ssl != true
+            raise Msf::ValidationError, 'The LDAP::CertFile option is required when using SCHANNEL authentication.' if pfx_path.blank?
+            raise Msf::ValidationError, 'The SSL option must be enabled when using SCHANNEL authentication.' if ssl != true
 
             unless ::File.file?(pfx_path) && ::File.readable?(pfx_path)
-              raise ValidationError, 'Failed to load the PFX certificate file. The path was not a readable file.'
+              raise Msf::ValidationError, 'Failed to load the PFX certificate file. The path was not a readable file.'
             end
 
             begin
               pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
             rescue StandardError => e
-              raise ValidationError, "Failed to load the PFX file (#{e})"
+              raise Msf::ValidationError, "Failed to load the PFX file (#{e})"
             end
 
             connect_opts[:auth] = {
@@ -53,12 +53,12 @@ module Metasploit
               }
             }
           when Msf::Exploit::Remote::AuthOption::KERBEROS
-            raise ValidationError, 'The Ldap::Rhostname option is required when using Kerberos authentication.' if opts[:ldap_rhostname].blank?
-            raise ValidationError, 'The DOMAIN option is required when using Kerberos authentication.' if opts[:domain].blank?
-            raise ValidationError, 'The DomainControllerRhost is required when using Kerberos authentication.' if opts[:domain_controller_rhost].blank?
+            raise Msf::ValidationError, 'The Ldap::Rhostname option is required when using Kerberos authentication.' if opts[:ldap_rhostname].blank?
+            raise Msf::ValidationError, 'The DOMAIN option is required when using Kerberos authentication.' if opts[:domain].blank?
+            raise Msf::ValidationError, 'The DomainControllerRhost is required when using Kerberos authentication.' if opts[:domain_controller_rhost].blank?
 
             offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(opts[:ldap_krb_offered_enc_types])
-            raise ValidationError, 'At least one encryption type is required when using Kerberos authentication.' if offered_etypes.empty?
+            raise Msf::ValidationError, 'At least one encryption type is required when using Kerberos authentication.' if offered_etypes.empty?
 
             kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
               host: opts[:domain_controller_rhost],

--- a/lib/metasploit/framework/ldap/client.rb
+++ b/lib/metasploit/framework/ldap/client.rb
@@ -57,6 +57,7 @@ module Metasploit
             raise ValidationError, 'The Ldap::Rhostname option is required when using Kerberos authentication.' if opts[:ldap_rhostname].blank?
             raise ValidationError, 'The DOMAIN option is required when using Kerberos authentication.' if opts[:domain].blank?
             raise ValidationError, 'The DomainControllerRhost is required when using Kerberos authentication.' if opts[:domain_controller_rhost].blank?
+
             offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(opts[:ldap_krb_offered_enc_types])
             raise ValidationError, 'At least one encryption type is required when using Kerberos authentication.' if offered_etypes.empty?
 

--- a/lib/metasploit/framework/ldap/client.rb
+++ b/lib/metasploit/framework/ldap/client.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Metasploit
+  module Framework
+    module LDAP
+      module Client
+        def ldap_connect_opts(rhost, rport, connect_timout, ssl: true, opts: {})
+          connect_opts = {
+            host: rhost,
+            port: rport,
+            connect_timeout: connect_timout
+          }
+
+          if ssl
+            connect_opts[:encryption] = {
+              method: :simple_tls,
+              tls_options: {
+                verify_mode: OpenSSL::SSL::VERIFY_NONE
+              }
+            }
+          end
+
+          case opts[:ldap_auth]
+          when Msf::Exploit::Remote::AuthOption::SCHANNEL
+            pfx_path = opts[:ldap_cert_file]
+            fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The LDAP::CertFile option is required when using SCHANNEL authentication.') if pfx_path.blank?
+            fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The SSL option must be enabled when using SCHANNEL authentication.') if ssl != true
+
+            unless ::File.file?(pfx_path) && ::File.readable?(pfx_path)
+              fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'Failed to load the PFX certificate file. The path was not a readable file.')
+            end
+
+            begin
+              pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
+            rescue StandardError => e
+              fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Failed to load the PFX file (#{e})")
+            end
+
+            connect_opts[:auth] = {
+              method: :sasl,
+              mechanism: 'EXTERNAL',
+              initial_credential: '',
+              challenge_response: true
+            }
+            connect_opts[:encryption] = {
+              method: :start_tls,
+              tls_options: {
+                verify_mode: OpenSSL::SSL::VERIFY_NONE,
+                cert: pkcs.certificate,
+                key: pkcs.key
+              }
+            }
+          when Msf::Exploit::Remote::AuthOption::KERBEROS
+            fail_with(Msf::Exploit::Failure::BadConfig, 'The Ldap::Rhostname option is required when using Kerberos authentication.') if opts[:ldap_rhostname].blank?
+            fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if opts[:domain].blank?
+            fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if opts[:domain_controller_rhost].blank?
+            offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(opts[:ldap_krb_offered_enc_types])
+            fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
+
+            kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
+              host: opts[:domain_controller_rhost],
+              hostname: opts[:ldap_rhostname],
+              realm: opts[:domain],
+              username: opts[:username],
+              password: opts[:password],
+              framework: opts[:framework],
+              framework_module: self,
+              cache_file: opts[:ldap_krb5_cname].blank? ? nil : opts[:ldap_krb5_cname],
+              ticket_storage: opts[:kerberos_ticket_storage],
+              offered_etypes: offered_etypes
+            )
+
+            kerberos_result = kerberos_authenticator.authenticate
+
+            connect_opts[:auth] = {
+              method: :sasl,
+              mechanism: 'GSS-SPNEGO',
+              initial_credential: kerberos_result[:security_blob],
+              challenge_response: true
+            }
+          when Msf::Exploit::Remote::AuthOption::NTLM
+            ntlm_client = RubySMB::NTLM::Client.new(
+              opts[:username],
+              opts[:password],
+              workstation: 'WORKSTATION',
+              domain: opts[:domain].blank? ? '.' : opts[:domain],
+              flags:
+                RubySMB::NTLM::NEGOTIATE_FLAGS[:UNICODE] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:REQUEST_TARGET] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:NTLM] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:ALWAYS_SIGN] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:KEY_EXCHANGE] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:TARGET_INFO] |
+                  RubySMB::NTLM::NEGOTIATE_FLAGS[:VERSION_INFO]
+            )
+
+            negotiate = proc do |challenge|
+              ntlmssp_offset = challenge.index('NTLMSSP')
+              type2_blob = challenge.slice(ntlmssp_offset..-1)
+              challenge = [type2_blob].pack('m')
+              type3_message = ntlm_client.init_context(challenge)
+              type3_message.serialize
+            end
+
+            connect_opts[:auth] = {
+              method: :sasl,
+              mechanism: 'GSS-SPNEGO',
+              initial_credential: ntlm_client.init_context.serialize,
+              challenge_response: negotiate
+            }
+          when Msf::Exploit::Remote::AuthOption::PLAINTEXT
+            username = opts[:username].dup
+            username << "@#{domain}" unless domain.blank?
+            connect_opts[:auth] = {
+              method: :simple,
+              username: username,
+              password: opts[:password]
+            }
+          when Msf::Exploit::Remote::AuthOption::AUTO
+            unless opts[:username].blank? # plaintext if specified
+              username = opts[:username].dup
+              username << "@#{domain}" unless domain.blank?
+              connect_opts[:auth] = {
+                method: :simple,
+                username: username,
+                password: opts[:password]
+              }
+            end
+          end
+
+          connect_opts
+        end
+
+        def ldap_open(connect_opts, &block)
+          Net::LDAP.open(connect_opts, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/ldap/client.rb
+++ b/lib/metasploit/framework/ldap/client.rb
@@ -4,13 +4,12 @@ module Metasploit
   module Framework
     module LDAP
 
-      class ValidationError < RuntimeError; end
       module Client
-        def ldap_connect_opts(rhost, rport, connect_timout, ssl: true, opts: {})
+        def ldap_connect_opts(rhost, rport, connect_timeout, ssl: true, opts: {})
           connect_opts = {
             host: rhost,
             port: rport,
-            connect_timeout: connect_timout,
+            connect_timeout: connect_timeout,
             proxies: opts[:proxies]
           }
 
@@ -115,20 +114,16 @@ module Metasploit
               challenge_response: negotiate
             }
           when Msf::Exploit::Remote::AuthOption::PLAINTEXT
-            username = opts[:username].dup
-            username << "@#{opts[:domain]}" unless opts[:domain].blank?
             connect_opts[:auth] = {
               method: :simple,
-              username: username,
+              username: opts[:username],
               password: opts[:password]
             }
           when Msf::Exploit::Remote::AuthOption::AUTO
             unless opts[:username].blank? # plaintext if specified
-              username = opts[:username].dup
-              username << "@#{opts[:domain]}" unless opts[:domain].blank?
               connect_opts[:auth] = {
                 method: :simple,
-                username: username,
+                username: opts[:username],
                 password: opts[:password]
               }
             end

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -58,10 +58,14 @@ module Metasploit
             # so make sure that whatever it is, we end up with a Credential.
             credential = raw_cred.to_credential
 
-            if (opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::KERBEROS && opts[:ldap_krb5_cname]) ||
-               opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::SCHANNEL
-              # If we're using kerberos auth with a ccache or doing schannel auth then the password is irrelevant
+            if opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::KERBEROS && opts[:ldap_krb5_cname]
+              # If we're using kerberos auth with a ccache then the password is irrelevant
               # Remove it from the credential so we don't store it
+              credential.private = nil
+            elsif opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::SCHANNEL
+              # If we're using kerberos auth with schannel then the user/password is irrelevant
+              # Remove it from the credential so we don't store it
+              credential.public = nil
               credential.private = nil
             end
 

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -58,6 +58,13 @@ module Metasploit
             # so make sure that whatever it is, we end up with a Credential.
             credential = raw_cred.to_credential
 
+            if (opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::KERBEROS && opts[:ldap_krb5_cname]) ||
+               opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::SCHANNEL
+              # If we're using kerberos auth with a ccache or doing schannel auth then the password is irrelevant
+              # Remove it from the credential so we don't store it
+              credential.private = nil
+            end
+
             if credential.realm.present? && realm_key.present?
               credential.realm_key = realm_key
             elsif credential.realm.present? && realm_key.blank?

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/ldap/client'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      class LDAP
+        include Metasploit::Framework::LoginScanner::Base
+        include Metasploit::Framework::LDAP::Client
+
+        REALM_KEY = nil
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'ldap'
+          }
+
+          result_opts.merge!(do_login(credential))
+          Result.new(result_opts)
+        end
+
+        def do_login(credential)
+          opts = {
+            username: credential.public,
+            password: credential.private
+          }
+          connect_opts = ldap_connect_opts(host, port, connection_timeout, ssl: false, opts: opts)
+          ldap_open(connect_opts) do |ldap|
+            return status_code(ldap.get_operation_result.table)
+          rescue StandardError => e
+            vprint_status("Failed to connect: #{e}")
+            { status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e }
+          end
+        end
+
+        def status_code(bind_result)
+          case bind_result[:code]
+          when 0
+            { status: Metasploit::Model::Login::Status::SUCCESSFUL }
+          else
+            { status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: "Bind Result: #{bind_result}" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -48,7 +48,7 @@ module Metasploit
           when 0
             { status: Metasploit::Model::Login::Status::SUCCESSFUL }
           else
-            { status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: "Bind Result: #{operation_result}" }
+            { status: Metasploit::Model::Login::Status::INCORRECT, proof: "Bind Result: #{operation_result}" }
           end
         end
 

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -27,6 +27,7 @@ module Auxiliary::AuthBrute
       OptBool.new('DB_ALL_PASS', [false,"Add all passwords in the current database to the list",false]),
       OptEnum.new('DB_SKIP_EXISTING', [false,"Skip existing credentials stored in the current database", 'none', %w[ none user user&realm ]]),
       OptBool.new('STOP_ON_SUCCESS', [ true, "Stop guessing when a credential works for a host", false]),
+      OptBool.new('ANONYMOUS_LOGIN', [ true, "Attempt to login with a blank username and password", false])
     ], Auxiliary::AuthBrute)
 
     register_advanced_options([

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -5,7 +5,6 @@
 #
 
 require 'rex/proto/ldap'
-require 'metasploit/framework/ldap/client'
 
 module Msf
   module Exploit::Remote::LDAP
@@ -84,137 +83,20 @@ module Msf
         ldap_rhostname: datastore['Ldap::Rhostname'],
         ldap_krb_offered_enc_types: datastore['Ldap::KrbOfferedEncryptionTypes'],
         ldap_krb5_cname: datastore['Ldap::Krb5Ccname'],
-        proxies: datastore['Proxies']
+        proxies: datastore['Proxies'],
+        framework_module: self
       }
 
       ldap_connect_opts(rhost, rport, datastore['LDAP::ConnectTimeout'], ssl: datastore['SSL'], opts: opts)
-
-      # connect_opts = {
-      #   host: rhost, # TODO
-      #   port: rport, # TODO
-      #   connect_timeout: ldap_connect_timeout
-      # }
-      #
-      # if ssl
-      #   connect_opts[:encryption] = {
-      #     method: :simple_tls,
-      #     tls_options: {
-      #       verify_mode: OpenSSL::SSL::VERIFY_NONE
-      #     }
-      #   }
-      # end
-      #
-      # case ldap_auth
-      # when Msf::Exploit::Remote::AuthOption::SCHANNEL
-      #   pfx_path = ldap_cert_file
-      #   fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The LDAP::CertFile option is required when using SCHANNEL authentication.') if pfx_path.blank?
-      #   fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The SSL option must be enabled when using SCHANNEL authentication.') if ssl != true
-      #
-      #   unless ::File.file?(pfx_path) and ::File.readable?(pfx_path)
-      #     fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'Failed to load the PFX certificate file. The path was not a readable file.')
-      #   end
-      #
-      #   begin
-      #     pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
-      #   rescue => e
-      #     fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Failed to load the PFX file (#{e})")
-      #   end
-      #
-      #   connect_opts[:auth] = {
-      #     method: :sasl,
-      #     mechanism: 'EXTERNAL',
-      #     initial_credential: '',
-      #     challenge_response: true
-      #   }
-      #   connect_opts[:encryption] = {
-      #     method: :start_tls,
-      #     tls_options: {
-      #       verify_mode: OpenSSL::SSL::VERIFY_NONE,
-      #       cert: pkcs.certificate,
-      #       key: pkcs.key
-      #     }
-      #   }
-      # when Msf::Exploit::Remote::AuthOption::KERBEROS
-      #   fail_with(Msf::Exploit::Failure::BadConfig, 'The Ldap::Rhostname option is required when using Kerberos authentication.') if ldap_rhostname.blank?
-      #   fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if domain.blank?
-      #   fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if domain_controller_rhost.blank?
-      #   offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(ldap_krb_offered_enc_types)
-      #   fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
-      #
-      #   kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
-      #     host: domain_controller_rhost,
-      #     hostname: ldap_rhostname,
-      #     realm: domain,
-      #     username: username,
-      #     password: password,
-      #     framework: framework,
-      #     framework_module: self,
-      #     cache_file: ldap_krb5_cname.blank? ? nil : ldap_krb5_cname,
-      #     ticket_storage: kerberos_ticket_storage,
-      #     offered_etypes: offered_etypes
-      #   )
-      #
-      #   kerberos_result = kerberos_authenticator.authenticate
-      #
-      #   connect_opts[:auth] = {
-      #     method: :sasl,
-      #     mechanism: 'GSS-SPNEGO',
-      #     initial_credential: kerberos_result[:security_blob],
-      #     challenge_response: true
-      #   }
-      # when Msf::Exploit::Remote::AuthOption::NTLM
-      #   ntlm_client = RubySMB::NTLM::Client.new(
-      #     username,
-      #     password,
-      #     workstation: 'WORKSTATION',
-      #     domain: domain.blank? ? '.' : domain,
-      #     flags:
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:UNICODE] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:REQUEST_TARGET] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:NTLM] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:ALWAYS_SIGN] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:KEY_EXCHANGE] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:TARGET_INFO] |
-      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:VERSION_INFO]
-      #   )
-      #
-      #   negotiate = proc do |challenge|
-      #     ntlmssp_offset = challenge.index('NTLMSSP')
-      #     type2_blob = challenge.slice(ntlmssp_offset..-1)
-      #     challenge = [type2_blob].pack('m')
-      #     type3_message = ntlm_client.init_context(challenge)
-      #     type3_message.serialize
-      #   end
-      #
-      #   connect_opts[:auth] = {
-      #     method: :sasl,
-      #     mechanism: 'GSS-SPNEGO',
-      #     initial_credential: ntlm_client.init_context.serialize,
-      #     challenge_response: negotiate
-      #   }
-      # when Msf::Exploit::Remote::AuthOption::PLAINTEXT
-      #   username = username.dup
-      #   username << "@#{domain}" unless domain.blank?
-      #   connect_opts[:auth] = {
-      #     method: :simple,
-      #     username: username,
-      #     password: password
-      #   }
-      # when Msf::Exploit::Remote::AuthOption::AUTO
-      #   unless username.blank? # plaintext if specified
-      #     username = username.dup
-      #     username << "@#{domain}" unless domain.blank?
-      #     connect_opts[:auth] = {
-      #       method: :simple,
-      #       username: username,
-      #       password: password
-      #     }
-      #   end
-      # end
-      #
-      # connect_opts.merge(opts)
     end
+
+    # @see #ldap_open
+    # @return [Object] The result of whatever the block that was
+    #   passed in via the "block" parameter yielded.
+    def ldap_connect(opts = {}, &block)
+      ldap_open(get_connect_opts.merge(opts), &block)
+    end
+
 
     # Connect to the target LDAP server using the options provided,
     # and pass the resulting connection object to the proc provided.
@@ -227,8 +109,21 @@ module Msf
     # @see Net::LDAP.open
     # @return [Object] The result of whatever the block that was
     #   passed in via the "block" parameter yielded.
-    def ldap_connect(opts = {}, &block)
-      Net::LDAP.open(get_connect_opts.merge(opts), &block)
+    def ldap_open(connect_opts, &block)
+      opts = resolve_connect_opts(connect_opts)
+      Net::LDAP.open(opts, &block)
+    end
+
+
+    def resolve_connect_opts(connect_opts)
+      return connect_opts unless connect_opts[:auth][:initial_credential].is_a?(Proc)
+
+      opts = connect_opts.dup
+      # For scenarios such as Kerberos, we might need to make additional calls out to a separate services to acquire an initial credential
+      opts[:auth].merge!(
+        initial_credential: opts[:auth][:initial_credential].call
+      )
+      opts
     end
 
     # Create a new LDAP connection using Net::LDAP.new and yield the
@@ -239,7 +134,8 @@ module Msf
     # @yieldparam ldap [Net::LDAP] The LDAP connection handle to use for connecting to
     #   the target LDAP server.
     def ldap_new(opts = {})
-      ldap = Net::LDAP.new(get_connect_opts.merge(opts))
+
+      ldap = Net::LDAP.new(resolve_connect_opts(get_connect_opts.merge(opts)))
 
       # NASTY, but required
       # monkey patch ldap object in order to ignore bind errors
@@ -312,7 +208,7 @@ module Msf
       end
 
       # NOTE: Find the first entry that starts with `DC=` as this will likely be the base DN.
-      naming_contexts.select! { |context| context =~ /^(DC=[A-Za-z0-9-]+,?)+$/ }
+      naming_contexts.select! { |context| context =~ /^([Dd][Cc]=[A-Za-z0-9-]+,?)+$/ }
       naming_contexts.reject! { |context| context =~ /(Configuration)|(Schema)|(ForestDnsZones)/ }
       if naming_contexts.blank?
         print_error("#{peer} A base DN matching the expected format could not be found!")

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -5,6 +5,7 @@
 #
 
 require 'rex/proto/ldap'
+require 'metasploit/framework/ldap/client'
 
 module Msf
   module Exploit::Remote::LDAP

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -98,12 +98,11 @@ module Msf
       ldap_open(get_connect_opts.merge(opts), &block)
     end
 
-
     # Connect to the target LDAP server using the options provided,
     # and pass the resulting connection object to the proc provided.
     # Terminate the connection once the proc finishes executing.
     #
-    # @param opts [Hash] Options for the LDAP connection.
+    # @param connect_opts [Hash] Options for the LDAP connection.
     # @param block [Proc] A proc containing the functionality to execute
     #   after the LDAP connection has succeeded. The connection is closed
     #   once this proc finishes executing.
@@ -117,7 +116,7 @@ module Msf
 
 
     def resolve_connect_opts(connect_opts)
-      return connect_opts unless connect_opts[:auth][:initial_credential].is_a?(Proc)
+      return connect_opts unless connect_opts.dig(:auth, :initial_credential).is_a?(Proc)
 
       opts = connect_opts.dup
       # For scenarios such as Kerberos, we might need to make additional calls out to a separate services to acquire an initial credential

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -5,11 +5,13 @@
 #
 
 require 'rex/proto/ldap'
+require 'metasploit/framework/ldap/client'
 
 module Msf
   module Exploit::Remote::LDAP
     include Msf::Exploit::Remote::Kerberos::Ticket::Storage
     include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
+    include Metasploit::Framework::LDAP::Client
 
     # Initialize the LDAP client and set up the LDAP specific datastore
     # options to allow the client to perform authentication and timeout
@@ -72,133 +74,146 @@ module Msf
     # @return [Hash] The options to use when connecting to the target
     #    LDAP server.
     def get_connect_opts
-      connect_opts = {
-        host: rhost,
-        port: rport,
-        proxies: datastore['Proxies'],
-        connect_timeout: datastore['LDAP::ConnectTimeout']
+      opts = {
+        username: datastore['USERNAME'],
+        password: datastore['PASSWORD'],
+        domain: datastore['DOMAIN'],
+        domain_controller_rhost: datastore['DomainControllerRhost'],
+        ldap_auth: datastore['LDAP::Auth'],
+        ldap_cert_file: datastore['LDAP::CertFile'],
+        ldap_rhostname: datastore['Ldap::Rhostname'],
+        ldap_krb_offered_enc_types: datastore['Ldap::KrbOfferedEncryptionTypes'],
+        ldap_krb5_cname: datastore['Ldap::Krb5Ccname'],
+        proxies: datastore['Proxies']
       }
 
-      if datastore['SSL']
-        connect_opts[:encryption] = {
-          method: :simple_tls,
-          tls_options: {
-            verify_mode: OpenSSL::SSL::VERIFY_NONE
-          }
-        }
-      end
+      ldap_connect_opts(rhost, rport, datastore['LDAP::ConnectTimeout'], ssl: datastore['SSL'], opts: opts)
 
-      case datastore['LDAP::Auth']
-      when Msf::Exploit::Remote::AuthOption::SCHANNEL
-        pfx_path = datastore['LDAP::CertFile']
-        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The LDAP::CertFile option is required when using SCHANNEL authentication.') if pfx_path.blank?
-        fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The SSL option must be enabled when using SCHANNEL authentication.') if datastore['SSL'] != true
-
-        unless ::File.file?(pfx_path) and ::File.readable?(pfx_path)
-          fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'Failed to load the PFX certificate file. The path was not a readable file.')
-        end
-
-        begin
-          pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
-        rescue => e
-          fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Failed to load the PFX file (#{e})")
-        end
-
-        connect_opts[:auth] = {
-          method: :sasl,
-          mechanism: 'EXTERNAL',
-          initial_credential: '',
-          challenge_response: true
-        }
-        connect_opts[:encryption] = {
-          method: :start_tls,
-          tls_options: {
-            verify_mode: OpenSSL::SSL::VERIFY_NONE,
-            cert: pkcs.certificate,
-            key: pkcs.key
-          }
-        }
-      when Msf::Exploit::Remote::AuthOption::KERBEROS
-        fail_with(Msf::Exploit::Failure::BadConfig, 'The Ldap::Rhostname option is required when using Kerberos authentication.') if datastore['Ldap::Rhostname'].blank?
-        fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
-        fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
-        offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['Ldap::KrbOfferedEncryptionTypes'])
-        fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
-
-        kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
-          host: datastore['DomainControllerRhost'],
-          hostname: datastore['Ldap::Rhostname'],
-          proxies: datastore['Proxies'],
-          realm: datastore['DOMAIN'],
-          username: datastore['USERNAME'],
-          password: datastore['PASSWORD'],
-          framework: framework,
-          framework_module: self,
-          cache_file: datastore['Ldap::Krb5Ccname'].blank? ? nil : datastore['Ldap::Krb5Ccname'],
-          ticket_storage: kerberos_ticket_storage,
-          offered_etypes: offered_etypes
-        )
-
-        kerberos_result = kerberos_authenticator.authenticate
-
-        connect_opts[:auth] = {
-          method: :sasl,
-          mechanism: 'GSS-SPNEGO',
-          initial_credential: kerberos_result[:security_blob],
-          challenge_response: true
-        }
-      when Msf::Exploit::Remote::AuthOption::NTLM
-        ntlm_client = RubySMB::NTLM::Client.new(
-          datastore['USERNAME'],
-          datastore['PASSWORD'],
-          workstation: 'WORKSTATION',
-          domain: datastore['DOMAIN'].blank? ? '.' : datastore['DOMAIN'],
-          flags:
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:UNICODE] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:REQUEST_TARGET] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:NTLM] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:ALWAYS_SIGN] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:KEY_EXCHANGE] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:TARGET_INFO] |
-            RubySMB::NTLM::NEGOTIATE_FLAGS[:VERSION_INFO]
-        )
-
-        negotiate = proc do |challenge|
-          ntlmssp_offset = challenge.index('NTLMSSP')
-          type2_blob = challenge.slice(ntlmssp_offset..-1)
-          challenge = [type2_blob].pack('m')
-          type3_message = ntlm_client.init_context(challenge)
-          type3_message.serialize
-        end
-
-        connect_opts[:auth] = {
-          method: :sasl,
-          mechanism: 'GSS-SPNEGO',
-          initial_credential: ntlm_client.init_context.serialize,
-          challenge_response: negotiate
-        }
-      when Msf::Exploit::Remote::AuthOption::PLAINTEXT
-        username = datastore['USERNAME'].dup
-        username << "@#{datastore['DOMAIN']}" unless datastore['DOMAIN'].blank?
-        connect_opts[:auth] = {
-          method: :simple,
-          username: username,
-          password: datastore['PASSWORD']
-        }
-      when Msf::Exploit::Remote::AuthOption::AUTO
-        unless datastore['USERNAME'].blank? # plaintext if specified
-          username = datastore['USERNAME'].dup
-          username << "@#{datastore['DOMAIN']}" unless datastore['DOMAIN'].blank?
-          connect_opts[:auth] = {
-            method: :simple,
-            username: username,
-            password: datastore['PASSWORD']
-          }
-        end
-      end
-
-      connect_opts
+      # connect_opts = {
+      #   host: rhost, # TODO
+      #   port: rport, # TODO
+      #   connect_timeout: ldap_connect_timeout
+      # }
+      #
+      # if ssl
+      #   connect_opts[:encryption] = {
+      #     method: :simple_tls,
+      #     tls_options: {
+      #       verify_mode: OpenSSL::SSL::VERIFY_NONE
+      #     }
+      #   }
+      # end
+      #
+      # case ldap_auth
+      # when Msf::Exploit::Remote::AuthOption::SCHANNEL
+      #   pfx_path = ldap_cert_file
+      #   fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The LDAP::CertFile option is required when using SCHANNEL authentication.') if pfx_path.blank?
+      #   fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'The SSL option must be enabled when using SCHANNEL authentication.') if ssl != true
+      #
+      #   unless ::File.file?(pfx_path) and ::File.readable?(pfx_path)
+      #     fail_with(Msf::Exploit::Remote::Failure::BadConfig, 'Failed to load the PFX certificate file. The path was not a readable file.')
+      #   end
+      #
+      #   begin
+      #     pkcs = OpenSSL::PKCS12.new(File.binread(pfx_path), '')
+      #   rescue => e
+      #     fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Failed to load the PFX file (#{e})")
+      #   end
+      #
+      #   connect_opts[:auth] = {
+      #     method: :sasl,
+      #     mechanism: 'EXTERNAL',
+      #     initial_credential: '',
+      #     challenge_response: true
+      #   }
+      #   connect_opts[:encryption] = {
+      #     method: :start_tls,
+      #     tls_options: {
+      #       verify_mode: OpenSSL::SSL::VERIFY_NONE,
+      #       cert: pkcs.certificate,
+      #       key: pkcs.key
+      #     }
+      #   }
+      # when Msf::Exploit::Remote::AuthOption::KERBEROS
+      #   fail_with(Msf::Exploit::Failure::BadConfig, 'The Ldap::Rhostname option is required when using Kerberos authentication.') if ldap_rhostname.blank?
+      #   fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if domain.blank?
+      #   fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if domain_controller_rhost.blank?
+      #   offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(ldap_krb_offered_enc_types)
+      #   fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
+      #
+      #   kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
+      #     host: domain_controller_rhost,
+      #     hostname: ldap_rhostname,
+      #     realm: domain,
+      #     username: username,
+      #     password: password,
+      #     framework: framework,
+      #     framework_module: self,
+      #     cache_file: ldap_krb5_cname.blank? ? nil : ldap_krb5_cname,
+      #     ticket_storage: kerberos_ticket_storage,
+      #     offered_etypes: offered_etypes
+      #   )
+      #
+      #   kerberos_result = kerberos_authenticator.authenticate
+      #
+      #   connect_opts[:auth] = {
+      #     method: :sasl,
+      #     mechanism: 'GSS-SPNEGO',
+      #     initial_credential: kerberos_result[:security_blob],
+      #     challenge_response: true
+      #   }
+      # when Msf::Exploit::Remote::AuthOption::NTLM
+      #   ntlm_client = RubySMB::NTLM::Client.new(
+      #     username,
+      #     password,
+      #     workstation: 'WORKSTATION',
+      #     domain: domain.blank? ? '.' : domain,
+      #     flags:
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:UNICODE] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:REQUEST_TARGET] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:NTLM] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:ALWAYS_SIGN] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:KEY_EXCHANGE] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:TARGET_INFO] |
+      #       RubySMB::NTLM::NEGOTIATE_FLAGS[:VERSION_INFO]
+      #   )
+      #
+      #   negotiate = proc do |challenge|
+      #     ntlmssp_offset = challenge.index('NTLMSSP')
+      #     type2_blob = challenge.slice(ntlmssp_offset..-1)
+      #     challenge = [type2_blob].pack('m')
+      #     type3_message = ntlm_client.init_context(challenge)
+      #     type3_message.serialize
+      #   end
+      #
+      #   connect_opts[:auth] = {
+      #     method: :sasl,
+      #     mechanism: 'GSS-SPNEGO',
+      #     initial_credential: ntlm_client.init_context.serialize,
+      #     challenge_response: negotiate
+      #   }
+      # when Msf::Exploit::Remote::AuthOption::PLAINTEXT
+      #   username = username.dup
+      #   username << "@#{domain}" unless domain.blank?
+      #   connect_opts[:auth] = {
+      #     method: :simple,
+      #     username: username,
+      #     password: password
+      #   }
+      # when Msf::Exploit::Remote::AuthOption::AUTO
+      #   unless username.blank? # plaintext if specified
+      #     username = username.dup
+      #     username << "@#{domain}" unless domain.blank?
+      #     connect_opts[:auth] = {
+      #       method: :simple,
+      #       username: username,
+      #       password: password
+      #     }
+      #   end
+      # end
+      #
+      # connect_opts.merge(opts)
     end
 
     # Connect to the target LDAP server using the options provided,

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -103,9 +103,13 @@ class MetasploitModule < Msf::Auxiliary
         protocol: 'tcp'
       )
       if result.success?
-        create_credential_and_login(credential_data)
-
-        print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}'"
+        if opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::SCHANNEL
+          # Schannel auth has no meaningful credential information to store in the DB
+          print_brute level: :good, ip: ip, msg: "Success: 'Cert File #{opts[:ldap_cert_file]}'"
+        else
+          create_credential_and_login(credential_data)
+          print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}'"
+        end
       else
         invalidate_login(credential_data)
         vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptBool.new(
           'APPEND_DOMAIN', [true, 'Appends `@<DOMAIN> to the username for authentication`', false],
-          conditions: ['LDAP::Auth', 'in', %w[AUTO PLAINTEXT]]
+          conditions: ['LDAP::Auth', 'in', [Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::PLAINTEXT]]
         )
       ]
     )

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
   def validate_connect_options!
     # Verify we can create arbitrary connect opts, this won't make a connection out to the real host - but will verify the values are valid
     get_connect_opts
-  rescue ValidationError => e
+  rescue Msf::ValidationError => e
     fail_with(Msf::Exploit::Remote::Failure::BadConfig, "Invalid datastore options for chosen auth type: #{e.message}")
   end
 

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
       username: datastore['USERNAME'],
       password: datastore['PASSWORD'],
       realm: datastore['DOMAIN'],
-      anonymous_login: false,
+      anonymous_login: datastore['ANONYMOUS_LOGIN'],
       blank_passwords: false
     )
 
@@ -71,7 +71,9 @@ class MetasploitModule < Msf::Auxiliary
       ldap_cert_file: datastore['LDAP::CertFile'],
       ldap_rhostname: datastore['Ldap::Rhostname'],
       ldap_krb_offered_enc_types: datastore['Ldap::KrbOfferedEncryptionTypes'],
-      ldap_krb5_cname: datastore['Ldap::Krb5Ccname']
+      ldap_krb5_cname: datastore['Ldap::Krb5Ccname'],
+      # Write only cache so we keep all gathered tickets but don't reuse them for auth while running the module
+      kerberos_ticket_storage: kerberos_ticket_storage({ read: false, write: true })
     }
 
     realm_key = nil

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -1,0 +1,70 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/credential_collection'
+require 'metasploit/framework/login_scanner/ldap'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::LDAP
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'LDAP Login Scanner',
+        'Description' => 'This module attempts to login to the LDAP service.',
+        'Author' => [ 'Dean Welch' ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+  end
+
+  def run_host(ip)
+    cred_collection = build_credential_collection(
+      username: datastore['USERNAME'],
+      password: datastore['PASSWORD'],
+      realm: datastore['DOMAIN']
+    )
+
+    scanner = Metasploit::Framework::LoginScanner::LDAP.new(
+      host: ip,
+      port: rport,
+      # proxies: datastore['PROXIES'],
+      cred_details: cred_collection,
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+      connection_timeout: datastore['LDAP::ConnectTimeout'].to_i,
+      framework: framework,
+      framework_module: self
+      # ssl: datastore['SSL']
+    )
+
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      )
+      if result.success?
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        store_valid_credential(user: result.credential.public, private: result.credential.private)
+        # create_credential_login(credential_data)
+
+        print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}'"
+      else
+        invalidate_login(credential_data)
+        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -87,7 +87,8 @@ class MetasploitModule < Msf::Auxiliary
           framework: framework,
           framework_module: self,
           cache_file: datastore['Smb::Krb5Ccname'].blank? ? nil : datastore['Smb::Krb5Ccname'],
-          ticket_storage: kerberos_ticket_storage
+          # Write only cache so we keep all gathered tickets but don't reuse them for auth while running the module
+          ticket_storage: kerberos_ticket_storage({ read: false, write: true })
         )
       end
     end

--- a/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
@@ -1,0 +1,67 @@
+
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/ldap'
+
+RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do
+
+  let(:mock_credential) do
+    Metasploit::Framework::Credential.new(
+      public: 'mock_public',
+      private: 'mock_private',
+      realm: 'DEMO.LOCAL'
+    )
+  end
+
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base', has_realm_key: false, has_default_realm: false
+
+  let(:ldap) { spy }
+  before(:each) do
+    allow(subject).to receive(:ldap_connect_opts).and_return({})
+    allow(subject).to receive(:ldap_open).and_yield(ldap)
+  end
+
+  it 'successfully authenticates' do
+    allow(ldap).to receive(:get_operation_result).and_return(OpenStruct.new(code: 0))
+
+    result = subject.attempt_login(mock_credential)
+    expect(result.status).to eq(Metasploit::Model::Login::Status::SUCCESSFUL)
+  end
+
+  it 'fails to authenticate' do
+    allow(ldap).to receive(:get_operation_result).and_return(OpenStruct.new(code: 1))
+
+    result = subject.attempt_login(mock_credential)
+    expect(result.status).to eq(Metasploit::Model::Login::Status::INCORRECT)
+  end
+
+
+  it 'gracefully handles an exception during authentication' do
+    allow(ldap).to receive(:get_operation_result).and_raise(RuntimeError)
+
+    result = subject.attempt_login(mock_credential)
+    expect(result.status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+  end
+end
+
+RSpec.describe Metasploit::Framework::LoginScanner::LDAP do
+
+  auth_types = [
+    Msf::Exploit::Remote::AuthOption::NTLM,
+    Msf::Exploit::Remote::AuthOption::KERBEROS,
+    Msf::Exploit::Remote::AuthOption::PLAINTEXT,
+    Msf::Exploit::Remote::AuthOption::SCHANNEL,
+    Msf::Exploit::Remote::AuthOption::AUTO
+  ]
+
+
+  auth_types.each do |auth_type|
+    context "#{auth_type} auth" do
+
+      subject(:ldap_scanner) do
+        described_class.new(opts: { ldap_auth: auth_type })
+      end
+
+      it_behaves_like 'Metasploit::Framework::LoginScanner::LDAP'
+    end
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
@@ -1,9 +1,7 @@
-
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/ldap'
 
 RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do
-
   let(:mock_credential) do
     Metasploit::Framework::Credential.new(
       public: 'mock_public',
@@ -12,7 +10,28 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do
     )
   end
 
-  it_behaves_like 'Metasploit::Framework::LoginScanner::Base', has_realm_key: false, has_default_realm: false
+  let(:public) { 'root' }
+  let(:private) { 'toor' }
+  let(:realm) { 'myrealm' }
+  let(:realm_key) { Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN }
+
+  let(:pub_pri) do
+    Metasploit::Framework::Credential.new(
+      paired: true,
+      public: public,
+      private: private
+    )
+  end
+
+  let(:ad_cred) do
+    Metasploit::Framework::Credential.new(
+      paired: true,
+      public: public,
+      private: private,
+      realm: realm,
+      realm_key: realm_key
+    )
+  end
 
   let(:ldap) { spy }
   before(:each) do
@@ -34,17 +53,68 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do
     expect(result.status).to eq(Metasploit::Model::Login::Status::INCORRECT)
   end
 
-
   it 'gracefully handles an exception during authentication' do
     allow(ldap).to receive(:get_operation_result).and_raise(RuntimeError)
 
     result = subject.attempt_login(mock_credential)
     expect(result.status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
   end
+
+  describe '#each_credential' do
+    context 'when the login_scanner has a realm key' do
+      before(:example) do
+        subject.realm_key = realm_key
+      end
+      context 'when the credential has a realm' do
+        before(:example) do
+          subject.cred_details = [ad_cred]
+        end
+        it 'set the realm_key on the credential to that of the scanner' do
+          output_cred = ad_cred.dup
+          output_cred.realm_key = realm_key
+          expect { |b| subject.each_credential(&b) }.to yield_with_args(output_cred)
+        end
+      end
+
+      context 'when the credential has no realm' do
+        before(:example) do
+          subject.cred_details = [ad_cred]
+        end
+        it 'yields the original credential' do
+          first_cred = ad_cred.dup
+          first_cred.realm = nil
+          first_cred.realm_key = nil
+          expect { |b| subject.each_credential(&b) }.to yield_successive_args(ad_cred)
+        end
+      end
+    end
+
+    context 'when login_scanner has no realm key' do
+      context 'when the credential has a realm' do
+        before(:example) do
+          subject.cred_details = [ad_cred]
+        end
+        it 'yields the original credential' do
+          first_cred = ad_cred.dup
+          first_cred.realm = nil
+          first_cred.realm_key = nil
+          expect { |b| subject.each_credential(&b) }.to yield_successive_args(ad_cred)
+        end
+      end
+
+      context 'when the credential does not have a realm' do
+        before(:example) do
+          subject.cred_details = [pub_pri]
+        end
+        it 'simply yields the original credential' do
+          expect { |b| subject.each_credential(&b) }.to yield_with_args(pub_pri)
+        end
+      end
+    end
+  end
 end
 
 RSpec.describe Metasploit::Framework::LoginScanner::LDAP do
-
   auth_types = [
     Msf::Exploit::Remote::AuthOption::NTLM,
     Msf::Exploit::Remote::AuthOption::KERBEROS,
@@ -53,10 +123,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::LDAP do
     Msf::Exploit::Remote::AuthOption::AUTO
   ]
 
-
   auth_types.each do |auth_type|
     context "#{auth_type} auth" do
-
       subject(:ldap_scanner) do
         described_class.new(opts: { ldap_auth: auth_type })
       end

--- a/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
@@ -10,7 +10,10 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do |ldap_a
     )
   end
 
-  let(:public) { 'root' }
+  let(:public) do
+    # SChannel auth doesn't use a username
+    ldap_auth_type == Msf::Exploit::Remote::AuthOption::SCHANNEL ? nil : 'root'
+  end
   let(:private) do
     # SChannel auth doesn't use a password
     ldap_auth_type == Msf::Exploit::Remote::AuthOption::SCHANNEL ? nil : 'toor'

--- a/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ldap_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/ldap'
 
-RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do
+RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do |ldap_auth_type|
   let(:mock_credential) do
     Metasploit::Framework::Credential.new(
       public: 'mock_public',
@@ -11,7 +11,11 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::LDAP' do
   end
 
   let(:public) { 'root' }
-  let(:private) { 'toor' }
+  let(:private) do
+    # SChannel auth doesn't use a password
+    ldap_auth_type == Msf::Exploit::Remote::AuthOption::SCHANNEL ? nil : 'toor'
+  end
+
   let(:realm) { 'myrealm' }
   let(:realm_key) { Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN }
 
@@ -129,7 +133,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::LDAP do
         described_class.new(opts: { ldap_auth: auth_type })
       end
 
-      it_behaves_like 'Metasploit::Framework::LoginScanner::LDAP'
+      it_behaves_like 'Metasploit::Framework::LoginScanner::LDAP', auth_type
     end
   end
 end

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::LDAP do
+
+  subject do
+    mod = ::Msf::Exploit.new
+    mod.extend described_class
+
+    mod.send(:initialize)
+    mod
+  end
+
+  let(:rhost) do
+    'rhost.example.com'
+  end
+
+  let(:rport) do
+    1234
+  end
+
+  let(:ldap_connect_timeout) do
+    30
+  end
+
+  let(:ssl) do
+    false
+  end
+
+  let(:ldap_proc) do
+    proc {}
+  end
+
+  before do
+    subject.datastore['LDAP::ConnectTimeout'] = ldap_connect_timeout
+    subject.datastore['ssl'] = ssl
+    allow(subject).to receive(:rhost).and_return(rhost)
+    allow(subject).to receive(:rport).and_return(rport)
+  end
+
+  after do
+    # Do nothing
+  end
+
+  describe '#get_connect_opts' do
+    it { expect(subject.get_connect_opts).to be_a(Hash) }
+    it do
+      expect(subject).to receive(:ldap_connect_opts).with(rhost, rport, ldap_connect_timeout, ssl: ssl, opts: Hash)
+      subject.get_connect_opts
+    end
+  end
+
+  describe '#ldap_open' do
+    it do
+      opts = {}
+      expect(Net::LDAP).to receive(:open).with(opts, &ldap_proc)
+      expect(subject).not_to receive(:get_connect_opts)
+      expect(subject).to receive(:resolve_connect_opts).and_return(opts)
+      subject.ldap_open(opts, &ldap_proc)
+    end
+  end
+
+  describe '#ldap_connect' do
+    it do
+      opts = { x: 0 }
+      connect_opts = { y: 1 }
+      merged_opts = opts.merge(connect_opts)
+
+      expect(subject).to receive(:ldap_open).with(merged_opts, &ldap_proc)
+      expect(subject).to receive(:get_connect_opts).and_return(connect_opts)
+      subject.ldap_connect(opts, &ldap_proc)
+    end
+  end
+
+  describe '#ldap_new' do
+    it do
+      opts = { x: 0 }
+      connect_opts = { y: 1 }
+      merged_opts = opts.merge(connect_opts)
+      expect(Net::LDAP).to receive(:new).with(merged_opts)
+      expect(subject).to receive(:get_connect_opts).and_return(connect_opts)
+      expect(subject).to receive(:resolve_connect_opts).and_return(merged_opts)
+      subject.ldap_new(opts, &ldap_proc)
+    end
+  end
+
+  describe '#resolve_connect_opts' do
+    let(:cred) do
+      'I am a cred'
+    end
+
+    context 'with no credential proc' do
+      let(:connect_opts) do
+        { auth: { initial_credential: cred } }
+      end
+      it { expect(subject.resolve_connect_opts(connect_opts)).to be(connect_opts) }
+    end
+
+    context 'with credential proc' do
+      let(:cred_proc) do
+        proc { cred }
+      end
+
+      let(:connect_opts) do
+        { auth: { initial_credential: cred_proc } }
+      end
+
+      it do
+        resolved_connect_opts = subject.resolve_connect_opts(connect_opts)
+        expect(resolved_connect_opts[:auth][:initial_credential]).not_to be_a(Proc)
+        expect(resolved_connect_opts[:auth][:initial_credential]).to eq(cred)
+      end
+    end
+  end
+
+  describe '#get_naming_contexts' do
+    let(:ldap) do
+      instance_double(Net::LDAP)
+    end
+    context 'Could not retrieve root DSE' do
+      it do
+        expect(ldap).to receive(:search_root_dse).and_return(false)
+        expect(subject.get_naming_contexts(ldap)).to be(nil)
+      end
+    end
+
+    context 'Empty naming contexts' do
+      let(:root_dse) do
+        { namingcontexts: [] }
+      end
+      it do
+        expect(ldap).to receive(:search_root_dse).and_return(root_dse)
+        expect(subject.get_naming_contexts(ldap)).to be(nil)
+      end
+    end
+
+    context 'Naming contexts are present' do
+
+      let(:naming_contexts) {
+        %w[context1 context2]
+      }
+
+      let(:root_dse) do
+        { namingcontexts: naming_contexts }
+      end
+
+      it do
+        expect(ldap).to receive(:search_root_dse).and_return(root_dse)
+        expect(subject.get_naming_contexts(ldap)).to be(naming_contexts)
+      end
+    end
+  end
+
+  describe '#discover_base_dn' do
+    let(:ldap) do
+      instance_double(Net::LDAP)
+    end
+
+    context 'No naming contexts' do
+      it do
+        expect(subject).to receive(:get_naming_contexts).with(ldap).and_return(nil)
+        expect(subject.discover_base_dn(ldap)).to be(nil)
+      end
+    end
+
+    context 'Invalid naming contexts' do
+      let(:invalid_naming_contexts) do
+        %w[invalid1 invalid2]
+      end
+      it do
+        expect(subject).to receive(:get_naming_contexts).with(ldap).and_return(invalid_naming_contexts)
+        expect(subject.discover_base_dn(ldap)).to be(nil)
+      end
+    end
+
+    context 'Valid naming contexts' do
+      let(:base_dn) do
+        'DC=abcdef'
+      end
+      let(:valid_naming_contexts) do
+        [base_dn]
+      end
+      it do
+        expect(subject).to receive(:get_naming_contexts).with(ldap).and_return(valid_naming_contexts)
+        expect(subject.discover_base_dn(ldap)).to be(base_dn)
+      end
+    end
+
+    context 'Valid naming contexts (lowercase dc)' do
+      let(:base_dn) do
+        'dc=abcdef'
+      end
+      let(:valid_naming_contexts) do
+        [base_dn]
+      end
+      it do
+        expect(subject).to receive(:get_naming_contexts).with(ldap).and_return(valid_naming_contexts)
+        expect(subject.discover_base_dn(ldap)).to be(base_dn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new login scanner module for LDAP
resolves #18130 

# Verification steps
- Run with valid and invalid creds for all authentication mechanisms
  - [x] Auto
  - [x] Plaintext
  - [x] NTLM
  - [x] Kerberos
    - [x] Logging in with kerberos successfully but without access to LDAP should not store the credentials
  - [x] SChannel 
- [x] Valid credentials are stored in the DB
- [x] Invalid credentials are not stored

#TODO: If the creds are used to get a kerberos ticket then that ticket is used for ldap access the creds are still stored in the db as plaintext password which is kind of confusing but I'm not sure what I'd expect the UX for that to be either