### PR TITLE
Improve tab completion for `set` command.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1995,13 +1995,25 @@ class Core
   # at least 1 when tab completion has reached this stage since the command itself has been completed
   def cmd_set_tabs(str, words)
     # A value has already been specified
-    return [] if words.length > 2
-
-    # A value needs to be specified
-    if words.length == 2
-      return tab_complete_option_values(active_module, str, words, opt: words[1])
+    if words.length > 3
+      return []
+    elsif words.length == 3 and words[1] != '-g' and words[1] != '--global'
+      return []
     end
-    tab_complete_option_names(active_module, str, words)
+
+    # A value needs to be specified, show tab completion options where possible
+    if words.length == 3 or (words.length == 2 and words[1][0] != '-')
+      return tab_complete_option_values(active_module, str, words, opt: words[-1])
+    end
+
+    option_names = tab_complete_option_names(active_module, str, words)
+    if words.length == 1
+      # Only the command has been provided, offer options which immediately follow the command
+      options = @@set_opts.option_keys.select { |opt| opt.start_with?(str) }
+      return options + option_names
+    end
+
+    option_names
   end
 
   def cmd_setg_help
@@ -2020,10 +2032,14 @@ class Core
   #   line. `words` is always at least 1 when tab completion has reached this
   #   stage since the command itself has been completed.
   def cmd_unset_tabs(str, words)
-    option_names = @@unset_opts.option_keys.select { |opt| opt.start_with?(str) }
     datastore_names = tab_complete_module_datastore_names(active_module, str, words)
+    if words.length == 1
+      # Only the command has been provided, offer options which immediately follow the command
+      options = @@unset_opts.option_keys.select { |opt| opt.start_with?(str) }
+      return options + datastore_names
+    end
 
-    option_names + datastore_names
+    datastore_names
   end
 
   #


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number. ✅ 

* Improve tab completion for `set` command.
* Also minor improvement for tab completion with the `unset` command.

Fixes #18217.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's. ✅ 

## Verification

List the steps needed to make sure this thing works

**NOTE:** that `<TAB>` seen below indicates pressing the tab key to initiate tab completion via the console.

- [ ] Start `msfconsole`
- [ ] test tab completion via `set <TAB><TAB>`
- [ ] **Verify** you see all options offered (including `-c`,`--clear`, `-g`, `--global`, `-h`, `--help`)
- [ ] test tab completion via `set Log<TAB>`
- [ ] **Verify** command is tab completed to become `set LogLevel`
- [ ] press enter to display current value of LogLevel
- [ ] test tab completion via `set -<TAB><TAB>`
- [ ]  **Verify** you see only `-c`,`--clear`, `-g`, `--global`, `-h`, and `--help` options offered
- [ ] type an additional `-<TAB><TAB>` (so that your command now looks like `set --<TAB><TAB>`)
- [ ]  **Verify** you see only `--clear`, `--global`, `--help` options offered
- [ ] type an additional `c<TAB>` to tab complete as `--clear`
- [ ] **Verify** your command is now `set --clear`
- [ ] type an additional `<TAB><TAB>`
- [ ]  **Verify** you see completion options for `ConsoleLogging`, `LogLevel`, `MeterpreterPrompt`, etc.
- [ ] type `L<TAB>`
- [ ] **Verify** command is tab completed to `set --clear LogLevel `
- [ ] press enter to clear LogLevel's value
- [ ] select the exploit multi handler module via `use exploit/multi/handler`
- [ ] type `set PAY<TAB>`
- [ ] **Verify** it tab completes to `set PAYLOAD`
- [ ]  type `<TAB><TAB>`
- [ ] **Verify** you are prompted to view all the available payloads
- [ ] type `n` to not list all PAYLOADS
- [ ] clear the command line (i.e. hit backspace a bunch)
- [ ] type `set LH<TAB>`
- [ ] **Verify** it tab completes to `set LHOST`
- [ ] press enter to show LHOST's value
- [ ]  type `set --clear LH<TAB>`
- [ ] **Verify** it tab completes to `set --clear LHOST`
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
  - N/A 
