### PR TITLE
fix for issue #18219, allow index selection for favorites

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1434,14 +1434,30 @@ module Msf
               return
             end
 
-            # create module set using the saved modules
-            fav_modules = {}
-            saved_favs = File.readlines(favs_file)
-            saved_favs.each do |mod|
-              module_name = mod.strip
-              fav_modules[module_name] = framework.modules[module_name]
+            # get the full module names from the favorites file and use then to search the MetaData Cache for matching modules
+            saved_favs = File.readlines(favs_file).map(&:strip)
+            @module_search_results = Msf::Modules::Metadata::Cache.instance.find('fullname' => [saved_favs, []])
+
+            count = -1
+            tbl = generate_module_table('Favorite Modules')
+
+            @module_search_results.each do |m|
+              tbl << [
+                  count += 1,
+                  m.fullname,
+                  m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
+                  m.rank,
+                  m.check ? 'Yes' : 'No',
+                  m.name,
+              ]
             end
-            show_module_metadata('Favorites', fav_modules)
+
+            print_line(tbl.to_s)
+            index_usage = "use #{@module_search_results.length - 1}"
+            index_info = "info #{@module_search_results.length - 1}"
+            name_usage = "use #{@module_search_results.last.fullname}"
+
+            print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
           end
 
           def show_missing(mod) # :nodoc:


### PR DESCRIPTION
# About
This change adds index selection for the modules returned via the `favorites`  (or `show favorites`) command. This feature was requested in https://github.com/rapid7/metasploit-framework/issues/18219 . I have used the search approach as for the `search` command. Because of that, there is a bit of code reuse for printing the table and the info lines below it, so let me know if you'd like me to move those to a common method.

# Example
```
msf6 > favorites

Favorite Modules
================

   #  Name                        Disclosure Date  Rank    Check  Description
   -  ----                        ---------------  ----    -----  -----------
   0  exploit/multi/handler                        manual  No     Generic Payload Handler
   1  exploit/windows/smb/psexec  1999-01-01       manual  No     Microsoft Windows Authenticated User Code Execution


Interact with a module by name or index. For example info 1, use 1 or use exploit/windows/smb/psexec

msf6 > use 1
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > use 0
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > 
```
