### PR TITLE
Add sasl scram 256 auth support to postgres modules

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ PATH
       mqtt
       msgpack (~> 1.6.0)
       nessus_rest
+      net-imap
       net-ldap
       net-smtp
       net-ssh
@@ -180,6 +181,7 @@ GEM
     cookiejar (0.3.3)
     crass (1.0.6)
     daemons (1.4.1)
+    date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -296,6 +298,9 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nessus_rest (0.1.6)
+    net-imap (0.3.7)
+      date
+      net-protocol
     net-ldap (0.18.0)
     net-protocol (0.2.1)
       timeout
@@ -496,7 +501,7 @@ GEM
     thor (1.2.2)
     tilt (2.2.0)
     timecop (0.9.6)
-    timeout (0.3.2)
+    timeout (0.4.0)
     ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/lib/postgres/buffer.rb
+++ b/lib/postgres/buffer.rb
@@ -11,7 +11,7 @@ module Db
 class Buffer
 
   class Error < RuntimeError; end
-  class EOF < Error; end 
+  class EOF < Error; end
 
   def self.from_string(str)
     new(str)
@@ -20,7 +20,7 @@ class Buffer
   def self.of_size(size)
     raise ArgumentError if size < 0
     new('#' * size)
-  end 
+  end
 
   def initialize(content)
     @size = content.size
@@ -34,6 +34,10 @@ class Buffer
 
   def position
     @position
+  end
+
+  def peek
+    @content[@position]
   end
 
   def position=(new_pos)
@@ -67,11 +71,11 @@ class Buffer
   def copy_from_stream(stream, n)
     raise ArgumentError if n < 0
     while n > 0
-      str = stream.read(n) 
+      str = stream.read(n)
       write(str)
       n -= str.size
     end
-    raise if n < 0 
+    raise if n < 0
   end
 
   NUL = "\000"

