### PR TITLE
Add a couple of tips

### DIFF
--- a/lib/msf/ui/tip.rb
+++ b/lib/msf/ui/tip.rb
@@ -40,7 +40,7 @@ module Msf
         "Use the #{highlight('analyze')} command to suggest runnable modules for hosts",
         "Set the current module's RHOSTS with database values using #{highlight('hosts -R')} or #{highlight('services -R')}",
         "Use the 'capture' plugin to start multiple authentication-capturing and poisoning services",
-        "The #{highlight('use')} command supports fuzzy searching, e.g. #{highlight('use kerberos/get_ticket')} or #{highlight('use kerberos forge silver ticket')}"
+        "The #{highlight('use')} command supports fuzzy searching to try and select the intended module, e.g. #{highlight('use kerberos/get_ticket')} or #{highlight('use kerberos forge silver ticket')}"
       ].freeze
       private_constant :COMMON_TIPS
 

--- a/lib/msf/ui/tip.rb
+++ b/lib/msf/ui/tip.rb
@@ -32,13 +32,15 @@ module Msf
         "Search can apply complex filters such as #{highlight('search cve:2009 type:exploit')}, see all the filters with #{highlight('help search')}",
         "Metasploit can be configured at startup, see #{highlight('msfconsole --help')} to learn more",
         "Display the Framework log using the #{highlight('log')} command, learn more with #{highlight('help log')}",
-        "Adapter names can be used for IP params #{highlight('set LHOST eth0')}",
+        "Network adapter names can be used for IP options #{highlight('set LHOST eth0')}",
         "Use #{highlight('sessions -1')} to interact with the last opened session",
         "View missing module options with #{highlight('show missing')}",
         "Start commands with a space to avoid saving them to history",
         "You can pivot connections over sessions started with the ssh_login modules",
         "Use the #{highlight('analyze')} command to suggest runnable modules for hosts",
-        "Set the current module's RHOSTS with database values using #{highlight('hosts -R')} or #{highlight('services -R')}"
+        "Set the current module's RHOSTS with database values using #{highlight('hosts -R')} or #{highlight('services -R')}",
+        "Use the 'capture' plugin to start multiple authentication-capturing and poisoning services",
+        "The #{highlight('use')} command supports fuzzy searching, e.g. #{highlight('use kerberos/get_ticket')} or #{highlight('use kerberos forge silver ticket')}"
       ].freeze
       private_constant :COMMON_TIPS
 


### PR DESCRIPTION
@bwatters-r7 suggested I add the using partial module names to the Metasploit tips trick I was using during my demos over the summer. I also added one for using the capture plugin. If there's another tip suggestion, feel free to leave it as a comment and I'll add it in.

# Testing

- [ ] Start msfconsole
- [ ] Run the `tips` command and see the new tips show up