### PR TITLE
Add hierarchical search table support

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -135,7 +135,7 @@ queries:
       - https://www.netspi.com/blog/technical/network-penetration-testing/exploiting-adidns/
       - https://github.com/dirkjanm/krbrelayx/blob/master/dnstool.py
   - action: ENUM_DNS_ZONES
-    description: 'Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This is needed as without this BASEDN prefix we often miss certain entries.'
+    description: 'Dump all known DNS zones using the dnsZone object class under the DC DomainDnsZones. Without A BASEDN prefix you can miss certain entries.'
     filter: '(objectClass=dnsZone)'
     base_dn_prefix: 'DC=DomainDnsZones'
     attributes:
@@ -325,7 +325,7 @@ queries:
     references:
       - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
   - action: ENUM_USER_ASREP_ROASTABLE
-    description: 'Dump info about all users who are configured not to require kerberos pre-authentication and are therefore AS-REP roastable.'
+    description: 'Dump all users who are configured not to require kerberos pre-authentication, i.e. AS-REP roastable.'
     filter: '(&(samAccountType=805306368)(userAccountControl:1.2.840.113556.1.4.803:=4194304))'
     attributes:
       - cn

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -21,6 +21,7 @@ module Msf
     METASPLOIT_PAYLOAD_WARNINGS = 'metasploit_payload_warnings'
     DEFER_MODULE_LOADS = 'defer_module_loads'
     DNS_FEATURE = 'dns_feature'
+    HIERARCHICAL_SEARCH_TABLE = 'hierarchical_search_table'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -58,6 +59,12 @@ module Msf
       {
         name: DNS_FEATURE,
         description: 'When enabled, allows configuration of DNS resolution behaviour in Metasploit',
+        requires_restart: false,
+        default_value: false
+      }.freeze,
+      {
+        name: HIERARCHICAL_SEARCH_TABLE,
+        description: 'When enabled, the search table is enhanced to show details on module actions and targets',
         requires_restart: false,
         default_value: false
       }.freeze

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -67,7 +67,10 @@ module Msf
             @dscache = {}
             @previous_module = nil
             @module_name_stack = []
+            # Array of individual modules that have been searched for
             @module_search_results = []
+            # Module search results, with additional metadata on what to do if the module is interacted with
+            @module_search_results_with_usage_metadata = []
             @@payload_show_results = []
             @dangerzone_map = nil
           end
@@ -139,11 +142,18 @@ module Msf
 
           # Handles the index selection formatting
           def print_module_search_results_usage
-            index_usage = "use #{@module_search_results.length - 1}"
-            index_info = "info #{@module_search_results.length - 1}"
-            name_usage = "use #{@module_search_results.last.fullname}"
+            last_mod_with_usage_metadata = @module_search_results_with_usage_metadata.last
+            index_usage = "use #{@module_search_results_with_usage_metadata.length - 1}"
+            index_info = "info #{@module_search_results_with_usage_metadata.length - 1}"
+            name_usage = "use #{last_mod_with_usage_metadata[:mod].fullname}"
 
-            print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+            additional_usage_message = ""
+            additional_usage_example = (last_mod_with_usage_metadata[:datastore] || {}).first
+            if framework.features.enabled?(Msf::FeatureManager::HIERARCHICAL_SEARCH_TABLE) && additional_usage_example
+              key, value = additional_usage_example
+              additional_usage_message = "\nAfter interacting with a module you can manually set a #{key} with %grnset #{key} '#{value}'%clr"
+            end
+            print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr#{additional_usage_message}\n\n")
           end
 
           #
@@ -179,12 +189,16 @@ module Msf
             args.each do |arg|
               mod_name = arg
 
+              additional_datastore_values = nil
+
               # Use a module by search index
-              index_from_list(@module_search_results, mod_name) do |mod|
+              index_from_list(@module_search_results_with_usage_metadata, mod_name) do |result|
+                mod = result&.[](:mod)
                 next unless mod && mod.respond_to?(:fullname)
 
-                # Module cache object from @module_search_results
+                # Module cache object
                 mod_name = mod.fullname
+                additional_datastore_values = result[:datastore]
               end
 
               # Ensure we have a reference name and not a path
@@ -192,6 +206,9 @@ module Msf
 
               # Creates an instance of the module
               mod = framework.modules.create(name)
+
+              # If any additional datastore values were provided, set these values
+              mod.datastore.update(additional_datastore_values) unless additional_datastore_values.nil?
 
               if mod.nil?
                 print_error("Invalid module: #{name}")
@@ -386,18 +403,20 @@ module Msf
               'stager'      => 'Modules with a matching stager reference name',
               'target'      => 'Modules affecting this target',
               'type'        => 'Modules of a specific type (exploit, payload, auxiliary, encoder, evasion, post, or nop)',
