### PR TITLE
Force `reload_all` to load unloaded modules before refreshing modules

### DIFF
--- a/lib/msf/base/simple/framework/module_paths.rb
+++ b/lib/msf/base/simple/framework/module_paths.rb
@@ -6,6 +6,7 @@ module Msf
       module ModulePaths
 
         attr_accessor :configured_module_paths
+        attr_accessor :module_paths_inited
 
         # Initialize the module paths
         #
@@ -43,8 +44,7 @@ module Msf
           end
 
           # Remove any duplicate paths
-          @configured_module_paths.uniq
-
+          @configured_module_paths.uniq!
           # return early if we're deferring module loading
           return if opts.delete(:defer_module_loads)
 

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -39,8 +39,10 @@ module Msf::ModuleManager::Reloading
     # default the count to zero the first time a type is accessed
     count_by_type = Hash.new(0)
 
+    framework.init_module_paths unless framework.module_paths_inited
+
     module_paths.each do |path|
-      path_count_by_type = load_modules(path, :force => true)
+      path_count_by_type = load_modules(path, force: true)
 
       # merge count with count from other paths
       path_count_by_type.each do |type, count|

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -46,9 +46,9 @@ class Cache
   # if there are changes.
   #
   def refresh_metadata(module_sets)
+    has_changes = false
     @mutex.synchronize {
       unchanged_module_references = get_unchanged_module_references
-      has_changes = false
       module_sets.each do |mt|
         unchanged_reference_name_set = unchanged_module_references[mt[0]]
 
@@ -78,13 +78,12 @@ class Cache
           end
         end
       end
-
-      if has_changes
-        update_store
-        clear_maps
-        update_stats
-      end
     }
+    if has_changes
+      update_store
+      clear_maps
+      update_stats
+    end
   end
 
   #######

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1095,6 +1095,7 @@ module Msf
               wlog(log_msg)
             end
 
+            self.driver.run_single('reload')
             self.driver.run_single("banner")
           end
 


### PR DESCRIPTION
When starting up framework with `defer_module_loads` set to `true` the `reload_all` command was only reloading any modules that had already been loaded which was an unexpected change so this PR addresses that by enforcing all modules to be loaded as part of `reload_all`

# Verification Steps
- [ ] boot `msfconsole`
- [ ] run `features set defer_module_loads false` then `save` and reboot `msfconsole`
- [ ] `search forge_ticket` you should see an output similar to below
```
msf6 auxiliary(admin/kerberos/forge_ticket) > use forge_ticket

Matching Modules
================

   #  Name                                   Disclosure Date  Rank    Check  Description
   -  ----                                   ---------------  ----    -----  -----------
   0  auxiliary/admin/kerberos/forge_ticket  .                normal  No     Kerberos Silver/Golden/Diamond/Sapphire Ticket Forging
   1    \_ action: FORGE_DIAMOND             .                .       .      Forge a Diamond Ticket
   2    \_ action: FORGE_GOLDEN              .                .       .      Forge a Golden Ticket
   3    \_ action: FORGE_SAPPHIRE            .                .       .      Forge a Sapphire Ticket
   4    \_ action: FORGE_SILVER              .                .       .      Forge a Silver Ticket
   5    \_ AKA: Ticketer                     .                .       .      .
   6    \_ AKA: Klist                        .                .       .      .
   ```
- [ ] use the forge ticket module
- [ ] run `show actions` should look like below
```
msf6 auxiliary(admin/kerberos/forge_ticket) > show actions

Auxiliary actions:

       Name            Description
       ----            -----------
       FORGE_DIAMOND   Forge a Diamond Ticket
   =>  FORGE_GOLDEN    Forge a Golden Ticket
       FORGE_SAPPHIRE  Forge a Sapphire Ticket
       FORGE_SILVER    Forge a Silver Ticket
```
- [ ] Open up the forge ticket module in your editor and add a new action
- [ ] Run `reload_all`
- [ ] Search and show actions again making sure the new action is now present
- [ ] Repeat the steps again but with `features set defer_module_loads true`

NOTE: if you get a message like `Could not verify the integrity of the Metasploit Payloads manifest` when starting framework with `defer_module_loads` set to `true` that's an unrelated issue that I'll be following up with a separate PR shortly