### PR TITLE
Fix a stack trace in forge_ticket when SPN is blank

### DIFF
--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -108,8 +108,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def forge_silver
-    raise Msf::OptionValidateError, 'SPN' if datastore['SPN'].blank?
-
     validate_spn!
     validate_sid!
     validate_key!
@@ -147,7 +145,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def validate_spn!
     unless datastore['SPN'] =~ %r{.*/.*}
-      fail_with(Msf::Exploit::Failure::BadConfig, 'Invalid SPN - must be in the format .*/.*. Ex. <service class>/<host><realm>:<port>/<service name>')
+      fail_with(Msf::Exploit::Failure::BadConfig, 'Invalid SPN, must be in the format <service class>/<host><realm>:<port>/<service name>. Ex: cifs/host.realm.local')
     end
   end
 


### PR DESCRIPTION
This fixes a stack trace in `auxiliary/admin/kerberos/forge_ticket` that would occur when you attempt to forge a silver ticket with a blank SPN.

Original stack trace:
```
msf6 auxiliary(admin/kerberos/forge_ticket) > show options 

Module options (auxiliary/admin/kerberos/forge_ticket):

   Name        Current Setting                                Required  Description
   ----        ---------------                                --------  -----------
   AES_KEY                                                    no        The krbtgt/service AES key
   DOMAIN      msflab.local                                   yes       The Domain (upper case) Ex: DEMO.LOCAL
   DOMAIN_SID  S-1-5-21-1755879683-3641577184-3486455962-519  yes       The Domain SID, Ex: S-1-5-21-1755879683-3641577184-3486455962
   DURATION    3650                                           yes       Duration of the ticket in days
   EXTRA_SIDS                                                 no        Extra sids separated by commas, Ex: S-1-5-21-1755879683-3641577184-3486455962-519
   NTHASH                                                     no        The krbtgt/service nthash
   USER        smcintyre                                      yes       The Domain User
   USER_RID    500                                            yes       The Domain User's relative identifier(RID)


   When ACTION is FORGE_SILVER:

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------
   SPN                    no        The Service Principal Name (Only used for silver ticket)


Auxiliary action:

   Name          Description
   ----          -----------
   FORGE_SILVER  Forge a Silver Ticket



View the full module info with the info, or info -d command.

msf6 auxiliary(admin/kerberos/forge_ticket) > forge_silver

[-] Auxiliary failed: NoMethodError undefined method `join' for "SPN":String
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exception.rb:41:in `initialize'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/kerberos/forge_ticket.rb:111:in `exception'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/kerberos/forge_ticket.rb:111:in `raise'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/kerberos/forge_ticket.rb:111:in `forge_silver'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/kerberos/forge_ticket.rb:71:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/forge_ticket) >
```

To reproduce this. Use the `auxiliary/admin/kerberos/forge_ticket` module. Set the `USER`, `DOMAIN` and `DOMAIN_SID` options then run the `FORGE_SILVER` action. The text in the exception that's raised when validating the SPN was changed as well. `Ex:` was presumably short for "example" so it should be an example of a legitimate SPN. It has been updated to the [example value](https://docs.metasploit.com/docs/pentesting/active-directory/kerberos/overview.html#authentication-example) used in the docs for clarity. The `DOMIN_SID` example, is already the value from the docs.

## Testing
- [ ] Use the `auxiliary/admin/kerberos/forge_ticket` module
- [ ] Set the `USER`, `DOMAIN` and `DOMAIN_SID` options
- [ ] Run the `FORGE_SILVER` action