### PR TITLE
Update deprecated report_auth_info in various modules

### DIFF
--- a/data/exploits/psnuffle/ftp.rb
+++ b/data/exploits/psnuffle/ftp.rb
@@ -40,7 +40,15 @@ class SnifferFTP < BaseProtocolParser
 
       when :login_fail
         if(s[:user] and s[:pass])
-          report_auth_info(s.merge({:active => false}))
+          report_cred(
+            :ip  => s[:host],
+            :port => 21,
+            :service_name => s[:sname],
+            :user => s[:user],
+            :password => s[:pass],
+            :proof => "Response code 5 from server",
+            :status => Metasploit::Model::Login::Status::INCORRECT
+          )
           print_status("Failed FTP Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]}")
 
           s[:pass] = ""
@@ -49,7 +57,15 @@ class SnifferFTP < BaseProtocolParser
 
       when :login_pass
         if(s[:user] and s[:pass])
-          report_auth_info(s)
+          report_cred(
+            :ip  => s[:host],
+            :port => 21,
+            :service_name => s[:sname],
+            :user => s[:user],
+            :password => s[:pass],
+            :proof => "Response code 230 from server",
+            :status => Metasploit::Model::Login::Status::SUCCESSFUL
+          )
           print_status("Successful FTP Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]}")
           # Remove it form the session objects so freeup memory
           sessions.delete(s[:session])
@@ -74,5 +90,31 @@ class SnifferFTP < BaseProtocolParser
 
     end # end of each_key
   end # end of parse
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: opts[:status],
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 end
 

--- a/data/exploits/psnuffle/ftp.rb
+++ b/data/exploits/psnuffle/ftp.rb
@@ -42,10 +42,11 @@ class SnifferFTP < BaseProtocolParser
         if(s[:user] and s[:pass])
           report_cred(
             :ip  => s[:host],
-            :port => 21,
+            :port => s[:port],
             :service_name => s[:sname],
             :user => s[:user],
             :password => s[:pass],
+            :type => :password,
             :proof => "Response code 5 from server",
             :status => Metasploit::Model::Login::Status::INCORRECT
           )
@@ -59,10 +60,11 @@ class SnifferFTP < BaseProtocolParser
         if(s[:user] and s[:pass])
           report_cred(
             :ip  => s[:host],
-            :port => 21,
+            :port => s[:port],
             :service_name => s[:sname],
             :user => s[:user],
             :password => s[:pass],
+            :type => :password,
             :proof => "Response code 230 from server",
             :status => Metasploit::Model::Login::Status::SUCCESSFUL
           )
@@ -90,31 +92,5 @@ class SnifferFTP < BaseProtocolParser
 
     end # end of each_key
   end # end of parse
-
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: opts[:status],
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
 end
 

--- a/data/exploits/psnuffle/imap.rb
+++ b/data/exploits/psnuffle/imap.rb
@@ -46,10 +46,11 @@ class SnifferIMAP < BaseProtocolParser
 
         report_cred(
           :ip  => s[:host],
-          :port => 143,
+          :port => s[:port],
           :service_name => s[:sname],
           :user => s[:user],
           :password => s[:pass],
+          :type => :password,
           :proof => "Capability OK reponse from server",
           :status => Metasploit::Model::Login::Status::SUCCESSFUL
         )
@@ -62,10 +63,11 @@ class SnifferIMAP < BaseProtocolParser
 
         report_cred(
           :ip  => s[:host],
-          :port => 143,
+          :port => s[:port],
           :service_name => s[:sname],
           :user => s[:user],
           :password => s[:pass],
+          :type => :password,
           :proof => "Capability NO response from server",
           :status => Metasploit::Model::Login::Status::INCORRECT
         )
@@ -77,10 +79,11 @@ class SnifferIMAP < BaseProtocolParser
       when :login_bad
         report_cred(
           :ip  => s[:host],
-          :port => 143,
+          :port => s[:port],
           :service_name => s[:sname],
           :user => s[:user],
           :password => s[:pass],
+          :type => :password,
           :proof => "Capability BAD response from server",
           :status => Metasploit::Model::Login::Status::INCORRECT
         )
@@ -100,31 +103,5 @@ class SnifferIMAP < BaseProtocolParser
       end # end case matched
     end # end of each_key
   end # end of parse
-
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: opts[:status],
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
 end
 

