### PR TITLE
Handle kerberos properly when an account has no pre-auth required

### DIFF
--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -29,8 +29,8 @@ module Metasploit
               password: credential.private,
               realm: credential.realm
             )
-            unless res.preauth_required
-              # Pre-auth not required - let's get an RC4-HMAC ticket, since it's more easily crackable
+            if !res.preauth_required && res.decrypted_part.nil?
+              # Pre-auth not required and we don't have a valid password - let's get an RC4-HMAC ticket, since it's more easily crackable
               begin
                 res = send_request_tgt(
                   server_name: server_name,

--- a/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
+++ b/lib/msf/core/exploit/remote/kerberos/auth_brute.rb
@@ -71,7 +71,7 @@ module Msf::Exploit::Remote::Kerberos::AuthBrute
 
           # Accounts that have 'Do not require Kerberos preauthentication' enabled, will receive an ASREP response with a
           # ticket present without requiring a password. This can be cracked offline.
-          if !proof.preauth_required
+          if !proof.preauth_required && proof.decrypted_part.nil?
             print_good("#{peer} - User: #{format_user(user)} does not require preauthentication. Hash: #{hash}")
           else
             print_good("#{peer} - User found: #{format_user(user)} with password #{password}. Hash: #{hash}")

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -331,7 +331,7 @@ module Msf
                     initial_as_res,
                     enc_key,
                   )
-                rescue
+                rescue Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError
                   # Must be an incorrect password
                 end
               end

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -238,6 +238,24 @@ module Msf
             end
           end
 
+          def get_server_ciphers_from_padata(pa_data, acceptable_etypes)
+            etype_entries = pa_data.find {|entry| entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2}
+
+            # No etypes specified - how are we supposed to negotiate ciphers?
+            raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new(encryption_type: acceptable_etypes) unless etype_entries
+
+            server_ciphers = etype_entries.decoded_value
+            valid_ciphers = server_ciphers.etype_info2_entries.select do |server_etypeinfo2_entry|
+              acceptable_etypes.include?(server_etypeinfo2_entry.etype)
+            end
+
+            if valid_ciphers.empty?
+              raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new(encryption_type: acceptable_etypes)
+            end
+
+            valid_ciphers
+          end
+
           # Sends the required kerberos AS requests for a kerberos Ticket Granting Ticket
           #
           # @param options [Hash]
@@ -289,12 +307,42 @@ module Msf
 
             # If we receive an AS_REP response immediately, no-preauthentication was required and we can return immediately
             if initial_as_res.msg_type == Rex::Proto::Kerberos::Model::AS_REP
-              return Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
+              decrypted_part = nil
+              krb_enc_key = nil
+              # If we've been provided a valid password, we should still be able to decrypt it
+              unless password.nil?
+                etype = initial_as_res.enc_part.etype
+                salt = nil
+                params = nil
+                unless initial_as_res.pa_data.nil?
+                  pa_etype = get_server_ciphers_from_padata(initial_as_res.pa_data, [etype])
+                  salt = pa_etype[0].salt
+                  params = pa_etype[0].s2kparams
+                end
+                encryptor = Rex::Proto::Kerberos::Crypto::Encryption::from_etype(etype)
+                enc_key = encryptor.string_to_key(password, salt, params: params)
+                krb_enc_key = {
+                  enctype: etype,
+                  key: enc_key,
+                  salt: salt
+                }
+                begin
+                  decrypted_part = decrypt_kdc_as_rep_enc_part(
+                    initial_as_res,
+                    enc_key,
+                  )
+                rescue
+                  # Must be an incorrect password
+                end
+              end
+
+              result = Msf::Exploit::Remote::Kerberos::Model::TgtResponse.new(
                 as_rep: initial_as_res,
                 preauth_required: false,
-                decrypted_part: nil,
-                krb_enc_key: nil,
+                decrypted_part: decrypted_part,
+                krb_enc_key: krb_enc_key
               )
