### PR TITLE
Enable Metasploit Payloads file warning messages by default

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -53,7 +53,7 @@ module Msf
         name: METASPLOIT_PAYLOAD_WARNINGS,
         description: 'When enabled Metasploit will output warnings about missing Metasploit payloads, for instance if they were removed by antivirus etc',
         requires_restart: true,
-        default_value: false,
+        default_value: true,
         developer_notes: 'Planned for default enablement in: Metasploit 6.4.x'
       }.freeze,
       {

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -377,7 +377,13 @@ class Driver < Msf::Ui::Driver
 
     run_single("banner") unless opts['DisableBanner']
 
-    payloads_manifest_errors = framework.features.enabled?(::Msf::FeatureManager::METASPLOIT_PAYLOAD_WARNINGS) ? ::MetasploitPayloads.manifest_errors : []
+    payloads_manifest_errors = []
+    begin
+      payloads_manifest_errors = ::MetasploitPayloads.manifest_errors if framework.features.enabled?(::Msf::FeatureManager::METASPLOIT_PAYLOAD_WARNINGS)
+    rescue ::StandardError => e
+      $stderr.print('Could not verify the integrity of the Metasploit Payloads manifest')
+      elog(e)
+    end
 
     av_warning_message if (framework.eicar_corrupted? || payloads_manifest_errors.any?)
 


### PR DESCRIPTION
This PR enables the feature previously added here: https://github.com/rapid7/metasploit-framework/pull/18405 which has been disabled by default.

## Verification
These steps have been copied from the PR linked above.

- [x] Start `msfconsole`
- [x] Ensure there are no startup error messages
- [x] Ensure you can get a session with `payload/python/meterpreter/reverse_tcp` normally
- [x] Exit msfconsole
- [x] In the local Metasploit Payloads gem, rename `data/meterpreter/meterpreter.py` to `meterpreter.py2`
- [x] Start `msfconsole`
- [x] Ensure you get a warning on startup that mentions missing `meterpreter.py`
- [x] Ensure `use payload/python/meterpreter/reverse_tcp` works
- [x] `to_handler`
- [x] Try to execute the payload on the target machine
- [x] Ensure you get an error: `Meterpreter path meterpreter/meterpreter.py not found.`
- [x] `use payload/python/meterpreter_reverse_tcp` (inline)
- [x] Ensure calling `to_handler` results in `Meterpreter path meterpreter/meterpreter.py not found.`
- [x] Ensure the errors are shown when calling `log`
- [x] Exit msfconsole
- [x] Change the `meterpreter.py2` file back to `meterpreter.py`
- [x] Modify the `meterpreter.py` file with an additional empty line
- [x] Start `msfconsole`
- [x] Ensure you get a warning on startup that mentions a hash mismatch for `meterpreter.py`