### PR TITLE
Fix an error in ThriftMessageType

### DIFF
--- a/lib/rex/proto/thrift.rb
+++ b/lib/rex/proto/thrift.rb
@@ -20,7 +20,7 @@ module Rex::Proto::Thrift
     CALL = 1
     REPLY = 2
 
-    default_parameter assert: -> { !MessageType.name(value).nil? }
+    default_parameter assert: -> { !ThriftMessageType.name(value).nil? }
 
     def self.name(value)
       constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }


### PR DESCRIPTION
This fixes an error in the `ThriftMessageType` that was left over from when I refactored it to make the class names unique for BinData. I noticed it while looking at  #18273 and using the definitions to read the binary blobs embedded within the module.

## Verification

- [ ] Start Metasploit and enter into a Pry or IRB session
- [ ] Paste the following blob and see that it is parsed correctly without a stack trace

```
get_node_type_req = "\x80\x01\x00\x01"
get_node_type_req += "\x00\x00\x00\x0b\x67\x65\x74\x4e"
get_node_type_req += "\x6f\x64\x65\x54\x79\x70\x65\x00"
get_node_type_req += "\x00\x00\x00\x00"
Rex::Proto::Thrift::ThriftHeader.read(get_node_type_req)
```

### Before 
```
[1] pry(#<Msf::Framework>)> get_node_type_req = "\x80\x01\x00\x01"    
=> "\x80\u0001\u0000\u0001"
[2] pry(#<Msf::Framework>)> get_node_type_req += "\x00\x00\x00\x0b\x67\x65\x74\x4e"    
=> "\x80\u0001\u0000\u0001\u0000\u0000\u0000\vgetN"
[3] pry(#<Msf::Framework>)> get_node_type_req += "\x6f\x64\x65\x54\x79\x70\x65\x00"    
=> "\x80\u0001\u0000\u0001\u0000\u0000\u0000\vgetNodeType\u0000"
[4] pry(#<Msf::Framework>)> get_node_type_req += "\x00\x00\x00\x00"    
=> "\x80\u0001\u0000\u0001\u0000\u0000\u0000\vgetNodeType\u0000\u0000\u0000\u0000\u0000"
[5] pry(#<Msf::Framework>)> Rex::Proto::Thrift::ThriftHeader.read(get_node_type_req).to_binary_s
NameError: uninitialized constant Rex::Proto::Thrift::ThriftMessageType::MessageType
Did you mean?  MessagePack
from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/proto/thrift.rb:23:in `block in <class:ThriftMessageType>'
```

### After
```
[1] pry(#<Msf::Framework>)> get_node_type_req = "\x80\x01\x00\x01"
=> "\x80\u0001\u0000\u0001"
[2] pry(#<Msf::Framework>)> get_node_type_req += "\x00\x00\x00\x0b\x67\x65\x74\x4e"
=> "\x80\u0001\u0000\u0001\u0000\u0000\u0000\vgetN"
[3] pry(#<Msf::Framework>)> get_node_type_req += "\x6f\x64\x65\x54\x79\x70\x65\x00"
=> "\x80\u0001\u0000\u0001\u0000\u0000\u0000\vgetNodeType\u0000"
[4] pry(#<Msf::Framework>)> get_node_type_req += "\x00\x00\x00\x00"
=> "\x80\u0001\u0000\u0001\u0000\u0000\u0000\vgetNodeType\u0000\u0000\u0000\u0000\u0000"
[5] pry(#<Msf::Framework>)> Rex::Proto::Thrift::ThriftHeader.read(get_node_type_req)
=> {:version=>32769, :message_type=>1, :method_name_length=>11, :method_name=>"getNodeType", :sequence_id=>0}
[6] pry(#<Msf::Framework>)>
```