+              return result
             end
 
             # If we're just AS_REP Roasting, we can't go any further
@@ -313,19 +361,7 @@ module Msf
             # Note that Clock skew issues may be raised at this point
 
             pa_data = initial_as_res.e_data_as_pa_data
-            etype_entries = pa_data.find {|entry| entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2}
-
-            # No etypes specified - how are we supposed to negotiate ciphers?
-            raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new(encryption_type: offered_etypes) unless etype_entries
-
-            server_ciphers = etype_entries.decoded_value
-            remaining_server_ciphers_to_attempt = server_ciphers.etype_info2_entries.select do |server_etypeinfo2_entry|
-              offered_etypes.include?(server_etypeinfo2_entry.etype)
-            end
-
-            if remaining_server_ciphers_to_attempt.empty?
-              raise Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported.new(encryption_type: offered_etypes)
-            end
+            remaining_server_ciphers_to_attempt = get_server_ciphers_from_padata(pa_data, offered_etypes)
 
             # Attempt to use the available ciphers; In some scenarios they can fail due to GPO configurations
             # So we need to iterate until a success - or there's no more ciphers available

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -563,7 +563,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       )
     end
 
-    if !tgt_result.preauth_required
+    if !tgt_result.preauth_required && tgt_result.decrypted_part.nil?
       raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(
         'Kerberos ticket does not require preauthentication. It is not possible to decrypt the encrypted message to request further TGS tickets. Try cracking the password via AS-REP Roasting techniques.',
       )

--- a/lib/rex/proto/kerberos/crypto/des3_cbc_sha1.rb
+++ b/lib/rex/proto/kerberos/crypto/des3_cbc_sha1.rb
@@ -20,7 +20,7 @@ module Rex
           # @param params [String] Unused for this encryption type
           # @return [String] The derived key
           def string_to_key(string, salt, params: nil)
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Params not supported for DES' unless params == nil
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Params not supported for DES' unless params == nil
             utf8_encoded = (string + salt).encode('UTF-8').bytes
             k = random_to_key(nfold(utf8_encoded, 21))
             k = k.pack('C*')
@@ -38,7 +38,7 @@ module Rex
 
           # Decrypts the cipher using DES3-CBC-SHA1 schema
           def decrypt_basic(ciphertext, key)
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext is not a multiple of block length' unless ciphertext.length % BLOCK_SIZE == 0
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext is not a multiple of block length' unless ciphertext.length % BLOCK_SIZE == 0
             cipher = OpenSSL::Cipher.new('des-ede3-cbc')
             cipher.decrypt
             cipher.key = key
@@ -67,7 +67,7 @@ module Rex
                 b | (b.digits(2).count(1) + 1) % 2
               end
               
-              raise Rex::Proto::Kerberos::Model::Error::KerberosError unless seed.length == 7
+              raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError unless seed.length == 7
         
               firstbytes = seed.map {|b| parity(b & ~1)}
               tmp = 7.times.map { |i| (seed[i] & 1) << i+1 }
@@ -80,7 +80,7 @@ module Rex
               keybytes
             end
         
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError unless seed.length == 21
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError unless seed.length == 21
             
             subkeys = seed.each_slice(7).map { |slice| expand(slice) }
             subkeys.flatten

--- a/lib/rex/proto/kerberos/crypto/des_cbc_md5.rb
+++ b/lib/rex/proto/kerberos/crypto/des_cbc_md5.rb
@@ -21,7 +21,7 @@ module Rex
           # @param params [String] Unused for this encryption type
           # @return [String] The derived key
           def string_to_key(password, salt, params: nil)
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Params not supported for DES' unless params == nil
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Params not supported for DES' unless params == nil
             reverse_this_block = false
             tempstring = [0,0,0,0,0,0,0,0]
 
