### PR TITLE
Add version numbers to apache nifi rce module

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -32,7 +32,7 @@ If authentication is required, then the `USERNAME` and `PASSWORD` options can be
 complex authentication flow is required (such as OpenId Connect), or a session token has already been obtained, a session token in the form
 of a JWT can be set using the `TOKEN` option. This module does not support authentication using a client certificate.
 
-Verified against 1.12.0, 1.12.1-RC2, and 1.20.0
+Verified against 1.12.1, 1.12.1-RC2, and 1.20.0
 
 ### Configuring a Vulnerable Environment
 

--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -32,6 +32,8 @@ If authentication is required, then the `USERNAME` and `PASSWORD` options can be
 complex authentication flow is required (such as OpenId Connect), or a session token has already been obtained, a session token in the form
 of a JWT can be set using the `TOKEN` option. This module does not support authentication using a client certificate.
 
+Verified against 1.12.0, 1.12.1-RC2, and 1.20.0
+
 ### Configuring a Vulnerable Environment
 
 #### Windows

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -5,7 +5,6 @@
 
 # Potential Improvements:
 # Add option to authenticate using client certificate
-# Add a scanner module?
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -23,6 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
           be unsecured (or credentials provided) and the ExecuteProcess processor must be available. An ExecuteProcessor
           processor is created then is configured with the payload and started. The processor is then stopped and
           deleted.
+
+          Verified against 1.12.1, 1.12.1-RC2, and 1.20.0
         },
         'License' => MSF_LICENSE,
         'Author' => ['Graeme Robinson'],


### PR DESCRIPTION
This PR adds version numbers to the apache nifi RCE module.  The 2 lower versions were found in the PR and docs, the 1.20.0 I tested today and it still works (its a feature!)