### PR TITLE
fixed a swap typo in credential documentation

### DIFF
--- a/lib/metasploit/framework/credential.rb
+++ b/lib/metasploit/framework/credential.rb
@@ -16,7 +16,7 @@ module Metasploit
       #   @return [Object] the parent object that had .to_credential called on it to create this object
       attr_accessor :parent
       # @!attribute private
-      #   The private credential component (e.g. username)
+      #   The private credential component (e.g. password)
       #
       #   @return [String] if {#paired} is `true` or {#private} is `nil`
       #   @return [String, nil] if {#paired} is `false` or {#private} is not `nil`.
@@ -28,7 +28,7 @@ module Metasploit
       #   @return [String]
       attr_accessor :private_type
       # @!attribute public
-      #   The public credential component (e.g. password)
+      #   The public credential component (e.g. username)
       #
       #   @return [String] if {#paired} is `true` or {#public} is `nil`
       #   @return [String, nil] if {#paired} is `false` or {#public} is not `nil`.


### PR DESCRIPTION
Change fixes swap typo in  `lib/metasploit/framework/credential.rb`


No code change, verification skipped. 