### PR TITLE
codespell for a bunch of modules

### DIFF
--- a/lib/msf/base/logging.rb
+++ b/lib/msf/base/logging.rb
@@ -94,7 +94,7 @@ class Logging
   # Stops logging for a given session.
   #
   # @param session [Msf::Session] the session to stop logging.
-  # @return [Boolean] true if sucessful. false if not.
+  # @return [Boolean] true if successful. false if not.
   def self.stop_session_log(session)
     rlog("\n[*] Logging stopped: #{Time.now}\n\n", session.log_source)
 

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -410,7 +410,7 @@ Shell Banner:
 
   def cmd_download(*args)
     if args.length != 2
-      # no argumnets, just print help message
+      # no arguments, just print help message
       return cmd_download_help
     end
 
@@ -445,7 +445,7 @@ Shell Banner:
 
   def cmd_upload(*args)
     if args.length != 2
-      # no argumnets, just print help message
+      # no arguments, just print help message
       return cmd_upload_help
     end
 
@@ -464,9 +464,9 @@ Shell Banner:
       content = File.binread(src)
       result = _file_transfer.write_file(dst, content)
       print_good("File <#{dst}> upload finished") if result
-      print_error("Error occured while uploading <#{src}> to <#{dst}>") unless result
+      print_error("Error occurred while uploading <#{src}> to <#{dst}>") unless result
     rescue => e
-      print_error("Error occured while uploading <#{src}> to <#{dst}> - #{e.message}")
+      print_error("Error occurred while uploading <#{src}> to <#{dst}> - #{e.message}")
       elog(e)
       return
     end

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -205,7 +205,7 @@ class Msf::Analyze::Result
     # Special cases
     if set.include?('unix')
       # Skip archaic old HPUX bugs if we have a solid match against another OS
-      return false if set.include?("hpux") && mod.refname.include?("hpux") && !hos.inlcude?("hpux")
+      return false if set.include?("hpux") && mod.refname.include?("hpux") && !hos.include?("hpux")
       # Skip AIX bugs if we have a solid match against another OS
       return false if set.include?("aix") && mod.refname.include?("aix") && !hos.include?("aix")
       # Skip IRIX bugs if we have a solid match against another OS

--- a/lib/msf/core/auxiliary/fuzzer.rb
+++ b/lib/msf/core/auxiliary/fuzzer.rb
@@ -34,7 +34,7 @@ module Auxiliary::Fuzzer
   end
 
 
-  # Will return or yield a string based on the presense of a block
+  # Will return or yield a string based on the presence of a block
   #
   # @return [Array] Returns and array of arrays of strings if there is no block given
   # @yield [Array] Yields array of strings if there is a block given
@@ -147,7 +147,7 @@ module Auxiliary::Fuzzer
     block_given? ? res.each { |n| yield(n) } : res
   end
 
-  # Generates a fuzz string If no block is set, it will retrive characters from the
+  # Generates a fuzz string If no block is set, it will retrieve characters from the
   # FuzzChar datastore option.
   #
   # @param len [Integer] String size.
@@ -240,7 +240,7 @@ module Auxiliary::Fuzzer
 
   # Generates various small URI string types
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_uris_small
     res = []
@@ -257,7 +257,7 @@ module Auxiliary::Fuzzer
 
 # Generates various long URI string types
 #
-# @return [Array] Returns an array of stings
+# @return [Array] Returns an array of strings
 
   def fuzzer_string_uris_long
     res = []
@@ -274,7 +274,7 @@ module Auxiliary::Fuzzer
 
   # Generates various giant URI string types
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_uris_giant
     res = []
@@ -291,7 +291,7 @@ module Auxiliary::Fuzzer
 
   # Format for the URI string generator
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_uris_format
     res = []
@@ -309,7 +309,7 @@ module Auxiliary::Fuzzer
 
   # Generates various small strings
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_uris_dos
     res = []
@@ -327,7 +327,7 @@ module Auxiliary::Fuzzer
 
   # Generates various small strings
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_paths_small
     res = []
@@ -343,7 +343,7 @@ module Auxiliary::Fuzzer
 
   # Generates various small strings
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_paths_long
     res = []
@@ -359,7 +359,7 @@ module Auxiliary::Fuzzer
 
   # Generates various giant strings
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_paths_giant
     res = []
@@ -375,7 +375,7 @@ module Auxiliary::Fuzzer
 
   # Format for the path generator
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_paths_format
     res = []
@@ -391,7 +391,7 @@ module Auxiliary::Fuzzer
 
   # Generates fuzzer strings using path prefixes
   #
-  # @return [Array] Returns an array of stings
+  # @return [Array] Returns an array of strings
 
   def fuzzer_string_paths_dos
     res = []

--- a/lib/msf/core/auxiliary/nfs.rb
+++ b/lib/msf/core/auxiliary/nfs.rb
@@ -36,7 +36,7 @@ module Msf
           location = "#{Regexp.last_match(1)}#{Rex::Socket.addr_atoc(Regexp.last_match(2))}"
         end
         return true if Rex::Socket::RangeWalker.new(location).include?(lhost)
-        # at this point we assume its a hostname, so we use Ruby's File fnmatch so that it proceses the wildcards
+        # at this point we assume its a hostname, so we use Ruby's File fnmatch so that it processes the wildcards
         # as its a quick and easy way to use glob matching for wildcards and get a boolean response
         return true if File.fnmatch(location, hostname)
       end

--- a/lib/msf/core/auxiliary/prometheus.rb
+++ b/lib/msf/core/auxiliary/prometheus.rb
@@ -446,7 +446,7 @@ module Msf
               dns_sd_configs['basic_auth']['password_file'] = scrape.dig('basic_auth', 'password_file') if scrape.dig('basic_auth', 'password_file')
             end
 
-            # pass in the 'scheme' from a level above to propely build the URI
+            # pass in the 'scheme' from a level above to properly build the URI
             if dns_sd_configs['scheme'].nil? && scrape['scheme']
               dns_sd_configs['scheme'] = scrape['scheme']
             end

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -454,7 +454,7 @@ module Auxiliary::Report
   end
 
   #
-  # Store some locally-generated data as a file, similiar to store_loot.
+  # Store some locally-generated data as a file, similar to store_loot.
   # Sometimes useful for keeping artifacts of an exploit or auxiliary
   # module, such as files from fileformat exploits. (TODO: actually
   # implement this on file format modules.)

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -66,7 +66,7 @@ module Msf
       # remove a response header so we have json-ish data
       res = res[8..]
 
-      # we have 2 json objects appended to eachother, so we now need to split that out and make it usable
+      # we have 2 json objects appended to each other, so we now need to split that out and make it usable
       res = res.split('}{')
 
       jsonable = []

--- a/lib/msf/core/auxiliary/vyos.rb
+++ b/lib/msf/core/auxiliary/vyos.rb
@@ -78,7 +78,7 @@ module Msf
       # in >= 1.3 'level' is no longer included and defaults to admin.
 
       r =  'user ([^ ]+) {\s*authentication {\s*'
-      r << 'encrypted-password (\$?[\w$\./\*]*)\s*' # leading $ is optional incase the password is all stars
+      r << 'encrypted-password (\$?[\w$\./\*]*)\s*' # leading $ is optional in case the password is all stars
       r << '(?:plaintext-password "([^"]*)")?\s*' # optional
       r << '}'
       r << '(?:\s*full-name "([^"]*)")?\s*' # optional

