### PR TITLE
Use first module with enabled hierarchical search

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -596,7 +596,7 @@ module Msf
                   end
                 end
               end
-              if @module_search_results_with_usage_metadata.length == 1 && use
+              if @module_search_results.length == 1 && use
                 used_module = @module_search_results_with_usage_metadata.first[:mod].fullname
                 cmd_use(used_module, true)
               end


### PR DESCRIPTION
When the hierarchical search functionality is enabled, and only one module result is found - the module will automatically be used

### before

The module isn't selected

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/fa359b0c-ed22-4c70-bd02-2072a1155ceb)

### After

The module is selected:

```
Matching Modules
================

   #  Name                                   Disclosure Date  Rank    Check  Description
   -  ----                                   ---------------  ----    -----  -----------
   0  auxiliary/admin/kerberos/forge_ticket  .                normal  No     Kerberos Silver/Golden/Diamond/Sapphire Ticket Forging
   1    \_ action: FORGE_DIAMOND             .                .       .      Forge a Diamond Ticket
   2    \_ action: FORGE_GOLDEN              .                .       .      Forge a Golden Ticket
   3    \_ action: FORGE_SAPPHIRE            .                .       .      Forge a Sapphire Ticket
   4    \_ action: FORGE_SILVER              .                .       .      Forge a Silver Ticket
   5    \_ AKA: Ticketer                     .                .       .      .
   6    \_ AKA: Klist                        .                .       .      .


Interact with a module by name or index. For example info 6, use 6 or use auxiliary/admin/kerberos/forge_ticket

[*] Using auxiliary/admin/kerberos/forge_ticket
msf6 auxiliary(admin/kerberos/forge_ticket) > 
```

## Verification

- Ensure `use forge_ticket` selects the first module
