### PR TITLE
Aux modules spelling

### DIFF
--- a/modules/auxiliary/admin/aws/aws_launch_instances.rb
+++ b/modules/auxiliary/admin/aws/aws_launch_instances.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       # need a better parser so we can avoid shit like this
       ip = doc['reservationSet']['item']['instancesSet']['item']['networkInterfaceSet']['item']['privateIpAddressesSet']['item']['association']['publicIp']
-      print_status("Instance #{instance_id} has IP adrress #{ip}")
+      print_status("Instance #{instance_id} has IP address #{ip}")
     rescue NoMethodError
       print_error("Could not retrieve instance IP address")
     end
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Auxiliary
     if doc['Response'].nil?
       doc = print_results(doc, action)
       if doc['keyName'].nil? || doc['keyFingerprint'].nil?
-        print_error("Error creating key using privided key material (SSH_PUB_KEY)")
+        print_error("Error creating key using provided key material (SSH_PUB_KEY)")
       else
         print_status("Created #{doc['keyName']} (#{doc['keyFingerprint']})")
       end
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
       if doc['Response']['Errors'] && doc['Response']['Errors']['Error']
         print_error(doc['Response']['Errors']['Error']['Message'])
       else
-        print_error("Error creating key using privided key material (SSH_PUB_KEY)")
+        print_error("Error creating key using provided key material (SSH_PUB_KEY)")
       end
     end
   end

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     #
-    # Define our tranfer parameters
+    # Define our transfer parameters
     #
     xenv =
     [

--- a/modules/auxiliary/admin/citrix/citrix_netscaler_config_decrypt.rb
+++ b/modules/auxiliary/admin/citrix/citrix_netscaler_config_decrypt.rb
@@ -110,11 +110,11 @@ class MetasploitModule < Msf::Auxiliary
     f1_hex = File.binread(ns_kek_f1)
     f2_hex = File.binread(ns_kek_f2)
     unless f1_hex.match?(/^[0-9a-f]+$/i)
-      print_error('Provided F1.key is not valid hexidecimal data')
+      print_error('Provided F1.key is not valid hexadecimal data')
       raise Msf::OptionValidateError, ['NS_KEK_F1']
     end
     unless f2_hex.match?(/^[0-9a-f]+$/i)
-      print_error('Provided F2.key is not valid hexidecimal data')
+      print_error('Provided F2.key is not valid hexadecimal data')
       raise Msf::OptionValidateError, ['NS_KEK_F2']
     end
     f1_key = f1_hex[66..130].scan(/../).map(&:hex).pack('C*')
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
           end
           print_status("Config line:\n#{config_entry}")
           if is_kek && !@ns_kek_key
-            print_warning('Entry was encrypted with KEK but no KEK fragement files provided, decryption will not be possible')
+            print_warning('Entry was encrypted with KEK but no KEK fragment files provided, decryption will not be possible')
             next
           end
           username = parse_username_from_config(config_entry)

--- a/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
+++ b/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'CVE', '2015-0964' ], # XSS vulnerability
           [ 'CVE', '2015-0965' ], # CSRF vulnerability
-          [ 'CVE', '2015-0966' ], # "techician/yZgO8Bvj" web interface backdoor
+          [ 'CVE', '2015-0966' ], # "technician/yZgO8Bvj" web interface backdoor
           [ 'URL', 'https://www.rapid7.com/blog/post/2015/06/05/r7-2015-01-csrf-backdoor-and-persistent-xss-on-arris-motorola-cable-modems/' ],
         ]
       )

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(_ip)
-    tmpfile = Rex::Text.rand_text_alphanumeric(20) # Store the base64 encoded traveral data in a hard-to-brute filename, just in case.
+    tmpfile = Rex::Text.rand_text_alphanumeric(20) # Store the base64 encoded traversal data in a hard-to-brute filename, just in case.
 
     print_status("Attempting to connect to #{rhost}:#{rport}")
     res = send_request_raw(

--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
       if res.body =~ %r{<password>(.*)</password>}
         print_good("#{rhost}:#{rport} - credentials successfully extracted")
 
-        # store all details as loot -> there is some usefull stuff in the response
+        # store all details as loot -> there is some useful stuff in the response
         loot = store_loot('dlink.dir645.config', 'text/plain', rhost, res.body)
         print_good("#{rhost}:#{rport} - Account details downloaded to: #{loot}")
 

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
           print_good("#{rhost}:#{rport} - Credentials successfully extracted")
         end
 
-        # store all details as loot -> there is some usefull stuff in the response
+        # store all details as loot -> there is some useful stuff in the response
         loot = store_loot('dlink.dsl320b.config', 'text/plain', rhost, res.body)
         print_good("#{rhost}:#{rport} - Configuration of DSL 320B downloaded to: #{loot}")
 

--- a/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
+++ b/modules/auxiliary/admin/http/hikvision_unauth_pwd_reset_cve_2017_7921.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res.nil?
-      return Exploit::CheckCode::Unknown('No response recieved from the target!')
+      return Exploit::CheckCode::Unknown('No response received from the target!')
     elsif res && res.code == 200
       xml_res = res.get_xml_document
       print_status('Following users are available for password reset...')

--- a/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
+++ b/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
       head_stager_uri = '/' + stager_base + '/' + head_stager_jsp_name + '.jsp'
       res = upload_file(stager_base, head_stager_jsp_name, head_stager_contents)
 
-      # We split the stager_jsp_code in multipe junks and transfer on the
+      # We split the stager_jsp_code in multiple junks and transfer on the
       # target with multiple requests
       current_pos = 0
       while current_pos < stager_contents.length
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    # Using HEAD may trigger a 500 Internal Server Error (at leat on 4.2.3.GA),
+    # Using HEAD may trigger a 500 Internal Server Error (at least on 4.2.3.GA),
     # but the file still gets written.
     unless res && (res.code == 200 || res.code == 500)
       fail_with(Failure::Unknown, 'Failed to deploy')

--- a/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
+++ b/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     })
 
-    # Yes, "sucess" is really mispelt, as is "Servelet" ... !
+    # Yes, "success" is really misspelt, as is "Servelet" ... !
     unless res && res.code == 200 && res.body && res.body.to_s =~ /sucess/
       print_error('Administrator account creation failed')
     end

--- a/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
+++ b/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     })
 
-    # Yes, "success" is really misspelt, as is "Servelet" ... !
+    # Yes, "sucess" is really misspelt, as is "Servelet" ... !
     unless res && res.code == 200 && res.body && res.body.to_s =~ /sucess/
       print_error('Administrator account creation failed')
     end

--- a/modules/auxiliary/admin/http/netgear_r7000_backup_cgi_heap_overflow_rce.rb
+++ b/modules/auxiliary/admin/http/netgear_r7000_backup_cgi_heap_overflow_rce.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         'Platform' => 'linux',
         'Author' => [
           'colorlight2019', # Vulnerability Discovery and Exploit Code
-          'SSD Disclosure', # Vulnerabilty Writeup
+          'SSD Disclosure', # Vulnerability Writeup
           'Grant Willcox (tekwizz123)' # Metasploit Module
         ],
         'DefaultTarget' => 0,

--- a/modules/auxiliary/admin/http/pfadmin_set_protected_alias.rb
+++ b/modules/auxiliary/admin/http/pfadmin_set_protected_alias.rb
@@ -108,9 +108,9 @@ class MetasploitModule < Msf::Auxiliary
       if res.nil? || res.body.nil?
         fail_with(Failure::UnexpectedReply, 'Unexpected reply while deleting the alias')
       elsif res.body =~ %r{<ul class="flash-error">.*<li.*#{target_alias}.*</li>.*</ul>}mi
-        fail_with(Failure::NotVulnerable, 'It seems the target is not vulerable, the deletion of the target alias failed.')
+        fail_with(Failure::NotVulnerable, 'It seems the target is not vulnerable, the deletion of the target alias failed.')
       else
-        fail_with(Failure::Unknown, 'An unexpected failure occured.')
+        fail_with(Failure::Unknown, 'An unexpected failure occurred.')
       end
     end
     print_good('Deleted the old alias')
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
       elsif res.body =~ /<ul class="flash-error">/mi
         fail_with(Failure::UnexpectedReply, 'It seems the new alias couldn\'t be added.')
       else
-        fail_with(Failure::Unknown, 'An unexpected failure occured.')
+        fail_with(Failure::Unknown, 'An unexpected failure occurred.')
       end
     end
     print_good('New alias created')

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'URI to the Tomcat instance', '/']),
         OptPath.new('SENSITIVE_FILES', [
-          true, 'File containing senstive files, one per line',
+          true, 'File containing sensitive files, one per line',
           File.join(Msf::Config.data_directory, 'wordlists', 'sensitive_files.txt')
         ]),
         OptInt.new('MAXDIRS', [ true, 'The maximum directory depth to search', 7]),

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'TrendMicro Data Loss Prevention 5.5 Directory Traversal',
       'Description' => %q{
-        This module tests whether a directory traversal vulnerablity is present
+        This module tests whether a directory traversal vulnerability is present
         in Trend Micro DLP (Data Loss Prevention) Appliance v5.5 build <= 1294.
         The vulnerability appears to be actually caused by the Tomcat UTF-8
         bug which is implemented in module tomcat_utf8_traversal CVE 2008-2938.
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8443),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptPath.new('SENSITIVE_FILES', [
-          true, 'File containing senstive files, one per line',
+          true, 'File containing sensitive files, one per line',
           File.join(Msf::Config.data_directory, 'wordlists', 'sensitive_files.txt')
         ]),
       ]

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def blind(field, table, condition, charset, digit_charset, patterns = {})
-    # Adding 9 so that the result has two digits, If the lenght is superior to 100-9 it won't work
+    # Adding 9 so that the result has two digits, If the length is superior to 100-9 it won't work
     offset = 9
     size = blind_size("length(#{field})+#{offset}",
                       table,
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if pattern1.to_s.eql?('') || pattern2.to_s.eql?('')
-      print_status("Couldn't determine Pattern1 and Pattern2 automatically, switching to user speficied values...")
+      print_status("Couldn't determine Pattern1 and Pattern2 automatically, switching to user specified values...")
       pattern1 = datastore['PATTERN1']
       pattern2 = datastore['PATTERN2']
     end

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
       final = datastore['ENC_KEY']
       print_status('Using provided Encryption Key')
     else
-      # build the encrption key to check
+      # build the encryption key to check
       seed = seed.to_s
       rnd1 = Digest::MD5.hexdigest(seed)
       rnd2 = Digest::MD5.hexdigest(rnd1)

--- a/modules/auxiliary/admin/http/wp_symposium_sql_injection.rb
+++ b/modules/auxiliary/admin/http/wp_symposium_sql_injection.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
 
     credentials = ''
 
-    vprint_status("#{peer} - Trying to retrieve the users informations...")
+    vprint_status("#{peer} - Trying to retrieve the users information...")
     for user_id in first_id..last_id
       separator = Rex::Text.rand_text_numeric(7, bad = '0')
       user_info = send_sql_request("concat_ws(#{separator},user_login,user_pass,user_email) from wp_users where id = #{user_id} ; --")

--- a/modules/auxiliary/admin/misc/sercomm_dump_config.rb
+++ b/modules/auxiliary/admin/misc/sercomm_dump_config.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
     ]
   }
 
