### PR TITLE
Fix lines in SmarterMail RCE docs for linting with msftidy_docs

### DIFF
--- a/documentation/modules/exploit/windows/http/smartermail_rce.md
+++ b/documentation/modules/exploit/windows/http/smartermail_rce.md
@@ -7,25 +7,45 @@ The vulnerability affects:
 
 ### Description
 
-This module exploits a vulnerability in the SmarterTools SmarterMail software for version numbers <= 16.x or for build numbers < 6985. The vulnerable versions and builds expose three .NET remoting endpoints on port 17001, namely `/Servers`, `/Mail` and `/Spool`. For example, a typical installation of SmarterMail Build 6970 will have the `/Servers` endpoint exposed to the public at `tcp://0.0.0.0:17001/Servers`, where serialized .NET commands can be sent through a TCP socket connection.
+This module exploits a vulnerability in the SmarterTools SmarterMail software for
+version numbers <= 16.x or for build numbers < 6985. The vulnerable versions and builds
+expose three .NET remoting endpoints on port 17001, namely `/Servers`, `/Mail` and `/Spool`.
+For example, a typical installation of SmarterMail Build 6970 will have the `/Servers` endpoint
+exposed to the public at `tcp://0.0.0.0:17001/Servers`, where serialized .NET commands can be sent
+through a TCP socket connection.
 
-The three endpoints perform deserialization of untrusted data (CVE-2019-7214), allowing an attacker to send arbitrary commands to be deserialized and executed. This module exploits this vulnerability to perform .NET deserialization attacks, allowing remote code execution for any unauthenticated user under the context of the SYSTEM account. Successful exploitation results in full administrative control of the target server under the `NT AUTHORITY\SYSTEM` account.
+The three endpoints perform deserialization of untrusted data (CVE-2019-7214), allowing an attacker
+to send arbitrary commands to be deserialized and executed. This module exploits this vulnerability
+to perform .NET deserialization attacks, allowing remote code execution for any unauthenticated user
+under the context of the SYSTEM account. Successful exploitation results in full administrative
+control of the target server under the `NT AUTHORITY\SYSTEM` account.
 
-This vulnerability was patched in Build 6985, where the 17001 port is no longer publicly accessible, although it can be accessible locally at `127.0.0.1:17001`. Hence, this would still allow for a privilege escalation vector if the server is compromised as a low-privileged user.
+This vulnerability was patched in Build 6985, where the 17001 port is no longer publicly accessible,
+although it can be accessible locally at `127.0.0.1:17001`. Hence, this would still allow for a
+privilege escalation vector if the server is compromised as a low-privileged user.
 
 ### Setup
 
-This module was tested on SmarterMail Build 6919, 6970 (with positive results), Build 6985 (with negative results), and on Version 16.3.6989 (with positive results).
+This module was tested on SmarterMail Build 6919, 6970 (with positive results),
+Build 6985 (with negative results), and on Version 16.3.6989 (with positive results).
 
