### PR TITLE
Verify ntpath works as expected

### DIFF
--- a/lib/rex/post/smb/ui/console/command_dispatcher/shares.rb
+++ b/lib/rex/post/smb/ui/console/command_dispatcher/shares.rb
@@ -276,7 +276,7 @@ module Rex
             return print_no_share_selected if !active_share
 
             path = args[0]
-            # TODO: Needs better normalization
+
             new_path = as_ntpath(Pathname.new(shell.cwd).join(path).to_s)
 
             begin

--- a/spec/lib/rex/post/smb/ui/console/command_dispatcher/shares_spec.rb
+++ b/spec/lib/rex/post/smb/ui/console/command_dispatcher/shares_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe Rex::Post::SMB::Ui::Console::CommandDispatcher::Shares do
 
   subject(:command_dispatcher) { described_class.new(session.console) }
 
-  # it_behaves_like 'session command dispatcher'
-
   describe '#as_ntpath' do
     let(:valid_windows_path) { 'some\\path\\that\\is\\valid' }
 

--- a/spec/lib/rex/post/smb/ui/console/command_dispatcher/shares_spec.rb
+++ b/spec/lib/rex/post/smb/ui/console/command_dispatcher/shares_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/post/smb/ui/console'
+require 'rex/post/smb/ui/console/command_dispatcher/shares'
+
+RSpec.describe Rex::Post::SMB::Ui::Console::CommandDispatcher::Shares do
+  let(:client) { instance_double(RubySMB::Client) }
+  let(:session) { Msf::Sessions::SMB.new(nil, { client: client }) }
+  let(:console) do
+    console = Rex::Post::SMB::Ui::Console.new(session)
+    console.disable_output = true
+    console
+  end
+
+  before(:each) do
+    allow(session).to receive(:client).and_return(client)
+    allow(session).to receive(:console).and_return(console)
+    allow(session).to receive(:name).and_return('test client name')
+    allow(session).to receive(:sid).and_return('test client sid')
+  end
+
+  subject(:command_dispatcher) { described_class.new(session.console) }
+
+  # it_behaves_like 'session command dispatcher'
+
+  describe '#as_ntpath' do
+    let(:valid_windows_path) { 'some\\path\\that\\is\\valid' }
+
+    [
+      'some\\path\\that\\is\\valid',
+      'some/path/that/is/valid',
+      'some/./path/that/./is/valid',
+      'some/extra/../path/that/extra/../is/valid',
+      '/some/path/that/is/valid'
+    ].each do |path|
+      context "when the path is #{path}" do
+        it 'formats it as a valid ntpath' do
+          formatted_path = subject.send(:as_ntpath, path)
+          expect(formatted_path).to eq valid_windows_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding in some tests to verify that the `as_ntpath` function used by the smb session type works as expected, I spent some time trying to break it but it seemed legit to me, figured I'd add in a couple of test cases though that can be added to if we do manage to break it in the future

# Verification Steps
- [ ] CI passes