### PR TITLE
Update metasploit side for java metasploit-payloads fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.154)
+      metasploit-payloads (= 2.0.156)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -278,7 +278,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.154)
+    metasploit-payloads (2.0.156)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -80,7 +80,7 @@ metasploit-concern, 5.0.1, "New BSD"
 metasploit-credential, 6.0.5, "New BSD"
 metasploit-framework, 6.3.38, "New BSD"
 metasploit-model, 5.0.1, "New BSD"
-metasploit-payloads, 2.0.154, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.156, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.2, "New BSD"
 metasploit_payloads-mettle, 1.0.26, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/lib/msf/core/payload/java/meterpreter_loader.rb
+++ b/lib/msf/core/payload/java/meterpreter_loader.rb
@@ -88,8 +88,7 @@ module Payload::Java::MeterpreterLoader
     # a second jar.
     [
       [ "javapayload", "stage", "Stage.class" ],
-      [ "com", "metasploit", "meterpreter", "MemoryBufferURLConnection.class" ],
-      [ "com", "metasploit", "meterpreter", "MemoryBufferURLStreamHandler.class" ],
+      [ "com", "metasploit", "meterpreter", "JarFileClassLoader.class" ],
       # Must be last!
       [ "javapayload", "stage", "Meterpreter.class" ],
     ]

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.154'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.156'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR is the framework side for https://github.com/rapid7/metasploit-payloads/pull/672 - full details are there. This should have the correct gem version added prior to landing.