### PR TITLE
Bump ruby smb version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ PATH
       rex-zip
       ruby-macho
       ruby-mysql
-      ruby_smb (~> 3.2.0)
+      ruby_smb (~> 3.3.0)
       rubyntlm
       rubyzip
       sinatra
@@ -473,7 +473,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.2.6)
+    ruby_smb (3.3.0)
       bindata
       openssl-ccm
       openssl-cmac

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -147,7 +147,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 3.2.0'
+  spec.add_runtime_dependency 'ruby_smb', '~> 3.3.0'
   spec.add_runtime_dependency 'net-imap' # Used in Postgres auth for its SASL stringprep implementation
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'


### PR DESCRIPTION
Bumping the ruby smb version
pulls in these PR from ruby smb:
https://github.com/rapid7/ruby_smb/pull/255
https://github.com/rapid7/ruby_smb/pull/256
https://github.com/rapid7/ruby_smb/pull/257