+              'action'      => 'Modules with a matching action name or description',
             }.each_pair do |keyword, description|
               print_line "  #{keyword.ljust 17}:  #{description}"
             end
             print_line
             print_line "Supported search columns:"
             {
-              'rank'                 => 'Sort modules by their exploitabilty rank',
+              'rank'                 => 'Sort modules by their exploitability rank',
               'date'                 => 'Sort modules by their disclosure date. Alias for disclosure_date',
               'disclosure_date'      => 'Sort modules by their disclosure date',
               'name'                 => 'Sort modules by their name',
               'type'                 => 'Sort modules by their type',
               'check'                => 'Sort modules by whether or not they have a check method',
+              'action'                => 'Sort modules by whether or not they have actions',
             }.each_pair do |keyword, description|
               print_line "  #{keyword.ljust 17}:  #{description}"
             end
@@ -422,7 +441,7 @@ module Msf
             count        = -1
             search_terms = []
             sort_attribute  = 'name'
-            valid_sort_attributes = ['rank','disclosure_date','name','date','type','check']
+            valid_sort_attributes = ['action', 'rank','disclosure_date','name','date','type','check']
             reverse_sort = false
             ignore_use_exact_match = false
 
@@ -449,7 +468,7 @@ module Msf
             end
 
             if args.empty?
-              if @module_search_results.empty?
+              if @module_search_results_with_usage_metadata.empty?
                 cmd_search_help
                 return false
               end
@@ -470,7 +489,9 @@ module Msf
                 @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
 
                 @module_search_results.sort_by! do |module_metadata|
-                  if sort_attribute == 'check'
+                  if sort_attribute == 'action'
+                    module_metadata.actions&.any? ? 0 : 1
+                  elsif sort_attribute == 'check'
                     module_metadata.check ? 0 : 1
                   elsif sort_attribute == 'disclosure_date' || sort_attribute == 'date'
                     # Not all modules have disclosure_date, i.e. multi/handler
@@ -491,7 +512,7 @@ module Msf
               end
 
               if ignore_use_exact_match && @module_search_results.length == 1 &&
-                  @module_search_results.first.fullname == match.strip
+                @module_search_results.first.fullname == match.strip
                 return false
               end
 
@@ -504,19 +525,79 @@ module Msf
               # Generate the table used to display matches
               tbl = generate_module_table('Matching Modules', search_terms, row_filter)
 
+              @module_search_results_with_usage_metadata = []
               @module_search_results.each do |m|
+                @module_search_results_with_usage_metadata << { mod: m }
+                count += 1
                 tbl << [
-                    count += 1,
-                    m.fullname,
-                    m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
-                    m.rank,
-                    m.check ? 'Yes' : 'No',
-                    m.name,
+                  count,
+                  "#{m.fullname}",
+                  m.disclosure_date.nil? ? '' : m.disclosure_date.strftime("%Y-%m-%d"),
+                  m.rank,
+                  m.check ? 'Yes' : 'No',
+                  m.name,
                 ]
-              end
 
-              if @module_search_results.length == 1 && use
-                used_module = @module_search_results.first.fullname
+                if framework.features.enabled?(Msf::FeatureManager::HIERARCHICAL_SEARCH_TABLE)
+                  total_children_rows = (m.actions&.length || 0) + (m.targets&.length || 0) + (m.notes&.[]('AKA')&.length || 0)
+                  show_child_items = total_children_rows > 1
+                  next unless show_child_items
+
+                  # XXX: By default rex-text tables strip preceding whitespace:
+                  #   https://github.com/rapid7/rex-text/blob/1a7b639ca62fd9102665d6986f918ae42cae244e/lib/rex/text/table.rb#L221-L222
+                  #   So use https://en.wikipedia.org/wiki/Non-breaking_space as a workaround for now. A change should exist in Rex-Text to support this requirement
+                  indent = "\xc2\xa0\xc2\xa0\\_ "
+                  # Note: We still use visual indicators for blank values as it's easier to read
+                  # We can't always use a generic formatter/styler, as it would be applied to the 'parent' rows too
+                  blank_value = '.'
+                  if (m.actions&.length || 0) > 1
+                    m.actions.each do |action|
+                      @module_search_results_with_usage_metadata << { mod: m, datastore: { 'ACTION' => action['name'] } }
+                      count += 1
+                      tbl << [
+                        count,
+                        "#{indent}action: #{action['name']}",
+                        blank_value,
+                        blank_value,
+                        blank_value,
+                        action['description'],
+                      ]
+                    end
+                  end
+
+                  if (m.targets&.length || 0) > 1
+                    m.targets.each do |target|
+                      @module_search_results_with_usage_metadata << { mod: m, datastore: { 'TARGET' => target } }
+                      count += 1
+                      tbl << [
+                        count,
+                        "#{indent}target: #{target}",
+                        blank_value,
+                        blank_value,
+                        blank_value,
+                        blank_value
+                      ]
+                    end
+                  end
+
+                  if (m.notes&.[]('AKA')&.length || 0) > 1
+                    m.notes['AKA'].each do |aka|
+                      @module_search_results_with_usage_metadata << { mod: m }
+                      count += 1
+                      tbl << [
+                        count,
+                        "#{indent}AKA: #{aka}",
+                        blank_value,
+                        blank_value,
+                        blank_value,
+                        blank_value
+                      ]
+                    end
+                  end
+                end
+              end
+              if @module_search_results_with_usage_metadata.length == 1 && use
+                used_module = @module_search_results_with_usage_metadata.first[:mod].fullname
                 cmd_use(used_module, true)
               end
             rescue ArgumentError
