### PR TITLE
fix related modules references

### DIFF
--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -39,9 +39,9 @@ class MetasploitModule < Msf::Auxiliary
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS],
+          'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
         },
-        'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
         'DisclosureDate' => '2021-09-06',
         'DefaultTarget' => 0
       )

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -52,9 +52,9 @@ class MetasploitModule < Msf::Auxiliary
           'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
           # resetting the router to the default factory password.
           'Stability' => [ CRASH_SERVICE_DOWN ], # This module will crash the target service after it is run.
-          'Reliability' => []
+          'Reliability' => [],
+          'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
         },
-        'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
         'DisclosureDate' => '2020-06-15',
         'DefaultTarget' => 0
       )

--- a/modules/auxiliary/gather/pulse_secure_file_disclosure.rb
+++ b/modules/auxiliary/gather/pulse_secure_file_disclosure.rb
@@ -54,6 +54,7 @@ class MetasploitModule < Msf::Auxiliary
       'Notes'               => {
         'Stability'         => [CRASH_SAFE],
         'SideEffects'       => [IOC_IN_LOGS],
+        'Reliability'       => [],
         'RelatedModules'    => ['exploit/linux/http/pulse_secure_cmd_exec']
       }
     ))

--- a/modules/auxiliary/scanner/http/emby_ssrf_scanner.rb
+++ b/modules/auxiliary/scanner/http/emby_ssrf_scanner.rb
@@ -18,7 +18,12 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => 'Btnz',
       'License' => MSF_LICENSE,
       'Disclosure Date' => '2020-10-01',
-      'RelatedModules' => ['auxiliary/scanner/http/emby_version_ssrf'],
+      'Notes'               => {
+        'Stability'         => [],
+        'SideEffects'       => [],
+        'Reliability'       => [],
+        'RelatedModules' => ['auxiliary/scanner/http/emby_version_ssrf'],
+      }
       'References' => [
         ['CVE', '2020-26948'],
         ['URL', 'https://github.com/btnz-k/emby_ssrf']

--- a/modules/auxiliary/scanner/http/emby_ssrf_scanner.rb
+++ b/modules/auxiliary/scanner/http/emby_ssrf_scanner.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         'SideEffects'       => [],
         'Reliability'       => [],
         'RelatedModules' => ['auxiliary/scanner/http/emby_version_ssrf'],
-      }
+      },
       'References' => [
         ['CVE', '2020-26948'],
         ['URL', 'https://github.com/btnz-k/emby_ssrf']

--- a/modules/auxiliary/scanner/http/emby_version_ssrf.rb
+++ b/modules/auxiliary/scanner/http/emby_version_ssrf.rb
@@ -17,7 +17,12 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => 'Btnz',
       'License' => MSF_LICENSE,
       'Disclosure Date' => '2020-10-01',
-      'RelatedModules' => ['auxiliary/scanner/http/emby_ssrf_scanner'],
+      'Notes'               => {
+        'Stability'         => [],
+        'SideEffects'       => [],
+        'Reliability'       => [],
+        'RelatedModules' => ['auxiliary/scanner/http/emby_ssrf_scanner'],
+      }
       'References' => [
         ['CVE', '2020-26948'],
         ['URL', 'https://github.com/btnz-k/emby_ssrf']

--- a/modules/auxiliary/scanner/http/emby_version_ssrf.rb
+++ b/modules/auxiliary/scanner/http/emby_version_ssrf.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Auxiliary
         'Stability'         => [],
         'SideEffects'       => [],
         'Reliability'       => [],
-        'RelatedModules' => ['auxiliary/scanner/http/emby_ssrf_scanner'],
-      }
+        'RelatedModules'    => ['auxiliary/scanner/http/emby_ssrf_scanner'],
+      },
       'References' => [
         ['CVE', '2020-26948'],
         ['URL', 'https://github.com/btnz-k/emby_ssrf']

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'RelatedModules'   => ['exploit/windows/smb/smb_doublepulsar_rce'],
         'Stability'        => [CRASH_OS_DOWN],
         'Reliability'      => [REPEATABLE_SESSION],
-        'SideEffects' => []
+        'SideEffects'      => []
       }
     ))
 

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'AKA'              => ['DOUBLEPULSAR'],
         'RelatedModules'   => ['exploit/windows/smb/smb_doublepulsar_rce'],
         'Stability'        => [CRASH_OS_DOWN],
-        'Reliability'      => [REPEATABLE_SESSION]
+        'Reliability'      => [REPEATABLE_SESSION],
+        'SideEffects' => []
       }
     ))
 

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'exploit/windows/smb/ms17_010_eternalblue'
         ],
         'Stability'        => [CRASH_OS_DOWN],
-        'Reliability'      => [REPEATABLE_SESSION]
+        'Reliability'      => [REPEATABLE_SESSION],
         'SideEffects'      => []
       }
     ))

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -78,6 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Stability'        => [CRASH_OS_DOWN],
         'Reliability'      => [REPEATABLE_SESSION]
+        'SideEffects'      => []
       }
     ))
 


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/18351#pullrequestreview-1626973828

Related Modules have to be within the Notes field. This moves any stragglers to where they should be, and adds a few missing fields within notes. This will fail lint as I didn't run `rubocop` because that's outside the scope of this PR

## Verification

- [x] Start `msfconsole`
- [x] Pick a module which was altered
- [x] **Verify** run `info` and make sure you see a related module field