### PR TITLE
Fix FileDropper to properly clone string variables before storing them

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -40,7 +40,7 @@ module Exploit::FileDropper
   #   exploiting).
   # @return [void]
   def register_files_for_cleanup(*files)
-    @dropped_files += files
+    @dropped_files += files.map(&:clone)
   end
 
   def allow_no_cleanup
@@ -56,7 +56,7 @@ module Exploit::FileDropper
   #   exploiting).
   # @return [void]
   def register_dirs_for_cleanup(*dirs)
-    @dropped_dirs += dirs
+    @dropped_dirs += dirs.map(&:clone)
   end
 
   # Singular versions

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -40,7 +40,7 @@ module Exploit::FileDropper
   #   exploiting).
   # @return [void]
   def register_files_for_cleanup(*files)
-    @dropped_files += files.map(&:clone)
+    @dropped_files += files.map(&:dup)
   end
 
   def allow_no_cleanup

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -56,7 +56,7 @@ module Exploit::FileDropper
   #   exploiting).
   # @return [void]
   def register_dirs_for_cleanup(*dirs)
-    @dropped_dirs += dirs.map(&:clone)
+    @dropped_dirs += dirs.map(&:dup)
   end
 
   # Singular versions


### PR DESCRIPTION
This fix an issue I spotted while testing this [PR](https://github.com/rapid7/metasploit-framework/pull/18314).

The way `register_files_for_cleanup ` and `register_dirs_for_cleanup` store the strings in `@dropped_files` and `@dropped_dirs` can cause issues when the array passed as argument contains references to a string variable.

Please see this [comment](https://github.com/rapid7/metasploit-framework/pull/18314#pullrequestreview-1643871283) for a detailed example of what could happen.

## Verification
A basic example would be:
```ruby
dir = 'C:\\one'
mkdir(dir)
dir << '\\two'
mkdir(dir)
dir << '\\three'
mkdir(dir)
```

`mkdir` takes care of calling `register_dirs_for_cleanup` and will end up having `@dropped_dirs` with three identical entries:
```
[1] pry(main)> @dropped_dirs
=> ["C:\\one\\two\\three",
 "C:\\one\\two\\three",
 "C:\\one\\two\\three"]
```

After this fix, `@dropped_dirs` should contains the expected entries:
```
[1] pry(main)> @dropped_dirs
=> ["C:\\one",
 "C:\\one\\two",
 "C:\\one\\two\\three"]
```

Maybe the easiest way to test this is to follow the steps in the [PR](https://github.com/rapid7/metasploit-framework/pull/18314) I mentioned earlier and make sure the expected directories are correctly cleaned up.