### PR TITLE
Fix bootsnap warning when booting msfrpc service

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -91,8 +91,8 @@ begin
   }
   invalidate_bootsnap_cache!(bootsnap_config)
   Bootsnap.setup(**bootsnap_config)
-rescue
-  $stderr.puts 'Warning: Failed bootsnap cache setup'
+rescue => e
+  $stderr.puts "Warning: Failed bootsnap cache setup - #{e.class} #{e} #{e.backtrace}"
   begin
     FileUtils.rm_rf(cache_dir, secure: true)
   rescue

--- a/msf-json-rpc.ru
+++ b/msf-json-rpc.ru
@@ -7,7 +7,7 @@ require 'pathname'
 @framework_path = File.expand_path(File.dirname(__FILE__))
 root = Pathname.new(@framework_path).expand_path
 @framework_lib_path = root.join('lib')
-$LOAD_PATH << @framework_lib_path unless $LOAD_PATH.include?(@framework_lib_path)
+$LOAD_PATH << @framework_lib_path.to_path unless $LOAD_PATH.include?(@framework_lib_path)
 
 require 'msfenv'
 

--- a/msf-ws.ru
+++ b/msf-ws.ru
@@ -5,7 +5,7 @@ require 'pathname'
 @framework_path = '.'
 root = Pathname.new(@framework_path).expand_path
 @framework_lib_path = root.join('lib')
-$LOAD_PATH << @framework_lib_path unless $LOAD_PATH.include?(@framework_lib_path)
+$LOAD_PATH << @framework_lib_path.to_path unless $LOAD_PATH.include?(@framework_lib_path)
 
 require 'msfenv'
 


### PR DESCRIPTION
Spotted as part of testing https://github.com/rapid7/metasploit-framework/issues/18241

Before when booting up the msfrpc service you get the following error:
```
Warning: Failed bootsnap cache setup
```

Detailed error:
```
Caused by TypeError: no implicit conversion of Pathname into String
from /Users/adfoster/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/loaded_features_index.rb:39:in `start_with?'
```

Caused by the loadpath containing pathname objects:
```
[7] pry(main)> $LOAD_PATH
=> ["/Users/user/Documents/code/metasploit-framework/lib",
 ....
 "/Users/user/.rvm/rubies/ruby-3.0.5/lib/ruby/3.0.0",
 "/Users/user/.rvm/rubies/ruby-3.0.5/lib/ruby/3.0.0/x86_64-darwin20",
 #<Pathname:/Users/user/Documents/code/metasploit-framework/lib>] <--- Issue
```

## Verification

Verify the msfrpc service doesn't produce warnings:

```
bundle exec thin --rackup msf-json-rpc.ru --address 0.0.0.0 --port 8081 --environment production --tag msf-json-rpc start
```

