### PR TITLE
Bump ruby_smb to 3.2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.6)
+    ruby_smb (3.2.7)
       bindata
       openssl-ccm
       openssl-cmac


### PR DESCRIPTION
This PR bumps the ruby_smb to the new 3.2.7, taking in the bug fix in https://github.com/rapid7/ruby_smb/pull/255
- [ ] Make sure specs pass