### PR TITLE
Add DB Stats Command to Console

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -54,7 +54,7 @@ class Db
       "db_nmap"       => "Executes nmap and records the output automatically",
       "db_rebuild_cache" => "Rebuilds the database-stored module cache (deprecated)",
       "analyze"       => "Analyze database information about a specific address or address range",
-      "stats"         => "Show statistics for the database"
+      "db_stats"         => "Show statistics for the database"
     }
 
     # Always include commands that only make sense when connected.
@@ -750,14 +750,9 @@ class Db
     output
   end
 
-  def cmd_stats(*args)
+  def cmd_db_stats(*args)
     return unless active?
     print_line "Session Type: #{db_connection_info(framework)}"
-
-    tbl = Rex::Text::Table.new(
-        'Header'     => 'Database Stats',
-        'Columns'    => ['ID', 'Hosts', 'Vulnerabilities', 'Notes', 'Services'],
-    )
 
     current_workspace = framework.db.workspace
     example_workspaces = ::Mdm::Workspace.order(id: :desc).take(10)
@@ -767,22 +762,28 @@ class Db
     'Header'  => "Database Stats",
     'Columns' =>
       [
-        "Active",
+        "IsTarget",
         "ID",
         "Name",
         "Hosts",
         "Services",
         "Services per Host",
         "Vulnerabilities",
-        "Vulnerabilities per Host",
+        "Vulns per Host",
         "Notes",
       ],
+    'SortIndex' => 1,
+    'ColProps' => {
+      'IsTarget' => {
+        'Stylers' => [Msf::Ui::Console::TablePrint::RowIndicatorStyler.new],
+        'ColumnStylers' => [Msf::Ui::Console::TablePrint::OmitColumnHeader.new],
+        'Width' => 2
+      }
+    }
     )
-    tbl.sort_index = 1 # ID
     ordered_workspaces.map do |workspace|
-      active = current_workspace.id == workspace.id ? "=>" : ''
       tbl << [
-        active,
+        current_workspace.id == workspace.id,
         workspace.id,
         workspace.name,
         workspace.hosts.count.to_fs(:delimited),

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -807,8 +807,8 @@ class Db
     # total row
     tbl << [
       "",
-      "",
-      "Total (#{::Mdm::Workspace.count.to_fs(:delimited)})",
+      "Total",
+      ::Mdm::Workspace.count.to_fs(:delimited),
       ::Mdm::Host.count.to_fs(:delimited),
       ::Mdm::Service.count.to_fs(:delimited),
       ::Mdm::Host.count> 0 ? (::Mdm::Service.count.to_f / ::Mdm::Host.count).truncate(2) : 0,

--- a/lib/msf/ui/console/command_dispatcher/db/klist.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/klist.rb
@@ -169,8 +169,9 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
 
   # @param [Array<Rex::Socket::RangeWalker>] host_ranges Search for tickets associated with these hosts
   # @param [Array<Integer>, nil] id_search List of ticket IDs to search for
+  # @param [Workspace] workspace to search against
   # @return [Array<Msf::Exploit::Remote::Kerberos::Ticket::Storage::StoredTicket>]
-  def ticket_search(host_ranges, id_search)
+  def ticket_search(host_ranges, id_search, workspace = framework.db.workspace)
     ticket_results = []
 
     # Iterating over each id here since the remote db doesn't support bulk id searches
@@ -178,7 +179,7 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
       begin
         ticket_results += id_search.flat_map do |id|
           kerberos_ticket_storage.tickets(
-            workspace: framework.db.workspace,
+            workspace: workspace,
             id: id
           )
         end
@@ -192,7 +193,7 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
         next if host_search&.empty?
 
         ticket_results += kerberos_ticket_storage.tickets(
-          workspace: framework.db.workspace,
+          workspace: workspace,
           host: host_search
         )
       end

--- a/lib/msf/ui/console/command_dispatcher/db/klist.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/klist.rb
@@ -170,8 +170,9 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
   # @param [Array<Rex::Socket::RangeWalker>] host_ranges Search for tickets associated with these hosts
   # @param [Array<Integer>, nil] id_search List of ticket IDs to search for
   # @param [Workspace] workspace to search against
+  # @option [Symbol] :workspace The framework.db.workspace to search against (optional)
   # @return [Array<Msf::Exploit::Remote::Kerberos::Ticket::Storage::StoredTicket>]
-  def ticket_search(host_ranges, id_search, workspace = framework.db.workspace)
+  def ticket_search(host_ranges, id_search, workspace: framework.db.workspace)
     ticket_results = []
 
     # Iterating over each id here since the remote db doesn't support bulk id searches
@@ -191,7 +192,6 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
     else
       each_host_range_chunk(host_ranges) do |host_search|
         next if host_search&.empty?
-
         ticket_results += kerberos_ticket_storage.tickets(
           workspace: workspace,
           host: host_search


### PR DESCRIPTION
fix #13136 

@leebaird 3yrs later :)

This PR adds a `db_stats` command which gives the user information about how much data is in their database/workspace. It is very similar to `debug --database`, in fact borrowing some code from there, however this prints in console friendly format instead of markdown. I've also added some quick calculations for services/host, and vulns/host.

![image](https://github.com/rapid7/metasploit-framework/assets/752491/8fa2c618-a12e-49ad-b447-a99195447d6e)

## Verification

- [ ] Start `msfconsole`
- [ ] have some hosts/vulns/services/notes/creds/kerberos_tickets in workspaces
- [ ] **Verify** `db_stats` prints out a friendly formatted table with the information
