### PR TITLE
date and link on grafana dir traversal module

### DIFF
--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -26,14 +26,15 @@ class MetasploitModule < Msf::Auxiliary
           'Reliability' => [],
           'SideEffects' => [IOC_IN_LOGS]
         },
+        'DisclosureDate' => '2021-12-02',
         'References' => [
           ['CVE', '2021-43798'],
           ['URL', 'https://github.com/grafana/grafana/security/advisories/GHSA-8pjx-jj86-j47p'],
           ['URL', 'https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/'],
           ['EDB', '50581'],
           ['URL', 'https://github.com/jas502n/Grafana-CVE-2021-43798'],
-          ['URL', 'https://github.com/grafana/grafana/commit/c798c0e958d15d9cc7f27c72113d572fa58545ce']
-
+          ['URL', 'https://github.com/grafana/grafana/commit/c798c0e958d15d9cc7f27c72113d572fa58545ce'],
+          ['URL', 'https://labs.detectify.com/security-guidance/how-i-found-the-grafana-zero-day-path-traversal-exploit-that-gave-me-access-to-your-logs/']
         ]
       )
     )


### PR DESCRIPTION
Quick PR to add a disclosure date and link to the original disclosure blog post to the grafana plugin traversal module.
