### PR TITLE
Show the tip while MSF is loading

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -4,11 +4,12 @@
 
 require 'metasploit/framework/command'
 require 'metasploit/framework/command/base'
+require 'rex/text'
 
 # Based on pattern used for lib/rails/commands in the railties gem.
 class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::Base
 
-  # Provides an animated spinner in a seperate thread.
+  # Provides an animated spinner in a separate thread.
   #
   # See GitHub issue #4147, as this may be blocking some
   # Windows instances, which is why Windows platforms
@@ -44,7 +45,12 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
     else
-      spinner unless parsed_options.options.console.quiet
+      unless parsed_options.options.console.quiet
+        colorizor = Struct.new(:supports_color?).new(false).extend(Rex::Text::Color)
+        $stdout.print colorizor.substitute_colors(Rex::Text.wordwrap("Metasploit tip: #{Msf::Ui::Tip.sample}\n", indent = 0, cols = 80))
+        spinner
+      end
+
       driver.run
     end
   end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -260,7 +260,6 @@ class Core
     banner << ("+ -- --=[ %-#{padding}s]\n" % eva)
 
     banner << "\n"
-    banner << Rex::Text.wordwrap("Metasploit tip: #{Tip.sample}\n", indent = 0, cols = 60)
     banner << Rex::Text.wordwrap('Metasploit Documentation: https://docs.metasploit.com/', indent = 0, cols = 60)
 
     # Display the banner


### PR DESCRIPTION
This moves the MSF tip to be displayed while Metasploit is loading. This is similar to what a lot of video games do (e.g. Skyrim). The intention is to increase the chances that users will read the tip while they're waiting instead of ignoring it and proceeding straight to beginning the task they started MSF to accomplish.

Colors aren't supported because the driver hasn't been initialized yet. Initializing the driver at this point to check if colors are supported breaks the spinner.

## Testing

- [x] Start `msfconsole`
- [x] Enjoy some light reading material while things are loading
- [x] Learn something new
