### PR TITLE
Fixes invalid references in modules not being detected

### DIFF
--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -69,6 +69,7 @@ module Msf::Module::ModuleInfo
     if(refs and not refs.empty?)
       refs.each_index do |i|
         if !(refs[i].respond_to?('[]') and refs[i].length == 2)
+          $stderr.puts "invalid #{self.method(:initialize).source_location[0]} refs! #{refs.inspect}"
           refs[i] = nil
         end
       end


### PR DESCRIPTION
This PR adds a fix to detect invalid references in modules.

See [this](https://github.com/rapid7/metasploit-framework/pull/18225) PR for more context.

## Verification

List the steps needed to make sure this thing works

- [ ] Ensure code changes are sane
- [ ] Verify CI passes
