### PR TITLE
Remove invalid modification time test

### DIFF
--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -410,6 +410,7 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
           module_info_by_path_from_database!
         end
 
+        it { expect(subject[:modification_time]).to be_a(Time) }
         it { expect(subject[:parent_path]).to eq(parent_path) }
         it { expect(subject[:reference_name]).to eq(reference_name) }
         it { expect(subject[:type]).to eq(type) }

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -410,7 +410,6 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
           module_info_by_path_from_database!
         end
 
-        it { expect(subject[:modification_time]).to be_within(10.seconds).of(pathname_modification_time) }
         it { expect(subject[:parent_path]).to eq(parent_path) }
         it { expect(subject[:reference_name]).to eq(reference_name) }
         it { expect(subject[:type]).to eq(type) }


### PR DESCRIPTION
Removes a test that the metadata cache will always have the same modification time as the module files modifcation time on the filesystem.
The reason for this is that this logic does not hold true when you are deferring module loading (via `features set defer_module_loads true`)  since the modules don't all get loaded at boot time the cache won't be updated to reflect the modification time of the file until that module has been loaded, this led to intermittent failures for this test

Since the caches modification time and the filesystems modification time are no longer guaranteed to be synced I think the most sensible thing to do here is just remove the test
