### PR TITLE
Replace grep with getent in entrypoint.sh

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,14 +12,14 @@ if [ "$MSF_UID" -eq "0" ]; then
 else
   # if the users group already exists, create a random GID, otherwise
   # reuse it
-  if ! grep ":$MSF_GID:" /etc/group > /dev/null; then
+  if ! getent group $MSF_GID > /dev/null; then
     addgroup -g $MSF_GID $MSF_GROUP
   else
     addgroup $MSF_GROUP
   fi
 
   # check if user id already exists
-  if ! grep ":$MSF_UID:" /etc/passwd > /dev/null; then
+  if ! getent passwd $MSF_UID > /dev/null; then
     adduser -u $MSF_UID -D $MSF_USER -g $MSF_USER -G $MSF_GROUP $MSF_USER
     # add user to metasploit group so it can read the source
     addgroup $MSF_USER $METASPLOIT_GROUP


### PR DESCRIPTION
Use simpler, native "getent" command to get entries from NSS insead of "grep".