### PR TITLE
Nessus docs

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/appletv_login.md
+++ b/documentation/modules/auxiliary/scanner/http/appletv_login.md
@@ -1,0 +1,111 @@
+## Vulnerable Application
+
+This module attempts to authenticate to an AppleTV service with the username, 'AirPlay'.
+The device has two different access control modes: OnScreen and Password.
+The difference between the two is the password in OnScreen mode is numeric-only and four digits long,
+which means when this option is enabled, this option, the module will make sure to cover all of them - from 0000 to 9999.
+The Password mode is more complex, therefore the usual online bruteforce strategies apply.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/appletv_login`
+3. Do: set the passwords via the `password` option, or pass a list of passwords via the`pass_file` option. Pass a userlist via "user_list".
+4. Do: `run`
+5. Hopefully you see somthing like this:
+```
+[+] 127.0.0.1:7000 - Login Successful: admin:adminpassword
+```
+
+## Options
+List each option and how to use it.
+
+### BLANK_PASSWORD
+
+Boolean value on if an additional login attempt should be attempted with an empty password for every user.
+
+### BRUTEFORCE_SPEED
+
+How fast to bruteforce, from 0 to 5
+
+### Onscreen
+
+Enable if AppleTV is using the Onscreen access control
+
+### PASSWORD
+
+A specific password to authenticate with
+
+### PASS_FILE
+
+File containing passwords, one per line
+
+### STOP_ON_SUCCESS
+
+Stop guessing when a credential works for a host
+
+### THREADS
+
+The number of concurrent threads (max one per host)
+
+### USERPASS_FILE
+
+File containing users and passwords separated by space, one pair per line
+
+### USER_FILE
+
+File containing usernames, one per line
+
+### VERBOSE
+
+Whether to print output for all attempts
+
+### VHOST
+
+HTTP server virtual host
+
+## Scenarios
+```
+msf > use auxiliary/scanner/http/appletv_login
+msf6 auxiliary(scanner/http/appletv_login) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/appletv_login) > set password N0tpassword!
+password => N0tpassword!
+msf6 auxiliary(scanner/http/appletv_login) > set userfile ./USERNAMES
+userfile => ./USERNAMES
+msf6 auxiliary(scanner/http/appletv_login) > options
+
+Module options (auxiliary/scanner/http/appletv_login):
+
+   Name              Current Setting                                     Required  Description
+   ----              ---------------                                     --------  -----------
+   BLANK_PASSWORDS   false                                               no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                                                   yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_PASS       false                                               no        Add all passwords in the current database to the list
+   Onscreen          false                                               no        Enable if AppleTV is using the Onscreen access control
+   PASSWORD                                                              no        A specific password to authenticate with
+   PASS_FILE         /usr/share/metasploit-framework/data/wordlists/htt  no        File containing passwords, one per line
+                     p_default_pass.txt
+   Proxies                                                               no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                                                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasp
+                                                                                   loit.html
+   RPORT             7000                                                yes       The target port (TCP)
+   SSL               false                                               no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   true                                                yes       Stop guessing when a credential works for a host
+   THREADS           1                                                   yes       The number of concurrent threads (max one per host)
+   USERPASS_FILE                                                         no        File containing users and passwords separated by space, one pair per line
+   USER_FILE                                                             no        File containing usernames, one per line
+   VERBOSE           true                                                yes       Whether to print output for all attempts
+   VHOST                                                                 no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/http/appletv_login) > run
+
+[*] Attempting to login to /stop using password list
+[!] 127.0.0.1:7000        - No active DB -- Credential data will not be saved!
+[-] 127.0.0.1:7000        - Failed: 'AirPlay:password'
+[+] 127.0.0.1:7000         - 127.0.0.1:7000 - Login Successful: WORKSTATION\sa:N0tpassword!
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/appletv_login) >
+```

--- a/documentation/modules/auxiliary/scanner/http/appletv_login.md
+++ b/documentation/modules/auxiliary/scanner/http/appletv_login.md
@@ -9,7 +9,7 @@ The Password mode is more complex, therefore the usual online bruteforce strateg
 ## Verification Steps
 1. Start msfconsole
 2. Do: `use auxiliary/scanner/http/appletv_login`
-3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+3. Do: set the passwords via the `password` option, or pass a list of passwords via the`pass_file` option. Pass a userlist via "user_list".
 4. Do: `run`
 5. Hopefully you see somthing like this:
 ```