@@ -87,10 +87,10 @@ module Rex
           # @param key [String] the key to decrypt
           # @param msg_type [Integer] ignored for this algorithm
           # @return [String] the decrypted cipher
-          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosError] if decryption doesn't succeed
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError] if decryption doesn't succeed
           def decrypt(ciphertext, key, msg_type)
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext too short' unless ciphertext && ciphertext.length > BLOCK_SIZE + HASH_LENGTH
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext is not a multiple of block length' unless ciphertext.length % BLOCK_SIZE == 0
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext too short' unless ciphertext && ciphertext.length > BLOCK_SIZE + HASH_LENGTH
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext is not a multiple of block length' unless ciphertext.length % BLOCK_SIZE == 0
 
 
             cipher = OpenSSL::Cipher.new('des-cbc')
@@ -107,7 +107,7 @@ module Rex
             hash_fn = OpenSSL::Digest.new('MD5')
 
             if hash_fn.digest(hashed_data) != checksum
-              raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'HMAC integrity error'
+              raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'HMAC integrity error'
             end
 
             plaintext
@@ -132,7 +132,7 @@ module Rex
             hash_fn = OpenSSL::Digest.new('MD5')
             checksum = hash_fn.digest(hashed_data)
 
-            raise Rex::Proto::Kerberos::Model::Error::KerberosError, 'Invalid checksum size' unless checksum.length == HASH_LENGTH
+            raise Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Invalid checksum size' unless checksum.length == HASH_LENGTH
 
             plaintext = confounder + checksum + padded_data
 

--- a/lib/rex/proto/kerberos/model/error.rb
+++ b/lib/rex/proto/kerberos/model/error.rb
@@ -194,6 +194,10 @@ module Rex
               super(message || "Kerberos target does not support the required encryption")
             end
           end
+
+          # Runtime error which will be raised when a Kerberos cryptography routine fails
+          class KerberosCryptographyError < KerberosError
+          end
         end
       end
     end

--- a/spec/lib/rex/proto/kerberos/crypto/aes128_cts_sha1_spec.rb
+++ b/spec/lib/rex/proto/kerberos/crypto/aes128_cts_sha1_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe Rex::Proto::Kerberos::Crypto::Aes128CtsSha1 do
     mod_byte = encrypted[11].ord
     mod_byte ^= 1
     encrypted = encrypted[0,11] + mod_byte.chr + encrypted[12,encrypted.length]
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'HMAC integrity error')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'HMAC integrity error')
   end
 
   it 'Short length throws error' do
     key = "\xf1\x49\xc1\xf2\xe1\x54\xa7\x34\x52\xd4\x3e\x7f\xe6\x2a\x56\xe5"
     msg_type = 4
     encrypted = 'abc'
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext too short')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext too short')
   end
 end

--- a/spec/lib/rex/proto/kerberos/crypto/aes256_cts_sha1_spec.rb
+++ b/spec/lib/rex/proto/kerberos/crypto/aes256_cts_sha1_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe Rex::Proto::Kerberos::Crypto::Aes256CtsSha1 do
     mod_byte = encrypted[11].ord
     mod_byte ^= 1
     encrypted = encrypted[0,11] + mod_byte.chr + encrypted[12,encrypted.length]
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'HMAC integrity error')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'HMAC integrity error')
   end
 
   it 'Short length throws error' do
     key = "\xfe\x69\x7b\x52\xbc\x0d\x3c\xe1\x44\x32\xba\x03\x6a\x92\xe6\x5b\xbb\x52\x28\x09\x90\xa2\xfa\x27\x88\x39\x98\xd7\x2a\xf3\x01\x61"
     msg_type = 4
     encrypted = 'abc'
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext too short')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext too short')
   end
 end

