### PR TITLE
Bump the minimum version of apktool

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -240,8 +240,10 @@ class Msf::Payload::Apk
     check_apktool_output_for_exceptions(check_apktool)
 
     apktool_version = Rex::Version.new(check_apktool.split("\n").first.strip)
-    min_required_apktool_version = Rex::Version.new('2.7.0')
+    min_required_apktool_version = Rex::Version.new('2.9.2')
     unless apktool_version >= min_required_apktool_version
+      # technically MSF supports 2.7.0+ but versions < 2.9.2 are vulnerable to CVE-2024-21633
+      # see: https://github.com/iBotPeaches/Apktool/security/advisories/GHSA-2hqv-2xv4-5h5w
       raise RuntimeError, "apktool version #{apktool_version} not supported, please download at least version #{min_required_apktool_version}."
     end
 


### PR DESCRIPTION
Bump the minimum version of apktool to avoid CVE-2024-21633. We don't ship apktool ourselves, but this extra check will help ensure our users are unable to accidentally invoke a vulnerable version it that they themselves have provided.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Invoke `#backdoor_apk` with an old version of apktool and see that it's no longer supported
- [ ] Don't get pwned