@@ -64,8 +64,6 @@ Whether to print output for all attempts
 HTTP server virtual host
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
-
 ```
 msf > use auxiliary/scanner/http/appletv_login
 msf6 auxiliary(scanner/http/appletv_login) > set rhosts 127.0.0.1

--- a/documentation/modules/auxiliary/scanner/http/appletv_login.md
+++ b/documentation/modules/auxiliary/scanner/http/appletv_login.md
@@ -1,0 +1,113 @@
+## Vulnerable Application
+
+This module attempts to authenticate to an AppleTV service with the username, 'AirPlay'.
+The device has two different access control modes: OnScreen and Password.
+The difference between the two is the password in OnScreen mode is numeric-only and four digits long,
+which means when this option is enabled, this option, the module will make sure to cover all of them - from 0000 to 9999.
+The Password mode is more complex, therefore the usual online bruteforce strategies apply.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/appletv_login`
+3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+4. Do: `run`
+5. Hopefully you see somthing like this:
+```
+[+] 127.0.0.1:7000 - Login Successful: admin:adminpassword
+```
+
+## Options
+List each option and how to use it.
+
+### BLANK_PASSWORD
+
+Boolean value on if an additional login attempt should be attempted with an empty password for every user.
+
+### BRUTEFORCE_SPEED
+
+How fast to bruteforce, from 0 to 5
+
+### Onscreen
+
+Enable if AppleTV is using the Onscreen access control
+
+### PASSWORD
+
+A specific password to authenticate with
+
+### PASS_FILE
+
+File containing passwords, one per line
+
+### STOP_ON_SUCCESS
+
+Stop guessing when a credential works for a host
+
+### THREADS
+
+The number of concurrent threads (max one per host)
+
+### USERPASS_FILE
+
+File containing users and passwords separated by space, one pair per line
+
+### USER_FILE
+
+File containing usernames, one per line
+
+### VERBOSE
+
+Whether to print output for all attempts
+
+### VHOST
+
+HTTP server virtual host
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+```
+msf > use auxiliary/scanner/http/appletv_login
+msf6 auxiliary(scanner/http/appletv_login) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/appletv_login) > set password N0tpassword!
+password => N0tpassword!
+msf6 auxiliary(scanner/http/appletv_login) > set userfile ./USERNAMES
+userfile => ./USERNAMES
+msf6 auxiliary(scanner/http/appletv_login) > options
+
+Module options (auxiliary/scanner/http/appletv_login):
+
+   Name              Current Setting                                     Required  Description
+   ----              ---------------                                     --------  -----------
+   BLANK_PASSWORDS   false                                               no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                                                   yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_PASS       false                                               no        Add all passwords in the current database to the list
+   Onscreen          false                                               no        Enable if AppleTV is using the Onscreen access control
+   PASSWORD                                                              no        A specific password to authenticate with
+   PASS_FILE         /usr/share/metasploit-framework/data/wordlists/htt  no        File containing passwords, one per line
+                     p_default_pass.txt
+   Proxies                                                               no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                                                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasp
+                                                                                   loit.html
+   RPORT             7000                                                yes       The target port (TCP)
+   SSL               false                                               no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   true                                                yes       Stop guessing when a credential works for a host
+   THREADS           1                                                   yes       The number of concurrent threads (max one per host)
+   USERPASS_FILE                                                         no        File containing users and passwords separated by space, one pair per line
+   USER_FILE                                                             no        File containing usernames, one per line
+   VERBOSE           true                                                yes       Whether to print output for all attempts
+   VHOST                                                                 no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/http/appletv_login) > run
+
+[*] Attempting to login to /stop using password list
+[!] 127.0.0.1:7000        - No active DB -- Credential data will not be saved!
+[-] 127.0.0.1:7000        - Failed: 'AirPlay:password'
+[+] 127.0.0.1:7000         - 127.0.0.1:7000 - Login Successful: WORKSTATION\sa:N0tpassword!
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/appletv_login) >
+```

