### PR TITLE
Add at rest encryption to Meterpreter payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.156)
+      metasploit-payloads (= 2.0.159)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -278,7 +278,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.156)
+    metasploit-payloads (2.0.159)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -82,7 +82,7 @@ metasploit-concern, 5.0.2, "New BSD"
 metasploit-credential, 6.0.6, "New BSD"
 metasploit-framework, 6.3.39, "New BSD"
 metasploit-model, 5.0.2, "New BSD"
-metasploit-payloads, 2.0.156, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.159, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.3, "New BSD"
 metasploit_payloads-mettle, 1.0.26, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -127,7 +127,13 @@ module Msf::Payload::Android
       [ "AndroidManifest.xml" ],
       [ "resources.arsc" ]
     ]
-    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
+
+    files.each do |file|
+      path = ['android', 'apk', file].flatten.join('/')
+      contents = ::MetasploitPayloads.read(path)
+      jar.add_file(file.join('/'), contents)
+    end
+
     jar.add_file("classes.dex", fix_dex_header(classes))
     jar.build_manifest
 

--- a/lib/msf/core/payload/java.rb
+++ b/lib/msf/core/payload/java.rb
@@ -58,7 +58,14 @@ module Msf::Payload::Java
     jar = Rex::Zip::Jar.new
     jar.add_sub("metasploit") if opts[:random]
     jar.add_file("metasploit.dat", stager_config(opts))
-    jar.add_files(paths, ::MetasploitPayloads.path('java'))
+    jar.add_file('metasploit/', '') # Create the metasploit dir
+
+    paths.each do |path_parts|
+      path = ['java', path_parts].flatten.join('/')
+      contents = ::MetasploitPayloads.read(path)
+      jar.add_file(path_parts.join('/'), contents)
+    end
+
     jar.build_manifest(:main_class => main_class)
 
     jar
@@ -103,7 +110,14 @@ module Msf::Payload::Java
     zip.add_file('WEB-INF/', '')
     zip.add_file('WEB-INF/web.xml', web_xml)
     zip.add_file("WEB-INF/classes/", "")
-    zip.add_files(paths, MetasploitPayloads.path('java'), 'WEB-INF/classes/')
+    zip.add_file('metasploit/', '') # Create the metasploit dir
+
+    paths.each do |path_parts|
+      path = ['java', path_parts].flatten.join('/')
+      contents = ::MetasploitPayloads.read(path)
+      zip.add_file(path_parts.join('/'), contents)
+    end
+
     zip.add_file("WEB-INF/classes/metasploit.dat", stager_config(opts))
 
     zip
@@ -138,7 +152,14 @@ module Msf::Payload::Java
     zip = Rex::Zip::Jar.new
     zip.add_file('META-INF/', '')
     zip.add_file('META-INF/services.xml', services_xml)
-    zip.add_files(paths, MetasploitPayloads.path('java'))
+    zip.add_file('metasploit/', '') # Create the metasploit dir
+
+    paths.each do |path_parts|
+      path = ['java', path_parts].flatten.join('/')
+      contents = ::MetasploitPayloads.read(path)
+      zip.add_file(path_parts.join('/'), contents)
+    end
+
     zip.add_file('metasploit.dat', stager_config(opts))
     zip.build_manifest(:app_name => app_name)
 

--- a/lib/msf/core/payload/windows/dll_inject.rb
+++ b/lib/msf/core/payload/windows/dll_inject.rb
@@ -205,9 +205,8 @@ module Payload::Windows::DllInject
     data = library_name + "\x00"
 
     begin
-      File.open(library_path, "rb") { |f|
-        data += f.read
-      }
+      encrypted_contents = ::File.binread(library_path)
+      data += ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_contents)
     rescue
       print_error("Failed to load DLL: #{$!}.")
 

