### PR TITLE
Add PostgreSQL Session Type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ PATH
       rb-readline
       recog
       redcarpet
+      reline
       rex-arch
       rex-bin_tools
       rex-core
@@ -377,7 +378,7 @@ GEM
       nokogiri
     redcarpet (3.6.0)
     regexp_parser (2.8.1)
-    reline (0.3.8)
+    reline (0.4.1)
       io-console (~> 0.5)
     require_all (3.0.0)
     rex-arch (0.1.15)

--- a/lib/metasploit/framework/login_scanner/postgres.rb
+++ b/lib/metasploit/framework/login_scanner/postgres.rb
@@ -11,6 +11,10 @@ module Metasploit
       class Postgres
         include Metasploit::Framework::LoginScanner::Base
 
+        # @returns [Boolean] If a login is successful and this attribute is true - a PostgreSQL::Client instance is used as proof,
+        #   and the socket is not immediately closed
+        attr_accessor :use_client_as_proof
+
         DEFAULT_PORT         = 5432
         DEFAULT_REALM        = 'template1'
         LIKELY_PORTS         = [ DEFAULT_PORT ]
@@ -42,7 +46,7 @@ module Metasploit
 
           begin
             pg_conn = Msf::Db::PostgresPR::Connection.new(db_name,credential.public,credential.private,uri)
