### PR TITLE
Updates MySQL modules to now support the new MySQL session type

### DIFF
--- a/lib/msf/core/exploit/remote/mysql.rb
+++ b/lib/msf/core/exploit/remote/mysql.rb
@@ -19,6 +19,10 @@ module Exploit::Remote::MYSQL
 
   include Exploit::Remote::Tcp
 
+  # @!attribute [rw] mysql_conn
+  # @return [::Mysql]
+  attr_accessor :mysql_conn
+
   def initialize(info = {})
     super
 
@@ -33,17 +37,11 @@ module Exploit::Remote::MYSQL
   end
 
   def mysql_login(user='root', pass='', db=nil)
-    unless defined?(session).nil? || session.nil?
-      print_status("Using existing session #{session.sid}")
-      @mysql_handle = session.client
-      return true
-    end
-
-    disconnect if self.sock
+    disconnect if sock
     connect
 
     begin
-      @mysql_handle = ::Mysql.connect(rhost, user, pass, db, rport, io: sock)
+      self.mysql_conn = ::Mysql.connect(rhost, user, pass, db, rport, io: sock)
 
     rescue Errno::ECONNREFUSED
       print_error("Connection refused")
@@ -62,21 +60,9 @@ module Exploit::Remote::MYSQL
       return false
     end
 
-    vprint_good "#{rhost}:#{rport} MySQL - Logged in to '#{db}' with '#{user}':'#{pass}'"
+    vprint_good "#{mysql_conn.host}:#{mysql_conn.port} MySQL - Logged in to '#{db}' with '#{user}':'#{pass}'"
 
     return true
-  end
-
-  def mysql_logoff
-    # Don't log out if we are using a session.
-    if defined?(session) && session
-      vprint_status "#{rhost}:#{rport} MySQL - Skipping disconnecting from the session"
-      return
-    end
-
-    @mysql_handle = nil if @mysql_handle
-    disconnect if self.sock
-    vprint_status "#{rhost}:#{rport} MySQL - Disconnected"
   end
 
   def mysql_login_datastore
@@ -92,7 +78,7 @@ module Exploit::Remote::MYSQL
 
   def mysql_query(sql)
     begin
-      res = @mysql_handle.query(sql)
+      res = mysql_conn.query(sql)
     rescue ::Mysql::Error => e
       print_error("MySQL Error: #{e.class} #{e.to_s}")
       return nil
@@ -101,7 +87,7 @@ module Exploit::Remote::MYSQL
       return nil
     end
 
-    vprint_status "#{rhost}:#{rport} MySQL - querying with '#{sql}'"
+    vprint_status "#{mysql_conn.host}:#{mysql_conn.port} MySQL - querying with '#{sql}'"
     res
   end
 

--- a/lib/msf/core/exploit/remote/mysql.rb
+++ b/lib/msf/core/exploit/remote/mysql.rb
@@ -42,6 +42,8 @@ module Exploit::Remote::MYSQL
 
     begin
       self.mysql_conn = ::Mysql.connect(rhost, user, pass, db, rport, io: sock)
+      # Deprecating this in favor off `mysql_conn`
+      @mysql_handle = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :mysql_conn, :@mysql_handle, ActiveSupport::Deprecation.new)
 
     rescue Errno::ECONNREFUSED
       print_error("Connection refused")
@@ -63,6 +65,12 @@ module Exploit::Remote::MYSQL
     vprint_good "#{mysql_conn.host}:#{mysql_conn.port} MySQL - Logged in to '#{db}' with '#{user}':'#{pass}'"
 
     return true
+  end
+
+  def mysql_logoff
+    mysql_conn.close if mysql_conn
+    disconnect if sock
+    vprint_status "#{rhost}:#{rport} MySQL - Disconnected"
   end
 
   def mysql_login_datastore

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -26,7 +26,7 @@ module Msf::OptionalSession
         [
           Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
           Msf::Opt::RHOST(nil, false),
-          Msf::Opt::RPORT(nil, false)
+          Msf::Opt::RPORT(3306, false)
         ]
       )
     end

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::MYSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -16,6 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
         'License'       => MSF_LICENSE,
