### PR TITLE
Clearer RHOST error message

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -217,10 +217,15 @@ module Msf
         rhosts_walker = Msf::RhostsWalker.new(datastore['RHOSTS'], datastore)
         rhosts_count = rhosts_walker.count
         unless rhosts_walker.valid?
-          invalid_values = rhosts_walker.to_enum(:errors).take(5).map(&:value)
+          errors = rhosts_walker.to_enum(:errors).to_a
+          grouped = errors.group_by { |err| err.cause.nil? ? nil : (err.cause.class.const_defined?(:MESSAGE) ? err.cause.class::MESSAGE : nil) }
           error_options << 'RHOSTS'
-          if invalid_values.any?
-            error_reasons['RHOSTS'] << "unexpected values: #{invalid_values.join(', ')}"
+          if grouped.any?
+            grouped.each do | message, error_subset |
+              invalid_values = error_subset.map(&:value).take(5)
+              message = 'Unexpected values' if message.nil?
+              error_reasons['RHOSTS'] << "#{message}: #{invalid_values.join(', ')}"
+            end
           end
         end
 

--- a/spec/lib/msf/core/option_container_spec.rb
+++ b/spec/lib/msf/core/option_container_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Msf::OptionContainer do
         expect { options_with_rhosts.validate(datastore) }.to raise_error(Msf::OptionValidateError) { |error|
           expected_reasons = {
             'RHOSTS' => [
-              'unexpected values: http://198.51.100.1:8080path, http://foo:bar@198.51.100.1:8080path'
+              'Unexpected values: http://198.51.100.1:8080path, http://foo:bar@198.51.100.1:8080path'
             ]
           }
           expect(error.options).to eq(['RHOSTS', 'HttpUsername', 'HttpPassword'])


### PR DESCRIPTION
Per the request in #18526: when RHOSTS failed to validate - especially as a result of DNS failures - the error message presented to the user left something to be desired. We could afford to provide a clearer error message in that case.

This PR achieves that by outputting the reason for an RHOST validation failure: failure parsing a URL, invalid CIDR, or DNS resolution failure.

This does change the behaviour of some modules slightly, but I think in a reasonable way. Previously, if some hosts didn't DNS-resolve, it would just continue without error. For example:

Before:
```
msf6 auxiliary(scanner/http/http_header) > run rhosts=non-existent758923.com google.com

[+] 142.250.71.78:80     : CACHE-CONTROL: public, max-age=2592000
[+] 142.250.71.78:80     : CONTENT-SECURITY-POLICY-REPORT-ONLY: object-src 'none';base-uri 'self';script-src 'nonce-QTM28aplJaCub155R8HZXQ' 'strict-dynamic' 'report-sample' 'unsafe-eval' 'unsafe-inline' https: http:;report-uri https://csp.withgoogle.com/csp/gws/other-hp
[+] 142.250.71.78:80     : CONTENT-TYPE: text/html; charset=UTF-8
[+] 142.250.71.78:80     : CROSS-ORIGIN-OPENER-POLICY: same-origin-allow-popups; report-to="gws"
[+] 142.250.71.78:80     : LOCATION: http://www.google.com/
[+] 142.250.71.78:80     : REPORT-TO: {"group":"gws","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/gws/other"}]}
[+] 142.250.71.78:80     : SERVER: gws
[+] 142.250.71.78:80     : X-FRAME-OPTIONS: SAMEORIGIN
[+] 142.250.71.78:80     : X-XSS-PROTECTION: 0
[+] 142.250.71.78:80     : detected 9 headers
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```

After:
```
msf6 auxiliary(scanner/http/http_header) > run rhosts=non-existent758923.com google.com

[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option RHOSTS: Host resolution failed: non-existent758923.com
```

I think this makes much more sense, but am open to opinions on that one.

## Verification

- [ ] Start `msfconsole`
- [ ] `use http/http_header`
- [ ] Coerce errors:
  - [ ] Non-existent domain (i.e. <nonexistent>.com) - should say "Host resolution failed"
  - [ ] Non-existent URL (i.e. `https://<non-existent>.com`) - should say "Host resolution failed"
  - [ ] Invalid CIDR (e.g. cidr:123) - should say "Invalid CIDR"
  - [ ] Empty domain (`""`) - should just say "failed to vaildate"
  - [ ] Combination of multiple options; some of which work, and some of which don't
- [ ] Check that the happy path still works