--- a/documentation/modules/auxiliary/scanner/http/axis_login.md
+++ b/documentation/modules/auxiliary/scanner/http/axis_login.md
@@ -1,0 +1,131 @@
+## Vulnerable Application
+
+This module attempts to login to an Apache Axis2 instance using username and password
+combinations indicated by the USER_FILE, PASS_FILE, and USERPASS_FILE options.
+It has been verified to work on at least versions 1.4.1 and 1.6.2.
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/axis_login`
+3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+4. Do: `run`
+5. Hopefully you see somthing like this:
+```
+[+] 127.0.0.1:8080 - Login Successful: axisadmin:4x15pa$$
+```
+
+## Options
+List each option and how to use it.
+
+### BLANK_PASSWORDS
+
+Try blank passwords for all users
+
+### BLANK_PASSWORD
+
+Boolean value on if an additional login attempt should be attempted with an empty password for every user.
+
+### BRUTEFORCE_SPEED
+
+How fast to bruteforce, from 0 to 5
+
+### DB_ALL_CREDS
+
+Try each user/password couple stored in the current database
+
+### DB_ALL_PASS
+
+Add all passwords in the current database to the list
+
+
+### DB_ALL_USERS
+
+Add all users in the current database to the list
+
+### DB_SKIP_EXISTING
+
+Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+
+
+### PASSWORD
+
+A specific password to authenticate with
+
+### PASS_FILE
+
+File containing passwords, one per line
+
+### STOP_ON_SUCCESS
+
+Stop guessing when a credential works for a host
+
+### THREADS
+
+The number of concurrent threads (max one per host)
+
+### USERPASS_FILE
+
+File containing users and passwords separated by space, one pair per line
+
+### USER_FILE
+
+File containing usernames, one per line
+
+### VERBOSE
+
+Whether to print output for all attempts
+
+### VHOST
+
+HTTP server virtual host
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+```
+msf > use auxiliary/scanner/http/axis_login
+msf6 auxiliary(scanner/http/axis_login) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/axis_login) > set password N0tpassword!
+password => N0tpassword!
+msf6 auxiliary(scanner/http/axis_login) > set userfile ./USERNAMES
+userfile => ./USERNAMES
+msf6 auxiliary(scanner/http/axis_login) > show options
+
+Module options (auxiliary/scanner/http/axis_login):
+
+   Name              Current Setting           Required  Description
+   ----              ---------------           --------  -----------
+   BLANK_PASSWORDS   false                     no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                         yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_CREDS      false                     no        Try each user/password couple stored in the current database
+   DB_ALL_PASS       false                     no        Add all passwords in the current database to the list
+   DB_ALL_USERS      false                     no        Add all users in the current database to the list
+   DB_SKIP_EXISTING  none                      no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+   PASSWORD                                    no        A specific password to authenticate with
+   PASS_FILE                                   no        File containing passwords, one per line
+   Proxies                                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT             8080                      yes       The target port (TCP)
+   SSL               false                     no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   false                     yes       Stop guessing when a credential works for a host
+   TARGETURI         /axis2/axis2-admin/login  no        Path to the Apache Axis Administration page
+   THREADS           1                         yes       The number of concurrent threads (max one per host)
+   USERNAME                                    no        A specific username to authenticate as
+   USERPASS_FILE                               no        File containing users and passwords separated by space, one pair per line
+   USER_AS_PASS      false                     no        Try the username as the password for all users
+   USER_FILE                                   no        File containing usernames, one per line
+   VERBOSE           true                      yes       Whether to print output for all attempts
+   VHOST                                       no        HTTP server virtual host
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/http/axis_login) > run
+
+[*] Attempting to login to /stop using password list
+[!] 127.0.0.1:8080        - No active DB -- Credential data will not be saved!
+[-] 127.0.0.1:8080        - Failed: 'AxisRoot:password'
+[+] 127.0.0.1:8080         - 127.0.0.1:8080 - Login Successful: WORKSTATION\AxisRoot:N0tpassword!
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/axis_login) >
+```

--- a/documentation/modules/auxiliary/scanner/http/axis_login.md
+++ b/documentation/modules/auxiliary/scanner/http/axis_login.md
@@ -11,7 +11,7 @@ It has been verified to work on at least versions 1.4.1 and 1.6.2.
 4. Do: `run`
 5. Hopefully you see somthing like this:
 ```