--- a/spec/lib/rex/proto/kerberos/crypto/des3_cbc_sha1_spec.rb
+++ b/spec/lib/rex/proto/kerberos/crypto/des3_cbc_sha1_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Rex::Proto::Kerberos::Crypto::Des3CbcSha1 do
     last_byte = encrypted[-1].ord
     last_byte ^= 1
     encrypted = encrypted[0,encrypted.length - 1] + last_byte.chr
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'HMAC integrity error')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'HMAC integrity error')
   end
 
   it 'Invalid length throws error' do
@@ -127,13 +127,13 @@ RSpec.describe Rex::Proto::Kerberos::Crypto::Des3CbcSha1 do
     encrypted = encryptor.encrypt(plaintext, key, msg_type)
     # Let's remove one byte
     encrypted = encrypted[0,encrypted.length - 1]
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext is not a multiple of block length')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext is not a multiple of block length')
   end
 
   it 'Short length throws error' do
     key = ["85763726585dbc1cce6ec43e1f751f07f1c4cbb098f40b19"].pack("H*")
     msg_type = 4
     encrypted = 'abc'
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext too short')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext too short')
   end
 end

--- a/spec/lib/rex/proto/kerberos/crypto/des_cbc_md5_spec.rb
+++ b/spec/lib/rex/proto/kerberos/crypto/des_cbc_md5_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Rex::Proto::Kerberos::Crypto::DesCbcMd5 do
     mod_byte = encrypted[11].ord
     mod_byte ^= 1
     encrypted = encrypted[0,11] + mod_byte.chr + encrypted[12,encrypted.length]
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'HMAC integrity error')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'HMAC integrity error')
   end
 
   it 'Invalid length throws error' do
@@ -97,13 +97,13 @@ RSpec.describe Rex::Proto::Kerberos::Crypto::DesCbcMd5 do
     encrypted = encryptor.encrypt(plaintext, key, msg_type)
     # Let's remove one byte
     encrypted = encrypted[0,encrypted.length - 1]
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext is not a multiple of block length')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext is not a multiple of block length')
   end
 
   it 'Short length throws error' do
     key = "\xc4\xbf\x6b\x25\xad\xf7\xa4\xf8"
     msg_type = 4
     encrypted = 'abc'
-    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError, 'Ciphertext too short')
+    expect { encryptor.decrypt(encrypted, key, msg_type) }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosCryptographyError, 'Ciphertext too short')
   end
 end


### PR DESCRIPTION
This fixes an issue relating to accounts with Kerberos pre-auth disabled.

Upon encountering such an account, the KDC sends us an AS-REP that we could use for authentication, as long as we know the password. However, Metasploit has not performed this step. Rather, it just returns with "The account has pre-auth disabled; you can crack this ticket with Hashcat". This works fine for the kerberos brute force module; but for modules that actually intend to use kerberos to perform some action, the action will fail for such accounts. But if we know the account password, we can treat this exactly as with any other account: decrypt the AS-REP enc-part, and carry on.

This bug appeared when setting the correct password on a Kerberos module (e.g. `winrm_cmd`) would return with an error message, when it should be able to succeed:

```
msf6 auxiliary(scanner/winrm/winrm_cmd) > run rhosts=192.168.20.210 domain=pod8.lan username=administrator winrm::auth=kerberos winrm::rhostname=WIN2012DC.POD8.LAN domaincontrollerrhost=192.168.20.210 password=Password123!

[*] Error: 192.168.20.210: Rex::Proto::Kerberos::Model::Error::KerberosError Kerberos ticket does not require preauthentication. It is not possible to decrypt the encrypted message to request further TGS tickets. Try cracking the password via AS-REP Roasting techniques.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use winrm_cmd`
- [ ] Run the module against an admin account with pre-auth disabled, using the correct password
- [ ] Verify that the module completes successfully
- [ ] `use kerberos_login`
- [ ] Run the module against an account with pre-auth disabled, using the correct password
- [ ] Verify that it shows that the password is correct
- [ ] Run the module against an account with pre-auth disabled, using the incorrect password
- [ ] Verify that it shows the crackable hash