### PR TITLE
MS9177 MSSQL part 1 - client consolidation

### DIFF
--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -68,6 +68,7 @@ module Metasploit
           begin
             if mssql_login(credential.public, credential.private, '', credential.realm)
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
+              disconnect
             else
               result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
             end

--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -22,7 +22,20 @@ module Metasploit
         attr_accessor :tdsencryption
         attr_accessor :sock
         attr_accessor :auth
-
+        attr_accessor :ssl
+        attr_accessor :ssl_version
+        attr_accessor :ssl_verify_mode
+        attr_accessor :ssl_cipher
+        attr_accessor :proxies
+        attr_accessor :connection_timeout
+        attr_accessor :send_lm
+        attr_accessor :send_ntlm
+        attr_accessor :send_spn
+        attr_accessor :use_lmkey
+        attr_accessor :use_ntlm2_session
+        attr_accessor :use_ntlmv2
+        attr_accessor :windows_authentication
+        
         # @!attribute max_send_size
         #   @return [Integer] The max size of the data to encapsulate in a single packet
         attr_accessor :max_send_size
@@ -393,7 +406,6 @@ module Metasploit
           info = {:errors => []}
           info = mssql_parse_reply(resp, info)
 
-          disconnect
 
           return false if not info
           info[:login_ack] ? true : false
@@ -748,40 +760,44 @@ module Metasploit
         protected
 
         # def auth
+        #   Msf::Exploit::Remote::AuthOption::AUTO
+        # end
+
+        # def tdsencryption
+        #   false
+        # end
+
+        # def domain_controller_rhost
         #   raise NotImplementedError
         # end
 
-        def domain_controller_rhost
-          raise NotImplementedError
-        end
+        # def hostname
+        #   raise NotImplementedError
+        # end
 
-        def hostname
-          raise NotImplementedError
-        end
+        # def windows_authentication
+        #   raise NotImplementedError
+        # end
 
-        def windows_authentication
-          raise NotImplementedError
-        end
+        # def use_ntlm2_session
+        #   raise NotImplementedError
+        # end
 
-        def use_ntlm2_session
-          raise NotImplementedError
-        end
+        # def use_ntlmv2
+        #   raise NotImplementedError
+        # end
 
-        def use_ntlmv2
-          raise NotImplementedError
-        end
+        # def send_lm
+        #   raise NotImplementedError
+        # end
 
-        def send_lm
-          raise NotImplementedError
-        end
+        # def send_ntlm
+        #   raise NotImplementedError
+        # end
 
-        def send_ntlm
-          raise NotImplementedError
-        end
-
-        def send_spn
-          raise NotImplementedError
-        end
+        # def send_spn
+        #   raise NotImplementedError
+        # end
 
       end
 

--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -757,6 +757,23 @@ module Metasploit
           print_status("Be sure to cleanup #{var_payload}.exe...")
         end
 
+        def set_sane_defaults
+          self.connection_timeout    ||= 30
+          self.max_send_size         ||= 0
+          self.send_delay            ||= 0
+      
+          # Don't use ||= with booleans
+          self.send_lm                = true if self.send_lm.nil?
+          self.send_ntlm              = true if self.send_ntlm.nil?
+          self.send_spn               = true if self.send_spn.nil?
+          self.use_lmkey              = false if self.use_lmkey.nil?
+          self.use_ntlm2_session      = true if self.use_ntlm2_session.nil?
+          self.use_ntlmv2             = true if self.use_ntlmv2.nil?
+          self.auth                   = Msf::Exploit::Remote::AuthOption::AUTO if self.auth.nil?
+      
+          self.windows_authentication = datastore['USE_WINDOWS_AUTHENT']
+          self.tdsencryption          = false if self.tdsencryption.nil?
+        end 
         protected
 
         # def auth

--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -80,7 +80,6 @@ module Metasploit
           else
             dossl = ssl
           end
-
           nsock = Rex::Socket::Tcp.create(
               'PeerHost'      =>  opts['RHOST'] || rhost,
               'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['RHOSTNAME'],
@@ -93,10 +92,11 @@ module Metasploit
               'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
               'Proxies'       => proxies,
               'Timeout'       => (opts['ConnectTimeout'] || connection_timeout || 10).to_i,
-              'Context'       => { 'Msf' => framework, 'MsfExploit' => framework_module }
+              'Context'       => { 'Msf' => framework, 'MsfExploit' => self }
               )
           # enable evasions on this socket
           set_tcp_evasions(nsock)
