### PR TITLE
Add option to reload all libs when calling `run` or `check` on a module

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -41,7 +41,11 @@ class Auxiliary
   #
   # Executes an auxiliary module
   #
-  def cmd_run(*args, action: nil)
+  def cmd_run(*args, action: nil, opts: {})
+    if (args.include?('-r') || args.include?('--reload-libs')) && !opts[:previously_reloaded]
+      driver.run_single('reload_lib -a')
+    end
+
     return false unless (args = parse_run_opts(args, action: action))
     jobify = args[:jobify]
 
@@ -132,8 +136,14 @@ class Auxiliary
   # Reloads an auxiliary module and executes it
   #
   def cmd_rerun(*args)
+    opts = {}
+    if args.include?('-r') || args.include?('--reload-libs')
+      driver.run_single('reload_lib -a')
+      opts[:previously_reloaded] = true
+    end
+
     if reload(true)
-      cmd_run(*args)
+      cmd_run(*args, opts: opts)
     end
   end
 
@@ -146,9 +156,15 @@ class Auxiliary
   # vulnerable.
   #
   def cmd_rcheck(*args)
+    opts = {}
+    if args.include?('-r') || args.include?('--reload-libs')
+      driver.run_single('reload_lib -a')
+      opts[:previously_reloaded] = true
+    end
+
     reload()
 
-    cmd_check(*args)
+    cmd_check(*args, opts: opts)
   end
 
   alias cmd_recheck cmd_rcheck

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -74,6 +74,7 @@ class Exploit
         '-n' => [ framework.nops.map { |refname, mod| refname }     ],
         '-o' => [ true                                              ],
         '-p' => [ framework.payloads.map { |refname, mod| refname } ],
+        '-r' => [ nil                                               ],
         '-t' => [ true                                              ],
         '-z' => [ nil                                               ]
     }
@@ -90,7 +91,11 @@ class Exploit
   #
   # Launches exploitation attempts.
   #
-  def cmd_exploit(*args)
+  def cmd_exploit(*args, opts: {})
+    if (args.include?('-r') || args.include?('--reload-libs')) && !opts[:previously_reloaded]
+      driver.run_single('reload_lib -a')
+    end
+
     return false unless (args = parse_exploit_opts(args))
 
     any_session = false
@@ -138,6 +143,7 @@ class Exploit
       return false
     end
 
+    driver.run_single('reload_lib -a') if args[:reload_libs]
 
     if rhosts && has_rhosts_option
       rhosts_walker = Msf::RhostsWalker.new(rhosts, mod_with_opts.datastore)
@@ -234,9 +240,15 @@ class Exploit
   # vulnerable.
   #
   def cmd_rcheck(*args)
+    opts = {}
+    if args.include?('-r') || args.include?('--reload-libs')
+      driver.run_single('reload_lib -a')
+      opts[:previously_reloaded] = true
+    end
+
     reload()
 
-    cmd_check(*args)
+    cmd_check(*args, opts: opts)
   end
 
   alias cmd_recheck cmd_rcheck
@@ -245,12 +257,18 @@ class Exploit
   # Reloads an exploit module and launches an exploit.
   #
   def cmd_rexploit(*args)
-    return cmd_rexploit_help if args.include? "-h"
+    opts = {}
+    if args.include?('-r') || args.include?('--reload-libs')
+      driver.run_single('reload_lib -a')
+      opts[:previously_reloaded] = true
+    end
+
+    return cmd_rexploit_help if args.include?('-h') || args.include?('--help')
 
     # Stop existing job and reload the module
     if reload(true)
       # Delegate to the exploit command unless the reload failed
-      cmd_exploit(*args)
+      cmd_exploit(*args, opts: opts)
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -45,7 +45,11 @@ module Msf
             )
           end
 