--- a/data/exploits/psnuffle/imap.rb
+++ b/data/exploits/psnuffle/imap.rb
@@ -85,7 +85,7 @@ class SnifferIMAP < BaseProtocolParser
           :password => s[:pass],
           :type => :password,
           :proof => "Capability BAD response from server",
-          :status => Metasploit::Model::Login::Status::INCORRECT
+          :status => Metasploit::Model::Login::Status::UNTRIED
         )
         print_status("Bad IMAP Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
 

--- a/data/exploits/psnuffle/imap.rb
+++ b/data/exploits/psnuffle/imap.rb
@@ -44,7 +44,15 @@ class SnifferIMAP < BaseProtocolParser
 
       when :login_pass
 
-        report_auth_info(s)
+        report_cred(
+          :ip  => s[:host],
+          :port => 143,
+          :service_name => s[:sname],
+          :user => s[:user],
+          :password => s[:pass],
+          :proof => "Capability OK reponse from server",
+          :status => Metasploit::Model::Login::Status::SUCCESSFUL
+        )
         print_status("Successful IMAP Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
 
         # Remove it form the session objects so freeup
@@ -52,14 +60,30 @@ class SnifferIMAP < BaseProtocolParser
 
       when :login_fail
 
-        report_auth_info(s.merge({:active => false}))
+        report_cred(
+          :ip  => s[:host],
+          :port => 143,
+          :service_name => s[:sname],
+          :user => s[:user],
+          :password => s[:pass],
+          :proof => "Capability NO response from server",
+          :status => Metasploit::Model::Login::Status::INCORRECT
+        )
         print_status("Failed IMAP Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
 
         # Remove it form the session objects so freeup
         sessions.delete(s[:session])
 
       when :login_bad
-        report_auth_info(s.merge({:active => false}))
+        report_cred(
+          :ip  => s[:host],
+          :port => 143,
+          :service_name => s[:sname],
+          :user => s[:user],
+          :password => s[:pass],
+          :proof => "Capability BAD response from server",
+          :status => Metasploit::Model::Login::Status::INCORRECT
+        )
         print_status("Bad IMAP Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
 
         # Remove it form the session objects so freeup
@@ -76,5 +100,31 @@ class SnifferIMAP < BaseProtocolParser
       end # end case matched
     end # end of each_key
   end # end of parse
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: opts[:status],
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 end
 

--- a/data/exploits/psnuffle/pop3.rb
+++ b/data/exploits/psnuffle/pop3.rb
@@ -52,7 +52,15 @@ class SnifferPOP3 < BaseProtocolParser
               s[:proto] = "tcp"
               s[:name]  = "pop3"
               s[:extra] = "Successful Login. Banner: #{s[:banner]}"
-              report_auth_info(s)
+              report_cred(
+                :ip  => s[:host],
+                :port => 110,
+                :service_name => s[:sname],
+                :user => s[:user],
+                :password => s[:pass],
+                :proof => "OK response after PASS response from server",
+                :status => Metasploit::Model::Login::Status::SUCCESSFUL
+              )
               print_status("Successful POP3 Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
 
               # Remove it form the session objects so freeup
@@ -72,7 +80,15 @@ class SnifferPOP3 < BaseProtocolParser
 
               s[:proto]="pop3"
               s[:extra]="Failed Login. Banner: #{s[:banner]}"
-              report_auth_info(s)
+              report_cred(
+                :ip  => s[:host],
+                :port => 110,
+                :service_name => s[:sname],
+                :user => s[:user],
+                :password => s[:pass],
+                :proof => "ERR response after PASS response from server",
+                :status => Metasploit::Model::Login::Status::INCORRECT
+              )
               print_status("Invalid POP3 Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
               s[:pass]=""
           end
@@ -84,5 +100,31 @@ class SnifferPOP3 < BaseProtocolParser
       end # end case matched
     end # end of each_key
   end # end of parse
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: opts[:status],
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 end
 

--- a/data/exploits/psnuffle/pop3.rb
+++ b/data/exploits/psnuffle/pop3.rb
@@ -54,11 +54,12 @@ class SnifferPOP3 < BaseProtocolParser
               s[:extra] = "Successful Login. Banner: #{s[:banner]}"
               report_cred(
                 :ip  => s[:host],
-                :port => 110,
-                :service_name => s[:sname],
+                :port => s[:port],
+                :service_name => s[:name],
                 :user => s[:user],
                 :password => s[:pass],
-                :proof => "OK response after PASS response from server",
+                :type => :password,
+                :proof => s[:extra],
                 :status => Metasploit::Model::Login::Status::SUCCESSFUL
               )
               print_status("Successful POP3 Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
@@ -82,11 +83,12 @@ class SnifferPOP3 < BaseProtocolParser
               s[:extra]="Failed Login. Banner: #{s[:banner]}"
               report_cred(
                 :ip  => s[:host],
-                :port => 110,
-                :service_name => s[:sname],
+                :port => s[:port],
+                :service_name => s[:proto],
                 :user => s[:user],
                 :password => s[:pass],
-                :proof => "ERR response after PASS response from server",
+                :type => :password,
+                :proof => s[:extra],
                 :status => Metasploit::Model::Login::Status::INCORRECT
               )
               print_status("Invalid POP3 Login: #{s[:session]} >> #{s[:user]} / #{s[:pass]} (#{s[:banner].strip})")
@@ -100,31 +102,5 @@ class SnifferPOP3 < BaseProtocolParser
       end # end case matched
     end # end of each_key
   end # end of parse
-
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: opts[:status],
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
 end
 

--- a/data/exploits/psnuffle/smb.rb
+++ b/data/exploits/psnuffle/smb.rb
@@ -4,7 +4,7 @@
 # When db is available reports go into db
 #
 
-#Memo : 
+#Memo :
 #FOR SMBV1
   # Authentification without extended security set
     #1) client -> server : smb_negotiate (0x72) : smb.flags2.extended_sec  =  0
@@ -20,7 +20,7 @@
     #5) client -> server : smb_setup_andx (0x73) : contains an ntlm_type3 message with the lm/ntlm hashes
     #6) server -> client : smb_setup_andx (0x73) : if status = success then authentification = ok
 #FOR SMBV2
-  #SMBv2 is pretty similar. However, extended security is always set and it is using a newer set of smb negociate and session_setup command for requets/response 
+  #SMBv2 is pretty similar. However, extended security is always set and it is using a newer set of smb negociate and session_setup command for requets/response
 
 class SnifferSMB < BaseProtocolParser
 
@@ -132,7 +132,7 @@ class SnifferSMB < BaseProtocolParser
         ntlmlength = 	payload[53,2].unpack("v")[0]
         s[:lmhash] = 	payload[65,lmlength].unpack("H*")[0]
         s[:ntlmhash] =  payload[65 + lmlength, ntlmlength].unpack("H*")[0]
-      
+
         names = payload[Range.new(65 + lmlength + ntlmlength,-1)].split("\x00\x00").map { |x| x.gsub(/\x00/, '') }
 
         s[:user] = names[0]
@@ -145,8 +145,8 @@ class SnifferSMB < BaseProtocolParser
         if s[:last] == :ntlm_type3 or s[:last] == :smb_no_ntlm
           #do not output anonymous/guest logging
           unless s[:user] == '' or s[:ntlmhash] == '' or s[:ntlmhash] =~ /^(00)*$/m
-            #set lmhash to a default value if not provided						   	
-            s[:lmhash] = "00" * 24 if s[:lmhash] == '' or s[:lmhash] =~ /^(00)*$/m 
+            #set lmhash to a default value if not provided
+            s[:lmhash] = "00" * 24 if s[:lmhash] == '' or s[:lmhash] =~ /^(00)*$/m
             s[:lmhash] = "00" * 24 if s[:lmhash] == s[:ntlmhash]
 
             smb_status = payload[9,4].unpack("V")[0]
@@ -157,29 +157,27 @@ class SnifferSMB < BaseProtocolParser
               logmessage =
                 "#{ntlm_ver} Response Captured in #{s[:smb_version]} session : #{s[:session]} \n" +
                 "USER:#{s[:user]} DOMAIN:#{s[:domain]} OS:#{s[:peer_os]} LM:#{s[:peer_lm]}\n" +
-                "SERVER CHALLENGE:#{s[:challenge]} " + 
-                "\nLMHASH:#{s[:lmhash]} " + 
+                "SERVER CHALLENGE:#{s[:challenge]} " +
+                "\nLMHASH:#{s[:lmhash]} " +
                 "\nNTHASH:#{s[:ntlmhash]}\n"
               print_status(logmessage)
 
               src_ip = s[:client_host]
               dst_ip = s[:host]
-              # know this is ugly , last code added :-/
               smb_db_type_hash = case ntlm_ver
-                     when "NTLMv1" 		then "smb_netv1_hash"
-                     when "NTLM2_SESSION" 	then "smb_netv1_hash"
-                     when "NTLMv2" 		then "smb_netv2_hash"
+                     when "NTLMv1" 		then "netntlm"
+                     when "NTLM2_SESSION" 	then "netntlm"
+                     when "NTLMv2" 		then "netntlmv2"
                      end
               # DB reporting
-              report_auth_info(
-                :host  => dst_ip,
+              report_cred(
+                :ip  => dst_ip,
                 :port => 445,
-                :sname => 'smb',
+                :service_name => 'smb',
                 :user => s[:user],
-                :pass => s[:domain] + ":" + s[:lmhash] + ":" + s[:ntlmhash] + ":" + s[:challenge],
-                :type => smb_db_type_hash,
+                :password => s[:domain] + ":" + s[:lmhash] + ":" + s[:ntlmhash] + ":" + s[:challenge],
+                :jtr_format => smb_db_type_hash,
                 :proof => "DOMAIN=#{s[:domain]} OS=#{s[:peer_os]}",
-                :active => true
               )
 
               report_note(
@@ -207,5 +205,32 @@ class SnifferSMB < BaseProtocolParser
         sessions.delete(s[:session])
       end
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash,
+      jtr_format: opts[:jtr_format]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 end

--- a/data/exploits/psnuffle/smb.rb
+++ b/data/exploits/psnuffle/smb.rb
@@ -172,12 +172,14 @@ class SnifferSMB < BaseProtocolParser
               # DB reporting
               report_cred(
                 :ip  => dst_ip,
-                :port => 445,
+                :port => s[:port],
                 :service_name => 'smb',
                 :user => s[:user],
                 :password => s[:domain] + ":" + s[:lmhash] + ":" + s[:ntlmhash] + ":" + s[:challenge],
+                :type => :nonreplayable_hash,
                 :jtr_format => smb_db_type_hash,
                 :proof => "DOMAIN=#{s[:domain]} OS=#{s[:peer_os]}",
+                :status => Metasploit::Model::Login::Status::SUCCESSFUL
               )
 
               report_note(
@@ -205,32 +207,5 @@ class SnifferSMB < BaseProtocolParser
         sessions.delete(s[:session])
       end
     end
-  end
-
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :nonreplayable_hash,
-      jtr_format: opts[:jtr_format]
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
   end
 end

--- a/data/exploits/psnuffle/url.rb
+++ b/data/exploits/psnuffle/url.rb
@@ -44,7 +44,14 @@ class SnifferURL < BaseProtocolParser
         end
         if s[:basic_auth]
           s[:user], s[:pass] = Rex::Text.decode_base64(s[:basic_auth]).split(':', 2)
-          report_auth_info s
+          report_cred(
+            :ip  => s[:host],
+            :port => 80,
+            :service_name => s[:sname],
+            :user => s[:user],
+            :password => s[:pass],
+            :proof => "Session: #{s[:session]} Basic Auth: #{s[:basic_auth]}",
+          )
           print_status "HTTP Basic Authentication: #{s[:session]} >> #{s[:user]} / #{s[:pass]}"
         end
       when nil
@@ -52,4 +59,30 @@ class SnifferURL < BaseProtocolParser
       end # end case matched
     end # end of each_key
   end # end of parse
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 end # end of URL sniffer

--- a/data/exploits/psnuffle/url.rb
+++ b/data/exploits/psnuffle/url.rb
@@ -46,11 +46,13 @@ class SnifferURL < BaseProtocolParser
           s[:user], s[:pass] = Rex::Text.decode_base64(s[:basic_auth]).split(':', 2)
           report_cred(
             :ip  => s[:host],
-            :port => 80,
-            :service_name => s[:sname],
+            :port => s[:port],
+            :service_name => 'http',
             :user => s[:user],
             :password => s[:pass],
+            :type => :password,
             :proof => "Session: #{s[:session]} Basic Auth: #{s[:basic_auth]}",
+            :status => Metasploit::Model::Login::Status::UNTRIED
           )
           print_status "HTTP Basic Authentication: #{s[:session]} >> #{s[:user]} / #{s[:pass]}"
         end
@@ -59,30 +61,4 @@ class SnifferURL < BaseProtocolParser
       end # end case matched
     end # end of each_key
   end # end of parse
-
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
 end # end of URL sniffer

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -185,12 +185,12 @@ class MetasploitModule < Msf::Auxiliary
     logins << ["http", httpuser, httppass]
 
     report_cred(
-      :ip => ip,
-      :port => 80,
-      :service_name => 'http',
-      :user => httpuser,
-      :password => httppass,
-      :proof => proof
+      ip: ip,
+      port: rport,
+      service_name: 'http',
+      user: httpuser,
+      password: httppass,
+      proof: proof
     )
 
     logins << ["scada-write", "", writecreds[1]]

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -174,21 +174,25 @@ class MetasploitModule < Msf::Auxiliary
     if httpcreds
       httpuser = httpcreds[1].split(/[\r\n]+/)[0]
       httppass = httpcreds[1].split(/[\r\n]+/)[1]
+      proof = "FTP PASV data socket: #{httpcreds}"
     else
       # Usual defaults
       httpuser = "USER"
       httppass = "USER"
+      proof = "Usual defaults"
     end
     print_status("#{rhost}:#{rport} - FTP - Storing HTTP credentials")
     logins << ["http", httpuser, httppass]
-    report_auth_info(
-      :host	=> ip,
-      :port	=> 80,
-      :sname	=> "http",
-      :user	=> httpuser,
-      :pass	=> httppass,
-      :active	=> true
+
+    report_cred(
+      :ip => ip,
+      :port => 80,
+      :service_name => 'http',
+      :user => httpuser,
+      :password => httppass,
+      :proof => proof
     )
+
     logins << ["scada-write", "", writecreds[1]]
     if writecreds # This is like an enable password, used after HTTP authentication.
       report_note(

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -190,6 +190,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def report_cred(opts)
 
+    service_data = service_details.merge({workspace_id: myworkspace_id})
+
     credential_data = {
       origin_type: :service,
       module_fullname: fullname,
@@ -197,7 +199,7 @@ class MetasploitModule < Msf::Auxiliary
       private_data: opts[:password],
       private_type: :nonreplayable_hash,
       jtr_format: 'dominosec'
-    }.merge(service_details)
+    }.merge(service_data)
 
     login_data = {
       core: create_credential(credential_data),

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -174,17 +174,14 @@ class MetasploitModule < Msf::Auxiliary
             :port => rport,
             :name => (ssl ? 'https' : 'http')
           )
-          report_auth_info(
-            :host        => rhost,
-            :port        => rport,
-            :sname       => (ssl ? 'https' : 'http'),
-            :user        => short_name,
-            :pass        => pass_hash,
-            :ptype       => 'domino_hash',
-            :source_id   => domino_svc&.id,
-            :source_type => 'service',
-            :proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
-            :active      => true
+
+          report_cred(
+            ip: rhost,
+            port: rport,
+            service_name: (ssl ? "https" : "http"),
+            user: short_name,
+            password: pass_hash,
+            proof: "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}"
           )
         end
       end
@@ -192,5 +189,32 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash,
+      jtr_format: 'dominosec'
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 end

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -176,9 +176,6 @@ class MetasploitModule < Msf::Auxiliary
           )
 
           report_cred(
-            ip: rhost,
-            port: rport,
-            service_name: (ssl ? "https" : "http"),
             user: short_name,
             password: pass_hash,
             proof: "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}"
@@ -192,13 +189,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
 
     credential_data = {
       origin_type: :service,
@@ -207,7 +197,7 @@ class MetasploitModule < Msf::Auxiliary
       private_data: opts[:password],
       private_type: :nonreplayable_hash,
       jtr_format: 'dominosec'
-    }.merge(service_data)
+    }.merge(service_details)
 
     login_data = {
       core: create_credential(credential_data),

--- a/modules/auxiliary/sniffer/psnuffle.rb
+++ b/modules/auxiliary/sniffer/psnuffle.rb
@@ -102,7 +102,6 @@ end
 
 # Basic class for taking care of sessions
 class BaseProtocolParser
-  include Msf::Auxiliary::Report
 
   attr_accessor :framework, :module, :sessions, :dport, :sigs
 
@@ -155,7 +154,7 @@ class BaseProtocolParser
     end
 
     login_data = {
-      core: create_credential(credential_data),
+      core: self.module.create_credential(credential_data),
       status: opts[:status],
       proof: opts[:proof]
     }.merge(service_data)
@@ -164,7 +163,7 @@ class BaseProtocolParser
       login_data.merge!(last_attempted_at: DateTime.now)
     end
 
-    create_credential_login(login_data)
+    self.module.create_credential_login(login_data)
   end
 
   def report_note(*s)

--- a/modules/auxiliary/sniffer/psnuffle.rb
+++ b/modules/auxiliary/sniffer/psnuffle.rb
@@ -102,6 +102,7 @@ end
 
 # Basic class for taking care of sessions
 class BaseProtocolParser
+  include Msf::Auxiliary::Report
 
   attr_accessor :framework, :module, :sessions, :dport, :sigs
 
@@ -132,8 +133,38 @@ class BaseProtocolParser
     self.module.print_error(msg)
   end
 
-  def report_auth_info(*s)
-    self.module.report_auth_info(*s)
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: self.module.myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: self.module.fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: opts[:type]
+    }.merge(service_data)
+
+    if opts[:type] == :nonreplayable_hash
+      credential_data.merge!(jtr_format: opts[:jtr_format])
+    end
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: opts[:status],
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    unless opts[:status] == Metasploit::Model::Login::Status::UNTRIED
+      login_data.merge!(last_attempted_at: DateTime.now)
+    end
+
+    create_credential_login(login_data)
   end
 
   def report_note(*s)

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -399,17 +399,6 @@ class MetasploitModule < Msf::Exploit::Remote
           status: Metasploit::Model::Login::Status::UNTRIED
       }.merge(service_details)
       create_credential_and_login(connection_details)
-
-      # why is this stored another way?
-      report_auth_info({
-        :host => rhost,
-        :port => rport,
-        :user => user[0],
-        :pass => user[1],
-        :type => "hash",
-        :sname => (ssl ? "https" : "http"),
-        :proof => "salt: #{user[2]}" # Using proof to store the hash salt
-      })
       users << user
     end
 

--- a/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Lotus Domino Hashes' do
   before(:each) do
     allow(subject).to receive(:send_request_raw).and_return(result)
     allow(subject).to receive(:report_service).and_return(service)
-    allow(subject).to receive(:report_auth_info)
+    allow(subject).to receive(:report_cred)
   end
 
   describe '#dump_hashes' do
@@ -49,7 +49,7 @@ RSpec.describe 'Lotus Domino Hashes' do
       context 'when the database is connected' do
         it 'reports the extracted user and password' do
           subject.dump_hashes(view_id, cookie, uri)
-          expect(subject).to have_received(:report_auth_info).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
+          expect(subject).to have_received(:report_cred).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe 'Lotus Domino Hashes' do
 
         it 'reports the extracted user and password' do
           subject.dump_hashes(view_id, cookie, uri)
-          expect(subject).to have_received(:report_auth_info).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
+          expect(subject).to have_received(:report_cred).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
         end
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe 'Lotus Domino Hashes' do
       end
       it 'when provided valid XML missing a credential' do
         subject.dump_hashes(view_id, cookie, uri)
-        expect(subject).not_to have_received(:report_auth_info)
+        expect(subject).not_to have_received(:report_cred)
       end
     end
   end

--- a/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/lotus/lotus_domino_hashes_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Lotus Domino Hashes' do
       context 'when the database is connected' do
         it 'reports the extracted user and password' do
           subject.dump_hashes(view_id, cookie, uri)
-          expect(subject).to have_received(:report_cred).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
+          expect(subject).to have_received(:report_cred).with(hash_including({ user: 'Bdn Alln', password: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe 'Lotus Domino Hashes' do
 
         it 'reports the extracted user and password' do
           subject.dump_hashes(view_id, cookie, uri)
-          expect(subject).to have_received(:report_cred).with(hash_including({ user: 'Bdn Alln', pass: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
+          expect(subject).to have_received(:report_cred).with(hash_including({ user: 'Bdn Alln', password: '(Da2Bd765Be64aF01b5652ce32eaA283d)', proof: a_string_matching(/USER_MAIL=NULL/) }))
         end
       end
     end


### PR DESCRIPTION
Updates the deprecated report_auth_info in various modules to use the new credential API instead.
Updates the spec file for lotus_domino_password_hashes to comply with the new API

Related to https://github.com/rapid7/metasploit-framework/issues/10314

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <module>`
- [ ] ...
- [ ] **Verify** the credentials are stored using the proper API