### PR TITLE
Fix opt address local crash when ipaddr is nil

### DIFF
--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -23,7 +23,7 @@ class OptAddressLocal < OptAddress
     addrs = addrs.map { |x| x['addr'].split('%').first }.select do |addr|
       begin
         IPAddr.new(addr)
-      rescue IPAddr::InvalidAddressError
+      rescue IPAddr::Error
         false
       end
     end

--- a/spec/lib/msf/core/opt_address_local_spec.rb
+++ b/spec/lib/msf/core/opt_address_local_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Msf::OptAddressLocal do
             # Darwin AF_LINK
             18 => [
               {
-                'addr' => '55:44:33:22:11:00',
+                'addr' => '',
                 'netmask' => nil,
                 'broadcast' => nil
               }


### PR DESCRIPTION
Fixes the following crash with OptAddressLocal:

```
  1) Msf::OptAddressLocal behaves like an option with valid values should be valid and normalize appropriately: utun2
     Failure/Error: IPAddr.new(addr)
     
     IPAddr::AddressFamilyError:
       address family must be specified
 
```

Caused by darwin AF_LINK having an empty string for its addr

## Verification

Ensure CI passes