@@ -712,15 +793,19 @@ module Msf
             # Try to create an instance of the supplied module name
             mod_name = args[0]
 
+            additional_datastore_values = nil
+
             # Use a module by search index
-            index_from_list(@module_search_results, mod_name) do |mod|
+            index_from_list(@module_search_results_with_usage_metadata, mod_name) do |result|
+              mod = result&.[](:mod)
               unless mod && mod.respond_to?(:fullname)
                 print_error("Invalid module index: #{mod_name}")
                 return false
               end
 
-              # Module cache object from @module_search_results
+              # Module cache object from @module_search_results_with_usage_metadata
               mod_name = mod.fullname
+              additional_datastore_values = result[:datastore]
             end
 
             # See if the supplied module name has already been resolved
@@ -802,6 +887,12 @@ module Msf
             # If a datastore cache exists for this module, then load it up
             if @dscache[active_module.fullname]
               active_module.datastore.update(@dscache[active_module.fullname])
+            end
+
+            # If any additional datastore values were provided, set these values
+            unless additional_datastore_values.nil?
+              mod.datastore.update(additional_datastore_values)
+              print_status("Additionally setting #{additional_datastore_values.map { |k,v| "#{k} => #{v}" }.join(", ")}")
             end
 
             # Choose a default payload when the module is used, not run
@@ -1479,6 +1570,7 @@ module Msf
               end
               @module_search_results = filtered_results.flatten.sort_by(&:fullname)
             end
+            @module_search_results_with_usage_metadata = @module_search_results
 
             show_module_metadata('Favorites', fav_modules)
             print_module_search_results_usage
@@ -1675,12 +1767,15 @@ module Msf
           end
 
           def generate_module_table(type, search_terms = [], row_filter = nil) # :nodoc:
+            table_hierarchy_formatters = framework.features.enabled?(Msf::FeatureManager::HIERARCHICAL_SEARCH_TABLE) ? [Msf::Ui::Console::TablePrint::BlankFormatter.new] : []
+
               Table.new(
                 Table::Style::Default,
                 'Header'     => type,
                 'Prefix'     => "\n",
                 'Postfix'    => "\n",
                 'SearchTerm' => row_filter,
+                'SortIndex' => -1,
                 # For now, don't perform any word wrapping on the search table as it breaks the workflow of
                 # copying module names in conjunction with the `use <paste-buffer>` command
                 'WordWrap' => false,
@@ -1694,14 +1789,31 @@ module Msf
                 ],
                 'ColProps' => {
                   'Rank' => {
-                    'Formatters' => [Msf::Ui::Console::TablePrint::RankFormatter.new],
-                    'Stylers' => [Msf::Ui::Console::TablePrint::RankStyler.new]
+                    'Formatters' => [
+                      *table_hierarchy_formatters,
+                      Msf::Ui::Console::TablePrint::RankFormatter.new
+                    ],
+                    'Stylers' => [
+                      Msf::Ui::Console::TablePrint::RankStyler.new
+                    ]
                   },
                   'Name' => {
                     'Stylers' => [Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new(search_terms)]
                   },
+                  'Check' => {
+                    'Formatters' => [
+                      *table_hierarchy_formatters,
+                    ]
+                  },
+                  'Disclosure Date' => {
+                    'Formatters' => [
+                      *table_hierarchy_formatters,
+                    ]
+                  },
                   'Description' => {
-                    'Stylers' => [Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new(search_terms)]
+                    'Stylers' => [
+                      Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new(search_terms)
+                    ]
                   }
                 }
               )

--- a/lib/msf/ui/console/table_print/blank_formatter.rb
+++ b/lib/msf/ui/console/table_print/blank_formatter.rb
@@ -1,0 +1,17 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class BlankFormatter
+          def format(value)
+            return '.' if value.blank?
+
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/ui/console/table_print/rank_formatter.rb
+++ b/lib/msf/ui/console/table_print/rank_formatter.rb
@@ -5,9 +5,8 @@ module Msf
     module Console
       module TablePrint
         class RankFormatter
-
           def format(rank)
