### PR TITLE
Put custom dns resolver behind feature flag

### DIFF
--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -82,7 +82,7 @@ class Framework
     require 'msf/core/cert_provider'
     Rex::Socket::Ssl.cert_provider = Msf::Ssl::CertProvider
 
-    if options.include?('CustomDnsResolver')
+    if options.include?('CustomDnsResolver') && Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS_FEATURE)
       self.dns_resolver = options['CustomDnsResolver']
       self.dns_resolver.set_framework(self)
       Rex::Socket._install_global_resolver(self.dns_resolver)


### PR DESCRIPTION
Resolves #18639 #18574 #18624

There is an issue with the custom dns resolver which is leading to some issues for users, I believe it was intended to be placed behind a feature flag `dns_feature` so that's what I'm doing here to resolve the issue and give us time to properly investigate the issue
