### PR TITLE
Add tests for Msf::Exploit::Local exploit_type and sysinfo methods

### DIFF
--- a/spec/lib/msf/exploit/local_spec.rb
+++ b/spec/lib/msf/exploit/local_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'rex/post/meterpreter/extensions/stdapi/sys/config'
+
+RSpec.describe Msf::Exploit::Local do
+  describe '#exploit_type' do
+    it 'indicates that the exploit is local' do
+      expect(subject.exploit_type).to eq 'local'
+    end
+  end
+
+  describe '#sysinfo' do
+    before(:each) do
+      allow(subject).to receive(:session).and_return(session)
+    end
+
+    context 'when the session is nil' do
+      let(:session) { nil }
+
+      it 'returns nil' do
+        expect(subject.sysinfo).to eq nil
+      end
+    end
+
+    context 'when the session is not Meterpreter' do
+      let(:session) do
+        connection = nil
+        Msf::Sessions::CommandShell.new(connection)
+      end
+
+      it 'returns nil' do
+        expect(subject.sysinfo).to eq nil
+      end
+    end
+
+    context 'when the session is Meterpreter' do
+      let(:session) do
+        connection = nil
+        session = Msf::Sessions::Meterpreter_x86_Win.new(connection)
+        session.register_extension_alias(
+          'sys',
+          Rex::Post::Meterpreter::ObjectAliases.new(
+            'config' => instance_double(
+              ::Rex::Post::Meterpreter::Extensions::Stdapi::Sys::Config,
+              sysinfo: { 'Computer' => 'FooComputer' }
+            )
+          )
+        )
+        session
+      end
+
+      it 'returns the sysinfo object' do
+        expect(subject.sysinfo).to eq({ 'Computer' => 'FooComputer' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/18667

Add tests for Msf::Exploit::Local module types to ensure that sysinfo will not break again in the future

## Verification

- Ensure CI passes
- Ensure the tests fail if the `sysinfo` method is removed:
```
Randomized with seed 30258
Msf::Exploit::Local FFF.

  1) Msf::Exploit::Local#sysinfo when the session is Meterpreter returns the sysinfo object
     Failure/Error: expect(subject.sysinfo).to eq({ 'Computer' => 'FooComputer' })
     
     NoMethodError:
       undefined method `sysinfo' for #<Msf::Exploit::Local:0x00007f96ce25d200 @module_info_copy={"Compat"=>{"Meterpreter"=>{"Commands"=>["stdapi_sys_config_sysinfo", "stdapi_sys_config_getenv", "stdapi_sys_process_execute"]}, "Encoder"=>{}, "Nop"=>{}, "Payload"=>{"ConnectionType"
```