-  attr_accessor :endianess
+  attr_accessor :endianness
   attr_accessor :credentials
 
   def initialize(info={})
@@ -61,12 +61,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Attempting to connect and check endianess...")
-    @endianess = fingerprint_endian
+    print_status("Attempting to connect and check endianness...")
+    @endianness = fingerprint_endian
     @credentials = {}
 
-    if endianess.nil?
-      print_error("Failed to check endianess, aborting...")
+    if endianness.nil?
+      print_error("Failed to check endianness, aborting...")
       return
     end
     print_good("#{string_endianess} device found...")
@@ -114,11 +114,11 @@ class MetasploitModule < Msf::Auxiliary
   private
 
   def little_endian?
-    return endianess == 'LE'
+    return endianness == 'LE'
   end
 
   def big_endian?
-    return endianess == 'BE'
+    return endianness == 'BE'
   end
 
   def string_endianess

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # DEFINE SEARCH QUERY AS VARIABLE
     sql = "
-    -- CHECK IF VERSION IS COMPATABLE = > than 2000
+    -- CHECK IF VERSION IS COMPATIBLE = > than 2000
     IF (SELECT SUBSTRING(CAST(SERVERPROPERTY('ProductVersion') as VARCHAR), 1,
     CHARINDEX('.',cast(SERVERPROPERTY('ProductVersion') as VARCHAR),1)-1)) > 0
     BEGIN
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
       DECLARE @SEARCH_TERMS varchar(800);
       SET @SEARCH_TERMS = ''; -- Leave this blank
 
-      -- START WHILE LOOP HERE -- BEGIN TO ITTERATE THROUGH KEYWORDS
+      -- START WHILE LOOP HERE -- BEGIN TO ITERATE THROUGH KEYWORDS
 
         WHILE LEN(@KEYWORDS) > 0
           BEGIN
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
             SET @KEYWORDS = SUBSTRING(@KEYWORDS,@change+1,LEN(@KEYWORDS));
 
           END
-        -- REMOVE UNEEDED
+        -- REMOVE UNNEEDED
         SELECT @SEARCH_TERMS = SUBSTRING(@SEARCH_TERMS,0,LEN(@SEARCH_TERMS)-2);
 
       --------------------------------------------------
@@ -370,7 +370,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     return
     else
-      #SETUP COLUM WIDTH FOR QUERY RESULTS
+      #SETUP COLUMN WIDTH FOR QUERY RESULTS
       #Save loot status
       save_loot="yes"
       column_data.each { |row|

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     sql = "exec master..xp_dirtree '\\\\\\\\#{datastore['SMBPROXY']}\\#{rand_filename}'"
     print_status("Attempting to force backend DB to authenticate to the #{datastore['SMBPROXY']}")
 
-    # Execute query to force authentation from backend database to smbproxy
+    # Execute query to force authentication from backend database to smbproxy
     mssql_query(sql)
   end
 end

--- a/modules/auxiliary/admin/natpmp/natpmp_map.rb
+++ b/modules/auxiliary/admin/natpmp/natpmp_map.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('EXTERNAL_PORTS', [true, 'The external ports to foward from (0 to let the target choose)', 0]),
+        OptString.new('EXTERNAL_PORTS', [true, 'The external ports to forward from (0 to let the target choose)', 0]),
         OptString.new('INTERNAL_PORTS', [true, 'The internal ports to forward to', '22,135-139,80,443,445'])
       ],
       self.class

--- a/modules/auxiliary/admin/netbios/netbios_spoof.rb
+++ b/modules/auxiliary/admin/netbios/netbios_spoof.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
   def netbios_spam
     payload =
         "\xff\xff"   + # TX ID (will brute force this)
-        "\x85\x00"   + # Flags = response + authoratative + recursion desired
+        "\x85\x00"   + # Flags = response + authoritative + recursion desired
         "\x00\x00"   + # Questions = 0
         "\x00\x01"   + # Answer RRs = 1
         "\x00\x00"   + # Authority RRs = 0

--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -350,7 +350,7 @@ class MetasploitModule < Msf::Auxiliary
         :sname => 'oracle',
         :port => datastore['RPORT'],
         :type => 'ORA_ENUM',
-        :data => "Password Maximun Reuse Time: #{passreusemax[0].chomp}",
+        :data => "Password Maximum Reuse Time: #{passreusemax[0].chomp}",
         :update => :unique_data
       )
       print_status("\tThe Number of Times a Password can be reused is set to #{passreuse[0].chomp}")

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error "#{rhost}:#{rport} Postgres - No such file or directory."
         vprint_status "#{rhost}:#{rport} Postgres - #{ret[:sql_error]}"
       when /^C42501/
-        print_error "#{rhost}:#{rport} Postgres - Insufficent file permissions."
+        print_error "#{rhost}:#{rport} Postgres - Insufficient file permissions."
         vprint_status "#{rhost}:#{rport} Postgres - #{ret[:sql_error]}"
       else
         print_error "#{rhost}:#{rport} Postgres - #{ret[:sql_error]}"

--- a/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe.rb
+++ b/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe.rb
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Auxiliary
 
       # Check second HTTP response
       if second_response.nil? || second_response.code != 200 || !second_response.body.include?('area shape=rect')
-        return -2 # Reponse from second HTTP request was not what was expected!
+        return -2 # Response from second HTTP request was not what was expected!
       end
 
       get_file_content(second_response.body)

--- a/modules/auxiliary/admin/scada/multi_cip_command.rb
+++ b/modules/auxiliary/admin/scada/multi_cip_command.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
         raise ::Rex::ConnectionTimeout
       end
     rescue ::Interrupt
-      print_error("#{rhost}:#{rport} - CIP - Interrupt during session negotation")
+      print_error("#{rhost}:#{rport} - CIP - Interrupt during session negotiation")
       raise $!
     rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused => e
       print_error("#{rhost}:#{rport} - CIP - Network error during session negotiation: #{e}")

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Auxiliary
   # Copies the SYSTEM hive file to the Temp directory on the target host
   def copy_sys_hive
     begin
-      # Try to crate the sys hive copy
+      # Try to create the sys hive copy
       command = "%COMSPEC% /C reg.exe save HKLM\\SYSTEM %WINDIR%\\Temp\\sys /y"
       return psexec(command)
     rescue StandardError => hiveerror
@@ -190,7 +190,7 @@ class MetasploitModule < Msf::Auxiliary
       ntds_path = store_loot("psexec.ntdsgrab.ntds", "application/octet-stream", @ip, data, "ntds.dit")
       print_good("ntds.dit stored at #{ntds_path}")
     rescue StandardError => ntdsdownloaderror
-      print_error("Unable to downlaod ntds.dit: #{ntdsdownloaderror}")
+      print_error("Unable to download ntds.dit: #{ntdsdownloaderror}")
       return ntdsdownloaderror
     end
     simple.disconnect("\\\\#{@ip}\\#{@smbshare}")

--- a/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
+++ b/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def mode
-    datastore['MODE'] || "octect"
+    datastore['MODE'] || "octet"
   end
 
   def remote_file
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # Run in case something untoward happend with the connection and the
+  # Run in case something untoward happened with the connection and the
   # client object didn't get stopped on its own. This can happen with
   # transfers that got interrupted or malformed (like sending a 0 byte
   # file).

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if (res and res.message == "OK")
-      print_status("Get informations about database...")
+      print_status("Get information about database...")
 
       n = 0
       c = 0
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if (c == 0)
-        print_status("Could not obtain informations about database.")
+        print_status("Could not obtain information about database.")
       end
 
     else

--- a/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
+++ b/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
@@ -49,8 +49,8 @@ class MetasploitModule < Msf::Auxiliary
       'Context'   => { 'Msf' => framework, 'MsfExploit' => self }
     )
 
-    # If the autovnc option is set to true this will spawn a vncviewer on the lcoal machine
-    # targetting the proxy listener.
+    # If the autovnc option is set to true this will spawn a vncviewer on the local machine
+    # targeting the proxy listener.
     if (datastore['AUTOVNC'])
       unless (check_vncviewer())
         print_error("The vncviewer does not appear to be installed, exiting...")

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
-  # Not all hash formats include an 'id' field, which coresponds which db entry
+  # Not all hash formats include an 'id' field, which corresponds which db entry
   # an item is to its hash.  This can be problematic, especially when a username
   # is used as a salt.  Due to all the variations, we make a small HashLookup
   # class to handle all the fields for easier lookup later.

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           OptString.new('OUTINF',    [true, 'The external interface connected to the internet', 'eth1']),
           OptString.new('ININF',     [true, 'The internal interface connected to the network', 'eth2']),
-          OptString.new('CLIENTIP',  [true, 'The ip of the client behing the BNAT router', '192.168.3.2']),
+          OptString.new('CLIENTIP',  [true, 'The ip of the client behind the BNAT router', '192.168.3.2']),
           OptString.new('SERVERIP',  [true, 'The ip of the server you are targeting', '1.1.2.1']),
           OptString.new('BNATIP',    [true, 'The ip of the bnat response you are getting', '1.1.2.2']),
         ])

--- a/modules/auxiliary/client/iec104/iec104.rb
+++ b/modules/auxiliary/client/iec104/iec104.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   # sends the frame data over tcp connection and returns received string
-  # using sock.get is causing quite some delay, but scripte needs to process responses from 104 server
+  # using sock.get is causing quite some delay, but script needs to process responses from 104 server
   def send_frame(data)
     begin
       sock.put(data)

--- a/modules/auxiliary/client/telegram/send_message.rb
+++ b/modules/auxiliary/client/telegram/send_message.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('CHAT_ID', [false, 'Chat ID for the BOT', '']),
         OptPath.new('DOCUMENT', [false, 'The path to the document(binary, video etc)']),
         OptPath.new('IDFILE', [false, 'File containing chat IDs, one per line']),
-        OptEnum.new('FORMATTING', [false, 'Message formating option (Markdown|MarkdownV2|HTML)', 'Markdown', [ 'Markdown', 'MarkdownV2', 'HTML']])
+        OptEnum.new('FORMATTING', [false, 'Message formatting option (Markdown|MarkdownV2|HTML)', 'Markdown', [ 'Markdown', 'MarkdownV2', 'HTML']])
       ], self.class
     )
   end

--- a/modules/auxiliary/client/telegram/send_message.rb
+++ b/modules/auxiliary/client/telegram/send_message.rb
@@ -8,18 +8,18 @@ require 'faraday'
 class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
