### PR TITLE
Readd the #sysinfo method

### DIFF
--- a/lib/msf/core/session_compatibility.rb
+++ b/lib/msf/core/session_compatibility.rb
@@ -102,6 +102,19 @@ module Msf
     alias :client :session
 
     #
+    # Cached sysinfo, returns nil for non-meterpreter sessions
+    #
+    # @return [Hash,nil]
+    def sysinfo
+      begin
+        @sysinfo ||= session.sys.config.sysinfo
+      rescue NoMethodError
+        @sysinfo = nil
+      end
+      @sysinfo
+    end
+
+    #
     # Can be overridden by individual modules to add new commands
     #
     def post_commands


### PR DESCRIPTION
This fixes #18647 by re-adding the `#sysinfo` instance method for sessions. When #18539 was landed, the methods were mostly moved from `post_mixin.rb` to `session_compatibility.rb` but for some reason, `#sysinfo` was left out which is causing a lot of post modules to fail.

## Verification

- [ ] Start `msfconsole`
- [ ] Obtain a Meterpreter session
- [ ] Run the `post/multi/manage/autoroute` module, see that it works
