### PR TITLE
asan local better check

### DIFF
--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options [
-      OptString.new('SUID_EXECUTABLE', [true, 'Path to a SUID executable compiled with ASan', '']),
+      OptString.new('SUID_EXECUTABLE', [true, 'Path to a SUID executable compiled with ASan']),
       OptInt.new('SPRAY_SIZE', [true, 'Number of PID symlinks to create', 50])
     ]
     register_advanced_options [
@@ -131,7 +131,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Safe('A valid SUID_EXECUTABLE option is required') if suid_exe_path.blank?
     return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
     return CheckCode::Safe("#{suid_exe_path} is not setuid") unless setuid? suid_exe_path
 

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Safe('A valid SUID_EXECUTABLE option is required') if suid_exe_path.empty?
+    return CheckCode::Safe('A valid SUID_EXECUTABLE option is required') if suid_exe_path.blank?
     return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
     return CheckCode::Safe("#{suid_exe_path} is not setuid") unless setuid? suid_exe_path
 

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -131,6 +131,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    return CheckCode::Safe('A valid SUID_EXECUTABLE option is required') if suid_exe_path.empty?
     return CheckCode::Safe("#{suid_exe_path} file not found") unless file? suid_exe_path
     return CheckCode::Safe("#{suid_exe_path} is not setuid") unless setuid? suid_exe_path
 


### PR DESCRIPTION
When running `asan_suid_executable_priv_esc` check method w/o setting `SUID_EXECUTABLE` (such as with `local_exploit_suggester`) the `check` command output seems unintuitive: `[*] The target is not exploitable.  file not found`.  What file wasn't found? Turns out, it's an empty string.

This PR adds a new check to determine if `SUID_EXECUTABLE` was set or not, and if not it prints a more informative response.

## Verification


- [ ] Start `msfconsole`
- [ ] get a shell on a linux box
- [ ] `use linux/local/asan_suid_executable_priv_esc`
- [ ] `set session [#]`
- [ ] `check`
- [ ] **Verify** you get `[*] The target is not exploitable. A valid SUID_EXECUTABLE option is required`
- [ ] **Verify** you don't get `[*] The target is not exploitable.  file not found`