-    'Name' => 'Telegram Message Client',
-    'Description' => %q{
+      'Name' => 'Telegram Message Client',
+      'Description' => %q{
         This module can be used to send a document and/or message to
         multiple chats on telegram. Please refer to the module
         documentation for info on how to retrieve the bot token and corresponding chat
         ID values.
         },
-    'Author' => [
-      'Ege Balcı <egebalci[at]pm.me>', # Aka @egeblc of https://pentest.blog
-      'Gaurav Purswani' # @pingport80
-    ],
-    'License' => MSF_LICENSE,
+      'Author' => [
+        'Ege Balcı <egebalci[at]pm.me>', # Aka @egeblc of https://pentest.blog
+        'Gaurav Purswani' # @pingport80
+      ],
+      'License' => MSF_LICENSE,
     )
 
     register_options(

--- a/modules/auxiliary/dos/http/flexense_http_server_dos.rb
+++ b/modules/auxiliary/dos/http/flexense_http_server_dos.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
         Vulnerability caused by a user mode write access memory violation and can be triggered with
         rapidly sending variety of HTTP requests with long HTTP header values.
 
-        Multiple Flexense applications that are using Flexense HTTP server 10.6.24 and below vesions reportedly vulnerable.
+        Multiple Flexense applications that are using Flexense HTTP server 10.6.24 and below versions reportedly vulnerable.
       },
       'Author' 		=> [ 'Ege Balci <ege.balci@invictuseurope.com>' ],
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/dos/http/ws_dos.rb
+++ b/modules/auxiliary/dos/http/ws_dos.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
       if data =~ /101/   #This is the expected HTTP status code. IF it's present, we have a valid upgrade response.
         print_error("WebSocket Upgrade request Successful, service not vulnerable.")
       else
-        fail_with(Failure::Unknown, "An unknown error occured")
+        fail_with(Failure::Unknown, "An unknown error occurred")
       end
 
       disconnect

--- a/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
+++ b/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
   def enip_register_session_pkt
     # ENIP encapsulation Header
     "\x65\x00" + # Command register session (0x0065)
-    "\x04\x00" + # Lenght (4)
+    "\x04\x00" + # Length (4)
     "\x00\x00\x00\x00" + # Session handle (0x00000000)
     "\x00\x00\x00\x00" + # Status success (0x00000000)
     "\x00\x00\x00\x00\x00\x00\x00\x00" + # Sender context (0x0000000000000000)
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
   def enip_ccm_forward_open_pkt(enip_session_handle)
     # ENIP encapsulation header
     "\x6f\x00" + # Send RR data (0x006f)
-    "\x3e\x00" + # Lenght (63)
+    "\x3e\x00" + # Length (63)
     enip_session_handle + # Session handle (retrieved from register session)
     "\x00\x00\x00\x00" + # Status success (0x00000000)
     "\x00\x00\x00\x00\x00\x00\x00\x00" + # Sender context (0x0000000000000000)

--- a/modules/auxiliary/dos/ssl/openssl_aesni.rb
+++ b/modules/auxiliary/dos/ssl/openssl_aesni.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# auxilary/dos/ssl/openssl_aesni
+# auxiliary/dos/ssl/openssl_aesni
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Dos

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     # the 0xff's must be doubled, the server will un-and-re-double them.
     ffs = "\xff" * (0x7e*2)
 
-    # Continuing after the first exception sometimes leads to this being derefenced.
+    # Continuing after the first exception sometimes leads to this being dereferenced.
     buf[0,3] = [0xdeadbe00].pack('V')[1,3]
 
     buf[4,ffs.length] = ffs

--- a/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
+++ b/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
       '0000' +  # opcode
       '0' +     # conflict
       '0' +     # truncation
-      '0' +     # tenative
+      '0' +     # tentative
       '0000' +  # zero (reserved)
       '0000'    # rcode
       )].pack('B16')

--- a/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
             print_error("Failed to write any data to the mailslot: #{e}")
             break
           end
-          print_error("Exception occurred on interation #{i}")
+          print_error("Exception occurred on iteration #{i}")
           print_error("Error: #{e.class} > #{e}")
           break
         end

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
     nbdghdr =
       "\x11" +              # DIRECT_GROUP datagram
       "\x02" +              # first and only fragment
-      [rand(0xffff)].pack('n') +  # Transation Id (DGM_ID)
+      [rand(0xffff)].pack('n') +  # Transaction Id (DGM_ID)
       ip_src +
       "\x00\x8a" +          # Source Port (138)
       "\x00\xa7" +          # DGM_LENGTH, patched in after

--- a/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
+++ b/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
       modproplong << modprops[rand(modprops.size)] + ","
     }
 
-    boundry = Rex::Text.rand_text_alphanumeric(8) + "." + Rex::Text.rand_text_alphanumeric(8)
+    boundary = Rex::Text.rand_text_alphanumeric(8) + "." + Rex::Text.rand_text_alphanumeric(8)
 
 
     # Really, the randomization above only crashes /sometimes/ - it's MUCH more
@@ -80,10 +80,10 @@ class MetasploitModule < Msf::Auxiliary
     mail <<		"Subject: #{datastore['SUBJECT']}\r\n"
     mail <<		"Content-class: urn:content-classes:calendarmessage\r\n"
     mail <<		"MIME-Version: 1.0\r\n"
-    mail <<		"Content-Type: multipart/alternative;boundary=\"#{boundry}\"\r\n"
+    mail <<		"Content-Type: multipart/alternative;boundary=\"#{boundary}\"\r\n"
     mail <<		"X-MimeOLE: Produced By Microsoft Exchange V6.5.7226.0\r\n"
     mail <<     "\r\n"
-    mail << 	"--#{boundry}\r\n"
+    mail << 	"--#{boundary}\r\n"
     mail <<		"Content-class: urn:content-classes:calendarmessage\r\n"
     mail <<		"Content-Type: text/calendar; method=REQUEST; name=\"meeting.ics\"\r\n"
     mail <<		"Content-Transfer-Encoding: 8bit\r\n"
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
     mail <<		"X-MICROSOFT-CDO-MODPROPS:#{modproplong.chop}\r\n"
     mail <<		"END:VEVENT\r\n"
     mail <<		"END:VCALENDAR\r\n"
-    mail <<		"\r\n--#{boundry}\r\n"
+    mail <<		"\r\n--#{boundary}\r\n"
     mail <<		"\r\n.\r\n"
 
 

--- a/modules/auxiliary/fileformat/badpdf.rb
+++ b/modules/auxiliary/fileformat/badpdf.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     File.open(newfilename, 'wb') { |file| file.write(newdata) }
     # Check file exists and display path or error message
     if File.exist?(newfilename)
-      print_good("Malicious file writen to: #{newfilename}")
+      print_good("Malicious file written to: #{newfilename}")
     else
       print_error 'Something went wrong creating malicious PDF file'
     end

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -291,7 +291,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def get_field_val(input)
     tmp = input.split(/\=/)
-    # get delimeter
+    # get delimiter
     tmp2 = tmp[1].strip
     delim = tmp2[0,1]
     if delim != "'" && delim != '"'
@@ -377,7 +377,7 @@ class MetasploitModule < Msf::Auxiliary
           if subdata.size > 1
             subdata.each do | thisinput |
               if skipflag == 1
-                # first, find the delimeter
+                # first, find the delimiter
                 fielddata = thisinput.downcase.split(/>/)
                 fields = fielddata[0].split(/ /)
                 fieldname = ""

--- a/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
     cnt = datastore['STARTLEN'] - 1
 
-    1.upto(datastore['INTERACTIONS']) do |interection|
+    1.upto(datastore['INTERACTIONS']) do |interaction|
       cnt += 1
 
       str = fuzzer_gen_string(cnt)
@@ -126,10 +126,10 @@ class MetasploitModule < Msf::Auxiliary
           disconnect
         end
 
-        print_status("Fuzzing with iteration #{interection}\n #{@result}")
+        print_status("Fuzzing with iteration #{interaction}\n #{@result}")
 
       rescue ::Interrupt
-        print_status("Exiting on interrupt: iteration #{interection} using string  #{str}")
+        print_status("Exiting on interrupt: iteration #{interaction} using string  #{str}")
         raise $!
       rescue ::Exception => e
         last_err = e

--- a/modules/auxiliary/gather/adobe_coldfusion_fileread_cve_2023_26360.rb
+++ b/modules/auxiliary/gather/adobe_coldfusion_fileread_cve_2023_26360.rb
@@ -103,14 +103,14 @@ class MetasploitModule < Msf::Auxiliary
       file_data = res.body[res.body.index(wddx_packet_tag) + wddx_packet_tag.length..]
 
       # If the default CFC options were used, we know the output will end with the result of calling wizardHash. So we can
-      # remove the result which is a SHA1 hash and two 32 byte random strings, comma seperated and a trailing space.
+      # remove the result which is a SHA1 hash and two 32 byte random strings, comma separated and a trailing space.
       if datastore['CFC_ENDPOINT'] == '/CFIDE/wizards/common/utils.cfc' && datastore['CFC_METHOD'] == 'wizardHash'
         file_data = file_data[0..file_data.length - (40 + 32 + 32 + 2 + 1) - 1]
       end
     else
       # ColdFusion has a non-default option 'Enable Request Debugging Output', which if enabled may return a HTTP 500
       # or 404 error, while also including the arbitrary file read output. We detect this here and retrieve the file
-      # output which is pre-pended to the error page.
+      # output which is prepended to the error page.
       request_debugging_tag = '<!-- " ---></TD></TD></TD></TH></TH></TH>'
 
       if res && (res.code == 404 || res.code == 500) && (res.body.include? request_debugging_tag)

--- a/modules/auxiliary/gather/android_stock_browser_uxss.rb
+++ b/modules/auxiliary/gather/android_stock_browser_uxss.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         and is much less stealthy, but is generally harmless-looking.
 
         By supplying a CUSTOM_JS parameter and ensuring CLOSE_POPUP is set to false, this
