### PR TITLE
Add feature flag for logging and tracking close method calls

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -20,6 +20,7 @@ module Msf
     MANAGER_COMMANDS = 'manager_commands'
     METASPLOIT_PAYLOAD_WARNINGS = 'metasploit_payload_warnings'
     DEFER_MODULE_LOADS = 'defer_module_loads'
+    LOG_ALL_CLOSE_METHOD_CALLS = 'log_all_close_method_calls'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -51,6 +52,12 @@ module Msf
       {
         name: DEFER_MODULE_LOADS,
         description: 'When enabled will not eagerly load all modules',
+        requires_restart: true,
+        default_value: false
+      }.freeze,
+      {
+        name: LOG_ALL_CLOSE_METHOD_CALLS,
+        description: 'Log all close method calls - used to debug crashes reported in https://github.com/rapid7/metasploit-framework/issues/18462',
         requires_restart: true,
         default_value: false
       }.freeze


### PR DESCRIPTION
Add feature flag for logging and tracking close method calls for  https://github.com/rapid7/metasploit-framework/issues/18462

## Verification

Enable the logging with:

```
# Open msfconsole then:
features set servicemanager_command true
save
exit

# Now reopen console
```

Logs will be generated to:

```
ls -lh ~/.msf4/logs/close
total 32928
-rw-r--r--  1 adfoster  staff   7.5M 14 Nov 00:26 2023-11-13-13:23:36-+0000.log
-rw-r--r--  1 adfoster  staff   7.5M 14 Nov 00:27 2023-11-13-13:26:30-+0000.log
```

These logs won't rotate, so watch out for running out of disk space.