### PR TITLE
Remove left behind debug logging from prometheus exporter

### DIFF
--- a/lib/msf/core/auxiliary/prometheus.rb
+++ b/lib/msf/core/auxiliary/prometheus.rb
@@ -515,7 +515,6 @@ module Msf
           end
         elsif scrape['http_sd_configs']
           scrape['http_sd_configs']&.each do |http_sd_configs|
-            puts http_sd_configs
             process_http_sd_configs(scrape['job_name'], http_sd_configs)
           end
         elsif scrape['digitalocean_sd_configs']


### PR DESCRIPTION
Remove left behind debug logging from prometheus exporter


## Verification

There should no longer be logging in the `bundle exec rspec ./spec/lib/msf/core/auxiliary/prometheus_spec.rb` test

```
Randomized with seed 17250
Msf::Auxiliary::Prometheus ...............{"url"=>"http://example2.com/prometheus"}
{"url"=>"http://username:password@example1.com/prometheus"}
..................
```