-[+] 127.0.0.1:8080 - Login Successful: axisadmin:4x15pa$$
+[+] 127.0.0.1:8080 - Login Successful: axisadmin:4x15pa$$w0rd
 ```
 
 ## Options

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_ntp_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_ntp_login.md
@@ -1,0 +1,40 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+code or console output
+```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_ntp_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_ntp_login.md
@@ -1,40 +1,98 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This module attempts to authenticate to a Nessus NTP service.
 
 ## Verification Steps
 Example steps in this format (is also in the PR):
 
-1. Install the application
 1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell.
+2. Do: `use auxiliary/scanner/nessus/nessus_rest_login`
+3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+4. Do: `run`
+5. Hopefully you see somthing like this:
+```
+[+] 127.0.0.1:1214 - Successful: nessus:4x15pa$$w0rd
+```
 
 ## Options
-List each option and how to use it.
+### BLANK_PASSWORDS
+Try blank passwords for all users
 
-### Option Name
+### BRUTEFORCE_SPEED
+How fast to bruteforce, from 0 to 5
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+### DB_ALL_CREDS
+Try each user/password couple stored in the current database
+
+### DB_ALL_PASS
+Add all passwords in the current database to the list
+
+### DB_ALL_USERS
+Add all users in the current database to the list
+
+### DB_SKIP_EXISTING
+Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+
+### PASSWORD
+A specific password to authenticate with
+
+### PASS_FILE
+File containing passwords, one per line
+
+### Proxies
+A proxy chain of format type:host:port[,type:host:port][...]
+
+### RHOSTS
+The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+
+### RPORT
+The target port (TCP)
+
+### SSL
+Negotiate SSL/TLS for outgoing connections
+
+### STOP_ON_SUCCESS
+Stop guessing when a credential works for a host
+
+### TARGETURI
+The path to the Nessus server login API
+
+### THREADS
+The number of concurrent threads (max one per host)
+
+### USERNAME
+A specific username to authenticate as
+
+### USERPASS_FILE
+File containing users and passwords separated by space, one pair per line
+
+### USER_AS_PASS
+Try the username as the password for all users
+
+### USER_FILE
+File containing usernames, one per line
+
+### VERBOSE
+Whether to print output for all attempts
+
+### VHOST
+HTTP server virtual host
 
 ## Scenarios
 Specific demo of using the module that might be useful in a real world scenario.
 
-### Version and OS
-
 ```
-code or console output
-```
+msf > use scanner/nessus/nessus_rest_login
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set password N0tpassword!
+password => N0tpassword!
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set username notuser
+username => notuser 
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > run
 
-For example:
-
-To do this specific thing, here's how you do it:
-
-```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+[*] Attempting to login to /stop using password list
+[+] 127.0.0.1:1214         -    Success: 'notuser:N0tpassword'!
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/nessus/nessus_rest_login) >
 ```

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_ntp_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_ntp_login.md
@@ -3,8 +3,6 @@
 This module attempts to authenticate to a Nessus NTP service.
 
 ## Verification Steps
-Example steps in this format (is also in the PR):
-
 1. Start msfconsole
 2. Do: `use auxiliary/scanner/nessus/nessus_rest_login`
 3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
@@ -39,18 +37,6 @@ A specific password to authenticate with
 ### PASS_FILE
 File containing passwords, one per line
 
-### Proxies
-A proxy chain of format type:host:port[,type:host:port][...]
-
-### RHOSTS
-The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-
-### RPORT
-The target port (TCP)
-
-### SSL
-Negotiate SSL/TLS for outgoing connections
-
 ### STOP_ON_SUCCESS
 Stop guessing when a credential works for a host
 
@@ -79,8 +65,6 @@ Whether to print output for all attempts
 HTTP server virtual host
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
-
 ```
 msf > use scanner/nessus/nessus_rest_login
 msf6 auxiliary(scanner/nessus/nessus_rest_login) > set rhosts 127.0.0.1

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_rest_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_rest_login.md
@@ -1,0 +1,40 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+code or console output
+```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_rest_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_rest_login.md
@@ -1,40 +1,98 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This module will attempt to authenticate to a Nessus server RPC interface.
 
 ## Verification Steps
 Example steps in this format (is also in the PR):
 
