### PR TITLE
ssh_version module

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
@@ -2,7 +2,8 @@
 
 SSH, Secure SHell, is an encrypted network protocol used to remotely interact with an Operating System at a command line level.  SSH is available on most every system, including Windows, but is mainly used by *nix administrators.
 
-This module identifies the version of SSH service in use by the server based on the server's banner. Any SSH server should return this information.
+This module identifies the version of SSH service in use by the server based on the server's banner. Any SSH server should return this information. It also identifies
+the varous cryptographic settings and vulnerabilities associated with those.
 
 ## Vulnerable Application
 
@@ -11,6 +12,20 @@ This module is tested on several different SSH services, such as:
 - Virtual testing environment: SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.8
 - `github.com`: SSH-2.0-babeld-38be96bc
 - `gitlab.com`: SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.8
+
+### Vulnerable Ubuntu 14.04.1
+
+The following `Dockerfile` can be used to create an Ubuntu 14.04.1 image with SSH running.
+
+```
+FROM ubuntu:14.04.1
+
+RUN apt-get update && apt-get -y install --no-install-recommends openssh-server=1:6.6p1-2ubuntu1 openssh-client=1:6.6p1-2ubuntu1 openssh-sftp-server=1:6.6p1-2ubuntu1
+RUN mkdir /var/run/sshd
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd","-D"]
+```
 
 ## Verification Steps
 
@@ -22,13 +37,157 @@ This module is tested on several different SSH services, such as:
 
 ### SSH-2.0 on GitHub
 
-  ```
-msf5 auxiliary(scanner/ssh/ssh_version) > use auxiliary/scanner/ssh/ssh_version
+```
+msf5 > use auxiliary/scanner/ssh/ssh_version
 msf5 auxiliary(scanner/ssh/ssh_version) > set RHOSTS github.com
 RHOSTS => github.com
 msf5 auxiliary(scanner/ssh/ssh_version) > run
 
