### PR TITLE
Add a command to customise DNS resolution (including through sessions)

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -593,6 +593,10 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     sock
   end
 
+  def supports_udp?
+    true
+  end
+
   #
   # Get a string representation of the current session platform
   #

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -287,6 +287,10 @@ module Msf::Sessions
       sock
     end
 
+    def supports_udp?
+      false
+    end
+
     def create_server_channel(params)
       msf_channel = nil
       mutex = Mutex.new

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -20,6 +20,7 @@ module Msf
     MANAGER_COMMANDS = 'manager_commands'
     METASPLOIT_PAYLOAD_WARNINGS = 'metasploit_payload_warnings'
     DEFER_MODULE_LOADS = 'defer_module_loads'
+    DNS_FEATURE = 'dns_feature'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -52,6 +53,12 @@ module Msf
         name: DEFER_MODULE_LOADS,
         description: 'When enabled will not eagerly load all modules',
         requires_restart: true,
+        default_value: false
+      }.freeze,
+      {
+        name: DNS_FEATURE,
+        description: 'When enabled, allows configuration of DNS resolution behaviour in Metasploit',
+        requires_restart: false,
         default_value: false
       }.freeze
     ].freeze

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -81,7 +81,11 @@ class Framework
     # Configure the SSL certificate generator
     require 'msf/core/cert_provider'
     Rex::Socket::Ssl.cert_provider = Msf::Ssl::CertProvider
-    initialize_dns_resolver
+
+    if options.include?('CustomDnsResolver')
+      self.dns_resolver = options['CustomDnsResolver']
+      Rex::Socket._install_global_resolver(self.dns_resolver)
+    end
 
     subscriber = FrameworkEventSubscriber.new(self)
     events.add_exploit_subscriber(subscriber)
@@ -89,13 +93,6 @@ class Framework
     events.add_general_subscriber(subscriber)
     events.add_db_subscriber(subscriber)
     events.add_ui_subscriber(subscriber)
-  end
-
-  def initialize_dns_resolver
-    self.dns_resolver = Rex::Proto::DNS::CachedResolver.new
-    self.dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    self.dns_resolver.load_config
-    Rex::Socket._install_global_resolver(self.dns_resolver)
   end
 
   def dns_resolver

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -94,6 +94,7 @@ class Framework
   def initialize_dns_resolver
     self.dns_resolver = Rex::Proto::DNS::CachedResolver.new
     self.dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    self.dns_resolver.load_config
     Rex::Socket._install_global_resolver(self.dns_resolver)
   end
 

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -84,6 +84,7 @@ class Framework
 
     if options.include?('CustomDnsResolver')
       self.dns_resolver = options['CustomDnsResolver']
+      self.dns_resolver.set_framework(self)
       Rex::Socket._install_global_resolver(self.dns_resolver)
     end
 

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -81,6 +81,7 @@ class Framework
     # Configure the SSL certificate generator
     require 'msf/core/cert_provider'
     Rex::Socket::Ssl.cert_provider = Msf::Ssl::CertProvider
+    initialize_dns_resolver
 
     subscriber = FrameworkEventSubscriber.new(self)
     events.add_exploit_subscriber(subscriber)
@@ -88,6 +89,16 @@ class Framework
     events.add_general_subscriber(subscriber)
     events.add_db_subscriber(subscriber)
     events.add_ui_subscriber(subscriber)
+  end
+
+  def initialize_dns_resolver
+    self.dns_resolver = Rex::Proto::DNS::CachedResolver.new
+    self.dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    Rex::Socket._install_global_resolver(self.dns_resolver)
+  end
+
+  def dns_resolver
+    self.dns_resolver
   end
 
   def inspect
@@ -147,6 +158,10 @@ class Framework
     Version
   end
 
+  #
+  # DNS resolver for the framework
+  #
+  attr_reader   :dns_resolver
   #
   # Event management interface for registering event handler subscribers and
   # for interacting with the correlation engine.
@@ -278,6 +293,7 @@ protected
   #   @return [Hash]
   attr_accessor :options
 
