### PR TITLE
Use the new style of Windows version detection for CVE-2022-3699

### DIFF
--- a/modules/exploits/windows/local/cve_2022_3699_lenovo_diagnostics_driver.rb
+++ b/modules/exploits/windows/local/cve_2022_3699_lenovo_diagnostics_driver.rb
@@ -76,12 +76,12 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def target_compatible?
-    build_num = sysinfo['OS'].match(/Build (\d+)/)[1].to_i
-    vprint_status("Windows Build Number = #{build_num}")
+    version = get_version_info
+    vprint_status("Windows Build Number = #{version.build_number}")
 
-    return true if sysinfo['OS'] =~ /Windows 10/ && build_num >= 14393 && build_num <= 19045
-    return true if sysinfo['OS'] =~ /Windows 11/ && build_num == 22000
-    return true if sysinfo['OS'] =~ /Windows 2016\+/ && build_num >= 17763 && build_num <= 20348
+    return true if version.build_number.between?(Msf::WindowsVersion::Win10_1607, Msf::WindowsVersion::Win10_22H2)
+    return true if version.build_number == Msf::WindowsVersion::Win11_21H2
+    return true if version.build_number.between?(Msf::WindowsVersion::Server2019, Msf::WindowsVersion::Server2022)
 
     false
   end


### PR DESCRIPTION
Use the new style of Windows version detection that was added in #17336. This will become more important once the Windows Meterpreter returns a more accurate string for the sysinfo OS field.

This will ensure that things continue to work accurately once rapid7/metasploit-payloads#687 is landed.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Obtain a session on a Windows Server 2019 or Windows Server 2022 system
- [x] Set VERBOSE to True to see the output
- [x] Drop into a `pry` session
- [x] Run the `target_compatible?` method and see that it makes the target as compatible whether or not the system is actually vulnerable

```
msf6 exploit(windows/local/cve_2022_3699_lenovo_diagnostics_driver) > pry
[*] Starting Pry shell...
[*] You are in the "exploit/windows/local/cve_2022_3699_lenovo_diagnostics_driver" module object

[1] pry(#<Msf::Modules::Exploit__Windows__Local__Cve_2022_3699_lenovo_diagnostics_driver::MetasploitModule>)> target_compatible?

[*] Windows Build Number = 10.0.20348.0
=> true
[2] pry(#<Msf::Modules::Exploit__Windows__Local__Cve_2022_3699_lenovo_diagnostics_driver::MetasploitModule>)>
```
