### PR TITLE
Allow external modules to specify default options

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -35,8 +35,10 @@ class Msf::Modules::External::Shim
     ERB.new(File.read(template)).result(binding)
   end
 
-  def self.common_metadata(meta = {})
-    render_template('common_metadata.erb', meta)
+  def self.common_metadata(meta = {}, default_options: {})
+    # Combine any template defaults with the defaults specified within the external module's metadata
+    default_options = default_options.merge(meta[:default_options])
+    render_template('common_metadata.erb', meta.merge(default_options: default_options))
   end
 
   def self.common_check(meta = {})
@@ -54,12 +56,8 @@ class Msf::Modules::External::Shim
     meta[:capabilities]     = mod.meta['capabilities']
     meta[:notes]            = transform_notes(mod.meta['notes'])
 
-    if mod.meta['describe_payload_options'].nil?
-      mod.meta['describe_payload_options'] = {}
-    end
-    meta[:default_options]  = mod.meta['describe_payload_options'].map do |name, value|
-      "#{name.dump} => #{value.inspect}"
-    end.join(",\n          ")
+    # Additionally check the 'describe_payload_options' key for backwards compatibility
+    meta[:default_options] = (mod.meta['default_options'] || mod.meta['describe_payload_options'] || {})
 
     meta
   end

--- a/lib/msf/core/modules/external/templates/common_metadata.erb
+++ b/lib/msf/core/modules/external/templates/common_metadata.erb
@@ -6,3 +6,6 @@
         ],
       'License'     => <%= meta[:license] %>,
       'Notes'       => <%= meta[:notes] %>,
+      'DefaultOptions' => {
+        <%= meta[:default_options].map { |name, value| "#{name.dump} => #{value.inspect}" }.join(",\n#{' ' * 8}") %>
+      },

--- a/lib/msf/core/modules/external/templates/evasion.erb
+++ b/lib/msf/core/modules/external/templates/evasion.erb
@@ -16,11 +16,7 @@ class MetasploitModule < Msf::Evasion
       'Targets'         =>
         [
           <%= meta[:targets] %>
-        ],
-      'DefaultOptions' =>
-        {
-          <%= meta[:default_options] %>
-        }
+        ]
       })
 
       register_options([

--- a/lib/msf/core/modules/external/templates/remote_exploit.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit.erb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-	  <%= common_metadata meta %>
+      <%= common_metadata meta, default_options: { 'WfsDelay' => meta[:wfsdelay] }  %>
       'References'  =>
         [
           <%= meta[:references] %>
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Exploit::Remote
           <%= meta[:targets] %>
         ],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => { 'WfsDelay' => <%= meta[:wfsdelay] %> },
       ))
 
       register_options([

--- a/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-	  <%= common_metadata meta %>
+      <%= common_metadata meta, default_options: { 'WfsDelay' => meta[:wfsdelay] }  %>
       'References'  =>
         [
           <%= meta[:references] %>
@@ -23,7 +23,6 @@ class MetasploitModule < Msf::Exploit::Remote
           <%= meta[:targets] %>
         ],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => { 'WfsDelay' => <%= meta[:wfsdelay] %> },
       ))
 
       register_options([


### PR DESCRIPTION
Allow external modules to specify default options

Spotted as part of https://github.com/rapid7/metasploit-framework/discussions/18556

~~I'll need to see why users need to specify `describe_payload_options` in their modules instead of `default_options` - added in this commit https://github.com/rapid7/metasploit-framework/pull/11333/commits/0908d5a2d2e5421fffa84609329f97684836b707~~

^ It was used here - https://github.com/zeroSteiner/crimson-forge/blob/a4a2b5a8f7024aa17b1b5c93a1bcc9f3af7ded21/crimson_forge/metasploit.py#L97 - I've now added support for a `default_options` field as users would expect

## Verification

I patched a Python module locally `modules/auxiliary/dos/cisco/cisco_7937g_dos.py`:

```python
#!/usr/bin/env python3
# -*- coding: utf-8 -*-

from metasploit import module
import logging

metadata = {
    'name': 'Cisco 7937G Denial-of-Service Attack',
    'description': '''
        Test
    ''',
    'authors': [
        'test'
    ],
    'date': '2020-06-02',
    'license': 'GPL_LICENSE',
    'references': [
    ],
    'type': 'dos',
    'options': {
        'rhost': {'type': 'address',
		'description': 'Target address',
		'required': True,
		'default': 'None'},
        'timeout': {'type': 'int',
		'description':
		'Timeout in seconds',
		'required': True,
		'default': 15},
        'foo': {'type': 'int',
        'description':
        'Timeout in seconds',
        'required': False}
    },
    'describe_payload_options': {
        'foo': '50'
    }
}

def run(args):
    module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
    logging.info("Set values:" + str(args))

    return


if __name__ == '__main__':
    module.run(metadata, run)

```

Then ran the module and verified the default value of `50` for `foo` was set:

```
msf6 auxiliary(scanner/postgres/postgres_login) > use modules/auxiliary/dos/cisco/cisco_7937g_dos
msf6 auxiliary(dos/cisco/cisco_7937g_dos) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf6 auxiliary(dos/cisco/cisco_7937g_dos) > run

[*] Starting server...
[*] 127.0.0.1 - Set values:{'rhost': '127.0.0.1', 'VERBOSE': 'true', 'timeout': '15', 'foo': '50', 'WORKSPACE': ''}
[*] Auxiliary module execution completed
```

Additionally ensure the `exploit/linux/smtp/haraka` module loads