### PR TITLE
Save Kerberos tickets in the MSF cache upon a successful login

### DIFF
--- a/documentation/modules/auxiliary/scanner/kerberos/kerberos_login.md
+++ b/documentation/modules/auxiliary/scanner/kerberos/kerberos_login.md
@@ -3,7 +3,9 @@
 The `auxiliary/scanner/kerberos/kerberos_login` module can verify Kerberos credentials against a range of machines and
 report successful logins. If you have loaded a database plugin
 and connected to a database this module will record successful
-logins and hosts so you can track your access.
+logins and hosts so you can track your access. It will also
+store kerberos tickets that can be used even after the user's
+password has been changed.
 
 Kerberos accounts which do not require pre-authentication will
 have the TGT logged for offline cracking, this technique is known as AS-REP Roasting.

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -75,6 +75,8 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
             print_good("#{peer} - User: #{format_user(user)} does not require preauthentication. Hash: #{hash}")
           else
             print_good("#{peer} - User found: #{format_user(user)} with password #{password}. Hash: #{hash}")
+            ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(result.proof.as_rep, result.proof.decrypted_part)
+            Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(ccache, host: rhost, framework_module: self)
           end
           report_cred(user: user, password: password, asrep: hash)
         else


### PR DESCRIPTION
When we receive a successful Kerberos login (in the `kerberos_login` brute force module), we have an opportunity to cache the ticket. This is particularly helpful when a brute force is detected by a defender, and a user changes a user's password, because the ticket may still be valid until it expires. It also reduces the amount of interaction required with the DC in future.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Clear the Kerberos cache: `klist -d`
- [ ] `use kerberos_login`
- [ ] Run a successful brute force against an account
- [ ] Verify that the user's TGT is stored in the MSF kerberos cache (`klist`)
- [ ] Run a module that uses the TGT (e.g. `winrm_cmd`). Ensure that the TGT is used (do not provide the user's password in the command, and verify that the log shows the cached ticket being used)
- [ ] With the `kerberos_login` module, run the command against an account with pre-auth not-required
- [ ] Verify that the ticket is not placed in the kerberos cache.
