### PR TITLE
Fix broken msfconsole histories when switching between shell sessions

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -221,7 +221,6 @@ Shell Banner:
     end
 
     if prompt_yesno("Background session #{name}?")
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
       self.interacting = false
     end
   end
@@ -256,7 +255,6 @@ Shell Banner:
       print_status("Session #{self.name} is already interactive.")
     else
       print_status("Backgrounding session #{self.name}...")
-      Rex::Ui::Text::Shell::HistoryManager.pop_context
       # store the next session id so that it can be referenced as soon
       # as this session is no longer interacting
       self.next_session = args[0]
@@ -548,7 +546,7 @@ Shell Banner:
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"self\" (session) object\n")
-      Rex::Ui::Text::Shell::HistoryManager.with_context(name: :irb) do
+      Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: :irb) do
         Rex::Ui::Text::IrbShell.new(self).run
       end
     else
@@ -587,7 +585,7 @@ Shell Banner:
     print_status('Starting Pry shell...')
     print_status("You are in the \"self\" (session) object\n")
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(history_file: Msf::Config.pry_history, name: :pry) do
       self.pry
     end
   end
@@ -748,7 +746,7 @@ protected
   # shell_write instead of operating on rstream directly.
   def _interact
     framework.events.on_session_interact(self)
-    Rex::Ui::Text::Shell::HistoryManager.with_context(name: self.type.to_sym) {
+    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: self.type.to_sym) {
       _interact_stream
     }
   end

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -17,7 +17,7 @@ module Msf
     WRAPPED_TABLES = 'wrapped_tables'
     DATASTORE_FALLBACKS = 'datastore_fallbacks'
     FULLY_INTERACTIVE_SHELLS = 'fully_interactive_shells'
-    SERVICEMANAGER_COMMAND = 'servicemanager_command'
+    MANAGER_COMMANDS = 'manager_commands'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -30,8 +30,8 @@ module Msf
         default_value: false
       }.freeze,
       {
-        name: SERVICEMANAGER_COMMAND,
-        description: 'When enabled you will have access to the _servicemanager command',
+        name: MANAGER_COMMANDS,
+        description: 'When enabled you will have access to manager commands such as _servicemanager and _historymanager',
         default_value: false
       }.freeze,
       {

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -19,6 +19,12 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     ['-l', '--list'] => [false, 'View the currently running services' ]
   )
 
+  @@_historymanager_opts = Rex::Parser::Arguments.new(
+    '-h' => [false, 'Help menu.'             ],
+    ['-l', '--list'] => [true,  'View the current history manager contexts.'],
+    ['-d', '--debug'] => [true,  'Debug the current history manager contexts.']
+  )
+
   def initialize(driver)
     super
     @modified_files = modified_file_paths(print_errors: false)
@@ -37,8 +43,9 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       'log'        => 'Display framework.log paged to the end if possible',
       'time'       => 'Time how long it takes to run a particular command'
     }
-    if framework.features.enabled?(Msf::FeatureManager::SERVICEMANAGER_COMMAND)
+    if framework.features.enabled?(Msf::FeatureManager::MANAGER_COMMANDS)
       commands['_servicemanager'] = 'Interact with the Rex::ServiceManager'
+      commands['_historymanager'] = 'Interact with the Rex::Ui::Text::Shell::HistoryManager'
     end
     commands
   end
@@ -122,7 +129,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     if expressions.empty?
       print_status('Starting IRB shell...')
 
-      Rex::Ui::Text::Shell::HistoryManager.with_context(name: :irb) do
+      Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: :irb) do
         begin
           if active_module
             print_status("You are in #{active_module.fullname}\n")
@@ -185,7 +192,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     print_status('Starting Pry shell...')
 
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(history_file: Msf::Config.pry_history, name: :pry) do
       if active_module
         print_status("You are in the \"#{active_module.fullname}\" module object\n")
         active_module.pry
