### PR TITLE
fix spelling in tools folder

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -320,7 +320,7 @@ class MsftidyRunner
 
   # See if 'require "rubygems"' or equivalent is used, and
   # warn if so. Since Ruby 1.9 this has not been necessary and
-  # the framework only suports 1.9+
+  # the framework only supports 1.9+
   def check_rubygems
     @lines.each do |line|
       if line_has_require?(line, 'rubygems')

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -240,7 +240,7 @@ class MsftidyDoc
         in_options = false
       end
 
-      if in_options && ln =~ /^\s*\*\*[a-z]+\*\*$/i # catch options in old format like **command** instead of ### comand
+      if in_options && ln =~ /^\s*\*\*[a-z]+\*\*$/i # catch options in old format like **command** instead of ### command
         warn("Options should use ### instead of bolds (**)", idx)
       end
 

--- a/tools/dev/update_wordpress_vulnerabilities.rb
+++ b/tools/dev/update_wordpress_vulnerabilities.rb
@@ -3,7 +3,7 @@
 
 #
 # Update modules/auxiliary/scanner/http/wordpress_scanner.rb to have the most
-# up to date list of vuln compontents based on exploits/scanners in the framework
+# up to date list of vuln components based on exploits/scanners in the framework
 #
 # by h00die
 #

--- a/tools/docs/issue_finder.py
+++ b/tools/docs/issue_finder.py
@@ -16,7 +16,7 @@ parser = argparse.ArgumentParser(description='This script identifies issues with
     prefix_chars='--', )
 parser.add_argument('-m', '--modules', type=str, default='auxiliary/scanner', help='Choose the modules category to work with. Respect the module category names as in metasploit-framework. Only one category should be passed, e.g. "auxiliary/admin", "exploits/android/browser" or "encoders" are valid entries.')
 parser.add_argument('--show_all', action="store_true", default=False, help='Show the complete list of items. In default mode, modules with documentation are marked "[x]" and modules without are marked "[ ]". In issues mode, documentation files without module are marked "[ ]" and documentation files with module are marked "[x]".')
-parser.add_argument('--show_issues', action="store_true", default=False, help='Show the list of documentation files without modules instead of modules withouth documentation file.')
+parser.add_argument('--show_issues', action="store_true", default=False, help='Show the list of documentation files without modules instead of modules without documentation file.')
 parser.add_argument('-o', '--output', help="Writes to a file.")
 args = parser.parse_args()
 

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -39,7 +39,7 @@ require 'metasm'
 @Arch = ['Ia32','MIPS','ARM','X86_64']
 @Endian = ['little','big']
 @architecture = ""
-@endianess = ""
+@endianness = ""
 
 def usage
   $stderr.puts("\nUsage: #{$0} <options>\n" + $args.usage)
