### PR TITLE
Fix msfrpc edgecase when cleaning up console instance

### DIFF
--- a/lib/msf/ui/web/web_console.rb
+++ b/lib/msf/ui/web/web_console.rb
@@ -116,8 +116,8 @@ class WebConsole
   end
 
   def shutdown
-    self.pipe.close
     self.thread.kill
+    self.pipe.close
   end
 
   def busy


### PR DESCRIPTION
Fix msfrpc edgecase when cleaning up console instance

## Verification

Verify CI passes. This is tested by `bundle exec rspec spec/lib/msf/core/rpc/v10/rpc_console_spec.rb`