### PR TITLE
Update metasploit-payloads to 2.0.161

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.159)
+      metasploit-payloads (= 2.0.161)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -278,7 +278,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.159)
+    metasploit-payloads (2.0.161)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.159'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.161'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps metasploit-payloads to 2.0.161 and pulls in:
https://github.com/rapid7/metasploit-payloads/pull/687
https://github.com/rapid7/metasploit-payloads/pull/685

- [x] Make sure tests pass
- [x] Land after noon Thursday