### PR TITLE
Update payload size warnings to errors on CI

### DIFF
--- a/lib/msf/core/handler/bind_aws_instance_connect.rb
+++ b/lib/msf/core/handler/bind_aws_instance_connect.rb
@@ -48,7 +48,7 @@ module BindAwsInstanceConnect
 
     register_options(
       [
-        OptString.new('EC2_ID', [true, 'The EC2 ID of the instance ', nil]),
+        OptString.new('EC2_ID', [true, 'The EC2 ID of the instance ', '']),
         OptString.new('REGION', [true, 'AWS region containing the instance', 'us-east-1']),
         OptString.new('ACCESS_KEY_ID', [false, 'AWS access key', nil]),
         OptString.new('SECRET_ACCESS_KEY', [false, 'AWS secret key', nil]),

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -630,6 +630,26 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/unix/bind_awk'
   end
 
+  context 'cmd/unix/bind_aws_instance_connect' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/unix/bind_aws_instance_connect'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/bind_aws_instance_connect'
+  end
+
+  context 'cmd/unix/adduser' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/cmd/unix/adduser'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/adduser'
+  end
+
   context 'cmd/unix/bind_busybox_telnetd' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -1394,6 +1414,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/shell_bind_tcp'
+  end
+
+  context 'generic/shell_bind_aws_ssm' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/generic/shell_bind_aws_ssm'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'generic/shell_bind_aws_ssm'
   end
 
   context 'generic/shell_reverse_tcp' do
@@ -2178,6 +2208,47 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_reverse_tcp_ssl'
+  end
+
+  context 'osx/aarch64/meterpreter/reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'stagers/osx/aarch64/reverse_tcp',
+                            'stages/osx/aarch64/meterpreter'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/aarch64/meterpreter/reverse_tcp'
+  end
+
+  context 'osx/aarch64/meterpreter_reverse_http' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/osx/aarch64/meterpreter_reverse_http'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/aarch64/meterpreter_reverse_http'
+  end
+
+  context 'osx/aarch64/meterpreter_reverse_https' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/osx/aarch64/meterpreter_reverse_https'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/aarch64/meterpreter_reverse_https'
+  end
+
+  context 'osx/aarch64/meterpreter_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/osx/aarch64/meterpreter_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/aarch64/meterpreter_reverse_tcp'
   end
 
   context 'osx/armle/execute/bind_tcp' do

--- a/spec/support/shared/contexts/untested_payloads.rb
+++ b/spec/support/shared/contexts/untested_payloads.rb
@@ -59,20 +59,6 @@ RSpec.shared_context 'untested payloads' do |options={}|
   after(:context) do
     missing_ancestor_reference_name_set = @expected_ancestor_reference_name_set - @actual_ancestor_reference_name_set
 
-    untested_payloads_pathname = Pathname.new('log/untested-payloads.log')
-
-    if missing_ancestor_reference_name_set.empty?
-      if untested_payloads_pathname.exist?
-        untested_payloads_pathname.delete
-      end
-    else
-      untested_payloads_pathname.open('w') do |f|
-        missing_ancestor_reference_name_set.sort.each do |missing_ancestor_reference_name|
-          f.puts missing_ancestor_reference_name
-        end
-      end
-
-      $stderr.puts "Some payloads are untested.  See log/untested-payload.log for details."
-    end
+    expect(missing_ancestor_reference_name_set).to be_empty, "Some payloads are untested: #{missing_ancestor_reference_name_set.join(', ')}. Please update `modules/payloads_spec.rb` with the payload definitions"
   end
 end


### PR DESCRIPTION
This PR updates payload size warnings to errors on CI. Previously when new payloads are added - users normally forget to update `modules/payloads_spec.rb` with the payload definitions, and then someone has to come along later to manually update the file.

Now CI will fail with an error:
```
An error occurred in an `after(:context)` hook.
Failure/Error: raise "Some payloads are untested.  See log/untested-payload.log for details."

RuntimeError:
  Some payloads are untested.  See log/untested-payload.log for details.
```

## Verification

- [ ] Verify code changes are sane
- [ ] Ensure CI goes green
- [ ] Run `bundle exec rspec ./spec/modules/payloads_spec.rb` and ensure no errors are raised