### PR TITLE
Fix uninitialized exploit driver exception

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -82,7 +82,7 @@ module Exploit
       exploit.options.validate(exploit.datastore)
 
       # Start it up
-      driver = ExploitDriver.new(exploit.framework)
+      driver = Msf::ExploitDriver.new(exploit.framework)
 
       # Keep the handler of driver running if exploiting multiple targets.
       driver.keep_handler = true if opts['multi']


### PR DESCRIPTION
Fixes an uninitialized exploit driver exception that could sometimes occur when running Metasploit framework's payload modules

Spotted when running the acceptance tests:

```
[read] msf6 payload(python/meterpreter_reverse_tcp) > 
[write] to_handler
[read] [-] Exploit failed: uninitialized constant Msf::Simple::Exploit::ExploitDriver
Did you mean?  Msf::ExploitDriver
               Msf::ExploitError
```

## Verification

Ensure CI passes