### PR TITLE
Get crackable ASREP hashes

### DIFF
--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -23,12 +23,22 @@ module Metasploit
           }
 
           begin
-            res = send_request_tgt(
-              server_name: server_name,
-              client_name: credential.public,
-              password: credential.private,
-              realm: credential.realm
-            )
+            begin
+              res = send_request_tgt(
+                server_name: server_name,
+                client_name: credential.public,
+                password: credential.private,
+                realm: credential.realm,
+                offered_etypes: [Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC]
+              )
+            rescue Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported => e
+              # RC4 likely disabled - let's try again with our full complement of default etypes
+              res = send_request_tgt(
+                server_name: server_name,
+                client_name: credential.public,
+                password: credential.private,
+                realm: credential.realm)
+            end
 
             result_options = result_options.merge(
               {

--- a/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
       server_name: 'demo.local_server',
       client_name: 'mock_public',
       password: 'mock_private',
-      realm: 'DEMO.LOCAL'
+      realm: 'DEMO.LOCAL',
+      offered_etypes: [Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC]
     }
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/kerberos_spec.rb
@@ -18,13 +18,22 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
     )
   end
 
-  let(:expected_tgt_request) do
+  let(:expected_tgt_request_hmac) do
     {
       server_name: 'demo.local_server',
       client_name: 'mock_public',
       password: 'mock_private',
       realm: 'DEMO.LOCAL',
-      offered_etypes: [Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC]
+      offered_etypes: [::Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC]
+    }
+  end
+
+  let(:expected_tgt_request) do
+    {
+      server_name: 'demo.local_server',
+      client_name: 'mock_public',
+      password: 'mock_private',
+      realm: 'DEMO.LOCAL'
     }
   end
 
@@ -40,7 +49,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
   let(:tgt_response_success) do
     Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
       as_rep: instance_double(::Rex::Proto::Kerberos::Model::KdcResponse),
-      preauth_required: false,
+      preauth_required: true,
       krb_enc_key: {
         enctype: Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC,
         key: 'mock-key',
@@ -94,6 +103,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Kerberos do
     context 'when the login does not require preauthentication' do
       before(:each) do
         allow(subject).to receive(:send_request_tgt).with(expected_tgt_request).and_return(tgt_response_no_preauth_required)
+        allow(subject).to receive(:send_request_tgt).with(expected_tgt_request_hmac).and_return(tgt_response_no_preauth_required)
       end
 
       it 'returns the correct login status' do


### PR DESCRIPTION
This PR fixes the ASREP roasting workflow in Metasploit, which resolves #17988. A note on that ticket: That ticket states that the behaviour (and thus the bug) is in the `get_user_spns` module, but that module is actually TGS-REP roasting (kerberoasting), and I was unable to reproduce any issues with that module. But the issue correctly describes a replicable issue in the `kerberos_login` module, so that's what this ticket addresses.

The cause of this issue was that, when we offer AES ciphers alongside our RC4 cipher, the server complies, and gives us an ASREP encrypted with one of the AES ciphers. Cracking this is slow, and is not currently supported by JtR or Hashcat, so is less valuable. To fix this, we just tell the server that we only support RC4_HMAC, and it gives us what we want.

If we made only this change, it would potentially break the login scanner in the (admittedly rare) situation where RC4 has been disabled in the domain. So if we receive an "encryption type not supported" error, we retry with our defaults.

## Verification

- [ ] Configure a domain containing a user with pre-authentication disabled
- [ ] Start `msfconsole`
- [ ] `use kerberos_login`
- [ ] Run the module against the pre-auth-disabled user
- [ ] Verify that the output has etype 23
- [ ] Verify that the hash is crackable by hashcat, using a wordlist containing the correct password: `hashcat -m18200 '$krb5asrep$23$user...' -a 3 --force /tmp/wordlist`
- [ ] Verify that the `kerberos_login` module still works to brute force passwords for users without pre-auth disabled
- [ ] Verify that the `kerberos_login` module still works to brute force passwords for users without pre-auth disabled, when RC4 is disabled in the domain (In Group Policy, Computer Configuration >> Windows Settings >> Security Settings >> Local Policies >> Security Options >> "Network security: Configure encryption types allowed for Kerberos")