-          rescue RuntimeError => e
+          rescue ::RuntimeError => e
             case e.to_s.split("\t")[1]
               when "C3D000"
                 result_options.merge!({
@@ -70,8 +74,16 @@ module Metasploit
           end
 
           if pg_conn
-            pg_conn.close
             result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
+
+            # This module no longer owns the socket so return it as proof so the calling context can perform additional operations
+            # Additionally assign values to nil to avoid closing the socket etc automatically
+            if use_client_as_proof
+              result_options[:proof] = pg_conn
+              pg_conn = nil
+            else
+              pg_conn.close
+            end
           else
             result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
           end

--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -221,6 +221,13 @@ class Config < Hash
     self.new.smb_session_history
   end
 
+  # Returns the full path to the PostgreSQL session history file.
+  #
+  # @return [String] path to the history file.
+  def self.postgresql_session_history
+    self.new.postgresql_session_history
+  end
+
   def self.pry_history
     self.new.pry_history
   end
@@ -328,6 +335,10 @@ class Config < Hash
 
   def smb_session_history
     config_directory + FileSep + "smb_session_history"
+  end
+
+  def postgresql_session_history
+    config_directory + FileSep + "postgresql_session_history"
   end
 
   def pry_history

--- a/lib/msf/base/sessions/postgresql.rb
+++ b/lib/msf/base/sessions/postgresql.rb
@@ -31,13 +31,21 @@ class Msf::Sessions::PostgreSQL
     @info = "PostgreSQL #{datastore['USERNAME']} @ #{@peer_info}"
   end
 
+  def execute_file(full_path, args)
+    if File.extname(full_path) == '.rb'
+      Rex::Script::Shell.new(self, full_path).run(args)
+    else
+      console.load_resource(full_path)
+    end
+  end
+
   def process_autoruns(datastore)
     ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
       next if datastore[key].nil? || datastore[key].empty?
 
       args = Shellwords.shellwords(datastore[key])
-      print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-      session.execute_script(args.shift, *args)
+      print_status("Session ID #{self.sid} (#{self.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
+      self.execute_script(args.shift, *args)
     end
   end
 

--- a/lib/msf/base/sessions/postgresql.rb
+++ b/lib/msf/base/sessions/postgresql.rb
@@ -1,0 +1,139 @@
+# -*- coding: binary -*-
+
+require 'rex/post/postgresql'
+
+class Msf::Sessions::PostgreSQL
+  #
+  # This interface supports basic interaction.
+  #
+  include Msf::Session::Basic
+  include Msf::Sessions::Scriptable
+
+  # @return [Rex::Post::PostgreSQL::Ui::Console] The interactive console
+  attr_accessor :console
+  # @return [PostgreSQL::Client]
+  attr_accessor :client
+  attr_accessor :platform, :arch
+
+  # @param[Rex::IO::Stream] rstream
+  # @param [Hash] opts
+  # @param opts [PostgreSQL::Client] :client
+  def initialize(rstream, opts = {})
+    @client = opts.fetch(:client)
+    @console = ::Rex::Post::PostgreSQL::Ui::Console.new(self)
+    super(rstream, opts)
+  end
+
+  def bootstrap(datastore = {}, handler = nil)
+    session = self
+    session.init_ui(user_input, user_output)
+
+    @info = "PostgreSQL #{datastore['USERNAME']} @ #{@peer_info}"
+  end
+
+  def process_autoruns(datastore)
+    ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
+      next if datastore[key].nil? || datastore[key].empty?
+
+      args = Shellwords.shellwords(datastore[key])
+      print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
+      session.execute_script(args.shift, *args)
+    end
+  end
+
+  def type
+    self.class.type
+  end
+
+  #
+  # @return [String] The type of the session
+  #
+  def self.type
+    'PostgreSQL'
+  end
+
+  #
+  # @return [Boolean] Can the session clean up after itself
+  def self.can_cleanup_files
+    false
+  end
+
+  #
+  # @return [String] The session description
+  #
+  def desc
+    'PostgreSQL'
+  end
+
+  def address
+    return @address if @address
+
+    @address, @port = @client.conn.peerinfo.split(':')
+    @address
+  end
+
+  def port
+    return @port if @port
+
+    @address, @port = @client.conn.peerinfo.split(':')
+    @port
+  end
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  # Initializes the console's I/O handles.
+  #
+  def init_ui(input, output)
+    super(input, output)
+
+    console.init_ui(input, output)
+    console.set_log_source(self.log_source)
+  end
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  # Resets the console's I/O handles.
+  #
+  def reset_ui
+    console.unset_log_source
+    console.reset_ui
+  end
+
+  def exit
+    console.stop
+  end
+
+  protected
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  # Override the basic session interaction to use shell_read and
+  # shell_write instead of operating on rstream directly.
+  def _interact
+    framework.events.on_session_interact(self)
+    framework.history_manager.with_context(name: type.to_sym) { _interact_stream }
+  end
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  def _interact_stream
+    framework.events.on_session_interact(self)
+
+    console.framework = framework
+
+    # Call the console interaction of the PostgreSQL client and
+    # pass it a block that returns whether or not we should still be
+    # interacting.  This will allow the shell to abort if interaction is
+    # canceled.
+    console.interact { interacting != true }
+    console.framework = nil
+
+    # If the stop flag has been set, then that means the user exited.  Raise
+    # the EOFError so we can drop this handle like a bad habit.
+    raise ::EOFError if (console.stopped? == true)
+  end
+end

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -97,34 +97,35 @@ module Exploit::Remote::Postgres
     db = opts[:database]       || datastore['DATABASE']
     username = opts[:username] || datastore['USERNAME']
     password = opts[:password] || datastore['PASSWORD']
-    ip = opts[:server]         || rhost
-    port = opts[:port]         || rport
+    ip = opts[:server]         || datastore['RHOST']
+    port = opts[:port]         || datastore['RPORT']
     uri = "tcp://#{ip}:#{port}"
 
     if Rex::Socket.is_ipv6?(ip)
       uri = "tcp://[#{ip}]:#{port}"
     end
 
+    verbose = opts[:verbose] || datastore['VERBOSE']
     begin
       self.postgres_conn = Connection.new(db,username,password,uri)
     rescue RuntimeError => e
       case e.to_s.split("\t")[1]
       when "C3D000"
-        vprint_status "#{ip}:#{port} Postgres - Invalid database: #{db} (Credentials '#{username}:#{password}' are OK)"
+        print_status "#{ip}:#{port} Postgres - Invalid database: #{db} (Credentials '#{username}:#{password}' are OK)" if verbose
         return :error_database # Note this means the user:pass is good!
       when "C28000", "C28P01"
-        vprint_error "#{ip}:#{port} Postgres - Invalid username or password: '#{username}':'#{password}'"
+        print_error "#{ip}:#{port} Postgres - Invalid username or password: '#{username}':'#{password}'" if verbose
         return :error_credentials
       else
-        vprint_error "#{ip}:#{port} Postgres - Error: #{e.inspect}"
+        print_error "#{ip}:#{port} Postgres - Error: #{e.inspect}" if verbose
         return :error
       end
     rescue ::Rex::ConnectionRefused => e
-      print_error "#{ip}:#{port} Postgres - Connection Refused: #{e}"
+      print_error "#{ip}:#{port} Postgres - Connection Refused: #{e}" if verbose
       return :connection_refused
     end
     if self.postgres_conn
-      vprint_good "#{ip}:#{port} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'"
+      print_good "#{ip}:#{port} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
       return :connected
     end
   end
@@ -133,9 +134,12 @@ module Exploit::Remote::Postgres
   #
   # @return [void]
   def postgres_logout
+    ip = datastore['RHOST']
+    port = datastore['RPORT']
+    verbose = datastore['VERBOSE']
     # Don't log out if we are using a session.
     if defined?(session) && session
-      vprint_status "#{rhost}:#{rport} Postgres - Skipping disconnecting from the session"
+      print_status "#{ip}:#{port} Postgres - Skipping disconnecting from the session" if verbose
       return
     end
 
@@ -143,7 +147,7 @@ module Exploit::Remote::Postgres
       self.postgres_conn.close if(self.postgres_conn.kind_of?(Connection) && self.postgres_conn.instance_variable_get("@conn"))
       self.postgres_conn = nil
     end
-    vprint_status "#{rhost}:#{rport} Postgres - Disconnected"
+    print_status "#{ip}:#{port} Postgres - Disconnected" if verbose
   end
 
   # If not currently connected, attempt to connect. If an
@@ -153,17 +157,18 @@ module Exploit::Remote::Postgres
   # @param sql [String] The query to run
   # @param doprint [Boolean] Whether the result should be printed
   # @return [Hash]
-  def postgres_query(sql = nil, doprint = false)
+  def postgres_query(sql=nil,doprint=false)
+    ip = datastore['RHOST']
+    port = datastore['RPORT']
     unless self.postgres_conn
       result = postgres_login
       unless result == :connected
         return { :conn_error => result }
       end
     end
-
     if self.postgres_conn
       sql ||= datastore['SQL']
-      vprint_status "#{rhost}:#{rport} Postgres - querying with '#{sql}'"
+      vprint_status "#{ip}:#{port} Postgres - querying with '#{sql}'"
       begin
         resp = self.postgres_conn.query(sql)
       rescue RuntimeError => e
@@ -197,9 +202,12 @@ module Exploit::Remote::Postgres
   # Otherwise, create a rowset using Rex::Text::Table (if there's
   # more than 0 rows) and return :complete.
   def postgres_print_reply(resp=nil,sql=nil)
+    ip = datastore['RHOST']
+    port = datastore['RPORT']
+    verbose = datastore['VERBOSE']
     return :error unless resp.kind_of? Connection::Result
     if resp.rows and resp.fields
-      vprint_status "#{rhost}:#{rport} Rows Returned: #{resp.rows.size}"
+      print_status "#{ip}:#{port} Rows Returned: #{resp.rows.size}" if verbose
       if resp.rows.size > 0
         tbl = Rex::Text::Table.new(
           'Indent' => 4,
@@ -226,14 +234,15 @@ module Exploit::Remote::Postgres
     db = args[:database]       || datastore['DATABASE']
     username = args[:username] || datastore['USERNAME']
     password = args[:password] || datastore['PASSWORD']
-    ip = args[:server]         || rhost
-    port = args[:port]         || rport
+    rhost = args[:server]      || datastore['RHOST']
+    rport = args[:port]        || datastore['RPORT']
 
-    uri = "tcp://#{ip}:#{port}"
-    if Rex::Socket.is_ipv6?(ip)
-      uri = "tcp://[#{ip}]:#{port}"
+    uri = "tcp://#{rhost}:#{rport}"
+    if Rex::Socket.is_ipv6?(rhost)
+      uri = "tcp://[#{rhost}]:#{rport}"
     end
 
+    verbose = args[:verbose]   || datastore['VERBOSE']
     begin
       self.postgres_conn = Connection.new(db,username,password,uri)
     rescue RuntimeError => e

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -119,6 +119,9 @@ module Exploit::Remote::Postgres
         vprint_error "#{ip}:#{port} Postgres - Error: #{e.inspect}"
         return :error
       end
+    rescue ::Rex::ConnectionRefused => e
+      print_error "#{ip}:#{port} Postgres - Connection Refused: #{e}"
+      return :connection_refused
     end
     if self.postgres_conn
       vprint_good "#{ip}:#{port} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'"

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -88,36 +88,40 @@ module Exploit::Remote::Postgres
   # @return [:error] if some other error occurred
   # @return [:connected] if everything went as planned
   def postgres_login(opts={})
+    unless defined?(session).nil? || session.nil?
+      self.postgres_conn = session.client
+      return :connected
+    end
+
     postgres_logout if self.postgres_conn
     db = opts[:database]       || datastore['DATABASE']
     username = opts[:username] || datastore['USERNAME']
     password = opts[:password] || datastore['PASSWORD']
-    ip = opts[:server]         || datastore['RHOST']
-    port = opts[:port]         || datastore['RPORT']
+    ip = opts[:server]         || rhost
+    port = opts[:port]         || rport
     uri = "tcp://#{ip}:#{port}"
 
     if Rex::Socket.is_ipv6?(ip)
       uri = "tcp://[#{ip}]:#{port}"
     end
 
-    verbose = opts[:verbose]   || datastore['VERBOSE']
     begin
       self.postgres_conn = Connection.new(db,username,password,uri)
     rescue RuntimeError => e
       case e.to_s.split("\t")[1]
       when "C3D000"
-        print_status "#{ip}:#{port} Postgres - Invalid database: #{db} (Credentials '#{username}:#{password}' are OK)" if verbose
+        vprint_status "#{ip}:#{port} Postgres - Invalid database: #{db} (Credentials '#{username}:#{password}' are OK)"
         return :error_database # Note this means the user:pass is good!
       when "C28000", "C28P01"
-        print_error "#{ip}:#{port} Postgres - Invalid username or password: '#{username}':'#{password}'" if verbose
+        vprint_error "#{ip}:#{port} Postgres - Invalid username or password: '#{username}':'#{password}'"
         return :error_credentials
       else
-        print_error "#{ip}:#{port} Postgres - Error: #{e.inspect}" if verbose
+        vprint_error "#{ip}:#{port} Postgres - Error: #{e.inspect}"
         return :error
       end
     end
     if self.postgres_conn
-      print_good "#{ip}:#{port} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
+      vprint_good "#{ip}:#{port} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'"
       return :connected
     end
   end
@@ -126,14 +130,17 @@ module Exploit::Remote::Postgres
   #
   # @return [void]
   def postgres_logout
-    ip = datastore['RHOST']
-    port = datastore['RPORT']
-    verbose = datastore['VERBOSE']
+    # Don't log out if we are using a session.
+    if defined?(session) && session
+      vprint_status "#{rhost}:#{rport} Postgres - Skipping disconnecting from the session"
+      return
+    end
+
     if self.postgres_conn
       self.postgres_conn.close if(self.postgres_conn.kind_of?(Connection) && self.postgres_conn.instance_variable_get("@conn"))
       self.postgres_conn = nil
     end
-    print_status "#{ip}:#{port} Postgres - Disconnected" if verbose
+    vprint_status "#{rhost}:#{rport} Postgres - Disconnected"
   end
 
   # If not currently connected, attempt to connect. If an
@@ -143,16 +150,17 @@ module Exploit::Remote::Postgres
   # @param sql [String] The query to run
   # @param doprint [Boolean] Whether the result should be printed
   # @return [Hash]
-  def postgres_query(sql=nil,doprint=false)
-    ip = datastore['RHOST']
-    port = datastore['RPORT']
-    postgres_login unless self.postgres_conn
+  def postgres_query(sql = nil, doprint = false)
     unless self.postgres_conn
-      return {:conn_error => true}
+      result = postgres_login
+      unless result == :connected
+        return { :conn_error => result }
+      end
     end
+
     if self.postgres_conn
       sql ||= datastore['SQL']
-      vprint_status "#{ip}:#{port} Postgres - querying with '#{sql}'"
+      vprint_status "#{rhost}:#{rport} Postgres - querying with '#{sql}'"
       begin
         resp = self.postgres_conn.query(sql)
       rescue RuntimeError => e
@@ -186,12 +194,9 @@ module Exploit::Remote::Postgres
   # Otherwise, create a rowset using Rex::Text::Table (if there's
   # more than 0 rows) and return :complete.
   def postgres_print_reply(resp=nil,sql=nil)
-    ip = datastore['RHOST']
-    port = datastore['RPORT']
-    verbose = datastore['VERBOSE']
     return :error unless resp.kind_of? Connection::Result
     if resp.rows and resp.fields
-      print_status "#{ip}:#{port} Rows Returned: #{resp.rows.size}" if verbose
+      vprint_status "#{rhost}:#{rport} Rows Returned: #{resp.rows.size}"
       if resp.rows.size > 0
         tbl = Rex::Text::Table.new(
           'Indent' => 4,
@@ -218,15 +223,14 @@ module Exploit::Remote::Postgres
     db = args[:database]       || datastore['DATABASE']
     username = args[:username] || datastore['USERNAME']
     password = args[:password] || datastore['PASSWORD']
-    rhost = args[:server]      || datastore['RHOST']
-    rport = args[:port]        || datastore['RPORT']
+    ip = args[:server]         || rhost
+    port = args[:port]         || rport
 
-    uri = "tcp://#{rhost}:#{rport}"
-    if Rex::Socket.is_ipv6?(rhost)
-      uri = "tcp://[#{rhost}]:#{rport}"
+    uri = "tcp://#{ip}:#{port}"
+    if Rex::Socket.is_ipv6?(ip)
+      uri = "tcp://[#{ip}]:#{port}"
     end
 
-    verbose = args[:verbose]   || datastore['VERBOSE']
     begin
       self.postgres_conn = Connection.new(db,username,password,uri)
     rescue RuntimeError => e

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -23,6 +23,7 @@ module Msf
     DNS_FEATURE = 'dns_feature'
     HIERARCHICAL_SEARCH_TABLE = 'hierarchical_search_table'
     SMB_SESSION_TYPE = 'smb_session_type'
+    POSTGRESQL_SESSION_TYPE = 'postgresql_session_type'
     DEFAULTS = [
       {
         name: WRAPPED_TABLES,
@@ -66,6 +67,12 @@ module Msf
       {
         name: SMB_SESSION_TYPE,
         description: 'When enabled will allow for the creation/use of smb sessions',
+        requires_restart: true,
+        default_value: false
+      }.freeze,
+      {
+        name: POSTGRESQL_SESSION_TYPE,
+        description: 'When enabled will allow for the creation/use of PostgreSQL sessions',
         requires_restart: true,
         default_value: false
       }.freeze,

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -9,7 +9,6 @@ module Msf::OptionalSession
 
   def initialize(info = {})
     super
-
     if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
       register_options(
         [
@@ -19,10 +18,22 @@ module Msf::OptionalSession
         ]
       )
     end
+
+    if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
+      register_options(
+        [
+          Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
+          Msf::OptString.new('DATABASE', [ false, 'The database to authenticate against', 'postgres']),
+          Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'postgres']),
+          Msf::Opt::RHOST(nil, false),
+          Msf::Opt::RPORT(nil, false)
+        ]
+      )
+    end
   end
 
   def session
-    return nil unless framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+    return nil unless (framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE) || framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE))
 
     super
   end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -25,11 +25,13 @@ module Msf::Post::Common
   def rhost
     return super unless defined?(session) and session
 
-    case session.type
+    case session.type.downcase
     when 'meterpreter'
       session.sock.peerhost
     when 'shell', 'powershell'
       session.session_host
+    when 'postgresql'
+      session.address
     end
   rescue
     return nil
@@ -38,11 +40,13 @@ module Msf::Post::Common
   def rport
     return super unless defined?(session) and session
 
-    case session.type
+    case session.type.downcase
     when 'meterpreter'
       session.sock.peerport
     when 'shell', 'powershell'
       session.session_port
+    when 'postgresql'
+      session.port
     end
   rescue
     return nil

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -187,6 +187,7 @@ class MsfAutoload
       'cli' => 'CLI',
       'sqlitei' => 'SQLitei',
       'mysqli' => 'MySQLi',
+      'postgresql' => 'PostgreSQL',
       'postgresqli' => 'PostgreSQLi',
       'ssh' => 'SSH',
       'winrm' => 'WinRM',

--- a/lib/postgres/postgres-pr/connection.rb
+++ b/lib/postgres/postgres-pr/connection.rb
@@ -60,7 +60,7 @@ class Connection
     uri ||= DEFAULT_URI
 
     @transaction_status = nil
-    @params = {}
+    @params = { 'username' => user, 'database' => database }
     establish_connection(uri)
 
     # Check if the password supplied is a Postgres-style md5 hash

--- a/lib/rex/post.rb
+++ b/lib/rex/post.rb
@@ -3,6 +3,7 @@
 # Post-exploitation clients
 require 'rex/post/meterpreter'
 require 'rex/post/smb'
+require 'rex/post/postgresql'
 
 module Rex::Post
 

--- a/lib/rex/post/postgresql.rb
+++ b/lib/rex/post/postgresql.rb
@@ -1,0 +1,3 @@
+# -*- coding: binary -*-
+
+require 'rex/post/postgresql/ui'

--- a/lib/rex/post/postgresql/ui.rb
+++ b/lib/rex/post/postgresql/ui.rb
@@ -1,0 +1,3 @@
+# -*- coding: binary -*-
+
+require 'rex/post/postgresql/ui/console'

--- a/lib/rex/post/postgresql/ui/console.rb
+++ b/lib/rex/post/postgresql/ui/console.rb
@@ -1,0 +1,135 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    module PostgreSQL
+      module Ui
+        ###
+        #
+        # This class provides a shell driven interface to the PostgreSQL client API.
+        #
+        ###
+        class Console
+          include Rex::Ui::Text::DispatcherShell
+
+          # Dispatchers
+          require 'rex/post/postgresql/ui/console/command_dispatcher'
+          require 'rex/post/postgresql/ui/console/command_dispatcher/core'
+          require 'rex/post/postgresql/ui/console/command_dispatcher/client'
+          require 'rex/post/postgresql/ui/console/command_dispatcher/modules'
+
+          #
+          # Initialize the PostgreSQL console.
+          #
+          # @param [Msf::Sessions::PostgreSQL] session
+          def initialize(session)
+            # The postgresql client context
+            self.session = session
+            self.client = session.client
+            self.cwd = client.params['database']
+            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{cwd})%clr"
+            history_manager = Msf::Config.postgresql_session_history
+            super(prompt, '>', history_manager, nil, :postgresql)
+
+            # Queued commands array
+            self.commands = []
+
+            # Point the input/output handles elsewhere
+            reset_ui
+
+            enstack_dispatcher(::Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Core)
+            enstack_dispatcher(::Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Client)
+            enstack_dispatcher(::Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Modules)
+
+            # Set up logging to whatever logsink 'core' is using
+            if ! $dispatcher['postgresql']
+              $dispatcher['postgresql'] = $dispatcher['core']
+            end
+          end
+
+          #
+          # Called when someone wants to interact with the postgresql client.  It's
+          # assumed that init_ui has been called prior.
+          #
+          def interact(&block)
+            # Run queued commands
+            commands.delete_if do |ent|
+              run_single(ent)
+              true
+            end
+
+            # Run the interactive loop
+            run do |line|
+              # Run the command
+              run_single(line)
+
+              # If a block was supplied, call it, otherwise return false
+              if block
+                block.call
+              else
+                false
+              end
+            end
+          end
+
+          #
+          # Queues a command to be run when the interactive loop is entered.
+          #
+          def queue_cmd(cmd)
+            self.commands << cmd
+          end
+
+          #
+          # Runs the specified command wrapper in something to catch meterpreter
+          # exceptions.
+          #
+          def run_command(dispatcher, method, arguments)
+            begin
+              super
+            rescue ::Timeout::Error
+              log_error('Operation timed out.')
+            rescue ::Rex::InvalidDestination => e
+              log_error(e.message)
+            rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
+              self.session.kill
+            rescue ::StandardError => e
+              log_error("Error running command #{method}: #{e.class} #{e}")
+              elog(e)
+            end
+          end
+
+          #
+          # Logs that an error occurred and persists the callstack.
+          #
+          def log_error(msg)
+            print_error(msg)
+
+            elog(msg, 'postgresql')
+
+            dlog("Call stack:\n#{$@.join("\n")}", 'postgresql')
+          end
+
+          # @return [Msf::Sessions::PostgreSQL]
+          attr_reader :session
+
+          # @return [PostgreSQL::Client]
+          attr_reader :client # :nodoc:
+
+          # @return [String]
+          attr_accessor :cwd
+
+          def format_prompt(val)
+            cwd ||= client.params['database']
+            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{cwd})%clr > "
+            substitute_colors(prompt, true)
+          end
+
+          protected
+
+          attr_writer :session, :client # :nodoc:
+          attr_accessor :commands # :nodoc:
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher.rb
@@ -1,0 +1,103 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/dispatcher_shell'
+
+module Rex
+  module Post
+    module PostgreSQL
+      module Ui
+        ###
+        #
+        # Base class for all command dispatchers within the PostgreSQL console user interface.
+        #
+        ###
+        module Console::CommandDispatcher
+          include Msf::Ui::Console::CommandDispatcher::Session
+
+          #
+          # Initializes an instance of the core command set using the supplied session and client
+          # for interactivity.
+          #
+          # @param [Rex::Post::PostgreSQL::Ui::Console] console
+          def initialize(console)
+            super
+            @msf_loaded = nil
+            @filtered_commands = []
+          end
+
+          #
+          # Returns the PostgreSQL client context.
+          #
+          # @return [PostgreSQL::Client]
+          def client
+            console = shell
+            console.client
+          end
+
+          #
+          # Returns the PostgreSQL session context.
+          #
+          # @return [Msf::Sessions::PostgreSQL]
+          def session
+            console = shell
+            console.session
+          end
+
+          #
+          # Returns the commands that meet the requirements
+          #
+          def filter_commands(all, reqs)
+            all.delete_if do |cmd, _desc|
+              if reqs[cmd]&.any? { |req| !client.commands.include?(req) }
+                @filtered_commands << cmd
+                true
+              end
+            end
+          end
+
+          def unknown_command(cmd, line)
+            if @filtered_commands.include?(cmd)
+              print_error("The \"#{cmd}\" command is not supported by this session type (#{session.session_type})")
+              return :handled
+            end
+
+            super
+          end
+
+          #
+          # Return the subdir of the `documentation/` directory that should be used
+          # to find usage documentation
+          #
+          def docs_dir
+            ::File.join(super, 'postgresql_session')
+          end
+
+          #
+          # Returns true if the client has a framework object.
+          #
+          # Used for firing framework session events
+          #
+          def msf_loaded?
+            return @msf_loaded unless @msf_loaded.nil?
+
+            # if we get here we must not have initialized yet
+
+            @msf_loaded = !session.framework.nil?
+            @msf_loaded
+          end
+
+          #
+          # Log that an error occurred.
+          #
+          def log_error(msg)
+            print_error(msg)
+
+            elog(msg, 'postgresql')
+
+            dlog("Call stack:\n#{$ERROR_POSITION.join("\n")}", 'postgresql')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
@@ -95,7 +95,7 @@ module Rex
                 return
               end
 
-              formatted_query = raw_query.split.map { |word| word.chomp('\\') }.reject(&:empty?).compact.join(' ')
+              formatted_query = process_query(query: raw_query)
 
               unless formatted_query.empty?
                 print_status "Running SQL Command: '#{formatted_query}'"
@@ -154,6 +154,12 @@ module Rex
               table = format_result(result)
               print_line(table.to_s)
             end
+          end
+
+          def process_query(query: '')
+            return '' if query.empty?
+
+            query.lines.each.map { |line| line.chomp("\\\n").strip }.reject(&:empty?).compact.join(' ')
           end
         end
       end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
@@ -61,11 +61,10 @@ module Rex
           end
 
           def cmd_shell(*args)
-            cmd_shell_help && return if help_args?(args)
-
-            prompt_proc_before = ::Reline.prompt_proc
-
-            ::Reline.prompt_proc = proc { |line_buffer| line_buffer.each_with_index.map { |_line, i| i > 0 ? 'SQL *> ' : 'SQL >> ' } }
+            if help_args?(args)
+              cmd_shell_help
+              return
+            end
 
             stop_words = %w[stop s exit e end quit q].freeze
 
@@ -73,13 +72,19 @@ module Rex
             finished = false
             until finished
               begin
+                # This needs to be here, otherwise the `ensure` block would reset it to the previous
+                # value after a single query, meaning future queries would have the default prompt_block.
+                prompt_proc_before = ::Reline.prompt_proc
+                ::Reline.prompt_proc = proc { |line_buffer| line_buffer.each_with_index.map { |_line, i| i > 0 ? 'SQL *> ' : 'SQL >> ' } }
+
                 # This will loop until it receives `true`.
                 raw_query = ::Reline.readmultiline('SQL >> ', use_history = true) do |multiline_input|
-                  finished = stop_words.include?(multiline_input.split.last)
+                  # In the case only a stop word was input, exit out of the REPL shell
+                  finished = multiline_input.split.count == 1 && stop_words.include?(multiline_input.split.last)
                   # Accept the input until the current line does not end with '\', similar to a shell
-                  finished || !multiline_input.split.last.end_with?('\\')
+                  finished || multiline_input.split.empty? || !multiline_input.split.last&.end_with?('\\')
                 end
-              rescue ::Interrupt
+              rescue ::Interrupt => _e
                 finished = true
               ensure
                 ::Reline.prompt_proc = prompt_proc_before
@@ -92,16 +97,22 @@ module Rex
 
               formatted_query = raw_query.split.map { |word| word.chomp('\\') }.reject(&:empty?).compact.join(' ')
 
-              print_status "Running SQL Command: '#{formatted_query}'"
-              cmd_query(formatted_query)
+              unless formatted_query.empty?
+                print_status "Running SQL Command: '#{formatted_query}'"
+                cmd_query(formatted_query)
+              end
             end
           end
 
           def cmd_query_help
             print_line 'Usage: query'
             print_line
-            print_line 'You can also use `sql`.'
             print_line 'Run a raw SQL query on the target.'
+            print_line
+            print_line 'Examples:'
+            print_line "\tquery SELECT user;"
+            print_line "\tquery SELECT version();"
+            print_line "\tquery SELECT * FROM pg_catalog.pg_tables;"
             print_line
           end
 
@@ -123,16 +134,27 @@ module Rex
           end
 
           def cmd_query(*args)
-            cmd_query_help && return if help_args?(args)
+            if help_args?(args)
+              cmd_query_help
+              return
+            end
 
-            result = client.query(args.join(' ').to_s)
-            table = format_result(result)
+            begin
+              result = client.query(args.join(' ').to_s)
+            rescue ::RuntimeError => e
+              print_error "Query result: #{e}"
+              print_line
+              return
+            end
 
-            print_line(table.to_s)
+            print_status result.cmd_tag
+            print_line
+
+            unless result.rows.empty?
+              table = format_result(result)
+              print_line(table.to_s)
+            end
           end
-
-          alias cmd_sql cmd_query
-          alias cmd_sql_help cmd_query_help
         end
       end
     end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
@@ -1,0 +1,140 @@
+# -*- coding: binary -*-
+
+require 'pathname'
+require 'reline'
+
+module Rex
+  module Post
+    module PostgreSQL
+      module Ui
+
+        ###
+        #
+        # Core PostgreSQL client commands
+        #
+        ###
+        class Console::CommandDispatcher::Client
+
+          include Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher
+
+          #
+          # Initializes an instance of the core command set using the supplied console
+          # for interactivity.
+          #
+          # @param [Rex::Post::PostgreSQL::Ui::Console] console
+          def initialize(console)
+            super
+
+            @db_search_results = []
+          end
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            cmds = {
+              'query'   => 'Run a raw SQL query',
+              'shell'   => 'Enter a raw shell where SQL queries can be executed',
+            }
+
+            reqs = {}
+
+            filter_commands(cmds, reqs)
+          end
+
+          def name
+            'PostgreSQL Client'
+          end
+
+          def help_args?(args)
+            return false unless args.instance_of?(::Array)
+
+            args.include?('-h') || args.include?('--help')
+          end
+
+          def cmd_shell_help
+            print_line 'Usage: shell'
+            print_line
+            print_line 'Go into a raw SQL shell where SQL queries can be executed.'
+            print_line 'To exit, type `exit`, `quit`, `end` or `stop`.'
+            print_line
+          end
+
+          def cmd_shell(*args)
+            cmd_shell_help && return if help_args?(args)
+
+            prompt_proc_before = ::Reline.prompt_proc
+
+            ::Reline.prompt_proc = proc { |line_buffer| line_buffer.each_with_index.map { |_line, i| i > 0 ? 'SQL *> ' : 'SQL >> ' } }
+
+            stop_words = %w[stop s exit e end quit q].freeze
+
+            # Allow the user to query the DB in a loop.
+            finished = false
+            until finished
+              begin
+                # This will loop until it receives `true`.
+                raw_query = ::Reline.readmultiline('SQL >> ', use_history = true) do |multiline_input|
+                  finished = stop_words.include?(multiline_input.split.last)
+                  # Accept the input until the current line does not end with '\', similar to a shell
+                  finished || !multiline_input.split.last.end_with?('\\')
+                end
+              rescue ::Interrupt
+                finished = true
+              ensure
+                ::Reline.prompt_proc = prompt_proc_before
+              end
+
+              if finished
+                print_status 'Exiting Shell mode.'
+                return
+              end
+
+              formatted_query = raw_query.split.map { |word| word.chomp('\\') }.reject(&:empty?).compact.join(' ')
+
+              print_status "Running SQL Command: '#{formatted_query}'"
+              cmd_query(formatted_query)
+            end
+          end
+
+          def cmd_query_help
+            print_line 'Usage: query'
+            print_line
+            print_line 'You can also use `sql`.'
+            print_line 'Run a raw SQL query on the target.'
+            print_line
+          end
+
+          #
+          # @param [::Msf::Db::PostgresPR::Connection::Result] result The result of an SQL query to format.
+          def format_result(result)
+            columns = ['#']
+            columns.append(result.fields.map.each { |field| field[:name] })
+            flat_columns = columns.flatten
+
+            ::Rex::Text::Table.new(
+              'Header' => 'Query',
+              'Indent' => 4,
+              'Columns' => flat_columns,
+              'Rows' => result.rows.map.each.with_index do |row, i|
+                [i, row].flatten
+              end
+            )
+          end
+
+          def cmd_query(*args)
+            cmd_query_help && return if help_args?(args)
+
+            result = client.query(args.join(' ').to_s)
+            table = format_result(result)
+
+            print_line(table.to_s)
+          end
+
+          alias cmd_sql cmd_query
+          alias cmd_sql_help cmd_query_help
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/core.rb
@@ -1,0 +1,50 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    module PostgreSQL
+      module Ui
+
+        ###
+        #
+        # Core PostgreSQL client commands
+        #
+        ###
+        class Console::CommandDispatcher::Core
+
+          include Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            cmds = {
+              '?'                        => 'Help menu',
+              'background'               => 'Backgrounds the current session',
+              'bg'                       => 'Alias for background',
+              'exit'                     => 'Terminate the PostgreSQL session',
+              'help'                     => 'Help menu',
+              'irb'                      => 'Open an interactive Ruby shell on the current session',
+              'pry'                      => 'Open the Pry debugger on the current session',
+              'sessions'                 => 'Quickly switch to another session',
+            }
+
+            reqs = {}
+
+            filter_commands(cmds, reqs)
+          end
+
+          def name
+            'Core'
+          end
+
+          def unknown_command(cmd, line)
+            status = super
+
+            status
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/modules.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/modules.rb
@@ -37,9 +37,13 @@ module Rex
           end
 
           def cmd_run_help
-            print_line 'Usage: Modules'
+            print_line 'Usage: run'
             print_line
-            print_line 'Run a module.'
+            print_line 'Run a module or script against the current session.'
+            print_line
+            print_line 'Example:'
+            print_line "\trun auxiliary/scanner/postgres/postgres_schemadump"
+            print_line "\trun my_erb_script.rc"
             print_line
           end
 

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/modules.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/modules.rb
@@ -1,0 +1,95 @@
+# -*- coding: binary -*-
+
+require 'pathname'
+
+module Rex
+  module Post
+    module PostgreSQL
+      module Ui
+        ###
+        #
+        # PostgreSQL client commands for running modules
+        #
+        ###
+        class Console::CommandDispatcher::Modules
+
+          include Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher
+
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            cmds = {
+              'run' => 'Run a module'
+            }
+
+            reqs = {}
+
+            filter_commands(cmds, reqs)
+          end
+
+          #
+          # Modules
+          #
+          def name
+            'Modules'
+          end
+
+          def cmd_run_help
+            print_line 'Usage: Modules'
+            print_line
+            print_line 'Run a module.'
+            print_line
+          end
+
+          #
+          # Executes a module/script in the context of the PostgreSQL session.
+          #
+          def cmd_run(*args)
+            if args.empty? || args.first == '-h' || args.first == '--help'
+              cmd_run_help
+              return true
+            end
+
+            # Get the script name
+            begin
+              script_name = args.shift
+              # First try it as a module if we have access to the Metasploit
+              # Framework instance.  If we don't, or if no such module exists,
+              # fall back to using the scripting interface.
+              if msf_loaded? && (mod = session.framework.modules.create(script_name))
+                original_mod = mod
+                reloaded_mod = session.framework.modules.reload_module(original_mod)
+
+                unless reloaded_mod
+                  error = session.framework.modules.module_load_error_by_path[original_mod.file_path]
+                  print_error("Failed to reload module: #{error}")
+
+                  return
+                end
+
+                opts = ''
+
+                opts << (args + [ "SESSION=#{session.sid}" ]).join(',')
+                result = reloaded_mod.run_simple(
+                  'LocalInput' => shell.input,
+                  'LocalOutput' => shell.output,
+                  'OptionStr' => opts
+                )
+
+                print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
+              else
+                # the rest of the arguments get passed in through the binding
+                session.execute_script(script_name, args)
+              end
+            rescue StandardError => e
+              print_error("Error in script: #{script_name}")
+              elog("Error in script: #{script_name}", error: e)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -244,4 +244,6 @@ Gem::Specification.new do |spec|
   # Do not use this to process untrusted PNG files! This is only to be used
   # to generate PNG files, not to parse untrusted PNG files.
   spec.add_runtime_dependency 'chunky_png'
+
+  spec.add_runtime_dependency 'reline'
 end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -245,5 +245,6 @@ Gem::Specification.new do |spec|
   # to generate PNG files, not to parse untrusted PNG files.
   spec.add_runtime_dependency 'chunky_png'
 
+  # Needed for multiline REPL support for interactive SQL sessions
   spec.add_runtime_dependency 'reline'
 end

--- a/spec/lib/msf/base/sessions/postgresql_spec.rb
+++ b/spec/lib/msf/base/sessions/postgresql_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'postgres/postgres-pr/connection'
+
+RSpec.describe Msf::Sessions::PostgreSQL do
+  let(:rstream) { instance_double(::Rex::Socket) }
+  let(:client) { instance_double(Msf::Db::PostgresPR::Connection) }
+  let(:opts) { { client: client } }
+  let(:console_class) { Rex::Post::PostgreSQL::Ui::Console }
+  let(:user_input) { instance_double(Rex::Ui::Text::Input::Readline) }
+  let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }
+  let(:name) { 'postgresql' }
+  let(:log_source) { "session_#{name}" }
+  let(:type) { 'PostgreSQL' }
+  let(:description) { 'PostgreSQL' }
+  let(:can_cleanup_files) { false }
+  let(:address) { '192.0.2.1' }
+  let(:port) { '5432' }
+  let(:peer_info) { "#{address}:#{port}" }
+  let(:postgres_db) { 'template1' }
+
+  before(:each) do
+    allow(user_input).to receive(:intrinsic_shell?).and_return(true)
+    allow(user_input).to receive(:output=)
+    allow(rstream).to receive(:peerinfo).and_return(peer_info)
+    allow(client).to receive(:conn).and_return(rstream)
+    allow(client).to receive(:params).and_return({ 'database' => postgres_db })
+  end
+
+  subject(:session) do
+    postgresql_session = described_class.new(rstream, opts)
+    postgresql_session.user_input = user_input
+    postgresql_session.user_output = user_output
+    postgresql_session.name = name
+    postgresql_session
+  end
+
+  describe '.type' do
+    it 'should have the correct type' do
+      expect(described_class.type).to eq(type)
+    end
+  end
+
+  describe '.can_cleanup_files' do
+    it 'should be able to cleanup files' do
+      expect(described_class.can_cleanup_files).to eq(can_cleanup_files)
+    end
+  end
+
+  describe '#desc' do
+    it 'should have the correct description' do
+      expect(subject.desc).to eq(description)
+    end
+  end
+
+  describe '#type' do
+    it 'should have the correct type' do
+      expect(subject.type).to eq(type)
+    end
+  end
+
+  describe '#initialize' do
+    context 'without a client' do
+      let(:opts) { {} }
+
+      it 'raises a KeyError' do
+        expect { subject }.to raise_exception(KeyError)
+      end
+    end
+    context 'with a client' do
+      it 'does not raise an exception' do
+        expect { subject }.not_to raise_exception
+      end
+    end
+
+    it 'creates a new console' do
+      expect(subject.console).to be_a(console_class)
+    end
+  end
+
+  describe '#bootstrap' do
+    subject { session.bootstrap }
+
+    it 'keeps the sessions user input' do
+      expect { subject }.not_to change(session, :user_input).from(user_input)
+    end
+
+    it 'keeps the sessions user output' do
+      expect { subject }.not_to change(session, :user_output).from(user_output)
+    end
+
+    it 'sets the console input' do
+      expect { subject }.to change(session.console, :input).to(user_input)
+    end
+
+    it 'sets the console output' do
+      expect { subject }.to change(session.console, :output).to(user_output)
+    end
+
+    it 'sets the log source' do
+      expect { subject }.to change(session.console, :log_source).to(log_source)
+    end
+  end
+
+  describe '#reset_ui' do
+    before(:each) do
+      session.bootstrap
+    end
+
+    subject { session.reset_ui }
+
+    it 'keeps the sessions user input' do
+      expect { subject }.not_to change(session, :user_input).from(user_input)
+    end
+
+    it 'keeps the sessions user output' do
+      expect { subject }.not_to change(session, :user_output).from(user_output)
+    end
+
+    it 'resets the console input' do
+      expect { subject }.to change(session.console, :input).from(user_input).to(nil)
+    end
+
+    it 'resets the console output' do
+      expect { subject }.to change(session.console, :output).from(user_output).to(nil)
+    end
+  end
+
+  describe '#exit' do
+    subject { session.exit }
+
+    it 'exits the session' do
+      expect { subject }.to change(session.console, :stopped?).from(false).to(true)
+    end
+  end
+
+  describe '#address' do
+    subject { session.address }
+
+    it { is_expected.to eq(address) }
+  end
+
+  describe '#port' do
+    subject { session.port }
+
+    it { is_expected.to eq(port) }
+  end
+end

