### PR TITLE
Minor documentation fix to SMB documentation page

### DIFF
--- a/docs/metasploit-framework.wiki/Metasploit-Guide-SMB.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-SMB.md
@@ -24,7 +24,7 @@ Metasploit has support for multiple SMB modules, including:
 There are more modules than listed here, for the full list of modules run the `search` command within msfconsole:
 
 ```msf
-msf6 > search mysql
+msf6 > search smb
 ```
 
 ### Lab Environment


### PR DESCRIPTION
The current Metasploit documentation shows the search command for smb related modules as

`search mysql`

It should be

`search smb`

## Verification

No verification needed, as there are no code changes.