--- a/lib/msf/core/post/windows/reflective_dll_injection.rb
+++ b/lib/msf/core/post/windows/reflective_dll_injection.rb
@@ -78,8 +78,9 @@ module Msf::Post::Windows::ReflectiveDLLInjection
   # @return [Array] Tuple of allocated memory address and offset to the
   #   +ReflectiveLoader+ function.
   def inject_dll_data_into_process(process, dll_data, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
-    offset = load_rdi_dll_from_data(dll_data, loader_name: loader_name, loader_ordinal: loader_ordinal)
-    dll_mem = inject_into_process(process, dll_data)
+    decrypted_dll_data = ::MetasploitPayloads.decrypt_payload(payload: dll_data)
+    offset = load_rdi_dll_from_data(decrypted_dll_data, loader_name: loader_name, loader_ordinal: loader_ordinal)
+    dll_mem = inject_into_process(process, decrypted_dll_data)
 
     return dll_mem, offset
   end

--- a/lib/msf/core/post/windows/reflective_dll_injection.rb
+++ b/lib/msf/core/post/windows/reflective_dll_injection.rb
@@ -78,7 +78,7 @@ module Msf::Post::Windows::ReflectiveDLLInjection
   # @return [Array] Tuple of allocated memory address and offset to the
   #   +ReflectiveLoader+ function.
   def inject_dll_data_into_process(process, dll_data, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
-    decrypted_dll_data = ::MetasploitPayloads.decrypt_payload(payload: dll_data)
+    decrypted_dll_data = ::MetasploitPayloads::Crypto.decrypt(ciphertext: dll_data)
     offset = load_rdi_dll_from_data(decrypted_dll_data, loader_name: loader_name, loader_ordinal: loader_ordinal)
     dll_mem = inject_into_process(process, decrypted_dll_data)
 

--- a/lib/msf/core/reflective_dll_loader.rb
+++ b/lib/msf/core/reflective_dll_loader.rb
@@ -24,8 +24,8 @@ module Msf::ReflectiveDLLLoader
   # @return [Array] Tuple of DLL contents and offset to the
   #                 +ReflectiveLoader+ function within the DLL.
   def load_rdi_dll(dll_path, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
-    dll = ''
-    ::File.open(dll_path, 'rb') { |f| dll = f.read }
+    encrypted_dll = ::File.binread(dll_path)
+    dll = ::MetasploitPayloads.decrypt_payload(payload: encrypted_dll)
 
     offset = parse_pe(dll, loader_name: loader_name, loader_ordinal: loader_ordinal)
 
@@ -43,7 +43,8 @@ module Msf::ReflectiveDLLLoader
   #
   # @return [Integer] offset to the +ReflectiveLoader+ function within the DLL.
   def load_rdi_dll_from_data(dll_data, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
-    offset = parse_pe(dll_data, loader_name: loader_name, loader_ordinal: loader_ordinal)
+    decrypted_dll_data = ::MetasploitPayloads.decrypt_payload(payload: dll_data)
+    offset = parse_pe(decrypted_dll_data, loader_name: loader_name, loader_ordinal: loader_ordinal)
 
     unless offset
       raise 'Cannot find the ReflectiveLoader entry point in DLL data'

--- a/lib/msf/core/reflective_dll_loader.rb
+++ b/lib/msf/core/reflective_dll_loader.rb
@@ -25,7 +25,7 @@ module Msf::ReflectiveDLLLoader
   #                 +ReflectiveLoader+ function within the DLL.
   def load_rdi_dll(dll_path, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
     encrypted_dll = ::File.binread(dll_path)
-    dll = ::MetasploitPayloads.decrypt_payload(payload: encrypted_dll)
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_dll)
 
     offset = parse_pe(dll, loader_name: loader_name, loader_ordinal: loader_ordinal)
 
@@ -43,7 +43,7 @@ module Msf::ReflectiveDLLLoader
   #
   # @return [Integer] offset to the +ReflectiveLoader+ function within the DLL.
   def load_rdi_dll_from_data(dll_data, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
-    decrypted_dll_data = ::MetasploitPayloads.decrypt_payload(payload: dll_data)
+    decrypted_dll_data = ::MetasploitPayloads::Crypto.decrypt(ciphertext: dll_data)
     offset = parse_pe(decrypted_dll_data, loader_name: loader_name, loader_ordinal: loader_ordinal)
 
     unless offset

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1599,7 +1599,14 @@ require 'digest/sha1'
     paths = [
       [ "metasploit", "Payload.class" ],
     ]
-    zip.add_files(paths, MetasploitPayloads.path('java'))
+
+    zip.add_file('metasploit/', '')
+    paths.each do |path_parts|
+      path = ['java', path_parts].flatten.join('/')
+      contents = ::MetasploitPayloads.read(path)
+      zip.add_file(path_parts.join('/'), contents)
+    end
+
     zip.build_manifest :main_class => "metasploit.Payload"
     config = "Spawn=#{spawn}\r\nExecutable=#{exe_name}\r\n"
     zip.add_file("metasploit.dat", config)

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -258,7 +258,8 @@ class ClientCore < Extension
       end
 
       if library_image
-        request.add_tlv(TLV_TYPE_DATA, library_image, false, client.capabilities[:zlib])
+        decrypted_library_image = ::MetasploitPayloads.decrypt_payload(payload: library_image)
+        request.add_tlv(TLV_TYPE_DATA, decrypted_library_image, false, client.capabilities[:zlib])
       else
         raise RuntimeError, "Failed to serialize library #{library_path}.", caller
       end

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -258,7 +258,7 @@ class ClientCore < Extension
       end
 
       if library_image
-        decrypted_library_image = ::MetasploitPayloads.decrypt_payload(payload: library_image)
+        decrypted_library_image = ::MetasploitPayloads::Crypto.decrypt(ciphertext: library_image)
         request.add_tlv(TLV_TYPE_DATA, decrypted_library_image, false, client.capabilities[:zlib])
       else
         raise RuntimeError, "Failed to serialize library #{library_path}.", caller

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -83,7 +83,7 @@ class Priv < Extension
       end
 
       encrypted_elevator_data = ::File.binread(elevator_path)
-      elevator_data = ::MetasploitPayloads.decrypt_payload(payload: encrypted_elevator_data)
+      elevator_data = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_elevator_data)
 
       request.add_tlv(TLV_TYPE_ELEVATE_SERVICE_DLL, elevator_data)
       request.add_tlv(TLV_TYPE_ELEVATE_SERVICE_LENGTH, elevator_data.length)

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -82,11 +82,8 @@ class Priv < Extension
         raise RuntimeError, "#{elevators.chomp(', ')} not found", caller
       end
 
-      elevator_data = ''
-
-      ::File.open(elevator_path, 'rb') { |f|
-        elevator_data += f.read(f.stat.size)
-      }
+      encrypted_elevator_data = ::File.binread(elevator_path)
+      elevator_data = ::MetasploitPayloads.decrypt_payload(payload: encrypted_elevator_data)
 
       request.add_tlv(TLV_TYPE_ELEVATE_SERVICE_DLL, elevator_data)
       request.add_tlv(TLV_TYPE_ELEVATE_SERVICE_LENGTH, elevator_data.length)

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -185,10 +185,8 @@ class UI < Rex::Post::UI
           raise RuntimeError, "screenshot.x64.dll not found", caller
         end
 
-        screenshot_dll  = ''
-        ::File.open( screenshot_path, 'rb' ) do |f|
-          screenshot_dll += f.read( f.stat.size )
-        end
+        encrypted_screenshot_dll = ::File.binread(screenshot_path)
+        screenshot_dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_screenshot_dll)
 
         request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_BUFFER, screenshot_dll, false, true )
       end
@@ -199,10 +197,8 @@ class UI < Rex::Post::UI
         raise RuntimeError, "screenshot.x86.dll not found", caller
       end
 
-      screenshot_dll  = ''
-      ::File.open( screenshot_path, 'rb' ) do |f|
-        screenshot_dll += f.read( f.stat.size )
-      end
+      encrypted_screenshot_dll = ::File.binread(screenshot_path)
+      screenshot_dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_screenshot_dll)
 
       request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_BUFFER, screenshot_dll, false, true )
     end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.156'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.159'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -69,7 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ["metasploit", "JMXPayloadMBean.class"],
         ["metasploit", "JMXPayload.class"],
       ]
