### PR TITLE
Check the cache for a TGT without a host

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -205,18 +205,23 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       else
         # load a cached TGS
         options[:credential] = get_cached_credential(options)
+        tgt_sname = Rex::Proto::Kerberos::Model::PrincipalName.new(
+          name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+          name_string: [
+            "krbtgt",
+            realm
+          ]
+        )
         unless options[:credential]
-          # load a cached TGT
+          # load a cached TGT (specific host)
           options[:credential] = get_cached_credential(
-            options.merge(
-              sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
-                name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-                name_string: [
-                  "krbtgt",
-                  realm
-                ]
-              )
-            )
+            options.merge(sname: tgt_sname)
+          )
+        end
+        unless options[:credential]
+          # load a cached TGT (any host)
+          options[:credential] = get_cached_credential(
+            options.merge(sname: tgt_sname, host: nil)
           )
         end
         if options[:credential]
@@ -994,7 +999,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def get_cached_credential(options = {})
     driver = options.fetch(:ticket_storage, @ticket_storage)
     driver.load_credential(
-      host: rhost,
+      host: options.fetch(:host) { rhost },
       client: options.fetch(:username) { self.username },
       server: options.fetch(:sname, nil),
       realm: options.fetch(:realm) { self.realm }


### PR DESCRIPTION
This fix attempts to address the same problem noted in #18426 but in a slightly different way. It adjusts the cache lookup logic to add another step when attempting to fetch a TGT. If no TGT for the specified host is found, it will try again but with any host. From my understanding TGTs are not tied to a specific target host or service as TGSs are so it is unnecessary to filter TGTs by the target host.

This fixes the workflow where a user can currently forge a golden ticket, but that ticket will not be automatically used for authentication by other services. This will also fix the future issue of the TGT that's created by the diamond and sapphire techniques once #18560 is landed.

## Verification

List the steps needed to make sure this thing works

- [x] Dump the secrets from a target DC using the `windows_secrets_dump` module
- [x] Delete all existing kerberos tickets to opreate with a clean slate using `klist --delete` from within msfconsole
- [x] Use the `krbtgt` AES key to forge a **golden** ticket useing the `kerberos/forge_ticket` module
- [x] Use a module that can authenticate with Kerberos such as `exploit/windows/smb/psexec`
- [x] Set all of the necessary options to run it with Kerberos authentication
- [x] Make sure the `KrbCacheMode` is read-enabled by setting it to `read-only` or `read-write` (the default value)
- [x] Do **not** set a password (this will prove that the TGT from the cache is used)
- [x] Do **not** set a the `::Krb5Ccname` option (this will prove that the TGT from the cache is used)
- [x] See that the module authenticates with the forged golden ticket by retrieving it from the cache and using it to fetch a TGS
