### PR TITLE
Update java reverse http and https to be dynamic

### DIFF
--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5356
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 6165
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -570,7 +570,7 @@ RSpec.describe "Metasploit's json-rpc" do
               host: host_ip,
               analyze_options: {
                 payloads: [
-                  'java/meterpreter/reverse_http'
+                  'windows/meterpreter_reverse_http'
                 ]
               }
             }

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1492,7 +1492,7 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/reverse_http',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_http'
   end
@@ -1503,7 +1503,7 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/reverse_https',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_https'
   end


### PR DESCRIPTION
The Java reverse_http and reverse_https can actually change size due to the Zip compression handling the generated `stager_config` values differently.

Example `metasploit.dat` file inside of the Metasploit Jar file that would impact the size:

```
Spawn=2
HeaderUser-Agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0
URL=http://255.255.255.255:4444/20BHl
```

Example failure:

```
  1) modules/payloads java/meterpreter/reverse_http it should behave like payload cached size is consistent java/meterpreter/reverse_http has a valid cached_size
     Failure/Error: expect(pinst.cached_size).to eq(pinst.generate_simple(module_options).size)

       expected: 5355
            got: 5356

       (compared using ==)
     Shared Example Group: "payload cached size is consistent" called from ./spec/modules/payloads_spec.rb:1490
     # ./spec/support/shared/examples/payload_cached_size_is_consistent.rb:140:in `block (3 levels) in <top (required)>'
```

## Verification

Verify we're happy with the payload size