+
 
           # Set this socket to the global socket as necessary
           self.sock = nsock if (global)

--- a/lib/msf/core/module/alert.rb
+++ b/lib/msf/core/module/alert.rb
@@ -202,8 +202,7 @@ module Msf::Module::Alert
   def alert_user
     self.you_have_been_warned ||= {}
 
-    errors.each do |msg| 
-      # require 'pry-byebug'; binding.pry
+    errors.each do |msg|
       if msg && !self.you_have_been_warned[msg.hash]
         print_error(msg.full_message)
         self.you_have_been_warned[msg.hash] = true

--- a/lib/msf/core/module/alert.rb
+++ b/lib/msf/core/module/alert.rb
@@ -202,9 +202,10 @@ module Msf::Module::Alert
   def alert_user
     self.you_have_been_warned ||= {}
 
-    errors.each do |msg|
+    errors.each do |msg| 
+      # require 'pry-byebug'; binding.pry
       if msg && !self.you_have_been_warned[msg.hash]
-        print_error(msg)
+        print_error(msg.full_message)
         self.you_have_been_warned[msg.hash] = true
       end
     end

--- a/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
@@ -173,21 +173,4 @@ class MetasploitModule < Msf::Auxiliary
 
     verified_sql_logins
   end
-
-  def set_sane_defaults
-    self.connection_timeout    ||= 30
-    self.max_send_size         ||= 0
-    self.send_delay            ||= 0
-
-    # Don't use ||= with booleans
-    self.send_lm                = true if self.send_lm.nil?
-    self.send_ntlm              = true if self.send_ntlm.nil?
-    self.send_spn               = true if self.send_spn.nil?
-    self.use_lmkey              = false if self.use_lmkey.nil?
-    self.use_ntlm2_session      = true if self.use_ntlm2_session.nil?
-    self.use_ntlmv2             = true if self.use_ntlmv2.nil?
-    self.auth                   = Msf::Exploit::Remote::AuthOption::AUTO if self.auth.nil?
-    self.windows_authentication = false if self.windows_authentication.nil?
-    self.tdsencryption = datastore['TDSENCRYPTION']
-  end
 end

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -2,10 +2,10 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -20,12 +20,24 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     => [[ 'URL','http://technet.microsoft.com/en-us/library/ms188676(v=sql.105).aspx']]
     ))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+      ])
   end
 
   def run
+    set_sane_defaults
     # Check connection and issue initial query
     print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
-    if mssql_login_datastore
+
+    if mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
       print_good('Connected.')
     else
       print_error('Login was unsuccessful. Check your credentials.')

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -2,10 +2,10 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -19,12 +19,24 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  => [['URL','http://msdn.microsoft.com/en-us/library/ms178640.aspx']]
     ))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+      ])
   end
 
   def run
+    set_sane_defaults
     # Check connection and issue initial query
     print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
-    if mssql_login_datastore
+
+    if mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
       print_good('Connected.')
     else
       print_error('Login was unsuccessful. Check your credentials.')

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def sql_statement()
-    
+
     # DEFINED HEADER TEXT
     headings = [
       ["Server","Database", "Schema", "Table", "Column", "Data Type", "Sample Data","Row Count"]

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -2,9 +2,10 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
@@ -34,7 +35,15 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('KEYWORDS', [ true, 'Keywords to search for','passw|credit|card']),
         OptInt.new('SAMPLE_SIZE', [ true, 'Number of rows to sample',  1]),
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ])
+
+    set_sane_defaults
   end
 
   def print_with_underline(str)
