### PR TITLE
Use upstream ruby-mysql in Remote::MYSQL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,7 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-macho (4.0.0)
-    ruby-mysql (4.0.0)
+    ruby-mysql (4.1.0)
     ruby-prof (1.4.2)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)

--- a/lib/msf/core/exploit/remote/mysql.rb
+++ b/lib/msf/core/exploit/remote/mysql.rb
@@ -12,7 +12,7 @@
 ###
 
 
-require 'rbmysql'
+require 'mysql'
 
 module Msf
 module Exploit::Remote::MYSQL
@@ -37,21 +37,21 @@ module Exploit::Remote::MYSQL
     connect
 
     begin
-      @mysql_handle = ::RbMysql.connect(rhost, user, pass, db, rport, sock)
+      @mysql_handle = ::Mysql.connect(rhost, user, pass, db, rport, io: sock)
 
     rescue Errno::ECONNREFUSED
       print_error("Connection refused")
       return false
-    rescue RbMysql::ClientError
+    rescue ::Mysql::ClientError
       print_error("Connection timedout")
       return false
     rescue Errno::ETIMEDOUT
       print_error("Operation timedout")
       return false
-    rescue RbMysql::HostNotPrivileged
+    rescue ::Mysql::HostNotPrivileged
       print_error("Unable to login from this host due to policy")
       return false
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       print_error("Access denied")
       return false
     end
@@ -78,7 +78,7 @@ module Exploit::Remote::MYSQL
   def mysql_query(sql)
     begin
       res = @mysql_handle.query(sql)
-    rescue ::RbMysql::Error => e
+    rescue ::Mysql::Error => e
       print_error("MySQL Error: #{e.class} #{e.to_s}")
       return nil
     rescue Rex::ConnectionTimeout => e

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -61,15 +61,15 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       socket = connect(false)
-      mysql_client = ::RbMysql.connect(rhost, username, password, nil, rport, socket)
+      mysql_client = ::Mysql.connect(rhost, username, password, nil, rport, io: socket)
       results << mysql_client
 
       print_good "#{rhost}:#{rport} The server accepted our first login as #{username} with a bad password. URI: mysql://#{username}:#{password}@#{rhost}:#{rport}"
 
-    rescue RbMysql::HostNotPrivileged
+    rescue ::Mysql::HostNotPrivileged
       print_error "#{rhost}:#{rport} Unable to login from this host due to policy (may still be vulnerable)"
       return
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       print_good "#{rhost}:#{rport} The server allows logins, proceeding with bypass test"
     rescue ::Interrupt
       raise $!
@@ -113,11 +113,11 @@ class MetasploitModule < Msf::Auxiliary
           begin
             # Create our socket and make the connection
             s = connect(false)
-            mysql_client = ::RbMysql.connect(rhost, username, password, nil, rport, s)
+            mysql_client = ::Mysql.connect(rhost, username, password, nil, rport, io: s)
 
             print_good "#{rhost}:#{rport} Successfully bypassed authentication after #{count} attempts. URI: mysql://#{username}:#{password}@#{rhost}:#{rport}"
             results << mysql_client
-          rescue RbMysql::AccessDeniedError
+          rescue ::Mysql::AccessDeniedError
           rescue ::Exception => e
             print_bad "#{rhost}:#{rport} Thread #{count}] caught an unhandled exception: #{e}"
           end

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       mysql_query_no_handle("USE " + datastore['DATABASE_NAME'])
-    rescue ::RbMysql::Error => e
+    rescue ::Mysql::Error => e
       vprint_error("MySQL Error: #{e.class} #{e.to_s}")
       return
     rescue Rex::ConnectionTimeout => e
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
   def check_dir dir
     begin
       res = mysql_query_no_handle("LOAD DATA INFILE '" + dir + "' INTO TABLE " + datastore['TABLE_NAME'])
-    rescue ::RbMysql::TextfileNotReadable
+    rescue ::Mysql::TextfileNotReadable
       print_good("#{dir} is a directory and exists")
       report_note(
         :host  => rhost,
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :update => :unique_data
       )
-    rescue ::RbMysql::DataTooLong, ::RbMysql::TruncatedWrongValueForField
+    rescue ::Mysql::DataTooLong, ::Mysql::TruncatedWrongValueForField
       print_good("#{dir} is a file and exists")
       report_note(
         :host  => rhost,
@@ -101,9 +101,9 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :update => :unique_data
       )
-    rescue ::RbMysql::ServerError
+    rescue ::Mysql::ServerError
       vprint_warning("#{dir} does not exist")
-    rescue ::RbMysql::Error => e
+    rescue ::Mysql::Error => e
       vprint_error("MySQL Error: #{e.class} #{e.to_s}")
       return
     rescue Rex::ConnectionTimeout => e

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       print_status("Checking #{dir}...")
       res = mysql_query_no_handle("SELECT _utf8'test' INTO DUMPFILE '#{dir}/" + datastore['FILE_NAME'] + "'")