+        'SessionTypes'  => %w[MySQL],
         'References'    =>
         [
           [ 'URL', 'https://cisecurity.org/benchmarks.html' ]
@@ -53,6 +55,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     return if not mysql_login_datastore
+
     print_status("Running MySQL Enumerator...")
     print_status("Enumerating Parameters")
     #-------------------------------------------------------

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -58,6 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     if session
       print_status("Using existing session #{session.sid}")
       self.mysql_conn = session.client
+      self.sock = session.client.socket
     else
       # otherwise fallback to attempting to login
       return unless mysql_login_datastore
@@ -247,5 +248,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
       end
     end
+
+    mysql_logoff unless session
   end
 end

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -54,7 +54,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    return if not mysql_login_datastore
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      return unless mysql_login_datastore
+    end
 
     print_status("Running MySQL Enumerator...")
     print_status("Enumerating Parameters")
@@ -114,8 +121,8 @@ class MetasploitModule < Msf::Auxiliary
       res.each do |row|
         print_good("\t\tUser: #{row[0]} Host: #{row[1]} Password Hash: #{row[2]}")
         report_cred(
-          ip: rhost,
-          port: rport,
+          ip: mysql_conn.host,
+          port: mysql_conn.port,
           user: row[0],
           password: row[2],
           service_name: 'mysql',
@@ -240,7 +247,5 @@ class MetasploitModule < Msf::Auxiliary
         print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
       end
     end
-
-    mysql_logoff
   end
 end

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -14,7 +15,8 @@ class MetasploitModule < Msf::Auxiliary
           against a MySQL instance given the appropriate credentials.
       },
       'Author'		=> [ 'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>' ],
-      'License'		=> MSF_LICENSE
+      'License'		=> MSF_LICENSE,
+      'SessionTypes' => %w[MySQL]
     ))
 
     register_options(
@@ -33,7 +35,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    return if not mysql_login_datastore
+    return unless mysql_login_datastore
+
     print_status("Sending statement: '#{datastore['SQL']}'...")
     res = mysql_query(datastore['SQL']) || []
     res.each do |row|

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -35,7 +35,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    return unless mysql_login_datastore
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      return unless mysql_login_datastore
+    end
 
     print_status("Sending statement: '#{datastore['SQL']}'...")
     res = mysql_query(datastore['SQL']) || []

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Short circuit if we already won
     if results.length > 0
-      @mysql_handle = results.first
+      self.mysql_conn = results.first
       return dump_hashes
     end
 
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if results.length > 0
       print_good("#{rhost}:#{rport} Successfully exploited the authentication bypass flaw, dumping hashes...")
-      @mysql_handle = results.first
+      self.mysql_conn = results.first
       return dump_hashes
     end
 

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -39,14 +39,21 @@ class MetasploitModule < Msf::Auxiliary
   # This function does not handle any errors, if you use this
   # make sure you handle the errors yourself
   def mysql_query_no_handle(sql)
-    res = @mysql_handle.query(sql)
+    res = self.mysql_conn.query(sql)
     res
   end
 
   def run_host(ip)
     vprint_status("Login...") unless session
 
-    return unless mysql_login_datastore
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      return unless mysql_login_datastore
+    end
 
     begin
       mysql_query_no_handle("USE " + datastore['DATABASE_NAME'])
@@ -84,20 +91,20 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Mysql::TextfileNotReadable
       print_good("#{dir} is a directory and exists")
       report_note(
-        :host  => rhost,
+        :host  => mysql_conn.host,
         :type  => "filesystem.dir",
         :data  => "#{dir} is a directory and exists",
-        :port  => rport,
+        :port  => mysql_conn.port,
         :proto => 'tcp',
         :update => :unique_data
       )
     rescue ::Mysql::DataTooLong, ::Mysql::TruncatedWrongValueForField
       print_good("#{dir} is a file and exists")
       report_note(
-        :host  => rhost,
+        :host  => mysql_conn.host,
         :type  => "filesystem.file",
         :data  => "#{dir} is a file and exists",
-        :port  => rport,
+        :port  => mysql_conn.port,
         :proto => 'tcp',
         :update => :unique_data
       )
@@ -112,10 +119,10 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_good("#{dir} is a file and exists")
       report_note(
-        :host  => rhost,
+        :host  => mysql_conn.host,
         :type  => "filesystem.file",
         :data  => "#{dir} is a file and exists",
-        :port  => rport,
+        :port  => mysql_conn.port,
         :proto => 'tcp',
         :update => :unique_data
       )

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -22,7 +23,8 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://pauldotcom.com/2013/01/mysql-file-system-enumeration.html' ],
         [ 'URL', 'http://www.digininja.org/projects/mysql_file_enum.php' ]
       ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'  => %w[MySQL]
     )
 
     register_options([
@@ -42,11 +44,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    vprint_status("Login...")
+    vprint_status("Login...") unless session
 
-    if (not mysql_login_datastore)
-      return
-    end
+    return unless mysql_login_datastore
 
     begin
       mysql_query_no_handle("USE " + datastore['DATABASE_NAME'])

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -23,11 +23,18 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    return unless mysql_login_datastore
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      return unless mysql_login_datastore
+    end
 
     service_data = {
-      address: rhost,
-      port: rport,
+      address: ip,
+      port: mysql_conn.port,
       service_name: 'mysql',
       protocol: 'tcp',
       workspace_id: myworkspace_id
@@ -75,8 +82,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     service_data = {
-      address: ::Rex::Socket.getaddress(rhost, true),
-      port: rport,
+      address: ::Rex::Socket.getaddress(mysql_conn.host, true),
+      port: mysql_conn.port,
       service_name: 'mysql',
       protocol: 'tcp',
       workspace_id: myworkspace_id

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -6,8 +6,8 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
-
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -17,16 +17,16 @@ class MetasploitModule < Msf::Auxiliary
         hashes from a MySQL server and stores them for later cracking.
       ),
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'  => %w[MySQL]
     )
   end
 
   def run_host(ip)
-
     return unless mysql_login_datastore
 
     service_data = {
-      address: ip,
+      address: rhost,
       port: rport,
       service_name: 'mysql',
       protocol: 'tcp',

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -30,28 +30,35 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    return unless mysql_login_datastore
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      return unless mysql_login_datastore
+    end
 
     mysql_schema = get_schema
     mysql_schema.each do |db|
       report_note(
-        :host  => rhost,
+        :host  => mysql_conn.host,
         :type  => "mysql.db.schema",
         :data  => db,
-        :port  => rport,
+        :port  => mysql_conn.port,
         :proto => 'tcp',
         :update => :unique_data
       )
     end
-    output = "MySQL Server Schema \n Host: #{datastore['RHOST']} \n Port: #{datastore['RPORT']} \n ====================\n\n"
+    output = "MySQL Server Schema \n Host: #{mysql_conn.host} \n Port: #{mysql_conn.port} \n ====================\n\n"
     output << YAML.dump(mysql_schema)
     this_service = report_service(
-          :host  => datastore['RHOST'],
-          :port => datastore['RPORT'],
+          :host  => mysql_conn.host,
+          :port => mysql_conn.port,
           :name => 'mysql',
           :proto => 'tcp'
           )
-    p = store_loot('mysql_schema', "text/plain", datastore['RHOST'], output, "#{datastore['RHOST']}_mysql_schema.txt", "MySQL Schema", this_service)
+    p = store_loot('mysql_schema', "text/plain", mysql_conn.host, output, "#{mysql_conn.host}_mysql_schema.txt", "MySQL Schema", this_service)
     print_good("Schema stored in: #{p}")
     print_good output if datastore['DISPLAY_RESULTS']
   end

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -8,8 +8,8 @@ require 'yaml'
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
-
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -19,7 +19,8 @@ class MetasploitModule < Msf::Auxiliary
           MySQL DB server.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'  => %w[MySQL]
     )
 
     register_options([
@@ -29,10 +30,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    return unless mysql_login_datastore
 
-    if (not mysql_login_datastore)
-      return
-    end
     mysql_schema = get_schema
     mysql_schema.each do |db|
       report_note(

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -29,11 +29,12 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     begin
       if session
-        version = session.client.server_info
-        print_good("#{rhost}:#{rport} is running MySQL #{version}")
+        sql_conn = session.client
+        version = sql_conn.server_info
+        print_good("#{sql_conn.host}:#{sql_conn.port} is running MySQL #{version}")
         report_service(
-          :host => rhost,
-          :port => rport,
+          :host => sql_conn.host,
+          :port => sql_conn.port,
           :name => "mysql",
           :info => version
         )

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -20,7 +21,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'  => [
         [ 'URL', 'https://dev.mysql.com/doc/refman/5.7/en/select-into.html' ]
       ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'  => %w[MySQL]
     )
 
     register_options([

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -36,17 +36,21 @@ class MetasploitModule < Msf::Auxiliary
   # This function does not handle any errors, if you use this
   # make sure you handle the errors yourself
   def mysql_query_no_handle(sql)
-    res = @mysql_handle.query(sql)
+    res = self.mysql_conn.query(sql)
     res
   end
 
   def run_host(ip)
     print_warning("For every writable directory found, a file called #{datastore['FILE_NAME']} with the text test will be written to the directory.")
-    print_status("Login...")
+    print_status("Login...") unless session
 
-    unless mysql_login_datastore
-      print_error('Unable to login to the server.')
-      return
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      return unless mysql_login_datastore
     end
 
     File.read(datastore['DIR_LIST']).each_line do |dir|
@@ -66,10 +70,10 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_good("#{dir} is writeable")
       report_note(
-        :host  => rhost,
+        :host  => mysql_conn.host,
         :type  => "filesystem.file",
         :data  => "#{dir} is writeable",
-        :port  => rport,
+        :port  => mysql_conn.port,
         :proto => 'tcp',
         :update => :unique_data
       )

--- a/modules/exploits/multi/mysql/mysql_udf_payload.rb
+++ b/modules/exploits/multi/mysql/mysql_udf_payload.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::MYSQL
   include Msf::Exploit::CmdStager
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(
@@ -37,6 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'http://bernardodamele.blogspot.com/2009/01/command-execution-with-mysql-udf.html' ]
           ],
         'Platform'       => ['win', 'linux'],
+        'SessionTypes'   => %w[MySQL],
         'Targets'        =>
           [
             [ 'Windows', {'CmdStagerFlavor' => 'vbs'} ], # Confirmed on MySQL 4.1.22, 5.5.9, and 5.1.56 (64bit)

--- a/modules/exploits/multi/mysql/mysql_udf_payload.rb
+++ b/modules/exploits/multi/mysql/mysql_udf_payload.rb
@@ -67,8 +67,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login_and_get_sys_exec
-    m = mysql_login(username,password,'mysql')
-    return if not m
+    # If we have a session make use of it
+    if session
+      print_status("Using existing session #{session.sid}")
+      self.mysql_conn = session.client
+    else
+      # otherwise fallback to attempting to login
+      m = mysql_login(username,password,'mysql')
+      return unless m
+    end
+
     @mysql_arch = mysql_get_arch
     @mysql_sys_exec_available = mysql_check_for_sys_exec()
     if !@mysql_sys_exec_available || datastore['FORCE_UDF_UPLOAD']

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::WbemExec
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -34,6 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://seclists.org/fulldisclosure/2012/Dec/13']
         ],
       'Platform'       => 'win',
+      'SessionTypes'   => %w[MySQL],
       'Targets'        =>
         [
           [ 'MySQL on Windows prior to Vista', { } ]

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -94,8 +94,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Attempting to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
     begin
-      m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
-      return if not m
+      # If we have a session make use of it
+      if session
+        print_status("Using existing session #{session.sid}")
+        self.mysql_conn = session.client
+      else
+        # otherwise fallback to attempting to login
+        m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
+        return unless m
+      end
     rescue ::Mysql::AccessDeniedError
       print_error("Access denied.")
       return

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -103,14 +103,22 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, "STARTUP_FOLDER should start and end with '/' Ex: /programdata/microsoft/windows/start menu/programs/startup/")
     end
 
-    print_status("Attempting to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
+    print_status("Attempting to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'") unless session
     begin
-      m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
+      # If we have a session make use of it
+      if session
+        print_status("Using existing session #{session.sid}")
+        self.mysql_conn = session.client
+      else
+        # otherwise fallback to attempting to login
+        m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
+        return unless m
+      end
     rescue ::Mysql::AccessDeniedError
       fail_with(Failure::NoAccess, "#{peer} - Access denied")
     end
 
-    fail_with(Failure::NoAccess, "#{peer} - Unable to Login") unless m
+    fail_with(Failure::NoAccess, "#{peer} - Unable to Login") unless m || session
 
     unless is_windows?
       fail_with(Failure::NoTarget, "#{peer} - Remote host isn't Windows")

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::MYSQL
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -38,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://seclists.org/fulldisclosure/2012/Dec/13']
         ],
       'Platform'       => 'win',
+      'SessionTypes'   => %w[MySQL],
       'Targets'        =>
         [
           [ 'MySQL on Windows', { } ]


### PR DESCRIPTION
This PR is a continuation of https://github.com/rapid7/metasploit-framework/pull/18718, make sure it is merged before landing this.

This PR updates existing MySQL modules to know work with an existing session, as well as the original `rhost` functionality:
```
run session=1
```

### `modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb`
I updated the MySQL modules to make use of `self.mysql_conn` instead of `@mysql_handle`. This module was the only other module that wasn't updated as part of this PR that relied on `@mysql_handle`, I updated it to now use `self.mysql_conn`  and tested it and I believe it works as expected, the module completes but I didn't have an old enough version of MySQL to test it fully.
Hopefully that was the right call. Happy to revert if needed 👍 


## Verification

### Targets I used
#### vulhub/mysql:5.5.23
```
docker run -d -p 3306:3306 --name=mysql-server --env="MYSQL_ROOT_PASSWORD=123456" vulhub/mysql:5.5.23
```

#### mariadb:latest 
```
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 3306:3306 mariadb:latest
```

#### Windows 10 via [MySQL installer](https://dev.mysql.com/doc/refman/8.3/en/windows-installation.html)

### Resource script to test modules
```
<ruby>

  @windows_session = nil

  # Get the docker session
  # run_single("use scanner/mysql/mysql_login")
  # run_single("run 'mysql://root:password@127.0.0.1' CreateSession=true rport=3306")

  # Get the windows session
  @windows_session = true
  run_single("use scanner/mysql/mysql_login")
  run_single("run 'mysql://foo:password@192.168.175.193' CreateSession=true rport=3306")

  modules = %w[
  auxiliary/admin/mysql/mysql_enum
  auxiliary/admin/mysql/mysql_sql
  auxiliary/scanner/mysql/mysql_file_enum
  auxiliary/scanner/mysql/mysql_hashdump
  auxiliary/scanner/mysql/mysql_schemadump
  auxiliary/scanner/mysql/mysql_version
  auxiliary/scanner/mysql/mysql_writable_dirs
  exploits/multi/mysql/mysql_udf_payload
]

windows_username = 'foo'
windows_ip = 'XXX.XXX.XXX.XXX'

docker_username = 'root'
docker_ip = '127.0.0.1'

windows_modules = %w[
  exploits/windows/mysql/mysql_mof
  exploits/windows/mysql/mysql_start_up
]

modules += windows_modules if @windows_session

modules.each do |mod|
  if @windows_session
    rhost = windows_ip
    username = windows_username
  else
    rhost = docker_ip
    username = docker_username
  end

  print_line
  print_line

  print_status("Running module - #{mod}")
  run_single("use #{mod}")

  print_line

  print_warning("******** RHOST ********")
  if mod.include?("file_enum")
    run_single("run rhosts=#{rhost} username=#{username} password=password rport=3306 file_list=/")
  elsif mod.include?("writable_dirs")
    run_single("run rhosts=#{rhost} username=#{username} password=password rport=3306 dir_list=/")
  else
    run_single("run rhosts=#{rhost} username=#{username} password=password rport=3306")
  end

  print_line
  print_warning("******** SESSION ********")
  if mod.include?("file_enum")
    run_single("run session=1 file_list=/")
  elsif mod.include?("writable_dirs")
    run_single("run session=1 dir_list=/")
  else
    run_single("run session=1")
  end


  print_line
  print_line
end
</ruby>
```

### Testing steps
- [ ] Start `msfconsole`
- [ ] Turn on the `mysql_session_type` feature
- [ ] Test each update module against each of the follow run methods:
- [ ] `run session=1`
- [ ] `run rhosts=127.0.0.1 username=root password=password rport=3306` 
- [ ] `run 'mysql://root:password@127.0.0.1'`
- [ ] **Verify** they work as they previously did on master