--- a/lib/postgres/postgres-pr/scram_sha_256.rb
+++ b/lib/postgres/postgres-pr/scram_sha_256.rb
@@ -1,0 +1,151 @@
+# -*- coding: binary -*-
+
+require 'base64'
+require 'openssl'
+require 'net/imap/sasl'
+
+# Namespace for Metasploit branch.
+module Msf
+module Db
+module PostgresPR
+
+# Implements SCRAM-SHA-256 authentication; The caller of #negotiate can additionally wrap the calculated authentication
+# models with SASL/GSSAPI as appropriate
+#
+# https://datatracker.ietf.org/doc/html/rfc7677#section-3
+class ScramSha256
+  class NormalizeError < ArgumentError
+  end
+
+  # @param [String] user
+  # @param [String] password
+  def negotiate(user, password)
+    random_nonce = b64(SecureRandom.bytes(32))
+
+    # Attributes: https://datatracker.ietf.org/doc/html/rfc5802#section-5
+    client_first_without_gs2_header = "n=#{normalize(user)},r=#{random_nonce}"
+    client_gs2_header = gs2_header(channel_binding: false)
+    client_first = "#{client_gs2_header}#{client_first_without_gs2_header}"
+
+    server_first_string = yield :client_first, client_first
+
+    server_first = parse_server_response(server_first_string)
+    server_nonce = server_first[:r]
+    server_salt = Base64.strict_decode64(server_first[:s])
+    iterations = server_first[:i].to_i
+
+    # https://datatracker.ietf.org/doc/html/rfc5802#section-3
+    salted_password = hi(normalize(password), server_salt, iterations)
+    client_key = hmac(salted_password, "Client Key")
+    stored_key = h(client_key)
+
+    client_final_without_proof = "c=#{b64(client_gs2_header)},r=#{server_nonce}"
+
+    auth_message = [client_first_without_gs2_header, server_first_string, client_final_without_proof].join(',')
+    client_signature = hmac(stored_key, auth_message)
+    client_proof = xor_strings(client_key, client_signature)
+    server_key = hmac(salted_password, "Server Key")
+    expected_server_signature = hmac(server_key, auth_message)
+
+    client_final = "#{client_final_without_proof},p=#{b64(client_proof)}"
+
+    server_final = yield :client_final, client_final
+    raise AuthenticationMethodMismatch, 'Server proof failed' if server_final != "v=#{b64(expected_server_signature)}"
+
+    nil
+  end
+
+  # Implements Normalize from https://datatracker.ietf.org/doc/html/rfc4013 -
+  # Apply the SASLprep profile [RFC4013] of the "stringprep" algorithm [RFC3454]
+  #
+  # @param [String] value
+  # @return [String]
+  def normalize(value)
+    ::Net::IMAP::SASL.saslprep(value, exception: true)
+  rescue ArgumentError => e
+    raise NormalizeError, e.message
+  end
+
+  # Hi function implementation from
+  # https://datatracker.ietf.org/doc/html/rfc5802#section-2.2
+  #
+  # @param [String] str
+  # @param [String] salt
+  # @param [Numeric] iteration_count
+  def hi(str, salt, iteration_count)
+    u = hmac(str, "#{salt.b}#{"\x00\x00\x00\x01".b}")
+    u_i = u
+    (iteration_count - 1).times do
+      u_i = hmac(str, u_i)
+      u = xor_strings(u, u_i)
+    end
+
+    u
+  end
+
+  # @return [String]
+  def hash_function_name
+    'SHA256'
+  end
+
+  # H function from
+  # https://datatracker.ietf.org/doc/html/rfc5802#section-2.2
+  #
+  # @param [String] str
+  def h(str)
+    OpenSSL::Digest.digest(hash_function_name, str)
+  end
+
+  # @param [String] key
+  # @param [String] message
+  # @return [String]
+  def hmac(key, message)
+    OpenSSL::HMAC.digest(hash_function_name, key, message)
+  end
+
+  # Implements https://datatracker.ietf.org/doc/html/rfc5801#section-4
+  # @return [String] The bytes for a gs2 header
+  def gs2_header(channel_binding: false)
+    # Specified as gs2-cb-flag
+    if channel_binding
+      # gs2_channel_binding_flag = 'y'
+      # Implementation skipped for now, just haven't
+      raise NotImplementedError, 'Channel binding not implemented'
+    else
+      gs2_channel_binding_flag = 'n'
+    end
+
+    gs2_authzid = nil
+    gs2_header = "#{gs2_channel_binding_flag},#{gs2_authzid},"
+    gs2_header
+  end
+
+  private
+
+  # @param [String] value
+  def b64(value)
+    Base64.strict_encode64(value)
+  end
+
+  # @param [String] s1
+  # @param [String] s2
+  # @return [String] the strings XOR'd
+  def xor_strings(s1, s2)
+    s1.bytes.zip(s2.bytes).map { |(b1, b2)| b1 ^ b2 }.pack("C*")
+  end
+
+  # Parses a server response string such as 'r=2kRpTcHEFyoG+UgDEpRBdVcJLTWh5WtxARhYOHcG27i7YxAi,s=GNpgixWS5E4INbrMf665Kw==,i=4096'
+  # into a Ruby hash equivalent { r: '2kRpT...', i: '4096' }
+  # @param [String] string Server string response string
+  def parse_server_response(string)
+    string.split(',')
+          .each_with_object({}) do |key_value, result|
+      key, value = key_value.split('=', 2)
+      result[key.to_sym] = value
+    end
+  end
+end
+
+end
+end
+end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -147,6 +147,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
   spec.add_runtime_dependency 'ruby_smb', '~> 3.2.0'
+  spec.add_runtime_dependency 'net-imap' # Used in Postgres auth for its SASL stringprep implementation
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'winrm'

