### PR TITLE
Fix db2 scanner module crashes

### DIFF
--- a/lib/metasploit/framework/login_scanner/db2.rb
+++ b/lib/metasploit/framework/login_scanner/db2.rb
@@ -92,7 +92,7 @@ module Metasploit
 
           response_data = {}
           if valid_response?(response)
-            packet = Rex::Proto::DRDA::SERVER_PACKET.new.read(response)
+            packet = Rex::Proto::DRDA::Packet::SERVER_PACKET.new.read(response)
             response_data = Rex::Proto::DRDA::Utils.server_packet_info(packet)
           end
           response_data
@@ -115,7 +115,7 @@ module Metasploit
         # @param response [String] The unprocessed response packet
         # @return [Boolean] Whether the authentication was successful
         def successful_login?(response)
-          packet = Rex::Proto::DRDA::SERVER_PACKET.new.read(response)
+          packet = Rex::Proto::DRDA::Packet::SERVER_PACKET.new.read(response)
           packet_info = Rex::Proto::DRDA::Utils.server_packet_info(packet)
           if packet_info[:db_login_success]
             true

--- a/lib/msf/core/exploit/remote/db2.rb
+++ b/lib/msf/core/exploit/remote/db2.rb
@@ -44,7 +44,7 @@ module Exploit::Remote::DB2
 
     return {} if not resp
     return {} if resp.length == 0
-    pkt = Rex::Proto::DRDA::SERVER_PACKET.new.read(resp)
+    pkt = Rex::Proto::DRDA::Packet::SERVER_PACKET.new.read(resp)
     return Rex::Proto::DRDA::Utils.server_packet_info(pkt)
   end
 
@@ -58,7 +58,7 @@ module Exploit::Remote::DB2
     resp = sock.get_once
     return {} if not resp
     return {} if resp.length == 0
-    pkt = Rex::Proto::DRDA::SERVER_PACKET.new.read(resp)
+    pkt = Rex::Proto::DRDA::Packet::SERVER_PACKET.new.read(resp)
     return Rex::Proto::DRDA::Utils.server_packet_info(pkt)
   end
 

--- a/lib/rex/proto/drda/packet.rb
+++ b/lib/rex/proto/drda/packet.rb
@@ -12,7 +12,7 @@ class RespError < Error; end
 # http://publib.boulder.ibm.com/infocenter/dzichelp/v2r2/index.jsp?topic=/com.ibm.db29.doc.drda/db2z_excsat.htm
 class MGRLVLLS_PARAM < Struct.new(:length, :codepoint, :payload)
   def initialize(args={})
-    self[:codepoint] = Constants::MGRLVLLS
+    self[:codepoint] = Rex::Proto::DRDA::Constants::MGRLVLLS
     self[:payload] = "\x14\x03\x00\x0a\x24\x07\x00\x0a" +
       "\x14\x74\x00\x05\x24\x0f\x00\x08" +
       "\x14\x40\x00\x09\x1c\x08\x04\xb8"