+  attr_writer   :dns_resolver #:nodoc:
   attr_writer   :events # :nodoc:
   attr_writer   :modules # :nodoc:
   attr_writer   :datastore # :nodoc:

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -95,10 +95,6 @@ class Framework
     events.add_ui_subscriber(subscriber)
   end
 
-  def dns_resolver
-    self.dns_resolver
-  end
-
   def inspect
     "#<Framework (#{sessions.length} sessions, #{jobs.length} jobs, #{plugins.length} plugins#{db.active ? ", #{db.driver} database active" : ""})>"
   end

--- a/lib/msf/core/session/comm.rb
+++ b/lib/msf/core/session/comm.rb
@@ -22,6 +22,13 @@ module Comm
   def create(param)
     raise NotImplementedError
   end
+
+  #
+  # Does the Comm support sending UDP messages?
+  #
+  def supports_udp?
+    raise NotImplementedError
+  end
 end
 
 end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1350,6 +1350,7 @@ class Core
       # Save the framework's datastore
       begin
         framework.save_config
+        driver.framework.dns_resolver.save_config
 
         if active_module
           active_module.save_config

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -109,7 +109,6 @@ class DNS
     print_line "  add - add a DNS resolution entry to resolve certain domain names through a particular DNS server"
     print_line "  remove - delete a DNS resolution entry; 'del' is an alias"
     print_line "  flush - remove all DNS resolution entries"
-    print_line "  get - display the DNS server(s) and communication channel that would be used for a given target"
     print_line "  print - show all active DNS resolution entries"
     print_line
     print_line "Examples:"
@@ -124,9 +123,6 @@ class DNS
     print_line
     print_line "  Set the DNS server to be used for all requests that match no rules"
     print_line "    route add 8.8.8.8 8.8.4.4"
