### PR TITLE
Fix the save command when dns_feature is disabled

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1350,7 +1350,9 @@ class Core
       # Save the framework's datastore
       begin
         framework.save_config
-        driver.framework.dns_resolver.save_config
+        if driver.framework.dns_resolver
+          driver.framework.dns_resolver.save_config
+        end
 
         if active_module
           active_module.save_config


### PR DESCRIPTION
This fixes a bug in the `save` command that would cause an exception when the `dns_feature` is disabled.

- [ ] Run: `features set dns_feature false`
- [ ] Restart msfconsole
- [ ] Run: `save` and do not see a crash

## New and fixed

```
msf6 > use exploit/windows/smb/psexec
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > save
Saved configuration to: /home/smcintyre/.msf4/config
msf6 exploit(windows/smb/psexec) > features

Features table
==============

   #  Name                         Enabled  Description
   -  ----                         -------  -----------
   0  wrapped_tables               true     When enabled Metasploit will wordwrap all tables to fit into the available terminal width
   1  fully_interactive_shells     false    When enabled you will have the option to drop into a fully interactive shell from within meterpreter
   2  manager_commands             false    When enabled you will have access to manager commands such as _servicemanager and _historymanager
   3  datastore_fallbacks          true     When enabled you can consistently set username across modules, instead of setting SMBUser/FTPUser/BIND_DN/etc
   4  metasploit_payload_warnings  true     When enabled Metasploit will output warnings about missing Metasploit payloads, for instance if they were remov
                                            ed by antivirus etc
   5  defer_module_loads           false    When enabled will not eagerly load all modules
   6  smb_session_type             false    When enabled will allow for the creation/use of smb sessions
   7  dns_feature                  false    When enabled, allows configuration of DNS resolution behaviour in Metasploit
   8  hierarchical_search_table    false    When enabled, the search table is enhanced to show details on module actions and targets


msf6 exploit(windows/smb/psexec) > 
```

### Old and broken

```
msf6 > use exploit/windows/smb/psexec
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/smb/psexec) > save
[-] Save failed: undefined method `save_config' for nil:NilClass
msf6 exploit(windows/smb/psexec) > features

Features table
==============

   #  Name                         Enabled  Description
   -  ----                         -------  -----------
   0  wrapped_tables               true     When enabled Metasploit will wordwrap all tables to fit into the availa
                                            ble terminal width
   1  fully_interactive_shells     false    When enabled you will have the option to drop into a fully interactive
                                            shell from within meterpreter
   2  manager_commands             false    When enabled you will have access to manager commands such as _servicem
                                            anager and _historymanager
   3  datastore_fallbacks          true     When enabled you can consistently set username across modules, instead
                                            of setting SMBUser/FTPUser/BIND_DN/etc
   4  metasploit_payload_warnings  true     When enabled Metasploit will output warnings about missing Metasploit p
                                            ayloads, for instance if they were removed by antivirus etc
   5  defer_module_loads           false    When enabled will not eagerly load all modules
   6  smb_session_type             false    When enabled will allow for the creation/use of smb sessions
   7  dns_feature                  false    When enabled, allows configuration of DNS resolution behaviour in Metas
                                            ploit
   8  hierarchical_search_table    false    When enabled, the search table is enhanced to show details on module ac
                                            tions and targets


msf6 exploit(windows/smb/psexec) >
```