### PR TITLE
Code quality changes added

### DIFF
--- a/modules/exploits/aix/local/xorg_x11_server.rb
+++ b/modules/exploits/aix/local/xorg_x11_server.rb
@@ -40,6 +40,8 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => '2018-10-25',
       'Notes'         =>
         {
+          'Reliability' => [],
+          'Stability' => [],
           'SideEffects' => [ CONFIG_CHANGES ]
         },
       'References'     =>

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -62,7 +62,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => '2009-10-07'))
+      'DisclosureDate' => '2009-10-07',
+      'Notes' => {
+        'Reliability' => [],
+        'Stability' => [],
+        'SideEffects' => []
+      }))
 
   end
 

--- a/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
+++ b/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
@@ -227,7 +227,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => '2009-06-17'))
+      'DisclosureDate' => '2009-06-17',
+      'Notes' => {
+        'Reliability' => [],
+        'Stability' => [],
+        'SideEffects' => []
+      }))
 
   end
 


### PR DESCRIPTION
**Working on metasploit code quality. Issue https://github.com/rapid7/metasploit-framework/issues/17582. Added missing notes for 3 modules.

# Verification 
 - [ ] start terminal and change directory to the metasploit-framework project
 - [ ]  run the `rubocop --only Lint/ModuleEnforceNotes modules/exploits/` command
 - [ ]  see that there are no warnings regarding missing notes for the modified modules 