-          def cmd_to_handler(*_args)
+          def cmd_to_handler(*args)
+            if args.include?('-r') || args.include?('--reload-libs')
+              driver.run_single('reload_lib -a')
+            end
+
             handler = framework.modules.create('exploit/multi/handler')
 
             handler_opts = {

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -47,9 +47,15 @@ class Post
   # Reloads a post module and executes it
   #
   def cmd_rerun(*args)
+    opts = {}
+    if args.include?('-r') || args.include?('--reload-libs')
+      driver.run_single('reload_lib -a')
+      opts[:previously_reloaded] = true
+    end
+
     # Stop existing job and reload the module
     if reload(true)
-      cmd_run(*args)
+      cmd_run(*args, opts: opts)
     end
   end
 
@@ -65,7 +71,11 @@ class Post
   #
   # Executes a post module
   #
-  def cmd_run(*args, action: nil)
+  def cmd_run(*args, action: nil, opts: {})
+    if (args.include?('-r') || args.include?('--reload-libs')) && !opts[:previously_reloaded]
+      driver.run_single('reload_lib -a')
+    end
+
     return false unless (args = parse_run_opts(args, action: action))
     jobify = args[:jobify]
 

--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -17,11 +17,12 @@ module ModuleArgumentParsing
 
   # Options which are standard and predictable across all modules
   @@module_opts = Rex::Parser::Arguments.new(
-    ['-h', '--help']       => [ false, 'Help banner.'                                                       ],
-    ['-j', '--job']        => [ false, 'Run in the context of a job.'                                       ],
-    ['-J', '--foreground'] => [ false, 'Force running in the foreground, even if passive.'                  ],
-    ['-o', '--options']    => [ true,  'A comma separated list of options in VAR=VAL format.', '<options>'  ],
-    ['-q', '--quiet']      => [ false, 'Run the module in quiet mode with no output'                        ]
+    ['-h', '--help']        => [ false, 'Help banner.'                                                       ],
+    ['-j', '--job']         => [ false, 'Run in the context of a job.'                                       ],
+    ['-J', '--foreground']  => [ false, 'Force running in the foreground, even if passive.'                  ],
+    ['-o', '--options']     => [ true,  'A comma separated list of options in VAR=VAL format.', '<options>'  ],
+    ['-q', '--quiet']       => [ false, 'Run the module in quiet mode with no output'                        ],
+    ['-r', '--reload-libs'] => [ false, 'Reload all libraries before running.'                               ]
   )
 
   @@module_opts_with_action_support = @@module_opts.merge(
@@ -41,7 +42,7 @@ module ModuleArgumentParsing
     help_cmd = proc do |_result|
       cmd_check_help
     end
-    parse_opts(@@module_opts_with_action_support, args, help_cmd: help_cmd)&.slice(:datastore_options)
+    parse_opts(@@module_opts_with_action_support, args, help_cmd: help_cmd)&.slice(:datastore_options, :reload_libs)
   end
 
   def parse_run_opts(args, action: nil)
@@ -127,6 +128,8 @@ module ModuleArgumentParsing
         end
       when '-p'
         result[:payload] = val
+      when '-r'
+        result[:reload_libs] = true
       when '-t'
         result[:target] = val.to_i
       when '-z'

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -134,7 +134,11 @@ module ModuleCommandDispatcher
   #
   # Checks to see if a target is vulnerable.
   #
-  def cmd_check(*args)
+  def cmd_check(*args, opts: {})
+    if (args.include?('-r') || args.include?('--reload-libs')) && !opts[:previously_reloaded]
+      driver.run_single('reload_lib -a')
+    end
+
     return false unless (args = parse_check_opts(args))
 
     mod_with_opts = mod.replicant
@@ -243,6 +247,12 @@ module ModuleCommandDispatcher
   # Reloads the active module
   #
   def cmd_reload(*args)
+    if args.include?('-r') || args.include?('--reload-libs')
+      driver.run_single('reload_lib -a')
+    end
+
+    return cmd_reload_help if args.include?('-h') || args.include?('--help')
+
     begin
       reload
     rescue


### PR DESCRIPTION
This PR adds in a new `-r` and `--reload-libs` flag that allows for reloading all libraries before running `check`, `recheck`, `to_handler`, `reload`, `run` and `rerun`. The libraries are reloaded before other argument parsing takes place.

## Example
<details>

```ruby
msf6 exploit(windows/local/cve_2023_28252_clfs_driver) > check -r session=-1
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/module_action_commands.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/module_argument_parsing.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/post.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/auxiliary.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/evasion.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/module_command_dispatcher.rb
[*] The target is not exploitable.
msf6 exploit(windows/local/cve_2023_28252_clfs_driver) > recheck -r session=-1
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/module_action_commands.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/module_argument_parsing.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/post.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/auxiliary.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher/evasion.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/command_dispatcher.rb
[*] Reloading /Users/sjanusz/Programming/metasploit-framework/lib/msf/ui/console/module_command_dispatcher.rb
[*] Reloading module...
[*] The target is not exploitable.
```

</details>

## Verification
- [ ] Start `msfconsole`
- [ ] `use` a module such as `exploit/windows/local/cve_2023_28252_clfs_driver`
- [ ] check if `check -r` reloads all libraries but not the module
- [ ] check if `recheck -r` reloads the module and all libraries
- [ ] check if `run -r` reloads all libraries but not the module
- [ ] check if `rerun -r` reloads the module and all libraries
- [ ] check if `to_handler -r` reloads all libraries and correctly starts a payload handler
- [ ] check if `reload -r` reloads all libraries and the current module
- [ ] check if `reload` reloads only the current module
- [ ] ensure the `-r` command works for `exploit`, `post`, `auxiliary` and `evasion` modules
- [ ] ensure the `-r, --reload-libs` flag shows up when you call `-h` for `check` and `run` commands
- [ ] ensure the `-r, --reload-libs` command gets tab-completed