--- a/spec/lib/rex/post/postgresql/ui/console/command_dispatcher/client_spec.rb
+++ b/spec/lib/rex/post/postgresql/ui/console/command_dispatcher/client_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/post/postgresql'
+
+RSpec.describe Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Client do
+  let (:client) { described_class.new(nil) }
+
+  before(:each) do
+    allow(client).to receive(:process_query).and_call_original
+  end
+
+  describe '.process_query' do
+    [
+      { query: "SELECT \\\nVERSION();", result: 'SELECT VERSION();' },
+      { query: "SELECT \VERSION();", result: 'SELECT VERSION();' },
+      { query: "SELECT * \\\nFROM dummy_table\\\nWHERE name='example_name'\\\n;", result: "SELECT * FROM dummy_table WHERE name='example_name' ;" },
+      { query: "SELECT \\\n* FROM dummy_table\\\n WHERE name='example_name';\n", result: "SELECT * FROM dummy_table WHERE name='example_name';" },
+      { query: "INSERT INTO dummy_table VALUES (\\\n'username' \\\n'password_!@£$%^&*()\\'\\\n);", result: "INSERT INTO dummy_table VALUES ( 'username' 'password_!@£$%^&*()\\' );" },
+      { query: "DELETE\\\n FROM\\\n dummy_table\\\n WHERE\\\n field='\"\\'\\\n;", result: "DELETE FROM dummy_table WHERE field='\"\\' ;" },
+      { query: "SELECT * FROM dummy_table WHERE field='example\\\nfield'", result: "SELECT * FROM dummy_table WHERE field='example field'" },
+    ].each do |expected|
+      it 'returns the expected value' do
+        expect(client.process_query(query: expected[:query])).to eq(expected[:result])
+      end
+    end
+  end
+end

