### PR TITLE
Add action support to exploit modules

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -11,6 +11,7 @@ module Msf
 #
 ###
 class Exploit < Msf::Module
+  include HasActions
 
 ##
   # Exceptions
@@ -619,13 +620,6 @@ class Exploit < Msf::Module
   #
   def aggressive?
     stance.include?(Stance::Aggressive)
-  end
-
-  #
-  # Returns if the exploit has a passive stance. Aggressive exploits are always aggressive.
-  #
-  def passive?
-    stance.include?(Stance::Passive) && !stance.include?(Stance::Aggressive)
   end
 
   #

--- a/lib/msf/core/module/has_actions.rb
+++ b/lib/msf/core/module/has_actions.rb
@@ -7,8 +7,7 @@ module Msf::Module::HasActions
       info['Actions'], Array,
       [ Msf::Module::AuxiliaryAction ], 'AuxiliaryAction'
     )
-
-    self.passive = (info['Passive'] and info['Passive'] == true) || false
+    self.passive = (info['Stance'] and info['Stance'].include?(Msf::Exploit::Stance::Passive)) || false
     self.default_action = info['DefaultAction']
     self.passive_actions = info['PassiveActions'] || []
   end
@@ -31,9 +30,10 @@ module Msf::Module::HasActions
   # Returns a boolean indicating whether this module should be run passively
   #
   def passive?
-    act = action()
-    return passive_action?(act.name) if act
-    return self.passive
+    act = action
+    return passive || passive_action?(act.name) if act
+
+    passive
   end
 
   #

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -28,7 +28,7 @@ module Msf::PostMixin
     ] , Msf::Post)
 
     # Default stance is active
-    self.passive = info['Passive'] || false
+    self.passive = (info['Stance'] and info['Stance'].include?(Msf::Exploit::Stance::Passive)) || false
     self.session_types = info['SessionTypes'] || []
   end
 

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -26,7 +26,12 @@ class MetasploitModule < Msf::Auxiliary
         {
           'SRVPORT' => 80
         },
-      'Passive' => true))
+      'Notes' => {
+      'Stability' => [],
+      'Reliability' => [],
+      'SideEffects' => []
+      },
+      'Stance' => Msf::Exploit::Stance::Passive))
 
     register_options(
       [
@@ -84,4 +89,3 @@ EOS
     end
   end
 end
-


### PR DESCRIPTION
I noticed while working on adding actions to `smb_relay` that exploit modules don't currently support actions

https://github.com/rapid7/metasploit-framework/blob/c748cc4ebbe810e4ee473106f1243baa056a0ae2/modules/exploits/windows/smb/smb_relay.rb#L111

I can't think of any reason why we wouldn't want to be able to use actions in an exploit module so I'm throwing this PR up to get feedback from people, if there are any issues that might crop up from this, that sort of thing

The main thing that has me a little worried about a change like this is the `passive?` method which `HasActions` redefines to check if any of the individual actions are `passive` as opposed to checking the existing `passive?` method defined in `msf/core/exploit.rb` which checks the modules metadata

I think the changes I've made cover everything and also fix up a couple places where we were trying to read the key `Passive` from a modules metadata instead of `Stance` and checking if `Stance` was passive

