### PR TITLE
Make check_vm.rb DRY and Stealthy

### DIFF
--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -156,10 +156,6 @@ class MetasploitModule < Msf::Post
 
     return true if services_exist?(hyperv_services)
 
-    @scsi_port_0 = get_regval_str('HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0', 'Identifier')
-
-    return true if @scsi_port_0 =~ /Msft    Virtual Disk    1.0/i
-
     false
   end
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -225,7 +225,9 @@ class MetasploitModule < Msf::Post
     return true if key?(keys, 'VBOX__')
 
     for i in 0..2 do
-      return true if regval_match?("HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port #{i}0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0",
+      return true if regval_match?(
+        "HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port #{i}0\\Scsi Bus 0\\Target
+         Id 0\\Logical Unit Id 0",
         'Identifier',
          /vbox/i )    
     end
@@ -322,9 +324,6 @@ class MetasploitModule < Msf::Post
 
    def parallels?
     bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
-    if bios_version.kind_of?(Array)
-      bios_version = bios_version.join
-    end
     return true if bios_version =~ /parallels/i
     return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'VideoBiosVersion') =~ /parallels/i
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
 
   # enumerates through a list of VM signature processes and compares them to
   # the processes running, returns true upon a match. 
-  def process_exists?(vm_processes)
+  def processes_exist?(vm_processes)
     vm_processes.each do |x|
       @processes.each do |p|
         return true if p['name'].casecmp?(x) 
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Post
 
   # loops over a list of services that are known to be signatures of vm's and
   # compares them to the list of running services. 
-  def services_exists?(vm_services)
+  def services_exist?(vm_services)
     vm_services.each do |srvc|
       return true if service_exists?(srvc)
     end 
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Post
       end 
     end
 
-    return true if @system_bios_version =~ /vrtual/i
+    return true if @system_bios_version =~ /vrtual/i ||  @system_bios_version == 'Hyper-V'
 
     @keys = %w[HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT]
 
@@ -154,9 +154,7 @@ class MetasploitModule < Msf::Post
     
     hyperv_services = %w[vmicexchange vmicheartbeat vmicshutdown vmicvss]
 
-    return true if services_exists?(hyperv_services)
-
-    return true if @system_bios_version == 'Hyper-V'
+    return true if services_exist?(hyperv_services)
 
     @scsi_port_0 = get_regval_str('HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0', 'Identifier')
 
@@ -169,10 +167,7 @@ class MetasploitModule < Msf::Post
     vmware_services = %w[vmdebug vmmouse VMTools VMMEMCTL tpautoconnsvc 
       tpvcgateway vmware wmci vmx86]
 
-    return true if services_exists?(vmware_services)
-
-    # list of lists containg registers keypath, a value and the regex to match 
-    # against
+    return true if services_exist?(vmware_services)
 
     @system_manufacturer = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 
         'SystemManufacturer')
@@ -199,7 +194,7 @@ class MetasploitModule < Msf::Post
       'vmwareuser.exe'
     ]
 
-    return true if process_exists?(vmwareprocs)
+    return true if processes_exist?(vmwareprocs)
     
     false
   end
@@ -210,7 +205,7 @@ class MetasploitModule < Msf::Post
       'vboxtray.exe'
     ]
 
-    return true if process_exists?(vboxprocs)
+    return true if processes_exist?(vboxprocs)
 
     return true if key?(@keys, 'VBOX__')
 
@@ -231,7 +226,7 @@ class MetasploitModule < Msf::Post
 
     vbox_services = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
 
-    return true if services_exists?(vbox_services)
+    return true if services_exist?(vbox_services)
 
     false
   end
@@ -241,13 +236,13 @@ class MetasploitModule < Msf::Post
       'xenservice.exe'
     ]
 
-    return true if process_exists?(xenprocs)
+    return true if processes_exist?(xenprocs)
 
     return true if key?(@keys,'Xen')
 
     xen_services = %w[xenevtchn xennet xennet6 xensvc xenvdb]
 