@@ -382,10 +389,73 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   end
 
   def cmd__servicemanager_help
-    print_line 'Usage: servicemanager'
+    print_line 'Usage: _servicemanager'
     print_line
     print_line 'Manage running framework services'
     print @@_servicemanager_opts.usage
+    print_line
+  end
+
+  #
+  # Interact with framework's history manager
+  #
+  def cmd__historymanager(*args)
+    if args.include?('-h') || args.include?('--help')
+      cmd__historymanager_help
+      return false
+    end
+
+    opts = {}
+    @@_historymanager_opts.parse(args) do |opt, idx, val|
+      case opt
+      when '-l', '--list'
+        opts[:list] = true
+      when '-d', '--debug'
+        opts[:debug] = val.nil? ? true : val.downcase.start_with?(/t|y/)
+      end
+    end
+
+    if opts.empty?
+      opts[:list] = true
+    end
+
+    if opts.key?(:debug)
+      Rex::Ui::Text::Shell::HistoryManager.instance._debug = opts[:debug]
+      print_status("HistoryManager debugging is now #{opts[:debug] ? 'on' : 'off'}")
+    end
+
+    if opts[:list]
+      table = Rex::Text::Table.new(
+        'Header'  => 'History contexts',
+        'Indent'  => 1,
+        'Columns' => ['Id', 'File', 'Name']
+      )
+      Rex::Ui::Text::Shell::HistoryManager.instance._contexts.each.with_index do |context, id|
+        table << [id, context[:history_file], context[:name]]
+      end
+
+      if table.rows.empty?
+        print_status("No history contexts present.")
+      else
+        print_line(table.to_s)
+      end
+    end
+  end
+
+  #
+  # Tab completion for the _historymanager command
+  #
+  def cmd__historymanager_tabs(_str, words)
+    return [] if words.length > 1
+
+    @@_historymanager_opts.option_keys
+  end
+
+  def cmd__historymanager_help
+    print_line 'Usage: _historymanager'
+    print_line
+    print_line 'Manage the history manager'
+    print @@_historymanager_opts.usage
     print_line
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -599,7 +599,7 @@ class Console::CommandDispatcher::Core
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"client\" (session) object\n")
-      Rex::Ui::Text::Shell::HistoryManager.with_context(name: :irb) do
+      Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: :irb) do
         Rex::Ui::Text::IrbShell.new(client).run
       end
     else
@@ -639,7 +639,7 @@ class Console::CommandDispatcher::Core
     print_status("You are in the \"client\" (session) object\n")
 
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(history_file: Msf::Config.pry_history, name: :pry) do
       client.pry
     end
   end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'singleton'
+
 module Rex
 module Ui
 module Text
@@ -7,121 +9,162 @@ module Shell
 
 class HistoryManager
 
+  include Singleton
+
   MAX_HISTORY = 2000
 
-  @@contexts = []
-
-  @@write_mutex = Mutex.new
-  @@write_queue = {}
-
-  def self.inspect
-    "#<HistoryManager stack size: #{@@contexts.length}>"
+  def initialize
+    @contexts = []
+    @write_mutex = Mutex.new
+    @write_queue = {}
+    @debug = false
   end
 
-  def self.context_stack
-    @@contexts
-  end
-
-  def self.push_context(history_file: nil, name: nil)
-    dlog("HistoryManager.push_context name: #{name.inspect}")
-    new_context = { history_file: history_file, name: name }
-
-    switch_context(new_context, @@contexts.last)
-    @@contexts.push(new_context)
-  end
-
-  def self.pop_context
-    if @@contexts.empty?
-      elog("HistoryManager.pop_context called even when the stack was already empty!")
-      return
-    end
-
-    old_context = @@contexts.pop
-    switch_context(@@contexts.last, old_context)
-
-    dlog("HistoryManager.pop_context name: #{old_context&.fetch(:name, nil).inspect}")
-  end
-
-  def self.with_context(**kwargs, &block)
-    push_context(**kwargs)
+  # Create a new history command context when executing the given block
+  #
+  # @param [String,nil] history_file The file to load and persist commands to
+  # @param [String] name Human readable history context name
+  # @param [Proc] block
+  # @return [nil]
+  def with_context(history_file: nil, name: nil, &block)
+    push_context(history_file: history_file, name: name)
 
     begin
       block.call
     ensure
       pop_context
     end
