### PR TITLE
Be less strict on hostname matching for ccache credentials

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -1030,7 +1030,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
         next
       end
 
-      unless !sname_hostname || sname_hostname.to_s.casecmp?(credential.server.components[1])
+      unless !sname_hostname ||
+        sname_hostname.to_s.downcase == credential.server.components[1] ||
+        sname_hostname.to_s.downcase.ends_with?('.' + credential.server.components[1])
         wlog("Filtered credential #{file_path} ##{index} reason: SPN (#{sname_hostname}) hostname does not match (spn: #{credential.server.components.snapshot.join('/')})")
         next
       end


### PR DESCRIPTION
Discovered this while testing #18359 

The service authenticator was filtering out valid credentials when the hostname wasn't an exact match when credentials for a domain (i.e. `windomain.local`) should work on a subdomain (i.e. dc.windomain.local)

Forged ticket: `/Users/dwelch/.msf4/loot/20230918134837_default_unknown_mit.kerberos.cca_481496.bin`
![image](https://github.com/rapid7/metasploit-framework/assets/19910435/2896a7c3-9a16-4da3-99e7-7004135532bf)

Before:
`[-] [2023.09.18-13:50:12] 192.168.176.3:445 - Exploit failed: Rex::Proto::Kerberos::Model::Error::KerberosError Failed to load a usable credential from ticket file: /Users/dwelch/.msf4/loot/20230918134837_default_unknown_mit.kerberos.cca_481496.bin`
![image](https://github.com/rapid7/metasploit-framework/assets/19910435/87a97840-ec9b-4820-97a3-1ba85b40e2e0)

After:
`Loaded a credential from ticket file: /Users/dwelch/.msf4/loot/20230918134837_default_unknown_mit.kerberos.cca_481496.bin`
![image](https://github.com/rapid7/metasploit-framework/assets/19910435/aef27993-35a3-47da-8fb2-5740e30a7a07)

Same ccache file used for both, the credential was valid but was being filtered out a bit too eagerly

# Verification steps
- [ ] Forge a silver ticket for your kerberos environment
- [ ] Check that the same ticket works with and without this change
- [ ] Target a subdomain in the environment
- [ ] Check that the ticket gets filtered out without the change and that with this change it works