### PR TITLE
Add a new lmkdir command to be able to create directory on local machine from meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -90,6 +90,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'getwd'      => 'Print working directory',
       'lcat'       => 'Read the contents of a local file to the screen',
       'lcd'        => 'Change local working directory',
+      'lmkdir'     => 'Create new directory on local machine',
       'lpwd'       => 'Print local working directory',
       'ls'         => 'List files',
       'lls'        => 'List local files',
@@ -117,6 +118,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'getwd'      => [COMMAND_ID_STDAPI_FS_GETWD],
       'lcat'       => [],
       'lcd'        => [],
+      'lmkdir'     => [],
       'lpwd'       => [],
       'ls'         => [COMMAND_ID_STDAPI_FS_STAT, COMMAND_ID_STDAPI_FS_LS],
       'lls'        => [],
@@ -382,6 +384,22 @@ class Console::CommandDispatcher::Stdapi::Fs
 
     return true
   end
+
+ def cmd_lmkdir(*args)
+   if (args.length == 0)
+     print_line("Usage: lmkdir directory")
+     return true
+   end
+
+   begin
+     ::Dir.mkdir(args[0])
+     print_line("Directory '#{args[0]}' created successfully.")
+   rescue => e
+     print_error("Error creating directory: #{e}")
+   end
+
+   return true
+ end
 
   #
   # Tab completion for the lcd command

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -401,12 +401,15 @@ class Console::CommandDispatcher::Stdapi::Fs
      return true
    end
 
-   begin
-     ::FileUtils.mkdir_p(path)
-     print_line("Directory '#{args[0]}' created successfully.")
-   rescue => e
-     print_error("Error creating directory: #{e}")
-   end
+   args.each { |path|
+     begin
+       ::FileUtils.mkdir_p(path)
+       print_line("Directory '#{path}' created successfully.")
+     rescue => e
+       print_error("Error creating #{path} directory: #{e}")
+     end
+   }
+
   
    return true
  end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -402,7 +402,7 @@ class Console::CommandDispatcher::Stdapi::Fs
    end
 
    begin
-     ::Dir.mkdir(args[0])
+     ::FileUtils.mkdir_p(path)
      print_line("Directory '#{args[0]}' created successfully.")
    rescue => e
      print_error("Error creating directory: #{e}")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -397,7 +397,7 @@ class Console::CommandDispatcher::Stdapi::Fs
   # 
  def cmd_lmkdir(*args)
    if (args.length == 0)
-     print_line("Usage: lmkdir directory")
+     print_line("Usage: lmkdir </path/to/directory>")
      return
    end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -401,14 +401,14 @@ class Console::CommandDispatcher::Stdapi::Fs
      return true
    end
 
-   args.each { |path|
+   args.each do |path|
      begin
        ::FileUtils.mkdir_p(path)
        print_line("Directory '#{path}' created successfully.")
-     rescue => e
+     rescue ::StandardError => e
        print_error("Error creating #{path} directory: #{e}")
      end
-   }
+   end
 
   
    return true

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -411,7 +411,6 @@ class Console::CommandDispatcher::Stdapi::Fs
    end
 
   
-   return true
  end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -398,7 +398,7 @@ class Console::CommandDispatcher::Stdapi::Fs
  def cmd_lmkdir(*args)
    if (args.length == 0)
      print_line("Usage: lmkdir directory")
-     return true
+     return
    end
 
    args.each do |path|

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -90,7 +90,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'getwd'      => 'Print working directory',
       'lcat'       => 'Read the contents of a local file to the screen',
       'lcd'        => 'Change local working directory',
-      'lmkdir'     => 'create new directory on local machine',
+      'lmkdir'     => 'Create new directory on local machine',
       'lpwd'       => 'Print local working directory',
       'ls'         => 'List files',
       'lls'        => 'List local files',

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -90,7 +90,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'getwd'      => 'Print working directory',
       'lcat'       => 'Read the contents of a local file to the screen',
       'lcd'        => 'Change local working directory',
-      'lmkdir'     => 'Create new directory on local machine',
+      'lmkdir'     => 'create new directory on local machine',
       'lpwd'       => 'Print local working directory',
       'ls'         => 'List files',
       'lls'        => 'List local files',
@@ -385,6 +385,16 @@ class Console::CommandDispatcher::Stdapi::Fs
     return true
   end
 
+  #
+  # Tab completion for the lcd command
+  #
+  def cmd_lcd_tabs(str, words)
+    tab_complete_directory(str, words)
+  end
+
+  #
+  # Create new directory on local machine
+  # 
  def cmd_lmkdir(*args)
    if (args.length == 0)
      print_line("Usage: lmkdir directory")
@@ -397,16 +407,9 @@ class Console::CommandDispatcher::Stdapi::Fs
    rescue => e
      print_error("Error creating directory: #{e}")
    end
-
+  
    return true
  end
-
-  #
-  # Tab completion for the lcd command
-  #
-  def cmd_lcd_tabs(str, words)
-    tab_complete_directory(str, words)
-  end
 
   #
   # Retrieve the checksum of a file


### PR DESCRIPTION
Added lmkdir command to create new directory on local machine.

- [x] Start `msfconsole`
- [x] `use windows/x64/meterpreter/reverse_tcp`
- [x] `run`
- [x] `lmkdir test`
- [x] **Verify** lmkdir successfully create a new directory on local machine
- [x] **Verify** if lmkdir fails it displays an error message
- [x] **Document** lmkdir <directory> creates a new directory on local machine while in meterpreter