### PR TITLE
Refactor deprecated report_auth_info in various modules

### DIFF
--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -174,21 +174,25 @@ class MetasploitModule < Msf::Auxiliary
     if httpcreds
       httpuser = httpcreds[1].split(/[\r\n]+/)[0]
       httppass = httpcreds[1].split(/[\r\n]+/)[1]
+      proof = "FTP PASV data socket: #{httpcreds}"
     else
       # Usual defaults
       httpuser = "USER"
       httppass = "USER"
+      proof = "Usual defaults"
     end
     print_status("#{rhost}:#{rport} - FTP - Storing HTTP credentials")
     logins << ["http", httpuser, httppass]
-    report_auth_info(
-      :host	=> ip,
-      :port	=> 80,
-      :sname	=> "http",
-      :user	=> httpuser,
-      :pass	=> httppass,
-      :active	=> true
+
+    report_cred(
+      :ip => ip,
+      :port => 80,
+      :service_name => 'http',
+      :user => httpuser,
+      :password => httppass,
+      :proof => proof
     )
+
     logins << ["scada-write", "", writecreds[1]]
     if writecreds # This is like an enable password, used after HTTP authentication.
       report_note(

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -174,18 +174,18 @@ class MetasploitModule < Msf::Auxiliary
             :port => rport,
             :name => (ssl ? 'https' : 'http')
           )
-          report_auth_info(
-            :host        => rhost,
-            :port        => rport,
-            :sname       => (ssl ? 'https' : 'http'),
-            :user        => short_name,
-            :pass        => pass_hash,
-            :ptype       => 'domino_hash',
-            :source_id   => domino_svc&.id,
-            :source_type => 'service',
-            :proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
-            :active      => true
-          )
+
+          connection_details = {
+            module_fullname: self.fullname,
+            username: short_name,
+            private_data: pass_hash,
+            private_type: :nonreplayable_hash,
+            jtr_format: 'dominosec',
+            workspace_id: myworkspace_id,
+            proof: "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }.merge(service_details)
+          create_credential_and_login(connection_details)
         end
       end
 

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -174,17 +174,14 @@ class MetasploitModule < Msf::Auxiliary
             :port => rport,
             :name => (ssl ? 'https' : 'http')
           )
-          report_auth_info(
-            :host        => rhost,
-            :port        => rport,
-            :sname       => (ssl ? 'https' : 'http'),
-            :user        => short_name,
-            :pass        => pass_hash,
-            :ptype       => 'domino_hash',
-            :source_id   => domino_svc&.id,
-            :source_type => 'service',
-            :proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
-            :active      => true
+
+          report_cred(
+            ip: rhost,
+            port: rport,
+            service_name: (ssl ? "https" : "http"),
+            user: short_name,
+            password: pass_hash,
+            proof: "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}"
           )
         end
       end
@@ -192,5 +189,32 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash,
+      jtr_format: 'dominosec'
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 end

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -174,18 +174,18 @@ class MetasploitModule < Msf::Auxiliary
             :port => rport,
             :name => (ssl ? 'https' : 'http')
           )
-
-          connection_details = {
-            module_fullname: self.fullname,
-            username: short_name,
-            private_data: pass_hash,
-            private_type: :nonreplayable_hash,
-            jtr_format: 'dominosec',
-            workspace_id: myworkspace_id,
-            proof: "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
-            status: Metasploit::Model::Login::Status::UNTRIED
-          }.merge(service_details)
-          create_credential_and_login(connection_details)
+          report_auth_info(
+            :host        => rhost,
+            :port        => rport,
+            :sname       => (ssl ? 'https' : 'http'),
+            :user        => short_name,
+            :pass        => pass_hash,
+            :ptype       => 'domino_hash',
+            :source_id   => domino_svc&.id,
+            :source_type => 'service',
+            :proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
+            :active      => true
+          )
         end
       end
 

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -400,16 +400,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }.merge(service_details)
       create_credential_and_login(connection_details)
 
-      # why is this stored another way?
-      report_auth_info({
-        :host => rhost,
-        :port => rport,
-        :user => user[0],
-        :pass => user[1],
-        :type => "hash",
-        :sname => (ssl ? "https" : "http"),
-        :proof => "salt: #{user[2]}" # Using proof to store the hash salt
-      })
       users << user
     end
 


### PR DESCRIPTION
Updates the deprecated report_auth_info in [lotus_domino_hashesh.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb) and [modicon_password_recovery.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/admin/scada/modicon_password_recovery.rb)
Remove the redundant report_auth_info from [vbulletin_vote_sqli_exec.rb
](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb)

Related to https://github.com/rapid7/metasploit-framework/issues/10314

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <module>`
- [ ] ...
- [ ] **Verify** the credentials are stored using the proper API