-      @jar.add_files(paths, MetasploitPayloads.path('java'))
+
+      @jar.add_file('metasploit/', '')
+      paths.each do |path_parts|
+        path = ['java', path_parts].flatten.join('/')
+        contents = ::MetasploitPayloads.read(path)
+        @jar.add_file(path_parts.join('/'), contents)
+      end
     end
 
     if request.uri =~ /mlet$/

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -173,7 +173,13 @@ class MetasploitModule < Msf::Exploit::Remote
         [ "metasploit", "RMILoader.class" ],
         [ "metasploit", "RMIPayload.class" ],
       ]
-      jar.add_files(paths, MetasploitPayloads.path('java'))
+
+      jar.add_file('metasploit/', '') # create metasploit dir
+      paths.each do |path_parts|
+        path = ['java', path_parts].flatten.join('/')
+        contents = ::MetasploitPayloads.read(path)
+        jar.add_file(path_parts.join('/'), contents)
+      end
 
       send_response(cli, jar.pack,
       {

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -385,7 +385,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Reflectively injecting the exploit DLL into #{process.pid}...")
     encrypted_dll = ::File.binread(library_path)
-    dll = ::MetasploitPayloads.decrypt_payload(payload: encrypted_dll)
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_dll)
 
     patch_win32k_offsets(dll)
     patch_nt_offsets(dll)

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -384,8 +384,8 @@ class MetasploitModule < Msf::Exploit::Local
     library_path = ::File.expand_path(library_path)
 
     print_status("Reflectively injecting the exploit DLL into #{process.pid}...")
-    dll = ''
-    ::File.open(library_path, 'rb') { |f| dll = f.read }
+    encrypted_dll = ::File.binread(library_path)
+    dll = ::MetasploitPayloads.decrypt_payload(payload: encrypted_dll)
 
     patch_win32k_offsets(dll)
     patch_nt_offsets(dll)


### PR DESCRIPTION
This PR is requires https://github.com/rapid7/metasploit-payloads/pull/679
The change to `client_core.rb` is necessary to support encrypted stdapi libraries.
Other changes were made to support encrypted file contents being added to zip/jar/archive files by using `::MetasploitPayloads.read` which will handle encrypted/plain-text payloads as `#add_files` cannot take in a buffer, and we have to resort to calling `#add_file` for each file with the contents instead.

## Verification

- [ ] Start `msfconsole`
- [ ] Use a payload, for example `use payload/python/meterpreter/reverse_tcp`
- [ ] Ensure you can get get a session as usual
- [ ] When in `irb`, check that the payload being read is stored as an encrypted file on disk
  - [ ] `path = ::MetasploitPayloads.path('meterpreter', 'meterpreter.py')`
  - [ ] `raw_contents = ::File.binread(path); nil`
  - [ ] `raw_contents[0..5] == "msf\x01\x01\x01"`
  - [ ] `decrypted_contents = ::MetasploitPayloads.read('meterpreter', 'meterpreter.py')`