+
+    nil
   end
 
-  def self.flush
-    sleep 0.1 until @@write_queue.empty?
+  # Flush the contents of the write queue to disk. Blocks synchronously.
+  def flush
+    sleep 0.1 until @write_queue.empty?
+
+    nil
   end
 
-  class << self
-    private
+  def inspect
+    "#<HistoryManager stack size: #{@contexts.length}>"
+  end
 
-    def clear_readline
-      Readline::HISTORY.length.times { Readline::HISTORY.pop }
+  def _contexts
+    @contexts
+  end
+
+  def _debug=(value)
+    @debug = value
+  end
+
+  private
+
+  def debug?
+    @debug
+  end
+
+  def push_context(history_file: nil, name: nil)
+    $stderr.puts("Push context before\n#{JSON.pretty_generate(_contexts)}") if debug?
+    new_context = { history_file: history_file, name: name }
+
+    switch_context(new_context, @contexts.last)
+    @contexts.push(new_context)
+    $stderr.puts("Push context after\n#{JSON.pretty_generate(_contexts)}") if debug?
+
+    nil
+  end
+
+  def pop_context
+    $stderr.puts("Pop context before\n#{JSON.pretty_generate(_contexts)}") if debug?
+    return if @contexts.empty?
+
+    old_context = @contexts.pop
+    $stderr.puts("Pop context after\n#{JSON.pretty_generate(_contexts)}") if debug?
+    switch_context(@contexts.last, old_context)
+
+    nil
+  end
+
+  def readline_available?
+    defined?(::Readline)
+  end
+
+  def clear_readline
+    return unless readline_available?
+
+    ::Readline::HISTORY.length.times { ::Readline::HISTORY.pop }
+  end
+
+  def load_history_file(history_file)
+    return unless readline_available?
+
+    clear_readline
+    commands = from_storage_queue(history_file)
+    if commands
+      commands.reverse.each do |c|
+        ::Readline::HISTORY << c
+      end
+    else
+      if File.exist?(history_file)
+        File.readlines(history_file).each do |e|
+          ::Readline::HISTORY << e.chomp
+        end
+      end
+    end
+  end
+
+  def store_history_file(history_file)
+    return unless readline_available?
+    cmds = []
+    history_diff = ::Readline::HISTORY.length < MAX_HISTORY ? ::Readline::HISTORY.length : MAX_HISTORY
+    history_diff.times do
+      entry = ::Readline::HISTORY.pop
+      cmds.push(entry) unless entry.nil?
     end
 
-    def load_history_file(history_file)
+    write_history_file(history_file, cmds)
+  end
+
+  def switch_context(new_context, old_context=nil)
+    if old_context && old_context[:history_file]
+      store_history_file(old_context[:history_file])
+    end
+
+    if new_context && new_context[:history_file]
+      load_history_file(new_context[:history_file])
+    else
       clear_readline
-      if commands = from_storage_queue(history_file)
-        commands.reverse.each do |c|
-          Readline::HISTORY << c
-        end
-      else
-        if File.exist?(history_file)
-          File.readlines(history_file).each do |e|
-            Readline::HISTORY << e.chomp
-          end
-        end
-      end
     end
+  rescue SignalException => e
+    clear_readline
+  end
 