-1. Install the application
 1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell.
+2. Do: `use auxiliary/scanner/nessus/nessus_rest_login`
+3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+4. Do: `run`
+5. Hopefully you see somthing like this:
+```
+[+] 127.0.0.1:8834 - Successful: nessus:4x15pa$$w0rd
+```
 
 ## Options
-List each option and how to use it.
+### BLANK_PASSWORDS
+Try blank passwords for all users
 
-### Option Name
+### BRUTEFORCE_SPEED
+How fast to bruteforce, from 0 to 5
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+### DB_ALL_CREDS
+Try each user/password couple stored in the current database
+
+### DB_ALL_PASS
+Add all passwords in the current database to the list
+
+### DB_ALL_USERS
+Add all users in the current database to the list
+
+### DB_SKIP_EXISTING
+Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+
+### PASSWORD
+A specific password to authenticate with
+
+### PASS_FILE
+File containing passwords, one per line
+
+### Proxies
+A proxy chain of format type:host:port[,type:host:port][...]
+
+### RHOSTS
+The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+
+### RPORT
+The target port (TCP)
+
+### SSL
+Negotiate SSL/TLS for outgoing connections
+
+### STOP_ON_SUCCESS
+Stop guessing when a credential works for a host
+
+### TARGETURI
+The path to the Nessus server login API
+
+### THREADS
+The number of concurrent threads (max one per host)
+
+### USERNAME
+A specific username to authenticate as
+
+### USERPASS_FILE
+File containing users and passwords separated by space, one pair per line
+
+### USER_AS_PASS
+Try the username as the password for all users
+
+### USER_FILE
+File containing usernames, one per line
+
+### VERBOSE
+Whether to print output for all attempts
+
+### VHOST
+HTTP server virtual host
 
 ## Scenarios
 Specific demo of using the module that might be useful in a real world scenario.
 
-### Version and OS
-
 ```
-code or console output
-```
+msf > use scanner/nessus/nessus_rest_login
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set password N0tpassword!
+password => N0tpassword!
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set username notuser
+username => notuser 
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > run
 
-For example:
-
-To do this specific thing, here's how you do it:
-
-```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+[*] Attempting to login to /stop using password list
+[+] 127.0.0.1:8834         -    Success: 'notuser:N0tpassword'!
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/nessus/nessus_rest_login) >
 ```

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_rest_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_rest_login.md
@@ -3,8 +3,6 @@
 This module will attempt to authenticate to a Nessus server RPC interface.
 
 ## Verification Steps
-Example steps in this format (is also in the PR):
-
 1. Start msfconsole
 2. Do: `use auxiliary/scanner/nessus/nessus_rest_login`
 3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
@@ -38,18 +36,6 @@ A specific password to authenticate with
 
 ### PASS_FILE
 File containing passwords, one per line
-
-### Proxies
-A proxy chain of format type:host:port[,type:host:port][...]
-
-### RHOSTS
-The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-
-### RPORT
-The target port (TCP)
-
-### SSL
-Negotiate SSL/TLS for outgoing connections
 
 ### STOP_ON_SUCCESS
 Stop guessing when a credential works for a host

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
@@ -1,0 +1,40 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+code or console output
+```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
@@ -1,40 +1,98 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This module simply attempts to login to a Nessus XMLRPC interface using a       specific user/pass.
 
 ## Verification Steps
 Example steps in this format (is also in the PR):
 
-1. Install the application
 1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell.
+2. Do: `use auxiliary/scanner/nessus/nessus_rest_login`
+3. Do: set usernames and passwords via the `username` and `password` options, or pass a list via `user_file` and `pass_file` options
+4. Do: `run`
+5. Hopefully you see somthing like this:
+```
+[+] 127.0.0.1:1214 - Successful: nessus:4x15pa$$w0rd
+```
 
 ## Options
-List each option and how to use it.
+### BLANK_PASSWORDS
+Try blank passwords for all users
 
-### Option Name
+### BRUTEFORCE_SPEED
+How fast to bruteforce, from 0 to 5
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+### DB_ALL_CREDS
+Try each user/password couple stored in the current database
+
+### DB_ALL_PASS
+Add all passwords in the current database to the list
+
+### DB_ALL_USERS
+Add all users in the current database to the list
+
+### DB_SKIP_EXISTING
+Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+
+### PASSWORD
+A specific password to authenticate with
+
+### PASS_FILE
+File containing passwords, one per line
+
+### Proxies
+A proxy chain of format type:host:port[,type:host:port][...]
+
+### RHOSTS
+The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+
+### RPORT
+The target port (TCP)
+
+### SSL
+Negotiate SSL/TLS for outgoing connections
+
+### STOP_ON_SUCCESS
+Stop guessing when a credential works for a host
+
+### TARGETURI
+The path to the Nessus server login API
+
+### THREADS
+The number of concurrent threads (max one per host)
+
+### USERNAME
+A specific username to authenticate as
+
+### USERPASS_FILE
+File containing users and passwords separated by space, one pair per line
+
+### USER_AS_PASS
+Try the username as the password for all users
+
+### USER_FILE
+File containing usernames, one per line
+
+### VERBOSE
+Whether to print output for all attempts
+
+### VHOST
+HTTP server virtual host
 
 ## Scenarios
 Specific demo of using the module that might be useful in a real world scenario.
 
-### Version and OS
-
 ```
