### PR TITLE
Fix reverse ssh handler warnings on windows bootup

### DIFF
--- a/lib/msf/core/handler/reverse_ssh.rb
+++ b/lib/msf/core/handler/reverse_ssh.rb
@@ -150,8 +150,8 @@ module Msf
       def default_version_string
         default_version_string = 'SSH-2.0-OpenSSH_5.3p1'
 
-        # The current SSH server implementation does not support OpenSSL 3
-        return default_version_string if OpenSSL::OPENSSL_LIBRARY_VERSION.start_with? 'OpenSSL 3'
+        # The current SSH server implementation does not support OpenSSL 3 or windows
+        return default_version_string if OpenSSL::OPENSSL_LIBRARY_VERSION.start_with?('OpenSSL 3') || ::Gem.win_platform?
 
         require 'rex/proto/ssh/connection'
         Rex::Proto::Ssh::Connection.default_options['local_version']


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/18401

## Verification

### Before

```
msf6 > D:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb:13: warning: alread
y initialized constant HrrRbSsh::Connection::Channel::ChannelType::Session::NAME                                                                               
D:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb:13: warning: previous defi
nition of NAME was here                                                                                                                                        
D:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb:13: warning: already initi
alized constant HrrRbSsh::Connection::Channel::ChannelType::Session::NAME                                                                                      
D:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb:13: warning: previous defi
nition of NAME was here                                                                                                                                        
D:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb:13: warning: already initi
alized constant HrrRbSsh::Connection::Channel::ChannelType::Session::NAME                                                                                      
D:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/hrr_rb_ssh-0.4.2/lib/hrr_rb_ssh/connection/channel/channel_type/session.rb:13: warning: previous defi
nition of NAME was here                                                                                                                                        
... etc ...
```

### After

No warnings

```
C:\Users\Public>msfconsole
C:/metasploit-framework/embedded/lib/ruby/gems/3.0.0/gems/rex-core-0.1.31/lib/rex/compat.rb:381: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
Metasploit tip: Enable verbose logging with set VERBOSE true

         .                                         .
 .

      dBBBBBBb  dBBBP dBBBBBBP dBBBBBb  .                       o
       '   dB'                     BBP
    dB'dB'dB' dBBP     dBP     dBP BB
   dB'dB'dB' dBP      dBP     dBP  BB
  dB'dB'dB' dBBBBP   dBP     dBBBBBBB

                                   dBBBBBP  dBBBBBb  dBP    dBBBBP dBP dBBBBBBP
          .                  .                  dB' dBP    dB'.BP
                             |       dBP    dBBBB' dBP    dB'.BP dBP    dBP
                           --o--    dBP    dBP    dBP    dB'.BP dBP    dBP
                             |     dBBBBP dBP    dBBBBP dBBBBP dBP    dBP

                                                                    .
                .
        o                  To boldly go where no
                            shell has gone before


       =[ metasploit v6.3.38-dev-b32fe19545f2565714278680abc33d6c00d99340]
+ -- --=[ 2365 exploits - 1228 auxiliary - 413 post       ]
+ -- --=[ 1388 payloads - 46 encoders - 11 nops           ]
+ -- --=[ 9 evasion                                       ]

Metasploit Documentation: https://docs.metasploit.com/

msf6 >
```