### PR TITLE
Add history support to nasm and metasm shells

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -130,11 +130,8 @@ module Shell
       # Pry is a development dependency, if not available suppressing history_load can be safely ignored.
     end
 
-    framework.history_manager.with_context(history_file: histfile, name: name) do
-      self.hist_last_saved = Readline::HISTORY.length
-
+    with_history_manager_context do
       begin
-
         while true
           # If the stop flag was set or we've hit EOF, break out
           break if self.stop_flag || self.stop_count > 1
@@ -168,7 +165,6 @@ module Shell
             run_single(line)
             self.stop_count = 0
           end
-
         end
         # Prevent accidental console quits
       rescue ::Interrupt
@@ -176,9 +172,6 @@ module Shell
         retry
       end
     end
-  ensure
-    framework.history_manager.flush
-    self.hist_last_saved = Readline::HISTORY.length
   end
 
   #
@@ -298,9 +291,28 @@ module Shell
   attr_accessor :on_command_proc
   attr_accessor :on_print_proc
   attr_accessor :framework
+  attr_accessor :history_manager
   attr_accessor :hist_last_saved # the number of history lines when last saved/loaded
 
   protected
+
+  # Executes the yielded block under the context of a new HistoryManager context. The shell's history will be flushed
+  # to disk when no longer interacting with the shell. If no history manager is available, the history will not be persisted.
+  def with_history_manager_context
+    history_manager = self.history_manager || framework&.history_manager
+    return yield unless history_manager
+
+    begin
+      history_manager.with_context(history_file: histfile, name: name) do
+        self.hist_last_saved = Readline::HISTORY.length
+
+        yield
+      end
+    ensure
+      history_manager.flush
+      self.hist_last_saved = Readline::HISTORY.length
+    end
+  end
 
   def supports_color?
     true

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -160,8 +160,10 @@ end
 
 # Start a pseudo shell and dispatch lines to be assembled and then
 # disassembled.
-shell = Rex::Ui::Text::PseudoShell.new("%bldmetasm%clr")
+history_file = File.join(Msf::Config.config_directory, 'metasm_history')
+shell = Rex::Ui::Text::PseudoShell.new("%bldmetasm%clr", '>', history_file)
 shell.init_ui(Rex::Ui::Text::Input::Stdio.new, Rex::Ui::Text::Output::Stdio.new)
+shell.history_manager = Rex::Ui::Text::Shell::HistoryManager.new
 
 puts [
   'type "exit" or "quit" to quit',

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -39,8 +39,10 @@ end
 
 # Start a pseudo shell and dispatch lines to be assembled and then
 # disassembled.
-shell = Rex::Ui::Text::PseudoShell.new("%bldnasm%clr")
+history_file = File.join(Msf::Config.config_directory, 'nasm_history')
+shell = Rex::Ui::Text::PseudoShell.new("%bldnasm%clr", '>', history_file)
 shell.init_ui(Rex::Ui::Text::Input::Stdio.new, Rex::Ui::Text::Output::Stdio.new)
+shell.history_manager = Rex::Ui::Text::Shell::HistoryManager.new
 
 shell.run { |line|
   line.gsub!(/(\r|\n)/, '')


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18423

Adds history support to the nasm and metasm shells, which can be found in the `tools/exploit/nasm_shell.rb` directory if installed with the nightly installers - or `msf-metasm_shell` with Kali. Now when re-opening these shells, previously typed commands should be remembered and available.

## Verification

### Before

Crashes (a regression) - but even prior to this commit there was no history functionality

### After

All history is remembered; Fresh console:

```
bundle exec ruby tools/exploit/metasm_shell.rb                
xor al, 12type "exit" or "quit" to quit
use ";" or "\n" for newline
type "file <file>" to parse a GAS assembler source file

metasm > xor al, 12
"\x34\x0c"
metasm > exit
```

After re-opening the console, the up/down arrows should navigation history - and `ctrl+r` reverse search should work:

```
 bundle exec ruby tools/exploit/metasm_shell.rb
type "exit" or "quit" to quit
use ";" or "\n" for newline
type "file <file>" to parse a GAS assembler source file

(reverse-i-search)`xo': xor al, 12
```

The `tools/exploit/nasm_shell.rb` should also work