-code or console output
-```
+msf > use scanner/nessus/nessus_rest_login
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set password N0tpassword!
+password => N0tpassword!
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > set username notuser
+username => notuser 
+msf6 auxiliary(scanner/nessus/nessus_rest_login) > run
 
-For example:
-
-To do this specific thing, here's how you do it:
-
-```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+[*] Attempting to login to /stop using password list
+[+] 127.0.0.1:1214         -    Success: 'notuser:N0tpassword'!
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/nessus/nessus_rest_login) >
 ```

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
@@ -1,9 +1,8 @@
 ## Vulnerable Application
 
-This module simply attempts to login to a Nessus XMLRPC interface using a       specific user/pass.
+This module simply attempts to login to a Nessus XMLRPC interface using a specific user/pass.
 
-### Verification Steps
-Example steps in this format (is also in the PR):
+## Verification Steps
 
 1. Start msfconsole
 2. Do: `use auxiliary/scanner/nessus/nessus_rest_login`
@@ -38,18 +37,6 @@ A specific password to authenticate with
 
 ### PASS_FILE
 File containing passwords, one per line
-
-### Proxies
-A proxy chain of format type:host:port[,type:host:port][...]
-
-### RHOSTS
-The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-
-### RPORT
-The target port (TCP)
-
-### SSL
-Negotiate SSL/TLS for outgoing connections
 
 ### STOP_ON_SUCCESS
 Stop guessing when a credential works for a host

--- a/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
+++ b/documentation/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.md
@@ -2,7 +2,7 @@
 
 This module simply attempts to login to a Nessus XMLRPC interface using a       specific user/pass.
 
-## Verification Steps
+### Verification Steps
 Example steps in this format (is also in the PR):
 
 1. Start msfconsole
@@ -11,7 +11,7 @@ Example steps in this format (is also in the PR):
 4. Do: `run`
 5. Hopefully you see somthing like this:
 ```
-[+] 127.0.0.1:1214 - Successful: nessus:4x15pa$$w0rd
+[+] 127.0.0.1:8834 - Successful: nessus:4x15pa$$w0rd
 ```
 
 ## Options
@@ -92,7 +92,7 @@ username => notuser
 msf6 auxiliary(scanner/nessus/nessus_rest_login) > run
 
 [*] Attempting to login to /stop using password list
-[+] 127.0.0.1:1214         -    Success: 'notuser:N0tpassword'!
+[+] 127.0.0.1:8834         -    Success: 'notuser:N0tpassword'!
 [*] Auxiliary module execution completed
 msf6 auxiliary(scanner/nessus/nessus_rest_login) >
 ```


### PR DESCRIPTION
Working on auxilary scanner docs. Issue https://github.com/rapid7/metasploit-framework/issues/12389. Added documentation for nessus_login.

# Verification

Steps needed to make things work are as follows:
- [x] Start `msfconsole`
- [x] run `msf> use auxiliary/scanner/http/appletv_login`
- [x] run `msf> info -d`
- [x] Verify that you see proper documentation