### PR TITLE
Fix how port forwards are listed

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -431,16 +431,17 @@ class Console::CommandDispatcher::Stdapi::Net
         cnt = 0
 
         # Enumerate each TCP relay
-        service.each_tcp_relay { |lhost, lport, rhost, rport, opts|
-          next if (opts['MeterpreterRelay'] == nil)
+        service.each_tcp_relay do |lhost, lport, rhost, rport, opts|
+          next unless opts['MeterpreterRelay']
 
-          direction = 'Forward'
-          direction = 'Reverse' if opts['Reverse'] == true
-
-          table << [cnt + 1, "#{netloc(rhost, rport)}", "#{netloc(lhost, lport)}", direction]
+          if opts['Reverse']
+            table << [cnt + 1, "#{netloc(rhost, rport)}", "#{netloc(lhost, lport)}", 'Reverse']
+          else
+            table << [cnt + 1, "#{netloc(lhost, lport)}", "#{netloc(rhost, rport)}", 'Forward']
+          end
 
           cnt += 1
-        }
+        end
 
         print_line
         if cnt > 0


### PR DESCRIPTION
This fixes #18291 by switching the order in which the `lhost` and `lport` are displayed to the user in the portfwd command. The use of "Local" in the context of a portfwd is a bit confusing, but when it's a reverse portfwd the `lhost` and `rhost` should be switched as represented by the direction. This only changes how the information is displayed in the UI. The actual functionality was working correctly before and remains unchanged.

# Testing

- [x] Start a Meterpreter session
- [x] Start a portfwd
- [x] Start a reverse portfwd
- [x] List the open port forwards and see that they are all correct
    - [x] The remote argument (`-r`) for the forward direction is listed in the "Remote" column
    * In the original ticket, these arguments were reversed which lead to the confusion
    - [x] The local argument (`-L`) for the reverse direction is listed in the "Local" column

# Example

In this case 192.168.250.5 is a local web server running on another system that can be used to test connections with `curl`. You can also double check the process that is listening on the socket using `netstat` to ensure it's Ruby or the Meterpreter if you're running both on the same system.


```
meterpreter > resource test_18291.rc
[*] Processing test_18291.rc for ERB directives.
resource (test_18291.rc)> portfwd add    -p 80   -l 8080 -r 192.168.250.5
[*] Forward TCP relay created: (local) :8080 -> (remote) 192.168.250.5:80
resource (test_18291.rc)> portfwd add -R -p 9090 -l 80   -L 192.168.250.5
[*] Reverse TCP relay created: (remote) [::]:9090 -> (local) 192.168.250.5:80
resource (test_18291.rc)> portfwd list

Active Port Forwards
====================

   Index  Local             Remote            Direction
   -----  -----             ------            ---------
   1      0.0.0.0:8080      192.168.250.5:80  Forward
   2      192.168.250.5:80  [::]:9090         Reverse

2 total active port forwards.

meterpreter >
```