--- a/spec/lib/postgres/postgres-pr/connection_spec.rb
+++ b/spec/lib/postgres/postgres-pr/connection_spec.rb
@@ -1,0 +1,121 @@
+require 'postgres/postgres-pr/connection'
+
+RSpec.describe Msf::Db::PostgresPR::Connection do
+  describe '#negotiate_sasl' do
+    subject { described_class.allocate }
+    let(:user) { 'postgres' }
+    let(:password) { 'mysecretpassword' }
+    let(:server_responses) { [] }
+
+    before(:each) do
+      allow(subject).to receive(:write_message)
+      read_message_mock = allow(Msf::Db::PostgresPR::Message).to receive(:read)
+      read_message_mock.and_return(*server_responses) if server_responses.any?
+      allow(SecureRandom).to receive(:bytes).with(32).and_return(("\x01" * 32).b)
+    end
+
+    context 'when the mechanism contains SCRAM-SHA-256' do
+      context 'and the negotiation is a success' do
+        let(:server_responses) do
+          [
+            # server-first, containing server nonce, salt, and iteration count
+            Msf::Db::PostgresPR::AuthenticationSASLContinue.new(
+              value: 'r=AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=FUeV3rVpQpa2s8ECj3aXa6vw,s=RwsYP2UCANr95SzCJfmP4A==,i=4096'
+            ),
+            # server-final, server signature
+            Msf::Db::PostgresPR::AuthenticationSASLFinal.new(
+              value: 'v=V4CwoEsGBGMe2jGf5lpKbapnqiooWXnoyuHT3VDl6WY='
+            )
+          ]
+        end
+
+        it 'negotaites successfully' do
+          message = Msf::Db::PostgresPR::AuthenticationSASL.new(
+            mechanisms: ['SCRAM-SHA-256']
+          )
+          subject.negotiate_sasl(message, user, password)
+          expect(subject).to have_received(:write_message).with(
+            Msf::Db::PostgresPR::SaslInitialResponseMessage.new(
+              mechanism: 'SCRAM-SHA-256',
+              value: 'n,,n=postgres,r=AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE='
+            )
+          ).ordered
+          expect(subject).to have_received(:write_message).with(
+            Msf::Db::PostgresPR::SASLResponseMessage.new(
+              value: 'c=biws,r=AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=FUeV3rVpQpa2s8ECj3aXa6vw,p=MN8FiTy5Aqut/H/TOggmlOWXHmpI/+RrnNgQFBk1eBs='
+            )
+          ).ordered
+        end
+      end
+
+      context 'and server-final does not contain the expected calculated server proof' do
+        let(:server_responses) do
+          [
+            # server-first, containing server nonce, salt, and iteration count
+            Msf::Db::PostgresPR::AuthenticationSASLContinue.new(
+              value: 'r=AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=FUeV3rVpQpa2s8ECj3aXa6vw,s=RwsYP2UCANr95SzCJfmP4A==,i=4096'
+            ),
+            # server-final, server signature
+            Msf::Db::PostgresPR::AuthenticationSASLFinal.new(
+              value: 'v=invalid_server_proof'
+            )
+          ]
+        end
+
+        it 'raises an error' do
+          message = Msf::Db::PostgresPR::AuthenticationSASL.new(
+            mechanisms: ['SCRAM-SHA-256']
+          )
+          expect { subject.negotiate_sasl(message, user, password) }.to raise_error 'Server proof failed'
+        end
+      end
+
+      context 'and the password is invalid' do
+        let(:server_responses) do
+          [
+            # server-first, containing server nonce, salt, and iteration count
+            Msf::Db::PostgresPR::AuthenticationSASLContinue.new(
+              value: 'r=2kRpTcHEFyoG+UgDEpRBdVcJLTWh5WtxARhYOHcG27i7YxAi,s=GNpgixWS5E4INbrMf665Kw==,i=4096'
+            ),
+            # For auth failure; server-final isn't AuthenticationSASLFinal - but just a generic Postgres ErrorResponse
+            Msf::Db::PostgresPR::ErrorResponse.new(
+              83,
+              ["FATAL", "VFATAL", "C28P01", "Mpassword authentication failed for user \"user\"", "Fauth.c", "L326", "Rauth_failed"]
+            )
+          ]
+        end
+
+        it 'raises an error' do
+          message = Msf::Db::PostgresPR::AuthenticationSASL.new(
+            mechanisms: ['SCRAM-SHA-256']
+          )
+          # Runtime error raised for consistency with login scanner expectations, but could be changed to a better exception in the future
+          expect { subject.negotiate_sasl(message, user, password) }.to raise_error RuntimeError, "FATAL\tVFATAL\tC28P01\tMpassword authentication failed for user \"user\"\tFauth.c\tL326\tRauth_failed"
+        end
+      end
+
+      context 'and a AuthenticationSASLContinue is not returned' do
+        let(:server_responses) do
+          [
+            nil
+          ]
+        end
+        it 'raises' do
+          message = Msf::Db::PostgresPR::AuthenticationSASL.new(
+            mechanisms: ['SCRAM-SHA-256']
+          )
+          expect { subject.negotiate_sasl(message, user, password) }.to raise_error Msf::Db::PostgresPR::AuthenticationMethodMismatch, /Did not receive AuthenticationSASLContinue/
+        end
+      end
+    end
+
+    context 'when the mechanism is not supported' do
+      it 'raises an exception' do
+        message = Msf::Db::PostgresPR::AuthenticationSASL.new(
+          mechanisms: ['SCRAM-SHA-256-PLUS']
+        )
+        expect { subject.negotiate_sasl(message, user, password) }.to raise_error Msf::Db::PostgresPR::AuthenticationMethodMismatch, /unsupported SASL mechanisms/
+      end
+    end
+  end
+end

