### PR TITLE
Add support for ruby 3.3.0-preview2

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,7 +67,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
-          - '3.3.0-preview1'
+          - '3.3.0-preview2'
         os:
           - ubuntu-20.04
           - ubuntu-latest

--- a/msfconsole
+++ b/msfconsole
@@ -10,7 +10,7 @@ begin
 
   # Silences warnings as they only serve to confuse end users
   if defined?(Warning) && Warning.respond_to?(:[]=)
-    Warning[:deprecated] = false
+    Warning[:deprecated] = false unless ENV['CI']
   end
 
   # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5


### PR DESCRIPTION
Add support for ruby 3.3.0-preview2

This PR is a continuation of the 3.3.0-preview1 work https://github.com/rapid7/metasploit-framework/pull/18147

## Verification

Install and use 3.3.0-preview2 locally

```
rvm install 3.3.0-preview2  --with-openssl-dir=$(brew --prefix openssl@3)
rvm use 3.3.0-preview2
BUNDLE_FORCE_RUBY_PLATFORM=true bundle
```

- Ensure CI passes
- Ensure `msfconsole` boots locally