### PR TITLE
Test large Meterpreter file uploads/downloads

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -37,6 +37,7 @@ on:
       - 'lib/msf/core/payload/**'
       - 'lib/msf/core/**'
       - 'tools/dev/**'
+      - 'test/**'
       - 'spec/acceptance/**'
       - 'spec/support/acceptance/**'
       - 'spec/acceptance_spec_helper.rb'

--- a/spec/acceptance/meterpreter_spec.rb
+++ b/spec/acceptance/meterpreter_spec.rb
@@ -165,8 +165,9 @@ RSpec.describe 'Meterpreter' do
           def get_file_attachment_contents(path)
             return 'none resent' unless File.exist?(path)
 
-            content = File.binread(path)
-            content.blank? ? 'file created - but empty' : content
+            # content = File.binread(path)
+            # content.blank? ? 'file created - but empty' : content
+            'placeholder as file.binread dies on large files'
           end
 
           before :each do |example|


### PR DESCRIPTION
Adds test to verify that Meterpreter can handle uploading/downloading large binary files

Closes https://github.com/rapid7/metasploit-framework/issues/18717

## Verification

- Ensure CI passes