### PR TITLE
Adds new search keywords to msfconsole

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -7,8 +7,39 @@
 module Msf::Modules::Metadata::Search
 
   VALID_PARAMS =
-      %w[aka author authors arch cve bid edb check date disclosure_date description fullname fullname mod_time
-      name os platform path port rport rank ref ref_name reference references target targets text type]
+    %w[
+      adapter
+      aka
+      arch
+      author
+      authors
+      bid
+      check
+      cve
+      date
+      description
+      disclosure_date
+      edb
+      fullname
+      mod_time
+      name
+      os
+      path
+      platform
+      port
+      rank
+      ref
+      ref_name
+      reference
+      references
+      rport
+      stage
+      stager
+      target
+      targets
+      text
+      type
+    ]
 
   #
   # Module Type Shorthands
@@ -43,7 +74,7 @@ module Msf::Modules::Metadata::Search
 
     terms.each do |term|
       # Split it on the `:`, with the part before the first `:` going into keyword, the part after first `:`
-      # but before any later instances of `:` going into search_term, and the characters after the second 
+      # but before any later instances of `:` going into search_term, and the characters after the second
       # `:` or later in the string going into _excess to be ignored.
       #
       # Example is `use exploit/linux/local/nested_namespace_idmap_limit_priv_esc::a`
@@ -172,6 +203,12 @@ module Msf::Modules::Metadata::Search
               end
             when 'path'
               match = [keyword, search_term] if module_metadata.fullname =~ regex
+            when 'stage'
+              match = [keyword, search_term] if module_metadata.stage_refname =~ regex
+            when 'stager'
+              match = [keyword, search_term] if module_metadata.stager_refname =~ regex
+            when 'adapter'
+              match = [keyword, search_term] if module_metadata.adapter_refname =~ regex
             when 'port', 'rport'
               match = [keyword, search_term] if module_metadata.rport.to_s =~ regex
             when 'rank'
@@ -267,4 +304,3 @@ module Msf::Modules::Metadata::Search
   end
 
 end
-

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -363,6 +363,7 @@ module Msf
             print_line
             print_line "Keywords:"
             {
+              'adapter'     => 'Modules with a matching adater reference name',
               'aka'         => 'Modules with a matching AKA (also-known-as) name',
               'author'      => 'Modules written by this author',
               'arch'        => 'Modules affecting this architecture',
@@ -381,6 +382,8 @@ module Msf
               'rank'        => 'Modules with a matching rank (Can be descriptive (ex: \'good\') or numeric with comparison operators (ex: \'gte400\'))',
               'ref'         => 'Modules with a matching ref',
               'reference'   => 'Modules with a matching reference',
+              'stage'       => 'Modules with a matching stage reference name',
+              'stager'      => 'Modules with a matching stager reference name',
               'target'      => 'Modules affecting this target',
               'type'        => 'Modules of a specific type (exploit, payload, auxiliary, encoder, evasion, post, or nop)',
             }.each_pair do |keyword, description|

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("text:postgres:")).to eq({"text"=>[["postgres"], []]}) }
     it { expect(described_class.parse_search_string("postgres::::")).to eq({"text"=>[["postgres"], []]}) }
     it { expect(described_class.parse_search_string("turtle:bobcat postgres:")).to eq({"text"=>[["postgres"], []], "turtle"=>[["bobcat"], []]}) }
+    it { expect(described_class.parse_search_string("stage:linux/x64/meterpreter ")).to eq({"stage"=>[["linux/x64/meterpreter"], []]}) }
+    it { expect(described_class.parse_search_string("stager:linux/x64/reverse_tcp ")).to eq({"stager"=>[["linux/x64/reverse_tcp"], []]}) }
+    it { expect(described_class.parse_search_string("adapter:cmd/linux/http/mips64 ")).to eq({"adapter"=>[["cmd/linux/http/mips64"], []]}) }
   end
 
   describe '#find' do
@@ -139,6 +142,38 @@ RSpec.describe Msf::Modules::Metadata::Search do
       reject = %w(author:sinn3r)
 
       it_should_behave_like 'search_filter', :accept => accept, :reject => reject
+    end
+
+    context 'on a module with a #stage_refname of "linux/x64/meterpreter"' do
+      let(:opts) { { 'stage_refname' => 'linux/x64/meterpreter' } }
+      accept = %w[stage:linux/x64/meterpreter]
+      reject = %w[stage:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #stager_refname of "linux/x64/reverse_tcp"' do
+      let(:opts) { { 'stager_refname' => 'linux/x64/reverse_tcp' } }
+      accept = %w[stager:linux/x64/reverse_tcp]
+      reject = %w[stager:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #adapter_refname of "cmd/linux/http/mips64"' do
+      let(:opts) { { 'adapter_refname' => 'cmd/linux/http/mips64' } }
+      accept = %w[adapter:cmd/linux/http/mips64]
+      reject = %w[adapter:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #adapter_refname of "linux/x64/meterpreter_reverse_https"' do
+      let(:opts) { { 'adapter_refname' => 'linux/x64/meterpreter_reverse_https' } }
+      accept = %w[adapter:linux/x64/meterpreter_reverse_http adapter:linux/x64/meterpreter_reverse_https]
+      reject = %w[adapter:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
     end
 
     context 'on a module that supports the osx platform' do


### PR DESCRIPTION
This PR adds some extra search keywords to the existing search functionally. This has been done to to improve the data mining process for our wrap-up script, which now makes use of these new keywords. PR can be found [here](https://github.com/rapid7/metasploit-stats/pull/50/).

The new keywords and the module metadata they refer to:
| Keyword | Corresponding metadata reference |  
|----------|:-------------:|
| stager |  `stager_refname` |
| stage | `stage_refname` |
| adapter | `adapter_refname` |

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] **Verify** the search command now works for each of these new keywords. Examples can be found in the new tests that was added.