-    print_line
-    print_line "  Display the DNS server that would be used for the given domain name"
-    print_line "    route get subdomain.metasploit.com"
     print_line
   end
 

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -1,0 +1,151 @@
+# -*- coding: binary -*-
+
+class Msf::Ui::Console::CommandDispatcher::DNS
+
+  include Msf::Ui::Console::CommandDispatcher
+
+  @@add_opts = Rex::Parser::Arguments.new(
+    ['-r', '--rule'] => [true, 'Set a DNS wildcard entry to match against' ],
+    ['-s', '--session'] => [true, 'Force the DNS request to occur over a particular channel (override routing rules)' ],
+  )
+
+  def initialize(driver)
+    super
+  end
+
+  def name
+    'DNS'
+  end
+
+  def commands
+    commands = {}
+
+    if framework.features.enabled?(Msf::FeatureManager::DNS_FEATURE)
+      commands = {
+        'dns'        => "Manage Metasploit's DNS resolving behaviour"
+      }
+    end
+    commands
+  end
+
+  def cmd_dns_help
+    print_line 'Usage: dns'
+    print_line
+    print_line "Manage Metasploit's DNS resolution behaviour"
+    print_line
+    print_line "Usage:"
+    print_line "  dns [add/remove] [--session <session_id>] [--rule <wildcard DNS entry>] <IP Address> <IP Address> ..."
+    print_line "  dns [get] <hostname>"
+    print_line "  dns [flush]"
+    print_line "  dns [print]"
+    print_line
+    print_line "Subcommands:"
+    print_line "  add - add a DNS resolution entry to resolve certain domain names through a particular DNS server"
+    print_line "  remove - delete a DNS resolution entry; 'del' is an alias"
+    print_line "  flush - remove all DNS resolution entries"
+    print_line "  get - display the DNS server(s) and communication channel that would be used for a given target"
+    print_line "  print - show all active DNS resolution entries"
+    print_line
+    print_line "Examples:"
+    print_line "  Set the DNS server to be used for *.metasploit.com to 192.168.1.10"
+    print_line "    route add --rule *.metasploit.com 192.168.1.10"
+    print_line
+    print_line "  Set the DNS server to be used for *.metasploit.com to 192.168.1.10, but specifically to go through session 2"
+    print_line "    route add --session 2 --rule *.metasploit.com 192.168.1.10"
+    print_line
+    print_line "  Delete the above DNS resolution rule"
+    print_line "    route remove --session 2 --rule *.metasploit.com 192.168.1.10"
+    print_line
+    print_line "  Set the DNS server to be used for all requests that match no rules"
+    print_line "    route add 8.8.8.8 8.8.4.4"
+    print_line
+    print_line "  Display the DNS server that would be used for the given domain name"
+    print_line "    route get subdomain.metasploit.com"
+    print_line
+  end
+
+  #
+  # Manage Metasploit's DNS resolution rules
+  #
+  def cmd_dns(*args)
+    args << 'print' if args.length == 0
+    # Short-circuit help
+    if args.delete("-h") || args.delete("--help")
+      cmd_dns_help
+      return
+    end
+
+    action = args.shift
+    begin
+      case action
+      when "add"
+        add_dns(*args)
+      when "remove", "del"
+        remove_dns(*args)
+      when "purge"
+        purge_dns(*args)
+      when "print"
+        print_dns(*args)
+      when "help"
+        cmd_dns_help
+      end
+    rescue ::ArgumentError => e
+      print_error(e.message)
+    end
+  end
+
+  def add_dns(*args)
+    rules = []
+    comm = nil
+    servers = []
+    @@add_opts.parse(args) do |opt, idx, val|
+      unless servers.empty? || opt.nil?
+        raise ::ArgumentError.new("Invalid command near #{opt}")
+      end
+      case opt
+      when '--rule', '-r'
+        if val.nil?
+          raise ::ArgumentError.new('No rule specified')
+        end
+
+        rules << val
+      when '--session', '-s'
+        if val.nil?
+          raise ::ArgumentError.new('No session specified')
+        end
+
+        unless comm.nil?
+          raise ::ArgumentError.new('Only one session can be specified')
+        end
+
+        comm = val
+      when nil
+        servers << val
+      else
+        raise ::ArgumentError.new("Unknown flag: #{opt}")
+      end
+    end
+
+    # The remaining args should be the DNS servers
+
+    if servers.length < 1
+      raise ::ArgumentError.new("You must specify at least one DNS server")
+    end
+
+    servers.each do |host|
+      unless host =~ Resolv::IPv4::Regex || 
+             host =~ Resolv::IPv6::Regex
+        raise ::ArgumentError.new("Invalid DNS server: #{host}")
+      end
+    end
+  end
+
+  def remove_dns(*args)
+  end
+
+  def purge_dns(*args)
+  end
+
+  def print_dns(*args)
+  end
+end

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -44,6 +44,8 @@ class DNS
   # @param words [Array<String>] the previously completed words on the command line.  words is always
   # at least 1 when tab completion has reached this stage since the command itself has been completed
   def cmd_dns_tabs(str, words)
+    return if driver.framework.dns_resolver.nil?
+
     if words.length == 1
       options = ['add','del','remove','flush','print']
       return options.select { |opt| opt.start_with?(str) }
@@ -132,6 +134,8 @@ class DNS
   # Manage Metasploit's DNS resolution rules
   #
   def cmd_dns(*args)
+    return if driver.framework.dns_resolver.nil?
+
     args << 'print' if args.length == 0
     # Short-circuit help
     if args.delete("-h") || args.delete("--help")

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -114,7 +114,6 @@ class DNS
       case opt
       when '--rule', '-r'
         raise ::ArgumentError.new('No rule specified') if val.nil?
-        raise ::ArgumentError.new("Invalid rule: #{val}") unless valid_rule(val)
 
         rules << val
       when '--session', '-s'
@@ -162,13 +161,8 @@ class DNS
   end
 
   #
-  # Is the given wildcard DNS entry valid?
-  def valid_rule(rule)
-    rule =~ /^(\*\.)?([a-z\d][a-z\d-]*[a-z\d]\.)+[a-z]+$/
-  end
-
-  #
   # Remove all matching user-configured DNS entries
+  #
   def remove_dns(*args)
     remove_ids = []
     @@remove_opts.parse(args) do |opt, idx, val|
@@ -184,12 +178,14 @@ class DNS
 
   #
   # Delete all user-configured DNS settings
