### PR TITLE
fix #18326 (ssl_version module bug when selecting specific ssl version)

### DIFF
--- a/modules/auxiliary/scanner/ssl/ssl_version.rb
+++ b/modules/auxiliary/scanner/ssl/ssl_version.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Auxiliary
       return Array.new(OpenSSL::SSL::SSLContext.new.ciphers.length) { |i| (OpenSSL::SSL::SSLContext.new.ciphers[i][1]).to_s }.uniq.reverse
     end
 
-    datastore['SSLVersion']
+    [datastore['SSLVersion']]
   end
 
   def get_metasploit_ssl_cipher_suites(ssl_version)


### PR DESCRIPTION
fix #18326 

Functions within the `ssl_version` module expected `get_metasploit_ssl_versions` to give a list/array, however if the user selected an individual ssl version, it returned a string. This fixes that.

@mzach99 feel free to give this a try and let me know if it fixes the problem

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssl/ssl_version`
- [ ] `set rhost [ip]`
- [ ] `run`
- [ ] **Verify** it runs (defaults to All)
- [ ] `set SSLVersion TLSv1.0`
- [ ] `run`
- [ ] **Verify** it no longer crashes