--- a/lib/msf/core/auxiliary/web/form.rb
+++ b/lib/msf/core/auxiliary/web/form.rb
@@ -81,7 +81,7 @@ class Form < Fuzzable
   end
 
   #
-  # Hash of params to be submited (derived by #inputs)
+  # Hash of params to be submitted (derived by #inputs)
   #
   # Examples
   #
@@ -174,7 +174,7 @@ class Form < Fuzzable
   #
   # Update the form inputs.
   #
-  # field -   Field name as a Sting (updated if already exists, created otherwise).
+  # field -   Field name as a String (updated if already exists, created otherwise).
   # value -   Field Value as a String.
   # type -    Field type ('text' if no type has been provided).
   #
@@ -195,7 +195,7 @@ class Form < Fuzzable
   #
   # Get a field type, by name, as a String.
   #
-  # field -   Field name as a Sting
+  # field -   Field name as a String
   #
   def field_type_for( name )
     inputs.select{ |i| i[:name] == name.to_s }[:type]

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -111,7 +111,7 @@ class DataStore < Hash
   def import_options_from_s(option_str, delim = nil)
     hash = {}
 
-    # Figure out the delimeter, default to space.
+    # Figure out the delimiter, default to space.
     if (delim.nil?)
       delim = /\s/
 
@@ -120,7 +120,7 @@ class DataStore < Hash
       end
     end
 