--- a/spec/lib/rex/post/postgresql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/postgresql/ui/console/command_dispatcher/core_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/post/postgresql/ui/console'
+require 'postgres/postgres-pr/connection'
+
+RSpec.describe Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Core do
+  let(:rstream) { instance_double(::Rex::Socket) }
+  let(:client) { instance_double(Msf::Db::PostgresPR::Connection) }
+  let(:address) { '192.0.2.1' }
+  let(:port) { '5432' }
+  let(:postgres_db) { 'template1' }
+  let(:peer_info) { "#{address}:#{port}" }
+  let(:session) { Msf::Sessions::PostgreSQL.new(nil, { client: client }) }
+  let(:console) do
+    console = Rex::Post::PostgreSQL::Ui::Console.new(session)
+    console.disable_output = true
+    console
+  end
+
+  before(:each) do
+    allow(client).to receive(:conn).and_return(rstream)
+    allow(client).to receive(:params).and_return({ 'database' => postgres_db })
+    allow(rstream).to receive(:peerinfo).and_return(peer_info)
+    allow(session).to receive(:client).and_return(client)
+    allow(session).to receive(:console).and_return(console)
+    allow(session).to receive(:name).and_return('test client name')
+    allow(session).to receive(:sid).and_return('test client sid')
+  end
+
+  subject(:command_dispatcher) { described_class.new(session.console) }
+
+  it_behaves_like 'session command dispatcher'
+end