@@ -47,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def sql_statement()
-
+    
     # DEFINED HEADER TEXT
     headings = [
       ["Server","Database", "Schema", "Table", "Column", "Data Type", "Sample Data","Row Count"]
@@ -342,7 +351,9 @@ class MetasploitModule < Msf::Auxiliary
 
     # CREATE DATABASE CONNECTION AND SUBMIT QUERY WITH ERROR HANDLING
     begin
-      result = mssql_query(sql, false) if mssql_login_datastore
+      #here
+      result = mssql_query(sql, false) if mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
+
       column_data = result[:rows]
       print_good("Successfully connected to #{rhost}:#{rport}")
     rescue

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -11,9 +11,10 @@
 # 'interesting' columns and data
 #
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -35,6 +36,12 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('NAMES', [ true, 'Pipe separated list of column names',  'passw|bank|credit|card']),
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ])
   end
 
@@ -44,6 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    set_sane_defaults
     headings = [
       ["Database", "Schema", "Table", "Column", "Data Type", "Row Count"]
     ]

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -2,9 +2,10 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -25,6 +26,12 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('SQL', [ false, 'The SQL query to execute',  'select @@version']),
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ])
   end
 
@@ -38,6 +45,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    set_sane_defaults
     mssql_query(datastore['SQL'], true) if mssql_login_datastore
     disconnect
   end

--- a/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
@@ -2,9 +2,11 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
+
   include Msf::Auxiliary::Fuzzer
 
   def initialize(info = {})
@@ -16,6 +18,16 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => [ 'hdm' ],
       'License'        => MSF_LICENSE
     ))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+      ])
   end
 
   # A copy of the mssql_login method with the ability to overload each option
@@ -117,6 +129,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    set_sane_defaults
     last_str = nil
     last_inp = nil
     last_err = nil

--- a/modules/auxiliary/fuzzers/tds/tds_login_username.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_username.rb
@@ -2,9 +2,11 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
+
   include Msf::Auxiliary::Fuzzer
 
   def initialize(info = {})
@@ -16,6 +18,16 @@ class MetasploitModule < Msf::Auxiliary
       'Author'         => [ 'hdm' ],
       'License'        => MSF_LICENSE
     ))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+      ])
   end
 
   # A copy of the mssql_login method with the ability to overload each option
@@ -113,6 +125,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    set_sane_defaults
+
     last_str = nil
     last_inp = nil
     last_err = nil

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -5,7 +5,7 @@
 
 require 'metasploit/framework/credential_collection'
 require 'metasploit/framework/login_scanner/mssql'
-require 'metasploit/framework/mssql/client' 
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
   include Metasploit::Framework::MSSQL::Client
@@ -119,5 +119,5 @@ class MetasploitModule < Msf::Auxiliary
 
     self.windows_authentication = datastore['USE_WINDOWS_AUTHENT']
     self.tdsencryption          = datastore['TDSENCRYPTION']
-  end  
+  end
 end

--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -2,9 +2,11 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
+
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
@@ -16,6 +18,12 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
+    register_options(
+      [
+        Opt::RHOST,
+        OptInt.new('THREADS', [true, "The number of concurrent threads (max one per host)", 1]),
+      ])
+    set_sane_defaults
     deregister_options('RPORT')
   end
 

--- a/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
+++ b/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
@@ -2,11 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
   include Msf::Exploit::EXE
 
   def initialize(info = {})
@@ -35,7 +36,17 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2005-12-08'
-      ))
+    ))
+    register_options([
+      OptBool.new('DISPLAY_RESULTS', [true, "Display the Results to the Screen", true]),
+      Opt::RHOST,
+      Opt::RPORT(1433),
+      OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+      OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+      OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+      OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+    ])
+    set_sane_defaults
   end
 
   # Do not automatically run this module, it can lead to lockouts with SQL Server 2005

--- a/modules/exploits/windows/mssql/ms02_039_slammer.rb
+++ b/modules/exploits/windows/mssql/ms02_039_slammer.rb
@@ -2,11 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
 
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -53,8 +54,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(1434)
+        Opt::RPORT(1434),
+        Opt::RHOST,
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ])
+    set_sane_defaults
   end
 
 

--- a/modules/exploits/windows/mssql/ms02_056_hello.rb
+++ b/modules/exploits/windows/mssql/ms02_056_hello.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'DisclosureDate' => '2002-08-05',
       'DefaultTarget' => 0))
