### PR TITLE
Don't change the main modules datastore options

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -118,6 +118,7 @@ module Msf
             plat = nil
             keep = false
             verbose = false
+            mod_with_opts = mod.replicant
 
             @@generate_opts.parse(args) do |opt, _idx, val|
               case opt
@@ -164,16 +165,16 @@ module Msf
                   return false
                 end
 
-                mod.datastore.import_options_from_s(val)
+                mod_with_opts.datastore.import_options_from_s(val)
               end
             end
-            if encoder_name.nil? && mod.datastore['ENCODER']
-              encoder_name = mod.datastore['ENCODER']
+            if encoder_name.nil? && mod_with_opts.datastore['ENCODER']
+              encoder_name = mod_with_opts.datastore['ENCODER']
             end
 
             # Generate the payload
             begin
-              buf = mod.generate_simple(
+              buf = mod_with_opts.generate_simple(
                 'BadChars' => badchars,
                 'Encoder' => encoder_name,
                 'Format' => format,


### PR DESCRIPTION
This fixes an issue that @adfoster-r7 noticed while testing another PR of mine. When datastore options are passed on the command line in msfconsole using the `command KEY=VALUE` syntax, the datastore options should *not* be reflected in the output of `show options` because they should have only effected the module for that specific command invocation. This was not the case for the `generate` command that is available to payloads.

## Testing Steps

- [ ] Start `msfconsole`
- [ ] Use a payload module (`payload/cmd/windows/adduser` is a good test case because the datastore options are visible in the output)
- [ ] Run the generate command, and set one or more options on the command line
- [ ] See that the options were incorporated into the payload that was generated
- [ ] See that the options *are not* reflected in the output of `show options`

## New And Fixed

```
msf6 payload(cmd/windows/adduser) > show options 

Module options (payload/cmd/windows/adduser):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   CUSTOM                   no        Custom group name to be used instead of default
   PASS    Metasploit$1     yes       The password for this user
   USER    metasploit       yes       The username to create
   WMIC    false            yes       Use WMIC on the target to resolve administrators group


View the full module info with the info, or info -d command.

msf6 payload(cmd/windows/adduser) > generate -f raw USER=smcintyre
cmd.exe /c net user smcintyre Metasploit$1 /ADD && net localgroup Administrators smcintyre /ADD
msf6 payload(cmd/windows/adduser) > show options 

Module options (payload/cmd/windows/adduser):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   CUSTOM                   no        Custom group name to be used instead of default
   PASS    Metasploit$1     yes       The password for this user
   USER    metasploit       yes       The username to create
   WMIC    false            yes       Use WMIC on the target to resolve administrators group


View the full module info with the info, or info -d command.

msf6 payload(cmd/windows/adduser) >
```

## Old And Broken

```
msf6 payload(cmd/windows/adduser) > show options 

Module options (payload/cmd/windows/adduser):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   CUSTOM                   no        Custom group name to be used instead of default
   PASS    Metasploit$1     yes       The password for this user
   USER    metasploit       yes       The username to create
   WMIC    false            yes       Use WMIC on the target to resolve administrators group


View the full module info with the info, or info -d command.

msf6 payload(cmd/windows/adduser) > generate -f raw USER=smcintyre
cmd.exe /c net user smcintyre Metasploit$1 /ADD && net localgroup Administrators smcintyre /ADD
msf6 payload(cmd/windows/adduser) > show options 

Module options (payload/cmd/windows/adduser):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   CUSTOM                   no        Custom group name to be used instead of default
   PASS    Metasploit$1     yes       The password for this user
   USER    smcintyre        yes       The username to create
   WMIC    false            yes       Use WMIC on the target to resolve administrators group


View the full module info with the info, or info -d command.

msf6 payload(cmd/windows/adduser) >
```