### PR TITLE
Makes some adjustments to the favorites command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -137,6 +137,15 @@ module Msf
             end
           end
 
+          # Handles the index selection formatting
+          def print_module_search_results_usage
+            index_usage = "use #{@module_search_results.length - 1}"
+            index_info = "info #{@module_search_results.length - 1}"
+            name_usage = "use #{@module_search_results.last.fullname}"
+
+            print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+          end
+
           #
           # Displays information about one or more module.
           #
@@ -520,11 +529,7 @@ module Msf
               }
             else
               print_line(tbl.to_s)
-              index_usage = "use #{@module_search_results.length - 1}"
-              index_info = "info #{@module_search_results.length - 1}"
-              name_usage = "use #{@module_search_results.last.fullname}"
-
-              print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+              print_module_search_results_usage
 
               print_status("Using #{used_module}") if used_module
             end
@@ -1434,30 +1439,27 @@ module Msf
               return
             end
 
+            # create module set using the saved modules
+            fav_modules = {}
+
             # get the full module names from the favorites file and use then to search the MetaData Cache for matching modules
             saved_favs = File.readlines(favs_file).map(&:strip)
-            @module_search_results = Msf::Modules::Metadata::Cache.instance.find('fullname' => [saved_favs, []])
-
-            count = -1
-            tbl = generate_module_table('Favorite Modules')
-
-            @module_search_results.each do |m|
-              tbl << [
-                  count += 1,
-                  m.fullname,
-                  m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
-                  m.rank,
-                  m.check ? 'Yes' : 'No',
-                  m.name,
-              ]
+            saved_favs.each do |mod|
+              # populate hash with module fullname and module object
+              fav_modules[mod] = framework.modules[mod]
             end
 
-            print_line(tbl.to_s)
-            index_usage = "use #{@module_search_results.length - 1}"
-            index_info = "info #{@module_search_results.length - 1}"
-            name_usage = "use #{@module_search_results.last.fullname}"
+            fav_modules.each do |fullname, mod_obj|
+              if mod_obj.nil?
+                print_warning("#{favs_file} contains a module that can not be found - #{fullname}.")
+              end
+            end
 
-            print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+            # find cache module instance and add it to @module_search_results
+            @module_search_results = Msf::Modules::Metadata::Cache.instance.find('fullname' => [saved_favs, []]).sort_by(&:fullname)
+
+            show_module_metadata('Favorites', fav_modules)
+            print_module_search_results_usage
           end
 
           def show_missing(mod) # :nodoc:


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18219.

This PR implements some feedback gave on #18231.

It tidies up some code duplication and adds error handling for the scenario of a module is ever delete whilst in a users favorites file.

## Verification

- [ ] Start `msfconsole`
- [ ] Favorite some modules - run `favorite` when using a module
- [ ] Then run `favorites` to see the list of favorites 
- [ ] Use the index selection method to jump between modules - `use 2`
- [ ] `Review` code changes