### PR TITLE
Code quality

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Notes' =>
           {
               'AKA' => ['EXPLODINGCAN'],
-              'Stability' => [CRASH_SAFE], 
+              'Stability' => [CRASH_SERVICE_DOWN],
               'Reliability' => [REPEATABLE_SESSION],
               'Side Effects' => []
-          }
+            }
     ))
 
     register_options(

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -73,7 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
           {
               'AKA' => ['EXPLODINGCAN'],
               'Stability' => [CRASH_SAFE], 
-              'Reliability' => [REPEATABLE_SESSION]
+              'Reliability' => [REPEATABLE_SESSION],
+              'Side Effects' => []
           }
     ))
 

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -71,7 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'Notes' =>
           {
-              'AKA' => ['EXPLODINGCAN']
+              'AKA' => ['EXPLODINGCAN'],
+              'Stability' => [CRASH_SAFE], 
+              'Reliability' => [REPEATABLE_SESSION]
           }
     ))
 


### PR DESCRIPTION
**Working on metasploit code quality. Issue https://github.com/rapid7/metasploit-framework/issues/17582. Added missing notes for the IIS 6.0 explodingcan exploit. It sometimes crashes the IIS server, is expected to gain a shell whenever the server is up and running, and has no known side effects.

# Verification 
 - [ ] start terminal and change directory to the metasploit-framework project
 - [ ]  run the `rubocop --only Lint/ModuleEnforceNotes modules/exploits/` command
 - [ ]  see that there are no warnings regarding missing notes for the modified modules 