### PR TITLE
Fix net-ssh lib now requiring ssh key type

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.md
@@ -1,0 +1,93 @@
+## Vulnerable Application
+
+This module can determine what public keys are configured for key-based authentication across a range of machines,
+users, and sets of known keys. The SSH protocol indicates whether a particular key is accepted prior to the client
+performing the actual signed authentication request. To use this module, a text file containing one or more SSH keys
+should be provided. These can be private or public, so long as no passphrase is set on the private keys.
+
+If you have loaded a database plugin and connected to a database, this module will record authorized public keys and
+hosts so you can track your process. Key files may be a single public (unencrypted) key, or several public keys
+concatenated together as an ASCII text file. Non-key data should be silently ignored. Private keys will only utilize
+the public key component stored within the key file.
+
+### Setup
+
+This module has been tested against Metasploitable2. Installation and setup instructions and additional
+information can be found in the Rapid7 documentation here: https://docs.rapid7.com/metasploit/metasploitable-2/
+
+## Verification Steps
+
+1. Have Metasploitable2 running
+1. Copy the `msfadmin`'s public key from `/home/msfadmin/.ssh/id_rsa.pub` to your machine
+1. Start `msfconsole -q`
+1. Do: `use auxiliary/scanner/ssh/ssh_identify_pubkeys`
+1. Do: `set rhosts`
+1. Do: `set username root`
+1. Do: `set key_path` to the copied `id_rsa.pub` file
+1. Do: `run`
+
+## Options
+
+### KEY_FILE
+
+Filename of one or several cleartext public keys.
+
+### SSH_DEBUG
+
+When enabled, outputs verbose SSH debug messages.
+
+### SSH_BYPASS
+
+When enabled, verify that authentication was not bypassed when keys are found.
+
+### SSH_KEYFILE_B64
+
+Raw data of an unencrypted SSH public key. This should be used by programmatic interfaces to this module only.
+
+### KEY_DIR
+
+Directory of several keys. Filenames must not begin with a dot in order to be read.
+
+### SSH_TIMEOUT
+
+The maximum time to negotiate a SSH session.
+
+## Scenarios
+
+### Metasploitable22
+
+```shell
+msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > cat id_rsa.pub
+[*] exec: cat id_rsa.pub
+
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEApmGJFZNl0ibMNALQx7M6sGGoi4KNmj6PVxpbpG70lShHQqldJkcteZZdPFSbW76IUiPR0Oh+WBV0x1c6iPL/0zUYFHyFKAz1e6/5teoweG1jr2qOffdomVhvXXvSjGaSFwwOYB8R0QxsOWWTQTYSeBa66X6e777GVkHCDLYgZSo8wWr5JXln/Tw7XotowHr8FEGvw2zW1krU3Zo9Bzp0e0ac2U+qUGIzIu/WwgztLZs5/D9IyhtRWocyQPE+kcP+Jz2mt4y1uA73KqoXfdw5oGUkxdFo9f1nu2OwkjOc+Wv8Vw7bwkf+1RgiOMgiJ5cCs4WocyVxsXovcNnbALTp3w== msfadmin@metasploitable
+
+msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > options
+
+Module options (auxiliary/scanner/ssh/ssh_identify_pubkeys):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
+   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_USERS      false            no        Add all users in the current database to the list
+   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+   KEY_FILE          id_rsa.pub       yes       Filename of one or several cleartext public keys.
+   RHOSTS            192.168.112.178  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT             22               yes       The target port
+   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
+   THREADS           1                yes       The number of concurrent threads (max one per host)
+   USERNAME          root             no        A specific username to authenticate as
+   USER_FILE                          no        File containing usernames, one per line
+   VERBOSE           true             yes       Whether to print output for all attempts
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run
+
+[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
+[+] 192.168.112.178:22 - [1/1] - Public key accepted: 'root' with key '57:c3:11:5d:77:c5:63:90:33:2d:c5:c4:99:78:62:7a' (Private Key: No) - msfadmin@metasploitable
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/lib/net/ssh/pubkey_verifier.rb
+++ b/lib/net/ssh/pubkey_verifier.rb
@@ -39,7 +39,7 @@ module Net
 
         # The initial public key exchange
         pubkey_method = Net::SSH::Authentication::Methods::Publickey.new(auth)
-        pubkey_method.send(:send_request, key,user, "ssh-connection")
+        pubkey_method.send(:send_request, key, user, "ssh-connection", key.ssh_type)
 
         # Check the response to see if the public key is good
         response_message = auth.next_message

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     deregister_options(
-      'RHOST','PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS', 'USERPASS_FILE', 'DB_ALL_PASS', 'DB_ALL_CREDS'
+      'PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS', 'USERPASS_FILE', 'DB_ALL_PASS', 'DB_ALL_CREDS'
     )
 
     @good_credentials = {}


### PR DESCRIPTION
A recent update to the net-ssh library (here: https://github.com/net-ssh/net-ssh/pull/838) changed the definitions of a few functions by adding in an additional `alg` parameter. The module changed in this PR had to be updated.

This PR closes https://github.com/rapid7/metasploit-framework/issues/18555

I've tested this PR using Metasploitable2 as a target, following what this PR has shown: https://github.com/rapid7/metasploit-framework/pull/7339

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_identify_pubkeys`
- [ ] `set rhost`
- [ ] `set key_file`
- [ ] `set username`
- [ ] Make sure the code doesn't explode

