### PR TITLE
add support for HELO to smtp_relay auxiliary module in case EHLO is not supported

### DIFF
--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -84,6 +84,11 @@ class MetasploitModule < Msf::Auxiliary
 
       res = raw_send_recv("EHLO X\r\n")
       vprint_status("#{res.inspect}")
+      # check if the EHLO is actually supported. In case it's not, try the HELO command instead
+      if res.inspect&.include?('Command EHLO not known')
+        res = raw_send_recv("HELO X\r\n")
+        vprint_status("#{res.inspect}")
+      end
 
       res = raw_send_recv("#{mailfrom}\r\n")
       vprint_status("#{res.inspect}")

--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
       res = raw_send_recv("EHLO X\r\n")
       vprint_status("#{res.inspect}")
       # check if the EHLO is actually supported. In case it's not, try the HELO command instead
-      if res.inspect =~ /^"5\d\d/
+      if res.to_s =~ /^5\d\d/
         res = raw_send_recv("HELO X\r\n")
         vprint_status("#{res.inspect}")
       end

--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
       res = raw_send_recv("EHLO X\r\n")
       vprint_status("#{res.inspect}")
       # check if the EHLO is actually supported. In case it's not, try the HELO command instead
-      if res.inspect&.include?('Command EHLO not known')
+      if res.inspect =~ /^"5\d\d/
         res = raw_send_recv("HELO X\r\n")
         vprint_status("#{res.inspect}")
       end


### PR DESCRIPTION
# About
This change adds a check to the `smtp_relay auxiliary` scanner module to see if the `EHLO` command is actually supported by the server. If not, the module will try to initiate the session using the `HELO` command instead.

I encountered this scenario during an assessment and while the original module failed to detect open main relay, I was able to correctly identify the server as allowing for open SMTP relay after adding this simple check. I don't know the version info of the server from my scenario, since this info was not included in the banner, but here is the Nmap version scan output:
```
PORT   STATE SERVICE VERSION
25/tcp open  smtp    i5/OS V5R4M0 or OS/400 smtpd
```
I'm not sure how common this scenario is, but given that `EHLO` is an enhanced version of `HELO`, it seems likely that it's not a unique case and that some mail servers simply only support `HELO`. Some quick resources:
- https://www.gordano.com/knowledge-base/what-is-the-smtp-heloehlo-clause/
- https://www.ibm.com/docs/en/ias?topic=usm-ehlo-procedure-perform-initial-handshaking-smtp-server-return-extended-information

# Scenarios
## Failure of the original module to detect open SMTP relay due to unsupported `EHLO` command:
```
msf6 auxiliary(scanner/smtp/smtp_relay) > run

[+] 10.10.10.10:25        - SMTP 220 [OBFUSCATED].COM Service ready.\x0d\x0a
[*] 10.10.10.10:25        - "500 Command EHLO not known.\r\n"
[*] 10.10.10.10:25        - "503 HELO must be the first command in session.\r\n"
[*] 10.10.10.10:25        - "503 HELO must be the first command in session.\r\n"
[*] 10.10.10.10:25        - "503 HELO must be the first command in session.\r\n"
[*] 10.10.10.10:25        - "500 Command caTd not known.\r\n"
[*] 10.10.10.10:25        - No relay detected
[*] 10.10.10.10:25        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
## Successful run of the module after adding support for `HELO`
```
msf6 auxiliary(scanner/smtp/smtp_relay) > run

[+] 10.10.10.10:25        - SMTP 220 [OBFUSCATED] Service ready.\x0d\x0a
[*] 10.10.10.10:25        - "500 Command EHLO not known.\r\n"
[*] 10.10.10.10:25        - "250 [OBFUSCATED].\r\n"
[*] 10.10.10.10:25        - "250 OK.\r\n"
[*] 10.10.10.10:25        - "250 OK.\r\n"
[*] 10.10.10.10:25        - "354 Enter mail body. End mail with a '.' in column 1 on a line by itself.\r\n"
[*] 10.10.10.10:25        - "250 OK.\r\n"
[+] 10.10.10.10:25        - Potential open SMTP relay detected: - MAIL FROM:<sender@example.com> -> RCPT TO:<target@example.com>
[*] 10.10.10.10:25        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
# Note about linting
Rubocop flagged 37 issues for this module that can be autocorrected. In order not to add lots of noise to the PR, I have not yet included these autocorrections in the PR. Once this is approved, they can be added by simply running rubocop with -A.