### PR TITLE
Fix incorrect scope condition when populating RHOSTS using services command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -642,7 +642,7 @@ class Db
 
         tbl << columns
         if set_rhosts
-          addr = (host.scope ? host.address + '%' + host.scope : host.address)
+          addr = (host.scope.to_s != "" ? host.address + '%' + host.scope : host.address)
           rhosts << addr
         end
       end
@@ -880,7 +880,7 @@ class Db
         columns = [host.address] + col_names.map { |n| service[n].to_s || "" }
         tbl << columns
         if set_rhosts
-          addr = (host.scope ? host.address + '%' + host.scope : host.address )
+          addr = (host.scope.to_s != "" ? host.address + '%' + host.scope : host.address )
           rhosts << addr
         end
       end
@@ -1056,7 +1056,7 @@ class Db
       tbl << row
 
       if set_rhosts
-        addr = (vuln.host.scope ? vuln.host.address + '%' + vuln.host.scope : vuln.host.address)
+        addr = (vuln.host.scope.to_s != "" ? vuln.host.address + '%' + vuln.host.scope : vuln.host.address)
         rhosts << addr
       end
     end
@@ -1280,7 +1280,7 @@ class Db
         host = note.host
         row << host.address
         if set_rhosts
-          addr = (host.scope ? host.address + '%' + host.scope : host.address)
+          addr = (host.scope.to_s != "" ? host.address + '%' + host.scope : host.address)
           rhosts << addr
         end
       else


### PR DESCRIPTION
When the database contains hosts with empty scope columns (where scope is an empty string), they are not correctly added to `RHOSTS` via `services -R` because the command adds a trailing `%` sign to each address.  This can happen if the database is filled by an external program that sets `scope` to an empty string instead of `NULL`.

Fixes #18410.

## Verification

Make sure you have less then 5 hosts in the database (or add a filter that reduces the number of hits to less than 5) and make sure that the hosts have empty strings in their `scope` column and not `NULL`.

1. `msfconsole`
2. `services -R`

Now you see that the addresses in `RHOSTS` have trailing `%` signs. These are normally added to separate the address scope but in this case the scope is empty and they are added regardless.

## Fix

The reason why the ternary for adding or omitting the scope to the address fails is because empty strings (like `host.scope` in this case) are truthy in Ruby. Therefore, the conditional only works if `scope` is `nil`. This is fixed by casting potential `nil` values to a string and performing a more explicit condition (`host.scope.to_s != ""`).