### PR TITLE
Remove raised exception in acceptance tests

### DIFF
--- a/spec/acceptance/meterpreter_spec.rb
+++ b/spec/acceptance/meterpreter_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe 'Meterpreter' do
           end
 
           before :each do |example|
-            raise 'Failed to load allure metadata method' unless example.respond_to?(:parameter)
+            next unless example.respond_to?(:parameter)
 
             # Add the test environment metadata to the rspec example instance - so it appears in the final allure report UI
             test_environment.each do |key, value|


### PR DESCRIPTION
Remove raised exception in acceptance tests

## Verification

Verify the acceptance tests run locally

```
SPEC_OPTS='--tag acceptance' bundle exec rspec /Users/adfoster/Documents/code/metasploit-framework/spec/acceptance/meterpreter_spec.rb
```