### PR TITLE
Add a way to get the buildid via perf

### DIFF
--- a/modules/exploits/linux/local/glibc_tunables_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_tunables_priv_esc.rb
@@ -128,6 +128,8 @@ class MetasploitModule < Msf::Exploit::Local
       check_ld_so_build_id_file
     elsif command_exists?('readelf')
       check_ld_so_build_id_readelf
+    elsif command_exists?('perf')
+      check_ld_so_build_id_perf
     else
       print_warning('Unable to locate the commands to verify the BuildID for ld.so.')
     end
@@ -188,6 +190,35 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       print_warning('Unable to verify the BuildID for ld.so via `file`, the exploit has a chance of being incompatible with this target.')
+    end
+  end
+
+  def check_ld_so_build_id_perf
+    perf_cmd_output = ''
+
+    # This needs to be split up by distro as Ubuntu has readlink and which installed by default but "ld.so" is not
+    # defined on the path like it is on Debian. Also Ubuntu doesn't have ldconfig install by default.
+    sysinfo = get_sysinfo
+    case sysinfo[:distro]
+    when 'ubuntu'
+      if command_exists?('ldconfig')
+        perf_cmd_output = cmd_exec('perf buildid-list -i $(ldconfig -p | grep -oE "/.*ld-linux.*so\.[0-9]*")')
+      end
+    when 'debian'
+      perf_cmd_output = cmd_exec('perf buildid-list -i "$(readlink -f "$(command -v ld.so)")"')
+    else
+      fail_with(Failure::NoTarget, 'The module has not been tested against this Linux distribution')
+    end
+
+    if perf_cmd_output =~ /([0-9a-f]+)/
+      build_id = Regexp.last_match(1)
+      if BUILD_IDS.keys.include?(build_id)
+        print_good("The Build ID for ld.so: #{build_id} is in the list of supported Build IDs for the exploit.")
+      else
+        fail_with(Failure::NoTarget, "The Build ID for ld.so: #{build_id} is not in the list of supported Build IDs for the exploit.")
+      end
+    else
+      print_warning('Unable to verify the BuildID for ld.so via `perf`, the exploit has a chance of being incompatible with this target.')
     end
   end
 


### PR DESCRIPTION
In the same spirit than #18632, since it's pretty common to have `perf` installed on some production machines.

```console
$ perf buildid-list -i /bin/bash
0b6b11360e339f231f17484da2c87d0d78554e31
$
```