-Legacy builds and versions of SmarterMail can be obtained by signing up to the SmarterTools website to create a user account, and then navigating to the [Legacy Builds](https://www.smartertools.com/account#/downloads) page, where `EXE` and `MSI` files can be downloaded.
+Legacy builds and versions of SmarterMail can be obtained by signing up to the
+SmarterTools website to create a user account, and then navigating to the
+[Legacy Builds](https://www.smartertools.com/account#/downloads) page, where `EXE`
+and `MSI` files can be downloaded.
 
 ## Verification Steps
 
 1. Sign up to the [SmarterTools website](https://www.smartertools.com/). Log in with your created account.
-2. Download `EXE` legacy versions and builds from a dropdown menu at [Legacy Builds](https://www.smartertools.com/account#/downloads), specifically SmarterMail 16.x, Build 6970 and Build 6985.
-3. Install the executable file (e.g. `SmarterMail_6970.exe`) and follow the instructions provided. If reinstalling a different version/build, simply choose `Use an existing site` when prompted in `Site Configuration Type`, and select `SmarterMail` in the next option.
-4. Verify that the login page can be accessed at `http://localhost:9998/interface/root#/login`. Set Admin username and password to be `admin:admin` (or anything arbitrary) if prompted.
-5. Disable realtime protection on an Administrative PowerShell session with `Set-MpPreference -DisableRealtimeMonitoring $true`.
+2. Download `EXE` legacy versions and builds from a dropdown menu at [Legacy Builds](https://www.smartertools.com/account#/downloads),
+specifically SmarterMail 16.x, Build 6970 and Build 6985.
+3. Install the executable file (e.g. `SmarterMail_6970.exe`) and follow the instructions provided.
+If reinstalling a different version/build, simply choose `Use an existing site` when prompted
+in `Site Configuration Type`, and select `SmarterMail` in the next option.
+4. Verify that the login page can be accessed at `http://localhost:9998/interface/root#/login`.
+Set Admin username and password to be `admin:admin` (or anything arbitrary) if prompted.
+5. Disable realtime protection on an Administrative PowerShell session with
+`Set-MpPreference -DisableRealtimeMonitoring $true`.
 6. Start `msfconsole` and follow along with default options.
 7. Do: `use exploit/windows/http/smartermail_rce`
 8. Do: `set RHOSTS [SMARTERMAIL_SERVER_IP]`
@@ -38,23 +58,30 @@ Legacy builds and versions of SmarterMail can be obtained by signing up to the S
 
     0. Target 0 (default) - Windows Command uses a default PowerShell payload to execute
     code and open a Meterpreter session. However, any desired payload can be chosen. Choose with `set TARGET 0`.
-    1. Target 1 - x86/x64 Windows CmdStager uses a CmdStager with default `vbs` stager flavor to execute code and open a Meterpreter session. Choose with `set TARGET 1`.
+    1. Target 1 - x86/x64 Windows CmdStager uses a CmdStager with default `vbs` stager flavor to execute code
+    and open a Meterpreter session. Choose with `set TARGET 1`.
 
 ### ENDPOINT (Required)
 
-Choose one of three exposed .NET remoting endpoints, either `Servers`, `Spool` or `Mail`. The default is `Servers`, but any one of the three will do.
+Choose one of three exposed .NET remoting endpoints, either `Servers`, `Spool` or `Mail`.
+The default is `Servers`, but any one of the three will do.
 
 ### RPORT (Required)
 
-This is the port for the SmarterMail HTTP server, which is default on port 9998. Although this port is not required for exploitation, it is required for checking the vulnerability and version/build number of the SmarterMail software.
+This is the port for the SmarterMail HTTP server, which is default on port 9998.
+Although this port is not required for exploitation, it is required for checking the
+vulnerability and version/build number of the SmarterMail software.
 
 ### TARGETURI (Required)
 
-This is the base path of the SmarterMail HTTP server. The vulnerability check follows the redirect from base path `/` to the login page at `/interface/root#/login`, but this option is provided in case the login page is located at a different URI.
+This is the base path of the SmarterMail HTTP server. The vulnerability check follows the
+redirect from base path `/` to the login page at `/interface/root#/login`, but this option
+is provided in case the login page is located at a different URI.
 
 ### TCP_PORT (Required)
 
-This is the TCP port where the .NET remoting endpoints are located, and is required for sending serialized data and Meterpreter payloads. The default port is 17001.
+This is the TCP port where the .NET remoting endpoints are located, and is required for
+sending serialized data and Meterpreter payloads. The default port is 17001.
 
 ## Scenarios
 


### PR DESCRIPTION
This PR fixes formatting issues in `documentation/modules/exploit/windows/http/smartermail_rce.md` by breaking up long lines into shorter lines below 140 characters so that the lint test by `msftidy_docs` passes. No GitHub issue number.