### PR TITLE
fix spelling in some modules

### DIFF
--- a/modules/encoders/cmd/generic_sh.rb
+++ b/modules/encoders/cmd/generic_sh.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Encoder
 
       if (state.badchars.match(/\(|\)/))
 
-        # No paranthesis...
+        # No parenthesis...
         raise EncodingError
       end
 
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Encoder
     else
       if (state.badchars.match(/\(|\)/))
         if (state.badchars.include?(" "))
-          # No spaces allowed, no paranthesis, give up...
+          # No spaces allowed, no parenthesis, give up...
           raise EncodingError
         end
 

--- a/modules/encoders/generic/eicar.rb
+++ b/modules/encoders/generic/eicar.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Encoder
 
-  # Set to ManualRanking because actually using ths encoder will
+  # Set to ManualRanking because actually using this encoder will
   # certainly destroy any possibility of a successful shell.
   #
   Rank = ManualRanking

--- a/modules/encoders/mipsbe/byte_xori.rb
+++ b/modules/encoders/mipsbe/byte_xori.rb
@@ -90,7 +90,7 @@ loop:
   li(      $10,#{reg_5})                 ; cacheflush() nbytes parameter
   nor   $5, $10, $0                      ; same as above
 
-  li      ($2, 4147)                     ; 0x24021033 - cacheflush sytem call
+  li      ($2, 4147)                     ; 0x24021033 - cacheflush system call
   syscall 0x52950                        ; 0x014a540c
   nop                                    ; encoded shellcoded must be here (xor key right here ;) after decoding will result in a nop
 EOS

--- a/modules/encoders/mipsle/byte_xori.rb
+++ b/modules/encoders/mipsle/byte_xori.rb
@@ -90,7 +90,7 @@ loop:
   li(      $10,#{reg_5})                 ; cacheflush() nbytes parameter
   nor   $5, $10, $0                      ; same as above
 
-  li      ($2, 4147)                     ; 0x33100224 - cacheflush sytem call
+  li      ($2, 4147)                     ; 0x33100224 - cacheflush system call
   syscall 0x52950                        ; 0x0c544a01
   nop                                    ; encoded shellcoded must be here (xor key right here ;) after decoding will result in a nop
 EOS

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Encoder
     i = 0
     b64[i] = "chr(#{b64[i]})." while (b64[i].chr =~ %r{[0-9/+]})
 
-    # Similarly, when we seperate large payloads into chunks to avoid the
+    # Similarly, when we separate large payloads into chunks to avoid the
     # 998-byte problem mentioned above, we have to make sure that the first
     # character of each chunk is an alpha character.  This simple algorithm
     # will create a broken string in the case of 99 consecutive digits,

--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Encoder
   end
 
   #
-  # Conver the shellcode into a set of 4-byte chunks that can be
+  # Convert the shellcode into a set of 4-byte chunks that can be
   # encoding while making sure it is 4-byte aligned.
   #
   def prepare_shellcode(sc, protect_payload)
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Encoder
       raise EncodingError, "Invalid base register"
     end
 
-    # get the offset from the specified base register, or default to zero if not specifed
+    # get the offset from the specified base register, or default to zero if not specified
     reg_offset = (datastore['BufferOffset'] || 0).to_i
 
     # calculate two opposing values which we can use for zeroing out EAX

--- a/modules/encoders/x86/single_static_bit.rb
+++ b/modules/encoders/x86/single_static_bit.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Encoder
     bit_val = (datastore['BitValue'] || true)
 
     # variables:
-    # bit to ignore                                  (global - harcoded)
+    # bit to ignore                                  (global - hardcoded)
     # buf len (can be deduced with a jmp/call/pop)   (global - ebx)
     # current source byte ptr                        (global - esi)
     # current dest byte ptr                          (global - edi) ?

--- a/modules/encoders/x86/xor_poly.rb
+++ b/modules/encoders/x86/xor_poly.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Encoder::Xor
   def decoder_stub(state)
     state.decoder_key_size = 4
     state.decoder_key_pack = 'V'
-    # calculate the (negative) and positiv block count.
+    # calculate the (negative) and positive block count.
     block_count = [-(((state.buf.length - 1) / state.decoder_key_size) + 1)].pack('V')
     block_count_positive = [(((state.buf.length - 1) / state.decoder_key_size) + 1)].pack('V')
 

--- a/modules/evasion/windows/process_herpaderping.rb
+++ b/modules/evasion/windows/process_herpaderping.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Evasion
       OptString.new('REPLACED_WITH_FILE', [
         false,
         'File to replace the target with. If not set, the target file will be '\
-          'filled with random bytes (WARNING! it is likely to be catched by AV).',
+          'filled with random bytes (WARNING! it is likely to be caught by AV).',
         '%SystemRoot%\\System32\\calc.exe'
       ])
     ])

