### PR TITLE
Fix msfrpc hanging when updating saved command history

### DIFF
--- a/lib/metasploit/framework/spec/threads/suite.rb
+++ b/lib/metasploit/framework/spec/threads/suite.rb
@@ -96,6 +96,7 @@ module Metasploit
 
                       thread_list.each do |thread|
                         thread_uuid = thread[Metasploit::Framework::Spec::Threads::Suite::UUID_THREAD_LOCAL_VARIABLE]
+                        thread_name = thread[:tm_name]
 
                         # unmanaged thread, such as the main VM thread
                         unless thread_uuid
@@ -104,10 +105,10 @@ module Metasploit
 
                         caller = caller_by_thread_uuid[thread_uuid]
 
-                        error_lines << "Thread #{thread_uuid}'s status is #{thread.status.inspect} " \
+                        error_lines << "Thread #{thread_uuid}'s (name=#{thread_name} status is #{thread.status.inspect} " \
                                        "and was started here:\n"
-
                         error_lines.concat(caller)
+                        error_lines << "The thread backtrace was:\n#{thread.backtrace ? thread.backtrace.join("\n") : 'nil (no backtrace)'}\n"
                       end
                     else
                       error_lines << "Run `rake spec` to log where Thread.new is called."

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -546,7 +546,7 @@ Shell Banner:
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"self\" (session) object\n")
-      Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: :irb) do
+      framework.history_manager.with_context(name: :irb) do
         Rex::Ui::Text::IrbShell.new(self).run
       end
     else
@@ -585,7 +585,7 @@ Shell Banner:
     print_status('Starting Pry shell...')
     print_status("You are in the \"self\" (session) object\n")
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
       self.pry
     end
   end
@@ -746,7 +746,7 @@ protected
   # shell_write instead of operating on rstream directly.
   def _interact
     framework.events.on_session_interact(self)
-    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: self.type.to_sym) {
+    framework.history_manager.with_context(name: self.type.to_sym) {
       _interact_stream
     }
   end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -62,6 +62,8 @@ class Framework
     # Allow specific module types to be loaded
     types = options[:module_types] || Msf::MODULE_TYPES
 
+    self.history_manager = Rex::Ui::Text::Shell::HistoryManager.new
+
     self.features = FeatureManager.instance
     self.features.load_config
 
@@ -190,9 +192,13 @@ class Framework
   #
   # The framework instance's feature manager. The feature manager is responsible
   # for configuring feature flags that can change characteristics of framework.
-  #
+  # @return [Msf::FeatureManager]
   attr_reader   :features
 
+  # The framework instance's history manager, responsible for managing command history
+  # in different contexts
+  # @return [Rex::Ui::Text::Shell::HistoryManager]
+  attr_reader :history_manager
 
   #
   # The framework instance's data service proxy
@@ -281,7 +287,8 @@ protected
   attr_writer   :db # :nodoc:
   attr_writer   :browser_profiles # :nodoc:
   attr_writer   :analyze # :nodoc:
-  attr_writer   :features # :nodoc:
+  attr_writer   :features  # :nodoc:
+  attr_writer   :history_manager  # :nodoc:
 
   private
 

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -129,7 +129,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     if expressions.empty?
       print_status('Starting IRB shell...')
 
-      Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: :irb) do
+      framework.history_manager.with_context(name: :irb) do
         begin
           if active_module
             print_status("You are in #{active_module.fullname}\n")
@@ -192,7 +192,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     print_status('Starting Pry shell...')
 
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
       if active_module
         print_status("You are in the \"#{active_module.fullname}\" module object\n")
         active_module.pry
@@ -420,7 +420,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     end
 
     if opts.key?(:debug)
-      Rex::Ui::Text::Shell::HistoryManager.instance._debug = opts[:debug]
+      framework.history_manager._debug = opts[:debug]
       print_status("HistoryManager debugging is now #{opts[:debug] ? 'on' : 'off'}")
     end
 
@@ -430,7 +430,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
         'Indent'  => 1,
         'Columns' => ['Id', 'File', 'Name']
       )
-      Rex::Ui::Text::Shell::HistoryManager.instance._contexts.each.with_index do |context, id|
+      framework.history_manager._contexts.each.with_index do |context, id|
         table << [id, context[:history_file], context[:name]]
       end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -599,7 +599,7 @@ class Console::CommandDispatcher::Core
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"client\" (session) object\n")
-      Rex::Ui::Text::Shell::HistoryManager.instance.with_context(name: :irb) do
+      framework.history_manager.with_context(name: :irb) do
         Rex::Ui::Text::IrbShell.new(client).run
       end
     else
@@ -639,7 +639,7 @@ class Console::CommandDispatcher::Core
     print_status("You are in the \"client\" (session) object\n")
 
     Pry.config.history_load = false