+  #
   def purge_dns
     driver.framework.dns_resolver.purge
   end
 
   #
   # Display the user-configured DNS settings
+  #
   def print_dns
     results = driver.framework.dns_resolver.nameserver_entries
     columns = ['ID','Rule(s)', 'DNS Server(s)', 'Comm channel']
@@ -204,6 +200,7 @@ class DNS
 
   #
   # Get user-friendly text for displaying the session that this entry would go through
+  #
   def prettify_comm(comm, dns_server)
     if comm.nil?
       channel = Rex::Socket::SwitchBoard.best_comm(dns_server)
@@ -213,7 +210,7 @@ class DNS
         "Session #{channel.sid} (route)"
       end
     else
-      if comm.alive
+      if comm.alive?
         "Session #{comm.sid}"
       else
         "Closed session (#{comm.sid})"

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -160,6 +160,8 @@ class DNS
         print_dns
       when "help"
         cmd_dns_help
+      else
+        print_error("Invalid command. To view help: dns -h")
       end
     rescue ::ArgumentError => e
       print_error(e.message)
@@ -298,7 +300,7 @@ class DNS
   def print_dns_set(heading, result_set)
     return if result_set.length == 0
     if result_set[0][:wildcard_rules].any?
-      columns = ['ID', 'Rules(s)', 'DNS Server', 'Commm channel']
+      columns = ['ID', 'Rules(s)', 'DNS Server', 'Comm channel']
     else
       columns = ['ID', 'DNS Server', 'Commm channel']
     end

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -29,7 +29,8 @@ class Driver < Msf::Ui::Driver
     CommandDispatcher::Resource,
     CommandDispatcher::Db,
     CommandDispatcher::Creds,
-    CommandDispatcher::Developer
+    CommandDispatcher::Developer,
+    CommandDispatcher::DNS
   ]
 
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -80,8 +80,16 @@ class Driver < Msf::Ui::Driver
 
     # Initialize attributes
 
+    dns_resolver = Rex::Proto::DNS::CachedResolver.new
+    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    dns_resolver.load_config
+
     # Defer loading of modules until paths from opts can be added below
-    framework_create_options = opts.merge('DeferModuleLoads' => true)
+    framework_create_options = opts.merge({
+                                            'DeferModuleLoads' => true,
+                                            'CustomDnsResolver' => dns_resolver
+                                          }
+                                         )
     self.framework = opts['Framework'] || Msf::Simple::Framework.create(framework_create_options)
 
     if self.framework.datastore['Prompt']

--- a/lib/rex/proto/dns/cached_resolver.rb
+++ b/lib/rex/proto/dns/cached_resolver.rb
@@ -21,6 +21,7 @@ module DNS
     #
     # @return [nil]
     def initialize(config = {})
+      dns_cache_no_start = config.delete(:dns_cache_no_start)
       super(config)
       self.cache = Rex::Proto::DNS::Cache.new
       # Read hostsfile into cache
@@ -72,7 +73,7 @@ module DNS
         end
       end
       # TODO: inotify or similar on hostsfile for live updates? Easy-button functionality
-      self.cache.start unless config[:dns_cache_no_start]
+      self.cache.start unless dns_cache_no_start
       return
     end
 

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -82,7 +82,7 @@ module DNS
           with_rules << entry
         end
 
-        next_id = [id, next_id].max
+        next_id = [id + 1, next_id].max
       end
 
       # Now that config has successfully read, update the global values
@@ -118,11 +118,23 @@ module DNS
     #
     # Remove entries with the given IDs
     # Ignore entries that are not found
+    # @param [Array<Integer>] The IDs to removed
+    # @return [Array<Hash>] The removed entries
+    #
     def remove_ids(ids)
+      removed= []
       ids.each do |id|
-        self.entries_with_rules.delete_if {|entry| entry[:id] == id}
-        self.entries_without_rules.delete_if {|entry| entry[:id] == id}
+        removed_with, remaining_with = self.entries_with_rules.partition {|entry| entry[:id] == id}
+        self.entries_with_rules.replace(remaining_with)
+
+        removed_without, remaining_without = self.entries_without_rules.partition {|entry| entry[:id] == id}
+        self.entries_without_rules.replace(remaining_without)
+
+        removed.concat(removed_with)
+        removed.concat(removed_without)
       end