--- a/spec/lib/postgres/postgres-pr/message_spec.rb
+++ b/spec/lib/postgres/postgres-pr/message_spec.rb
@@ -1,0 +1,91 @@
+require 'postgres/postgres-pr/message'
+
+RSpec.describe Msf::Db::PostgresPR::Message do
+  let(:mock_socket_clazz) do
+    Class.new do
+      include Rex::IO::Stream
+
+      def initialize(data)
+        @read_data = data || ''
+      end
+
+      def read(n, _opts = {})
+        result, remaining = @read_data[0...n], @read_data[n..-1]
+        @read_data = remaining
+        result
+      end
+    end
+  end
+
+  def mock_socket(data)
+    mock_socket_clazz.new(data)
+  end
+
+  describe '.read' do
+    let(:startup) { false }
+    let(:stream_bytes) { '' }
+    let(:result) { described_class.read(mock_socket(stream_bytes), startup) }
+
+    context 'when reading a SASL authentication message' do
+      # Offered SASL mechanisms
+      let(:stream_bytes) { "R\x00\x00\x00\x17\x00\x00\x00\nSCRAM-SHA-256\x00\x00".b }
+
+      it 'parses a SCRAM-SHA-256 message' do
+        expect(result).to be_a(Msf::Db::PostgresPR::AuthenticationSASL)
+        expect(result.mechanisms).to eq(['SCRAM-SHA-256'])
+        expect(result.dump).to eq(stream_bytes)
+      end
+    end
+
+    context 'when reading a SASL continue message' do
+      # First SCRAM-SHA-256 server message
+      # https://datatracker.ietf.org/doc/html/rfc7677#section-3
+      let(:stream_bytes) do
+        "R\x00\x00\x00\\\x00\x00\x00\vr=2kRpTcHEFyoG+UgDEpRBdVcJLTWh5WtxARhYOHcG27i7YxAi,s=GNpgixWS5E4INbrMf665Kw==,i=4096".b
+      end
+
+      it 'parses a generic SASL message' do
+        expect(result).to be_a(Msf::Db::PostgresPR::AuthenticationSASLContinue)
+        expect(result.value).to eq('r=2kRpTcHEFyoG+UgDEpRBdVcJLTWh5WtxARhYOHcG27i7YxAi,s=GNpgixWS5E4INbrMf665Kw==,i=4096')
+        expect(result.dump).to eq(stream_bytes)
+      end
+    end
+
+    context 'when reading a SASL final message' do
+      # Final SCRAM-SHA-256 server message
+      # https://datatracker.ietf.org/doc/html/rfc7677#section-3
+      let(:stream_bytes) do
+        "R\x00\x00\x006\x00\x00\x00\fv=b10lbmDELI8EHr/DM47cmcVcwn2n4TgQC4d1gaE6QHI=".b
+      end
+
+      it 'parses a generic SASL message' do
+        expect(result).to be_a(Msf::Db::PostgresPR::AuthenticationSASLFinal)
+        expect(result.value).to eq('v=b10lbmDELI8EHr/DM47cmcVcwn2n4TgQC4d1gaE6QHI=')
+        expect(result.dump).to eq(stream_bytes)
+      end
+    end
+  end
+
+  describe Msf::Db::PostgresPR::SASLResponseMessage do
+    # Final SCRAM-SHA-256 client message
+    # https://datatracker.ietf.org/doc/html/rfc7677#section-3
+    let(:stream_bytes) do
+      "p\x00\x00\x00lc=biws,r=8P6L/8Vv+sEUZitMm7hnoNppbiGwnpKXKGXU1HqFPGjD6gtm,p=lpmyxOY7t6U+um1eCG/LLGS0fiFsieTgDv0EwJ8etso=".b
+    end
+
+    describe '#parse' do
+      it 'parses the value' do
+        subject.parse(Msf::Db::Buffer.new(stream_bytes))
+        expect(subject).to be_a(described_class)
+        expect(subject.value).to eq('c=biws,r=8P6L/8Vv+sEUZitMm7hnoNppbiGwnpKXKGXU1HqFPGjD6gtm,p=lpmyxOY7t6U+um1eCG/LLGS0fiFsieTgDv0EwJ8etso=')
+      end
+    end
+
+    describe '#dump' do
+      it 'dumps the value' do
+        subject.parse(Msf::Db::Buffer.new(stream_bytes))
+        expect(subject.dump).to eq(stream_bytes)
+      end
+    end
+  end
+end