-    def store_history_file(history_file)
-      cmds = []
-      history_diff = Readline::HISTORY.length < MAX_HISTORY ? Readline::HISTORY.length : MAX_HISTORY
-      history_diff.times do
-        cmds.push(Readline::HISTORY.pop)
-      end
-
-      write_history_file(history_file, cmds)
-    end
-
-    def switch_context(new_context, old_context=nil)
-      if old_context&.fetch(:history_file, nil)
-        store_history_file(old_context[:history_file])
-      end
-
-      if new_context&.fetch(:history_file, nil)
-        load_history_file(new_context[:history_file])
-      else
-        clear_readline
-      end
-    rescue SignalException => e
-      clear_readline
-    end
-
-    def write_history_file(history_file, cmds)
-      @@write_mutex.synchronize do
-        @@write_queue[history_file] = cmds
-      end
-
-      Rex::ThreadFactory.spawn("#{history_file} Writer", false) do
-        File.open(history_file, 'w+') do |f|
-          f.puts(cmds.reverse)
-        end
-
-        @@write_mutex.synchronize do
-          @@write_queue.delete(history_file)
+  def write_history_file(history_file, cmds)
+    entry_added = false
+    until entry_added
+      @write_mutex.synchronize do
+        if @write_queue[history_file].nil?
+          @write_queue[history_file] = cmds
+          entry_added = true
         end
       end
+      sleep 0.1 if !entry_added
     end
 
-    def from_storage_queue(history_file)
-      @@write_mutex.synchronize do
-        @@write_queue[history_file]
+    Rex::ThreadFactory.spawn("#{history_file} Writer", false) do
+      File.open(history_file, 'wb+') do |f|
+        f.puts(cmds.reverse)
       end
+
+      @write_mutex.synchronize do
+        @write_queue.delete(history_file)
+      end
+    end
+  end
+
+  def from_storage_queue(history_file)
+    @write_mutex.synchronize do
+      @write_queue[history_file]
     end
   end
 end