-    return true if services_exists?(xen_services)
+    return true if services_exist?(xen_services)
 
     return true if @system_product_name =~ /xen/i
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -65,6 +65,14 @@ class MetasploitModule < Msf::Post
     @processes = get_processes
   end 
 
+  # loops over a list of vm services and compares them to the list of running
+  # services. 
+  def services?(vm_services)
+    vm_services.each do |srvc|
+      return true if service_exists?(srvc)
+    end 
+  end 
+
   def get_services
     @services ||= registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
     @services

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -76,13 +76,15 @@ class MetasploitModule < Msf::Post
   end 
 
   def get_services
+    # previously @services was nil, making it an empty list as default helps
+    # remove an uneccesarry && call in service_exists?
     @services = []
     @services ||= registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
     @services
   end
 
   def service_exists?(service)
-    get_services.include?(service)
+    @services.include?(service)
   end
 
   def get_regval_str(key, valname)

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Post
   def register_keys(key_list)
     @keys = {}
     key_list.each do |k|
-      srvals = get_serval(k)
+      srvals = get_srval(k)(k)
       srvals = [] if srvals.nil?
       @keys.store(k, srvals)
     end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -123,8 +123,8 @@ class MetasploitModule < Msf::Post
 
   def parallels?
 
-    @bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
-    return true if @bios_version =~ /parallels/i
+    @system_bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
+    return true if @system_bios_version =~ /parallels/i
     
     @video_bios_version =  get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System'
     , 'VideoBiosVersion')
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Post
       end 
     end
 
-    return true if @bios_version =~ /vrtual/i
+    return true if @system_bios_version =~ /vrtual/i
 
     keys = %w[HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT]
 
@@ -163,9 +163,7 @@ class MetasploitModule < Msf::Post
 
     return true if services?(hyperv_services)
 
-    key_path = 'HKLM\\HARDWARE\\DESCRIPTION\\System'
-    system_bios_version = get_regval_str(key_path, 'SystemBiosVersion')
-    return true if system_bios_version && system_bios_version.include?('Hyper-V')
+    return true if @system_bios_version == 'Hyper-V'
 
     key_path = 'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0'
 
@@ -246,14 +244,13 @@ class MetasploitModule < Msf::Post
 
     # BiosVersion and VideoBiosVersion already queried and set in prior 
     # methods
-    return true if @bios_version =~ /vbox/i
+    return true if @system_bios_version =~ /vbox/i
     return true if @video_bios_version =~ /virtualbox/i
 
-    return true if regval_match?(
-      'HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS',
-      'SystemProductName',
-      /virtualbox/i
-    )
+    @system_product_name = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS','SystemProductName',)
+
+    return true if @system_product_name =~ /virtualbox/i
+    
       
     
 
@@ -283,14 +280,13 @@ class MetasploitModule < Msf::Post
 
     return true if services?(xen_services)
 
-    return true if regval_match?('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS',
-      'SystemProductName', /xen/i )
+    return true if @system_product_name =~ /xen/i
 
     false
   end
 
   def qemu?
-    return true if @bios_version =~ /qemu/i
+    return true if @system_bios_version =~ /qemu/i
     return true if @video_bios_version =~ /qemu/i
 
     regs = [

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -94,6 +94,7 @@ class MetasploitModule < Msf::Post
     @keys.each_value do |v|
       return true if v.include?(vm_k)
     end
+    false
   end
 
   def get_srval(key)

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -117,8 +117,10 @@ class MetasploitModule < Msf::Post
     @video_bios_version =  get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System'
     , 'VideoBiosVersion')
 
-    return true if @system_bios_version =~ /parallels/i || @video_bios_version =~ /parallels/i
-
+    if @system_bios_version =~ /parallels/i || @video_bios_version =~ /parallels/i
+      return true
+    end 
+    
     false
   end
 