+
+      removed
     end
 
     #

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -36,6 +36,9 @@ module DNS
       self.next_id = 0
     end
 
+    #
+    # Save the custom settings to the MSF config file
+    #
     def save_config
       new_config = {}
       [self.entries_with_rules, self.entries_without_rules].each do |entry_set|
@@ -52,6 +55,9 @@ module DNS
       Msf::Config.save(CONFIG_KEY => new_config)
     end
 
+    #
+    # Load the custom settings from the MSF config file
+    #
     def load_config
       config = Msf::Config.load
 
@@ -92,8 +98,8 @@ module DNS
     end
 
     # Add a custom nameserver entry to the custom provider
-    # @param [wildcard_rules] Array<String> The wildcard rules to match a DNS request against
-    # @param [dns_server] Array<String> The list of IP addresses that would be used for this custom rule
+    # @param wildcard_rules [Array<String>] The wildcard rules to match a DNS request against
+    # @param dns_server [Array<String>] The list of IP addresses that would be used for this custom rule
     # @param comm [Msf::Session::Comm] The communication channel to be used for these DNS requests
     def add_nameserver(wildcard_rules, dns_server, comm)
       raise ::ArgumentError.new("Invalid DNS server: #{dns_server}") unless Rex::Socket.is_ip_addr?(dns_server)
@@ -118,7 +124,7 @@ module DNS
     #
     # Remove entries with the given IDs
     # Ignore entries that are not found
-    # @param [Array<Integer>] The IDs to removed
+    # @param ids [Array<Integer>] The IDs to removed
     # @return [Array<Hash>] The removed entries
     #
     def remove_ids(ids)
@@ -140,6 +146,7 @@ module DNS
     #
     # The custom nameserver entries that have been configured
     # @return [Array<Array>] An array containing two elements: The entries with rules, and the entries without rules
+    #
     def nameserver_entries
       [entries_with_rules, entries_without_rules]
     end
@@ -148,6 +155,11 @@ module DNS
       init
     end
 
+    # The nameservers that match the given packet
+    # @param packet [Dnsruby::Message] The DNS packet to be sent
+    # @raise [ResolveError] If the packet contains multiple questions, which would end up sending to a different set of nameservers
+    # @return [Array<Array>] A list of nameservers, each with Rex::Socket options
+    #
     def nameservers_for_packet(packet)
       # Leaky abstraction: a packet could have multiple question entries,
       # and each of these could have different nameservers, or travel via

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -161,6 +161,9 @@ module DNS
     # @return [Array<Array>] A list of nameservers, each with Rex::Socket options
     #
     def nameservers_for_packet(packet)
+      unless feature_set.enabled?(Msf::FeatureManager::DNS_FEATURE)
+        return super
+      end
       # Leaky abstraction: a packet could have multiple question entries,
       # and each of these could have different nameservers, or travel via
       # different comm channels. We can't allow DNS leaks, so for now, we
@@ -172,9 +175,9 @@ module DNS
 
         self.entries_with_rules.each do |entry|
           entry[:wildcard_rules].each do |rule|
-            socket_options = {}
-            socket_options['Comm'] = entry[:comm] unless entry[:comm].nil?
             if matches(name, rule)
+              socket_options = {}
+              socket_options['Comm'] = entry[:comm] unless entry[:comm].nil?
               dns_servers.append([entry[:dns_server], socket_options])
               break
             end
@@ -208,6 +211,10 @@ module DNS
       mod.init
     end
 
+    def set_framework(framework)
+      self.feature_set = framework.features
+    end
+
     private
     #
     # Is the given wildcard DNS entry valid?
@@ -228,6 +235,7 @@ module DNS
     attr_accessor :entries_with_rules # Set of custom nameserver entries that specify a rule
     attr_accessor :entries_without_rules # Set of custom nameserver entries that do not include a rule
     attr_accessor :next_id # The next ID to have been allocated to an entry
