### PR TITLE
Fix `undefined method` error in `/api/v1/modules` endpoint

### DIFF
--- a/lib/msf/core/web_services.rb
+++ b/lib/msf/core/web_services.rb
@@ -1,3 +1,3 @@
 module Msf::WebServices
-
+  extend Msf::WebServices::ModuleSearch
 end

--- a/spec/lib/msf/core/web_services_spec.rb
+++ b/spec/lib/msf/core/web_services_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Msf::WebServices do
+  describe '#search_modules' do
+    it 'exists' do
+      expect(described_class).to respond_to(:search_modules)
+    end
+  end
+end


### PR DESCRIPTION
Closes #18472 by extending `Msf::WebServices` with `Msf::WebServices::ModuleSearch` that was originally present there but was accidentally removed 

Paired with @dwelch-r7 and @adfoster-r7 

## Verification

List the steps needed to make sure this thing works

- [ ] Start msfdb webservice: `msfdb --component webservice --address 0.0.0.0 start`
- [ ] Navigate to `http://localhost:5443/api/v1/modules?name=aux`
- [ ] **Verify** response includes list of modules
- [ ] **Verify** no error
