### PR TITLE
Update check method docs

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-write-a-check-method.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-check-method.md
@@ -40,11 +40,6 @@ return CheckCode::Appears('Vulnerable component XYZ is installed')
 Metasploit Framework check methods are used occasionally by other groups and projects to assist with vulnerability scanning.  Please do your best to ensure that the only return value from a check method is a check code.
 Basically, that means avoiding the use of `fail_with` or raising exceptions that are not handled within the check method.
 
-## Returning from a Check Method
-
-Metasploit Framework check methods are used in different ways and we'd like them to be useful for other products to consume.  As such, it is a good idea to make sure that any returns from a check method return a check code.
-
-
 ## Remote Check Example
 
 Here's an abstract example of how a Metasploit check might be written:

--- a/docs/metasploit-framework.wiki/How-to-write-a-check-method.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-check-method.md
@@ -37,8 +37,9 @@ The `CheckCode` also supports an optional description which is printed by the fr
 return CheckCode::Appears('Vulnerable component XYZ is installed')
 ```
 
-Metasploit Framework check methods are used occasionally by other groups and projects to assist with vulnerability scanning.  Please do your best to ensure that the only return value from a check method is a check code.
-Basically, that means avoiding the use of `fail_with` or raising exceptions that are not handled within the check method.
+`MetasploitModule#check` methods should capture any known `raise` from methods called and return value of class
+`Msf::Exploit::CheckCode`. Basically, that means avoiding the use of `fail_with` or raising exceptions that are not
+handled within the check method.
 
 ## Remote Check Example
 

--- a/docs/metasploit-framework.wiki/How-to-write-a-check-method.md
+++ b/docs/metasploit-framework.wiki/How-to-write-a-check-method.md
@@ -37,6 +37,14 @@ The `CheckCode` also supports an optional description which is printed by the fr
 return CheckCode::Appears('Vulnerable component XYZ is installed')
 ```
 
+Metasploit Framework check methods are used occasionally by other groups and projects to assist with vulnerability scanning.  Please do your best to ensure that the only return value from a check method is a check code.
+Basically, that means avoiding the use of `fail_with` or raising exceptions that are not handled within the check method.
+
+## Returning from a Check Method
+
+Metasploit Framework check methods are used in different ways and we'd like them to be useful for other products to consume.  As such, it is a good idea to make sure that any returns from a check method return a check code.
+
+
 ## Remote Check Example
 
 Here's an abstract example of how a Metasploit check might be written:


### PR DESCRIPTION
Internally and in reviews, we tell contributors not to use `fail_with` because we should always do our best to make sure a check method returns a check code.   I noticed that https://github.com/rapid7/metasploit-framework/pull/18283 had a `fail_with` and went to pull the relevant citation in our documentation and found it was not there.  This just adds the guidance and reasoning not to exit a check method without returning a check code.