-        module also allows running aribtrary javascript in the context of the targeted URL.
+        module also allows running arbitrary javascript in the context of the targeted URL.
         Some sample UXSS scripts are provided in data/exploits/uxss.
       },
       'Author'         => [

--- a/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
+++ b/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Auxiliary
 
 
   #
-  # Handle HTTP requets and responses
+  # Handle HTTP requests and responses
   #
   def on_request_uri(cli, request)
     if request.method.downcase == 'post'

--- a/modules/auxiliary/gather/asterisk_creds.rb
+++ b/modules/auxiliary/gather/asterisk_creds.rb
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # The response is a whitespace formatted table
     # We're only interested in the first two columns: username and secret
-    # To parse the table, we need the characer width of these two columns
+    # To parse the table, we need the character width of these two columns
     if res =~ /^(Username\s+)(Secret\s+)/
       user_len = $1.length
       pass_len = $2.length

--- a/modules/auxiliary/gather/cloud_lookup.rb
+++ b/modules/auxiliary/gather/cloud_lookup.rb
@@ -549,7 +549,7 @@ class MetasploitModule < Msf::Auxiliary
     domain_name = PublicSuffix.parse(datastore['HOSTNAME']).domain
     ip_list = []
 
-    # Start collecting informations for grabbing all IP adress(es).
+    # Start collecting information for grabbing all IP address(es).
 
     # ViewDNS.info
     ip_records = grab_domain_ip_history(domain_name)
@@ -597,7 +597,7 @@ class MetasploitModule < Msf::Auxiliary
     #  - addresses are not provided
 
     ip_blacklist = []
-    # Cleaning IP addresses if nessesary.
+    # Cleaning IP addresses if necessary.
     case @my_action.name
     when /ArvanCloud/
       ip_blacklist = arvancloud_ips

--- a/modules/auxiliary/gather/darkcomet_filedownloader.rb
+++ b/modules/auxiliary/gather/darkcomet_filedownloader.rb
@@ -262,7 +262,7 @@ class MetasploitModule < Msf::Auxiliary
       brute_max = 4
 
       if missing_bytecount > brute_max
-        print_status("Using inferrence attack ...")
+        print_status("Using inference attack ...")
 
         # Offsets to monitor for changes
         target_offset_range = []
@@ -317,7 +317,7 @@ class MetasploitModule < Msf::Auxiliary
           end
         end
 
-        # Inferrence attack done, reconstruct final keystream segment
+        # Inference attack done, reconstruct final keystream segment
         inf_seg = ["\x00"] * (keystream.length + missing_bytecount)
         inferrence_results.each do |x, val|
           inf_seg[x] = val

--- a/modules/auxiliary/gather/elasticsearch_enum.rb
+++ b/modules/auxiliary/gather/elasticsearch_enum.rb
@@ -18,10 +18,10 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           This module enumerates Elasticsearch instances. It uses the REST API
           in order to gather information about the server, the cluster, nodes,
-          in the cluster, indicies, and pull data from those indicies.
+          in the cluster, indices, and pull data from those indices.
         },
         'Author' => [
-          'Silas Cutler <Silas.Cutler[at]BlackListThisDomain.com>', # original indicies enum module
+          'Silas Cutler <Silas.Cutler[at]BlackListThisDomain.com>', # original indices enum module
           'h00die' # generic enum module
         ],
         'References' => [
@@ -136,12 +136,12 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    indicies = []
+    indices = []
 
     json_body.each do |index|
       next if datastore['VERBOSE'] == false && index['index'].starts_with?('.fleet')
 
-      indicies << index['index'] if index['docs.count'].to_i > 0 # avoid querying something with no data
+      indices << index['index'] if index['docs.count'].to_i > 0 # avoid querying something with no data
       elastic_table << [
         index['index'],
         index['health'],
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     print_good(elastic_table.to_s)
-    indicies.each do |index|
+    indices.each do |index|
       get_results(index)
     end
   end

--- a/modules/auxiliary/gather/exchange_proxylogon_collector.rb
+++ b/modules/auxiliary/gather/exchange_proxylogon_collector.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           All components are vulnerable by default.
         },
         'Author' => [
-          'Orange Tsai', # Dicovery (Officially acknowledged by MSRC)
+          'Orange Tsai', # Discovery (Officially acknowledged by MSRC)
           'GreyOrder', # PoC (https://github.com/GreyOrder)
           'mekhalleh (RAMELLA Sébastien)' # Module author independent researcher (work at Zeop Entreprise)
         ],
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
 
     response = send_xml('POST', ssrf, soap_countitems(action['id_attribute']))
     if response.body =~ /Success/
-      print_good("Successfuly connected to: #{action['id_attribute']}")
+      print_good("Successfully connected to: #{action['id_attribute']}")
       xml = Nokogiri::XML.parse(response.body)
 
       folder_id = xml.at_xpath('//t:ContactsFolder/t:FolderId', XMLNS)&.values&.at(0)
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
 
     response = send_xml('POST', ssrf, soap_countitems(datastore['FOLDER']))
     if response.body =~ /Success/
-      print_good("Successfuly connected to: #{datastore['FOLDER']}")
+      print_good("Successfully connected to: #{datastore['FOLDER']}")
       xml = Nokogiri::XML.parse(response.body)
 
       folder_id = xml.at_xpath('//t:Folder/t:FolderId', XMLNS)&.values&.at(0)
@@ -393,7 +393,7 @@ class MetasploitModule < Msf::Auxiliary
     server_name = response.headers['X-FEServer']
     print_status("Internal server name (#{server_name})")
 
-    # get informations by autodiscover request.
+    # get information by autodiscover request.
     print_status(message('Sending autodiscover request'))
     server_id, legacy_dn, owa_urls = request_autodiscover(server_name)
 

--- a/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
+++ b/modules/auxiliary/gather/hikvision_info_disclosure_cve_2017_7921.rb
@@ -203,7 +203,7 @@ class MetasploitModule < Msf::Auxiliary
           loot_data << "Device model: #{device.at_css('model').content}\n"
           loot_data << "Device S/N: #{device.at_css('serialNumber').content}\n"
           loot_data << "Device MAC: #{device.at_css('macAddress').content}\n"
-          loot_data << "Device firware version: #{device.at_css('firmwareVersion').content}\n"
+          loot_data << "Device firmware version: #{device.at_css('firmwareVersion').content}\n"
           loot_data << "Device firmware release: #{device.at_css('firmwareReleasedDate').content}\n"
           loot_data << "Device boot version: #{device.at_css('bootVersion').content}\n"
           loot_data << "Device boot release: #{device.at_css('bootReleasedDate').content}\n"

--- a/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
+++ b/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('SpecialChars', [false, 'Specify special chars (e.g. -_+!@&$/\?)', '' ]),
         OptString.new('PREFIX', [ false,  'Defines set prefix for each guess (e.g. user)', '']),
-        OptString.new('SUFFIX', [ false,  'Defines set post for each quess (e.g. _adm)', '']),
+        OptString.new('SUFFIX', [ false,  'Defines set post for each guess (e.g. _adm)', '']),
         OptInt.new('TIMING', [ true,  'Set pause between requests', 0]),
         OptInt.new('Threads', [ true,  'Number of test threads', 10])
       ])
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     print_status("Testing for IBM Lotus Notes Sametime User Enumeration flaw")
 
-    # test for expected response code on non-existant uid/email
+    # test for expected response code on non-existent uid/email
     if datastore['TYPE'] == "UID"
       random_val = Rex::Text.rand_text_alpha(32)
     else
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Auxiliary
     # start test handler
     test_handler
 
-    # ouput results
+    # output results
     output_results
   end
 

--- a/modules/auxiliary/gather/ibm_sametime_room_brute.rb
+++ b/modules/auxiliary/gather/ibm_sametime_room_brute.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Beginning IBM Lotus Notes Sametime Meeting Room Bruteforce")
     print_status("Using owner: #{datastore['OWNER']}")
 
-    # test for expected response code on non-existant meeting room name
+    # test for expected response code on non-existent meeting room name
     rval = Rex::Text.rand_text_alpha(64)
     uri = target_uri.path
     @reqpath = normalize_uri(uri, '/restapi')

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     print_status("Copying certificate from #{rhost}:#{rport}\n#{cert.subject} ")
-    vprint_status("Original Certifcate Details\n\n#{cert.to_text}")
+    vprint_status("Original Certificate Details\n\n#{cert.to_text}")
 
     begin
       keylength = /Key: \((\d+)/i.match(cert.signature_algorithm)[1] # Grab keylength from target cert

--- a/modules/auxiliary/gather/konica_minolta_pwd_extract.rb
+++ b/modules/auxiliary/gather/konica_minolta_pwd_extract.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
       'data'   => '<SOAP-ENV:Envelope></SOAP-ENV:Envelope>'
     }, datastore['TIMEOUT'].to_i)
     if response.nil?
-      print_error("No reponse from device")
+      print_error("No response from device")
       return
     else
       xml0_body = ::Nokogiri::XML(response.body)
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
   # This section logs on and retrieves AuthKey token
   def login(major, minor)
     authreq_xml = generate_authkey_request_xlm(major, minor)
-    # Send post request with crafted XML to login and retreive AuthKey
+    # Send post request with crafted XML to login and retrieve AuthKey
     begin
       response = send_request_cgi(
       {
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Auxiliary
         'data'   => authreq_xml.to_xml
       }, datastore['TIMEOUT'].to_i)
       if response.nil?
-        print_error("No reponse from device")
+        print_error("No response from device")
         return
       else
         xml1_body = ::Nokogiri::XML(response.body)
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Auxiliary
   # This section post xml soap message that will extract usernames and passwords
   def extract(major, minor, authkey)
     if (authkey != '')
-      # create xml request to extract user credintial settings
+      # create xml request to extract user credential settings
       smbreq_xml = generate_pwd_request_xlm(major, minor, authkey)
       # Send post request with crafted XML as data
       begin
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
           'data'   => smbreq_xml.to_xml
         }, datastore['TIMEOUT'].to_i)
         if response.nil?
-          print_error("No reponse from device")
+          print_error("No response from device")
           return
         else
           xml2_body = ::Nokogiri::XML(response.body)

--- a/modules/auxiliary/gather/ldap_hashdump.rb
+++ b/modules/auxiliary/gather/ldap_hashdump.rb
@@ -366,7 +366,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      # higlight unresolved hashes
+      # highlight unresolved hashes
       hash_format = '{crypt}' if hash =~ /{crypt}/i
 
       print_good("#{peer} Credentials (#{hash_format.empty? ? 'password' : hash_format}) found in #{attr}: #{dn}:#{hash}")

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
       OptPath.new('QUERY_FILE_PATH', [false, 'Path to the JSON or YAML file to load and run queries from'], conditions: %w[ACTION == RUN_QUERY_FILE]),
       OptString.new('QUERY_FILTER', [false, 'Filter to send to the target LDAP server to perform the query'], conditions: %w[ACTION == RUN_SINGLE_QUERY]),
-      OptString.new('QUERY_ATTRIBUTES', [false, 'Comma seperated list of attributes to retrieve from the server'], conditions: %w[ACTION == RUN_SINGLE_QUERY])
+      OptString.new('QUERY_ATTRIBUTES', [false, 'Comma separated list of attributes to retrieve from the server'], conditions: %w[ACTION == RUN_SINGLE_QUERY])
     ])
   end
 

--- a/modules/auxiliary/gather/mikrotik_winbox_fileread.py
+++ b/modules/auxiliary/gather/mikrotik_winbox_fileread.py
@@ -133,7 +133,7 @@ def run(args):
     a = bytearray(a)
     b = bytearray(b)
 
-    #Send hello and recieve the sesison id
+    #Send hello and receive the sesison id
     s.send(a)
     try:
         d = bytearray(s.recv(1024))

--- a/modules/auxiliary/gather/nuuo_cms_bruteforce.rb
+++ b/modules/auxiliary/gather/nuuo_cms_bruteforce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         heap address of the user object instead of a real session number when a user logs
         in. This can be used to reduce the keyspace for the session number from 10 million
         to 1.2 million, and with a bit of analysis it can be guessed in less than 500k tries.
