### PR TITLE
fix spelling in plugins folder

### DIFF
--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -494,7 +494,7 @@ module Msf
       begin
         require 'metasploit/aggregator'
       rescue LoadError
-        raise 'WARNING: metasploit/aggregator is not avaiable for now.'
+        raise 'WARNING: metasploit/aggregator is not available for now.'
       end
 
       add_console_dispatcher(AggregatorCommandDispatcher)

--- a/plugins/besecure.rb
+++ b/plugins/besecure.rb
@@ -152,7 +152,7 @@ module Msf
         end
 
         if body['error']
-          print_error("#{@hostname} - An error occured:")
+          print_error("#{@hostname} - An error occurred:")
           print_error(body)
           return ''
         end
@@ -207,7 +207,7 @@ module Msf
         end
 
         if body['error']
-          print_error("#{@hostname} - An error occured:")
+          print_error("#{@hostname} - An error occurred:")
           print_error(body)
           return ''
         end
@@ -257,7 +257,7 @@ module Msf
           end
 
           if body['error']
-            print_error("#{@hostname} - An error occured:")
+            print_error("#{@hostname} - An error occurred:")
             print_error(body)
             return ''
           end

--- a/plugins/libnotify.rb
+++ b/plugins/libnotify.rb
@@ -45,7 +45,7 @@ module Msf
 
     def on_db_host(host)
       notify_send('normal', 'New host',
-                  "Addess: #{host.address}\nOS: #{host.os_name}")
+                  "Address: #{host.address}\nOS: #{host.os_name}")
     end
 
     def on_db_host_state(host, _ostate)

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -851,7 +851,7 @@ module Msf
         print_good "\n"
         print_line tbl.to_s
         print_status('You can:')
-        print_status('Get detailed scan infromation about a specfic port: nessus_report_host_detail <hostname> <port> <protocol> <report id>')
+        print_status('Get detailed scan information about a specific port: nessus_report_host_detail <hostname> <port> <protocol> <report id>')
       end
 
       def cmd_nessus_report_del(*args)
@@ -1792,7 +1792,7 @@ module Msf
         elsif status == '500'
           print_error("The server failed to delete the user account having user ID #{user_id}")
         else
-          print_error("Unknown problem occured by deleting the user account having user ID #{user_id}.")
+          print_error("Unknown problem occurred by deleting the user account having user ID #{user_id}.")
         end
       end
 
@@ -1835,7 +1835,7 @@ module Msf
         elsif status == '500'
           print_error('Nessus server failed to changed the user password')
         else
-          print_error('Unknown problem occured while changing the user password')
+          print_error('Unknown problem occurred while changing the user password')
         end
       end
 
@@ -1913,7 +1913,7 @@ module Msf
         elsif status == '405'
           print_error("Policy ID #{policy_id} is currently in use and cannot be deleted")
         else
-          print_error("Unknown problem occured by deleting the user account having user ID #{user_id}.")
+          print_error("Unknown problem occurred by deleting the user account having user ID #{user_id}.")
         end
       end
     end

--- a/plugins/nexpose.rb
+++ b/plugins/nexpose.rb
@@ -545,7 +545,7 @@ module Msf
             print_status(" >> Scan has been completed with ID ##{sid}") if opt_verbose
           rescue ::Interrupt
             rep = false
-            print_status(" >> Terminating scan ID ##{sid} due to console interupt") if opt_verbose
+            print_status(" >> Terminating scan ID ##{sid} due to console interrupt") if opt_verbose
             @nsc.stop_scan(sid)
             break
           end

--- a/plugins/request.rb
+++ b/plugins/request.rb
@@ -195,7 +195,7 @@ module Msf
         [options, opt_parser]
       end
 
-      # Perform an HTTPS request based on the user specifed options.
+      # Perform an HTTPS request based on the user specified options.
       #
       # @param opts [Hash] The options to use for making the HTTPS request.
       # @option opts [String] :auth_username An optional username to use with
@@ -226,7 +226,7 @@ module Msf
         handle_request_http(opts, opt_parser)
       end
 
-      # Perform an HTTP request based on the user specifed options.
+      # Perform an HTTP request based on the user specified options.
       #
       # @param opts [Hash] The options to use for making the HTTP request.
       # @option opts [String] :auth_username An optional username to use with

--- a/plugins/session_notifier.rb
+++ b/plugins/session_notifier.rb
@@ -273,7 +273,7 @@ module Msf
         request.body = json_post_data
         res = http.request(request)
         if res.nil? || res.body.blank?
-          print_error('No response recieved from the DingTalk server!')
+          print_error('No response received from the DingTalk server!')
           return nil
         end
         begin
@@ -309,7 +309,7 @@ module Msf
         request.body = json_post_data
         res = http.request(request)
         if res.nil? || res.body.blank?
-          print_error('No response recieved from the Gotify server!')
+          print_error('No response received from the Gotify server!')
           return nil
         end
         begin

--- a/plugins/wiki.rb
+++ b/plugins/wiki.rb
@@ -424,7 +424,7 @@ module Msf
       # Converts a value to a wiki link
       # @param [String] text value to convert to a link
       # @param [String] namespace optional namespace to set for the link
-      # @return [String] the formated wiki link
+      # @return [String] the formatted wiki link
       def to_wikilink(text, namespace = '')
         return '[[' + namespace + text + ']]'
       end
@@ -537,7 +537,7 @@ module Msf
           end
           # Setup the table with some standard formatting options
           str << "{|class=\"wikitable\"\n"
-          # Output formated column names as the first row
+          # Output formatted column names as the first row
           unless columns.count.eql? 0
             str << '!'
             str << columns.join('!!')

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -327,7 +327,7 @@ module Msf
         self.nmaxdisplay = false
         self.runlocal = false
 
-        # Formating
+        # Formatting
         sizeline = 60
 
         wmap_show = 2**0
@@ -1091,7 +1091,7 @@ module Msf
 
           #
           # Handle modules that need to be after all tests, once.
-          # Good place to have modules that analize the test results and/or
+          # Good place to have modules that analyze the test results and/or
           # launch exploits.
           # :wmap_generic
           #
@@ -1409,7 +1409,7 @@ module Msf
           sites = serv.web_sites.where('vhost = ? and service_id = ?', vhost, serv.id)
 
           sites.each do |site|
-            # Initial defaul path
+            # Initial default path
             inipath = target.path
             if target.path.empty?
               inipath = '/'


### PR DESCRIPTION
Cleanup of spelling across the `plugins` folder. I avoided fixing apostrophes.

Most of these changes are in comments, some are in user prompts which will be nice.

## Verification

- [ ] manual review
- [ ] Start `msfconsole`
- [ ] use some things to make sure they dont break