@@ -48,7 +48,7 @@ end
 
 $args = Rex::Parser::Arguments.new(
   "-a" => [ true, "The architecture to encode as (#{@Arch.sort.collect{|a| a + ', ' }.join.gsub(/\, $/,'')})"],
-  "-e" => [ true, "The endianess to encode as (#{@Endian.sort.collect{|a| a + ', ' }.join.gsub(/\, $/,'')})" ],
+  "-e" => [ true, "The endianness to encode as (#{@Endian.sort.collect{|a| a + ', ' }.join.gsub(/\, $/,'')})" ],
   "-h" => [ false, "Display this help information" ])
 
 $args.parse(ARGV) { |opt, idx, val|
@@ -66,7 +66,7 @@ $args.parse(ARGV) { |opt, idx, val|
     found = nil
     @Endian.each { |e|
       if val.downcase == e.downcase
-        @endianess = e
+        @endianness = e
         found = true
       end
     }
@@ -79,10 +79,10 @@ $args.parse(ARGV) { |opt, idx, val|
 }
 
 unless @architecture.empty?
-  if @endianess.empty?
+  if @endianness.empty?
     String.class_eval("@@cpu = Metasm::#{@architecture}.new")
   else
-    String.class_eval("@@cpu = Metasm::#{@architecture}.new(:#{@endianess})")
+    String.class_eval("@@cpu = Metasm::#{@architecture}.new(:#{@endianness})")
   end
 end
 

--- a/tools/hardware/elm327_relay.rb
+++ b/tools/hardware/elm327_relay.rb
@@ -55,7 +55,7 @@ def print_error(msg='')
   $stdout.puts "[-] #{msg}"
 end
 
-# Base ELM327 Class for the Realy
+# Base ELM327 Class for the Relay
 module ELM327HWBridgeRelay
 
   class ELM327Relay < Msf::Auxiliary
@@ -146,7 +146,7 @@ module ELM327HWBridgeRelay
       resp
     end
 
-    # Connects to the ELM327, resets paramters, gets device version and sets up general comms.
+    # Connects to the ELM327, resets parameters, gets device version and sets up general comms.
     # Serial params are set via command options or during initialization
     #
     # @return [SerialPort] SerialPort object for communications. Also available as @ser
@@ -160,7 +160,7 @@ module ELM327HWBridgeRelay
       resp = send_cmd("ATZ")  # Turn off ECHO
       if resp =~ /ELM327/
         send_cmd("ATE0")  # Turn off ECHO
-        send_cmd("ATL0")  # Disble linefeeds
+        send_cmd("ATL0")  # Disable linefeeds
         @device_name = send_cmd("ATI")
         send_cmd("ATH1") # Show Headers
         @operational_status = 1
@@ -301,7 +301,7 @@ module ELM327HWBridgeRelay
       { "status" => "not supported" }
     end
 
-    # Handles incomming URI requests and calls their respective API functions
+    # Handles incoming URI requests and calls their respective API functions
     #
     # @param cli [Socket] Socket for the browser
     # @param request [Rex::Proto::Http::Request] HTTP Request sent by the browser

--- a/tools/modules/module_mixins.rb
+++ b/tools/modules/module_mixins.rb
@@ -35,7 +35,7 @@ $framework = Msf::Simple::Framework.create('DisableDatabase' => true)
 all_modules = $framework.exploits
 
 # If you give an argument (any argument will do), you really want a sorted
-# list of mixins, regardles of the module they're in.
+# list of mixins, regardless of the module they're in.
 if ARGV[0]
   mod_hash = {}
   longest_name = 0

--- a/tools/modules/module_ports.rb
+++ b/tools/modules/module_ports.rb
@@ -43,7 +43,7 @@ all_modules.each_module { |name, mod|
   ports = ports.map{|p| p.to_i}
   ports.uniq!
   ports.sort{|a,b| a <=> b}.each do |rport|
-    # Just record the first occurance.
+    # Just record the first occurrence.
     all_ports[rport] = x.fullname unless all_ports[rport]
   end
 }

--- a/tools/modules/module_rank.rb
+++ b/tools/modules/module_rank.rb
@@ -39,7 +39,7 @@ filters = ['all','exploit','payload','post','nop','encoder','auxiliary']
 
 opts = Rex::Parser::Arguments.new(
   "-h" => [ false, "Help menu." ],
-  "-M" => [ true, "Set Maxmimum Rank [Manual,Low,Average,Normal,Good,Great,Excellent] (Default = Excellent)." ],
+  "-M" => [ true, "Set Maximum Rank [Manual,Low,Average,Normal,Good,Great,Excellent] (Default = Excellent)." ],
   "-m" => [ true, "Set Minimum Rank [Manual,Low,Average,Normal,Good,Great,Excellent] (Default = Manual)."],
   "-s" => [ false, "Sort by Rank instead of Module Type."],
   "-r" => [ false, "Reverse Sort by Rank"],

--- a/tools/password/cpassword_decrypt.rb
+++ b/tools/password/cpassword_decrypt.rb
@@ -70,7 +70,7 @@ class CPassword
       plaintext = aes.update(decoded)
       plaintext << aes.final
     rescue OpenSSL::Cipher::CipherError
-      # Decryption failed possibily due to bad input
+      # Decryption failed possibly due to bad input
       return ''
     end
 

--- a/tools/password/halflm_second.rb
+++ b/tools/password/halflm_second.rb
@@ -36,7 +36,7 @@ end
 hash = pass = chall = nil
 
 $args = Rex::Parser::Arguments.new(
-  "-n" => [ true,  "The encypted LM hash to crack"                                    ],
+  "-n" => [ true,  "The encrypted LM hash to crack"                                    ],
   "-p" => [ true,  "The decrypted LANMAN password for bytes 1-7"                      ],
   "-s" => [ true,  "The server challenge (default value 1122334455667788)"            ],
   "-h" => [ false, "Display this help information"                                      ])

--- a/tools/password/lm2ntcrack.rb
+++ b/tools/password/lm2ntcrack.rb
@@ -8,7 +8,7 @@
 #
 # This script cracks any type of NTLM hash
 # Credit to	-Yannick Hamon <yannick.hamon[at]xmcopartners.com> for the original idea/perl code
-#		-Alexandre Maloteaux <a.maloteaux[at]gmail.com> for improvments
+#		-Alexandre Maloteaux <a.maloteaux[at]gmail.com> for improvements
 #
 
 msfbase = __FILE__
@@ -31,7 +31,7 @@ PASS_MODE =  3
 
 def usage
   $stderr.puts("\nUsage: #{$0} -t type <options>\n" + $args.usage)
-  $stderr.puts("This tool can be use in 3 ways whatever type is choosen\n")
+  $stderr.puts("This tool can be use in 3 ways whatever type is chosen\n")
   $stderr.puts("-If only a password (-p) is provided, it will display the hash.\n")
   $stderr.puts("-If a password (-p) and an hash (-a) is provided, it will test the password against the hash.\n")
   $stderr.puts("-If a list of password (-l) is provided and an hash (-a), it will try to bruteforce the hash \n\n")

--- a/tools/password/md5_lookup.rb
+++ b/tools/password/md5_lookup.rb
@@ -267,7 +267,7 @@ module Md5LookupUtility
     # Returns the parsed options from ARGV
     #
     # raise [OptionParser::InvalidOption] Invalid option found
-    # @return [OptionParser, Hash] The OptionParser object and an hash containg the options
+    # @return [OptionParser, Hash] The OptionParser object and an hash containing the options
     def self.get_parsed_options
       options = {}
       parser = OptionParser.new do |opt|
@@ -368,11 +368,11 @@ module Md5LookupUtility
       input = @opts[:input]
       dbs   = @opts[:databases]
 
-      disclamer = Md5LookupUtility::Disclaimer.new
+      disclaimer = Md5LookupUtility::Disclaimer.new
 
-      unless disclamer.has_waiver?
-        disclamer.ack
-        disclamer.save_waiver
+      unless disclaimer.has_waiver?
+        disclaimer.ack
+        disclaimer.save_waiver
       end
 
       get_hash_results(input, dbs) do |result|


### PR DESCRIPTION
Cleanup of spelling across the `tools` folder. I avoided fixing apostrophes.

Most of these changes are in comments, some are in user prompts which will be nice.

## Verification

- [ ] manual review
- [ ] Start some of the tool scripts
- [ ] use some things to make sure they dont break
