### PR TITLE
Reset password list file descriptor for later use

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -113,6 +113,7 @@ module Metasploit::Framework
           pass_from_file.chomp!
           yield Metasploit::Framework::Credential.new(private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
         end
+        pass_fd.seek(0)
       end
       additional_privates.each do |add_private|
         yield Metasploit::Framework::Credential.new(private: add_private, realm: realm, private_type: private_type(add_private))
@@ -243,6 +244,7 @@ module Metasploit::Framework
             pass_from_file.chomp!
             yield Metasploit::Framework::Credential.new(public: username, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
           end
+          pass_fd.seek(0)
         end
         additional_privates.each do |add_private|
           yield Metasploit::Framework::Credential.new(public: username, private: add_private, realm: realm, private_type: private_type(add_private))

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -120,6 +120,37 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       end
     end
 
+    context 'when given a username, user_file and pass_file' do
+      let(:password) { nil }
+      let(:username) { 'my_username' }
+      let(:user_file) do
+        filename = "user_file"
+        stub_file = StringIO.new("asdf\njkl\n")
+        allow(File).to receive(:open).with(filename, /^r/).and_yield stub_file
+
+        filename
+      end
+
+      let(:pass_file) do
+        filename = "pass_file"
+        stub_file = StringIO.new("asdf\njkl\n")
+        allow(File).to receive(:open).with(filename, /^r/).and_return stub_file
+
+        filename
+      end
+
+      it do
+        expect { |b| collection.each(&b) }.to yield_successive_args(
+                                                Metasploit::Framework::Credential.new(public: "my_username", private: "asdf"),
+                                                Metasploit::Framework::Credential.new(public: "my_username", private: "jkl"),
+                                                Metasploit::Framework::Credential.new(public: "asdf", private: "asdf"),
+                                                Metasploit::Framework::Credential.new(public: "asdf", private: "jkl"),
+                                                Metasploit::Framework::Credential.new(public: "jkl", private: "asdf"),
+                                                Metasploit::Framework::Credential.new(public: "jkl", private: "jkl")
+                                              )
+      end
+    end
+
     context "when :user_as_pass is true" do
       let(:user_as_pass) { true }
       specify  do


### PR DESCRIPTION
Ran into an issue where when setting `USERNAME`, `USER_FILE` and `PASS_FILE` the first username in the `USER_FILE` would not be tested against any password in `PASS_FILE`
This was due to the file descriptor for the `PASS_FILE` not being reset for later iterations, this PR addresses that

# Verification steps
- [ ] Use any login scanner
- [ ] set `USERNAME` to a distinct name
- [ ] set `USER_FILE` to a file containing two usernames
- [ ] set `PASS_FILE` to a file containing two passwords
- [ ] `set verbose true`
- [ ] run the module
- [ ] All 3 usernames (1 from `USERNAME`, 2 from `USER_FILE`) should be ran against both passwords from `PASS_FILE`, for a total of 6 login attempts
