### PR TITLE
Fix invalid references in modules

### DIFF
--- a/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
@@ -17,7 +17,7 @@ module MetasploitModule
       'Name'          => 'BSD x64 Command Shell, Bind TCP Inline (IPv6)',
       'Description'   => 'Listen for a connection and spawn a command shell over IPv6',
       'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
-      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_ipv6_bind_tcp.asm.c'],
+      'References'    => [['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_ipv6_bind_tcp.asm.c']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'bsd',
       'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
@@ -17,7 +17,7 @@ module MetasploitModule
       'Name'          => 'BSD x64 Command Shell, Bind TCP Inline',
       'Description'   => 'Listen for a connection and spawn a command shell',
       'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
-      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_bind_tcp.asm.c'],
+      'References'    => [['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_bind_tcp.asm.c']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'bsd',
       'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
@@ -17,7 +17,7 @@ module MetasploitModule
       'Name'          => 'BSD x64 Command Shell, Reverse TCP Inline (IPv6)',
       'Description'   => 'Connect back to attacker and spawn a command shell over IPv6',
       'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
-      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_ipv6_reverse_tcp.asm.c'],
+      'References'    => [['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_ipv6_reverse_tcp.asm.c']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'bsd',
       'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
@@ -17,7 +17,7 @@ module MetasploitModule
       'Name'          => 'BSD x64 Command Shell, Reverse TCP Inline',
       'Description'   => 'Connect back to attacker and spawn a command shell',
       'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
-      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_reverse_tcp.asm.c'],
+      'References'    => [['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_reverse_tcp.asm.c']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'bsd',
       'Arch'          => ARCH_X64,

--- a/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
@@ -17,7 +17,7 @@ module MetasploitModule
       'Name'          => 'Linux ARM Big Endian Command Shell, Bind TCP Inline',
       'Description'   => 'Listen for a connection and spawn a command shell',
       'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
-      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/armeb_linux_ipv4_bind_tcp.s'],
+      'References'    => [['URL', 'https://github.com/earthquake/shellcodes/blob/master/armeb_linux_ipv4_bind_tcp.s']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_ARMBE,

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -19,7 +19,7 @@ module MetasploitModule
       },
       'Author'        => 'Geyslan G. Bem <geyslan[at]gmail.com>',
       'License'       => BSD_LICENSE,
-      'References'    => ['URL', 'https://github.com/geyslan/SLAE/blob/master/improvements/tiny_shell_bind_tcp_random_port_x86_64.asm'],
+      'References'    => [['URL', 'https://github.com/geyslan/SLAE/blob/master/improvements/tiny_shell_bind_tcp_random_port_x86_64.asm']],
       'Platform'      => 'linux',
       'Arch'          => ARCH_X64
     ))

--- a/modules/payloads/singles/windows/shell_hidden_bind_tcp.rb
+++ b/modules/payloads/singles/windows/shell_hidden_bind_tcp.rb
@@ -26,7 +26,7 @@ module MetasploitModule
           'Borja Merino <bmerinofe[at]gmail.com>' # Add Hidden ACL functionality
         ],
       'License'       => MSF_LICENSE,
-      'References'    => ['URL', 'http://www.shelliscoming.com/2014/03/hidden-bind-shell-keep-your-shellcode.html'],
+      'References'    => [['URL', 'http://www.shelliscoming.com/2014/03/hidden-bind-shell-keep-your-shellcode.html']],
       'Platform'      => 'win',
       'Arch'          => ARCH_X86,
       'Handler'       => Msf::Handler::BindTcp,

--- a/modules/payloads/stagers/windows/bind_hidden_ipknock_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_hidden_ipknock_tcp.rb
@@ -32,7 +32,7 @@ module MetasploitModule
           'Borja Merino <bmerinofe[at]gmail.com>' # Add Hidden Ipknock functionality
         ],
       'License'       => MSF_LICENSE,
-      'References'    => ['URL', 'http://www.shelliscoming.com/2014/07/ip-knock-shellcode-spoofed-ip-as.html'],
+      'References'    => [['URL', 'http://www.shelliscoming.com/2014/07/ip-knock-shellcode-spoofed-ip-as.html']],
       'Platform'      => 'win',
       'Arch'          => ARCH_X86,
       'Handler'       => Msf::Handler::BindTcp,

--- a/modules/payloads/stagers/windows/bind_hidden_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_hidden_tcp.rb
@@ -28,7 +28,7 @@ module MetasploitModule
           'Borja Merino <bmerinofe[at]gmail.com>' # Add Hidden ACL functionality
         ],
       'License'       => MSF_LICENSE,
-      'References'    => ['URL', 'http://www.shelliscoming.com/2014/03/hidden-bind-shell-keep-your-shellcode.html'],
+      'References'    => [['URL', 'http://www.shelliscoming.com/2014/03/hidden-bind-shell-keep-your-shellcode.html']],
       'Platform'      => 'win',
       'Arch'          => ARCH_X86,
       'Handler'       => Msf::Handler::BindTcp,

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -32,7 +32,7 @@ module MetasploitModule
         'Platform' => 'win',
         'Arch' => ARCH_X86,
         'References' => [
-          'https://github.com/EgeBalci/Amber'
+          ['URL', 'https://github.com/EgeBalci/Amber']
         ],
         'PayloadCompat' => {
           'Convention' => 'sockedi handleedi -http -https'

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -29,7 +29,7 @@ module MetasploitModule
           'ege <egebalci[at]pm.me>'
         ],
         'References' => [
-          'https://github.com/EgeBalci/Amber'
+          ['URL', 'https://github.com/EgeBalci/Amber']
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',


### PR DESCRIPTION
Fixes multiple missing/invalid references in modules

Spotted as part of reviewing https://github.com/rapid7/metasploit-framework/pull/18225

I applied this patch locally to log out the invalid modules, but we should probably have this wired up better for catching future mistakes

```patch
diff --git a/lib/msf/core/module/module_info.rb b/lib/msf/core/module/module_info.rb
index 7bae76896d..6b0783369b 100644
--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -69,6 +69,7 @@ module Msf::Module::ModuleInfo
     if(refs and not refs.empty?)
       refs.each_index do |i|
         if !(refs[i].respond_to?('[]') and refs[i].length == 2)
+          $stderr.puts "invalid #{self.method(:initialize).source_location[0]} refs! #{refs.inspect}"
           refs[i] = nil
         end
       end
```

## Verification

- Verify CI passes
- Verify the changes make sense