@@ -144,7 +146,9 @@ class MetasploitModule < Msf::Post
       end 
     end
 
-    return true if @system_bios_version =~ /vrtual/i ||  @system_bios_version == 'Hyper-V'
+    if @system_bios_version =~ /vrtual/i || @system_bios_version == 'Hyper-V'
+      return true
+    end 
 
     @keys = %w[HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT]
 
@@ -205,7 +209,11 @@ class MetasploitModule < Msf::Post
       'vboxtray.exe'
     ]
 
-    return true if processes_exist?(vboxprocs)
+    vbox_srvcs = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
+
+    if services_exist?(vbox_srvcs) || processes_exist?(vboxprocs)
+      return true
+    end 
 
     return true if key?(@keys, 'VBOX__')
 
@@ -219,14 +227,9 @@ class MetasploitModule < Msf::Post
 
     return true if @system_bios_version =~ /vbox/i || @video_bios_version =~ /virtualbox/i
      
-
     @system_product_name = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS','SystemProductName',)
 
     return true if @system_product_name =~ /virtualbox/i
-
-    vbox_services = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
-
-    return true if services_exist?(vbox_services)
 
     false
   end
@@ -236,13 +239,13 @@ class MetasploitModule < Msf::Post
       'xenservice.exe'
     ]
 
-    return true if processes_exist?(xenprocs)
+    xen_srvcs = %w[xenevtchn xennet xennet6 xensvc xenvdb]
+
+    if processes_exist?(xenprocs) || services_exist?(xen_srvcs)
+      return true
+    end  
 
     return true if key?(@keys,'Xen')
-
-    xen_services = %w[xenevtchn xennet xennet6 xensvc xenvdb]
-
-    return true if services_exist?(xen_services)
 
     return true if @system_product_name =~ /xen/i
 
@@ -250,9 +253,13 @@ class MetasploitModule < Msf::Post
   end
 
   def qemu?
-    return true if @system_bios_version =~ /qemu/i || @video_bios_version =~ /qemu/i
+    if @system_bios_version =~ /qemu/i || @video_bios_version =~ /qemu/i
+      return true 
+    end 
 
-    return true if @scsi_port_0 =~ /qemu|virtio/i || @system_manufacturer =~ /qemu/i
+    if @scsi_port_0 =~ /qemu|virtio/i || @system_manufacturer =~ /qemu/i
+      return true
+    end 
     
     return true if regval_match?(
       'HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0',

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Post
 
     return true if key_present?('VRTUAL')
 
-    hyperv_services = %w[vmicexchange vmicshutdown vmicvss]
+    hyperv_services = %w[vmicexchange]
 
     return true if services_exist?(hyperv_services)
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -184,7 +184,6 @@ class MetasploitModule < Msf::Post
       /cl_vmx_svga|VMWare/i
     )
 
-    processes
 
     vmwareprocs = [
       'vmtoolsd.exe',

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Post
   end 
 
   # make only one call to get_processes and store in @processes instance variable, modify the list of dictionary elems to avoid making constant downcase calls
-  def processes
+  def procs?
     if @processes.nil?
       @processes = get_processes.each |process| do
         process['name'].downcase
@@ -135,11 +135,8 @@ class MetasploitModule < Msf::Post
       'vmwaretray.exe',
       'vmwareuser.exe'
     ]
-    get_processes.each do |x|
-      vmwareprocs.each do |p|
-        return true if p == x['name'].downcase
-      end
-    end
+    procs_present?(vmwareprocs)
+    
 
     false
   end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -82,8 +82,7 @@ class MetasploitModule < Msf::Post
   def register_keys(key_list)
     @keys = {}
     key_list.each do |k|
-      srvals = get_serval(k)
-      srvals = [] if srvals.nil?
+      srvals = get_serval(k); srvals = [] if srvals.nil?
       @keys.store(k, srvals) 
     end 
     @keys
