### PR TITLE
Update to rpc_plugin to use HashWithIndifferentAccess

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -1,4 +1,6 @@
 # -*- coding: binary -*-
+require 'active_support/hash_with_indifferent_access'
+
 module Msf
 module RPC
 class RPC_Plugin < RPC_Base
@@ -17,7 +19,7 @@ class RPC_Plugin < RPC_Base
   #  # Load the nexpose plugin
   #  rpc.call('plugin.load', 'nexpose')
   def rpc_load(path, xopts = {})
-    opts = {}
+    opts = ActiveSupport::HashWithIndifferentAccess.new
 
     xopts.each do |k, v|
       if k.class == String


### PR DESCRIPTION
Fixes #18545

## Verification

```bash
$ msfrpcd -a 127.0.0.1 -P root
[*] MSGRPC starting on 127.0.0.1:55553 (SSL):Msg...
[*] MSGRPC ready at 2023-11-16 22:07:52 -0600.
$ msfrpc -a 127.0.0.1 -P root
...
>> rpc.call('core.version')
=> {"version"=>"6.3.43-dev-", "ruby"=>"3.0.2 x86_64-linux 2021-07-07", "api"=>"1.0"}
>> rpc.call('plugin.load', 'msfd', {'ServerPort'=>44444})
=> {"result"=>"success"}
>> exit
$ netstat -tulpn
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 127.0.0.1:631           0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:55553         0.0.0.0:*               LISTEN      9444/msfrpcd   # IP and port for msfrpcd
tcp        0      0 127.0.0.1:44444         0.0.0.0:*               LISTEN      9444/msfrpcd   # Actually accepts correct value
tcp        0      0 127.0.0.53:53           0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:5433          0.0.0.0:*               LISTEN      6510/postgres
```
