### PR TITLE
Update metasploit-payloads gem to 2.0.165

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.164)
+      metasploit-payloads (= 2.0.165)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -278,7 +278,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.164)
+    metasploit-payloads (2.0.165)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -82,7 +82,7 @@ metasploit-concern, 5.0.2, "New BSD"
 metasploit-credential, 6.0.6, "New BSD"
 metasploit-framework, 6.3.53, "New BSD"
 metasploit-model, 5.0.2, "New BSD"
-metasploit-payloads, 2.0.161, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.165, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.3, "New BSD"
 metasploit_payloads-mettle, 1.0.26, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.164'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.165'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 175686
+  CachedSize = 176198
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 175686
+  CachedSize = 176198
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 176732
+  CachedSize = 177244
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 176732
+  CachedSize = 177244
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 175686
+  CachedSize = 176198
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 175686
+  CachedSize = 176198
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 200774
+  CachedSize = 201798
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 200774
+  CachedSize = 201798
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 201820
+  CachedSize = 202844
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 201820
+  CachedSize = 202844
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 200774
+  CachedSize = 201798
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 200774
+  CachedSize = 201798
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows


### PR DESCRIPTION
Includes changes from:
* rapid7/metasploit-payloads#694