@@ -92,12 +91,12 @@ class MetasploitModule < Msf::Post
   # checks the values of the keys and compares them to vm_k
   def key_present?(vm_k)
     @keys.each_value do |v|
-      return true if v.include?(k)
+      return true if v.include?(vm_k)
     end 
   end 
 
   def get_srval(key)
-    srvals = registry_enumkeys(k)
+    srvals = registry_enumkeys(key)
     srvals = [] if srvals.nil?
     srvals
   end 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -78,14 +78,33 @@ class MetasploitModule < Msf::Post
   def get_services
     # previously @services was nil, making it an empty list as default helps
     # remove an uneccesarry && call in service_exists?
-    @services = []
-    @services ||= registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
+    @services = registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
+    @services = [] if @services.nil?
     @services
   end
 
   def service_exists?(service)
     @services.include?(service)
   end
+
+  # via virtualbox?
+  # %w[HKLM\\HARDWARE\\ACPI\\DSDT HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT].each do |key|
+   #   srvvals = registry_enumkeys(key)
+  #    return true if srvvals && srvvals.include?('VBOX__')
+
+  # loops over a list of keys and sees if vm_key is included within them
+  def key?(keys, vm_key)
+    keys.each do |k|
+      srvals = get_servals 
+      return true if srvals.include?(vm_key)
+    end 
+  end 
+
+  def get_srvals(key)
+    srvals = registry_enumkeys(k)
+    srvals = [] if srvals.nil?
+    srvals
+  end 
 
   def get_regval_str(key, valname)
     ret = registry_getvaldata(key, valname)
@@ -94,7 +113,6 @@ class MetasploitModule < Msf::Post
     end
     ret
   end
-
 
   def hyperv?
     physical_host = get_regval_str('HKLM\\SOFTWARE\\Microsoft\\Virtual Machine\\Guest\\Parameters', 'PhysicalHostNameFullyQualified')

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -124,11 +124,11 @@ class MetasploitModule < Msf::Post
   def parallels?
 
     @system_bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
-    return true if @system_bios_version =~ /parallels/i
     
     @video_bios_version =  get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System'
     , 'VideoBiosVersion')
-    return true if @video_bios_version =~ /parallels/i
+
+    return true if @system_bios_version =~ /parallels/i || @video_bios_version =~ /parallels/i
 
     false
   end
@@ -187,11 +187,8 @@ class MetasploitModule < Msf::Post
     return true if @system_manufacturer =~ /vmware/i
 
     regs = [
-      [
-        'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id \\Logical Unit Id 0', 
-        'Identifier', 
-        /vmware/i
-      ],
+      #'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0'
+     
       [
         'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 1\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0', 
         'Identifier', 
@@ -242,8 +239,8 @@ class MetasploitModule < Msf::Post
          /vbox/i )    
     end
 
-    return true if @system_bios_version =~ /vbox/i
-    return true if @video_bios_version =~ /virtualbox/i
+    return true if @system_bios_version =~ /vbox/i || @video_bios_version =~ /virtualbox/i
+     
 
     @system_product_name = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS','SystemProductName',)
 
@@ -277,9 +274,8 @@ class MetasploitModule < Msf::Post
   end
 
   def qemu?
-    return true if @system_bios_version =~ /qemu/i
-    return true if @video_bios_version =~ /qemu/i
-
+    return true if @system_bios_version =~ /qemu/i || @video_bios_version =~ /qemu/i
+    
     regs = [
       [
         'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0',
@@ -291,11 +287,6 @@ class MetasploitModule < Msf::Post
         'ProcessorNameString',
         /qemu/i
       ],
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS',
-        'SystemManufacturer',
-        
-      ]
     ]
    
     return true if @system_manufacturer =~ /qemu/i

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -51,13 +51,6 @@ class MetasploitModule < Msf::Post
     false
   end
 
-  # Returns list of running processes and store them in @processes instance variable to avoid multiple process queries on the host system.
-  def processes
-    @processes = get_processes
-    @processes = [] if @processes.nil?
-    @processes
-  end
-
   # loops over a list of services that are known to be signatures of vm's and
   # compares them to the list of running services.
   def services_exist?(vm_services)