-        This module does exactly that - it uses a computed occurence table to try the most common
+        This module does exactly that - it uses a computed occurrence table to try the most common
         combinations up to 1.2 million to try to guess a valid user session.
         This session number can then be used to achieve code execution or download files - see
         the other Nuuo CMS auxiliary and exploit modules.

--- a/modules/auxiliary/gather/redis_extractor.rb
+++ b/modules/auxiliary/gather/redis_extractor.rb
@@ -109,13 +109,13 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    # Ensure version compatability
+    # Ensure version compatibility
     if (Rex::Version.new(redis_version) < Rex::Version.new(MIN_REDIS_VERSION))
       print_status("Module supports Redis #{MIN_REDIS_VERSION} or higher.")
       return
     end
 
-    # Connection was sucessful
+    # Connection was successful
     return info_data
   rescue Msf::Auxiliary::Failed => e
     # This error trips when auth is required but password not set

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -204,7 +204,7 @@ class MetasploitModule < Msf::Auxiliary
     start_service
 
     # Create our own HTTP server
-    # We will stay in this functino until we manually terminate execution
+    # We will stay in this function until we manually terminate execution
     start_http
   end
 

--- a/modules/auxiliary/gather/ssllabs_scan.rb
+++ b/modules/auxiliary/gather/ssllabs_scan.rb
@@ -552,7 +552,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    # Renegotioation
+    # Renegotiation
     case
     when r.details.reneg_support == 0
       report_warning "Secure renegotiation is not supported"

--- a/modules/auxiliary/gather/suite_crm_export_sqli.rb
+++ b/modules/auxiliary/gather/suite_crm_export_sqli.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # This module sends this same request multiple times. In order to reduce code it has beed moved it into it's owm method
+  # This module sends this same request multiple times. In order to reduce code it has been moved it into it's owm method
   def send_injection_request_cgi(payload)
     res = send_request_cgi({
       'method' => 'POST',

--- a/modules/auxiliary/gather/vbulletin_getindexablecontent_sqli.rb
+++ b/modules/auxiliary/gather/vbulletin_getindexablecontent_sqli.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     table_prfx = table_name.split('language')[0]
-    print_good("Sucessfully retrieved table to get prefix from #{table_name}.")
+    print_good("Successfully retrieved table to get prefix from #{table_name}.")
 
     table_prfx
   end
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && !parsed_resp['errors']
 
-    print_good("Sucessfully found node at id #{id}")
+    print_good("Successfully found node at id #{id}")
     true
   end
 

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Auxiliary
       @lm_hash_not_stored = false
     end
   rescue RubySMB::Dcerpc::Error::WinregError => e
-    vprint_warning("An error occured when checking NoLMHash policy: #{e}")
+    vprint_warning("An error occurred when checking NoLMHash policy: #{e}")
   end
 
   def save_registry_key(hive_name)
@@ -364,7 +364,7 @@ class MetasploitModule < Msf::Auxiliary
 
     svc_config.lp_service_start_name.to_s
   rescue RubySMB::Dcerpc::Error::SvcctlError => e
-    vprint_warning("An error occured when getting #{service_name} service account: #{e}")
+    vprint_warning("An error occurred when getting #{service_name} service account: #{e}")
     return nil
   ensure
     @svcctl.close_service_handle(svc_handle) if svc_handle
@@ -379,7 +379,7 @@ class MetasploitModule < Msf::Auxiliary
         bind: false
       )
     rescue RubySMB::Dcerpc::Error::WinregError => e
-      vprint_warning("An error occured when getting the default user name: #{e}")
+      vprint_warning("An error occurred when getting the default user name: #{e}")
       return nil
     end
     return nil if username.nil? || username.empty?
@@ -1001,7 +1001,7 @@ class MetasploitModule < Msf::Auxiliary
       @svcctl.change_service_config_w(svc_handle, start_type: RubySMB::Dcerpc::Svcctl::SERVICE_DISABLED)
     end
   rescue RubySMB::Dcerpc::Error::SvcctlError => e
-    vprint_warning("An error occured when cleaning up: #{e}")
+    vprint_warning("An error occurred when cleaning up: #{e}")
   ensure
     @svcctl.close_service_handle(svc_handle) if svc_handle
   end

--- a/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
+++ b/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Auxiliary
     ldap_trigger_post *= '&'
     method = 'POST'
 
-    print_status("Triggering LDAP reqeust")
+    print_status("Triggering LDAP request")
     res = make_request(ldap_trigger_page, method, ldap_trigger_post)
     res.code
   end

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptInt.new('LoginTimeOut', [ true, "Timout on login", 23 ]),
+        OptInt.new('LoginTimeOut', [ true, "Timeout on login", 23 ]),
         OptBool.new('RECORD_GUEST', [ false, "Record guest login to the database", false]),
         OptBool.new('CHECK_GUEST', [ false, "Check for guest login", true])
       ], self)

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
         results.each do |result|
           unless result.empty?
             if result['username'] and result['password']
-              print_good("Retrived #{result['type']} credentials for #{architecture[0]}")
+              print_good("Retrieved #{result['type']} credentials for #{architecture[0]}")
               creds_found = true
               domain = ""
               domain = result['domain'] if result['domain']

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @netifaces = true
     if not netifaces_implemented?
-      print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+      print_error("WARNING : Pcaprub is not up-to-date, some functionality will not be available")
       @netifaces = false
     end
 
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     ping6("ff02::1:2", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})  #All DHCP servers and relay agents on the local network site (defined in RFC 3315)
     ping6("ff05::1:3", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})  #All DHCP servers on the local network site (defined in RFC 3315)
 
-    # Listen for host advertisments
+    # Listen for host advertisements
     print_status("Listening for responses...")
     listen_for_ping_response()
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @netifaces = true
     if not netifaces_implemented?
-      print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+      print_error("WARNING : Pcaprub is not up-to-date, some functionality will not be available")
       @netifaces = false
     end
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Auxiliary
     @prefix = generate_prefix()
     @netifaces = true
     if not netifaces_implemented?
-      print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+      print_error("WARNING : Pcaprub is not up-to-date, some functionality will not be available")
       @netifaces = false
     end
 

--- a/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
       # additional check per https://github.com/bwatters-r7/metasploit-framework/blob/b44568dd85759a1aa2160a9d41397f2edc30d16f/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
       # and  #7582
       if sock.nil?
-        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; possible invalid response'
         print_status(error_msg)
         elog(error_msg)
       else
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
-          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; possible invalid response'
           print_status(error_msg)
           elog(error_msg)
           return

--- a/modules/auxiliary/scanner/ftp/easy_file_sharing_ftp.rb
+++ b/modules/auxiliary/scanner/ftp/easy_file_sharing_ftp.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
       connect_login
       sock = data_connect
       if sock.nil?
-        error_msg = 'data_connect failed; posssible invalid response'
+        error_msg = 'data_connect failed; possible invalid response'
         print_status(error_msg)
         elog(error_msg)
       else
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
-          error_msg = 'data_connect failed; posssible invalid response'
+          error_msg = 'data_connect failed; possible invalid response'
           print_status(error_msg)
           elog(error_msg)
           return

--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
       connect_login
       sock = data_connect
       if sock.nil?
-        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; possible invalid response'
         print_status(error_msg)
         elog(error_msg)
       else
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
-          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; possible invalid response'
           print_status(error_msg)
           elog(error_msg)
           return

--- a/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       connect_login
       sock = data_connect
       if sock.nil?
-        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; possible invalid response'
         print_status(error_msg)
         elog(error_msg)
       else
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
-          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; possible invalid response'
           print_status(error_msg)
           elog(error_msg)
           return

--- a/modules/auxiliary/scanner/http/accellion_fta_statecode_file_read.rb
+++ b/modules/auxiliary/scanner/http/accellion_fta_statecode_file_read.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
         res.body,
         fname
       )