+    attr_accessor :feature_set
   end
 end
 end

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -1,0 +1,85 @@
+module Rex
+module Proto
+module DNS
+
+  ##
+  # Provides a DNS resolver the ability to use different nameservers
+  # for different requests, based on the domain being queried.
+  ##
+  module CustomNameserverProvider
+
+    def init
+      self.entries_with_rules = []
+      self.entries_without_rules = []
+      self.next_id = 0
+    end
+
+    # Add a custom nameserver entry to the custom provider
+    # @param [wildcard_rules] Array<String> The wildcard rules to match a DNS request against
+    # @param [dns_server] Array<String> The list of IP addresses that would be used for this custom rule
+    # @param comm [Integer] The communication channel to be used for these DNS requests
+    def add_nameserver(wildcard_rules, dns_server, comm)
+      entry = {
+        :wildcard_rules => wildcard_rules,
+        :dns_server => dns_server,
+        :comm => comm,
+        :id => self.next_id
+      }
+      self.next_id += 1
+      if wildcard_rules.empty?
+        entries_without_rules << entry
+      else
+        entries_with_rules << entry
+      end
+    end
+
+    #
+    # The custom nameserver entries that have been configured
+    # @return [Array<Array>] An array containing two elements: The entries with rules, and the entries without rules
+    def nameserver_entries
+      [entries_with_rules, entries_without_rules]
+    end
+
+    def purge
+      init
+    end
+
+    def nameservers_for_packet(packet)
+      name = packet.question.qName
+      dns_servers = []
+
+      self.entries_with_rules.each do |entry|
+        entry[:wildcard_rules].each do |rule|
+          if matches(name, rule)
+            dns_servers.concat([entry[:dns_server], entry[:comm]])
+            break
+          end
+        end
+      end
+
+      # Only look at the rule-less entries if no rules were found (avoids DNS leaks)
+      if dns_servers.empty?
+        self.entries_without_rules.each do |entry|
+          dns_servers.concat([entry[:dns_server], entry[:comm]])
+        end
+      end
+      dns_servers.uniq!
+    end
+
+    def self.extended(mod)
+      mod.init
+    end
+
+    private
+
+    def matches(domain, pattern)
+      true
+    end
+
+    attr_accessor :entries_with_rules # Set of custom nameserver entries that specify a rule
+    attr_accessor :entries_without_rules # Set of custom nameserver entries that do not include a rule
+    attr_accessor :next_id # The next ID to have been allocated to an entry
+  end
+end
+end
+end

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -115,6 +115,7 @@ module DNS
     # @param dns_message [Dnsruby::Message] The DNS message to be sent
     #
     # @return [Array<Array>] A list of nameservers, each with Rex::Socket options
+    #
     def nameservers_for_packet(dns_message)
       @config[:nameservers].map {|ns| [ns, {}]}
     end
@@ -125,8 +126,8 @@ module DNS
     # @param argument [Object] An object holding the DNS message to be processed.
     # @param type [Fixnum] Type of record to look up
     # @param cls [Fixnum] Class of question to look up
-    #
     # @return [Dnsruby::Message] DNS response