@@ -65,13 +58,6 @@ class MetasploitModule < Msf::Post
       return true if service_exists?(srvc)
     end
     false
-  end
-
-  # gets active services on the machine and stores them in a list
-  def get_services
-    @services = registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
-    @services = [] if @services.nil?
-    @services
   end
 
   def service_exists?(service)
@@ -298,6 +284,11 @@ class MetasploitModule < Msf::Post
 
   def run
     print_status('Checking if the target is a Virtual Machine ...')
+    @processes = get_processes
+    @processes = [] if @processes.nil?
+
+    @services = registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
+    @services = [] if @services.nil?
 
     if parallels?
       report_vm('Parallels')

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Post
         return true if p['name'].casecmp?(x) 
       end 
     end 
+    false
   end 
 
   # This method is currently called in vmware? but should be called # in the first method that enumerates processes in run, thus if the order of
@@ -71,6 +72,7 @@ class MetasploitModule < Msf::Post
     vm_services.each do |srvc|
       return true if service_exists?(srvc)
     end 
+    false
   end 
 
   def get_services
@@ -118,9 +120,9 @@ class MetasploitModule < Msf::Post
       return true if srvvals && srvvals.include?('VRTUAL')
     end
 
-    %w[vmicexchange vmicheartbeat vmicshutdown vmicvss].each do |service|
-      return true if service_exists?(service)
-    end
+   hyperv_services = %w[vmicexchange vmicheartbeat vmicshutdown vmicvss]
+
+   return true if services?(hyperv_services)
 
     key_path = 'HKLM\\HARDWARE\\DESCRIPTION\\System'
     system_bios_version = get_regval_str(key_path, 'SystemBiosVersion')
@@ -133,10 +135,11 @@ class MetasploitModule < Msf::Post
   end
 
   def vmware?
-    %w[vmdebug vmmouse VMTools VMMEMCTL tpautoconnsvc tpvcgateway vmware wmci vmx86].each do |service|
-      return true if service_exists?(service)
-    end
+    vmware_services = %w[vmdebug vmmouse VMTools VMMEMCTL tpautoconnsvc 
+      tpvcgateway vmware wmci vmx86]
 
+    return true if services?(vmware_services)
+    
     return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 'SystemManufacturer') =~ /vmware/i
     return true if get_regval_str('HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0', 'Identifier') =~ /vmware/i
     return true if get_regval_str('HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 1\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0', 'Identifier') =~ /vmware/i
@@ -177,9 +180,8 @@ class MetasploitModule < Msf::Post
     return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'VideoBiosVersion') =~ /virtualbox/i
     return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 'SystemProductName') =~ /virtualbox/i
 
-    %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo].each do |service|
-      return true if service_exists?(service)
-    end
+    vbox_services = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
+    return true if services?(vbox_services)
 
     false
   end
@@ -196,9 +198,9 @@ class MetasploitModule < Msf::Post
       return true if srvvals && srvvals.include?('Xen')
     end
 
-    %w[xenevtchn xennet xennet6 xensvc xenvdb].each do |service|
-      return true if service_exists?(service)
-    end
+    xen_services = %w[xenevtchn xennet xennet6 xensvc xenvdb]
+
+    return true if services?(xen_services)
 
     return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 'SystemProductName') =~ /xen/i
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -135,9 +135,9 @@ class MetasploitModule < Msf::Post
       'vmwaretray.exe',
       'vmwareuser.exe'
     ]
-    procs_present?(vmwareprocs)
-    
 
+    return true if procs_present?(vmwareprocs)
+    
     false
   end
 
@@ -146,11 +146,8 @@ class MetasploitModule < Msf::Post
       'vboxservice.exe',
       'vboxtray.exe'
     ]