-      print_good("#{peer} Sucessfully downloaded #{datastore['FILEPATH']} as #{path}")
+      print_good("#{peer} Successfully downloaded #{datastore['FILEPATH']} as #{path}")
     else
       vprint_status(
         "#{peer} Unexpected response headers: (Server=#{res.headers['Server'].inspect} Expected=#{expected_server.inspect}) " +

--- a/modules/auxiliary/scanner/http/blind_sql_query.rb
+++ b/modules/auxiliary/scanner/http/blind_sql_query.rb
@@ -339,10 +339,10 @@ class MetasploitModule < Msf::Auxiliary
     # print_status("A")
 
     # DETECTION A
-    # Very simple way to compare responses, this can be improved alot , at this time just the simple way
+    # Very simple way to compare responses, this can be improved a lot , at this time just the simple way
 
     if normalr and truer
-      #Very simple way to compare responses, this can be improved alot , at this time just the simple way
+      #Very simple way to compare responses, this can be improved a lot , at this time just the simple way
       reltruesize = truer.body.length-(truer.body.scan(/#{tarr[1]}/).length*tarr[1].length)
       normalsize = normalr.body.length
 

--- a/modules/auxiliary/scanner/http/brute_dirs.rb
+++ b/modules/auxiliary/scanner/http/brute_dirs.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptInt.new('ErrorCode', [ true,  "The expected http code for non existant directories", 404]),
+        OptInt.new('ErrorCode', [ true,  "The expected http code for non existent directories", 404]),
         OptPath.new('HTTP404Sigs', [ false, "Path of 404 signatures to use",
           File.join(Msf::Config.data_directory, "wmap", "wmap_404s.txt")
         ]),

--- a/modules/auxiliary/scanner/http/cassandra_web_file_read.rb
+++ b/modules/auxiliary/scanner/http/cassandra_web_file_read.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           This module exploits an unauthenticated directory traversal vulnerability in Cassandra Web
           'Cassandra Web' version 0.5.0 and earlier, allowing arbitrary file read with the web server privileges.
-          This vulnerability occured due to the disabled Rack::Protection module
+          This vulnerability occurred due to the disabled Rack::Protection module
         },
         'References' => [
           ['URL', 'https://github.com/avalanche123/cassandra-web/commit/f11e47a26f316827f631d7bcfec14b9dd94f44be'],

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'           => 'Cisco Network Access Manager Directory Traversal Vulnerability',
       'Description'    => %q{
-        This module tests whether a directory traversal vulnerablity is present
+        This module tests whether a directory traversal vulnerability is present
         in versions of Cisco Network Access Manager 4.8.x You may wish to change
         FILE (e.g. passwd or hosts), MAXDIRS and RPORT depending on your environment.
         },

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Auxiliary
     password = Rex::Text.rand_text_alphanumeric(20)
 
     tries.times do |i|
-      vprint_good("Attemping to add User: #{username}, Pass: #{password}")
+      vprint_good("Attempting to add User: #{username}, Pass: #{password}")
       command = "username #{username} password #{password} privilege 15"
       resp = run_command(command, cookie)
 

--- a/modules/auxiliary/scanner/http/clansphere_traversal.rb
+++ b/modules/auxiliary/scanner/http/clansphere_traversal.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res and res.body =~ /^Fatal error\:/
-      print_error("Unable to read '#{datastore['FILE']}', possibily because:")
+      print_error("Unable to read '#{datastore['FILE']}', possibly because:")
       print_error("\t1. File does not exist.")
       print_error("\t2. No permission.")
       print_error("\t3. #{ip} isn't vulnerable to null byte poisoning.")

--- a/modules/auxiliary/scanner/http/copy_of_file.rb
+++ b/modules/auxiliary/scanner/http/copy_of_file.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     ecode = datastore['ErrorCode'].to_i
     dm = datastore['NoDetailMessages']
 
-    # Required to calculate error code for each case as special charcters amd spaces
+    # Required to calculate error code for each case as special characters amd spaces
     # trigger different responses
 
     prestr = [

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
   #
   # Data we will report:
   # - The path of any URL found by the crawler (web.uri, :path => page.path)
-  # - The occurence of any form (web.form :path, :type (get|post|path_info), :params)
+  # - The occurrence of any form (web.form :path, :type (get|post|path_info), :params)
   #
   def crawler_process_page(t, page, cnt)
     return if page.nil? # Skip over pages that don't contain any info aka page is nil. We can't process these types of pages since there is no data to process.

--- a/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'Dolibarr 16 pre-auth contact database dump',
         'Description' => %q{
           Dolibarr version 16 < 16.0.5 is vulnerable to a pre-authentication contact database dump.
-          An unauthenticated attacker may retreive a company’s entire customer file, prospects, suppliers,
+          An unauthenticated attacker may retrieve a company’s entire customer file, prospects, suppliers,
           and potentially employee information if a contact file exists.
           Both public and private notes are also included in the dump.
         },

--- a/modules/auxiliary/scanner/http/exchange_proxylogon.rb
+++ b/modules/auxiliary/scanner/http/exchange_proxylogon.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           All components are vulnerable by default.
         },
         'Author' => [
-          'Orange Tsai', # Dicovery (Officially acknowledged by MSRC)
+          'Orange Tsai', # Discovery (Officially acknowledged by MSRC)
           'mekhalleh (RAMELLA Sébastien)' # Module author (Zeop Entreprise)
         ],
         'References' => [

--- a/modules/auxiliary/scanner/http/files_dir.rb
+++ b/modules/auxiliary/scanner/http/files_dir.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptInt.new('ErrorCode', [ true,  "The expected http code for non existant files", 404]),
+        OptInt.new('ErrorCode', [ true,  "The expected http code for non existent files", 404]),
         OptPath.new('HTTP404Sigs',   [ false, "Path of 404 signatures to use",
             File.join(Msf::Config.data_directory, "wmap", "wmap_404s.txt")
           ]

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    # Header Names are case insensitve so convert them to upcase
+    # Header Names are case insensitive so convert them to upcase
     headers_uppercase = headers.inject({}) do |hash, keys|
       hash[keys[0].upcase] = keys[1]
       hash

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptString.new('HttpSuccessCodes', [ false, 'Comma seperated list of HTTP response codes or ranges to promote as successful login', '200,201,300-308']),
+        OptString.new('HttpSuccessCodes', [ false, 'Comma separated list of HTTP response codes or ranges to promote as successful login', '200,201,300-308']),
       ]
     )
 

--- a/modules/auxiliary/scanner/http/httpbl_lookup.rb
+++ b/modules/auxiliary/scanner/http/httpbl_lookup.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       print_status ""
-      print_status "#{ip} resloves to #{result} which means: #{typestring}"
+      print_status "#{ip} resolves to #{result} which means: #{typestring}"
       print_status "=> it was last seen #{lastseen} day ago and has a threat score of #{threatnum} or \'#{threat} spam messages\'"
       print_status "=> more info here: http://www.projecthoneypot.org/ip_#{ip}\n"
     end

--- a/modules/auxiliary/scanner/http/kodi_traversal.rb
+++ b/modules/auxiliary/scanner/http/kodi_traversal.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res and res.code != 200
-      print_error("Unable to read '#{datastore['FILE']}', possibily because:")
+      print_error("Unable to read '#{datastore['FILE']}', possibly because:")
       print_error("\t1. File does not exist.")
       print_error("\t2. No permission.")
 

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptPath.new('SENSITIVE_FILES',  [ true, "File containing senstive files, one per line",
+        OptPath.new('SENSITIVE_FILES',  [ true, "File containing sensitive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
         OptString.new('HttpUsername',[ true, 'User to login with', 'admin']),
         OptString.new('HttpPassword',[ true, 'Password to login with', 'password']),

--- a/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
 
       return if not res
 
-      # Sheck for alternates header
+      # Check for alternates header
       if(res.code == 406)
         print_status(ip.to_s)
       end

--- a/modules/auxiliary/scanner/http/netdecision_traversal.rb
+++ b/modules/auxiliary/scanner/http/netdecision_traversal.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     file = file[1,file.length] if file[0,1] == "\\"
 
     uri = "/#{trav}#{file}"
-    print_status("#{ip}:#{rport} - Retriving #{file}")
+    print_status("#{ip}:#{rport} - Retrieving #{file}")
 
     res = send_request_raw({
       'method' => 'GET',

--- a/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
+++ b/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'Netgear SPH200D Directory Traversal Vulnerability',
       'Description' => %q{
-          This module exploits a directory traversal vulnerablity which is present in
+          This module exploits a directory traversal vulnerability which is present in
         Netgear SPH200D Skype telephone.
       },
       'References'  =>

--- a/modules/auxiliary/scanner/http/novell_mdm_creds.rb
+++ b/modules/auxiliary/scanner/http/novell_mdm_creds.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name' => 'Novell Zenworks Mobile Device Managment Admin Credentials',
+      'Name' => 'Novell Zenworks Mobile Device Management Admin Credentials',
       'Description' => %q{
         This module attempts to pull the administrator credentials from
         a vulnerable Novell Zenworks MDM server.

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if datastore['VERIFYCONNECT']
-        # Verifiying CONNECT we check only the return code
+        # Verifying CONNECT we check only the return code
         if valid_codes.include?(res.code.to_s)
 
           print_good("#{peer} - Potentially open proxy [#{res.code}][#{target_method}]#{proxy_headers}")

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if !["OWA_2013", "OWA_2016"].include?(action.name) && res.get_cookies.empty?
-        print_error("#{msg} Received invalid repsonse due to a missing cookie (possibly due to invalid version), aborting")
+        print_error("#{msg} Received invalid response due to a missing cookie (possibly due to invalid version), aborting")
         return :abort
     end
     if ["OWA_2013", "OWA_2016"].include?(action.name)

--- a/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
+++ b/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptBool.new('STOP_ON_SUCCESS', [ true, "Stop guessing when a credential works for a host", true]),
         OptString.new('USERNAME', [true, "A specific username to authenticate as, default 'radware'", "radware"]),
-        OptString.new('PASSWORD', [true, "A specific password to authenticate with, deault 'radware'", "radware"])
+        OptString.new('PASSWORD', [true, "A specific password to authenticate with, default 'radware'", "radware"])
       ])
 
     deregister_options('HttpUsername', 'HttpPassword')

--- a/modules/auxiliary/scanner/http/replace_ext.rb
+++ b/modules/auxiliary/scanner/http/replace_ext.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptInt.new('ErrorCode', [ true,  "The expected http code for non existant files", 404]),
+        OptInt.new('ErrorCode', [ true,  "The expected http code for non existent files", 404]),
         OptPath.new('HTTP404Sigs',   [ false, "Path of 404 signatures to use",
             File.join(Msf::Config.data_directory, "wmap", "wmap_404s.txt")
           ]
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
 
       #
       # Detect error code. This module is a special case as each extension
-      # usually is handled diferently by the server with different error codes
+      # usually is handled differently by the server with different error codes
       #
       ecode = datastore['ErrorCode'].to_i
       begin

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'HTTP Robots.txt Content Scanner',
-      'Description' => 'Detect robots.txt files and analize its content',
+      'Description' => 'Detect robots.txt files and analyze its content',
       'Author'       => ['et'],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('PATH', [ true,  "The test path to the page to analize", '/']),
+        OptString.new('PATH', [ true,  "The test path to the page to analyze", '/']),
         OptRegexp.new('PATTERN', [ true,  "The regex to use (default regex is a sample to grab page title)", '<title>(.*)</title>'])
 
       ])

--- a/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
+++ b/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('USERNAME', [true, "A specific username to authenticate as, default 'admn'", "admn"]),
-        OptString.new('PASSWORD', [true, "A specific password to authenticate with, deault 'admn'", "admn"])
+        OptString.new('PASSWORD', [true, "A specific password to authenticate with, default 'admn'", "admn"])
       ])
   end
 

--- a/modules/auxiliary/scanner/http/sockso_traversal.rb
+++ b/modules/auxiliary/scanner/http/sockso_traversal.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
     file = file[1,file.length] if file[0,1] == "\\"
 
     uri = "/#{trav}#{file}"
-    print_status("#{ip}:#{rport} - Retriving #{file}")
+    print_status("#{ip}:#{rport} - Retrieving #{file}")
 
     res = send_request_raw({
       'method' => 'GET',

--- a/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res and res.code == 302
-      vprint_status("Login succesful")
+      vprint_status("Login successful")
     else
-      vprint_error("Login was not succesful!")
+      vprint_error("Login was not successful!")
       return
     end
 

--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'HTTP Subversion Scanner',
-      'Description' => 'Detect subversion directories and files and analize its content. Only SVN Version > 7 supported',
+      'Description' => 'Detect subversion directories and files and analyze its content. Only SVN Version > 7 supported',
       'Author'       => ['et'],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
+++ b/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptPath.new('SENSITIVE_FILES',  [ true, "File containing senstive files, one per line",
+        OptPath.new('SENSITIVE_FILES',  [ true, "File containing sensitive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
       ])
   end

--- a/modules/auxiliary/scanner/http/trace_axd.rb
+++ b/modules/auxiliary/scanner/http/trace_axd.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'HTTP trace.axd Content Scanner',
-      'Description' => 'Detect trace.axd files and analize its content',
+      'Description' => 'Detect trace.axd files and analyze its content',
       'Author'       => ['c4an'],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
         },
     }, 25)
 
-    print_good "File retreived successfully"
+    print_good "File retrieved successfully"
 
     # Show data if needed
     if res and res.code == 200

--- a/modules/auxiliary/scanner/http/web_vulndb.rb
+++ b/modules/auxiliary/scanner/http/web_vulndb.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptInt.new('ErrorCode', [ true,  "The expected http code for non existant files", 404]),
+        OptInt.new('ErrorCode', [ true,  "The expected http code for non existent files", 404]),
         OptPath.new('HTTP404Sigs',   [ false, "Path of 404 signatures to use",
             File.join(Msf::Config.data_directory, "wmap", "wmap_404s.txt")
           ]

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     if check_setup
       print_status("XMLRPC enabled, Hello message received!")
     else
-      print_error("Abborting the attack.")
+      print_error("Aborting the attack.")
       return
     end
 

--- a/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
+++ b/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
   # main control method
   def run_host(ip)
     unless wordpress_and_online?
-      print_error("#{ip} does not seeem to be Wordpress site")
+      print_error("#{ip} does not seem to be Wordpress site")
       return
     end
 

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
         elsif res.code == 200
           parsed = res.get_json_document
           if parsed.empty?
-            print_error('Response recieved, but no JSON content was provided.')
+            print_error('Response received, but no JSON content was provided.')
           else
             parsed.map do |child|
               name = child['name']

--- a/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
+++ b/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => "#{normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp')}/" # trailing / to browse directory
     })
     fail_with Failure::Unreachable, 'Connection failed' unless res
-    # find the debug file name, prefix during my testing was 14 alpha-numeric
+    # find the debug file name, prefix during my testing was 14 alphanumeric
     unless />\s*(?<debug_log>\w{5,15}_debug_log\.txt)/ =~ res.body
       unless aggressive
         fail_with Failure::NotVulnerable, 'Either debug log not turned on, or directory listings disabled.  Try AGGRESSIVE mode if this is a false positive'

--- a/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
         'vars_post' => {
           'type' => 'lp_course',
           'context' => 'order-items',
-          'context_id' => Rex::Text.rand_text_numeric(2, 0), # avoid 0s incase leading 0 gives bad results
+          'context_id' => Rex::Text.rand_text_numeric(2, 0), # avoid 0s in case leading 0 gives bad results
           'term' => Rex::Text.rand_text_alpha(8),
           'paged' => 1,
           'lp-ajax' => 'modal_search_items',

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         task in Novell ZENworks Asset Management 7.5. The vulnerability exists in the Web
         Console and can be triggered by sending a specially crafted request to the rtrlet component,
         allowing a remote unauthenticated user to retrieve the configuration parameters of
-        Novell Zenworks Asset Managment, including the database credentials in clear text.
+        Novell Zenworks Asset Management, including the database credentials in clear text.
         This module has been successfully tested on Novell ZENworks Asset Management 7.5.
       },
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/ipmi/ipmi_version.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_version.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     # Potential improvements:
-    # - Report a vulnerablity if info.ipmi_user_anonymous has been set
+    # - Report a vulnerability if info.ipmi_user_anonymous has been set
     # - Report a vulnerability if ipmi 2.0 and kg is set to default (almost always the case)
     # - Report a vulnerability if info.ipmi_user_null has been set (null username)
 

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scanner_process(data, shost, sport)
-    # Check the response data for a "STAT" repsonse
+    # Check the response data for a "STAT" response
     if data =~ /\x0d\x0aSTAT\x20/
       @results[shost] ||= []
       @results[shost] << data

--- a/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scanner_process(data, shost, sport)
-    # Check the response data for a "VERSION" repsonse
+    # Check the response data for a "VERSION" response
     if /VERSION (?<version>[\d\.]+)\r\n/ =~ data
       print_good("#{shost}:#{sport}/udp memcached version #{version}")
       report_service(

--- a/modules/auxiliary/scanner/misc/oki_scanner.rb
+++ b/modules/auxiliary/scanner/misc/oki_scanner.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# TODO: Split this module into two seperate SNMP and HTTP modules.
+# TODO: Split this module into two separate SNMP and HTTP modules.
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SNMPClient

--- a/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
@@ -34,13 +34,13 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
-  def do_report(ip, endianess)
+  def do_report(ip, endianness)
     report_vuln({
       :host => ip,
       :port => rport,
       :name => "SerComm Network Device Backdoor",
       :refs => self.references,
-      :info => "SerComm Network Device Backdoor found on a #{endianess} device"
+      :info => "SerComm Network Device Backdoor found on a #{endianness} device"
     })
   end
 

--- a/modules/auxiliary/scanner/msmail/shared/src/msmail/msmail.go
+++ b/modules/auxiliary/scanner/msmail/shared/src/msmail/msmail.go
@@ -114,7 +114,7 @@ func ReportValidUsers(ip string, validUsers []string) {
 			"address":      ip,
 			"protocol":     protocol,
 		}
-		module.LogInfo("Loging user: " + user)
+		module.LogInfo("Logging user: " + user)
 		module.ReportCredentialLogin(user, "", opts)
 	}
 }

--- a/modules/auxiliary/scanner/msmq/cve_2023_21554_queuejumper.rb
+++ b/modules/auxiliary/scanner/msmq/cve_2023_21554_queuejumper.rb
@@ -205,7 +205,7 @@ class MetasploitModule < Msf::Auxiliary
     # Flags: RC=1, DQ=7 (Direct Format Type), F=1 (MessagePropertiesHeader present), J=1 (HTTP used)
     user_header.flags = 18620418
 
-    # An arbitrary ip address and queue name was choosen to send the message.
+    # An arbitrary ip address and queue name was chosen to send the message.
     # Usually this need to match an existing IP address and queue name, however
     # for this Proof-of-Concept it doesn't matter what values are used.
     user_header.destination_queue = "http://192.168.10.100/msmq/private$/queuejumper\x00".encode('utf-16le')

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
     peer = "#{host}:#{datastore['RPORT']}"
     if (result == 0)
       # we always ask to map an external port to the same port on us.  If
-      # we get a successful reponse back but the port we requested be forwarded
+      # we get a successful response back but the port we requested be forwarded
       # is different, that means that someone else already has it open
       if (int != ext)
         state = Msf::ServiceState::Open

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
-  # Examine the monlist reponse +data+ and extract all peer tuples (saddd, dport, daddr)
+  # Examine the monlist response +data+ and extract all peer tuples (saddd, dport, daddr)
   def extract_peer_tuples(data)
     return [] if data.length < 76
 

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
     when :sql_error
       case res[:sql_error]
       when /^C42501/
-        print_error "#{datastore['RHOST']}:#{datastore['RPORT']} Postgres - Insufficent permissions."
+        print_error "#{datastore['RHOST']}:#{datastore['RPORT']} Postgres - Insufficient permissions."
       else
         print_error "#{datastore['RHOST']}:#{datastore['RPORT']} Postgres - #{res[:sql_error]}"
       end

--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -135,8 +135,8 @@ class MetasploitModule < Msf::Auxiliary
     # setting a key/value pair in the database to something such that when the
     # redis db is saved, the contents of what we are uploading will appear
     # intact in the middle of the db itself.  The hope is that something
-    # interpretting this file will ignore or be OK-enough with the rest of the
-    # file such that what we uploaded will be interpretted as if it contained
+    # interpreting this file will ignore or be OK-enough with the rest of the
+    # file such that what we uploaded will be interpreted as if it contained
     # only the contents of what we uploaded.  For example, here is a nearly
     # empty redis database that started with a single key (foo) value (bar)
     # pair, and the contents of what we uploaded was the current date:

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Attempts to negotiate the rsync protocol with the endpoint.
   def rsync_negotiate
-    # rsync is promiscuous and will send the negotitation and motd
+    # rsync is promiscuous and will send the negotiation and motd
     # upon connecting.  abort if we get nothing
     return unless (greeting = sock.get_once(-1, read_timeout))
 

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
     else
-      vprint_status("#{full_url} - not found (No Repsonse code Received)")
+      vprint_status("#{full_url} - not found (No Response code Received)")
     end
   end
 

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     when "\xab\x06"
       print_error('Slave Device Busy: Slave is engaged in processing a long-duration program command.')
     when "\xab\x07"
-      print_error('Negative Acknowledge: Slave cannot perform the programming function recieved in the query.')
+      print_error('Negative Acknowledge: Slave cannot perform the programming function received in the query.')
     when "\xab\x08"
       print_error('Memory Parity Error: Slave detected a parity error in memory.')
     when "\xab\x0a"

--- a/modules/auxiliary/scanner/scada/modbus_findunitid.rb
+++ b/modules/auxiliary/scanner/scada/modbus_findunitid.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(502),
         OptInt.new('UNIT_ID_FROM', [true, "ModBus Unit Identifier scan from value [1..254]", 1]),
         OptInt.new('UNIT_ID_TO', [true, "ModBus Unit Identifier scan to value [UNIT_ID_FROM..254]", 254]),
-        OptInt.new('BENICE', [true, "Seconds to sleep between StationID-probes, just for beeing nice", 1]),
+        OptInt.new('BENICE', [true, "Seconds to sleep between StationID-probes, just for being nice", 1]),
         OptInt.new('TIMEOUT', [true, 'Timeout for the network probe, 0 means no timeout', 2])
       ])
   end

--- a/modules/auxiliary/scanner/scada/modbusclient.rb
+++ b/modules/auxiliary/scanner/scada/modbusclient.rb
@@ -412,7 +412,7 @@ class MetasploitModule < Msf::Auxiliary
         obj_cnt -= 1
         obj_id_pos = obj_id_pos + obj_len + 2
         if obj_id_pos > max_ref_size
-          print_error('Out of bounds reference occured whilst processing READ ID operation! Check sender data!')
+          print_error('Out of bounds reference occurred whilst processing READ ID operation! Check sender data!')
           break
         end
         break unless obj_cnt > 0

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -85,12 +85,12 @@ class MetasploitModule < Msf::Auxiliary
       output.each_line { |line| cleanout << line.chomp if line.include?("HKEY") && line.split("-").size == 8 && !line.split("-")[7].include?("_")}
       return cleanout
     rescue StandardError => hku_error
-      print_error("Error runing query against HKU. #{hku_error.class}. #{hku_error}")
+      print_error("Error running query against HKU. #{hku_error.class}. #{hku_error}")
       return nil
     end
   end
 
-  # This method will retrive output from a specified textfile on the remote host
+  # This method will retrieve output from a specified textfile on the remote host
   def get_output(ip, smbshare, file)
     begin
       simple.connect("\\\\#{ip}\\#{smbshare}")
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # Method trys to use "query session" to determine logged in user
+  # Method tries to use "query session" to determine logged in user
   def query_session(smbshare, ip, cmd, text, bat)
     begin
       command = "#{cmd} /C echo query session ^> %SYSTEMDRIVE%#{text} > #{bat} & #{cmd} /C start cmd.exe /C #{bat}"

--- a/modules/auxiliary/scanner/ssh/ssh_enum_git_keys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enum_git_keys.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptPath.new('KEY_FILE', [false, 'Filename of a private key.', nil]),
-        OptPath.new('KEY_DIR', [false, 'Directory of several keys. Filenames will be recursivley found matching id_* (Ex: /home/user/.ssh)', nil]),
+        OptPath.new('KEY_DIR', [false, 'Directory of several keys. Filenames will be recursively found matching id_* (Ex: /home/user/.ssh)', nil]),
         OptString.new('GITSERVER', [true, 'Parameter to specify alternate Git Server (GitHub, GitLab, etc)', 'github.com'])
       ]
     )

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -562,7 +562,7 @@ class MetasploitModule < Msf::Auxiliary
   # Keydumping helper methods
   #
 