-[+] 140.82.118.4:22       - SSH server version: SSH-2.0-babeld-38be96bc
-[*] github.com:22         - Scanned 1 of 1 hosts (100% complete)
+[*] 140.82.113.3 - Key Fingerprint: 65:96:2d:fc:e8:d5:a9:11:64:0c:0f:ea:00:6e:5b:bd
+[+] 140.82.113.3 - Host Key Encryption ecdsa-sha2-nistp256 uses a weak elliptic curve and should not be used.
+[*] 140.82.113.3 - SSH server version: SSH-2.0-babeld-8e18a363
+[*] 140.82.113.3 - Server Encryption
+=================
+
+  Type                Value
+  ----                -----
+  Compression         none
+  Compression         zlib@openssh.com
+  Compression         zlib
+  Encryption          chacha20-poly1305@openssh.com
+  Encryption          aes256-gcm@openssh.com
+  Encryption          aes128-gcm@openssh.com
+  Encryption          aes256-ctr
+  Encryption          aes192-ctr
+  Encryption          aes128-ctr
+  HMAC                hmac-sha2-512-etm@openssh.com
+  HMAC                hmac-sha2-256-etm@openssh.com
+  HMAC                hmac-sha2-512
+  HMAC                hmac-sha2-256
+  Host Key            ssh-ed25519
+  Host Key            ecdsa-sha2-nistp256
+  Host Key            rsa-sha2-512
+  Host Key            rsa-sha2-256
+  Host Key            ssh-rsa
+  Key Exchange (kex)  curve25519-sha256
+  Key Exchange (kex)  curve25519-sha256@libssh.org
+  Key Exchange (kex)  ecdh-sha2-nistp256
+  Key Exchange (kex)  ecdh-sha2-nistp384
+  Key Exchange (kex)  ecdh-sha2-nistp521
+  Key Exchange (kex)  diffie-hellman-group-exchange-sha256
+  Key Exchange (kex)  kex-strict-s-v00@openssh.com
+
+[*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-  ```
+```
+
+### Docker image
+
+```
+msf5 > use auxiliary/scanner/ssh/ssh_version
+msf6 auxiliary(scanner/ssh/ssh_version) > set rhosts 172.17.0.2
+rhosts => 172.17.0.2
+msf6 auxiliary(scanner/ssh/ssh_version) > set verbose true
+verbose => true
+msf6 auxiliary(scanner/ssh/ssh_version) > run
+Calling Net::SSH::Buffer methods on HostKeyEntries PubKey is deprecated
+
+[*] 172.17.0.2 - Key Fingerprint: 49:43:e7:e8:ee:41:bb:36:83:e4:8c:2d:0a:81:dd:77
+[+] 172.17.0.2 - Encryption arcfour256 is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption arcfour256 is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption arcfour128 is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption arcfour128 is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption aes128-cbc is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption 3des-cbc is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption blowfish-cbc is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption cast128-cbc is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption aes192-cbc is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption aes256-cbc is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption arcfour is deprecated and should not be used.
+[+] 172.17.0.2 - Encryption rijndael-cbc@lysator.liu.se is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5-etm@openssh.com is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-ripemd160-etm@openssh.com is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-sha1-96-etm@openssh.com is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5-96-etm@openssh.com is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5-96-etm@openssh.com is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-ripemd160 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-ripemd160@openssh.com is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-sha1-96 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5-96 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5-96 is deprecated and should not be used.
+[+] 172.17.0.2 - Host Key Encryption ecdsa-sha2-nistp256 uses a weak elliptic curve and should not be used.
+[+] 172.17.0.2 - Key Exchange (kex) diffie-hellman-group-exchange-sha1 is deprecated and should not be used.
+[+] 172.17.0.2 - Key Exchange (kex) diffie-hellman-group1-sha1 is deprecated and should not be used.
+[*] 172.17.0.2 - SSH server version: SSH-2.0-OpenSSH_6.6p1 Ubuntu-2ubuntu1
+        service.version: 6.6p1
+        openssh.comment: Ubuntu-2ubuntu1
+        service.vendor: OpenBSD
+        service.family: OpenSSH
+        service.product: OpenSSH
+        service.cpe23: cpe:/a:openbsd:openssh:6.6p1
+        os.vendor: Ubuntu
+        os.family: Linux
+        os.product: Linux
+        os.version: 14.04
+        os.cpe23: cpe:/o:canonical:ubuntu_linux:14.04
+        service.protocol: ssh
+        fingerprint_db: ssh.banner
+[*] 172.17.0.2 - Server Encryption
+=================
+
+  Type                Value
+  ----                -----
+  Compression         none
+  Compression         zlib@openssh.com
+  Encryption          aes128-ctr
+  Encryption          aes192-ctr
+  Encryption          aes256-ctr
+  Encryption          arcfour256
+  Encryption          arcfour128
+  Encryption          aes128-gcm@openssh.com
+  Encryption          aes256-gcm@openssh.com
+  Encryption          chacha20-poly1305@openssh.com
+  Encryption          aes128-cbc
+  Encryption          3des-cbc
+  Encryption          blowfish-cbc
+  Encryption          cast128-cbc
+  Encryption          aes192-cbc
+  Encryption          aes256-cbc
+  Encryption          arcfour
+  Encryption          rijndael-cbc@lysator.liu.se
+  HMAC                hmac-md5-etm@openssh.com
+  HMAC                hmac-sha1-etm@openssh.com
+  HMAC                umac-64-etm@openssh.com
+  HMAC                umac-128-etm@openssh.com
+  HMAC                hmac-sha2-256-etm@openssh.com
+  HMAC                hmac-sha2-512-etm@openssh.com
+  HMAC                hmac-ripemd160-etm@openssh.com
+  HMAC                hmac-sha1-96-etm@openssh.com
+  HMAC                hmac-md5-96-etm@openssh.com
+  HMAC                hmac-md5
+  HMAC                hmac-sha1
+  HMAC                umac-64@openssh.com
+  HMAC                umac-128@openssh.com
+  HMAC                hmac-sha2-256
+  HMAC                hmac-sha2-512
+  HMAC                hmac-ripemd160
+  HMAC                hmac-ripemd160@openssh.com
+  HMAC                hmac-sha1-96
+  HMAC                hmac-md5-96
+  Host Key            ssh-rsa
+  Host Key            ssh-dss
+  Host Key            ecdsa-sha2-nistp256
+  Host Key            ssh-ed25519
+  Key Exchange (kex)  curve25519-sha256@libssh.org
+  Key Exchange (kex)  ecdh-sha2-nistp256
+  Key Exchange (kex)  ecdh-sha2-nistp384
+  Key Exchange (kex)  ecdh-sha2-nistp521
+  Key Exchange (kex)  diffie-hellman-group-exchange-sha256
+  Key Exchange (kex)  diffie-hellman-group-exchange-sha1
+  Key Exchange (kex)  diffie-hellman-group14-sha1
+  Key Exchange (kex)  diffie-hellman-group1-sha1
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
@@ -90,12 +90,17 @@ rhosts => 172.17.0.2
 msf6 auxiliary(scanner/ssh/ssh_version) > set verbose true
 verbose => true
 msf6 auxiliary(scanner/ssh/ssh_version) > run
-Calling Net::SSH::Buffer methods on HostKeyEntries PubKey is deprecated
 
-[*] 172.17.0.2 - Key Fingerprint: 49:43:e7:e8:ee:41:bb:36:83:e4:8c:2d:0a:81:dd:77
+[*] 172.17.0.2 - Key Fingerprint: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG52hWkobwr57akGxiK6eeMN9/M5MH+sQsNPv8Mci049
+[*] 172.17.0.2 - SSH server version: SSH-2.0-OpenSSH_6.6p1 Ubuntu-2ubuntu1
+[+] 172.17.0.2 - Key Exchange (kex) diffie-hellman-group-exchange-sha1 is deprecated and should not be used.
+[+] 172.17.0.2 - Key Exchange (kex) diffie-hellman-group1-sha1 is deprecated and should not be used.
+[+] 172.17.0.2 - Host Key Encryption ecdsa-sha2-nistp256 uses a weak elliptic curve and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-ripemd160 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-sha1-96 is deprecated and should not be used.
+[+] 172.17.0.2 - HMAC hmac-md5-96 is deprecated and should not be used.
 [+] 172.17.0.2 - Encryption arcfour256 is deprecated and should not be used.
-[+] 172.17.0.2 - Encryption arcfour256 is deprecated and should not be used.
-[+] 172.17.0.2 - Encryption arcfour128 is deprecated and should not be used.
 [+] 172.17.0.2 - Encryption arcfour128 is deprecated and should not be used.
 [+] 172.17.0.2 - Encryption aes128-cbc is deprecated and should not be used.
 [+] 172.17.0.2 - Encryption 3des-cbc is deprecated and should not be used.
@@ -105,88 +110,73 @@ Calling Net::SSH::Buffer methods on HostKeyEntries PubKey is deprecated
 [+] 172.17.0.2 - Encryption aes256-cbc is deprecated and should not be used.
 [+] 172.17.0.2 - Encryption arcfour is deprecated and should not be used.
 [+] 172.17.0.2 - Encryption rijndael-cbc@lysator.liu.se is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-md5-etm@openssh.com is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-ripemd160-etm@openssh.com is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-sha1-96-etm@openssh.com is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-md5-96-etm@openssh.com is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-md5-96-etm@openssh.com is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-md5 is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-ripemd160 is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-ripemd160@openssh.com is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-sha1-96 is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-md5-96 is deprecated and should not be used.
-[+] 172.17.0.2 - HMAC hmac-md5-96 is deprecated and should not be used.
-[+] 172.17.0.2 - Host Key Encryption ecdsa-sha2-nistp256 uses a weak elliptic curve and should not be used.
-[+] 172.17.0.2 - Key Exchange (kex) diffie-hellman-group-exchange-sha1 is deprecated and should not be used.
-[+] 172.17.0.2 - Key Exchange (kex) diffie-hellman-group1-sha1 is deprecated and should not be used.
-[*] 172.17.0.2 - SSH server version: SSH-2.0-OpenSSH_6.6p1 Ubuntu-2ubuntu1
-        service.version: 6.6p1
-        openssh.comment: Ubuntu-2ubuntu1
-        service.vendor: OpenBSD
-        service.family: OpenSSH
-        service.product: OpenSSH
-        service.cpe23: cpe:/a:openbsd:openssh:6.6p1
-        os.vendor: Ubuntu
-        os.family: Linux
-        os.product: Linux
-        os.version: 14.04
-        os.cpe23: cpe:/o:canonical:ubuntu_linux:14.04
-        service.protocol: ssh
-        fingerprint_db: ssh.banner
-[*] 172.17.0.2 - Server Encryption
-=================
+[*] 172.17.0.2 - Server Information and Encryption
+=================================
 
-  Type                Value
-  ----                -----
-  Compression         none
-  Compression         zlib@openssh.com
-  Encryption          aes128-ctr
-  Encryption          aes192-ctr
-  Encryption          aes256-ctr
-  Encryption          arcfour256
-  Encryption          arcfour128
-  Encryption          aes128-gcm@openssh.com
-  Encryption          aes256-gcm@openssh.com
-  Encryption          chacha20-poly1305@openssh.com
-  Encryption          aes128-cbc
-  Encryption          3des-cbc
-  Encryption          blowfish-cbc
-  Encryption          cast128-cbc
-  Encryption          aes192-cbc
-  Encryption          aes256-cbc
-  Encryption          arcfour
-  Encryption          rijndael-cbc@lysator.liu.se
-  HMAC                hmac-md5-etm@openssh.com
-  HMAC                hmac-sha1-etm@openssh.com
-  HMAC                umac-64-etm@openssh.com
-  HMAC                umac-128-etm@openssh.com
-  HMAC                hmac-sha2-256-etm@openssh.com
-  HMAC                hmac-sha2-512-etm@openssh.com
-  HMAC                hmac-ripemd160-etm@openssh.com
-  HMAC                hmac-sha1-96-etm@openssh.com
-  HMAC                hmac-md5-96-etm@openssh.com
-  HMAC                hmac-md5
-  HMAC                hmac-sha1
-  HMAC                umac-64@openssh.com
-  HMAC                umac-128@openssh.com
-  HMAC                hmac-sha2-256
-  HMAC                hmac-sha2-512
-  HMAC                hmac-ripemd160
-  HMAC                hmac-ripemd160@openssh.com
-  HMAC                hmac-sha1-96
-  HMAC                hmac-md5-96
-  Host Key            ssh-rsa
-  Host Key            ssh-dss
-  Host Key            ecdsa-sha2-nistp256
-  Host Key            ssh-ed25519
-  Key Exchange (kex)  curve25519-sha256@libssh.org
-  Key Exchange (kex)  ecdh-sha2-nistp256
-  Key Exchange (kex)  ecdh-sha2-nistp384
-  Key Exchange (kex)  ecdh-sha2-nistp521
-  Key Exchange (kex)  diffie-hellman-group-exchange-sha256
-  Key Exchange (kex)  diffie-hellman-group-exchange-sha1
-  Key Exchange (kex)  diffie-hellman-group14-sha1
-  Key Exchange (kex)  diffie-hellman-group1-sha1
+  Type                           Value                                 Note
+  ----                           -----                                 ----
+  encryption.compression         none
+  encryption.compression         zlib@openssh.com
+  encryption.encryption          aes128-ctr
+  encryption.encryption          aes192-ctr
+  encryption.encryption          aes256-ctr
+  encryption.encryption          arcfour256                            Deprecated
+  encryption.encryption          arcfour128                            Deprecated
+  encryption.encryption          aes128-gcm@openssh.com
+  encryption.encryption          aes256-gcm@openssh.com
+  encryption.encryption          chacha20-poly1305@openssh.com
+  encryption.encryption          aes128-cbc                            Deprecated
+  encryption.encryption          3des-cbc                              Deprecated
+  encryption.encryption          blowfish-cbc                          Deprecated
+  encryption.encryption          cast128-cbc                           Deprecated
+  encryption.encryption          aes192-cbc                            Deprecated
+  encryption.encryption          aes256-cbc                            Deprecated
+  encryption.encryption          arcfour                               Deprecated
+  encryption.encryption          rijndael-cbc@lysator.liu.se           Deprecated
+  encryption.hmac                hmac-md5-etm@openssh.com
+  encryption.hmac                hmac-sha1-etm@openssh.com
+  encryption.hmac                umac-64-etm@openssh.com
+  encryption.hmac                umac-128-etm@openssh.com
+  encryption.hmac                hmac-sha2-256-etm@openssh.com
+  encryption.hmac                hmac-sha2-512-etm@openssh.com
+  encryption.hmac                hmac-ripemd160-etm@openssh.com
+  encryption.hmac                hmac-sha1-96-etm@openssh.com
+  encryption.hmac                hmac-md5-96-etm@openssh.com
+  encryption.hmac                hmac-md5                              Deprecated
+  encryption.hmac                hmac-sha1
+  encryption.hmac                umac-64@openssh.com
+  encryption.hmac                umac-128@openssh.com
+  encryption.hmac                hmac-sha2-256
+  encryption.hmac                hmac-sha2-512
+  encryption.hmac                hmac-ripemd160                        Deprecated
+  encryption.hmac                hmac-ripemd160@openssh.com
+  encryption.hmac                hmac-sha1-96                          Deprecated
+  encryption.hmac                hmac-md5-96                           Deprecated
+  encryption.host_key            ssh-rsa
+  encryption.host_key            ssh-dss
+  encryption.host_key            ecdsa-sha2-nistp256                   Weak elliptic curve
+  encryption.host_key            ssh-ed25519
+  encryption.key_exchange_(kex)  curve25519-sha256@libssh.org
+  encryption.key_exchange_(kex)  ecdh-sha2-nistp256
+  encryption.key_exchange_(kex)  ecdh-sha2-nistp384
+  encryption.key_exchange_(kex)  ecdh-sha2-nistp521
+  encryption.key_exchange_(kex)  diffie-hellman-group-exchange-sha256
+  encryption.key_exchange_(kex)  diffie-hellman-group-exchange-sha1    Deprecated
+  encryption.key_exchange_(kex)  diffie-hellman-group14-sha1
+  encryption.key_exchange_(kex)  diffie-hellman-group1-sha1            Deprecated
+  fingerprint_db                 ssh.banner
+  openssh.comment                Ubuntu-2ubuntu1
+  os.cpe23                       cpe:/o:canonical:ubuntu_linux:14.04
+  os.family                      Linux
+  os.product                     Linux
+  os.vendor                      Ubuntu
+  os.version                     14.04
+  service.cpe23                  cpe:/a:openbsd:openssh:6.6p1
+  service.family                 OpenSSH
+  service.product                OpenSSH
+  service.protocol               ssh
+  service.vendor                 OpenBSD
+  service.version                6.6p1
 
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
@@ -191,3 +191,75 @@ Calling Net::SSH::Buffer methods on HostKeyEntries PubKey is deprecated
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+
+## Confirming using NMAP
+
+Utilizing the [ssh2-enum-algos](https://nmap.org/nsedoc/scripts/ssh2-enum-algos.html) NMAP script.
+
+```
+Starting Nmap 7.94SVN ( https://nmap.org ) at 2024-01-11 14:55 EST
+Nmap scan report for 172.17.0.2
+Host is up (0.000099s latency).
+
+PORT   STATE SERVICE VERSION
+22/tcp open  ssh     OpenSSH 6.6p1 Ubuntu 2ubuntu1 (Ubuntu Linux; protocol 2.0)
+| ssh2-enum-algos: 
+|   kex_algorithms: (8)
+|       curve25519-sha256@libssh.org
+|       ecdh-sha2-nistp256
+|       ecdh-sha2-nistp384
+|       ecdh-sha2-nistp521
+|       diffie-hellman-group-exchange-sha256
+|       diffie-hellman-group-exchange-sha1
+|       diffie-hellman-group14-sha1
+|       diffie-hellman-group1-sha1
+|   server_host_key_algorithms: (4)
+|       ssh-rsa
+|       ssh-dss
+|       ecdsa-sha2-nistp256
+|       ssh-ed25519
+|   encryption_algorithms: (16)
+|       aes128-ctr
+|       aes192-ctr
+|       aes256-ctr
+|       arcfour256
+|       arcfour128
+|       aes128-gcm@openssh.com
+|       aes256-gcm@openssh.com
+|       chacha20-poly1305@openssh.com
+|       aes128-cbc
+|       3des-cbc
+|       blowfish-cbc
+|       cast128-cbc
+|       aes192-cbc
+|       aes256-cbc
+|       arcfour
+|       rijndael-cbc@lysator.liu.se
+|   mac_algorithms: (19)
+|       hmac-md5-etm@openssh.com
+|       hmac-sha1-etm@openssh.com
+|       umac-64-etm@openssh.com
+|       umac-128-etm@openssh.com
+|       hmac-sha2-256-etm@openssh.com
+|       hmac-sha2-512-etm@openssh.com
+|       hmac-ripemd160-etm@openssh.com
+|       hmac-sha1-96-etm@openssh.com
+|       hmac-md5-96-etm@openssh.com
+|       hmac-md5
+|       hmac-sha1
+|       umac-64@openssh.com
+|       umac-128@openssh.com
+|       hmac-sha2-256
+|       hmac-sha2-512
+|       hmac-ripemd160
+|       hmac-ripemd160@openssh.com
+|       hmac-sha1-96
+|       hmac-md5-96
+|   compression_algorithms: (2)
+|       none
+|_      zlib@openssh.com
+Service Info: OS: Linux; CPE: cpe:/o:linux:linux_kernel
+
+Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
+Nmap done: 1 IP address (1 host up) scanned in 0.22 seconds
+```

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
@@ -1,11 +1,11 @@
-## Description
-
-SSH, Secure SHell, is an encrypted network protocol used to remotely interact with an Operating System at a command line level.  SSH is available on most every system, including Windows, but is mainly used by *nix administrators.
-
-This module identifies the version of SSH service in use by the server based on the server's banner. Any SSH server should return this information. It also identifies
-the varous cryptographic settings and vulnerabilities associated with those.
-
 ## Vulnerable Application
+
+SSH, Secure SHell, is an encrypted network protocol used to remotely interact with an Operating System at a command line level.
+SSH is available on most every system, including Windows, but is mainly used by *nix administrators.
+
+This module identifies the version of SSH service in use by the server based on the server's banner.
+Any SSH server should return this information. It also identifies the varous cryptographic settings
+and vulnerabilities associated with those.
 
 This module is tested on several different SSH services, such as:
 
@@ -32,6 +32,12 @@ CMD ["/usr/sbin/sshd","-D"]
   1. Do: `use auxiliary/scanner/ssh/ssh_version`
   2. Do: `set rhosts [ips]`
   3. Do: `run`
+
+## Options
+
+### ENCRYPTION
+
+Check encryption for issues. Defaults to `true`
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
@@ -35,9 +35,9 @@ CMD ["/usr/sbin/sshd","-D"]
 
 ## Options
 
-### ENCRYPTION
+### EXTENDED_CHECKS
 
-Check encryption for issues. Defaults to `true`
+Check for cryptographic issues. Defaults to `true`
 
 ## Scenarios
 
@@ -49,39 +49,38 @@ msf5 auxiliary(scanner/ssh/ssh_version) > set RHOSTS github.com
 RHOSTS => github.com
 msf5 auxiliary(scanner/ssh/ssh_version) > run
 
-[*] 140.82.113.3 - Key Fingerprint: 65:96:2d:fc:e8:d5:a9:11:64:0c:0f:ea:00:6e:5b:bd
-[+] 140.82.113.3 - Host Key Encryption ecdsa-sha2-nistp256 uses a weak elliptic curve and should not be used.
-[*] 140.82.113.3 - SSH server version: SSH-2.0-babeld-8e18a363
-[*] 140.82.113.3 - Server Encryption
-=================
+[*] 140.82.113.4 - Key Fingerprint: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+[*] 140.82.113.4 - SSH server version: SSH-2.0-babeld-8405f9f3
+[*] 140.82.113.4 - Server Information and Encryption
+=================================
 
-  Type                Value
-  ----                -----
-  Compression         none
-  Compression         zlib@openssh.com
-  Compression         zlib
-  Encryption          chacha20-poly1305@openssh.com
-  Encryption          aes256-gcm@openssh.com
-  Encryption          aes128-gcm@openssh.com
-  Encryption          aes256-ctr
-  Encryption          aes192-ctr
-  Encryption          aes128-ctr
-  HMAC                hmac-sha2-512-etm@openssh.com
-  HMAC                hmac-sha2-256-etm@openssh.com
-  HMAC                hmac-sha2-512
-  HMAC                hmac-sha2-256
-  Host Key            ssh-ed25519
-  Host Key            ecdsa-sha2-nistp256
-  Host Key            rsa-sha2-512
-  Host Key            rsa-sha2-256
-  Host Key            ssh-rsa
-  Key Exchange (kex)  curve25519-sha256
-  Key Exchange (kex)  curve25519-sha256@libssh.org
-  Key Exchange (kex)  ecdh-sha2-nistp256
-  Key Exchange (kex)  ecdh-sha2-nistp384
-  Key Exchange (kex)  ecdh-sha2-nistp521
-  Key Exchange (kex)  diffie-hellman-group-exchange-sha256
-  Key Exchange (kex)  kex-strict-s-v00@openssh.com
+  Type                           Value                                 Note
+  ----                           -----                                 ----
+  encryption.compression         none
+  encryption.compression         zlib@openssh.com
+  encryption.compression         zlib
+  encryption.encryption          chacha20-poly1305@openssh.com
+  encryption.encryption          aes256-gcm@openssh.com
+  encryption.encryption          aes128-gcm@openssh.com
+  encryption.encryption          aes256-ctr
+  encryption.encryption          aes192-ctr
+  encryption.encryption          aes128-ctr
+  encryption.hmac                hmac-sha2-512-etm@openssh.com
+  encryption.hmac                hmac-sha2-256-etm@openssh.com
+  encryption.hmac                hmac-sha2-512
+  encryption.hmac                hmac-sha2-256
+  encryption.host_key            ssh-ed25519
+  encryption.host_key            ecdsa-sha2-nistp256                   Weak elliptic curve
+  encryption.host_key            rsa-sha2-512
+  encryption.host_key            rsa-sha2-256
+  encryption.host_key            ssh-rsa
+  encryption.key_exchange_(kex)  curve25519-sha256
+  encryption.key_exchange_(kex)  curve25519-sha256@libssh.org
+  encryption.key_exchange_(kex)  ecdh-sha2-nistp256
+  encryption.key_exchange_(kex)  ecdh-sha2-nistp384
+  encryption.key_exchange_(kex)  ecdh-sha2-nistp521
+  encryption.key_exchange_(kex)  diffie-hellman-group-exchange-sha256
+  encryption.key_exchange_(kex)  kex-strict-s-v00@openssh.com
 
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_version.md
@@ -74,13 +74,13 @@ msf5 auxiliary(scanner/ssh/ssh_version) > run
   encryption.host_key            rsa-sha2-512
   encryption.host_key            rsa-sha2-256
   encryption.host_key            ssh-rsa
-  encryption.key_exchange_(kex)  curve25519-sha256
-  encryption.key_exchange_(kex)  curve25519-sha256@libssh.org
-  encryption.key_exchange_(kex)  ecdh-sha2-nistp256
-  encryption.key_exchange_(kex)  ecdh-sha2-nistp384
-  encryption.key_exchange_(kex)  ecdh-sha2-nistp521
-  encryption.key_exchange_(kex)  diffie-hellman-group-exchange-sha256
-  encryption.key_exchange_(kex)  kex-strict-s-v00@openssh.com
+  encryption.key_exchange        curve25519-sha256
+  encryption.key_exchange        curve25519-sha256@libssh.org
+  encryption.key_exchange        ecdh-sha2-nistp256
+  encryption.key_exchange        ecdh-sha2-nistp384
+  encryption.key_exchange        ecdh-sha2-nistp521
+  encryption.key_exchange        diffie-hellman-group-exchange-sha256
+  encryption.key_exchange        kex-strict-s-v00@openssh.com
 
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
@@ -161,14 +161,14 @@ msf6 auxiliary(scanner/ssh/ssh_version) > run
   encryption.host_key            ssh-dss
   encryption.host_key            ecdsa-sha2-nistp256                   Weak elliptic curve
   encryption.host_key            ssh-ed25519
-  encryption.key_exchange_(kex)  curve25519-sha256@libssh.org
-  encryption.key_exchange_(kex)  ecdh-sha2-nistp256
-  encryption.key_exchange_(kex)  ecdh-sha2-nistp384
-  encryption.key_exchange_(kex)  ecdh-sha2-nistp521
-  encryption.key_exchange_(kex)  diffie-hellman-group-exchange-sha256
-  encryption.key_exchange_(kex)  diffie-hellman-group-exchange-sha1    Deprecated
-  encryption.key_exchange_(kex)  diffie-hellman-group14-sha1
-  encryption.key_exchange_(kex)  diffie-hellman-group1-sha1            Deprecated
+  encryption.key_exchange        curve25519-sha256@libssh.org
+  encryption.key_exchange        ecdh-sha2-nistp256
+  encryption.key_exchange        ecdh-sha2-nistp384
+  encryption.key_exchange        ecdh-sha2-nistp521
+  encryption.key_exchange        diffie-hellman-group-exchange-sha256
+  encryption.key_exchange        diffie-hellman-group-exchange-sha1    Deprecated
+  encryption.key_exchange        diffie-hellman-group14-sha1
+  encryption.key_exchange        diffie-hellman-group1-sha1            Deprecated
   fingerprint_db                 ssh.banner
   openssh.comment                Ubuntu-2ubuntu1
   os.cpe23                       cpe:/o:canonical:ubuntu_linux:14.04

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Auxiliary
         )
         note = 'Deprecated'
       end
-      table << ['encryption.key_exchange_(kex)', kex, note]
+      table << ['encryption.key_exchange', kex, note]
     end
     table
   end

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(22),
         OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', 30]),
-        OptBool.new('ENCRYPTION', [false, 'Check encryption for issues', true])
+        OptBool.new('EXTENDED_CHECKS', [true, 'Check for cryptographic issues', true])
       ],
       self.class
     )
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Auxiliary
 
       report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
 
-      return unless datastore['ENCRYPTION']
+      return unless datastore['EXTENDED_CHECKS']
 
       table = Rex::Text::Table.new(
         'Header' => 'Server Information and Encryption',

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -4,96 +4,209 @@
 ##
 
 require 'recog'
+require 'net/ssh/transport/session'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  # the default timeout (in seconds) to wait, in total, for both a successful
-  # connection to a given endpoint and for the initial protocol response
-  # from the supposed SSH endpoint to be returned
-  DEFAULT_TIMEOUT = 30
-
   def initialize
     super(
-      'Name'        => 'SSH Version Scanner',
-      'Description' => 'Detect SSH Version.',
-      'References'  =>
-        [
-          [ 'URL', 'https://en.wikipedia.org/wiki/SecureShell' ]
-        ],
-      'Author'      => [ 'Daniel van Eeden <metasploit[at]myname.nl>' ],
-      'License'     => MSF_LICENSE
+      'Name' => 'SSH Version Scanner',
+      'Description' => 'Detect SSH Version, and the algorithms available from the server',
+      'References' => [
+        ['URL', 'https://en.wikipedia.org/wiki/SecureShell'], # general info
+        ['URL', 'https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'], # deprecation of kex gss-sha1 stuff
+        ['URL', 'https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'], # diffie-hellman-group-exchange-sha1, diffie-hellman-group1-sha1, rsa1024-sha1
+        ['URL', 'https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'], # arc4 deprecation
+        ['URL', 'https://github.com/net-ssh/net-ssh?tab=readme-ov-file#supported-algorithms'] # a bunch of diff removed things from the ruby lib
+      ],
+      'Author' => [
+        'Daniel van Eeden <metasploit[at]myname.nl>', # original author
+        'h00die' # algorithms enhancements
+      ],
+      'License' => MSF_LICENSE
     )
 
     register_options(
       [
         Opt::RPORT(22),
-        OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', DEFAULT_TIMEOUT])
+        OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', 30])
       ],
       self.class
     )
   end
 
   def timeout
-    datastore['TIMEOUT'] <= 0 ? DEFAULT_TIMEOUT : datastore['TIMEOUT']
+    datastore['TIMEOUT']
+  end
+
+  def rport
+    datastore['RPORT']
   end
 
   def run_host(target_host)
     ::Timeout.timeout(timeout) do
-      connect
+      transport = Net::SSH::Transport::Session.new(target_host, { port: rport })
 
-      resp = sock.get_once(-1, timeout)
-
-      if ! resp
-        vprint_warning("No response")
-        return Exploit::CheckCode::Unknown
+      server_data = transport.algorithms.instance_variable_get(:@server_data)
+      host_keys = transport.algorithms.session.instance_variable_get(:@host_keys).instance_variable_get(:@host_keys)
+      if !host_keys.empty?
+        print_status("Key Fingerprint: #{host_keys[0].fingerprint}")
       end
 
-      ident, first_message = resp.split(/[\r\n]+/)
-      info = ""
+      ident = transport.server_version.version
 
-      if /^SSH-\d+\.\d+-(.*)$/ !~ ident
-        vprint_warning("Was not SSH -- #{resp.size} bytes beginning with #{resp[0, 12]}")
-        return Exploit::CheckCode::Safe(details: { ident: ident })
+      table = Rex::Text::Table.new(
+        'Header' => 'Server Encryption',
+        'Indent' => 2,
+        'SortIndex' => 0,
+        'Columns' => [ 'Type', 'Value']
+      )
+
+      server_data[:language_server].each do |language|
+        table << ['Language', language]
       end
 
-      banner = $1
+      server_data[:compression_server].each do |compression|
+        table << ['Compression', compression]
+      end
+
+      server_data[:encryption_server].each do |encryption|
+        ['arcfour', 'arcfour128', 'arcfour256'].each do |bad_enc|
+          next unless encryption.downcase.start_with? bad_enc
+
+          print_good("Encryption #{encryption} is deprecated and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
+            refs: ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations']
+          )
+        end
+        [
+          'aes256-cbc', 'aes192-cbc', 'aes128-cbc', 'rijndael-cbc@lysator.liu.se',
+          'blowfish-ctr blowfish-cbc', 'cast128-ctr', 'cast128-cbc', '3des-ctr', '3des-cbc', 'idea-cbc', 'none'
+        ].each do |bad_enc|
+          next unless encryption.downcase.start_with? bad_enc
+
+          print_good("Encryption #{encryption} is deprecated and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
+            refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers']
+          )
+        end
+        table << ['Encryption', encryption]
+      end
+
+      server_data[:hmac_server].each do |hmac|
+        ['hmac-sha2-512-96', 'hmac-sha2-256-96', 'hmac-sha1-96', 'hmac-ripemd160', 'hmac-md5', 'hmac-md5-96', 'none'].each do |bad_hmac|
+          next unless hmac.downcase.start_with? bad_hmac
+
+          print_good("HMAC #{hmac} is deprecated and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH HMAC #{hmac} is available, but should be deprecated",
+            refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms']
+          )
+        end
+        table << ['HMAC', hmac]
+      end
+
+      server_data[:host_key].each do |host_key|
+        ['ecdsa-sha2-nistp521', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp256'].each do |bad_key|
+          next unless host_key.downcase.start_with? bad_key
+
+          print_good("Host Key Encryption #{host_key} uses a weak elliptic curve and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Host Key Encryption #{host_key} is available, but should be deprecated",
+            refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys']
+          )
+        end
+        table << ['Host Key', host_key]
+      end
+
+      server_data[:kex].each do |kex|
+        ['gss-group1-sha1-', 'gss-group14-sha1-', 'gss-gex-sha1-'].each do |bad_kex|
+          next unless kex.downcase.start_with? bad_kex
+
+          print_good("Key Exchange (kex) #{kex} is deprecated and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Encryption #{kex} is available, but should be deprecated",
+            refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms']
+          )
+        end
+        ['ecdsa-sha2-nistp521', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp256'].each do |bad_kex|
+          next unless kex.downcase.start_with? bad_kex
+
+          print_good("Key Exchange (kex) #{kex} uses a weak elliptic curve and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Encryption #{kex} is available, but should be deprecated",
+            refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange']
+          )
+        end
+        ['diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1', 'rsa1024-sha1'].each do |bad_kex|
+          next unless kex.downcase.start_with? bad_kex
+
+          print_good("Key Exchange (kex) #{kex} is deprecated and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Encryption #{kex} is available, but should be deprecated",
+            refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16']
+          )
+        end
+        table << ['Key Exchange (kex)', kex]
+      end
+
+      # XXX check for host key size?
+      # https://www.tenable.com/plugins/nessus/153954
 
       # Try to match with Recog and show the relevant fields to the user
-      recog_match = Recog::Nizer.match('ssh.banner', banner)
-      if recog_match
-        info << " ( "
-        recog_match.each_pair do |k,v|
-          next if k == 'matched'
-          info << "#{k}=#{v} "
-        end
-        info << ")"
-      end
+      info = ''
+      if /^SSH-\d+\.\d+-(.*)$/ =~ ident
+        recog_match = Recog::Nizer.match('ssh.banner', ::Regexp.last_match(1))
+        if recog_match
+          info << ' ( '
+          recog_match.each_pair do |k, v|
+            next if k == 'matched'
 
-      # Check to see if this is Kippo, which sends a premature
-      # key init exchange right on top of the SSH version without
-      # waiting for the required client identification string.
-      if first_message && first_message.size >= 5
-        extra = first_message.unpack("NCCA*") # sz, pad_sz, code, data
-        if (extra.last.size + 2 == extra[0]) && extra[2] == 20
-          info << " (Kippo Honeypot)"
+            info << "#{k}=#{v} "
+          end
+          info << ')'
         end
       end
 
-      print_good("SSH server version: #{ident}#{info}")
-      report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: ident)
-
-      Exploit::CheckCode::Detected(details: { ident: ident, info: info })
+      print_status("SSH server version: #{ident}#{info}")
+      report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
+      print_status(table.to_s)
     end
   rescue EOFError, Rex::ConnectionError => e
     vprint_error(e.message) # This may be a little noisy, but it is consistent
-    Exploit::CheckCode::Unknown
   rescue Timeout::Error
     vprint_warning("Timed out after #{timeout} seconds. Skipping.")
-    Exploit::CheckCode::Unknown
-  ensure
-    disconnect
   end
 end

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name' => 'SSH Version Scanner',
-      'Description' => 'Detect SSH Version, and the algorithms available from the server',
+      'Description' => 'Detect SSH Version, and the server encryption',
       'References' => [
         ['URL', 'https://en.wikipedia.org/wiki/SecureShell'], # general info
         ['URL', 'https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'], # deprecation of kex gss-sha1 stuff
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(22),
-        OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', 30])
+        OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', 30]),
+        OptBool.new('ENCRYPTION', [false, 'Check encryption for issues', true])
       ],
       self.class
     )
@@ -46,172 +47,227 @@ class MetasploitModule < Msf::Auxiliary
     datastore['RPORT']
   end
 
+  def perform_recog(ident)
+    table = []
+    recog_info = []
+    if /^SSH-\d+\.\d+-(.*)$/ =~ ident
+      recog_match = Recog::Nizer.match('ssh.banner', ::Regexp.last_match(1))
+      if recog_match
+        recog_match.each_pair do |k, v|
+          next if k == 'matched'
+
+          recog_info << "#{k}: #{v}"
+        end
+      end
+    end
+
+    return table if recog_info.empty?
+
+    recog_info.each do |info|
+      info = info.split(': ')
+      table << [info[0], info[1..].join(': ')]
+    end
+    table
+  end
+
+  def check_host_key(server_data)
+    table = []
+
+    host_key_checks = {
+      %w[
+        ecdsa-sha2-nistp521 ecdsa-sha2-nistp384
+        ecdsa-sha2-nistp256
+      ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys']
+    }
+    server_data[:host_key].each do |host_key|
+      note = ''
+      host_key_checks.each do |host_key_check, refs|
+        host_key_check.each do |bad_key|
+          next unless host_key.downcase == bad_key
+
+          vprint_good("#{target_host} - Host Key Encryption #{host_key} uses a weak elliptic curve and should not be used.")
+          report_vuln(
+            host: target_host,
+            port: rport,
+            proto: 'tcp',
+            name: name,
+            info: "Module #{fullname} confirmed SSH Host Key Encryption #{host_key} is available, but should be deprecated",
+            refs: refs
+          )
+          note = 'Weak elliptic curve'
+        end
+      end
+      table << ['encryption.host_key', host_key, note]
+    end
+    table
+  end
+
+  def check_encryption(server_data)
+    table = []
+
+    encryption_checks = {
+      'arcfour' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
+      'arcfour128' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
+      'arcfour256' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
+      'aes256-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'aes192-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'aes128-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'rijndael-cbc@lysator.liu.se' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'blowfish-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'cast128-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      '3des-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'idea-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'twofish-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'twofish128-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'twofish256-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
+      'blowfish-ctr' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'],
+      'cast128-ctr' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'],
+      '3des-ctr' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'],
+      'none' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers']
+    }
+
+    server_data[:encryption_server].each do |encryption|
+      note = ''
+      encryption_checks.each do |bad_enc, refs|
+        next unless encryption.downcase == bad_enc
+
+        vprint_good("#{target_host} - Encryption #{encryption} is deprecated and should not be used.")
+        report_vuln(
+          host: target_host,
+          port: rport,
+          proto: 'tcp',
+          name: name,
+          info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
+          refs: refs
+        )
+        note = 'Deprecated'
+      end
+      table << ['encryption.encryption', encryption, note]
+    end
+    table
+  end
+
+  def check_kex(server_data)
+    table = []
+    kex_checks = {
+      'gss-group1-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
+      'gss-group14-sha1-gss-gex-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
+      'gss-gex-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
+      'ecdsa-sha2-nistp521' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
+      'ecdsa-sha2-nistp384' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
+      'ecdsa-sha2-nistp256' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
+      'diffie-hellman-group-exchange-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'],
+      'diffie-hellman-group1-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'],
+      'rsa1024-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16']
+    }
+    server_data[:kex].each do |kex|
+      note = ''
+      kex_checks.each do |bad_kex, refs|
+        if bad_kex.ends_with? '*'
+          next unless kex.downcase.start_with? bad_kex[0..-2]
+        else
+          next unless kex.downcase == bad_kex
+        end
+
+        vprint_good("#{target_host} - Key Exchange (kex) #{kex} is deprecated and should not be used.")
+        report_vuln(
+          host: target_host,
+          port: rport,
+          proto: 'tcp',
+          name: name,
+          info: "Module #{fullname} confirmed SSH Encryption #{kex} is available, but should be deprecated",
+          refs: refs
+        )
+        note = 'Deprecated'
+      end
+      table << ['encryption.key_exchange_(kex)', kex, note]
+    end
+    table
+  end
+
+  def check_hmac(server_data)
+    table = []
+
+    hmac_checks = {
+      'hmac-sha2-512-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
+      'hmac-sha2-256-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
+      'hmac-sha1-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
+      'hmac-ripemd160' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
+      'hmac-md5' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
+      'hmac-md5-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
+      'none' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms']
+    }
+
+    server_data[:hmac_server].each do |hmac|
+      note = ''
+      hmac_checks.each do |bad_hmac, refs|
+        next unless hmac.downcase == bad_hmac
+
+        vprint_good("#{target_host} - HMAC #{hmac} is deprecated and should not be used.")
+        report_vuln(
+          host: target_host,
+          port: rport,
+          proto: 'tcp',
+          name: name,
+          info: "Module #{fullname} confirmed SSH HMAC #{hmac} is available, but should be deprecated",
+          refs: refs
+        )
+        note = 'Deprecated'
+      end
+      table << ['encryption.hmac', hmac, note]
+    end
+    table
+  end
+
   def run_host(target_host)
     ::Timeout.timeout(timeout) do
       transport = Net::SSH::Transport::Session.new(target_host, { port: rport })
 
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       host_keys = transport.algorithms.session.instance_variable_get(:@host_keys).instance_variable_get(:@host_keys)
-      print_status("#{target_host} - Key Fingerprint: #{host_keys[0].fingerprint}") if host_keys.length.positive?
+      host_keys.each do |host_key|
+        print_status("#{target_host} - Key Fingerprint: #{host_key.ssh_type} #{Base64.strict_encode64(host_key.to_blob)}")
+      end
 
       ident = transport.server_version.version
 
+      print_status("#{target_host} - SSH server version: #{ident}")
+
+      report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
+
+      return unless datastore['ENCRYPTION']
+
       table = Rex::Text::Table.new(
-        'Header' => 'Server Encryption',
+        'Header' => 'Server Information and Encryption',
         'Indent' => 2,
         'SortIndex' => 0,
-        'Columns' => %w[Type Value]
+        'Columns' => %w[Type Value Note]
       )
 
+      # if these ever get expanded to have checks, they should be moved to their own function
       server_data[:language_server].each do |language|
-        table << ['Language', language]
+        table << ['encryption.language', language, '']
       end
 
+      # if these ever get expanded to have checks, they should be moved to their own function
       server_data[:compression_server].each do |compression|
-        table << ['Compression', compression]
+        table << ['encryption.compression', compression, '']
       end
 
-      encryption_checks = {
-        %w[
-          arcfour arcfour128
-          arcfour256
-        ] => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
-        %w[
-          aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-cbc cast128-cbc 3des-cbc idea-cbc
-          twofish-cbc twofish128-cbc twofish256-cbc
-        ] => [
-          'https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'
-        ],
-        %w[
-          blowfish-ctr cast128-ctr 3des-ctr
-          none
-        ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers']
-      }
+      table.rows.concat check_kex(server_data)
 
-      server_data[:encryption_server].each do |encryption|
-        encryption_checks.each do |encryptions, refs|
-          encryptions.each do |bad_enc|
-            next unless encryption.downcase.start_with? bad_enc
+      table.rows.concat check_host_key(server_data)
 
-            print_good("#{target_host} - Encryption #{encryption} is deprecated and should not be used.")
-            report_vuln(
-              host: target_host,
-              port: rport,
-              proto: 'tcp',
-              name: name,
-              info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
-              refs: refs
-            )
-          end
-        end
-        table << ['Encryption', encryption]
-      end
+      table.rows.concat check_hmac(server_data)
 
-      hmac_checks = {
-        %w[
-          hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-md5 hmac-md5-96
-          none
-        ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms']
-      }
+      table.rows.concat check_encryption(server_data)
 
-      server_data[:hmac_server].each do |hmac|
-        hmac_checks.each do |hmacs, refs|
-          hmacs.each do |bad_hmac|
-            next unless hmac.downcase.start_with? bad_hmac
-
-            print_good("#{target_host} - HMAC #{hmac} is deprecated and should not be used.")
-            report_vuln(
-              host: target_host,
-              port: rport,
-              proto: 'tcp',
-              name: name,
-              info: "Module #{fullname} confirmed SSH HMAC #{hmac} is available, but should be deprecated",
-              refs: refs
-            )
-          end
-        end
-        table << ['HMAC', hmac]
-      end
-
-      host_key_checks = {
-        %w[
-          ecdsa-sha2-nistp521 ecdsa-sha2-nistp384
-          ecdsa-sha2-nistp256
-        ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys']
-      }
-      server_data[:host_key].each do |host_key|
-        host_key_checks.each do |host_key_check, refs|
-          host_key_check.each do |bad_key|
-            next unless host_key.downcase.start_with? bad_key
-
-            print_good("#{target_host} - Host Key Encryption #{host_key} uses a weak elliptic curve and should not be used.")
-            report_vuln(
-              host: target_host,
-              port: rport,
-              proto: 'tcp',
-              name: name,
-              info: "Module #{fullname} confirmed SSH Host Key Encryption #{host_key} is available, but should be deprecated",
-              refs: refs
-            )
-          end
-        end
-        table << ['Host Key', host_key]
-      end
-
-      kex_checks = {
-        %w[gss-group1-sha1- gss-group14-sha1-gss-gex-sha1-] => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
-        %w[
-          ecdsa-sha2-nistp521 ecdsa-sha2-nistp384
-          ecdsa-sha2-nistp256
-        ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
-        %w[
-          diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1
-          rsa1024-sha1
-        ] => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16']
-      }
-      server_data[:kex].each do |kex|
-        kex_checks.each do |kexs, refs|
-          kexs.each do |bad_kex|
-            next unless kex.downcase.start_with? bad_kex
-
-            print_good("#{target_host} - Key Exchange (kex) #{kex} is deprecated and should not be used.")
-            report_vuln(
-              host: target_host,
-              port: rport,
-              proto: 'tcp',
-              name: name,
-              info: "Module #{fullname} confirmed SSH Encryption #{kex} is available, but should be deprecated",
-              refs: refs
-            )
-          end
-        end
-        table << ['Key Exchange (kex)', kex]
-      end
+      table.rows.concat perform_recog(ident)
 
       # XXX check for host key size?
       # h00die - not sure how to get that info from the library.
       # https://www.tenable.com/plugins/nessus/153954
 
-      # Try to match with Recog and show the relevant fields to the user
-      recog_info = []
-      if /^SSH-\d+\.\d+-(.*)$/ =~ ident
-        recog_match = Recog::Nizer.match('ssh.banner', ::Regexp.last_match(1))
-        if recog_match
-          recog_match.each_pair do |k, v|
-            next if k == 'matched'
-
-            recog_info << "#{k}: #{v}"
-          end
-        end
-      end
-
-      if !recog_info.empty?
-        recog_info = "\n\t#{recog_info.join("\n\t")}"
-      else
-        recog_info = ''
-      end
-      print_status("#{target_host} - SSH server version: #{ident}#{recog_info}")
-      report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
       print_status("#{target_host} - #{table}")
     end
   rescue EOFError, Rex::ConnectionError => e


### PR DESCRIPTION
fix #18685


`ssh_version` module does what it says. However, it would be nice if we had the ability to pull ciphers, encryption methods etc.  Similar to the upgrade to `ssl_version` in #17149

This PR does that, it shows:

1. ssh server fingerprint
2. looks for encryption/hmac/kex/etc that are deprecated and prints those
3. prints the values returned by the server related to encryption/compression/etc

# Validation

 - [x] start `msfconsole`
 - [x] `use auxiliary/scanner/ssh/ssh_version`
 - [x] `set rhost` to the docker image, or any host really that you want
 - [x] `run`
 - [x] you should see info and warnings printed.