-    get_processes.each do |x|
-      vboxprocs.each do |p|
-        return true if p == x['name'].downcase
-      end
-    end
+
+    return true if procs?(vboxprocs)
 
     %w[HKLM\\HARDWARE\\ACPI\\DSDT HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT].each do |key|
       srvvals = registry_enumkeys(key)
@@ -176,11 +173,8 @@ class MetasploitModule < Msf::Post
     xenprocs = [
       'xenservice.exe'
     ]
-    get_processes.each do |x|
-      xenprocs.each do |p|
-        return true if p == x['name'].downcase
-      end
-    end
+
+    return true if procs?(xenprocs)
 
     %w[HKLM\\HARDWARE\\ACPI\\DSDT HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT].each do |key|
       srvvals = registry_enumkeys(key)

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Post
 
   def get_regval_str(key, valname)
     ret = registry_getvaldata(key, valname)
-    if ret.kind_of(Array)
+    if ret.kind_of?(Array)
       ret = ret.join
     end
     ret

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -76,12 +76,13 @@ class MetasploitModule < Msf::Post
   end 
 
   def get_services
+    @services = []
     @services ||= registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
     @services
   end
 
   def service_exists?(service)
-    get_services && get_services.include?(service)
+    get_services.include?(service)
   end
 
   def get_regval_str(key, valname)
@@ -181,6 +182,7 @@ class MetasploitModule < Msf::Post
     return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 'SystemProductName') =~ /virtualbox/i
 
     vbox_services = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
+
     return true if services?(vbox_services)
 
     false

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Post
       end 
     end
 
-    return true if regval_match?('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion', /vrtual/i)
+    return true if @bios_version =~ /vrtual/i
 
     keys = %w[HKLM\\HARDWARE\\ACPI\\FADT HKLM\\HARDWARE\\ACPI\\RSDT]
 
@@ -232,23 +232,18 @@ class MetasploitModule < Msf::Post
          /vbox/i )    
     end
 
-    regs = [
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System',
-        'SystemBiosVersion',
-        /vbox/i
-      ],
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System',
-        'VideoBiosVersion',
-         /virtualbox/i
-      ],
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 
-        'SystemProductName',
-        /virtualbox/i
-      ]
-    ]
+    # BiosVersion and VideoBiosVersion already queried and set in prior 
+    # methods
+    return true if @bios_version =~ /vbox/i
+    return true if @video_bios_version =~ /virtualbox/i
+
+    return true if regval_match?(
+      'HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS',
+      'SystemProductName',
+      /virtualbox/i
+    )
+      
+    
 
     regs.each do |l|
       return true if regval_match?(l[0], l[1], l[2])
@@ -283,6 +278,9 @@ class MetasploitModule < Msf::Post
   end
 
   def qemu?
+    return true if @bios_version =~ /qemu/i
+    return true if @video_bios_version =~ /qemu/i
+
     regs = [
       [
         'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id 0\\Logical Unit Id 0',
@@ -292,16 +290,6 @@ class MetasploitModule < Msf::Post
       [
         'HKLM\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0',
         'ProcessorNameString',
-        /qemu/i
-      ],
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System',
-        'SystemBiosVersion',
-        /qemu/i
-      ],
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System', 
-        'VideoBiosVersion',
         /qemu/i
       ],
       [
@@ -323,9 +311,13 @@ class MetasploitModule < Msf::Post
   end
 
    def parallels?
-    bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
-    return true if bios_version =~ /parallels/i
-    return true if get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'VideoBiosVersion') =~ /parallels/i
+
+    @bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
+    return true if @bios_version =~ /parallels/i
+    
+    @video_bios_version =  get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System'
+    , 'VideoBiosVersion')
+    return true if @video_bios_version =~ /parallels/i
 
     false
   end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -60,17 +60,14 @@ class MetasploitModule < Msf::Post
 
   # loops over a list of services that are known to be signatures of vm's and
   # compares them to the list of running services. 