-    Rex::Ui::Text::Shell::HistoryManager.instance.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    client.framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
       client.pry
     end
   end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -130,7 +130,7 @@ module Shell
       # Pry is a development dependency, if not available suppressing history_load can be safely ignored.
     end
 
-    HistoryManager.instance.with_context(history_file: histfile, name: name) do
+    framework.history_manager.with_context(history_file: histfile, name: name) do
       self.hist_last_saved = Readline::HISTORY.length
 
       begin
@@ -177,7 +177,7 @@ module Shell
       end
     end
   ensure
-    HistoryManager.instance.flush
+    framework.history_manager.flush
     self.hist_last_saved = Readline::HISTORY.length
   end
 


### PR DESCRIPTION
Fixes an msfrpc hang when updating saved command history

Context: The history manager spawns threads to write history files to disk. In some scenarios the a shell session can be killed with `thread.kill`, which causes this history context to try and write to disk the latest command history from an additionally created thread:

https://github.com/rapid7/metasploit-framework/blob/85cf00e68c164ff23bc9277b55f29161269c055b/lib/rex/ui/text/shell/history_manager.rb#L154-L163

Finally the ensure block tries to flush the history:

https://github.com/rapid7/metasploit-framework/blob/85cf00e68c164ff23bc9277b55f29161269c055b/lib/rex/ui/text/shell.rb#L179-L182

Flushing is a synchronous block waiting for the newly created history thread to finish writing:

https://github.com/rapid7/metasploit-framework/blob/85cf00e68c164ff23bc9277b55f29161269c055b/lib/rex/ui/text/shell/history_manager.rb#L41-L46

Unfortunately in the `thread.kill` scenario, it seems as though new threads aren't always created - so the shell instance can just hang forever waiting for the history to flush

Minimal example here:

```ruby
shell_session = Thread.new do
  loop do
    begin
      $stderr.puts "[shell] sleeping"
      sleep 1
    rescue ::Exception
      $stderr.puts "[shell] received exception"
    ensure
      $stderr.puts "[shell] running ensure block"
      loop do
        $stderr.puts '[shell] Ensure block running!'
        $stderr.puts "[shell] creating history cleanup thread:"
        begin
          history_thread = Thread.new do
            $stderr.puts '[history] creating history cleanup thread'
            loop do
              $stderr.puts '[history] saving history'
              sleep 1
            end
          end
          $stderr.puts "[shell] #{history_thread}"
        rescue Exception
          $stderr.puts "failed creating history thread"
        end
      end

      $stderr.puts "[shell] ensure sleep"
      sleep 0.1
    end
  end
end

sleep 1

$stderr.puts "[main] kill"
shell_session.kill
$stderr.puts "[main] joining"
shell_session.join
$stderr.puts "[main] joined"

sleep 5

```

The history cleanup thread isn't always created as the ensure block doesn't run:

```
ruby foo.rb
[shell] sleeping
[main] kill
[main] joining
[main] joined

```

Sometimes the ensure block runs, but the history thread isn't created:

```
ruby foo.rb
[shell] sleeping
[shell] running ensure block
[main] kill
[shell] Ensure block running!
[main] joining
[main] joined
```

But sometimes the history thread is created:

```
ruby foo.rb
[shell] sleeping
[shell] running ensure block
[shell] Ensure block running!
[shell] creating history cleanup thread:
[shell] #<Thread:0x00007fe4a491aab0 foo.rb:14 run>
[shell] Ensure block running!
[shell] creating history cleanup thread:
[shell] #<Thread:0x00007fe4a491a740 foo.rb:14 run>
[shell] Ensure block running!
[history] creating history cleanup thread
[history] saving history
[shell] creating history cleanup thread:
[shell] #<Thread:0x00007fe4a491a3f8 foo.rb:14 run>
[shell] Ensure block running!
[shell] creating history cleanup thread:
[shell] #<Thread:0x00007fe4a491a100 foo.rb:14 run>
[shell] Ensure block running!
[shell] creating history cleanup thread:
[shell] #<Thread:0x00007fe4a4919e08 foo.rb:14 run>
[main] kill
[history] creating history cleanup thread
[history] saving history
[history] creating history cleanup thread
[history] saving history
[main] joining
[main] joined
[history] creating history cleanup thread
[history] saving history
[history] creating history cleanup thread
[history] saving history
[history] saving history
[history] saving history
[history] saving history
[history] saving history
```

The solution is to use a single history monitor thread that's created upfront and reused for persisting history to the disk.

## Verification

- Verify CI passes
- Verify console history still works as expected - https://github.com/rapid7/metasploit-framework/pull/15062