### PR TITLE
Add remote webservice deletion notice

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -339,6 +339,10 @@ def reinit_db
   init_db
 end
 
+def print_webservice_removal_prompt
+  $stderr.puts "#{'[WARNING]'.red} The remote web service is being removed. Does this impact you? React here: https://github.com/rapid7/metasploit-framework/issues/18439"
+end
+
 class WebServicePIDStatus
   RUNNING = 0
   INACTIVE = 1
@@ -1062,6 +1066,9 @@ if $PROGRAM_NAME == __FILE__
   end
   if @options[:component] == :all
     @components.each { |component|
+      if component == :webservice
+        3.times { print_webservice_removal_prompt }
+      end
       puts '===================================================================='
       puts "Running the '#{command}' command for the #{component}:"
       invoke_command(commands, component.to_sym, command)
@@ -1070,6 +1077,9 @@ if $PROGRAM_NAME == __FILE__
     }
   else
     puts "Running the '#{command}' command for the #{@options[:component]}:"
+    if @options[:component] == :webservice
+      3.times { print_webservice_removal_prompt }
+    end
     invoke_command(commands, @options[:component], command)
   end
 end


### PR DESCRIPTION

https://github.com/rapid7/metasploit-framework/issues/18439

## Verification

When running `msfdb init --component webservice` or `msfdb init --component webservice` the user should be prompted:

```
$ bundle exec ruby ./msfdb init --component webservice
Running the 'init' command for the webservice:
[WARNING] The remote web service is being removed. Does this impact you? React here: https://github.com/rapid7/metasploit-framework/issues/18439
[WARNING] The remote web service is being removed. Does this impact you? React here: https://github.com/rapid7/metasploit-framework/issues/18439
[WARNING] The remote web service is being removed. Does this impact you? React here: https://github.com/rapid7/metasploit-framework/issues/18439
[?] Initial MSF web service account username? [user]: 

```