### PR TITLE
Fix msfrpc hanging forever if rsock pair doesnt connect

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,7 +414,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.53)
+    rex-socket (0.1.54)
       rex-core
     rex-sslscan (0.1.9)
       rex-core


### PR DESCRIPTION
Fix msfrpc hanging forever if rsock pair doesnt connect

Fix: https://github.com/rapid7/rex-socket/pull/62

## Verification

Verification steps from https://github.com/rapid7/rex-socket/pull/62