### PR TITLE
Add a new lmkdir command to be able to create directory on local machine from meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -90,6 +90,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'getwd'      => 'Print working directory',
       'lcat'       => 'Read the contents of a local file to the screen',
       'lcd'        => 'Change local working directory',
+      'lmkdir'     => 'Create new directory on local machine',
       'lpwd'       => 'Print local working directory',
       'ls'         => 'List files',
       'lls'        => 'List local files',
@@ -117,6 +118,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'getwd'      => [COMMAND_ID_STDAPI_FS_GETWD],
       'lcat'       => [],
       'lcd'        => [],
+      'lmkdir'     => [],
       'lpwd'       => [],
       'ls'         => [COMMAND_ID_STDAPI_FS_STAT, COMMAND_ID_STDAPI_FS_LS],
       'lls'        => [],
@@ -382,6 +384,22 @@ class Console::CommandDispatcher::Stdapi::Fs
 
     return true
   end
+
+ def cmd_lmkdir(*args)
+   if (args.length == 0)
+     print_line("Usage: lmkdir directory")
+     return true
+   end
+
+   begin
+     ::Dir.mkdir(args[0])
+     print_line("Directory '#{args[0]}' created successfully.")
+   rescue => e
+     print_error("Error creating directory: #{e}")
+   end
+
+   return true
+ end
 
   #
   # Tab completion for the lcd command


### PR DESCRIPTION
Added lmkdir command to create new directory on local machine.

- [x] Start `msfconsole`
- [x] `use windows/x64/meterpreter/reverse_tcp`
- [x] `run`
- [x] `lmkdir test`
- [x] **Verify** lmkdir successfully create a new directory on local machine
- [x] **Verify** if lmkdir fails it displays an error message
- [x] **Document** lmkdir <directory> creates a new directory on local machine while in meterpreter