### PR TITLE
Update Writing Module Docs to reference msftidy_docs.rb

### DIFF
--- a/docs/metasploit-framework.wiki/Writing-Module-Documentation.md
+++ b/docs/metasploit-framework.wiki/Writing-Module-Documentation.md
@@ -41,3 +41,18 @@ These are just suggestions, but it'd be nice if the KB had these sections:
  - **Verification Steps** - Tells users how to use the module and what the expected results are from running the module. 
  - **Options** - Provides descriptions of all the options that can be run with the module. Additionally, clearly identify the options that are required. 
  - **Scenarios** - Provides sample usage and describes caveats that the user may need to be aware of when running the module.
+
+### Before you submit your PR: msftidy_docs.rb
+
+A documentation file can be passed as a positional argument to `metasploit-framework/tools/dev/msftidy_docs.rb` and will
+highlight formatting errors the docs file might contain. Once all the errors and warnings thrown by msf_tidy_docs have
+been resolved, the documentation file is ready for submission.
+
+```
+➜  metasploit-framework git:(upstream-master) ✗ ruby tools/dev/msftidy_docs.rb documentation/modules/exploit/linux/http/panos_op_cmd_exec.md
+documentation/modules/exploit/linux/http/panos_op_cmd_exec.md - [INFO] Missing Section: ## Options
+documentation/modules/exploit/linux/http/panos_op_cmd_exec.md - [WARNING] Please add a newline at the end of the file
+documentation/modules/exploit/linux/http/panos_op_cmd_exec.md - [WARNING] H2 headings in incorrect order. Should be: Vulnerable Application, Verification Steps/Module usage, Options, Scenarios
+documentation/modules/exploit/linux/http/panos_op_cmd_exec.md:50 - [WARNING] Should use single backquotes (`) for single line literals instead of triple backquotes (```)
+documentation/modules/exploit/linux/http/panos_op_cmd_exec.md:53 - [WARNING] Spaces at EOL
+```

--- a/docs/metasploit-framework.wiki/Writing-Module-Documentation.md
+++ b/docs/metasploit-framework.wiki/Writing-Module-Documentation.md
@@ -45,7 +45,7 @@ These are just suggestions, but it'd be nice if the KB had these sections:
 ### Before you submit your PR: msftidy_docs.rb
 
 A documentation file can be passed as a positional argument to `metasploit-framework/tools/dev/msftidy_docs.rb` and will
-highlight formatting errors the docs file might contain. Once all the errors and warnings thrown by msf_tidy_docs have
+highlight formatting errors the docs file might contain. Once all the errors and warnings thrown by `msftidy_docs.rb` have
 been resolved, the documentation file is ready for submission.
 
 ```


### PR DESCRIPTION
msftidy_docs.rb is referenced under the [Checking Documentation Syntax](https://docs.metasploit.com/docs/development/get-started/creating-your-first-pr.html#checking-documentation-syntax)  in the Creating Your First PR page. However it seems like it should probably be mentioned in Writing-Module-Documentation.md as well. Especially as https://github.com/rapid7/metasploit-framework/issues/12389 directs users there via this helpful comment: https://github.com/rapid7/metasploit-framework/issues/12389#issuecomment-539061745