+    #
     def send(argument, type = Dnsruby::Types::A, cls = Dnsruby::Classes::IN)
       method = self.use_tcp? ? :send_tcp : :send_udp
 

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -15,7 +15,7 @@ module DNS
 
     Defaults = {
       :config_file => "/etc/resolv.conf",
-      :log_file => "/dev/null", # formerly $stdout, should be tied in with our loggers
+      :log_file => File::NULL, # formerly $stdout, should be tied in with our loggers
       :port => 53,
       :searchlist => [],
       :nameservers => [IPAddr.new("127.0.0.1")],

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -111,4 +111,14 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
      expect(ns).to eq([[ruled_nameserver, {}], [ruled_nameserver2, {}]])
    end
   end
+
+  context 'When a packet contains multiple questions that have different nameserver results' do
+   it 'Throws an error' do
+     packet = packet_for('subdomain.metasploit.com')
+     q = Dnsruby::Question.new('subdomain.notmetasploit.com', Dnsruby::Types::A, Dnsruby::Classes::IN)
+
+     packet.question.append(q)
+     expect {many_ruled_provider.nameservers_for_packet(packet)}.to raise_error(ResolverError)
+   end
+  end
 end

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -1,0 +1,114 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+require 'net/dns'
+
+
+RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
+  def packet_for(name)
+    packet = Net::DNS::Packet.new(name, Net::DNS::A, Net::DNS::IN)
+    Rex::Proto::DNS::Packet.encode_drb(packet)
+  end
+
+  let(:base_nameserver) do
+    '1.2.3.4'
+  end
+
+  let(:ruleless_nameserver) do
+    '1.2.3.5'
+  end
+
+  let(:ruled_nameserver) do
+    '1.2.3.6'
+  end
+
+  let(:ruled_nameserver2) do
+    '1.2.3.7'
+  end
+
+  let(:ruled_nameserver3) do
+    '1.2.3.8'
+  end
+
+  let (:config) do
+    {:dns_cache_no_start => true}
+  end
+
+  subject(:many_ruled_provider) do
+    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
+    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    dns_resolver.nameservers = [base_nameserver]
+    dns_resolver.add_nameserver([], ruleless_nameserver, nil)
+    dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver, nil)
+    dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver2, nil)
+    dns_resolver.add_nameserver(['*.notmetasploit.com'], ruled_nameserver3, nil)
+
+    dns_resolver
+  end
+
+  subject(:ruled_provider) do
+    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
+    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    dns_resolver.nameservers = [base_nameserver]
+    dns_resolver.add_nameserver([], ruleless_nameserver, nil)
+    dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver, nil)
+
+    dns_resolver
+  end
+
+  subject(:ruleless_provider) do
+    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
+    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    dns_resolver.nameservers = [base_nameserver]
+    dns_resolver.add_nameserver([], ruleless_nameserver, nil)
+
+    dns_resolver
+  end
+
+  subject(:empty_provider) do
+    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
+    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    dns_resolver.nameservers = [base_nameserver]
+
+    dns_resolver
+  end
+
+  context 'When no nameserver is configured' do
+   it 'The resolver base is returned' do
+     packet = packet_for('subdomain.metasploit.com')
+     ns = empty_provider.nameservers_for_packet(packet)
+     expect(ns).to eq([[base_nameserver, {}]])
+   end
+  end
+
+  context 'When a base nameserver is configured' do
+   it 'The base nameserver is returned' do
+     packet = packet_for('subdomain.metasploit.com')
+     ns = ruleless_provider.nameservers_for_packet(packet)
+     expect(ns).to eq([[ruleless_nameserver, {}]])
+   end
+  end
+
+  context 'When a nameserver rule is configured and a rule entry matches' do
+   it 'The correct nameserver is returned' do
+     packet = packet_for('subdomain.metasploit.com')
+     ns = ruled_provider.nameservers_for_packet(packet)
+     expect(ns).to eq([[ruled_nameserver, {}]])
+    end
+  end
+
+  context 'When a nameserver rule is configured and no rule entry is applicable' do
+   it 'The base nameserver is returned when no rule entry' do
+     packet = packet_for('subdomain.notmetasploit.com')
+     ns = ruled_provider.nameservers_for_packet(packet)
+     expect(ns).to eq([[ruleless_nameserver, {}]])
+   end
+  end
+
+  context 'When many rules are configured' do
+   it 'Returns multiple entries if multiple rules match' do
+     packet = packet_for('subdomain.metasploit.com')
+     ns = many_ruled_provider.nameservers_for_packet(packet)
+     expect(ns).to eq([[ruled_nameserver, {}], [ruled_nameserver2, {}]])
+   end
+  end
+end

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     {:dns_cache_no_start => true}
   end
 
+  let (:framework_with_dns_enabled) do
+    framework = Object.new
+    def framework.features
+      f = Object.new
+      def f.enabled?(_name)
+        true
+      end
+
+      f
+    end
+
+    framework
+  end
+
   subject(:many_ruled_provider) do
     dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
     dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