### PR DESCRIPTION
This PR adds a new session type for PostgreSQL sessions. It also changes the PostgreSQL login scanner module so that you can get a PostgreSQL session. Modules using this PostgreSQL session type will be added as a separate PR, similar to the SMB session type PR here: https://github.com/rapid7/metasploit-framework/pull/18539

The PostgreSQL session is also behind a feature flag and can be enabled with `features set postgresql_session_type true` in msfconsole (don't forget to save and relaunch msfconsole).

## Example PostgreSQL Session Interaction
Getting a session:
<details>

```ruby
msf6 auxiliary(scanner/postgres/postgres_login) > run CreateSession=true rhosts=127.0.0.1 rport=5432 username=postgres password=password database=template1

[+] 127.0.0.1:5432 - Login Successful: postgres:password@template1
[*] PostgreSQL session 1 opened (127.0.0.1:51969 -> 127.0.0.1:5432) at 2024-01-04 15:32:34 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf6 auxiliary(scanner/postgres/postgres_login) > sessions

Active sessions
===============

  Id  Name  Type        Information                           Connection
  --  ----  ----        -----------                           ----------
  1         PostgreSQL  PostgreSQL postgres @ 127.0.0.1:5432  127.0.0.1:51969 -> 127.0.0.1:5432 (127.0.0.1)
```

</details>

Interacting with a session:
<details>

```ruby
msf6 auxiliary(scanner/postgres/postgres_login) > sessions -i -1
[*] Starting interaction with 1...

PostgreSQL @ 127.0.0.1:5432 > help

Core Commands
=============

    Command       Description
    -------       -----------
    ?             Help menu
    background    Backgrounds the current session
    bg            Alias for background
    exit          Terminate the PostgreSQL session
    help          Help menu
    irb           Open an interactive Ruby shell on the current session
    pry           Open the Pry debugger on the current session
    sessions      Quickly switch to another session


PostgreSQL Client Commands
==========================

    Command       Description
    -------       -----------
    db            View the available databases and interact with one
    query         Run a raw SQL query
    shell         Enter a raw shell where SQL queries can be executed
    sql           Run a raw SQL query
    tables        View the available tables in the currently selected DB
```

</details>

Example command usage:

<details>

### Running Queries
```ruby
PostgreSQL @ 127.0.0.1:5432 > query 'select version()'
Query
=====

    #  version
    -  -------
    0  PostgreSQL 16.0 (Debian 16.0-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
```

### Listing Databases
```ruby
PostgreSQL @ 127.0.0.1:5432 > db
Query
=====

    #  Name       Owner ID  Encoding  LC_COLLATE  LC_CTYPE    Template?
    -  ----       --------  --------  ----------  --------    ---------
    0  postgres   10        6         en_US.utf8  en_US.utf8  f
    1  template1  10        6         en_US.utf8  en_US.utf8  t
    2  template0  10        6         en_US.utf8  en_US.utf8  t
```

### Listing Tables
```ruby
PostgreSQL @ 127.0.0.1:5432 > tables
Query
=====

    #    table_catal  table_schem  table_name   table_type  self_referen  reference_gen  user_defined_  user_defined_  user_defined  is_insertabl  is_typed  commit_action
         og           a                                     cing_column_  eration        type_catalog   type_schema    _type_name    e_into
                                                            name
    -    -----------  -----------  ----------   ----------  ------------  -------------  -------------  -------------  ------------  ------------  --------  -------------
    0    template1    pg_catalog   pg_statisti  BASE TABLE                                                                           YES           NO
                                   c
    1    template1    pg_catalog   pg_type      BASE TABLE                                                                           YES           NO
    2    template1    pg_catalog   pg_foreign_  BASE TABLE                                                                           YES           NO
                                   table
    3    template1    pg_catalog   pg_authid    BASE TABLE                                                                           YES           NO
...
```

### Interactive SQL Shell

Hopping into an interactive SQL Shell using the `shell` command allows the user to enter in SQL queries in a loop, until `exit`, `stop` or `quit` are entered, or Ctrl + C is pressed:
```ruby
SQL >> exit
[*] Exiting Shell mode.
```

#### Single-line Query
```ruby
PostgreSQL @ 127.0.0.1:5432 > shell
SQL >> select version()
[*] Running SQL Command: 'select version()'
Query
=====

    #  version
    -  -------
    0  PostgreSQL 16.0 (Debian 16.0-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit

SQL >>
```

#### Multi-line Query
Multi-line queries can be input by using the `\` character at the end of the line, similar to a Bash or ZSH shell. This implementation uses the updated `Reline` gem, which is being bumped as part of this PR.

```ruby
SQL >> select \
SQL *> version()
[*] Running SQL Command: 'select version()'
Query
=====

    #  version
    -  -------
    0  PostgreSQL 16.0 (Debian 16.0-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit

SQL >>
```

#### `Run` in the session context
```ruby
msf6 auxiliary(scanner/postgres/postgres_login) > run rhost=127.0.0.1 rport=5432 database=postgres username=postgres password=password

[+] 127.0.0.1:5432 - Login Successful: postgres:password@postgres
[*] PostgreSQL session 1 opened (127.0.0.1:64588 -> 127.0.0.1:5432) at 2024-01-18 17:48:22 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/postgres/postgres_login) > sessions -i -1
[*] Starting interaction with 1...

PostgreSQL @ 127.0.0.1:5432 (postgres) > run scanner/postgres/postgres_login rhost=127.0.0.1 rport=5432 database=postgres username=postgres password=password

[+] 127.0.0.1:5432 - Login Successful: postgres:password@postgres
[*] PostgreSQL session 2 opened (127.0.0.1:64598 -> 127.0.0.1:5432) at 2024-01-18 17:48:41 +0000
[*] Scanned 1 of 1 hosts (100% complete)
```

</details>

### Note
For this MVP, the `tables` and `db` commands were removed. That functionality can be emulated by interacting with the PostgreSQL session, and calling the following session commands:
```ruby
# Tables
query 'select * from information_schema.tables;'

# Databases
query 'SELECT datname FROM pg_database;'
```

## Verification

I tested this against PostgreSQL running in Docker:
```bash
docker run -it --rm -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:16
```

List the steps needed to make sure this thing works

- [ ] `bundle && bundle exec './msfconsole -q'`
- [ ] `features set postgresql_session_type true`
- [ ] `save`
- [ ] `exit`
- [ ] `bundle exec './msfconsole -q'`
- [ ] `use auxiliary/scanner/postgres/postgres_login`
- [ ] `run CreateSession=true rhosts=127.0.0.1 rport=5432 username=postgres password=password database=template1`
- [ ] Confirm you get a PostgreSQL session
- [ ] Confirm you can interact with the session and run some SQL commands, list databases & tables etc.
- [ ] Ensure tests pass