### PR TITLE
Update ssh login pubkey module to correctly identify windows ssh platform

### DIFF
--- a/lib/metasploit/framework/ssh/platform.rb
+++ b/lib/metasploit/framework/ssh/platform.rb
@@ -101,7 +101,7 @@ module Metasploit
             'hpux'
           when /AIX/i
             'aix'
-          when /cygwin|Win32|Windows|Microsoft/i
+          when /MSYS_NT|cygwin|Win32|Windows|Microsoft/i
             'windows'
           when /Unknown command or computer name|Line has invalid autocommand/i
             'cisco-ios'

--- a/spec/lib/metasploit/framework/ssh/platform_spec.rb
+++ b/spec/lib/metasploit/framework/ssh/platform_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'metasploit/framework/ssh/platform'
+
+RSpec.describe Metasploit::Framework::Ssh::Platform do
+  describe '.get_platform_from_info' do
+    [
+      {
+        info: 'uid=197616(vagrant) gid=197121(None) groups=197121(None),11(Authenticated Users),66048(LOCAL),66049(CONSOLE LOGON),4(INTERACTIVE),15(This Organization),545(Users),4095(CurrentSession),544(Administrators),559(Performance Log Users),405504(High Mandatory Level) MSYS_NT-10.0-17763 EC2AMAZ-PDSMQ8L 3.4.9.x86_64 2023-09-15 12:15 UTC x86_64 Msys ',
+        expected: 'windows'
+      }
+    ].each do |test|
+      it "correctly identifies #{test[:info]} as #{test[:expected]}" do
+        expect(described_class.get_platform_from_info(test[:info])).to eq(test[:expected])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,6 +169,7 @@ RSpec.configure do |config|
   #   https://github.com/rapid7/rex-text/blob/11e59416f7d8cce18b8b8b9893b3277e6ad0bea1/lib/rex/text/wrapped_table.rb#L74
   # This can cause some integration tests to fail if the tests are run from smaller consoles
   # This mock will ensure that the tests run without word-wrapping.
+  require 'bigdecimal'
   config.before(:each) do
     mock_io_console = double(:console, winsize: { rows: 30, columns: ::BigDecimal::INFINITY }.values)
     allow(::IO).to receive(:console).and_return(mock_io_console)


### PR DESCRIPTION
Update ssh login pubkey module to correctly identify windows ssh platform

After fixing this, I still had some issues with the target here - https://github.com/rapid7/metasploit-framework/pull/18547

### Before

No identification 

```
msf6 auxiliary(scanner/ssh/ssh_login_pubkey) > run

[*] 54.215.236.141:22 SSH - Testing Cleartext Keys
[+] 54.215.236.141:22 - Success: 'vagrant:-----BEGIN RSA PRIVATE KEY-----.... etc...' 'uid=197616(vagrant) gid=197121(None) groups=197121(None),11(Authenticated Users),66048(LOCAL),66049(CONSOLE LOGON),4(INTERACTIVE),15(This Organization),545(Users),4095(CurrentSession),544(Administrators),559(Performance Log Users),405504(High Mandatory Level) MSYS_NT-10.0-17763 EC2AMAZ-PDSMQ8L 3.4.9.x86_64 2023-09-15 12:15 UTC x86_64 Msys '
...
[-] x.x.x.x:22 - While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with device details so it can be handled in the future
```

### After

Identified as windows

## Verification

- Verify unit tests pass