@@ -41,6 +55,7 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver, nil)
     dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver2, nil)
     dns_resolver.add_nameserver(['*.notmetasploit.com'], ruled_nameserver3, nil)
+    dns_resolver.set_framework(framework_with_dns_enabled)
 
     dns_resolver
   end
@@ -51,6 +66,7 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     dns_resolver.nameservers = [base_nameserver]
     dns_resolver.add_nameserver([], ruleless_nameserver, nil)
     dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver, nil)
+    dns_resolver.set_framework(framework_with_dns_enabled)
 
     dns_resolver
   end
@@ -60,6 +76,7 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
     dns_resolver.nameservers = [base_nameserver]
     dns_resolver.add_nameserver([], ruleless_nameserver, nil)
+    dns_resolver.set_framework(framework_with_dns_enabled)
 
     dns_resolver
   end
@@ -68,6 +85,7 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
     dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
     dns_resolver.nameservers = [base_nameserver]
+    dns_resolver.set_framework(framework_with_dns_enabled)
 
     dns_resolver
   end


### PR DESCRIPTION
This work implements the `dns` command in Metasploit, to allow the user to customise the behaviour of DNS resolution in the framework.

The functionality, for now, is behind a feature flag. To use it, the feature needs to be enabled (`feature set dns_feature true`).

I use the existing `CachedResolver` implementation, registering it with `Rex::Socket` as the DNS resolver. Any existing code that resolves addresses through `Rex` will start using this functionality automatically.

This work allows users to resolve domains through communication channels (i.e. sessions). There are two ways this occurs:

- The new `dns` command supports setting a session value (`-s` or `--session`) to set the comm channel through which the communication will be sent.
- In the absence of a comm channel, the packet will be routed as per Metasploit's standard routing rules i.e. if a `route` has been set up for a particular CIDR, through a particular session, if the provided nameserver matches that CIDR, the DNS packet will be sent through it.
- Otherwise, it will be sent directly from the MSF host.

The `save` command will save any DNS rules that have been configured by the user, which will be loaded upon application restart.

An important aspect of this work is to ensure that DNS leaks don't happen: if someone sets a particular nameserver for a particular domain, DNS queries within that DNS zone should not go to the default nameservers. Thus, the resolution behaviour is as follows:

- If one or more rules match the domain being resolved, use the nameservers associated with those rules.
- If none match, use the custom nameservers that have been manually specified without any rule
- If no custom nameservers have been specified, use the existing behaviour (resolv.conf settings)

If a specific session was specified for a particular DNS rule, and then that session dies, DNS resolution will not fall back to custom or default nameservers, since we interpret the user's intentional use of a particular session to mean "I don't want DNS to fallback to other nameservers and potentially leak". Falling back upon a session closure would violate this.

This is also applicable when the application closes and re-opens. If the user's DNS configuration was saved, and that configuration had included a specific session to route certain DNS requests through, MSF will remember that there was a session associated with the rule, and that rule will be treated as a black hole: these DNS requests will deliberately fail, and not fall back.

If sending through a separate session was configured only using the `route` command and an application restarts, 

## Verification

To test DNS resolution, a separate module could be created just to do that, or an existing basic module such as `auxiliary/scanner/http/http_header` could be used.

- [ ] Start `msfconsole`.
- [ ] `feature set dns_feature true` (enable the feature).
- [ ] Verify each of the `dns` commands (add, remove/del, flush, print, help) behave as expected.
- [ ] Verify that when a rule is configured with a specific session, the DNS request goes out via that session (check Wireshark).
- [ ] Verify that DNS pivoting works on various types of sessions (meterpreter and SSH) - check Wireshark.
- [ ] Verify that a closed session causes DNS resolution to fail for that particular rule.
- [ ] Verify that the `save` command saves the DNS configuration (reloaded upon application restart)
- [ ] Verify that, when the `save` command is used to save an entry with a session associated with it, upon application restart (when the session will no longer exist), DNS does not fall back to nameservers that would not have been applicable prior to the application restart (DNS resolution should fail, unless other rules apply).
- [ ] Verify that setting a specific DNS entry gives a warning that "this won't match subdomains"
- [ ] Verify tab completion works.

