### PR TITLE
Removed Warning for missing notes for the following modules

### DIFF
--- a/modules/exploits/aix/local/xorg_x11_server.rb
+++ b/modules/exploits/aix/local/xorg_x11_server.rb
@@ -68,7 +68,13 @@ class MetasploitModule < Msf::Exploit::Local
           ['IBM AIX Version 7.1', {}],
           ['IBM AIX Version 7.2', {}]
         ],
-      'DefaultTarget'  => 1))
+      'DefaultTarget'  => 1,
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        }))
 
     register_options(
       [

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -62,7 +62,13 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => '2009-10-07'))
+      'DisclosureDate' => '2009-10-07',
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        }))
 
   end
 

--- a/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
+++ b/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
@@ -227,7 +227,13 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => '2009-06-17'))
+      'DisclosureDate' => '2009-06-17',
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        }))
 
   end
 

--- a/modules/exploits/android/adb/adb_server_exec.rb
+++ b/modules/exploits/android/adb/adb_server_exec.rb
@@ -28,7 +28,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ['mipsle', {'Arch' => ARCH_MIPSLE}]
       ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => '2016-01-01'
+      'DisclosureDate' => '2016-01-01',
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        }
     ))
 
     register_options([

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -41,6 +41,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'      => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
       'Targets'             => [ [ 'Automatic', {} ] ],
       'DisclosureDate'      => '2014-11-12',
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        },
       'DefaultTarget'       => 0,
 
       'BrowserRequirements' => {

--- a/modules/exploits/android/browser/stagefright_mp4_tx3g_64bit.rb
+++ b/modules/exploits/android/browser/stagefright_mp4_tx3g_64bit.rb
@@ -347,10 +347,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'DisclosureDate' => '2015-08-13',
       'DefaultTarget'  => 0,
-      'Notes' =>
-          {
-              'AKA' => ['stagefright']
-          }
+      'Notes'         =>
+        {
+          'AKA' => ['stagefright'],
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        }
       ))
 
 =begin

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -70,6 +70,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'      => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
       'Targets'             => [ [ 'Automatic', {} ] ],
       'DisclosureDate'      => '2012-12-21',
+      'Notes'         =>
+      {
+        'SideEffects' => [], 
+        'Stability' => [],
+        'Reliability' => []
+      },
       'DefaultTarget'       => 0,
       'BrowserRequirements' => {
         :source     => 'script',

--- a/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
+++ b/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
@@ -52,6 +52,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DisclosureDate' => '2014-04-13',
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        },
       'DefaultTarget'  => 0
     ))
 

--- a/modules/exploits/android/local/binder_uaf.rb
+++ b/modules/exploits/android/local/binder_uaf.rb
@@ -44,6 +44,12 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'https://github.com/grant-h/qu1ckr00t/blob/master/native/poc.c' ],
           ],
           'DisclosureDate' => '2019-09-26',
+          'Notes'         =>
+            {
+              'SideEffects' => [], 
+              'Stability' => [],
+              'Reliability' => []
+            },
           'SessionTypes' => [ 'meterpreter' ],
           'Platform' => [ "android", "linux" ],
           'Arch' => [ ARCH_AARCH64 ],

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -36,6 +36,12 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'https://forum.xda-developers.com/t/root-saferoot-root-for-vruemj7-mk2-and-android-4-3.2565758/' ],
           ],
           'DisclosureDate' => '2013-09-06',
+          'Notes'         =>
+            {
+              'SideEffects' => [], 
+              'Stability' => [],
+              'Reliability' => []
+            },
           'SessionTypes' => [ 'meterpreter' ],
           "Platform" => [ "android", "linux" ],
           'Targets' => [[ 'Automatic', {}]],

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -30,6 +30,12 @@ class MetasploitModule < Msf::Exploit::Local
       'Author'         => 'timwr',
       'License'        => MSF_LICENSE,
       'DisclosureDate' => '2017-08-31',
+      'Notes'         =>
+        {
+          'SideEffects' => [], 
+          'Stability' => [],
+          'Reliability' => []
+        },
       'SessionTypes'   => [ 'meterpreter', 'shell' ],
       'Platform'       => [ 'android', 'linux' ],
       'Arch'           => [ ARCH_AARCH64, ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE ],


### PR DESCRIPTION
**Working on metasploit code quality. Issue https://github.com/rapid7/metasploit-framework/issues/17582. Added missing notes for 11 modules.

# Verification 
 - [ ] start terminal and change directory to the metasploit-framework project
 - [ ]  run the `rubocop --only Lint/ModuleEnforceNotes modules/exploits/` command
 - [ ]  see that there are no warnings regarding missing notes for the modified modules 
