### PR TITLE
Fix appscan import failure on empty proof

### DIFF
--- a/lib/rex/parser/appscan_document.rb
+++ b/lib/rex/parser/appscan_document.rb
@@ -87,7 +87,7 @@ module Rex
       web_vuln_info[:method] = form_info[:method]
       web_vuln_info[:params] = form_info[:params]
       web_vuln_info[:pname] = @state[:issue][:vuln_param]
-      web_vuln_info[:proof] = "" # TODO: pick this up from <Difference> maybe?
+      web_vuln_info[:proof] = "unknown" # TODO: pick this up from <Difference> maybe?
       web_vuln_info[:risk] = @state[:issue][:risk]
       web_vuln_info[:name] = @state[:issue]["IssueTypeID"]
       web_vuln_info[:category] = "imported"


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/14209

## Verification

Verify the appscan import now works; Previously the following error would be raised:

```
[-] Error while running command db_import: Validation failed: Proof can't be blank

Call stack:
/home/gwillcox/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/validations.rb:80:in `raise_validation_error'
```

Now there's no error