## Before

<details>

```ruby
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run

[*] 192.168.112.132:22 SSH - Trying 1 cleartext key per user.
[-] Auxiliary failed: ArgumentError wrong number of arguments (given 3, expected 4..5)
[-] Call stack:
[-]   /Users/sjanusz/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/net-ssh-7.2.0/lib/net/ssh/authentication/methods/publickey.rb:39:in `send_request'
[-]   /Users/sjanusz/Programming/metasploit-framework/lib/net/ssh/pubkey_verifier.rb:42:in `verify'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:224:in `block (2 levels) in do_login'
[-]   /Users/sjanusz/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/timeout-0.4.0/lib/timeout.rb:186:in `block in timeout'
[-]   /Users/sjanusz/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/timeout-0.4.0/lib/timeout.rb:41:in `handle_timeout'
[-]   /Users/sjanusz/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/timeout-0.4.0/lib/timeout.rb:195:in `timeout'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:223:in `block in do_login'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:198:in `each'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:198:in `each_with_index'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:198:in `do_login'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:371:in `block in run_host'
[-]   /Users/sjanusz/Programming/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:303:in `block in each_user_pass'
[-]   /Users/sjanusz/Programming/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:271:in `each'
[-]   /Users/sjanusz/Programming/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:271:in `each_user_pass'
[-]   /Users/sjanusz/Programming/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:370:in `run_host'
[-]   /Users/sjanusz/Programming/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-]   /Users/sjanusz/Programming/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
```

</details>

## After

<details>

```ruby
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[+] 192.168.112.178:22 - [1/1] - Public key accepted: 'root' with key '57:c3:11:5d:77:c5:63:90:33:2d:c5:c4:99:78:62:7a' (Private Key: No) - msfadmin@metasploitable
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

</details>

## Testing RSA keys

<details>

```ruby
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_rsa username=msfadmin

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[-] 192.168.112.178:22 - [1/1] - User msfadmin does not accept key 1
[-] 192.168.112.178:22 SSH - Failed: 'msfadmin'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_rsa username=root

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[+] 192.168.112.178:22 - [1/1] - Public key accepted: 'root' with key '57:c3:11:5d:77:c5:63:90:33:2d:c5:c4:99:78:62:7a' (Private Key: Yes)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_rsa.pub username=msfadmin

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[-] 192.168.112.178:22 - [1/1] - User msfadmin does not accept key 1 - msfadmin@metasploitable
[-] 192.168.112.178:22 SSH - Failed: 'msfadmin'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_rsa.pub username=root

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[+] 192.168.112.178:22 - [1/1] - Public key accepted: 'root' with key '57:c3:11:5d:77:c5:63:90:33:2d:c5:c4:99:78:62:7a' (Private Key: No) - msfadmin@metasploitable
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

</details>

## Testing DSA Keys

<details>

```ruby
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_dsa username=msfadmin

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[+] 192.168.112.178:22 - [1/1] - Public key accepted: 'msfadmin' with key '70:ff:0f:ff:a3:8e:39:18:d7:30:c1:30:02:bc:20:3c' (Private Key: Yes)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_dsa username=root

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[-] 192.168.112.178:22 - [1/1] - User root does not accept key 1
[-] 192.168.112.178:22 SSH - Failed: 'root'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_dsa.pub username=root

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[-] 192.168.112.178:22 - [1/1] - User root does not accept key 1 - user@metasploitable
[-] 192.168.112.178:22 SSH - Failed: 'root'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_identify_pubkeys) > run key_file=/Users/sjanusz/Downloads/id_dsa.pub username=msfadmin

[*] 192.168.112.178:22 SSH - Trying 1 cleartext key per user.
[+] 192.168.112.178:22 - [1/1] - Public key accepted: 'msfadmin' with key '70:ff:0f:ff:a3:8e:39:18:d7:30:c1:30:02:bc:20:3c' (Private Key: No) - user@metasploitable
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

</details>