-    rescue ::RbMysql::ServerError => e
+    rescue ::Mysql::ServerError => e
       print_warning(e.to_s)
     rescue Rex::ConnectionTimeout => e
       print_error("Timeout: #{e.message}")

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res.each_hash do |row|
         rows << row
       end
-    rescue RbMysql::ParseError
+    rescue ::Mysql::ParseError
       return rows
     end
 
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
       return if not m
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       print_error("Access denied.")
       return
     end
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       upload_file(exe, dest)
       register_file_for_cleanup("#{exe_name}")
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       print_error("No permission to write. I blame kc :-)")
       return
     end
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       upload_file(mof, dest)
       register_file_for_cleanup("wbem\\mof\\good\\#{mof_name}")
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       print_error("No permission to write. Bail!")
       return
     end

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res.each_hash do |row|
         rows << row
       end
-    rescue RbMysql::ParseError
+    rescue ::Mysql::ParseError
       return rows
     end
 
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
     begin
       m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       fail_with(Failure::NoAccess, "#{peer} - Access denied")
     end
 
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       drive = get_drive_letter
-    rescue RbMysql::ParseError
+    rescue ::Mysql::ParseError
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine drive name")
     end
 
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Uploading to '#{dest}'")
     begin
       upload_file(exe, dest)
-    rescue RbMysql::AccessDeniedError
+    rescue ::Mysql::AccessDeniedError
       fail_with(Failure::NotVulnerable, "#{peer} - No permission to write. I blame kc :-)")
     end
     register_file_for_cleanup("#{dest}")


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/18278
Relates to https://github.com/rapid7/metasploit-framework/pull/18297

This is the next iteration of replacing the local `RbMysql` with the upstream `ruby-mysql` gem. It replaces `RbMysql` in `Msf::Exploit::Remote::MYSQL`.

There are two manual tests to confirm that this functionality works:
- `modules/auxiliary/scanner/mysql/mysql_file_enum.rb` (it seems to use most of the core functionality provided by `Msf::Exploit::Remote::MYSQL`) 
- `modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb` (it not only uses `Msf::Exploit::Remote::MYSQL` but it also uses `RbMysql` independently. ~~I cannot fully test this as I could not find a mysql container that is old enough to have the vulnerability, so it is a very high-level test, but enough to confirm that the code can connect to the MySQL instance (hopefully). ~~ Resolved by: https://github.com/rapid7/metasploit-framework/pull/18297

## Verification

Part 1 (`mysql_file_enum.rb`)

- [ ] `docker run --name some-mysql  -p 3306:3306 -e MYSQL_ROOT_PASSWORD=foo123 -d mysql:5.7.42 --secure-file-priv=/etc`
- [ ] `echo '/etc/my.cnf' > test.txt`
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/mysql/mysql_file_enum`
- [ ] `set RHOSTS 127.0.0.1`
- [ ] `set USERNAME root`
- [ ] `set PASSWORD foo123`
- [] `set FILE_LIST test.txt`
- [] `run`

You should see output as per the below:

![image](https://github.com/rapid7/metasploit-framework/assets/65485/c3b18f30-a066-49dd-bc30-8d2b8f9312f9)

Part 2 (mysql_authbypass_hashdump)

- [ ] `docker run --name some-mysql  -p 3306:3306 -e MYSQL_ROOT_PASSWORD=foo123 -d mysql:5.7.42
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/mysql/mysql_authbypass_hashdump`
- [ ] `set RHOSTS 127.0.0.1`
- [ ] run

You should see output as per the below:

![image](https://github.com/rapid7/metasploit-framework/assets/65485/3d9abcde-cc41-45b2-a113-06b020d8f3fe)

part 3 - mysql_authbypass_hashdump - vulnerable


```
docker run -it --rm -p 3306:3306 vulhub/mysql:5.5.23
```

Expected results from https://github.com/rapid7/metasploit-framework/pull/18297 :

```
msf6 auxiliary(scanner/mysql/mysql_authbypass_hashdump) > run rhosts=127.0.0.1

[+] 127.0.0.1:3306        - 127.0.0.1:3306 The server allows logins, proceeding with bypass test
[*] 127.0.0.1:3306        - 127.0.0.1:3306 Authentication bypass is 10% complete
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Successfully bypassed authentication after 138 attempts. URI: mysql://root:A@127.0.0.1:3306
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Successfully exploited the authentication bypass flaw, dumping hashes...
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
[+] 127.0.0.1:3306        - 127.0.0.1:3306 Hash Table has been saved: /Users/user/.msf4/loot/20231012170829_default_127.0.0.1_mysql.hashes_222750.txt
[*] 127.0.0.1:3306        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```