-    
+
       register_options(
         [
           Opt::RPORT(1433),

--- a/modules/exploits/windows/mssql/ms02_056_hello.rb
+++ b/modules/exploits/windows/mssql/ms02_056_hello.rb
@@ -2,11 +2,11 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
-
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -49,6 +49,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'DisclosureDate' => '2002-08-05',
       'DefaultTarget' => 0))
+    
+      register_options(
+        [
+          Opt::RPORT(1433),
+          Opt::RHOST,
+          OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+          OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+          OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+          OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+        ])
+      set_sane_defaults
   end
 
   def check

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -2,11 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
 
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
 
@@ -244,6 +245,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2008-12-09'
       ))
+    register_options(
+      [
+        Opt::RPORT(1433),
+        Opt::RHOST,
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+      ])
+    set_sane_defaults
 
   end
 
@@ -375,7 +386,7 @@ exec sp_executesql @z|
     runme.gsub!(/%STUFF%/, enc)
 
     # go!
-    if !mssql_login_datastore
+    if !mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
       fail_with(Failure::NoAccess, "Unable to log in!")
     end
     begin

--- a/modules/exploits/windows/mssql/mssql_clr_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_clr_payload.rb
@@ -2,11 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
 
   def initialize(info = {})
     super(update_info(info,
@@ -46,12 +47,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('DATABASE', [true, 'The database to load the CLR Assembly into.', 'master'])
-      ])
+        OptString.new('DATABASE', [true, 'The database to load the CLR Assembly into.', 'master']),
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+      ]
+    )
+    set_sane_defaults
   end
 
   def check
-    unless mssql_login_datastore(datastore['DATABASE'])
+    unless mssql_login(datastore['USERNAME'], datastore['PASSWORD'], datastore['DATABASE'])
       vprint_status('Invalid SQL Server credentials')
       return Exploit::CheckCode::Detected
     end
@@ -133,7 +142,7 @@ RECONFIGURE;
   end
 
   def exploit
-    unless mssql_login_datastore(datastore['DATABASE'])
+    unless mssql_login(datastore['USERNAME'], datastore['PASSWORD'], datastore['DATABASE'])
       fail_with(Failure::BadConfig, 'Unable to login with the given credentials')
     end
 

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -2,12 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GreatRanking
 
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
   include Msf::Auxiliary::Report
   include Msf::Exploit::CmdStager
 
@@ -60,13 +60,20 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptBool.new('DEPLOY',       [false, 'Deploy payload via the sysadmin links', false]),
         OptString.new('DEPLOYLIST', [false,'Comma separated list of systems to deploy to']),
-        OptString.new('PASSWORD',   [true, 'The password for the specified username'])
+        OptString.new('PASSWORD',   [true, 'The password for the specified username']),
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ])
 
     register_advanced_options(
       [
         OptString.new('POWERSHELL_PATH', [true, 'Path to powershell.exe', "C:\\windows\\syswow64\\WindowsPowerShell\\v1.0\\powershell.exe"])
       ])
+
+    set_sane_defaults
   end
 
   def exploit

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -2,11 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'metasploit/framework/mssql/client'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::MSSQL
+  include Metasploit::Framework::MSSQL::Client
   include Msf::Exploit::CmdStager
   #include Msf::Exploit::CmdStagerDebugAsm
   #include Msf::Exploit::CmdStagerDebugWrite
@@ -63,8 +64,15 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
     register_options(
       [
-        OptString.new('METHOD', [ true, 'Which payload delivery method to use (ps, cmd, or old)', 'cmd' ])
+        OptString.new('METHOD', [ true, 'Which payload delivery method to use (ps, cmd, or old)', 'cmd' ]),
+        Opt::RHOST,
+        Opt::RPORT(1433),
+        OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
+        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+        OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
       ])
+    set_sane_defaults
   end
 
   def check


### PR DESCRIPTION
In the name of making MSSQL client more consistent to other client types, this moves modules that rely on `Remote::MSSQL` to the new consolidated client.

To test:
- Load up any/each module changed in this pr, ie `mssql_login`
- Set up an MSSQL instance in a VM/Target
- set `RHOSTS` to the ip of the MSSQL target
- set `RPORT` to 1433, `USERNAME` and `PASSWORD` to MSSQL credentials
- run the module, ensure no difference between here and master

