### PR TITLE
Add pin to rails 7.0.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     metasploit-framework (6.3.38)
-      actionpack (~> 7.0)
-      activerecord (~> 7.0)
-      activesupport (~> 7.0)
+      actionpack (~> 7.0.0)
+      activerecord (~> 7.0.0)
+      activesupport (~> 7.0.0)
       aws-sdk-ec2
       aws-sdk-ec2instanceconnect
       aws-sdk-iam

--- a/lib/metasploit/framework/rails_version_constraint.rb
+++ b/lib/metasploit/framework/rails_version_constraint.rb
@@ -3,7 +3,7 @@
 module Metasploit
   module Framework
     module RailsVersionConstraint
-      RAILS_VERSION =  '~> 7.0'
+      RAILS_VERSION =  '~> 7.0.0'
     end
   end
 end


### PR DESCRIPTION
Rails 7.1 is released now https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released - with upgrade guide [here](https://edgeguides.rubyonrails.org/7_1_release_notes.html)

Let's pin ourselves to 7.0.x so there's no accidental bumps to 7.1.x without testing/planning things in advance

## Verification

Ensure CI passes