--- a/spec/lib/rex/ui/text/shell/history_manager_spec.rb
+++ b/spec/lib/rex/ui/text/shell/history_manager_spec.rb
@@ -1,0 +1,127 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+require 'rex/ui/text/shell/history_manager'
+
+RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
+  subject { described_class.send(:new) }
+  let(:readline_available) { false }
+
+  before(:each) do
+    allow(subject).to receive(:readline_available?).and_return(readline_available)
+  end
+
+  describe '#with_context' do
+    context 'when there is not an existing stack' do
+      it 'continues to have an empty stack' do
+        subject.with_context {
+          # noop
+        }
+        expected_contexts = [
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+
+      it 'yields and starts a new history context' do
+        (expect do |block|
+          subject.with_context(name: 'a') do
+            expected_contexts = [
+              { history_file: nil, name: 'a' },
+            ]
+            expect(subject._contexts).to eq(expected_contexts)
+            block.to_proc.call
+          end
+        end).to yield_control.once
+      end
+    end
+
+    context 'when there is an existing stack' do
+      before(:each) do
+        subject.send(:push_context, history_file: nil, name: 'a')
+      end
+
+      it 'continues to have the previous existing stack' do
+        subject.with_context {
+          # noop
+        }
+        expected_contexts = [
+          { history_file: nil, name: 'a' },
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+
+      it 'yields and starts a new history context' do
+        (expect do |block|
+          subject.with_context(name: 'b') do
+            expected_contexts = [
+              { history_file: nil, name: 'a' },
+              { history_file: nil, name: 'b' },
+            ]
+            expect(subject._contexts).to eq(expected_contexts)
+            block.to_proc.call
+          end
+        end).to yield_control.once
+      end
+
+      it 'continues to have the previous stack when an exception is raised' do
+        expect do
+          subject.with_context {
+            raise ArgumentError, 'Mock error'
+          }
+        end.to raise_exception ArgumentError, 'Mock error'
+        expected_contexts = [
+          { history_file: nil, name: 'a' },
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+    end
+  end
+
+  describe '#push_context' do
+    context 'when the stack is empty' do
+      it 'stores the history contexts' do
+        subject.send(:push_context, history_file: nil, name: 'a')
+        expected_contexts = [
+          { history_file: nil, name: 'a' }
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+    end
+
+    context 'when multiple values are pushed' do
+      it 'stores the history contexts' do
+        subject.send(:push_context, history_file: nil, name: 'a')
+        subject.send(:push_context, history_file: nil, name: 'b')
+        subject.send(:push_context, history_file: nil, name: 'c')
+        expected_contexts = [
+          { history_file: nil, name: 'a' },
+          { history_file: nil, name: 'b' },
+          { history_file: nil, name: 'c' },
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+    end
+  end
+
+  describe '#pop_context' do
+    context 'when the stack is empty' do
+      it 'continues to have an empty stack' do
+        subject.send(:pop_context)
+        expected_contexts = [
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+    end
+
+    context 'when the stack is not empty' do
+      it 'continues to have an empty stack' do
+        subject.send(:push_context, history_file: nil, name: 'a')
+        subject.send(:push_context, history_file: nil, name: 'b')
+        subject.send(:pop_context)
+        expected_contexts = [
+          { history_file: nil, name: 'a' },
+        ]
+        expect(subject._contexts).to eq(expected_contexts)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes broken msfconsole command history management when switching between shell sessions

Changes https://github.com/rapid7/metasploit-framework/pull/15062

## Verification

### Verifying history tracking

Verify msfconsole's history works:
- Open msfconsole
- type `echo "this is msfconsole history"` and press enter
- close msfconsole
- Reopen msfconsole and verify pressing the up arrow shows `echo "this is msfconsole history"`

Verify swapping between shells works:
- Open and interact with a new Meterpreter session
- Verify the history works
- Background the session, and verify pressing the up arrow shows the session interaction and eventually `echo "this is msfconsole history"`

- Verify swapping between a command shell session works (i.e. `osx/x86/shell_reverse_tcp`)
- Verify backgrounding the session will keep the top level history working

### Verifying _historymanager command

Enable the manager commands:

```
msf6 > features set manager_commands true
manager_commands => true
msf6 > features

Features table
==============

   #  Name                      Enabled  Description
   -  ----                      -------  -----------
...
   2  manager_commands          true     When enabled you will have access to manager commands such as _servicemanager and _historymanager
...

msf6 >
```

Verify you can now see the history context stack:

```
msf6 > _historymanager 
History contexts
================

 Id  File                       Name
 --  ----                       ----
 0   /Users/user/.msf4/history  msfconsole

```

Verify you can enable the history logging:
```
msf6 > _historymanager -d
[*] HistoryManager debugging is now on
```

And the stack push/pops are now logged to stderr:
```
msf6 payload(osx/x64/shell_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

Push context before
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  }
]
Push context after
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  },
  {
    "history_file": null,
    "name": "shell"
  }
]

background

Background session 1? [y/N]  y
Pop context before
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  },
  {
    "history_file": null,
    "name": "shell"
  }
]
Pop context after
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  }
]


msf6 payload(osx/x64/meterpreter_reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

Push context before
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  }
]
Push context after
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  },
  {
    "history_file": "/Users/user/.msf4/meterpreter_history",
    "name": "meterpreter"
  }
]
meterpreter > irb
[*] Starting IRB shell...
[*] You are in the "client" (session) object

Push context before
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  },
  {
    "history_file": "/Users/user/.msf4/meterpreter_history",
    "name": "meterpreter"
  }
]
Push context after
[
  {
    "history_file": "/Users/user/.msf4/history",
    "name": "msfconsole"
  },
  {
    "history_file": "/Users/user/.msf4/meterpreter_history",
    "name": "meterpreter"
  },
  {
    "history_file": null,
    "name": "irb"
  }
]
irb: warn: can't alias kill from irb_kill.
irb: warn: can't alias info from irb_debug_info.
>>
```