--- a/spec/lib/postgres/postgres-pr/scram_sha_256_spec.rb
+++ b/spec/lib/postgres/postgres-pr/scram_sha_256_spec.rb
@@ -1,0 +1,90 @@
+require 'postgres/postgres-pr/scram_sha_256'
+
+RSpec.describe Msf::Db::PostgresPR::ScramSha256 do
+  describe '#hi' do
+    [
+      { str: "a", salt: "c", iteration_count: 1, expected: "\xF5*3|\x9ALKB\xD1\x8D\x96d\xC1\x1D\v\xAEY^\xA8\xBB?o\x90\xE0\bE\xD5\xE1!\xA9={".b },
+      { str: "a", salt: "c", iteration_count: 4096, expected: ")\xA4\x1E\xF6$Vn\x17~w\xFAA\xB4\x8C\xEFY\x83\x82}, 2\xCB\x02\x19Q\xB7\xADOR\xD9\xDC".b },
+      { str: "pencil", salt: "\x00" * 16, iteration_count: 4096, expected: "\xB1q\x84\xD9\x8E\x0EG\xB2\"\xBD~\xB3-\xDABV?x\xC8'\xB7\xC8r\x9FJhG\xDAB%\xA0~".b },
+      { str: "pencil", salt: "\x8C\xDDM\x0E\xDBa\xD5\xE4?\x8C\xF3V\xC9\xC9\x94V", iteration_count: 4096, expected: "\xB1?1\xF3\x86\xF5\"\x0F\xCB\xE3=\xE1\xFF(\xF0\x9BODB\xDD\xEF8\xCC\n\x16\x83\x1A&C\xA2\x86F".b },
+    ].each do |test|
+      it "returns the expected value for the test #{test}" do
+        expect(subject.hi(test[:str], test[:salt], test[:iteration_count])).to eq(test[:expected])
+      end
+    end
+  end
+
+  describe '#gs2_header' do
+    context 'when channel binding is false' do
+      it 'returns a header without any channel bindings' do
+        expect(subject.gs2_header(channel_binding: false)).to eq 'n,,'
+      end
+    end
+
+    context 'when channel binding is true' do
+      it 'returns a header without any channel bindings' do
+        expect { subject.gs2_header(channel_binding: true) }.to raise_error NotImplementedError, 'Channel binding not implemented'
+      end
+    end
+  end
+
+  describe '#normalize' do
+    [
+      #
+      # Tests from spec https://datatracker.ietf.org/doc/html/rfc4013#section-3
+      #
+      { str: "I\u00ADX", expected: "IX" },
+      { str: "user", expected: "user" },
+      { str: "USER", expected: "USER" },
+      { str: "\u00AA", expected: "a" },
+      { str: "\u2168", expected: "IX" },
+      { str: "\u0007", error: /ASCII control characters/ },
+      { str: "\u0627\u0031", error: /must start.*end with RandAL/ },
+
+      #
+      # Tests from saslprep implementation in Ruby gem https://github.com/ruby/net-imap/blob/92dabbb8959a7a1e02990968ee6a5f4f73dded17/test/net/imap/test_saslprep.rb#L37-L69
+      #
+      # some more prohibited codepoints
+      { str: "\x7f", error: /ASCII control character/i },
+      { str: "\ufff9", error: /Non-ASCII control character/i },
+      { str: "\ue000", error: /private use.*C.3/i },
+      { str: "\u{f0000}", error: /private use.*C.3/i },
+      { str: "\u{100000}", error: /private use.*C.3/i },
+      { str: "\ufffe", error: /Non-character code point.*C.4/i },
+      { str: "\xed\xa0\x80", error: /invalid byte seq\w+ in UTF-8/i },
+      { str: "\ufffd", error: /inapprop.* plain text.*C.6/i },
+      { str: "\u2FFb", error: /inapprop.* canonical rep.*C.7/i },
+      { str: "\u202c", error: /change display.*deprecate.*C.8/i },
+      { str: "\u{e0001}", error: /tagging character/i },
+      # some more invalid bidirectional characters
+      { str: "\u0627abc\u0627", error: /must not contain.* Lcat/i },
+      { str: "\u0627123", error: /must start.*end with RandAL/i },
+
+      #
+      # Arbitrary tests:
+      #
+      { str: "abc".force_encoding("ASCII"), expected: "abc".force_encoding("UTF-8") },
+      { str: 'abcABC123!@£$%^&*()_+=[];l/.,?><|":]}{P+_) hello world', expected: 'abcABC123!@£$%^&*()_+=[];l/.,?><|":]}{P+_) hello world' }
+    ].each do |test|
+      it "returns the expected value for the test #{test}", skip: test[:skip] do
+        if test[:error]
+          expected_clazz = Msf::Db::PostgresPR::ScramSha256::NormalizeError
+          expected_message = test[:error]
+          expect { subject.normalize(test[:str]) }.to raise_error expected_clazz, expected_message
+        else
+          expect(subject.normalize(test[:str])).to eq(test[:expected])
+        end
+      end
+    end
+  end
+
+  describe '#hmac' do
+    [
+      { key: "\x00\x01\x02\x03", message: "hello world", expected: "abc".b }
+    ].each do |test|
+      it "returns the expected value for the test #{test}" do
+        expect(subject.hmac(test[:key], test[:message])).to eq("e\xA7\xB1r\xA9^9,\x90\x9Aey>FD\xF8\xCC\xD1\xDDH\xBB\x90\xDDU\xE5\x04\x05\xFA\xEC\xFC\x8Ew".b)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/18251

