### PR TITLE
Autoload Metasploit Payloads Gem

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -334,6 +334,7 @@ end
 autoload :Faker, 'faker'
 autoload :BinData, 'bindata'
 autoload :RubySMB, 'ruby_smb'
+autoload :MetasploitPayloads, 'metasploit-payloads'
 
 require 'rexml/document'
 


### PR DESCRIPTION
When `defer-module-loads` was set to `true` you would get a warning `Could not verify the integrity of the Metasploit Payloads manifest` because the Metasploit Payloads gem was not being loaded in time
We're fixing that here by just having the payloads gem be autoloaded

# Verification steps
- [ ] Boot `msfconsole`
- [ ] Run `features set defer_module_loads true`
- [ ] `save`, `exit` and boot console again
- [ ] The warning should no longer appear