### PR TITLE
Fix flakey opt address local spec

### DIFF
--- a/spec/lib/msf/core/opt_address_local_spec.rb
+++ b/spec/lib/msf/core/opt_address_local_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe Msf::OptAddressLocal do
       IPAddr.new(addr).ipv4? && !addr[/^127.*/]
     rescue IPAddr::InvalidAddressError
       false
+    end.sort_by do |addr|
+      ip_addr = IPAddr.new(addr)
+      [ip_addr.ipv4? ? 0 : 1, ip_addr.to_i]
     end.first
     { name: iface, addr: ip_address }
   end.select { |name_addr| name_addr[:addr] }.sort_by do |name_addr|
     ip_addr = IPAddr.new(name_addr[:addr])
-    [ip_addr.ipv4?, ip_addr.to_i]
+    [ip_addr.ipv4? ? 0 : 1, ip_addr.to_i]
   end.first
 
   valid_values = [


### PR DESCRIPTION
Paired with @dwelch-r7 

On CI the OptAddressLocal test was failing due to our test selecting the first returned IP address from `ifaddrs`, and our implementation choosing the lowest IP address found:

```
11:05:19   2) Msf::OptAddressLocal behaves like an option with valid values should be valid and normalize appropriately: ens160
11:05:19      Failure/Error: expect(subject.normalize(valid_value)).to eq normalized_value
11:05:19 
11:05:19        expected: "2.2.2.2"
11:05:19             got: "1.1.1.1"
11:05:19 
11:05:19        (compared using ==)
11:05:19      Shared Example Group: "an option" called from ./spec/lib/msf/core/opt_address_local_spec.rb:39
11:05:19      # ./spec/support/shared/examples/an_option.rb:34:in `block (5 levels) in <top (required)>'
11:05:19      # ./spec/support/shared/examples/an_option.rb:40:in `block (4 levels) in <top (required)>'
```

Running `ifconfig` shows only one ip:

```
$ ifconfig ens160
ens160: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 2.2.2.2  netmask 255.255.240.0  broadcast 2.2.2.255
        ether xx:xx:xx:xx:xx  txqueuelen 1000  (Ethernet)
        RX packets 6313497249  bytes 6862269667965 (6.8 TB)
        RX errors 0  dropped 43  overruns 0  frame 0
        TX packets 1469766199  bytes 4315195299313 (4.3 TB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

However - `ip addr` shows that there's actually a secondary IP address associated with this network adapter:

```
$ ip addr show ens160
2: ens160: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
    inet 2.2.2.2/20 brd 2.2.2.255 scope global ens160
       valid_lft forever preferred_lft forever
    inet 1.1.1.1/20 brd 1.1.1.255 scope global secondary dynamic ens160
       valid_lft 2840sec preferred_lft 2840sec
```

It looks like based on the linux Kernel man page for [rtnetlink](https://man7.org/linux/man-pages/man7/rtnetlink.7.html) an IP address can have additional metadata for primary/secondary:

> In Linux 2.2, an interface
> can carry multiple IP addresses, this replaces the alias
> device concept in Linux 2.0.  In Linux 2.2, these messages
> support IPv4 and IPv6 addresses.  They contain an
> ifaddrmsg structure, optionally followed by rtattr routing
> attributes.

This pull request ensures that the test is not flakey in the scenario of a secondary IP being present with a network adapter. However, we might want to update the underlying [network interfaces gem](https://github.com/rapid7/network_interface) implementation to preference the newer rtnetlink API instead of just using the older IPAddr implementation:

```c
              struct ifaddrmsg {
                  unsigned char ifa_family;    /* Address type */
                  unsigned char ifa_prefixlen; /* Prefixlength of address */
                  unsigned char ifa_flags;     /* Address flags */
                  unsigned char ifa_scope;     /* Address scope */
                  unsigned int  ifa_index;     /* Interface index */
              };
```

The metadata we should be reaching for is in ifa_flags:

> ifa_flags is a flag word of IFA_F_SECONDARY for
> secondary address (old alias interface), IFA_F_PERMANENT
> for a permanent address set by the user and other
> undocumented flags

For now we'll fix the test, as the ip addr should still be routable - even if we've not chose the primary IP in this particular scenario

## Verification

- Ensure CI passes