### PR TITLE
add cves to snmp modules

### DIFF
--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -19,7 +19,9 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol' ],
           [ 'URL', 'https://net-snmp.sourceforge.io/docs/man/snmpwalk.html' ],
           [ 'URL', 'http://www.nothink.org/codes/snmpcheck/index.php' ],
-        ],
+          [ 'CVE', '1999-0508' ], # Weak password
+          [ 'CVE', '1999-0517' ],
+          [ 'CVE', '1999-0516' ]        ],
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE
     ))

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -20,7 +20,9 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      => 'hdm',
       'References'     =>
         [
-          [ 'CVE', '1999-0508'] # Weak password
+          [ 'CVE', '1999-0508' ], # Weak password
+          [ 'CVE', '1999-0517' ],
+          [ 'CVE', '1999-0516' ],
         ],
       'License'     => MSF_LICENSE
     )


### PR DESCRIPTION
This PR adds 2 CVEs to related SNMP modules.
https://www.tenable.com/cve/CVE-1999-0516 -> guessable SNMP community string
https://www.tenable.com/cve/CVE-1999-0517 -> default/null/missing SNMP community string