## Verification

Verify multiple postgres versions work:

- 9 - `docker run -it --rm --publish 127.0.0.1:9000:5432 -e POSTGRES_PASSWORD=password postgres:9`
- 13 - `docker run -it --rm --publish 127.0.0.1:9000:5432 -e POSTGRES_PASSWORD=password postgres:13`
- 15 - `docker run -it --rm --publish 127.0.0.1:9000:5432 -e POSTGRES_PASSWORD=password postgres:15`

Verify multiple passwords work

Verify multiple postgres modules work - `postgres_login`:

```
msf6 auxiliary(scanner/postgres/postgres_login) > rerun rhost=127.0.0.1 rport=9000 username=postgres password="p4$$w0rd5" lhost=192.168.123.1
[*] Reloading module...

[!] No active DB -- Credential data will not be saved!
[+] 127.0.0.1:9000 - Login Successful: postgres:p4$$w0rd5@template1
```

`postgres_version` against 15.3:

```
msf6 auxiliary(scanner/postgres/postgres_version) > rerun rhost=127.0.0.1 rport=9000 username=postgres password="p4$$w0rd5" lhost=192.168.123.1
[*] Reloading module...

[*] 127.0.0.1:9000 Postgres - Trying username:'postgres' with password:'p4$$w0rd5' against 127.0.0.1:9000 on database 'template1'
[*] 127.0.0.1:9000 Postgres - querying with 'select version()'
[+] 127.0.0.1:9000 Postgres - Logged in to 'template1' with 'postgres':'p4$$w0rd5'
[*] 127.0.0.1:9000 Postgres - Version PostgreSQL 15.3 (Debian 15.3-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit (Post-Auth)
[!] No active DB -- Credential data will not be saved!
[*] 127.0.0.1:9000 Postgres - Disconnected
[*] Scanned 1 of 1 hosts (100% complete)
```

`postgres_version` against 9:

```
msf6 auxiliary(scanner/postgres/postgres_version) > rerun rhost=127.0.0.1 rport=9000 username=postgres password=password lhost=192.168.123.1
[*] Reloading module...

[*] 127.0.0.1:9000 Postgres - Trying username:'postgres' with password:'password' against 127.0.0.1:9000 on database 'template1'
[*] 127.0.0.1:9000 Postgres - querying with 'select version()'
[+] 127.0.0.1:9000 Postgres - Logged in to 'template1' with 'postgres':'password'
[*] 127.0.0.1:9000 Postgres - Version PostgreSQL 9.6.24 on x86_64-pc-linux-gnu (Debian 9.6.24-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit (Post-Auth)
[!] No active DB -- Credential data will not be saved!
[*] 127.0.0.1:9000 Postgres - Disconnected
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Proof of sasl-scram-sha256 working:

<img width="1342" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/926c1ffd-852a-4780-8344-164c724d29bd">

Proof of md5 password working:

<img width="1342" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/60357436/f3b0bfe2-3092-4c90-bd55-8fd876247927">