### PR TITLE
Add support to msfvenom for "-f octal"

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -69,6 +69,8 @@ module Buffer
         buf = Rex::Text.to_nim(buf)
       when 'rust', 'rustlang'
         buf = Rex::Text.to_rust(buf)
+      when 'octal'
+        buf = Rex::Text.to_octal(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
@@ -138,6 +140,7 @@ module Buffer
       'nim',
       'nimlang',
       'num',
+      'octal',
       'perl',
       'pl',
       'powershell',

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -85,7 +85,7 @@ module Buffer
   def self.comment(buf, fmt = "ruby")
     case fmt
       when 'raw'
-      when 'num', 'dword', 'dw', 'hex'
+      when 'num', 'dword', 'dw', 'hex', 'octal'
         buf = Rex::Text.to_js_comment(buf)
       when 'ruby', 'rb', 'python', 'py'
         buf = Rex::Text.to_ruby_comment(buf)

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -85,7 +85,8 @@ module Buffer
   def self.comment(buf, fmt = "ruby")
     case fmt
       when 'raw'
-      when 'num', 'dword', 'dw', 'hex', 'octal'
+      when 'num', 'dword', 'dw', 'hex', 'octal', 'base64', 'base32'
+        # These are string encodings, not languages; default to the js comment.
         buf = Rex::Text.to_js_comment(buf)
       when 'ruby', 'rb', 'python', 'py'
         buf = Rex::Text.to_ruby_comment(buf)

--- a/lib/msf/base/simple/payload.rb
+++ b/lib/msf/base/simple/payload.rb
@@ -29,7 +29,7 @@ module Payload
   #   NopSledSize => The number of NOPs to use
   #   MaxSize     => The maximum size of the payload.
   #   Iterations  => Number of times to encode.
-  #   Force       => Force encoding.
+  #   ForceEncode => Force encoding.
   #
   # raises:
   #

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -229,6 +229,31 @@ RSpec.describe Msf::PayloadGenerator do
       it { expect { new_payload_generator }.not_to raise_error }
     end
 
+    context 'when given any valid transform format without a prepended comment' do
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'octal',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            nocomment: true,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
+
+      it { expect { new_payload_generator }.not_to raise_error }
+    end
+
     context 'when given any valid executable format' do
       let(:format) { ::Msf::Util::EXE.to_executable_fmt_formats.sample }
       let(:generator_opts) {

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -229,31 +229,6 @@ RSpec.describe Msf::PayloadGenerator do
       it { expect { new_payload_generator }.not_to raise_error }
     end
 
-    context 'when given any valid transform format without a prepended comment' do
-      let(:generator_opts) {
-        {
-            add_code: false,
-            arch: 'x86',
-            badchars: "\x20\x0D\x0A",
-            encoder:  'x86/shikata_ga_nai',
-            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
-            format: 'octal',
-            framework: framework,
-            iterations: 1,
-            keep: false,
-            nops: 0,
-            payload: 'windows/meterpreter/reverse_tcp',
-            platform: 'Windows',
-            space: 1073741824,
-            stdin: nil,
-            nocomment: true,
-            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
-        }
-      }
-
-      it { expect { new_payload_generator }.not_to raise_error }
-    end
-
     context 'when given any valid executable format' do
       let(:format) { ::Msf::Util::EXE.to_executable_fmt_formats.sample }
       let(:generator_opts) {

--- a/spec/lib/msf/simple/payload_spec.rb
+++ b/spec/lib/msf/simple/payload_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Msf::Simple::Payload do
 
   it { expect { payload }.not_to raise_error }
 
-  ::Msf::Simple::Buffer.transform_formats.each do |format|
+  UNSUPPORTED_LANGS = %w(vbapplication vbscript)
+
+  (::Msf::Simple::Buffer.transform_formats - UNSUPPORTED_LANGS).each do |format|
     context "when given the transform format '#{format}'" do
       let(:generator_format) {  format }
       it { expect { payload }.not_to raise_error }

--- a/spec/lib/msf/simple/payload_spec.rb
+++ b/spec/lib/msf/simple/payload_spec.rb
@@ -35,11 +35,10 @@ RSpec.describe Msf::Simple::Payload do
 
   it { expect { payload }.not_to raise_error }
 
-  context 'when given any valid transform format' do
-    let(:generator_format) { 
-      'octal' # TODO change to ::Msf::Simple::Buffer.transform_formats.sample
-    }
-
-    it { expect { payload }.not_to raise_error }
+  ::Msf::Simple::Buffer.transform_formats.each do |format|
+    context "when given the transform format '#{format}'" do
+      let(:generator_format) {  format }
+      it { expect { payload }.not_to raise_error }
+    end
   end
 end

--- a/spec/lib/msf/simple/payload_spec.rb
+++ b/spec/lib/msf/simple/payload_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Simple::Payload do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:generator_format) { 'raw' }
+  let(:generator_opts) {
+    {
+        'BadChars' => '',
+        'Encoder' => '',
+        'Options' => { 'LHOST' => '1.1.1.1', 'LPORT' => '8443' } ,
+        'Format' => generator_format,
+        'NoComment' => false,
+        'NopSledSize' => 0,
+        'MaxSize' => 0,
+        'Iterations' => 1,
+        'ForceEncode' => false
+    }
+  }
+
+  let!(:payload_module) {
+    load_and_create_module(
+        ancestor_reference_names: %w{
+          stagers/windows/reverse_tcp
+          stages/windows/meterpreter
+        },
+        module_type: 'payload',
+        reference_name: 'windows/meterpreter/reverse_tcp'
+    )
+  }
+
+  subject(:payload) {
+    described_class.generate_simple(payload_module, generator_opts)
+  }
+
+  it { expect { payload }.not_to raise_error }
+
+  context 'when given any valid transform format' do
+    let(:generator_format) { 
+      'octal' # TODO change to ::Msf::Simple::Buffer.transform_formats.sample
+    }
+
+    it { expect { payload }.not_to raise_error }
+  end
+end

--- a/spec/lib/msf/simple/payload_spec.rb
+++ b/spec/lib/msf/simple/payload_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Msf::Simple::Payload do
 
   it { expect { payload }.not_to raise_error }
 
+  # These are languages that are missing a to_comment implementation in Rex::Text.
   UNSUPPORTED_LANGS = %w(vbapplication vbscript)
 
   (::Msf::Simple::Buffer.transform_formats - UNSUPPORTED_LANGS).each do |format|


### PR DESCRIPTION
This PR adds an octal transform format to msfvenom for use during payload generation. This is useful for `printf` in POSIX sh.

## Verification

List the steps needed to make sure this thing works

- [x] make sure 'raw' still works: `./msfvenom -p linux/aarch64/shell_reverse_tcp lhost=127.0.0.1 lport=5555 -f raw`
- [x] check that the new 'octal' works: `./msfvenom -p linux/aarch64/shell_reverse_tcp lhost=127.0.0.1 lport=5555 -f octal`
- [x] check that the new 'octal' works in msfconsole `./msfconsole` `use some_payload` `generate -f octal`