### PR TITLE
extend error message for timeouts to include more detail to user

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1576,7 +1576,7 @@ class Core
               rescue ::Rex::Post::Meterpreter::RequestError
                 print_error("Failed: #{$!.class} #{$!}")
               rescue Rex::TimeoutError
-                print_error("Operation timed out")
+                print_error("Operation timed out. Timeout currently #{session.response_timeout} seconds, you can configure this with %grnsessions -c <cmd> --timeout <value>%clr")
               end
             elsif session.type == 'shell' || session.type == 'powershell'
               output = session.shell_command(cmd)
@@ -1612,20 +1612,28 @@ class Core
 
         cmds.each do |cmd|
           sessions.each do |session|
-            session = verify_session(session)
-            unless session.type == 'meterpreter'
-              print_error "Session ##{session.sid} is not a Meterpreter shell. Skipping..."
-              next
-            end
+            begin
+              session = verify_session(session)
+              unless session.type == 'meterpreter'
+                print_error "Session ##{session.sid} is not a Meterpreter shell. Skipping..."
+                next
+              end
 
-            next unless session
-            print_status("Running '#{cmd}' on #{session.type} session #{session.sid} (#{session.session_host})")
-            if session.respond_to?(:response_timeout)
-              last_known_timeout = session.response_timeout
-              session.response_timeout = response_timeout
-            end
+              next unless session
+              print_status("Running '#{cmd}' on #{session.type} session #{session.sid} (#{session.session_host})")
+              if session.respond_to?(:response_timeout)
+                last_known_timeout = session.response_timeout
+                session.response_timeout = response_timeout
+                session.on_run_command_error_proc = log_on_timeout_error("Send timed out. Timeout currently #{session.response_timeout} seconds, you can configure this with %grnsessions -C <cmd> --timeout <value>%clr")
+              end
 
-            output = session.run_cmd(cmd, driver.output)
+              output = session.run_cmd(cmd, driver.output)
+            ensure
+              if session.respond_to?(:response_timeout) && last_known_timeout
+                session.response_timeout = last_known_timeout
+                session.on_run_command_error_proc = nil
+              end
+            end
           end
         end
     when 'kill'
@@ -1674,16 +1682,19 @@ class Core
           if session.respond_to?(:response_timeout)
             last_known_timeout = session.response_timeout
             session.response_timeout = response_timeout
+            session.on_run_command_error_proc = log_on_timeout_error("Send timed out. Timeout currently #{session.response_timeout} seconds, you can configure this with %grnsessions --interact <id> --timeout <value>%clr")
           end
           print_status("Starting interaction with #{session.name}...\n") unless quiet
           begin
             self.active_session = session
+
             sid = session.interact(driver.input.dup, driver.output)
             self.active_session = nil
             driver.input.reset_tab_completion if driver.input.supports_readline
           ensure
             if session.respond_to?(:response_timeout) && last_known_timeout
               session.response_timeout = last_known_timeout
+              session.on_run_command_error_proc = nil
             end
           end
         else
@@ -1708,12 +1719,14 @@ class Core
           if session.respond_to?(:response_timeout)
             last_known_timeout = session.response_timeout
             session.response_timeout = response_timeout
+            session.on_run_command_error_proc = log_on_timeout_error("Send timed out. Timeout currently #{session.response_timeout} seconds, you can configure this with %grnsessions --timeout <value> --script <script> <id>%clr")
           end
           begin
             print_status("Session #{sess_id} (#{session.session_host}):")
             print_status("Running #{script} on #{session.type} session" +
                           " #{sess_id} (#{session.session_host})")
             begin
+              session.init_ui(driver.input, driver.output)
               session.execute_script(script, *extra)
             rescue ::Exception => e
               log_error("Error executing script or module: #{e.class} #{e}")
@@ -1721,7 +1734,9 @@ class Core
           ensure
             if session.respond_to?(:response_timeout) && last_known_timeout
               session.response_timeout = last_known_timeout
+              session.on_run_command_error_proc = nil
             end
+            session.reset_ui
           end
         else
           print_error("Invalid session identifier: #{sess_id}")
@@ -2592,6 +2607,20 @@ class Core
     else
       print_error("Invalid session identifier: #{session_id}") unless quiet
       nil
+    end
+  end
+
+  #
+  # Custom error code to handle timeout errors
+  #
+  # @param message [String] The message to be printed when a timeout error is hit
+  # @return [Proc] proc function that prints the specified error when the error types match
+  def log_on_timeout_error(message)
+    proc do |e|
+      next unless e.is_a?(Rex::TimeoutError) || e.is_a?(Timeout::Error)
+      elog(e)
+      print_error(message)
+      :handled
     end
   end
 

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -128,6 +128,12 @@ module Interactive
   attr_accessor :on_print_proc
   attr_accessor :on_command_proc
 
+  #
+  # A function to be run when running a session command hits an error
+  #
+  # @return [Proc,nil] A function to be run when running a session command hits an error
+  attr_accessor :on_run_command_error_proc
+
 protected
 
   #


### PR DESCRIPTION
Partially addresses https://github.com/rapid7/metasploit-framework/issues/6274 - specifically implements https://github.com/rapid7/metasploit-framework/issues/6274#issuecomment-1680678622 for all functions that use that timeout error.

## Verification

List the steps needed to make sure this thing works
Short version - trigger any Rex::TimeoutError and verify more verbose text
Longer version:
For interactive:
- [ ] Start `msfconsole`
- [ ] Open up a reverse shell (ie in `windows/meterpreter/reverse_http`)
- [ ] `sessions -i your_session_id
- [ ] Send a command that triggers the timeout error (ie `powershell_execute 'sleep 20; echo abc'`)
- [ ] Error should read "Send timed out. Timeout currently 15 seconds, you can configure this with sessions --interact <id> --timeout <value>"

For script:
- [ ] create a `foo.rc` file with the following contents:
```
<ruby>
puts run_single("load powershell")
puts run_single("powershell_execute 'sleep 20; echo abc'")
</ruby>
```
- [ ] start `msfconsole`
- [ ] `sessions --script foo.rc your_session_id`
- [ ] verify the output reads "Send timed out. Timeout currently 15 seconds, you can configure this with sessions --timeout <value> --script <script> <id>"

For command:
- [ ] start `msfconsole`
- [ ] Open up a reverse shell (ie in `windows/meterpreter/reverse_http`)
- [ ] `sessions -C "load powershell" your_session_id`
- [ ] `sessions -C "powershell_execute 'sleep 20; echo abc'" your_session_id`
- [ ] verify the output reads "Send timed out. Timeout currently 15 seconds, you can configure this with sessions -C <cmd> --timeout <value>"

