### PR TITLE
Show errors on inaccessible payload files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.148)
+      metasploit-payloads (= 2.0.154)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -275,7 +275,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.148)
+    metasploit-payloads (2.0.154)
     metasploit_data_models (6.0.2)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -80,7 +80,7 @@ metasploit-concern, 5.0.1, "New BSD"
 metasploit-credential, 6.0.5, "New BSD"
 metasploit-framework, 6.3.37, "New BSD"
 metasploit-model, 5.0.1, "New BSD"
-metasploit-payloads, 2.0.148, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.154, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.2, "New BSD"
 metasploit_payloads-mettle, 1.0.26, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -18,6 +18,7 @@ module Msf
     DATASTORE_FALLBACKS = 'datastore_fallbacks'
     FULLY_INTERACTIVE_SHELLS = 'fully_interactive_shells'
     MANAGER_COMMANDS = 'manager_commands'
+    METASPLOIT_PAYLOAD_WARNINGS = 'metasploit_payload_warnings'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -39,6 +40,12 @@ module Msf
         description: 'When enabled you can consistently set username across modules, instead of setting SMBUser/FTPUser/BIND_DN/etc',
         requires_restart: true,
         default_value: true
+      }.freeze,
+      {
+        name: METASPLOIT_PAYLOAD_WARNINGS,
+        description: 'When enabled Metasploit will output warnings about missing Metasploit payloads, for instance if they were removed by antivirus etc',
+        requires_restart: true,
+        default_value: false
       }.freeze
     ].freeze
 

--- a/lib/msf/core/payload/java.rb
+++ b/lib/msf/core/payload/java.rb
@@ -58,7 +58,7 @@ module Msf::Payload::Java
     jar = Rex::Zip::Jar.new
     jar.add_sub("metasploit") if opts[:random]
     jar.add_file("metasploit.dat", stager_config(opts))
-    jar.add_files(paths, MetasploitPayloads.path('java'))
+    jar.add_files(paths, ::MetasploitPayloads.path('java'))
     jar.build_manifest(:main_class => main_class)
 
     jar

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -188,15 +188,14 @@ module Msf::Payload::Stager
         end
       end
 
-      p = generate_stage(opts)
-
-      # Encode the stage if stage encoding is enabled
+      # Generate and encode the stage if stage encoding is enabled
       begin
+        p = generate_stage(opts)
         p = encode_stage(p)
-      rescue ::RuntimeError
+      rescue ::RuntimeError, ::StandardError => e
         warning_msg = "Failed to stage"
         warning_msg << " (#{conn.peerhost})"  if conn.respond_to? :peerhost
-        warning_msg << ": #{$!}"
+        warning_msg << ": #{e}"
         print_warning warning_msg
         if conn.respond_to? :close && !conn.closed?
           conn.close

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -364,7 +364,19 @@ class Driver < Msf::Ui::Driver
 
     run_single("banner") unless opts['DisableBanner']
 
-    av_warning_message if framework.eicar_corrupted?
+    payloads_manifest_errors = framework.features.enabled?(::Msf::FeatureManager::METASPLOIT_PAYLOAD_WARNINGS) ? ::MetasploitPayloads.manifest_errors : []
+
+    av_warning_message if (framework.eicar_corrupted? || payloads_manifest_errors.any?)
+
+    if framework.features.enabled?(::Msf::FeatureManager::METASPLOIT_PAYLOAD_WARNINGS)
+      if payloads_manifest_errors.any?
+        warn_msg = "Metasploit Payloads manifest errors:\n"
+        payloads_manifest_errors.each do |file|
+          warn_msg << "\t#{file[:path]} : #{file[:error]}\n"
+        end
+        $stderr.print(warn_msg)
+      end
+    end
 
     opts["Plugins"].each do |plug|
       run_single("load '#{plug}'")

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -363,7 +363,12 @@ class ClientCore < Extension
         # Get us to the installation root and then into data/meterpreter, where
         # the file is expected to be
         modname = "ext_server_#{mod.downcase}"
-        path = MetasploitPayloads.meterpreter_path(modname, suffix, debug: client.debug_build)
+        begin
+          path = MetasploitPayloads.meterpreter_path(modname, suffix, debug: client.debug_build)
+        rescue ::StandardError => e
+          elog(e)
+          path = nil
+        end
 
         if opts['ExtensionPath']
           path = ::File.expand_path(opts['ExtensionPath'])

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.148'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.154'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 7503
+  CachedSize = 7497
 
   include Msf::Payload::Single
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/bind_tcp.rb
+++ b/modules/payloads/stagers/java/bind_tcp.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5262
+  CachedSize = 5256
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5262
+  CachedSize = 5256
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/scripts/resource/meterpreter_compatibility.rc
+++ b/scripts/resource/meterpreter_compatibility.rc
@@ -13,7 +13,7 @@ framework.sessions.values.map do |session|
     puts "[#{Time.now}][#{extension_name}] Starting to loading extension"
     session.core.use(extension_name)
     puts "[#{Time.now}][#{extension_name}] Loaded extension"
-  rescue ::RuntimeError
+  rescue ::RuntimeError, ::MetasploitPayloads::Error
     puts "[#{Time.now}][#{extension_name}] Failed loading"
     # noop
   end

--- a/test/modules/post/test/extapi.rb
+++ b/test/modules/post/test/extapi.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Post
       vprint_status("Loading extapi extension...")
       begin
         session.core.use("extapi")
-      rescue Errno::ENOENT, Rex::Post::Meterpreter::ExtensionLoadError
+      rescue Errno::ENOENT, Rex::Post::Meterpreter::ExtensionLoadError, ::MetasploitPayloads::Error
         print_status("This module is only available in a windows meterpreter session.")
         return
       end


