### PR TITLE
Fix #18544: Support x64 in enum_chrome

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
@@ -2300,7 +2300,7 @@ class Def_windows_kernel32
       ["HANDLE","hResInfo","in"],
       ])
 
-    dll.add_function( 'LocalAlloc', 'DWORD',[
+    dll.add_function( 'LocalAlloc', 'HANDLE',[
       ["DWORD","uFlags","in"],
       ["DWORD","uBytes","in"],
       ])
@@ -2318,7 +2318,7 @@ class Def_windows_kernel32
       ["HANDLE","hMem","in"],
       ])
 
-    dll.add_function( 'LocalFree', 'DWORD',[
+    dll.add_function( 'LocalFree', 'HANDLE',[
       ["HANDLE","hMem","in"],
       ])
 


### PR DESCRIPTION
The `enum_chrome` module's `#decrypt_data` method was crashing on 64-bit sessions due to an incorrect railgun definition for the `LocalAlloc` function. `LocalAlloc` was defined as having a return value of `DWORD` when it should infact be [HANDLE](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-localalloc#return-value). When it was defined as `DWORD`, the 64-bit value would be truncated to 32-bits causing the write operation to trigger a memory access violation which inturn cause the session to crash.

Fixed the issue by correcting the definition of `LocalAlloc`.

## #decrypt_data Refactoring
I also made the following changes to #decrypt_data since I was looking at it so closely:

* Removed an unused assignment to `memsize`
* Check that the initial memory was actually allocated before writing to it
* Don't pass 16 to [CryptUnprotectData](https://learn.microsoft.com/en-us/windows/win32/api/dpapi/nf-dpapi-cryptunprotectdata) as the ppszDataDescr parameter because it is not a valid LPWSTR
* Don't leak memory in the event that [CryptUnprotectData](https://learn.microsoft.com/en-us/windows/win32/api/dpapi/nf-dpapi-cryptunprotectdata) by ensuring `mem` and `addr` are always free'ed
* Combine free calls into one for speed
* Don't assume the sessions is ARCH_X64 if it is not ARCH_X86 because that may change some day

## Verification

- [ ] Install Chrome on a Windows target
- [ ] Add at least one saved password to Chrome (log into a website and allow Chrome to save the password for you)
- [ ] Start `msfconsole`
- [ ] Open a 64-bit Meterpreter sessions
- [ ] Run the `post/windows/gather/enum_chrome` mdoule and see that the session does not crash
