### PR TITLE
Print additional settings notice on non-empty datastore values

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -890,7 +890,7 @@ module Msf
             end
 
             # If any additional datastore values were provided, set these values
-            unless additional_datastore_values.nil?
+            unless additional_datastore_values.nil? || additional_datastore_values.empty?
               mod.datastore.update(additional_datastore_values)
               print_status("Additionally setting #{additional_datastore_values.map { |k,v| "#{k} => #{v}" }.join(", ")}")
             end


### PR DESCRIPTION
This PR removes the `Additionally setting` prompt when `additional_datastore_values` is empty.

## Before

```ruby
msf6 auxiliary(scanner/postgres/postgres_login) > favorites
[!] /Users/sjanusz/.msf4/fav_modules contains a module that can not be found - payloads/module/does/not/exist.
[!] /Users/sjanusz/.msf4/fav_modules contains a module that can not be found - post/windows/gather/openssh_password_search.
[!] /Users/sjanusz/.msf4/fav_modules contains a module that can not be found - auxiliary/scanner/postgres/postgres_sequel.

Favorites
=========

   #   Name                                              Disclosure Date  Rank    Check  Description
   -   ----                                              ---------------  ----    -----  -----------
   0   auxiliary/scanner/postgres/postgres_login         .                normal  No     PostgreSQL Login Utility
   1   auxiliary/scanner/postgres/postgres_schemadump    .                normal  No     Postgres Schema Dump
   2   auxiliary/scanner/smb/smb_login                   .                normal  No     SMB Login Check Scanner
   3   auxiliary/scanner/ssh/ssh_identify_pubkeys        .                normal  No     SSH Public Key Acceptance Scanner
   4   auxiliary/scanner/ssh/ssh_login_pubkey            .                normal  No     SSH Public Key Login Scanner
   5   exploit/windows/local/cve_2023_28252_clfs_driver  2023-04-11       good    Yes    Windows Common Log File System Driver (clfs.sys) Elevation of Privilege Vulnerability
   6   payload/android/meterpreter/reverse_tcp           .                normal  No     Android Meterpreter, Android Reverse TCP Stager
   7   payload/java/meterpreter/reverse_tcp              .                normal  No     Java Meterpreter, Java Reverse TCP Stager
   8   payload/python/meterpreter/reverse_tcp            .                normal  No     Python Meterpreter, Python Reverse TCP Stager
   9   payload/windows/meterpreter/reverse_tcp           .                normal  No     Windows Meterpreter (Reflective Injection), Reverse TCP Stager
   10  payload/windows/meterpreter_reverse_tcp           .                normal  No     Windows Meterpreter Shell, Reverse TCP Inline
   11  payload/windows/x64/meterpreter/reverse_tcp       .                normal  No     Windows Meterpreter (Reflective Injection x64), Windows x64 Reverse TCP Stager
   12  payload/windows/x64/meterpreter_reverse_tcp       .                normal  No     Windows Meterpreter Shell, Reverse TCP Inline x64

Interact with a module by name or index. For example info 12, use 12 or use payload/windows/x64/meterpreter_reverse_tcp

msf6 auxiliary(scanner/postgres/postgres_login) > use 2
[*] Additionally setting
msf6 auxiliary(scanner/smb/smb_login) >
```

## After

```ruby
msf6 auxiliary(scanner/postgres/postgres_schemadump) > favorites
[!] /Users/sjanusz/.msf4/fav_modules contains a module that can not be found - payloads/module/does/not/exist.
[!] /Users/sjanusz/.msf4/fav_modules contains a module that can not be found - post/windows/gather/openssh_password_search.
[!] /Users/sjanusz/.msf4/fav_modules contains a module that can not be found - auxiliary/scanner/postgres/postgres_sequel.
u
Favorites
=========

   #   Name                                              Disclosure Date  Rank    Check  Description
   -   ----                                              ---------------  ----    -----  -----------
   0   auxiliary/scanner/postgres/postgres_login         .                normal  No     PostgreSQL Login Utility
   1   auxiliary/scanner/postgres/postgres_schemadump    .                normal  No     Postgres Schema Dump
   2   auxiliary/scanner/smb/smb_login                   .                normal  No     SMB Login Check Scanner
   3   auxiliary/scanner/ssh/ssh_identify_pubkeys        .                normal  No     SSH Public Key Acceptance Scanner
   4   auxiliary/scanner/ssh/ssh_login_pubkey            .                normal  No     SSH Public Key Login Scanner
   5   exploit/windows/local/cve_2023_28252_clfs_driver  2023-04-11       good    Yes    Windows Common Log File System Driver (clfs.sys) Elevation of Privilege Vulnerability
   6   payload/android/meterpreter/reverse_tcp           .                normal  No     Android Meterpreter, Android Reverse TCP Stager
   7   payload/java/meterpreter/reverse_tcp              .                normal  No     Java Meterpreter, Java Reverse TCP Stager
   8   payload/python/meterpreter/reverse_tcp            .                normal  No     Python Meterpreter, Python Reverse TCP Stager
   9   payload/windows/meterpreter/reverse_tcp           .                normal  No     Windows Meterpreter (Reflective Injection), Reverse TCP Stager
   10  payload/windows/meterpreter_reverse_tcp           .                normal  No     Windows Meterpreter Shell, Reverse TCP Inline
   11  payload/windows/x64/meterpreter/reverse_tcp       .                normal  No     Windows Meterpreter (Reflective Injection x64), Windows x64 Reverse TCP Stager
   12  payload/windows/x64/meterpreter_reverse_tcp       .                normal  No     Windows Meterpreter Shell, Reverse TCP Inline x64

Interact with a module by name or index. For example info 12, use 12 or use payload/windows/x64/meterpreter_reverse_tcp

msf6 auxiliary(scanner/postgres/postgres_schemadump) > use 2
msf6 auxiliary(scanner/smb/smb_login) >
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `favorites`
- [ ] `use x`
- [ ] Ensure you no longer get `Additionally setting` being shown with no values