### PR TITLE
Apple Code Quality Fixed

### DIFF
--- a/modules/exploits/apple_ios/browser/safari_jit.rb
+++ b/modules/exploits/apple_ios/browser/safari_jit.rb
@@ -41,7 +41,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/armle/meterpreter_reverse_tcp' },
         'Targets' => [[ 'Automatic', {} ]],
-        'DisclosureDate' => '2016-08-25'
+        'DisclosureDate' => '2016-08-25',
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
     register_options(

--- a/modules/exploits/apple_ios/browser/safari_libtiff.rb
+++ b/modules/exploits/apple_ios/browser/safari_libtiff.rb
@@ -63,7 +63,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => '2006-08-01'
+      'DisclosureDate' => '2006-08-01',
+      'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       ))
   end
 

--- a/modules/exploits/apple_ios/browser/webkit_createthis.rb
+++ b/modules/exploits/apple_ios/browser/webkit_createthis.rb
@@ -55,7 +55,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/aarch64/meterpreter_reverse_tcp' },
       'Targets'        => [[ 'Automatic', {} ]],
-      'DisclosureDate' => '2018-03-15'))
+      'DisclosureDate' => '2018-03-15',
+      'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }))
     register_advanced_options([
       OptBool.new('DEBUG_EXPLOIT', [false, "Show debug information in the exploit javascript", false]),
       OptBool.new('DUMP_OFFSETS', [false, "Show newly found offsets in a javascript prompt", false]),

--- a/modules/exploits/apple_ios/browser/webkit_trident.rb
+++ b/modules/exploits/apple_ios/browser/webkit_trident.rb
@@ -43,7 +43,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/aarch64/meterpreter_reverse_tcp' },
       'Targets'        => [[ 'Automatic', {} ]],
-      'DisclosureDate' => '2016-08-25'))
+      'DisclosureDate' => '2016-08-25',
+      'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }))
     register_options(
       [
         OptPort.new('SRVPORT', [ true, "The local port to listen on.", 8080 ]),


### PR DESCRIPTION
**Working on metasploit code quality. Issue https://github.com/rapid7/metasploit-framework/issues/17582. Added missing notes for 4 Apple modules.

# Verification 
 - [ ] start terminal and change directory to the metasploit-framework project
 - [ ]  run the `rubocop --only Lint/ModuleEnforceNotes modules/exploits/` command
 - [ ]  see that there are no warnings regarding missing notes for the modified modules 