### PR TITLE
Fix pass by reference bug on the module side for windows error exploit

### DIFF
--- a/modules/exploits/windows/local/win_error_cve_2023_36874.rb
+++ b/modules/exploits/windows/local/win_error_cve_2023_36874.rb
@@ -74,6 +74,16 @@ class MetasploitModule < Msf::Exploit::Local
     ])
   end
 
+  # When we pass the directory value to the mkdir method, the mkdir method
+  # passes the reference to the string containing the directory.
+  # We do a lot of string manipulation in this module, so this is a quick
+  # hack to make sure that despite what we do with the string after we create
+  # the directory, it is  the actual directory we created that gets sent to
+  # the cleanup methods.
+  def clone_mkdir(dir)
+    mkdir(dir.clone)
+  end
+
   def upload_error_report
     wer_archive_dir = get_env('PROGRAMDATA')
     vprint_status(wer_archive_dir)
@@ -81,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Local
     report_dir = "#{wer_archive_dir}\\#{datastore['REPORT_DIR']}"
     report_filename = "#{report_dir}\\Report.wer"
     vprint_status("Creating #{report_dir}")
-    mkdir(report_dir)
+    clone_mkdir(report_dir)
     wer_report_data = exploit_data('CVE-2023-36874', 'Report.wer')
     vprint_status("Writing Report to #{report_filename}")
     write_file(report_filename, wer_report_data)
@@ -89,19 +99,19 @@ class MetasploitModule < Msf::Exploit::Local
 
   def build_shadow_archive_dir(shadow_base_dir)
     wer_archive_dir = shadow_base_dir
-    mkdir(wer_archive_dir)
+    clone_mkdir(wer_archive_dir)
     wer_archive_dir << '\\ProgramData\\'
-    mkdir(wer_archive_dir)
+    clone_mkdir(wer_archive_dir)
     wer_archive_dir << 'Microsoft\\'
-    mkdir(wer_archive_dir)
+    clone_mkdir(wer_archive_dir)
     wer_archive_dir << 'Windows\\'
-    mkdir(wer_archive_dir)
+    clone_mkdir(wer_archive_dir)
     wer_archive_dir << 'WER\\'
-    mkdir(wer_archive_dir)
+    clone_mkdir(wer_archive_dir)
     wer_archive_dir << 'ReportArchive\\'
-    mkdir(wer_archive_dir)
+    clone_mkdir(wer_archive_dir)
     report_dir = "#{wer_archive_dir}#{datastore['REPORT_DIR']}"
-    mkdir(report_dir)
+    clone_mkdir(report_dir)
     return report_dir
   end
 
@@ -115,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
   def build_shadow_system32(shadow_base_dir)
     shadow_win32 = "#{shadow_base_dir}\\system32"
     vprint_status("Creating #{shadow_win32}")
-    mkdir(shadow_win32)
+    clone_mkdir(shadow_win32)
     return shadow_win32
   end
 


### PR DESCRIPTION
This fixes a bug found by @cdelafuente-r7 where we're using a pass-by-reference for strings from the `mkdir` method to the cleanup methods.  This means that if we alter the string used to create the directory later in the module, the cleanup method tries to delete whatever is in the string at the end of the module, rather than what was in it when we called `mkdir`.  To fix it in this module, I just added a local method called `clone_mkdir` where we clone the string before passing it into mkdir.

We're working on a fix that will negate the need for this here: https://github.com/rapid7/metasploit-framework/pull/18403