### PR TITLE
Kerberos ticket_search fix passing in a workspace

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/base.rb
@@ -118,7 +118,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       unless (info = loot_info(options)).blank?
         filter[:info] = JSON.generate(info)
       end
-      loots = framework.db.loots(workspace: myworkspace, ltype: 'mit.kerberos.ccache', **filter).select do |loot|
+      loots = framework.db.loots(workspace: options.fetch(:workspace) { workspace }, ltype: 'mit.kerberos.ccache', **filter).select do |loot|
         # Remove any loot that isn't 'mit.kerberos.ccache'
         # Necessary when an `id` is provided in which case the `ltype` search above is ignored
         loot.ltype == 'mit.kerberos.ccache'


### PR DESCRIPTION
Thanks to @h00die for spotting this issue over here https://github.com/rapid7/metasploit-framework/pull/18373#issuecomment-1727931283 

When getting kerberos tickets the workspace was being passed in but being ignored, we were always using the users current workspace
This PR actually uses the passed in workspace while defaulting to the users current workspace

# Before (using `db_stats` provided by #18373)
![image](https://github.com/rapid7/metasploit-framework/assets/19910435/c912c766-6ab6-4750-b45d-0bcbf1424384)
Both workspaces have the same number in the `Kerberos Cache` column as the current workspace

# After (using `db_stats` provided by #18373)
![image](https://github.com/rapid7/metasploit-framework/assets/19910435/03a44150-b167-4bd2-8941-79a4d109c32e)
The correct number is displayed for each workspace regardless of the current workspace