### PR DESCRIPTION
This PR requires https://github.com/rapid7/metasploit-payloads/pull/673
It allows for outputting error messages on startup if any Metasploit Payload files defined in the manifest file are missing or the user does not have read permissions for.
This PR also adds error messages when calling `to_handler` on a stageless payload, as well as when a payload reaches out for a stage that is not accessible.

## Java Payload Sizes

The Java payload sizes are slightly different due Java compiler changes. Prior to this release we used 

The changes are minimal; Small change in the try/if logic:

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/69275b18-229b-4b92-aeac-07c350ed467e)

And some changes in the constant pool, verified with:

```
$ javap -v -c AESEncryption.class

... etc ...
Constant pool:
   #1 = Methodref          #24.#37        // java/lang/Object."<init>":()V
   #2 = Class              #38            // java/io/DataInputStream
   #3 = Methodref          #2.#39         // java/io/DataInputStream."<init>":(Ljava/io/InputStream;)V
   #4 = Methodref          #2.#40         // java/io/DataInputStream.readInt:()I
   #5 = Class              #41            // java/security/SecureRandom
   #6 = Methodref          #5.#37         // java/security/SecureRandom."<init>":()V
   #7 = Methodref          #5.#42         // java/security/SecureRandom.nextBytes:([B)V
   #8 = Methodref          #43.#44        // java/io/OutputStream.write:([B)V
   #9 = Methodref          #43.#45        // java/io/OutputStream.flush:()V
  #10 = Methodref          #2.#46         // java/io/DataInputStream.readFully:([B)V
  #11 = String             #47            // MD5
  #12 = Methodref          #48.#49        // java/security/MessageDigest.getInstance:(Ljava/lang/String;)Ljava/security/MessageDigest;
  #13 = Methodref          #50.#51        // java/lang/String.getBytes:()[B
  #14 = Methodref          #48.#52        // java/security/MessageDigest.digest:([B)[B
  #15 = String             #53            // AES/CFB8/NoPadding
  #16 = Methodref          #17.#54        // javax/crypto/Cipher.getInstance:(Ljava/lang/String;)Ljavax/crypto/Cipher;
  #17 = Class              #55            // javax/crypto/Cipher
  #18 = Class              #56            // javax/crypto/spec/SecretKeySpec
... etc ...
```

Diff:

```diff
  #16 = Methodref          #17.#54        // javax/crypto/Cipher.getInstance:(Ljava/lang/String;)Ljavax/crypto/Cipher;
-  #17 = Class              #55            // javax/crypto/spec/SecretKeySpec
+  #17 = Class              #55            // javax/crypto/Cipher
+  #18 = Class              #56            // javax/crypto/spec/SecretKeySpec
```

## Verification

- [ ] Start `msfconsole`
- [ ] Ensure there are no startup error messages
- [ ] Ensure you can get a session with `payload/python/meterpreter/reverse_tcp` normally
- [ ] Exit msfconsole
- [ ] In the local Metasploit Payloads gem, rename `data/meterpreter/meterpreter.py` to `meterpreter.py2`
- [ ] Start `msfconsole`
- [ ] Ensure you get a warning on startup that mentions missing `meterpreter.py`
- [ ] Ensure `use payload/python/meterpreter/reverse_tcp` works
- [ ] `to_handler`
- [ ] Try to execute the payload on the target machine
- [ ] Ensure you get an error: `Meterpreter path meterpreter/meterpreter.py not found.`
- [ ] `use payload/python/meterpreter_reverse_tcp` (inline)
- [ ] Ensure calling `to_handler` results in `Meterpreter path meterpreter/meterpreter.py not found.`
- [ ] Ensure the errors are shown when calling `log`
- [ ] Exit msfconsole
- [ ] Change the `meterpreter.py2` file back to `meterpreter.py`
- [ ] Modify the `meterpreter.py` file with an additional empty line
- [ ] Start `msfconsole`
- [ ] Ensure you get a warning on startup that mentions a hash mismatch for `meterpreter.py`

## Example Output
### Staged
When the file is inaccessible, this is expected to fail when a payload reaches back to MSF Console for a stage.
<details>

```ruby
msf6 payload(windows/meterpreter/reverse_tcp) > options

Module options (payload/windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.112.1    yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


View the full module info with the info, or info -d command.

msf6 payload(windows/meterpreter/reverse_tcp) > to_handler
[*] Payload Handler Started as Job 0

[*] Started reverse TCP handler on 192.168.112.1:4444
-- Execute the payload on the target machine --
msf6 payload(windows/meterpreter/reverse_tcp) > [-] Meterpreter path meterpreter/metsrv.x86.dll not found. Ensure antivirus is not enabled, or reinstall Metasploit.
```

</details>

### Stageless
When the file is inaccessible, this is expected to fail when calling `to_handler`.
<details>

```ruby
msf6 payload(windows/x64/meterpreter_reverse_tcp) > options

Module options (payload/windows/x64/meterpreter_reverse_tcp):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   EXITFUNC    process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   EXTENSIONS                   no        Comma-separate list of extensions to load
   EXTINIT                      no        Initialization strings for extensions
   LHOST       192.168.207.1    yes       The listen address (an interface may be specified)
   LPORT       4444             yes       The listen port


View the full module info with the info, or info -d command.

msf6 payload(windows/x64/meterpreter_reverse_tcp) > to_handler

[-] Exploit failed: Meterpreter path meterpreter/metsrv.x64.dll not found. Ensure antivirus is not enabled, or reinstall Metasploit.
```

</details>