### PR TITLE
Adds mixin to support resolving IPs across different session types

### DIFF
--- a/lib/msf/core/post/dns.rb
+++ b/lib/msf/core/post/dns.rb
@@ -1,0 +1,4 @@
+# -*- coding: binary -*-
+
+module Msf::Post::DNS
+end

--- a/lib/msf/core/post/dns/resolve_host.rb
+++ b/lib/msf/core/post/dns/resolve_host.rb
@@ -13,9 +13,9 @@ module Msf
         #
         # @param [String] host Hostname
         # @return [Array, nil] result[:ips], ips The resolved IPs
-        def resolve_host(host)
+        def resolve_host(host, family)
           if client.respond_to?(:net) && client.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_NET_RESOLVE_HOST)
-            result = client.net.resolve.resolve_host(host)
+            result = client.net.resolve.resolve_host(host, family)
             result[:ips]
           else
             ips = []

--- a/lib/msf/core/post/dns/resolve_host.rb
+++ b/lib/msf/core/post/dns/resolve_host.rb
@@ -1,0 +1,39 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Post
+    module DNS
+      ###
+      #
+      # This module resolves session DNS
+      #
+      ###
+      module ResolveHost
+        # Takes the host name and makes use of nslookup to resolve the IP
+        #
+        # @param [String] host Hostname
+        # @return [Array, nil] result[:ips], ips The resolved IPs
+        def resolve_host(host)
+          if client.respond_to?(:net) && client.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_NET_RESOLVE_HOST)
+            result = client.net.resolve.resolve_host(host)
+            result[:ips]
+          else
+            ips = []
+            data = cmd_exec("nslookup #{host}")
+            if data =~ /Name/
+              # Remove unnecessary data and get the section with the addresses
+              returned_data = data.split(/Name:/)[1]
+              # check each element of the array to see if they are IP
+              returned_data.gsub(/\r\n\t |\r\n|Aliases:|Addresses:|Address:/, ' ').split(' ').each do |e|
+                if Rex::Socket.dotted_ip?(e)
+                  ips << e
+                end
+              end
+            end
+            ips
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Registry
+  include Msf::Post::DNS::ResolveHost
 
   def initialize(info = {})
     super(
@@ -60,34 +61,16 @@ class MetasploitModule < Msf::Post
   #
   # @param [String] host Hostname
   # @return [String] ip The resolved IP
-  def resolve_host(host)
-    vprint_status("Looking up IP for #{host}")
-    return host if Rex::Socket.dotted_ip?(host)
-
-    ip = []
-    data = cmd_exec("nslookup #{host}")
-    if data =~ /Name/
-      # Remove unnecessary data and get the section with the addresses
-      returned_data = data.split(/Name:/)[1]
-      # check each element of the array to see if they are IP
-      returned_data.gsub(/\r\n\t |\r\n|Aliases:|Addresses:|Address:/, ' ').split(' ').each do |e|
-        if Rex::Socket.dotted_ip?(e)
-          ip << e
-        end
-      end
-    end
-
-    if ip.blank?
-      'Not resolvable'
-    else
-      ip.join(', ')
-    end
+  def gethost(hostname)
+    ## get IP for host
+    vprint_status("Looking up IP for #{hostname}")
+    resolve_host(hostname).join(', ')
   end
 
   def get_domain_computers
     computer_list = []
     divisor = "-------------------------------------------------------------------------------\r\n"
-    net_view_response = cmd_exec('net view')
+    net_view_response = cmd_exec("cmd.exe", "/c net view")
     unless net_view_response.include?(divisor)
       print_error("The net view command failed with: #{net_view_response}")
       return []
@@ -115,7 +98,7 @@ class MetasploitModule < Msf::Post
         ]
     )
     hosts.each do |hostname|
-      hostip = resolve_host(hostname)
+      hostip = gethost(hostname)
       tbl << [domain, hostname, hostip]
     end
 


### PR DESCRIPTION
This PR builds on a previous [PR](https://github.com/rapid7/metasploit-framework/pull/18383), specifically this [comment thread](https://github.com/rapid7/metasploit-framework/pull/18383#discussion_r1332908107).

This new mixin allows for DNS resolution for modules with multiple session types. E.g. [`modules/post/windows/gather/enum_computers.rb`](https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/enum_computers.rb) supports multiple sessions:
```
'SessionTypes' => %w[meterpreter powershell shell]
```
However the resolution across these session requires different logic. Meterpreter will now make use of the new Meterpreter API changes that will **_NEED_** to be landed before this PR can land.

metasploit-payloads PR - https://github.com/rapid7/metasploit-payloads/pull/681
metasploit-framework PR - https://github.com/rapid7/metasploit-framework/pull/18499

The mixin will check if we have a Meterpreter session with access to the `net` library and use the new Meterpreter API if so, otherwise fallback to `nslookup` if not.

## Note
A rescue was added to the `enum_computers` module to allow for instances when the DNS isn't able to be resolved via the meterpreter API. This is due to inconsistent resolving methods in the runtime languages. 

### With no errors
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/3e5117ac-b642-4875-967f-0d4a92af6d83)

### With every entry returning an error
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/e1f912cc-8269-412a-b446-04db923d55f3)

### Mixed results
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/f9bb23f9-b9f4-4089-9ca4-598aac9147f0)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use post/windows/gather/enum_computers.rb`
- [ ] **Target** a machine with multiple computers available
- [ ] Get a Meterpreter session
- [ ] **Verify** the module now list all expected computers as part of that domain
Example:
```
List of identified Hosts.
=========================

 Domain  Hostname  IPs
 ------  --------  ---
 VB      DC1       192.168.175.201, 192.168.175.200, 192.168.175.135
```