-  # Tries to retreive the private key
+  # Tries to retrieve the private key
   def get_keys
     connect_result = establish_connect
     disconnect

--- a/modules/auxiliary/scanner/ssl/ssl_version.rb
+++ b/modules/auxiliary/scanner/ssl/ssl_version.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CWE', '319'],
         # certificate expired
         [ 'CWE', '298' ],
-        # certificate broken or risky crypto aglorithms
+        # certificate broken or risky crypto algorithms
         [ 'CWE', '327' ],
         # certificate inadequate encryption strength
         [ 'CWE', '326' ]
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
     # Next, we'll find that many ciphers in OpenSSL::Cipher.ciphers are not applicable for various SSL versions.
     # The loop we previously looked at has (at the time of writing on Kali Rollin, msf 6.2.23) 3060 rounds.
     # This is a lot of iterations when we already know there are many combinations that will not be applicable for our
-    # use. Luckily there is a 2nd way which is much more efficent.
+    # use. Luckily there is a 2nd way which is much more efficient.
     #
     # The OpenSSL library includes https://docs.ruby-lang.org/en/2.4.0/OpenSSL/SSL/SSLContext.html#method-i-ciphers
     # which we can use to generate a list of all ciphers, and SSL versions they work with. The structure is:
@@ -509,8 +509,8 @@ class MetasploitModule < Msf::Auxiliary
           print_error("Exception encountered: #{e}")
         rescue StandardError => e
           if e.message.match(/connection was refused/) || e.message.match(/timed out/)
