### PR TITLE
Add File.expand_path to fix no such file error 

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -194,7 +194,8 @@ module Msf
               puts(buf)
             else
               print_status("Writing #{buf.length} bytes to #{ofile}...")
-              fd = File.open(ofile, 'wb')
+              f = File.expand_path(ofile)
+              fd = File.open(f, 'wb')
               fd.write(buf)
               fd.close
             end


### PR DESCRIPTION
With issue #18602 a "No such file or directory" error is given when using the `-o` flag to write the payload to a file. This change uses the `FIle.expand_path` function to allow for files to be written to the home path of the current user with the `~` character. 

## Verification
Running the `-o` option with a file path using `~` now works! 

```
~/metasploit-framework msfconsole
msf6 > reload_all

msf6 > use payload/osx/armle/shell/reverse_tcp 
msf6 payload(osx/armle/shell/reverse_tcp) > set LHOST 10.255.104.146
LHOST => 10.255.104.146
msf6 payload(osx/armle/shell/reverse_tcp) > generate -o ~/payload_test
[*] Writing 1244 bytes to ~/payload_text...

# In a regular shell
$ ls ~/payload*
payload_test
```