### PR TITLE
Allow setting of the host for a kerberos ticket in the cache

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -51,6 +51,23 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       set_ccache_status(ids: ids, status: 'active')
     end
 
+    def set_rhost(rhost, ids:)
+
+      updated_loots = []
+      host_obj = report_host(host: rhost)
+      ids.each do |id|
+        loot = objects({ id: id })
+        if loot.blank?
+          print_warning("Ccache with id: #{id} was not found in loot")
+          next
+        end
+        updated_loots << Array.wrap(framework.db.update_loot({ id: id, host: host_obj })).first
+      end
+      updated_loots.map do |stored_loot|
+        StoredTicket.new(stored_loot)
+      end
+    end
+
     private
 
     # @param [Array<Integer>] ids List of ticket IDs to update

--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/write_mixin.rb
@@ -61,7 +61,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
           print_warning("Ccache with id: #{id} was not found in loot")
           next
         end
-        updated_loots << Array.wrap(framework.db.update_loot({ id: id, host: host_obj })).first
+        updated_loots << Array.wrap(framework.db.update_loot({ id: id, host_id: host_obj.id })).first
       end
       updated_loots.map do |stored_loot|
         StoredTicket.new(stored_loot)

--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('EXTRA_SIDS', [ false, 'Extra sids separated by commas, Ex: S-1-5-21-1755879683-3641577184-3486455962-519']),
         OptString.new('SPN', [ false, 'The Service Principal Name (Only used for silver ticket)'], conditions: %w[ACTION == FORGE_SILVER]),
         OptInt.new('DURATION', [ true, 'Duration of the ticket in days', 3650]),
+        OptAddress.new('RHOST', [false, 'The host that this ticket will be registered to in the Metasploit Kerberos cache']),
       ]
     )
 
@@ -101,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
       is_golden: is_golden
     )
 
-    Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(ccache, framework_module: self)
+    Msf::Exploit::Remote::Kerberos::Ticket::Storage.store_ccache(ccache, framework_module: self, host: datastore['RHOST'])
 
     if datastore['VERBOSE']
       print_ccache_contents(ccache, key: enc_key)


### PR DESCRIPTION
Currently, tickets created by the `forge_ticket` module aren't automatically used in any kerberos-aware modules, because they do not have a `host` value set for them. Thus, the framework is reticent to use them, not knowing if they're intended for that system. This PR enables specifying a `host` value for a ticket in two ways:

- Setting a `RHOST` value in the `forge_ticket` module; or
- Setting it after the fact using the `klist` command.

This allows forged tickets to be automatically used by the framework for kerberos-aware modules (without needing to specify `krb5ccname`)

## Verification

- [ ] Start `msfconsole`

Create a ticket that is expected to not work:
- [ ] `klist -d` (delete all existing tickets so we don't mix up our testing)
- [ ] `use forge_ticket`
- [ ] `run aes_key=<krbtgt aes key> domain=<domain fqdn> domain_sid=<domain sid> user=<username> action=forge_golden`

Now let's try to use it:
- [ ] `use winrm_cmd`
- [ ] `run rhosts=<host> domain=<domain fqdn> username=<username> winrm::auth=kerberos winrm::rhostname=<hostname> domaincontrollerrhost=<hostname>`
- [ ] Expect that it won't work (should see a message like "Additional pre-authentication required", since it can't find a ticket

Now let's fix that ticket
- [ ] `klist` (note the id of the ticket)
- [ ] `klist -i <ticket id> -r <host IP/resolvable domain name>`
- [ ] `klist` 
- [ ] Verify the host has changed in the list

Now let's run the winrm module again:
- [ ] `run rhosts=<host> domain=<domain fqdn> username=<username> winrm::auth=kerberos winrm::rhostname=<hostname> domaincontrollerrhost=<hostname>`
- [ ] Verify that it succeeds

Now let's try the other approach to setting the host (setting it directly in the `forge_ticket` module)
- [ ] `klist -d` (Clear the existing kerberos cache)
- [ ] `use forge_ticket`
- [ ] `run aes_key=<krbtgt aes key> domain=<domain fqdn> domain_sid=<domain sid> user=<username> rhost=<host> action=forge_golden`
- [ ] `use winrm_cmd`
- [ ] `run rhosts=<host> domain=<domain fqdn> username=<username> winrm::auth=kerberos winrm::rhostname=<hostname> domaincontrollerrhost=<hostname>`
- [ ] Verify that it uses the ticket and successfully runs the command.