-            if (rank.respond_to? :to_i) && (Msf::RankingName.key?(rank.to_i))
+            if rank.present? && !rank.to_s.match?(/\D/) && Msf::RankingName.key?(rank.to_i)
               Msf::RankingName[rank.to_i]
             else
               rank

--- a/modules/auxiliary/admin/kerberos/forge_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/forge_ticket.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
           'Reliability' => [],
-          'AKA' => ['Silver Ticket', 'Golden Ticket', 'diamond', 'sapphire', 'Ticketer', 'Klist']
+          'AKA' => ['Ticketer', 'Klist']
         },
         'Actions' => [
           ['FORGE_SILVER', { 'Description' => 'Forge a Silver Ticket' } ],

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("stage:linux/x64/meterpreter ")).to eq({"stage"=>[["linux/x64/meterpreter"], []]}) }
     it { expect(described_class.parse_search_string("stager:linux/x64/reverse_tcp ")).to eq({"stager"=>[["linux/x64/reverse_tcp"], []]}) }
     it { expect(described_class.parse_search_string("adapter:cmd/linux/http/mips64 ")).to eq({"adapter"=>[["cmd/linux/http/mips64"], []]}) }
+    it { expect(described_class.parse_search_string("action:forge_golden ")).to eq({"action"=>[["forge_golden"], []]}) }
   end
 
   describe '#find' do
@@ -124,6 +125,14 @@ RSpec.describe Msf::Modules::Metadata::Search do
       end
       accept = %w(app:server)
       reject = %w(app:client)
+
+      it_should_behave_like 'search_filter', :accept => accept, :reject => reject
+    end
+
+    context 'on a module with actions' do
+      let(:opts) { ({ 'actions' => [{ 'name' => 'ACTION_NAME', 'description' => 'ACTION_DESCRIPTION'}] }) }
+      accept = %w(action:action_name action:action_description)
+      reject = %w(action:unrelated)
 
       it_should_behave_like 'search_filter', :accept => accept, :reject => reject
     end
@@ -305,7 +314,7 @@ RSpec.describe Msf::Modules::Metadata::Search do
 
     REF_TYPES.each do |ref_type|
       ref_num = '1234-1111'
-      context 'on a module with reference #{ref_type}-#{ref_num}' do
+      context "on a module with reference #{ref_type}-#{ref_num}" do
         let(:opts) { ({ 'references' => ["#{ref_type}-#{ref_num}"] }) }
         accept = ["#{ref_type.downcase}:#{ref_num}"]
         reject = %w(1235-1111 1234-1112 bad).map { |n| "#{ref_type.downcase}:#{n}" }

--- a/spec/lib/msf/ui/console/table_print/rank_formatter_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/rank_formatter_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Msf::Ui::Console::TablePrint::RankFormatter do
       expect(formatter.format(42)).to eql 42
       expect(formatter.format([])).to eql []
       expect(formatter.format({})).to eql Hash.new
+      expect(formatter.format(nil)).to eql nil
+      expect(formatter.format('')).to eql ''
+      expect(formatter.format('.')).to eql '.'
     end
   end
 end


### PR DESCRIPTION
Adds hierarchical search table support to Metasploit's search command functionality. Now the search table will include a module's actions, targets, and alias metadata. This functionality requires the user to opt-in with the command `features set hierarchical_search_table true`.

### Problem

We have a recurring discoverability/UX problem for user to find modules that have actions and configurable targets

In terms of impacted modules/numbers - we have:
- 198 modules with 1 Actions
- 101 modules with 2 or more Actions
- 897 modules with 2 or more Targets

Recently we've introduced more 'modern' modules which have multiple actions, but this functionality still isn't discoverable for the average user. There's no user affordance added to aid in the discovery of relevant modules that have actions that the user could use. i.e. The Kerberos `forge_ticket` module can forge 4 different ticket types - but only if you know the right incantations to set actions - potentially by reading [docs.metasploit.com](http://docs.metasploit.com/)

### Proposed solution

We update the search table to include hierarchical rows, including the available targets, actions, and AKA metadata.

## Verification

1. Ensure there are no changes in behavior to the search functionality when the feature flag is disabled
2. Ensure the feature flag can be enabled `features set hierarchical_search_table true`, and verify common scenarios

Searching for actions - `search forge_golden`

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/f26ea401-e8b3-44e1-ae35-f31aeab8fb89)

Searches that include targets and AKA metadata `search eternalblue`

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/6d3da0d4-57f4-4d19-9238-b57077dd76bc)

The `use <index>` functionality still works, and the target or action is automagically set for the user

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/6eb6e4f6-ded3-4076-b172-9743c060167d)

The `info <index>` functionality still works, and the target or action is automagically set for the user when the module info is generated

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/f54447e9-31fc-476f-95b3-3966339e2da7)