--- a/modules/nops/x64/simple.rb
+++ b/modules/nops/x64/simple.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Nop
   end
 
   # This instruction list is far from complete (Only single byte instructions and some multi byte ADD/MOV instructions are used).
-  # A more complete list might warrent an pseudo assembler (Rex::Arch::X64) instead of hardcoding these.
+  # A more complete list might warrant an pseudo assembler (Rex::Arch::X64) instead of hardcoding these.
   INSTRUCTIONS = [	[ "\x90",             0, "nop" ],
             [ "\x91",             0, "xchg eax, ecx" ],
             [ "\x92",             0, "xchg eax, edx" ],
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Nop
       end
       next if try_another
 
-      # Get the first bytes of the chosed instructions opcodes...
+      # Get the first bytes of the chosen instructions opcodes...
       opcodes = instruction[I_OP]
 
       # If their are additional bytes to append, do it now...
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Nop
         next
       end
 
-      # Reset the try_count for the next itteration.
+      # Reset the try_count for the next iteration.
       try_count = 32
 
       # save the opcodes we just generated.
@@ -228,7 +228,7 @@ class MetasploitModule < Msf::Nop
 
     # After we have pruned the instruction list we can proceed to generate a sled...
     if good_instructions.empty?
-      # If we are left with no valid instructions to use we simple cant generate a sled.
+      # If we are left with no valid instructions to use we simple can't generate a sled.
       sled = nil
     elsif not random
       if not badchars.include?( "\x90" )

--- a/modules/payloads/singles/cmd/mainframe/bind_shell_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/bind_shell_jcl.rb
@@ -19,7 +19,7 @@ module MetasploitModule
     super(merge_info(info,
                      'Name'          => 'Z/OS (MVS) Command Shell, Bind TCP',
                      'Description'   => 'Provide JCL which creates a bind shell
-                     This implmentation does not include ebcdic character translation,
+                     This implementation does not include ebcdic character translation,
                      so a client with translation capabilities is required.  MSF handles
                      this automatically.',
                      'Author'        => 'Bigendian Smalls',

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -146,7 +146,7 @@ finish:
   pop ebx                ; Clear off the current modules hash
   pop ebx                ; Clear off the current position in the module list
   popad                  ; Restore all of the callers registers, bar EAX, ECX and EDX which are clobbered
-  pop ecx                ; Pop off the origional return address our caller will have pushed
+  pop ecx                ; Pop off the original return address our caller will have pushed
   pop edx                ; Pop off the hash value our caller will have pushed
   push ecx               ; Push back the correct return value
   jmp eax                ; Jump into the required function

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -149,7 +149,7 @@ loop_modname:              ;
 not_lowercase:             ;
   ror edi, 13            ; Rotate right our hash value
   add edi, eax           ; Add the next byte of the name
-  loop loop_modname      ; Loop untill we have read enough
+  loop loop_modname      ; Loop until we have read enough
   ; We now have the module hash computed
   push edx               ; Save the current position in the module list for later
   push edi               ; Save the current module hash for later
@@ -198,7 +198,7 @@ finish:
   pop ebx                ; Clear off the current modules hash
   pop ebx                ; Clear off the current position in the module list
   popad                  ; Restore all of the callers registers, bar EAX, ECX and EDX which are clobbered
-  pop ecx                ; Pop off the origional return address our caller will have pushed
+  pop ecx                ; Pop off the original return address our caller will have pushed
   pop edx                ; Pop off the hash value our caller will have pushed
   push ecx               ; Push back the correct return value
   jmp eax                ; Jump into the required function

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -66,7 +66,7 @@ module MetasploitModule
 
         mov eax, 0x0190        ; EAX = sizeof( struct WSAData )
         sub esp, eax           ; alloc some space for the WSAData structure
-        push esp               ; push a pointer to this stuct
+        push esp               ; push a pointer to this struct
         push eax               ; push the wVersionRequested parameter
         push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
         call ebp               ; WSAStartup( 0x0190, &WSAData );

--- a/modules/payloads/singles/windows/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_reverse_tcp.rb
@@ -69,7 +69,7 @@ module MetasploitModule
 
           mov eax, 0x0190         ; EAX = sizeof( struct WSAData )
           sub esp, eax            ; alloc some space for the WSAData structure
-          push esp                ; push a pointer to this stuct
+          push esp                ; push a pointer to this struct
           push eax                ; push the wVersionRequested parameter
           push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
           call ebp                ; WSAStartup( 0x0190, &WSAData );
@@ -110,7 +110,7 @@ module MetasploitModule
           jnz try_connect
         failure:
           call exitfunk
-          ; this  lable is required so that reconnect attempts include
+          ; this  label is required so that reconnect attempts include
           ; the UUID stuff if required.
         connected:
         send_pingback:

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -78,17 +78,17 @@ module MetasploitModule
         not_lowercase:             ;
           ror r9d, 13              ; Rotate right our hash value
           add r9d, eax             ; Add the next byte of the name
-          loop loop_modname        ; Loop untill we have read enough
+          loop loop_modname        ; Loop until we have read enough
           ; We now have the module hash computed
           push rdx                 ; Save the current position in the module list for later
           push r9                  ; Save the current module hash for later
-          ; Proceed to itterate the export address table,
+          ; Proceed to iterate the export address table,
           mov rdx, [rdx+32]        ; Get this modules base address
           mov eax, dword [rdx+60]  ; Get PE header
           add rax, rdx             ; Add the modules base address
           cmp word [rax+24], 0x020B ; is this module actually a PE64 executable?
           ; this test case covers when running on wow64 but in a native x64 context via nativex64.asm and
-          ; their may be a PE32 module present in the PEB's module list, (typicaly the main module).
+          ; their may be a PE32 module present in the PEB's module list, (typically the main module).
           ; as we are using the win64 PEB ([gs:96]) we wont see the wow64 modules present in the win32 PEB ([fs:48])
           jne get_next_mod1         ; if not, proceed to the next module
           mov eax, dword [rax+136] ; Get export tables RVA
@@ -170,7 +170,7 @@ module MetasploitModule
           call rbp                ; LoadLibraryA( "ws2_32" )
 
         ; perform the call to WSAStartup...
-          mov rdx, r13            ; second param is a pointer to this stuct
+          mov rdx, r13            ; second param is a pointer to this struct
           push 0x0101             ;
           pop rcx                 ; set the param for the version requested
           mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
@@ -184,7 +184,7 @@ module MetasploitModule
 
         create_socket:
         ; perform the call to WSASocketA...
-          push rax                ; if we succeed, rax wil be zero, push zero for the flags param.
+          push rax                ; if we succeed, rax will be zero, push zero for the flags param.
           push rax                ; push null for reserved parameter
           xor r9, r9              ; we do not specify a WSAPROTOCOL_INFO structure
           xor r8, r8              ; we do not specify a protocol
@@ -217,7 +217,7 @@ module MetasploitModule
         failure:
           call exitfunk
 
-        ; this  lable is required so that reconnect attempts include
+        ; this label is required so that reconnect attempts include
         ; the UUID stuff if required.
         connected:
 

--- a/modules/payloads/stagers/windows/reverse_hop_http.rb
+++ b/modules/payloads/stagers/windows/reverse_hop_http.rb
@@ -136,7 +136,7 @@ finish:
   pop ebx                ; Clear off the current modules hash
   pop ebx                ; Clear off the current position in the module list
   popad                  ; Restore all of the callers registers, bar EAX, ECX and EDX
-  pop ecx                ; Pop off the origional return address our caller will have pushed
+  pop ecx                ; Pop off the original return address our caller will have pushed
   pop edx                ; Pop off the hash value our caller will have pushed
   push ecx               ; Push back the correct return value
   jmp eax                ; Jump into the required function


### PR DESCRIPTION
Cleanup of spelling across the `modules/payloads`, `modules/nops`, `modules/evasion` and `modules/encoders` folder. I avoided fixing apostrophes.

Most of these changes are in comments

## Verification

- [ ] manual review
- [ ] run some payloads and such against targets
- [ ] use some things to make sure they dont break
