### PR TITLE
better check for VMware vCenter vScalation Priv Esc

### DIFF
--- a/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
+++ b/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
@@ -72,8 +72,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    return CheckCode::Safe("#{java_wrapper_vmon} not found on system") unless file?(java_wrapper_vmon)
+    return CheckCode::Safe("#{java_wrapper_vmon} not writable") unless writable?(java_wrapper_vmon)
+
     group_owner = cmd_exec("stat -c \"%G\" \"#{java_wrapper_vmon}\"")
-    if writable?(java_wrapper_vmon) && group_owner == 'cis'
+    if group_owner == 'cis'
       return CheckCode::Appears("#{java_wrapper_vmon} is writable and owned by cis group")
     end
 


### PR DESCRIPTION
When running against a non-vmware vcenter system, (like with `local_exploit_suggester` the `check` method would try to stat a file which didn't exist. This caused the output to look like:

`/usr/lib/vmware-vmon/java-wrapper-vmon not owned by 'cis' group (owned by 'stat: cannot stat 'usr/lib/vmware-vmon/java-wrapper-vmon': no such file or directory'), or not writable`

We now check if the file exists and is writable before running stat.

## Verification

- [x] Start `msfconsole`
- [x] get a sesssion on a non-vcenter box
- [x] `use vcenter_java_wrapper`
- [x] `set session #`
- [x] `check`
- [x] **Verify** the output look sane and not like above