-            print_error("\tPort closed or timeout occured.")
-            return 'Port closed or timeout occured.'
+            print_error("\tPort closed or timeout occurred.")
+            return 'Port closed or timeout occurred.'
           end
           print_error("\tException encountered: #{e}")
         ensure

--- a/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(443),
         OptString.new('USERNAME', [ true, "The username to Authenticate with.", 'root' ]),
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ]),
-        OptBool.new('SCREENSHOT', [true, "Wheter or not to try to take a screenshot", true])
+        OptBool.new('SCREENSHOT', [true, "Whether or not to try to take a screenshot", true])
       ])
   end
 

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -519,7 +519,7 @@ class MetasploitModule < Msf::Auxiliary
     print_line
 
     # Sort the tests by reliability, descending.
-    # I don't like doing this directly (wihout a !), but any other sort wasn't sticking - NE
+    # I don't like doing this directly (without a !), but any other sort wasn't sticking - NE
     @all_tests = @all_tests.sort.reverse
 
     # This matters a lot less for noscript exploits since they basically
@@ -892,7 +892,7 @@ class MetasploitModule < Msf::Auxiliary
   # able to autodetect).  If the currently connected client's ua_name
   # is nil, then the fingerprinting didn't work for some reason.
   # Lastly, check to see if the client's browser matches the browser
-  # targetted by this group of exploits. In all of these cases, we
+  # targeted by this group of exploits. In all of these cases, we
   # need to send all the exploits in the list.
   #
   # In contrast, if we have all of that info and it doesn't match, we

--- a/modules/auxiliary/server/capture/http_ntlm.rb
+++ b/modules/auxiliary/server/capture/http_ntlm.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
       else
         vprint_status("Continuing auth '#{request.uri}'")
         method,hash = request.headers['Authorization'].split(/\s+/,2)
-        # If the method isn't NTLM something odd is goign on. Regardless, this won't get what we want, 404 them
+        # If the method isn't NTLM something odd is going on. Regardless, this won't get what we want, 404 them
         if(method != "NTLM")
           print_status("Unrecognized Authorization header, responding with 404")
           send_not_found(cli)

--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
     # slice of:
     #   * channel, packetno, window
     #   * login header
-    #   * client name lengt & offset
+    #   * client name length & offset
     login_hdr = data.slice!(0,4 + 36 + 4)
 
     username_offset = data.slice!(0,2).unpack('v')[0]

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     data = data.drop(1)
 
     # if only a username is submitted, it will appear as \00un\00
-    # we already cut off the empty username, so nowe we want to add on the empty password
+    # we already cut off the empty username, so now we want to add on the empty password
     if data.length == 1
       data << ''
     end

--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
         return false
       end
       method,hash = request.headers['Authorization'].split(/\s+/,2)
-      # If the method isn't NTLM something odd is goign on.
+      # If the method isn't NTLM something odd is going on.
       # Regardless, this won't get what we want, 404 them
       if(method != "NTLM")
         print_status("Unrecognized Authorization header, responding with 404")
@@ -463,7 +463,7 @@ class MetasploitModule < Msf::Auxiliary
     return files
   end
 
-  # start a service. This methos copies a lot of logic/code from psexec (and smb_relay)
+  # start a service. This method copies a lot of logic/code from psexec (and smb_relay)
   def smb_pwn(ser_sock, cli_sock)
 
     # filename is a little finicky, it needs to be in a format like

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       # check Pcaprub is up to date
       if not netifaces_implemented?
-        print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+        print_error("WARNING : Pcaprub is not up-to-date, some functionality will not be available")
         netifaces = false
       else
         netifaces = true
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Auxiliary
           # -(Windows) netsh firewall set opmode mode = ENABLE
 
           if packet.icmp_type == 0 and packet.icmp_code == 0 and packet.ip_saddr == @iface_ip
-            print_error "Dectected ICMP echo response. You must either disable ICMP handling"
+            print_error "Detected ICMP echo response. You must either disable ICMP handling"
             print_error "or try a more restrictive BPF filter. You might try:"
             print_error " set BPF_FILTER icmp and not src #{datastore['LOCALIP']}"
             return
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
 
           if data =~ /#{datastore['END_TRIGGER']}/
             # end of file marker found
-            print_status("#{@record_data.length} bytes of data recevied in total")
+            print_status("#{@record_data.length} bytes of data received in total")
             print_good("End of File received. Saving \"#{@filename}\" to loot")
             store_file
 

--- a/modules/auxiliary/server/local_hwbridge.rb
+++ b/modules/auxiliary/server/local_hwbridge.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   #
-  # Stub fucntion to test custom methods
+  # Stub function to test custom methods
   # Defines a method "sample_cmd" with one argument "data" which is required
   #
   def get_custom_methods
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
   # data = string of hex bytes to send
   # OPT = Options
   #    timeout = optional int to timeout on lack of response
-  #    maxpkts = max number of packets to recieve
+  #    maxpkts = max number of packets to receive
   #    padding = append bytes to end of packet (Doesn't increase reported ISO-TP size)
   #    fc = flow control, if true forces flow control packets
   def isotp_send_and_wait(bus, srcid, dstid, data, opt = {})
@@ -258,7 +258,7 @@ class MetasploitModule < Msf::Auxiliary
   #
   def sample_custom_method(data)
     res = {}
-    res["value"] = "Succesfully processed: #{data}"
+    res["value"] = "Successfully processed: #{data}"
     res
   end
 

--- a/modules/auxiliary/server/netbios_spoof_nat.rb
+++ b/modules/auxiliary/server/netbios_spoof_nat.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
   def netbios_spam
     payload =
         "\xff\xff"   + # TX ID (will brute force this)
-        "\x85\x00"   + # Flags = response + authoratative + recursion desired
+        "\x85\x00"   + # Flags = response + authoritative + recursion desired
         "\x00\x00"   + # Questions = 0
         "\x00\x01"   + # Answer RRs = 1
         "\x00\x00"   + # Authority RRs = 0

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -36,12 +36,12 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_advanced_options([
-      OptString.new('LOCALSMAC',    	[false, 'The MAC address of the local interface to use for hosts detection, this is usefull only if you want to spoof to another host with SMAC']),
+      OptString.new('LOCALSMAC',    	[false, 'The MAC address of the local interface to use for hosts detection, this is useful only if you want to spoof to another host with SMAC']),
       OptString.new('LOCALSIP',    	[false, 'The IP address of the local interface to use for hosts detection']),
       OptInt.new(   'PKT_DELAY',    	[true, 'The delay in milliseconds between each packet during poisoning', 100]),
       OptInt.new('TIMEOUT', [true, 'The number of seconds to wait for new data during host detection', 2]),
       # This mode will generate address ip conflict pop up  on most systems
-      OptBool.new(  'BROADCAST',    	[true, 'If set, the module will send replies on the broadcast address witout consideration of DHOSTS', false])
+      OptBool.new(  'BROADCAST',    	[true, 'If set, the module will send replies on the broadcast address without consideration of DHOSTS', false])
     ])
 
     deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE','RHOST','SECRET','GATEWAY_PROBE_HOST','GATEWAY_PROBE_PORT')
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     open_pcap({'SNAPLEN' => 68, 'FILTER' => "arp[6:2] == 0x0002"})
     @netifaces = true
     if not netifaces_implemented?
-      print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+      print_error("WARNING : Pcaprub is not up-to-date, some functionality will not be available")
       @netifaces = false
     end
     @spoofing = false
@@ -247,7 +247,7 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['LISTENER']
       start_listener(@dsthosts_cache, @srchosts_cache)
     end
-    # Do the job until user interupt it
+    # Do the job until user interrupt it
     print_status("ARP poisoning in progress...")
     @spoofing = true
     while(true)

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # time to build a response packet - Oh YEAH!
     response = nbnsq_transid +
-      "\x85\x00" + # Flags = response + authoratative + recursion desired +
+      "\x85\x00" + # Flags = response + authoritative + recursion desired +
       "\x00\x00" + # Questions = 0
       "\x00\x01" + # Answer RRs = 1
       "\x00\x00" + # Authority RRs = 0

--- a/modules/auxiliary/sqli/dlink/dlink_central_wifimanager_sqli.rb
+++ b/modules/auxiliary/sqli/dlink/dlink_central_wifimanager_sqli.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
           of SQL queries without authentication, using this vulnerability, it's
           possible to retrieve usernames and password hashes of registered users,
           device configuration, and other data, it's also possible to add users,
-          or edit database informations.
+          or edit database information.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/auxiliary/voip/sip_invite_spoof.rb
+++ b/modules/auxiliary/voip/sip_invite_spoof.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
       conn_string = ''
 
       if not ext.nil? and not ext.empty?
-        # set extesion name/number
+        # set extension name/number
         conn_string = "#{ext}@"
       end
 


### PR DESCRIPTION
Cleanup of spelling across the `modules/auxiliary/` folder. I avoided fixing apostrophes.

Most of these changes are in comments and in user prompts

Also ran rubocop against the `telegram/send_message` module as it was the only one `msf_tidy` was complaining about

## Verification

- [ ] manual review
- [ ] run some of the modules to make sure they work
- [ ] use some things to make sure they dont break
