### PR TITLE
Prevent deadlock when running `reload_all` with no module metadata cache

### DIFF
--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -46,9 +46,9 @@ class Cache
   # if there are changes.
   #
   def refresh_metadata(module_sets)
+    has_changes = false
     @mutex.synchronize {
       unchanged_module_references = get_unchanged_module_references
-      has_changes = false
       module_sets.each do |mt|
         unchanged_reference_name_set = unchanged_module_references[mt[0]]
 
@@ -78,13 +78,12 @@ class Cache
           end
         end
       end
-
-      if has_changes
-        update_store
-        clear_maps
-        update_stats
-      end
     }
+    if has_changes
+      update_store
+      clear_maps
+      update_stats
+    end
   end
 
   #######


### PR DESCRIPTION
Fixes an issue when running `reload_all` with the feature `defer_module_loads` set to `false` would result in a deadlock if the `db/modules_metadata_base.json` and `~/.msf4/store/modules_metadata.json` are missing

# Verification steps
- [ ] Reproduce the stacktrace by deleting/renaming `db/modules_metadata_base.json` and `~/.msf4/store/modules_metadata.json` then running `reload_all` from within msfconsole
- [ ] Check out this fix and run the test again, ensure that  there is no stacktrace and ``~/.msf4/store/modules_metadata.json`` is present (we don't expect `db/modules_metadata_base.json` to re-appear)