### PR TITLE
Fix flakey test failure

### DIFF
--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -410,7 +410,7 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
           module_info_by_path_from_database!
         end
 
-        it { expect(subject[:modification_time]).to be_within(1.second).of(pathname_modification_time) }
+        it { expect(subject[:modification_time]).to be_within(10.seconds).of(pathname_modification_time) }
         it { expect(subject[:parent_path]).to eq(parent_path) }
         it { expect(subject[:reference_name]).to eq(reference_name) }
         it { expect(subject[:type]).to eq(type) }


### PR DESCRIPTION
Fix a flakey test failure spotted on CI

```
02:00:28 Msf::ModuleManager ......................F..........................
02:00:28 
02:00:28   1) Msf::ModuleManager it should behave like Msf::ModuleManager::Cache #module_info_by_path_from_database! with database cache cache entry is expected to be within 1 of 2023-09-14 19:22:04.267979467 -0500
02:00:28      Failure/Error: it { expect(subject[:modification_time]).to be_within(1.second).of(pathname_modification_time) }
02:00:28        expected 2023-10-24 19:54:18.000000000 -0500 to be within 1 of 2023-09-14 19:22:04.267979467 -0500
02:00:28      Shared Example Group: "Msf::ModuleManager::Cache" called from ./spec/lib/msf/core/module_manager_spec.rb:29
02:00:28      # ./spec/support/shared/examples/msf/module_manager/cache.rb:413:in `block (5 levels) in <top (required)>'
```

## Verification

Ensure CI passes