### PR TITLE
Fix error downloading a file from generic shell 

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -797,7 +797,7 @@ protected
   end
 
   def _file_transfer
-    raise NotImplementedError.new('Session does not support file transfers.') if @session_type.ends_with?(':winpty')
+    raise NotImplementedError.new('Session does not support file transfers.') if session_type.ends_with?(':winpty')
 
     FileTransfer.new(self)
   end


### PR DESCRIPTION
This PR solves the issue #18371 Error downloading a file from generic shell.

I found that it was an issue of scoping of the variable 'session_type' in file lib/msf/base/sessions/command_shell.rb at line 800

```ruby
  def _file_transfer
    raise NotImplementedError.new('Session does not support file transfers.') if @session_type.ends_with?(':winpty')

    FileTransfer.new(self)
  end
```

The '@' should be removed

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] Connect to a target and create a shell session
- [ ] Download a file from the session
- [ ] The file is downloaded correctly

