### PR TITLE
Give better error messages when failing to load mettle extensions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 2.0.148)
       metasploit_data_models
-      metasploit_payloads-mettle (= 1.0.25)
+      metasploit_payloads-mettle (= 1.0.26)
       mqtt
       msgpack (~> 1.6.0)
       nessus_rest
@@ -269,7 +269,7 @@ GEM
       railties (~> 7.0)
       recog
       webrick
-    metasploit_payloads-mettle (1.0.25)
+    metasploit_payloads-mettle (1.0.26)
     method_source (1.0.0)
     mini_portile2 (2.8.2)
     minitest (5.18.0)

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -353,7 +353,12 @@ class ClientCore < Extension
       # If client.sys isn't setup, it's a Windows meterpreter
       if client.respond_to?(:sys) && !client.sys.config.sysinfo['BuildTuple'].blank?
         # Query the payload gem directly for the extension image
-        image = MetasploitPayloads::Mettle.load_extension(client.sys.config.sysinfo['BuildTuple'], mod.downcase, suffix)
+        begin
+          image = MetasploitPayloads::Mettle.load_extension(client.sys.config.sysinfo['BuildTuple'], mod.downcase, suffix)
+        rescue MetasploitPayloads::Mettle::NotFoundError => e
+          elog(e)
+          image = nil
+        end
       else
         # Get us to the installation root and then into data/meterpreter, where
         # the file is expected to be

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '2.0.148'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.25'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components
   # Locked until build env can handle newer version. See: https://github.com/msgpack/msgpack-ruby/issues/334
   spec.add_runtime_dependency 'msgpack', '~> 1.6.0'


### PR DESCRIPTION
Pulls in https://github.com/rapid7/mettle/pull/250

## Verification

Attempting to run the extapi test suite against linux meterpreter should no longer give the following error:

```diff
           linux: {
-            known_failures: [
-              "[-] Post failed: RuntimeError x86_64-linux-musl/extapi not found",
-              "[-] Call stack:",
-              "metasploit-framework/vendor/bundle/ruby/3.0.0/gems/metasploit_payloads-mettle-1.0.20/lib/metasploit_payloads/mettle.rb:205:in `load_extension'",
-              "metasploit-framework/lib/rex/post/meterpreter/client_core.rb:356:in `use'",
-              "metasploit-framework/test/modules/post/test/extapi.rb:32:in `setup'"
-            ]
+            known_failures: []
```

Ubuntu before:

```
msf6 post(test/extapi) > run session=-1

[-] Post failed: MetasploitPayloads::Mettle::NotFoundError i486-linux-musl/extapi. not found
[-] Call stack:
[-]   /home/a/.rvm/gems/ruby-3.1.2/gems/metasploit_payloads-mettle-1.0.26/lib/metasploit_payloads/mettle.rb:209:in `load_extension'
[-]   /home/a/metasploit-framework/lib/rex/post/meterpreter/client_core.rb:356:in `use'
[-]   /home/a/metasploit-framework/test/modules/post/test/extapi.rb:32:in `setup'
[*] Post module execution completed

```

Ubuntu after:

```
msf6 post(test/extapi) > run session=-1

[*] This module is only available in a windows meterpreter session.
[*] Running against session -1
[*] Session type is meterpreter and platform is linux
[*] SKIPPED: def test_clipboard_management (session platform is not windows)
[*] SKIPPED: def test_service_management (session platform is not windows)
[*] SKIPPED: def test_desktop_windows_management (session platform is not windows)
[*] Passed: 3; Failed: 0; Skipped: 3
[*] Post module execution completed
```