-    # Split on the delimeter
+    # Split on the delimiter
     option_str.split(delim).each { |opt|
       var, val = opt.split('=', 2)
 

--- a/lib/msf/core/data_store_with_fallbacks.rb
+++ b/lib/msf/core/data_store_with_fallbacks.rb
@@ -157,7 +157,7 @@ class DataStoreWithFallbacks
   def import_options_from_s(option_str, delim = nil)
     hash = {}
 
-    # Figure out the delimeter, default to space.
+    # Figure out the delimiter, default to space.
     if (delim.nil?)
       delim = /\s/
 
@@ -166,7 +166,7 @@ class DataStoreWithFallbacks
       end
     end
 
-    # Split on the delimeter
+    # Split on the delimiter
     option_str.split(delim).each { |opt|
       var, val = opt.split('=', 2)
 

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -23,7 +23,7 @@ module Msf::DBManager::ModuleCache
   # +'ILIKE'+
   #
   # @param values [Set<String>, #each] a list of strings.
-  # @return [Arrray<String>] strings wrapped like %<string>%
+  # @return [Array<String>] strings wrapped like %<string>%
   def match_values(values)
     values.collect { |value| "%#{value}%" }
   end

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -68,7 +68,7 @@ module Msf::DBManager::Note
   #
   # The +:update+ option can have the following values:
   # +:unique+::       allow only a single Note per +:host+/+:type+ pair
-  # +:unique_data+::  like +:uniqe+, but also compare +:data+
+  # +:unique_data+::  like +:unique+, but also compare +:data+
   # +:insert+::       always insert a new Note even if one with identical values exists
   #
   # If the provided +:host+ is an IP address and does not exist in the

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -156,7 +156,7 @@ class Encoder < Module
 
   ##
   #
-  # Encoder information accessors that can be overriden
+  # Encoder information accessors that can be overridden
   # by derived classes
   #
   ##

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -336,7 +336,7 @@ class Exploit < Msf::Module
   # exploit module.  It will also pre-generate the desired payload, though
   # exploits can re-generate the payload if necessary.
   #
-  # This method is designed to be overriden by exploit modules.
+  # This method is designed to be overridden by exploit modules.
   #
   def exploit
   end

--- a/lib/msf/core/exploit/brute.rb
+++ b/lib/msf/core/exploit/brute.rb
@@ -147,7 +147,7 @@ module Exploit::Brute
   # This routine is called once per brute force iteration.  The addresses
   # parameter is a hash of addresses that are incremented each iteration and
   # are derived from the target's bruteforce information or the module's
-  # datastore in case they are being overriden.
+  # datastore in case they are being overridden.
   #
   def brute_exploit(addrs)
   end

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -386,7 +386,7 @@ module Msf
         self.arp_cache = {}
       end
 
-      # For compatibilty with Msf::Exploit::Remote::Ip
+      # For compatibility with Msf::Exploit::Remote::Ip
       def rhost
         datastore['RHOST']
       end

--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -336,21 +336,21 @@ module Exploit::CmdStager
   end
 
   # Code to execute before the cmd stager stub. This method is designed to be
-  # overriden by a module this mixin.
+  # overridden by a module this mixin.
   #
   # @param opts [Hash] Hash of configuration options.
   def execute_cmdstager_begin(opts = {})
   end
 
   # Code to execute after the cmd stager stub. This method is designed to be
-  # overriden by a module this mixin.
+  # overridden by a module this mixin.
   #
   # @param opts [Hash] Hash of configuration options.
   def execute_cmdstager_end(opts = {})
   end
 
   # Code called to execute each command via an arbitrary module-defined vector.
-  # This method needs to be overriden by modules using this mixin.
+  # This method needs to be overridden by modules using this mixin.
   #
   # @param cmd [String] The command to execute.
   # @param opts [Hash] Hash of configuration options.

--- a/lib/msf/core/exploit/java_deserialization.rb
+++ b/lib/msf/core/exploit/java_deserialization.rb
@@ -17,7 +17,7 @@ module Exploit::JavaDeserialization
   #
   # @return [String] The opaque data blob.
   def generate_java_deserialization_for_command(name, shell, command)
-    # here we force usage of a modified type to avoid compatibility issues with command characters thar are present in
+    # here we force usage of a modified type to avoid compatibility issues with command characters that are present in
     # some ysoserial payloads
     unless %w{ bash cmd powershell }.include? shell
       raise RuntimeError, 'Invalid shell for Java Deserialization payload generation'

--- a/lib/msf/core/exploit/local/windows_kernel.rb
+++ b/lib/msf/core/exploit/local/windows_kernel.rb
@@ -160,7 +160,7 @@ module Exploit::Local::WindowsKernel
       tokenstealing << "\x8b\xc8"                                                    # mov ecx, eax
       tokenstealing << "\x8b\x98" + target['_TOKEN'] + "\x00\x00\x00"                # mov ebx, dword ptr [eax+0C8h]    # Retrieves TOKEN
       unless backup_token.nil?
-        tokenstealing << "\x89\x1d" + [backup_token].pack('V')                       # mov dword ptr ds:backup_token, ebx   # Optionaly write a copy of the token to the address provided
+        tokenstealing << "\x89\x1d" + [backup_token].pack('V')                       # mov dword ptr ds:backup_token, ebx   # Optionally write a copy of the token to the address provided
       end
       tokenstealing << "\x8b\x80" + target['_APLINKS'] + "\x00\x00\x00"              # mov eax, dword ptr [eax+88h]  <====| # Retrieve FLINK from ActiveProcessLinks
       tokenstealing << "\x81\xe8" + target['_APLINKS'] + "\x00\x00\x00"              # sub eax, 88h                       | # Retrieve _EPROCESS Pointer from the ActiveProcessLinks

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -114,7 +114,7 @@ module Exploit::Powershell
   end
 
   #
-  # Return a decompressed powershell sript
+  # Return a decompressed powershell script
   #
   # @param script_in [String] Compressed contents with decompression stub
   #

--- a/lib/msf/core/exploit/powershell/dot_net.rb
+++ b/lib/msf/core/exploit/powershell/dot_net.rb
@@ -8,7 +8,7 @@ module Msf
         super
         register_advanced_options(
         [
-          OptString.new('CERT_PATH', [false, 'Path on compiler host to .pfx fomatted certificate for signing' ]),
+          OptString.new('CERT_PATH', [false, 'Path on compiler host to .pfx formatted certificate for signing' ]),
 
         ], self.class)
       end

--- a/lib/msf/core/exploit/remote/afp.rb
+++ b/lib/msf/core/exploit/remote/afp.rb
@@ -91,8 +91,8 @@ module Exploit::Remote::AFP
     when -5001 #kFPAuthContinue
       return parse_login_response_add_send_login_count(response, {:p => p, :g => g, :ra => ra, :ma => ma,
         :password => pass, :user => user})
-    when -5023 #kFPUserNotAuth (User dosen't exists)
-      print_status("AFP #{rhost}:#{rport} User #{user} dosen't exists")
+    when -5023 #kFPUserNotAuth (User doesn't exists)
+      print_status("AFP #{rhost}:#{rport} User #{user} doesn't exists")
       return :skip_user
     else
       return :connection_error

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -123,7 +123,7 @@ module Msf
     # * It comes from a datastore option. It allows BrowserAutoPwn to share the unique prefix with
     #   its child exploits, so that these exploits don't have to gather browser information again.
     # * If the datastore option isn't set, then we assume the user is firing the exploit as a
-    #   standalone so we make somthing more unique, so that if there are two instances using the
+    #   standalone so we make something more unique, so that if there are two instances using the
     #   same exploit, they don't actually share info.
     def browser_profile_prefix
       self.datastore['BrowserProfilePrefix'] || @unique_prefix ||= lambda {

--- a/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/form/authenticate.rb
@@ -8,7 +8,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Form::Authenticate
   # @param password [String] Password
   # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
   # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError] if the request timed out
-  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError] if the authenticaiton failed
+  # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::AuthenticationError] if the authentication failed
   # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::CsrfError] if it was not possible to extract the CSRF token
   def gitlab_sign_in(username, password)
     sign_in_path = '/users/sign_in'

--- a/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/helpers.rb
@@ -25,7 +25,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Helpers
 
   # Extract the CSRF token at the given URI using the provided regex
   #
-  # @param path [String] the URI to retrive the CSRF token from
+  # @param path [String] the URI to retrieve the CSRF token from
   # @param regex [String] the regex used to extract the CSRF token from the HTML response
   # @return [String] the CSRF token
   # @raise [Msf::Exploit::Remote::HTTP::Gitlab::Error::ClientError] if the request timed out

--- a/lib/msf/core/exploit/remote/http/gitlab/rest/v4/groups.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/rest/v4/groups.rb
@@ -31,7 +31,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Rest::V4::Groups
 
   # Delete a group
   #
-  # @return [Bolean,GitLabClientError] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
+  # @return [Boolean,GitLabClientError] True if successful deleted, Msf::Exploit::Remote::HTTP::Gitlab::GitLabClientError otherwise
   def gitlab_delete_group(group_id, api_token)
     res = send_request_cgi({
       'method' => 'DELETE',

--- a/lib/msf/core/exploit/remote/http/jboss/base.rb
+++ b/lib/msf/core/exploit/remote/http/jboss/base.rb
@@ -15,7 +15,7 @@ module Msf::Exploit::Remote::HTTP::JBoss::Base
     end
 
     # JBoss might need some time for the deployment. Try 5 times at most and
-    # wait 5 seconds inbetween tries
+    # wait 5 seconds in between tries
     num_attempts.times do |attempt|
       res = send_request_cgi(opts, 5)
       msg = nil

--- a/lib/msf/core/exploit/remote/http/jboss/deployment_file_repository.rb
+++ b/lib/msf/core/exploit/remote/http/jboss/deployment_file_repository.rb
@@ -5,7 +5,7 @@ module Msf::Exploit::Remote::HTTP::JBoss::DeploymentFileRepository
   # Upload a text file with DeploymentFileRepository.store()
   #
   # @param base_name [String] The destination base name
-  # @param jsp_name [String] The destanation file name
+  # @param jsp_name [String] The destination file name
   # @param content [String] The content of the file
   # @return [Rex::Proto::Http::Response, nil] The {Rex::Proto::Http::Response} response, nil if timeout
   def upload_file(base_name, jsp_name, content)

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -176,7 +176,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     # Make sure we only use the cookies we need, otherwise we may encounter a session timeout
     auth_cookies = clean_cookies(pre_auth_cookies, auth_cookies)
 
-    # Try to visit the dasboard
+    # Try to visit the dashboard
     visit_nagios_dashboard(auth_cookies, finish_install)
   end
 
@@ -235,7 +235,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     unless res_index.code == 200 && res_index.body.include?('>Home Dashboard<')
       # Check if we need to sign the license agreement
       unless res_index.code == 302 && res_index.headers['Location'].end_with?('login.php?showlicense')
-        return [2, ['Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.']]
+        return [2, ['Received unexpected reply while trying to access the NagiosXI home dashboard after authenticating.']]
       end
 
       print_warning('The Nagios XI license agreement has not yet been signed on the target.')
@@ -251,7 +251,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return [5, [auth_cookies, nsp]]
     end
 
-    # Return the HTTP resonse body and the authentication cookies.
+    # Return the HTTP response body and the authentication cookies.
     # The response body can be used to obtain the version number.
     # The cookies can be used by exploit modules to send authenticated requests.
     [0, [res_index.body, auth_cookies]]

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -107,7 +107,7 @@ module Exploit::Remote::HttpClient
   end
 
 
-  # This method is meant to be overriden in the exploit module to specify a set of regexps to
+  # This method is meant to be overridden in the exploit module to specify a set of regexps to
   # attempt to match against. A failure to match any of them results in a RuntimeError exception
   # being raised.
   #

--- a/lib/msf/core/exploit/remote/http_server/html.rb
+++ b/lib/msf/core/exploit/remote/http_server/html.rb
@@ -33,7 +33,7 @@ protected
         # mixin supports encoding using them, however they are not
         # listed in the Option.
         OptEnum.new('HTML::unicode', [false, 'Enable HTTP obfuscation via unicode', UTF_NONE, [UTF_NONE, UTF_16_LE, UTF_16_BE, UTF_16_BE_MARKER, UTF_32_LE, UTF_32_BE]]),
-        OptEnum.new('HTML::base64', [false, 'Enable HTML obfuscation via an embeded base64 html object (IE not supported)', 'none', ['none', 'plain', 'single_pad', 'double_pad', 'random_space_injection']]),
+        OptEnum.new('HTML::base64', [false, 'Enable HTML obfuscation via an embedded base64 html object (IE not supported)', 'none', ['none', 'plain', 'single_pad', 'double_pad', 'random_space_injection']]),
         OptInt.new('HTML::javascript::escape', [false, 'Enable HTML obfuscation via HTML escaping (number of iterations)',  0]),
       ], Exploit::Remote::HttpServer::HTML)
   end

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -80,7 +80,7 @@ module Exploit::Remote::JndiInjection
   # Generate and serialize the payload as an LDAP search response
   #
   # @param msg_id [Integer] LDAP message identifier
-  # @param base_dn [Sting] LDAP distinguished name
+  # @param base_dn [String] LDAP distinguished name
   #
   # @return [Array] packed BER sequence
   def build_ldap_search_response(msg_id, base_dn)

--- a/lib/msf/core/exploit/remote/ms_samr.rb
+++ b/lib/msf/core/exploit/remote/ms_samr.rb
@@ -106,7 +106,7 @@ module Exploit::Remote::MsSamr
     ComputerInfo.new(computer_name, computer_password)
 
   rescue RubySMB::Dcerpc::Error::SamrError => e
-    raise MsSamrUnknownError, "A DCERPC SAMR error occured: #{e.message}"
+    raise MsSamrUnknownError, "A DCERPC SAMR error occurred: #{e.message}"
   ensure
     if samr_con
       samr_con.samr.close_handle(user_handle) if user_handle

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -33,7 +33,7 @@ module Exploit::Remote::MSSQL
         OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
         OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
         OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
-        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentification (requires DOMAIN option set)', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ], Msf::Exploit::Remote::MSSQL)
     register_advanced_options(
       [
@@ -322,7 +322,7 @@ module Exploit::Remote::MSSQL
         0x0000, #length
         0x0000, # SPID
         0x01,   # PacketID (unused upon specification
-        # but ms network monitor stil prefer 1 to decode correctly, wireshark don't care)
+        # but ms network monitor still prefer 1 to decode correctly, wireshark don't care)
         0x00   #Window
       ]
 
@@ -417,7 +417,7 @@ module Exploit::Remote::MSSQL
       # Rem : One have to set check_status to false here because sql server sp0 (and maybe above)
       # has a strange behavior that differs from the specifications
       # upon receiving the ntlm_negociate request it send an ntlm_challenge but the status flag of the tds packet header
-      # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentification
+      # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentication
       resp = mssql_send_recv(pkt, 15, false)
 
       info = {:errors => []}
@@ -435,7 +435,7 @@ module Exploit::Remote::MSSQL
           0x0000, #length
           0x0000, # SPID
           0x01,   # PacketID (unused upon specification
-            # but ms network monitor stil prefer 1 to decode correctly, wireshark don't care)
+            # but ms network monitor still prefer 1 to decode correctly, wireshark don't care)
           0x00   #Window
           ]
 
@@ -520,7 +520,7 @@ module Exploit::Remote::MSSQL
       # Rem : One have to set check_status to false here because sql server sp0 (and maybe above)
       # has a strange behavior that differs from the specifications
       # upon receiving the ntlm_negociate request it send an ntlm_challenge but the status flag of the tds packet header
-      # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentification
+      # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentication
       resp = mssql_send_recv(pkt, 15, false)
 
       unless resp.include?("NTLMSSP")
@@ -555,7 +555,7 @@ module Exploit::Remote::MSSQL
       resp = mssql_send_recv(pkt)
 
 
-    #SQL Server Authentification
+    #SQL Server authentication
     else
       idx = 0
       pkt = ''

--- a/lib/msf/core/exploit/remote/ndmp_socket.rb
+++ b/lib/msf/core/exploit/remote/ndmp_socket.rb
@@ -126,7 +126,7 @@ class Socket
   end
 
   #
-  # Send and recieve a pair of NDMP messages.
+  # Send and receive a pair of NDMP messages.
   #
   def do_request_response(msg, *args)
     return nil unless prepare_and_write_ndmp_msg(msg, *args)

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -344,7 +344,7 @@ module Exploit::Remote::Postgres
   def postgres_read_textfile(filename)
     # Check for temp table creation privs first.
     unless postgres_has_database_privilege('TEMP')
-      return({:sql_error => "Insufficent privileges for #{datastore['USERNAME']} on #{datastore['DATABASE']}"})
+      return({:sql_error => "Insufficient privileges for #{datastore['USERNAME']} on #{datastore['DATABASE']}"})
     end
 
     temp_table_name = Rex::Text.rand_text_alpha(rand(10)+6)

--- a/lib/msf/core/exploit/remote/rdp.rb
+++ b/lib/msf/core/exploit/remote/rdp.rb
@@ -476,8 +476,8 @@ module Exploit::Remote::RDP
     vprint_status("Sending client control request control PDU")
     rdp_send(rdp_build_pkt(pdu_client_control_request))
 
-    vprint_status("Sending client input sychronize PDU")
-    rdp_send(rdp_build_pkt(pdu_client_input_event_sychronize))
+    vprint_status("Sending client input synchronize PDU")
+    rdp_send(rdp_build_pkt(pdu_client_input_event_synchronize))
 
     vprint_status("Sending client font list PDU")
     rdp_send(rdp_build_pkt(pdu_client_font_list))
@@ -1145,7 +1145,7 @@ module Exploit::Remote::RDP
 
   # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/ff7f06f8-0dcf-4c8d-be1f-596ae60c4396
   # Client Input Event Data - TS_INPUT_PDU_DATA - 2.2.8.1.1.3.1
-  def pdu_client_input_event_sychronize
+  def pdu_client_input_event_synchronize
     pdu =
       "\x01\x00" +         # numEvents: 1
       "\x00\x00" +         # pad2Octets

--- a/lib/msf/core/exploit/remote/sip.rb
+++ b/lib/msf/core/exploit/remote/sip.rb
@@ -4,7 +4,7 @@
 module Msf
   # SIP protocol support
   module Exploit::Remote::SIP
-    # Parses +response+, extracts useful metdata and then reports on it.
+    # Parses +response+, extracts useful metadata and then reports on it.
     # Returns true iff the response was a valid SIP response
     def report_response(response, rhost, proto, desired_headers = %w(User-Agent Server Allow))
       endpoint = "#{rhost}:#{rport} #{proto}"

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -756,7 +756,7 @@ module Msf
         share_info
       end
 
-      # Retreive a list of all shares using any available method
+      # Retrieve a list of all shares using any available method
       def smb_netshareenumall
         begin
           return smb_srvsvc_netshareenumall

--- a/lib/msf/core/exploit/remote/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/remote/smb/client/psexec.rb
@@ -61,7 +61,7 @@ module Exploit::Remote::SMB::Client::Psexec
     @service_description ||= datastore['SERVICE_DESCRIPTION']
   end
 
-  # Retrives output from the executed command
+  # Retrieves output from the executed command
   #
   # @param smbshare [String] The SMBshare to connect to.  Usually C$
   # @param host [String] Remote host to connect to, as an IP address or
@@ -394,7 +394,7 @@ module Exploit::Remote::SMB::Client::Psexec
   end
 
   private
-  # Retrive output from command
+  # Retrieve output from command
   def get_output(file, smb_share, r_ip)
     print_status("Getting the command output...")
     output = smb_read_file(smb_share, r_ip, file)

--- a/lib/msf/core/exploit/remote/smb/client/psexec_ms17_010.rb
+++ b/lib/msf/core/exploit/remote/smb/client/psexec_ms17_010.rb
@@ -261,7 +261,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     # modify trans2.*ParameterCount and trans2.*DataCount to limit data
     new_data = [@ctx['trans2_addr']+@ctx['TRANS_FLINK_OFFSET'], @ctx['trans2_addr']+0x200, read_addr].pack(fmt * 3) #pack('<'+fmt*3, )  # OutParameter, InData, OutData
     new_data << [0, 0].pack("VV") #pack('<II', 0, 0)  # SetupCount, MaxSetupCount
-    new_data << [8, 8, 8].pack("VVV") #pack('<III', 8, 8, 8)  # ParamterCount, TotalParamterCount, MaxParameterCount
+    new_data << [8, 8, 8].pack("VVV") #pack('<III', 8, 8, 8)  # ParameterCount, TotalParameterCount, MaxParameterCount
     new_data << [read_size, read_size, read_size].pack("VVV") #pack('<III', read_size, read_size, read_size)  # DataCount, TotalDataCount, MaxDataCount
     new_data << [0, 5].pack("vv") #pack('<HH', 0, 5)  # Category, Function (NT_RENAME)
     pkt = create_nt_trans_secondary_packet(mid: @ctx['trans1_mid'], data: new_data, dataDisplacement: @ctx['TRANS_OUTPARAM_OFFSET'])
@@ -360,7 +360,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     # groom: srv buffer header
     @ctx['GROOM_POOL_SIZE'] = calc_alloc_size(GROOM_TRANS_SIZE + @ctx['SRV_BUFHDR_SIZE'] + @ctx['POOL_ALIGN'], @ctx['POOL_ALIGN'])
 
-    # groom paramters and data is alignment by 8 because it is NT_TRANS
+    # groom parameters and data is alignment by 8 because it is NT_TRANS
     @ctx['GROOM_DATA_SIZE'] = GROOM_TRANS_SIZE - TRANS_NAME_LEN - 4 - @ctx['TRANS_SIZE']  # alignment (4)
 
     # bride: srv buffer header, pool header (same as pool align size), empty transaction name (4)
@@ -372,7 +372,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
       print_status("BRIDE_TRANS_SIZE: 0x#{@ctx['BRIDE_TRANS_SIZE'].to_s(16)}")
     end
 
-    # bride paramters and data is alignment by 4 because it is TRANS
+    # bride parameters and data is alignment by 4 because it is TRANS
     @ctx['BRIDE_DATA_SIZE'] = @ctx['BRIDE_TRANS_SIZE'] - TRANS_NAME_LEN - @ctx['TRANS_SIZE']
 
     # ================================
@@ -522,7 +522,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     # From leaked transaction, we get
     # - leaked transaction address from InParameter or InData
     # - transaction, with mid=extra_mid2, address from LIST_ENTRY.Flink
-    # With these information, we can verify the transaction aligment from displacement.
+    # With these information, we can verify the transaction alignment from displacement.
 
     leakData = recv_transaction_data(mid_ntrename, 0x10d0 + 276)
     leakData = leakData[0x10d4..-1]  # skip parameters and its own input
@@ -616,7 +616,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     # groom packets
     # ================================
     # sum of transaction name, parameters and data length is 0x1000
-    # paramterCount = 0x100-TRANS_NAME_LEN
+    # parameterCount = 0x100-TRANS_NAME_LEN
     trans_param = [@ctx['fid']].pack("V") #pack('<HH', info['fid'], 0)
     for i in 0..11
       mid =  if i == 8 then @ctx['fid'] else next_extra_multiplex_id() end
@@ -698,7 +698,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     # To be able to use trans1 after trans2 is gone, we need to modify trans1 to be able to modify itself.
     # To be able to modify trans1 struct, we need to use trans2 param or data but write backward.
     # On 32 bit target, we can write to any address if parameter count is 0xffffffff.
-    # On 64 bit target, modifying paramter count is not enough because address size is 64 bit. Because our transactions
+    # On 64 bit target, modifying parameter count is not enough because address size is 64 bit. Because our transactions
     #   are allocated with RtlAllocateHeap(), the HIDWORD of InParameter is always 0. To be able to write backward with offset only,
     #   we also modify HIDWORD of InParameter to 0xffffffff.
 
@@ -716,7 +716,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     xPREV_TRANS_DISPLACEMENT = xTRANS_CHUNK_SIZE + @ctx['TRANS_SIZE'] + xTRANS_NAME_LEN
     xPREV_TRANS_OFFSET = 0x100000000 - xPREV_TRANS_DISPLACEMENT
 
-    # modify paramterCount of first transaction
+    # modify parameterCount of first transaction
     pkt = create_nt_trans_secondary_packet(mid: @@special_mid, param: "\xff"*4, paramDisplacement: xPREV_TRANS_OFFSET+@ctx['TRANS_TOTALPARAMCNT_OFFSET'])
     self.simple.client.smb_send(pkt.to_s)
 

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -81,7 +81,7 @@ module Exploit::Remote::SocketServer
   end
 
   #
-  # Cleans up the service; either closing the socket, or deferencing the service
+  # Cleans up the service; either closing the socket, or dereferencing the service
   #
   def cleanup_service
     if service

--- a/lib/msf/core/exploit/remote/tincd_exploit_client.rb
+++ b/lib/msf/core/exploit/remote/tincd_exploit_client.rb
@@ -55,7 +55,7 @@ module Exploit::Remote::TincdExploitClient
     @hex_enc_key_s1 = nil
     @bf_enc_cipher = nil
     init_ciphers(datastore['SERVER_PUBLIC_KEY_FILE'], datastore['CLIENT_PRIVATE_KEY_FILE'])
-    vprint_status('Ciphers locally initalized, private key and public key files seem to be ok')
+    vprint_status('Ciphers locally initialized, private key and public key files seem to be ok')
     @bf_dec_cipher = nil
   end
 
@@ -280,7 +280,7 @@ module Exploit::Remote::TincdExploitClient
 
   #
   # Sending metakey (transferring a symmetric key that will get encrypted with
-  # public key before beeing sent to the server)
+  # public key before being sent to the server)
   #
   def metakey
     msg = "1 94 64 0 0 #{@hex_enc_key_s1}\n"

--- a/lib/msf/core/exploit/remote/unirpc.rb
+++ b/lib/msf/core/exploit/remote/unirpc.rb
@@ -220,7 +220,7 @@ module Msf
 
             0x00000000, # Reserved (ignored)
 
-            2,                         # Encyption "key" - basically the XOR key (can only be 1 or 2)
+            2,                         # Encryption "key" - basically the XOR key (can only be 1 or 2)
             0,                         # Do compression?
             encrypt ? 1 : 0,           # Encryption (0 = not encrypted, 1 = encrypted)
             0x00,                      # Padding

--- a/lib/msf/core/exploit/sqli/common.rb
+++ b/lib/msf/core/exploit/sqli/common.rb
@@ -9,7 +9,7 @@ module Msf::Exploit::SQLi
     #   @param datastore [DataStore]
     #   @param framework [Framework]
     #   @param user_output [Rex::Ui::Text::Output::Stdio] 
-    #   @param opts [Hash] a dictionnary containing the parameters needed
+    #   @param opts [Hash] a dictionary containing the parameters needed
     #   @option opts [Integer] truncation_length :  [Optional] The number of characters returned, if the query result is truncated
     #   @option opts [String] concat_separator : [Optional] The separator to use when concatenating rows (default ',')
     #   @option opts [String] second_concat_separator : [Optional] The separator to use when concatenating columns (default ';')
@@ -24,7 +24,7 @@ module Msf::Exploit::SQLi
     #   - if it's a time-based blind SQL injection, the return value does not matter, the time the block takes to run is used to leak information.
     #
     def initialize(datastore, framework, user_output, opts = {}, &query_proc)
-      raise ArgumentError, 'Missing the bloc that does the requests' unless block_given?
+      raise ArgumentError, 'Missing the block that does the requests' unless block_given?
       raise ArgumentError, 'Positional arguments can\'t be nil' if [datastore, framework, user_output].any?(&:nil?)
 
       check_opts(opts)
@@ -42,9 +42,9 @@ module Msf::Exploit::SQLi
     end
 
     #
-    #   Queries the bloc with the given SQL query, without necessarly returning a result (needed for
+    #   Queries the block with the given SQL query, without necessarily returning a result (needed for
     #   example when uploading a file using a time-based SQL injection, as it's not necessary to
-    #   run multiple queries for that purpose), not to be overriden, it is guaranteed that the query
+    #   run multiple queries for that purpose), not to be overridden, it is guaranteed that the query
     #   will run only once.
     #   @param query [String] The SQL query to execute
     #   @return [void]
@@ -59,7 +59,7 @@ module Msf::Exploit::SQLi
     end
 
     #
-    #   Queries the bloc with the given SQL query, and returns the result, this method is overriden in
+    #   Queries the block with the given SQL query, and returns the result, this method is overridden in
     #   blind SQL injection classes, implementing the logic of leaking one bit at a time, and working 
     #   exactly the same as this method.
     #   @param query [String] The SQL query to execute

--- a/lib/msf/core/exploit/sqli/mssqli/boolean_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/boolean_based_blind.rb
@@ -6,7 +6,7 @@ class Msf::Exploit::SQLi::Mssqli::BooleanBasedBlind < Msf::Exploit::SQLi::Mssqli
 
   #
   # This method checks if the target is vulnerable to Blind boolean-based injection by checking that
-  # the values returned by the bloc for some boolean queries are correct.
+  # the values returned by the block for some boolean queries are correct.
   #
   def test_vulnerable
     out_true = blind_request('1=1')

--- a/lib/msf/core/exploit/sqli/mysqli/boolean_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/boolean_based_blind.rb
@@ -7,7 +7,7 @@ class Msf::Exploit::SQLi::MySQLi::BooleanBasedBlind < Msf::Exploit::SQLi::MySQLi
 
   #
   # This method checks if the target is vulnerable to Blind boolean-based injection by checking that
-  # the values returned by the bloc for some boolean queries are correct.
+  # the values returned by the block for some boolean queries are correct.
   # @return [Boolean] Whether the check determined that boolean-based blind SQL injection works
   #
   def test_vulnerable

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -3,7 +3,7 @@ require 'base64'
 #
 # This class represents a MySQL/MariaDB Injection object, its primary purpose is to provide the common SQL queries
 # needed when performing SQL injection.
-# This class should not be instanciated directly, refer to Msf::Exploit::SQLi#create_sqli.
+# This class should not be instantiated directly, refer to Msf::Exploit::SQLi#create_sqli.
 #
 module Msf::Exploit::SQLi::MySQLi
   class Common < Msf::Exploit::SQLi::Common

--- a/lib/msf/core/exploit/sqli/postgresqli/boolean_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/postgresqli/boolean_based_blind.rb
@@ -6,7 +6,7 @@ class Msf::Exploit::SQLi::PostgreSQLi::BooleanBasedBlind < Msf::Exploit::SQLi::P
 
   #
   # This method checks if the target is vulnerable to Blind boolean-based injection by checking that
-  # the values returned by the bloc for some boolean queries are correct.
+  # the values returned by the block for some boolean queries are correct.
   # @return [Boolean] Whether the check determined that boolean-based blind SQL injection works
   #
   def test_vulnerable

--- a/lib/msf/core/exploit/sqli/postgresqli/common.rb
+++ b/lib/msf/core/exploit/sqli/postgresqli/common.rb
@@ -3,7 +3,7 @@ require 'base64'
 #
 # This class represents a PostgreSQL Injection object, its primary purpose is to provide the common SQL queries
 # needed when performing SQL injection.
-# This class should not be instanciated directly, refer to Msf::Exploit::SQLi#create_sqli.
+# This class should not be instantiated directly, refer to Msf::Exploit::SQLi#create_sqli.
 #
 module Msf::Exploit::SQLi::PostgreSQLi
   class Common < Msf::Exploit::SQLi::Common

--- a/lib/msf/core/exploit/sqli/sqlitei/boolean_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/sqlitei/boolean_based_blind.rb
@@ -7,7 +7,7 @@ class Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind < Msf::Exploit::SQLi::SQLit
 
   #
   # This method checks if the target is vulnerable to Blind boolean-based injection by checking that
-  # the values returned by the bloc for some boolean queries are correct.
+  # the values returned by the block for some boolean queries are correct.
   # @return [Boolean] Whether the check confirmed that boolean-based blind SQL injection works
   #
   def test_vulnerable

--- a/lib/msf/core/exploit/sqli/sqlitei/common.rb
+++ b/lib/msf/core/exploit/sqli/sqlitei/common.rb
@@ -1,7 +1,7 @@
 #
 # This class represents an SQLite Injection object, its primary purpose is to provide the common SQL queries
 # needed for performing SQL injection on SQLite.
-# This class should not be instanciated directly, refer to Msf::Exploit::SQLi#create_sqli.
+# This class should not be instantiated directly, refer to Msf::Exploit::SQLi#create_sqli.
 #
 module Msf::Exploit::SQLi::SQLitei
   class Common < Msf::Exploit::SQLi::Common

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -17,7 +17,7 @@ class Msf::ModuleSet < Hash
   include Msf::Framework::Offspring
 
   # Wrapper that detects if a symbolic module is in use.  If it is, it creates an instance to demand load the module
-  # and then returns the now-loaded class afterwords.
+  # and then returns the now-loaded class afterwards.
   #
   # @param [String] name the module reference name
   # @return [Msf::Module] instance of the of the Msf::Module subclass with the given reference name

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -131,7 +131,7 @@ class Cache
     metadata_obj = Obj.new(module_instance)
 
     # Remove all instances of modules pointing to the same path. This prevents stale data hanging
-    # around when modules are incorrectly typed (eg: Auxilary that should be Exploit)
+    # around when modules are incorrectly typed (eg: Auxiliary that should be Exploit)
     @module_metadata_cache.delete_if {|_, module_metadata|
       module_metadata.path.eql? metadata_obj.path && module_metadata.type != module_metadata.type
     }

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -525,7 +525,7 @@ class Payload < Msf::Module
   end
 
   #
-  # A placeholder stub, to be overriden by mixins
+  # A placeholder stub, to be overridden by mixins
   #
   def apply_prepends(raw)
     raw

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -1005,7 +1005,7 @@ protected
       # produces a 0-length string. Some also allow octal escapes
       # without a format string, and do not truncate, so start with
       # that and try %b if it doesn't work. The standalone version seems
-      # to be more likely to work than the buitin version, so try it
+      # to be more likely to work than the builtin version, so try it
       # first.
       #
       # Both of these work for sure on Linux and FreeBSD

--- a/lib/msf/core/post/hardware/automotive/uds.rb
+++ b/lib/msf/core/post/hardware/automotive/uds.rb
@@ -199,7 +199,7 @@ module UDS
   end
 
   #
-  # Gets the engine coolant temprature in both Celcious and Fahrenheit
+  # Gets the engine coolant temperature in both Celcious and Fahrenheit
   #
   # @param bus [String] unique CAN bus identifier
   # @param src_id [Integer] Integer representation of the Sending CAN ID
@@ -623,7 +623,7 @@ module UDS
 
   ###############################################################################
   # Technically from here on down these are known as Service IDs or SIDs but we #
-  # will keep calling them Modes for consitency in our comments                 #
+  # will keep calling them Modes for consistency in our comments                 #
   ###############################################################################
   #### Mode $10 ###
 
@@ -666,7 +666,7 @@ module UDS
   # @param bus [String] unique CAN bus identifier
   # @param src_id [Integer] Integer representation of the Sending CAN ID
   # @param dst_id [Integer] Integer representation of the receiving CAN ID
-  # @param hard [Boolean] If true a hard reset will be peformed
+  # @param hard [Boolean] If true a hard reset will be performed
   # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
   #
   # @return [Hash] client.automtoive response (Could be no response)
@@ -707,12 +707,12 @@ module UDS
       return []
     end
     unless id.is_a? Array
-      print_error("ID paramater must be a two byte array")
+      print_error("ID parameter must be a two byte array")
       return {} if show_error
       return []
     end
     unless id.size == 2
-      print_error("ID paramater must be a two byte array")
+      print_error("ID parameter must be a two byte array")
       return {} if show_error
       return []
     end

--- a/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
+++ b/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
@@ -110,7 +110,7 @@ module RFTransceiver
   end
 
   #
-  # Transmits a RF Packet.  All data is base64 encoded before transmition to relay
+  # Transmits a RF Packet.  All data is base64 encoded before transmission to relay
   # @param data [String] Blog of data stored in a string.  Could be binary
   # @param repeat [Integer] Optional Repeat transmission
   # @param offset [Integer] Optional Offset within data section

--- a/lib/msf/core/post/hardware/zigbee/utils.rb
+++ b/lib/msf/core/post/hardware/zigbee/utils.rb
@@ -94,7 +94,7 @@ module Utils
     client.zigbee.inject(device, data)
   end
 
-  # Recieves data from the Zigbee device
+  # Receives data from the Zigbee device
   # @param device [String] Zigbee device ID
   # @return [String] Binary blob of returned data
   def recv(device)

--- a/lib/msf/core/post/vcenter/database.rb
+++ b/lib/msf/core/post/vcenter/database.rb
@@ -65,7 +65,7 @@ module Msf
 
           postgres_users.each do |postgres_user|
             row_data = postgres_user.split('|')
-            next if row_data.length < 2 # shoudld always be 2 based on query, but this will catch 'command not found' or other things like that
+            next if row_data.length < 2 # should always be 2 based on query, but this will catch 'command not found' or other things like that
 
             user = {
               'user' => row_data[0],
@@ -96,7 +96,7 @@ module Msf
 
           postgres_users.each do |postgres_user|
             row_data = postgres_user.split('|')
-            next if row_data.length < 2 # shoudld always be 2 based on query, but this will catch 'command not found' or other things like that
+            next if row_data.length < 2 # should always be 2 based on query, but this will catch 'command not found' or other things like that
 
             user = {
               'user' => row_data[0],
@@ -128,7 +128,7 @@ module Msf
 
           vpx_creds.each do |vpx_user|
             row_data = vpx_user.split('|')
-            next if row_data.length < 2 # shoudld always be 2 based on query, but this will catch 'command not found' or other things like that
+            next if row_data.length < 2 # should always be 2 based on query, but this will catch 'command not found' or other things like that
 
             user = {
               'user' => row_data[0],
@@ -232,7 +232,7 @@ module Msf
 
           vm_rows.each do |vm_row|
             row_data = vm_row.split('|')
-            next if row_data.length < 5 # shoudld always be 5 based on query, but this will catch 'command not found' or other things like that
+            next if row_data.length < 5 # should always be 5 based on query, but this will catch 'command not found' or other things like that
 
             vm = {
               'vmid' => row_data[0],
@@ -266,7 +266,7 @@ module Msf
 
           vpxuser_rows.each do |vpxuser_row|
             row_data = vpxuser_row.split('|')
-            next if row_data.length < 4 # shoudld always be 4 based on query, but this will catch 'command not found' or other things like that
+            next if row_data.length < 4 # should always be 4 based on query, but this will catch 'command not found' or other things like that
 
             user = {
               'fqdn' => row_data[0],

--- a/lib/msf/core/post/windows/packrat.rb
+++ b/lib/msf/core/post/windows/packrat.rb
@@ -5,7 +5,7 @@
 
 # PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
 # PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-# This is a mixin that will be included in each separated moduel. Further details can be found in the module documentation.
+# This is a mixin that will be included in each separated module. Further details can be found in the module documentation.
 #
 require 'sqlite3'
 module Msf

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -134,7 +134,7 @@ module Registry
   #
   # Deletes a registry value given the key and value name
   #
-  # returns true if succesful
+  # returns true if successful
   #
   def registry_deleteval(key, valname, view = REGISTRY_VIEW_NATIVE)
     if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_DELETE_KEY)
@@ -147,7 +147,7 @@ module Registry
   #
   # Delete a given registry key
   #
-  # returns true if succesful
+  # returns true if successful
   #
   def registry_deletekey(key, view = REGISTRY_VIEW_NATIVE)
     if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_DELETE_KEY)
@@ -204,7 +204,7 @@ module Registry
   #
   # Sets the data for a given value and type of data on the target registry
   #
-  # returns true if succesful
+  # returns true if successful
   #
   def registry_setvaldata(key, valname, data, type, view = REGISTRY_VIEW_NATIVE)
     if session.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_REGISTRY_SET_VALUE_DIRECT)

--- a/lib/msf/core/post/windows/task_scheduler.rb
+++ b/lib/msf/core/post/windows/task_scheduler.rb
@@ -483,7 +483,7 @@ module Msf
         def add_reg_key_value(reg_key, reg_value, reg_data, reg_type, opts = {})
           log_and_print('[Task Scheduler] Restoring the Security Descriptor registry key value to unhide the task')
 
-          # Override by default. It has to be explicitely set to false if we don't want the key to be overriden.
+          # Override by default. It has to be explicitly set to false if we don't want the key to be overridden.
           unless opts[:override].nil? || opts[:override]
             log_and_print('[Task Scheduler] Checking if the key value exists')
             if reg_key_value_exists?(reg_key, reg_value)

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -62,7 +62,7 @@ end
   # @raise [Msf::RPC::Exception] An error indicating a failed deauthentication, including:
   #                              * 500 Invalid authentication token.
   #                              * 500 Permanent authentication token.
-  # @return [Hash] A hash indiciating the action was successful. It contains the following key:
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  # This returns something like:

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -168,7 +168,7 @@ public
   #  * 'private_type' [String] Password type.
   #  * 'realm_value' [String] Realm.
   #  * 'realm_key' [String] Realm key.
-  #  * 'host' [String] Host (Only avilable if there's a :last_attempted_at and :status)
+  #  * 'host' [String] Host (Only available if there's a :last_attempted_at and :status)
   #  * 'sname' [String] Service name (only available if there's a :last_attempted_at and :status)
   #  * 'status' [Status] Login status (only available if there's a :last_attempted_at and :status)
   # @see https://github.com/rapid7/metasploit-credential/blob/master/lib/metasploit/credential/creation.rb#L107 #create_credential Documentation.
@@ -758,7 +758,7 @@ public
   # @option xopts [String] :address Same as :addr.
   # @option xopts [String] :host Same as :address.
   # @option xopts [Map<String, Object>]  :analyze_options  All returned modules will support these options
-  # * [Array<Sting>] :payloads Modules returned will be compatible with at least one payload
+  # * [Array<String>] :payloads Modules returned will be compatible with at least one payload
   # @raise [Msf::RPC::ServerException] You might get one of these errors:
   #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
   #  * 500 Database not loaded. Try: rpc.call('console.create')
@@ -1076,7 +1076,7 @@ end
   # @option xopts [String] :proto Along with +:host+ and +:port+, a service to associate with this note.
   # @option xopts [Hash] A hash that contains the following information.
   #  * :unique [Boolean] Allow only a single Note per +:host+/+:type+ pair.
-  #  * :unique_data [Boolean] Like +:uniqe+, but also compare +:data+.
+  #  * :unique_data [Boolean] Like +:unique+, but also compare +:data+.
   #  * :insert [Boolean] Always insert a new Note even if one with identical values exists.
   # @raise [Msf::RPC::ServerException] You might get one of these errors:
   #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
@@ -1873,7 +1873,7 @@ end
   # @option [String] :driver Driver name. For example: 'postgresql'. If this option is not set,
   #                  then the method returns the current one.
   # @return [Hash] A hash that contains:
-  #  * 'result' [String] Indiciating whether we've successfully set the driver or not.
+  #  * 'result' [String] Indicating whether we've successfully set the driver or not.
   #  * 'driver' [String] If the :driver option isn't set, then this returns the current one.
   # @example Here's how you would use this from the client:
   #  # Sets a driver

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -28,7 +28,7 @@ class RPC_Plugin < RPC_Base
     if path !~ /#{File::SEPARATOR}/
       plugin_file_name = path
 
-      # If the plugin isn't in the user direcotry (~/.msf3/plugins/), use the base
+      # If the plugin isn't in the user directory (~/.msf3/plugins/), use the base
       path = Msf::Config.user_plugin_directory + File::SEPARATOR + plugin_file_name
       if not File.exist?(path + ".rb")
         # If the following "path" doesn't exist it will be caught when we attempt to load

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -420,7 +420,7 @@ require 'digest/sha1'
       if (virtualAddress...virtualAddress+sizeOfRawData).include?(addressOfEntryPoint)
         importsTable = pe.hdr.opt.DataDirectory[8..(8+4)].unpack('V')[0]
         if (importsTable - addressOfEntryPoint) < code.length
-          #shift original entry point to prevent tables overwritting
+          #shift original entry point to prevent tables overwriting
           addressOfEntryPoint = importsTable - code.length + 4
 
           entry_point_offset = pe._dos_header.v['e_lfanew'] + entryPoint_offset
@@ -634,7 +634,7 @@ require 'digest/sha1'
   # @option opts        [Boolean] :sub_method use substitution technique with a
   #                                service template PE
   # @option opts        [String] :servicename name of the service, not used in
-  #                               substituion technique
+  #                               substitution technique
   #
   # @return [String] Windows Service PE file
   def self.to_win32pe_service(framework, code, opts = {})
@@ -1627,7 +1627,7 @@ require 'digest/sha1'
   #   tag. Mostly irrelevant, except as an identifier in web.xml. Defaults to
   #   random.
   # @option opts :extra_files [Array<String,String>] Additional files to add
-  #   to the archive. First elment is filename, second is data
+  #   to the archive. First element is filename, second is data
   #
   # @todo Refactor to return a {Rex::Zip::Archive} or {Rex::Zip::Jar}
   #
@@ -2020,7 +2020,7 @@ require 'digest/sha1'
   # @param code [String] The shellcode for the resulting executable to run
   # @param fmt [String] One of the executable formats as defined in
   #   {.to_executable_fmt_formats}
-  # @param exeopts [Hash] Passed directly to the approrpriate method for
+  # @param exeopts [Hash] Passed directly to the appropriate method for
   #   generating an executable for the given +arch+/+plat+ pair.
   # @return [String] An executable appropriate for the given
   #   architecture/platform pair.

--- a/lib/msf/util/windows_registry/registry_parser.rb
+++ b/lib/msf/util/windows_registry/registry_parser.rb
@@ -256,7 +256,7 @@ module WindowsRegistry
       nil
     end
 
-    # Search for a given key fro the ROOT key and returns it as a block
+    # Search for a given key from the ROOT key and returns it as a block
     #
     # @param key [String] The registry key to look for
     # @return [RegHbinBlock, nil] The key, if found, nil otherwise
@@ -341,7 +341,7 @@ module WindowsRegistry
         nk = get_block(offset)
         return offset if nk.key_name == key
       else
-        raise ArgumentError, "Unknow magic: #{magic}"
+        raise ArgumentError, "Unknown magic: #{magic}"
       end
     end
 

--- a/lib/msf/util/windows_registry/security.rb
+++ b/lib/msf/util/windows_registry/security.rb
@@ -81,7 +81,7 @@ module WindowsRegistry
 
     # Retrieve the decrypted LSA secret key from a given BootKey. This also sets
     # the @lsa_vista_style attributes according to the registry keys found
-    # under `HKLM\SECURTY\Policy`. If set to `true`, the system version is
+    # under `HKLM\SECURITY\Policy`. If set to `true`, the system version is
     # Windows Vista and above, otherwise it is Windows XP or below.
     #
     # @param boot_key [String] The BootKey
@@ -121,7 +121,7 @@ module WindowsRegistry
       lsa_key
     end
 
-    # Returns the decrypted LSA secrets under HKLM\SECURTY\Policy\Secrets. For
+    # Returns the decrypted LSA secrets under HKLM\SECURITY\Policy\Secrets. For
     # this, the LSA secret key must be provided, which can be retrieved with
     # the #lsa_secret_key method.
     #
@@ -152,7 +152,7 @@ module WindowsRegistry
     end
 
     # Returns the decrypted NLKM secret key from
-    # HKLM\SECURTY\Policy\Secrets\NL$KM\CurrVal. For this, the LSA secret key
+    # HKLM\SECURITY\Policy\Secrets\NL$KM\CurrVal. For this, the LSA secret key
     # must be provided, which can be retrieved with the #lsa_secret_key method.
     #
     # @param lsa_key [String] The LSA secret key

--- a/lib/rabal/tree.rb
+++ b/lib/rabal/tree.rb
@@ -120,7 +120,7 @@ class Tree
 
     subtree.parent = self
 
-    # FIXME: techinically this should no longer be called 'post_add' 
+    # FIXME: technically this should no longer be called 'post_add' 
     # but maybe 'add_hook'  
     subtree.post_add
 

--- a/lib/rbmysql.rb
+++ b/lib/rbmysql.rb
@@ -541,7 +541,7 @@ class RbMysql
     attr_reader :flags
     # @return [Integer] number of decimals
     attr_reader :decimals
-    # @return [String] defualt value
+    # @return [String] default value
     attr_reader :default
     alias :def :default
 


### PR DESCRIPTION
Recently learned about [codespell](https://github.com/codespell-project/codespell) @codespell-project . Pretty cool. Decided to throw it at MSF..... oh boy, there's a LOT of errors all over the place. This will be the first in a series of PRs to get spelling back under control.

## Verification

- [ ] Start `msfconsole`
- [ ] Make sure no new errors
- [ ] Check over the spelling changes