-  def services?(vm_services)
+  def services_exists?(vm_services)
     vm_services.each do |srvc|
       return true if service_exists?(srvc)
     end 
     false
   end 
 
-  # previously @services was nil, making it an empty list as default helps
-  # remove an uneccesarry && call in service_exists? that was implimented
-  # in order to avoid a no_method error when calling .include? on a nil
-
+  # gets active services on the machine and stores them in a list
   def get_services
     @services = registry_enumkeys('HKLM\\SYSTEM\\ControlSet001\\Services')
     @services = [] if @services.nil?
@@ -101,6 +98,7 @@ class MetasploitModule < Msf::Post
     false 
   end
 
+  # returns true if regval is eql to a string
   def regval_eql?(k,v,eq)
     get_regval_str(k,v) == eq
   end 
@@ -156,7 +154,7 @@ class MetasploitModule < Msf::Post
     
     hyperv_services = %w[vmicexchange vmicheartbeat vmicshutdown vmicvss]
 
-    return true if services?(hyperv_services)
+    return true if services_exists?(hyperv_services)
 
     return true if @system_bios_version == 'Hyper-V'
 
@@ -171,7 +169,7 @@ class MetasploitModule < Msf::Post
     vmware_services = %w[vmdebug vmmouse VMTools VMMEMCTL tpautoconnsvc 
       tpvcgateway vmware wmci vmx86]
 
-    return true if services?(vmware_services)
+    return true if services_exists?(vmware_services)
 
     # list of lists containg registers keypath, a value and the regex to match 
     # against
@@ -233,7 +231,7 @@ class MetasploitModule < Msf::Post
 
     vbox_services = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
 
-    return true if services?(vbox_services)
+    return true if services_exists?(vbox_services)
 
     false
   end
@@ -249,7 +247,7 @@ class MetasploitModule < Msf::Post
 
     xen_services = %w[xenevtchn xennet xennet6 xensvc xenvdb]
 
-    return true if services?(xen_services)
+    return true if services_exists?(xen_services)
 
     return true if @system_product_name =~ /xen/i
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -181,12 +181,12 @@ class MetasploitModule < Msf::Post
     # list of lists containg registers keypath, a value and the regex to match 
     # against
 
+    @system_manufacturer = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 
+        'SystemManufacturer')
+
+    return true if @system_manufacturer =~ /vmware/i
+
     regs = [
-      [
-        'HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS', 
-        'SystemManufacturer', 
-        /vmware/i
-      ],
       [
         'HKLM\\HARDWARE\\DEVICEMAP\\Scsi\\Scsi Port 0\\Scsi Bus 0\\Target Id \\Logical Unit Id 0', 
         'Identifier', 
@@ -242,21 +242,12 @@ class MetasploitModule < Msf::Post
          /vbox/i )    
     end
 
-    # BiosVersion and VideoBiosVersion already queried and set in prior 
-    # methods
     return true if @system_bios_version =~ /vbox/i
     return true if @video_bios_version =~ /virtualbox/i
 
     @system_product_name = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS','SystemProductName',)
 
     return true if @system_product_name =~ /virtualbox/i
-    
-      
-    
-
-    regs.each do |l|
-      return true if regval_match?(l[0], l[1], l[2])
-    end 
 
     vbox_services = %w[VBoxMouse VBoxGuest VBoxService VBoxSF VBoxVideo]
 
@@ -303,10 +294,12 @@ class MetasploitModule < Msf::Post
       [
         'HKLM\\HARDWARE\\DESCRIPTION\\System\\BIOS',
         'SystemManufacturer',
-        /qemu/i
+        
       ]
     ]
    
+    return true if @system_manufacturer =~ /qemu/i
+
     regs.each do |l|
       return true if regval_match?(l[0], l[1], l[2])
     end 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -121,6 +121,18 @@ class MetasploitModule < Msf::Post
     ret
   end
 
