### PR TITLE
Fix for issue #13724: fix crash for unloaded user32.dll: add library loading

### DIFF
--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -183,9 +183,12 @@ module MetasploitModule
       jmp next_mod
       start_main:
       pop rbp
+      lea rcx,qword ptr ds:[rbp + #{exitfunc.length + datastore['TEXT'].length + datastore['TITLE'].length + 0x105}]
+      mov r10d, #{api_hash('kernel32.dll', 'LoadLibraryA')}
+      call rbp
       mov r9, #{style}
-      lea rdx,qword ptr ds:[rbp + #{exitfunc.length + 0xf3}]
-      lea r8,qword ptr ds:[rbp + #{exitfunc.length + datastore['TEXT'].length + 0xf4}]
+      lea rdx,qword ptr ds:[rbp + #{exitfunc.length + 0x103}]
+      lea r8,qword ptr ds:[rbp + #{exitfunc.length + datastore['TEXT'].length + 0x104}]
       xor rcx,rcx
       mov r10d, #{api_hash('user32.dll', 'MessageBoxA')}
       call rbp
@@ -195,6 +198,7 @@ module MetasploitModule
     payload_data << exitfunc
     payload_data << datastore['TEXT'] + "\x00"
     payload_data << datastore['TITLE'] + "\x00"
+    payload_data << "user32.dll" + "\x00"
 
     return payload_data
   end

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 295
+  CachedSize = 322
 
   include Msf::Payload::Windows
   include Msf::Payload::Single


### PR DESCRIPTION
Fix `windows/x64/messagebox` shellcode segfault when loading in process that does not have `user32.dll`.

This issue mentioned here #13724 

## Verification

* Generate payload and execute it.
`msfvenom -p windows/x64/messagebox -f exe > test.exe`
