### PR TITLE
Use latest version of ruby-mysql from upstream

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
+      ruby-mysql
       ruby_smb (~> 3.2.0)
       rubyntlm
       rubyzip
@@ -442,6 +443,7 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-macho (3.0.0)
+    ruby-mysql (4.0.0)
     ruby-prof (1.4.2)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)

--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -1,5 +1,5 @@
 require 'metasploit/framework/tcp/client'
-require 'rbmysql'
+require 'mysql'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
 
@@ -35,29 +35,29 @@ module Metasploit
             disconnect if self.sock
             connect
 
-            ::RbMysql.connect(host, credential.public, credential.private, '', port, sock)
+            ::Mysql.connect(host, credential.public, credential.private, '', port, sock)
 
           rescue ::SystemCallError, Rex::ConnectionError => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e
             })
-          rescue RbMysql::ClientError => e
+          rescue Mysql::ClientError => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e
             })
-          rescue RbMysql::HostNotPrivileged => e
+          rescue Mysql::HostNotPrivileged => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e
             })
-          rescue RbMysql::AccessDeniedError => e
+          rescue Mysql::AccessDeniedError => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::INCORRECT,
               proof: e
             })
-          rescue RbMysql::HostIsBlocked => e
+          rescue Mysql::HostIsBlocked => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -106,6 +106,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'patch_finder'
   # Required for Metasploit Web Services
   spec.add_runtime_dependency 'puma'
+  spec.add_runtime_dependency 'ruby-mysql'
   spec.add_runtime_dependency 'thin'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'warden'

--- a/spec/lib/metasploit/framework/login_scanner/mysql_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mysql_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::MySQL do
 
     context 'when the attempt is successful' do
       it 'returns a result object with a status of Metasploit::Model::Login::Status::SUCCESSFUL' do
-        expect(::RbMysql).to receive(:connect).and_return "fake mysql handle"
+        expect(::Mysql).to receive(:connect).and_return "fake mysql handle"
         expect(login_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::SUCCESSFUL
       end
     end
@@ -45,61 +45,61 @@ RSpec.describe Metasploit::Framework::LoginScanner::MySQL do
     context 'when the attempt is unsuccessful' do
       context 'due to connection refused' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::RbMysql).to receive(:connect).and_raise Errno::ECONNREFUSED
+          expect(::Mysql).to receive(:connect).and_raise Errno::ECONNREFUSED
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::RbMysql).to receive(:connect).and_raise Errno::ECONNREFUSED
+          expect(::Mysql).to receive(:connect).and_raise Errno::ECONNREFUSED
           expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Errno::ECONNREFUSED)
         end
       end
 
       context 'due to connection timeout' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::RbMysql).to receive(:connect).and_raise RbMysql::ClientError, "Client Error"
+          expect(::Mysql).to receive(:connect).and_raise Mysql::ClientError, "Client Error"
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::RbMysql).to receive(:connect).and_raise RbMysql::ClientError, "Client Error"
-          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(RbMysql::ClientError)
+          expect(::Mysql).to receive(:connect).and_raise Mysql::ClientError, "Client Error"
+          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Mysql::ClientError)
         end
       end
 
       context 'due to operation timeout' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::RbMysql).to receive(:connect).and_raise Errno::ETIMEDOUT
+          expect(::Mysql).to receive(:connect).and_raise Errno::ETIMEDOUT
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::RbMysql).to receive(:connect).and_raise Errno::ETIMEDOUT
+          expect(::Mysql).to receive(:connect).and_raise Errno::ETIMEDOUT
           expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Errno::ETIMEDOUT)
         end
       end
 
       context 'due to not being allowed to connect from this host' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::RbMysql).to receive(:connect).and_raise RbMysql::HostNotPrivileged, "Host not privileged"
+          expect(::Mysql).to receive(:connect).and_raise Mysql::HostNotPrivileged, "Host not privileged"
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::RbMysql).to receive(:connect).and_raise RbMysql::HostNotPrivileged, "Host not privileged"
-          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(RbMysql::HostNotPrivileged)
+          expect(::Mysql).to receive(:connect).and_raise Mysql::HostNotPrivileged, "Host not privileged"
+          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Mysql::HostNotPrivileged)
         end
       end
 
       context 'due to access denied' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::INCORRECT' do
-          expect(::RbMysql).to receive(:connect).and_raise RbMysql::AccessDeniedError, "Access Denied"
+          expect(::Mysql).to receive(:connect).and_raise Mysql::AccessDeniedError, "Access Denied"
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::INCORRECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::RbMysql).to receive(:connect).and_raise RbMysql::AccessDeniedError, "Access Denied"
-          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(RbMysql::AccessDeniedError)
+          expect(::Mysql).to receive(:connect).and_raise Mysql::AccessDeniedError, "Access Denied"
+          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Mysql::AccessDeniedError)
         end
       end
     end


### PR DESCRIPTION
This should resolve #18154 .

I have pulled in the latest version of `ruby-mysql` from [upstream](https://gitlab.com/tmtms/ruby-mysql/-/commits/master). Other than the required renaming, I have not made any other changes to the code pulled in from upstream.

The issue refers to an error that manifested when using the MySQL login scanner. 

## Verification

I have tested it against the following: MySQL 5.7.42 (using default authentication), MySQL 8.0.33 (using default authentication - `caching_sha2_password` and MySQL 8.0.33 (using `mysql_native_password`).

The above scenarios are easiest to produce via Docker containers:

```bash
docker run --name some-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=foo123 -d mysql:5.7.42
docker run --name some-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=foo123 -d mysql:8.0
docker run --name some-mysql  -p 3306:3306 -e MYSQL_ROOT_PASSWORD=foo123 -d mysql:8.0 --default-authentication-plugin=mysql_native_password
```

To validate that it works (run the below sequence in `msfconsole` once per version):

```
use auxiliary/scanner/mysql/mysql_login
set RHOSTS 127.0.0.1
set USERNAME root
set PASSWORD foo123
run
```

The result should look like this (remote MySQL version will differ, depending which  container you are running against):

```
[+] 127.0.0.1:3306        - 127.0.0.1:3306 - Found remote MySQL version 8.0.33
[+] 127.0.0.1:3306        - 127.0.0.1:3306 - Success: 'root:foo123'
[*] 127.0.0.1:3306        - Scanned 1 of 1 hosts (100% complete)
```