+  def parallels?
+
+    @bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
+    return true if @bios_version =~ /parallels/i
+    
+    @video_bios_version =  get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System'
+    , 'VideoBiosVersion')
+    return true if @video_bios_version =~ /parallels/i
+
+    false
+  end
+
   def hyperv?
     physical_host = get_regval_str('HKLM\\SOFTWARE\\Microsoft\\Virtual Machine\\Guest\\Parameters', 'PhysicalHostNameFullyQualified')
     if physical_host
@@ -310,7 +322,7 @@ class MetasploitModule < Msf::Post
     false
   end
 
-   def parallels?
+  def parallels?
 
     @bios_version = get_regval_str('HKLM\\HARDWARE\\DESCRIPTION\\System', 'SystemBiosVersion')
     return true if @bios_version =~ /parallels/i

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
 
   # enumerates through a list of VM signature processes and compares them to
   # the processes running, returns true upon a match. 
-  def procs?(vm_processes)
+  def process_exists?(vm_processes)
     vm_processes.each do |x|
       @processes.each do |p|
         return true if p['name'].casecmp?(x) 
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Post
       'vmwareuser.exe'
     ]
 
-    return true if procs?(vmwareprocs)
+    return true if process_exists?(vmwareprocs)
     
     false
   end
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Post
       'vboxtray.exe'
     ]
 
-    return true if procs?(vboxprocs)
+    return true if process_exists?(vboxprocs)
 
     return true if key?(@keys, 'VBOX__')
 
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Post
       'xenservice.exe'
     ]
 
-    return true if procs?(xenprocs)
+    return true if process_exists?(xenprocs)
 
     return true if key?(@keys,'Xen')
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Post
   def register_keys(key_list)
     @keys = {}
     key_list.each do |k|
-      srvals = get_serval(k)
+      srvals = get_srval(k)
       srvals = [] if srvals.nil?
       @keys.store(k, srvals)
     end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Post
 
     return true if key_present?('VRTUAL')
 
-    hyperv_services = %w[vmicexchange vmicheartbeat vmicshutdown vmicvss]
+    hyperv_services = %w[vmicexchange vmicshutdown vmicvss]
 
     return true if services_exist?(hyperv_services)
 


### PR DESCRIPTION
According to #18149 the `check_vm .rb` module is very disorganized and makes repeated calls on the host system to retrieve registry keys, services and processes to determine if the machine is running inside of a virtual environment. Constantly calling enumerating registries, services and processes hinders stealth and is not a good programming practice because you're writing the same code over and over again. 

To solve this issue I organized the module so that whenever a process, registry key or service is initially  checked by the module on the host system that data would be stored in an instance variable. When another method needs to see if a given process, registry or service exists it does not have to repeat calls to the enumerate these services on the machine, it can just check the data in the instance variable.

Another issue was repeated looping over VM fingerprints and checking if these are included on the active machine. For example each of the different VM methods would loop over a given set of finger print processes and compare those to the running processes. I abstracted the enumeration of active vs fingerprints into the `processes_exist?` method which takes a list of fingerprint processes and checks to see if they are included within in the  list stored in the `@processes` variable.

 The `services_exist?` and `key_present?` methods were also created under a similar philosophy. For example the `services_exist?` method enumerates over the fingerprint services to see if they are included in the `@services` variable, which is an `array` containing the active services on the machine. The `@keys` instance variable is of type `hash` with the registry key as the key and it's corresponding value unironically assuming it's value. 

Additionally, the module will make calls to retrieve other keys like video bios, system bios or scsi bus values. These were more distinct than the other keys stored in `@keys` and were given their own instance variables, for example `@system_bios_version`.

Lastly, if the module goes to gather some data, be it a service, process or whatever and nothing is available then it will return a `nil` object. This is problematic because whenever `include?` is called a no-method error would arise and the previous developers wrote in a series of `nil` checks before calling include. To avoid these repetitive `nil` checks I would simply set the data to an empty `array` if it happened to be `nil` upon retrieval. 