@@ -32,7 +32,7 @@ class EXCSAT_DDM < Struct.new(:length, :magic, :format, :correlid, :length2,
     self[:magic] = 0xd0
     self[:format] = 0x41
     self[:correlid] = 1
-    self[:codepoint] = Constants::EXCSAT
+    self[:codepoint] = Rex::Proto::DRDA::Constants::EXCSAT
     self[:mgrlvlls] = args[:mgrlvlls] || MGRLVLLS_PARAM.new.to_s
     self[:length] = (10 + self[:mgrlvlls].to_s.size)
     self[:length2] = self[:length]-6
@@ -50,7 +50,7 @@ end
 class SECMEC_PARAM < Struct.new(:length, :codepoint, :payload)
   def initialize(args={})
     self[:length] = 6
-    self[:codepoint] = Constants::SECMEC
+    self[:codepoint] = Rex::Proto::DRDA::Constants::SECMEC
     self[:payload] = 3 # Plaintext username and password.
   end
   def to_s
@@ -62,7 +62,7 @@ end
 class RDBNAM_PARAM < Struct.new(:length, :codepoint, :payload)
   def initialize(args={})
     self[:length] = 22 # Since the database name is padded out.
-    self[:codepoint] = Constants::RDBNAM
+    self[:codepoint] = Rex::Proto::DRDA::Constants::RDBNAM
     self[:payload] = encode(args[:payload].to_s)
   end
 
@@ -90,7 +90,7 @@ class ACCSEC_DDM < Struct.new(:length, :magic, :format, :correlid, :length2,
     self[:magic] = 0xd0
     self[:format] = args[:format] || 0x01
     self[:correlid] = 2
-    self[:codepoint] = Constants::ACCSEC
+    self[:codepoint] = Rex::Proto::DRDA::Constants::ACCSEC
     self[:secmec] = SECMEC_PARAM.new.to_s
     if args[:dbname] # Include a database name if we're given one.
       self[:rdbnam] = RDBNAM_PARAM.new(:payload => args[:dbname]).to_s
@@ -144,7 +144,7 @@ class BASIC_DDM < Struct.new(:length, :magic, :format, :correlid,
     rest = str[10,self[:length2]-4]
     i = 0
     while (i < rest.size)
-      if self[:codepoint] == Constants::SQLCARD # These aren't DDM's.
+      if self[:codepoint] == Rex::Proto::DRDA::Constants::SQLCARD # These aren't DDM's.
         this_param = rest[i,self[:length]-10]
       else
         this_param = DDM_PARAM.new.read(rest[i,rest.size])
@@ -193,7 +193,7 @@ end
 
 class PASSWORD_PARAM < Struct.new(:length, :codepoint, :payload)
   def initialize(args={})
-    self[:codepoint] = Constants::PASSWORD
+    self[:codepoint] = Rex::Proto::DRDA::Constants::PASSWORD
     self[:payload] = Rex::Text.to_ebcdic(args[:payload].to_s)
     self[:length] = self[:payload].size + 4
   end
@@ -207,7 +207,7 @@ end
 
 class USERID_PARAM < Struct.new(:length, :codepoint, :payload)
   def initialize(args={})
-    self[:codepoint] = Constants::USERID
+    self[:codepoint] = Rex::Proto::DRDA::Constants::USERID
     self[:payload] = Rex::Text.to_ebcdic(args[:payload].to_s)
     self[:length] = self[:payload].size + 4
   end
@@ -225,7 +225,7 @@ class SECCHK_DDM < Struct.new(:length, :magic, :format, :correlid, :length2,
     self[:magic] = 0xd0
     self[:format] = 0x01
     self[:correlid] = 2
-    self[:codepoint] = Constants::SECCHK
+    self[:codepoint] = Rex::Proto::DRDA::Constants::SECCHK
     self[:secmec] = SECMEC_PARAM.new.to_s
     if args[:dbname] # Include a database name if we're given one.
       self[:rdbnam] = RDBNAM_PARAM.new(:payload => args[:dbname]).to_s

--- a/lib/rex/proto/drda/utils.rb
+++ b/lib/rex/proto/drda/utils.rb
@@ -10,8 +10,8 @@ class Utils
   # a reponse from the target server.
   def self.client_probe(dbname=nil)
     pkt = [
-      EXCSAT_DDM.new,
-      ACCSEC_DDM.new(:dbname => dbname)
+      Rex::Proto::DRDA::Packet::EXCSAT_DDM.new,
+      Rex::Proto::DRDA::Packet::ACCSEC_DDM.new(:dbname => dbname)
     ]
     pkt.map {|x| x.to_s}.join
   end
@@ -23,15 +23,15 @@ class Utils
     dbuser = args[:dbuser]
     dbpass = args[:dbpass]
     pkt = [
-      ACCSEC_DDM.new(:format => 0x41),
-      SECCHK_DDM.new(:dbname => dbname, :dbuser => dbuser, :dbpass => dbpass)
+      Rex::Proto::DRDA::Packet::ACCSEC_DDM.new(:format => 0x41),
+      Rex::Proto::DRDA::Packet::SECCHK_DDM.new(:dbname => dbname, :dbuser => dbuser, :dbpass => dbpass)
     ]
     pkt.map {|x| x.to_s}.join
   end
 
   def self.server_packet_info(obj)
     info_hash = {}
-    return info_hash unless obj.kind_of? Rex::Proto::DRDA::SERVER_PACKET
+    return info_hash unless obj.kind_of? Rex::Proto::DRDA::Packet::SERVER_PACKET
     obj.each do |ddm|
       case ddm.codepoint
       when Constants::EXCSATRD


### PR DESCRIPTION
Fixes a uninitialized constant error crash with all ibm db2 modules

```
msf6 auxiliary(scanner/db2/db2_version) > run rhost=127.0.0.1

[-] 127.0.0.1:50000       - Auxiliary failed: NameError uninitialized constant Rex::Proto::DRDA::Utils::EXCSAT_DDM
Did you mean?  Rex::Proto::DRDA::EXCSAT_DDM
[-] 127.0.0.1:50000       - Call stack:
[-] 127.0.0.1:50000       -   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/drda/utils.rb:13:in `client_probe'
[-] 127.0.0.1:50000       -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/db2.rb:41:in `db2_probe'
[-] 127.0.0.1:50000       -   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/db2/db2_version.rb:34:in `run_host'
[-] 127.0.0.1:50000       -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-] 127.0.0.1:50000       -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
```

## Verification

Ensure the db2 scanner module no longer crashes

I put some cycles into getting db2 to work from docker, but didn't succeed in getting it to work with either msfconsole or intellij's database connector

```
# Doesn't seem to support remote connections by default?
sudo docker run -it --privileged=true -p 50000:50000 -e LICENSE=accept -e DB2INST1_PASSWORD=password -e DBNAME=testdb ibmcom/db2

# Works via docker though, after docker exec -it docker_id /bin/bash
su db2inst1
[db2inst1@898cf36794a5 config]$ db2 list db directory

 System Database Directory

 Number of entries in the directory = 1

Database 1 entry:

 Database alias                       = TESTDB
 Database name                        = TESTDB
 Local database directory             = /database/data
 Database release level               = 15.00
 Comment                              =
 Directory entry type                 = Indirect
 Catalog database partition number    = 0
 Alternate server hostname            =
 Alternate server port number         =

```