### PR TITLE
Ensure DNS command config loading does not crash msfconsole

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -80,16 +80,16 @@ class Driver < Msf::Ui::Driver
 
     # Initialize attributes
 
-    dns_resolver = Rex::Proto::DNS::CachedResolver.new
-    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    dns_resolver.load_config
+    framework_create_options = opts.merge({ 'DeferModuleLoads' => true })
 
-    # Defer loading of modules until paths from opts can be added below
-    framework_create_options = opts.merge({
-                                            'DeferModuleLoads' => true,
-                                            'CustomDnsResolver' => dns_resolver
-                                          }
-                                         )
+    if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS_FEATURE)
+      dns_resolver = Rex::Proto::DNS::CachedResolver.new
+      dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+      dns_resolver.load_config
+
+      # Defer loading of modules until paths from opts can be added below
+      framework_create_options = framework_create_options.merge({ 'CustomDnsResolver' => dns_resolver })
+    end
     self.framework = opts['Framework'] || Msf::Simple::Framework.create(framework_create_options)
 
     if self.framework.datastore['Prompt']

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1084,17 +1084,21 @@ module Net # :nodoc:
           self.domain = arr[0]
           self.nameservers = arr[1]
         else
-          IO.foreach(@config[:config_file]) do |line|
-            line.gsub!(/\s*[;#].*/,"")
-            next unless line =~ /\S/
-            case line
-            when /^\s*domain\s+(\S+)/
-              self.domain = $1
-            when /^\s*search\s+(.*)/
-              self.searchlist = $1.split(" ")
-            when /^\s*nameserver\s+(.*)/
-              self.nameservers += $1.split(" ")
+          begin
+            IO.foreach(@config[:config_file]) do |line|
+              line.gsub!(/\s*[;#].*/,"")
+              next unless line =~ /\S/
+              case line
+              when /^\s*domain\s+(\S+)/
+                self.domain = $1
+              when /^\s*search\s+(.*)/
+                self.searchlist = $1.split(" ")
+              when /^\s*nameserver\s+(.*)/
+                self.nameservers += $1.split(" ")
+              end
             end
+          rescue => e
+            @logger.error(e)
           end
         end
       end


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18756
Continuation of https://github.com/rapid7/metasploit-framework/pull/18662

When starting termux (which isn't supported) msfconsole crashes due to failing to load `/etc/resolv.conf`:

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/b9d1dbf5-0a54-4068-bb31-9c2ddce16594)

However this could theoretically happen on other OS versions too so I've put in a naive rescue for now

Notes:
- This functionality should be behind a feature flag still
- We shouldn't crash
- For termux we should be reading a different file location: `/data/data/com.termux/files/usr/etc/resolv.conf`
- We probably want better fallback behavior, should we use cloudflare DNS or similar in the error scenario?

## Verification

List the steps needed to make sure this thing works

- [ ] Ensure termux no longer crashes on bootup
- [ ] Ensure that a missing config file no longer crashes msfconsole on bootup, I changed this config manually:
```
      Defaults = {
        :config_file => "/etc/resolv.conf",
```