### PR TITLE
Fix an uninitialized constant error in capture/http

### DIFF
--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -8,59 +8,6 @@ module Http
 
 ###
 #
-# Runtime extension of the HTTP clients that connect to the server.
-#
-###
-module ServerClient
-
-  #
-  # Initialize a new request instance.
-  #
-  def init_cli(server)
-    self.request   = Request.new
-    self.server    = server
-    self.keepalive = false
-  end
-
-  #
-  # Resets the parsing state.
-  #
-  def reset_cli
-    self.request.reset
-  end
-
-  #
-  # Transmits a response and adds the appropriate headers.
-  #
-  def send_response(response)
-    # Set the connection to close or keep-alive depending on what the client
-    # can support.
-    response['Connection'] = (keepalive) ? 'Keep-Alive' : 'close'
-
-    # Add any other standard response headers.
-    server.add_response_headers(response)
-
-    # Send it off.
-    put(response.to_s)
-  end
-
-  #
-  # The current request context.
-  #
-  attr_accessor :request
-  #
-  # Boolean that indicates whether or not the connection supports keep-alive.
-  #
-  attr_accessor :keepalive
-  #
-  # A reference to the server the client is associated with.
-  #
-  attr_accessor :server
-
-end
-
-###
-#
 # Acts as an HTTP server, processing requests and dispatching them to
 # registered procs.  Some of this server was modeled after webrick.
 #

--- a/lib/rex/proto/http/server_client.rb
+++ b/lib/rex/proto/http/server_client.rb
@@ -1,0 +1,64 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+
+
+module Rex
+module Proto
+module Http
+
+###
+#
+# Runtime extension of the HTTP clients that connect to the server.
+#
+###
+module ServerClient
+
+  #
+  # Initialize a new request instance.
+  #
+  def init_cli(server)
+    self.request   = Request.new
+    self.server    = server
+    self.keepalive = false
+  end
+
+  #
+  # Resets the parsing state.
+  #
+  def reset_cli
+    self.request.reset
+  end
+
+  #
+  # Transmits a response and adds the appropriate headers.
+  #
+  def send_response(response)
+    # Set the connection to close or keep-alive depending on what the client
+    # can support.
+    response['Connection'] = (keepalive) ? 'Keep-Alive' : 'close'
+
+    # Add any other standard response headers.
+    server.add_response_headers(response)
+
+    # Send it off.
+    put(response.to_s)
+  end
+
+  #
+  # The current request context.
+  #
+  attr_accessor :request
+  #
+  # Boolean that indicates whether or not the connection supports keep-alive.
+  #
+  attr_accessor :keepalive
+  #
+  # A reference to the server the client is associated with.
+  #
+  attr_accessor :server
+
+end
+
+end
+end
+end

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/proto/http/server'
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::TcpServer
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/proto/http/server'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::TcpServer
   include Msf::Auxiliary::Report


### PR DESCRIPTION
This fixes an error present in the `auxiliary/server/capture/http` module that was introduced in acf23e9c616a6782aaa4b7a172070460cc170754. Prior to these changes, the module would crash with an exception when a client made a connection to it.

```
[11/22/2023 11:46:36] [e(0)] core: Error in stream server server monitor: uninitialized constant Rex::Proto::Http::ServerClient
Did you mean?  Rex::Service

Call stack:
/home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/server/capture/http.rb:77:in `on_client_connect'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/tcp_server.rb:77:in `block in start_service'
/home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/rex-core-0.1.30/lib/rex/io/stream_server.rb:34:in `on_client_connect'
/home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/rex-core-0.1.30/lib/rex/io/stream_server.rb:153:in `monitor_listener'
/home/smcintyre/.rvm/gems/ruby-3.0.4@metasploit-framework/gems/rex-core-0.1.30/lib/rex/io/stream_server.rb:61:in `block in start'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
```

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/capture/http` and run the module
- [ ] Make an HTTP request to it and see that it responds instead of crashing

