### PR TITLE
Mssql session modules

### DIFF
--- a/lib/msf/base/sessions/mssql.rb
+++ b/lib/msf/base/sessions/mssql.rb
@@ -12,10 +12,6 @@ class Msf::Sessions::MSSQL
   # @return [MSSQL::Client] The MSSQL client
   attr_accessor :client
   attr_accessor :platform, :arch
-  # @return [String] The address MSSQL is running on
-  attr_accessor :address
-  # @return [Integer] The port MSSQL is running on
-  attr_accessor :port
   attr_reader :framework
 
   def initialize(rstream, opts = {})

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -46,8 +46,9 @@ module Exploit::Remote::MSSQL
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
   end
 
-  def set_session(session)
-    @mssql_client = session.client
+  def set_session(client)
+    print_status("Using existing session #{session.sid}")
+    @mssql_client = client
   end
 
   #

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -17,6 +17,8 @@ module Exploit::Remote::MSSQL
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
   include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
+  attr_accessor :mssql_client
+
   #
   # Creates an instance of a MSSQL exploit module.
   #

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -46,6 +46,10 @@ module Exploit::Remote::MSSQL
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
   end
 
+  def set_session(session)
+    @mssql_client = session.client
+  end
+
   #
   # This method sends a UDP query packet to the server and
   # parses out the reply packet into a hash

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -49,7 +49,6 @@ module Msf::OptionalSession
       register_options(
         [
           Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
-          Msf::OptString.new('DATABASE', [ false, 'The database to authenticate against', 'MSSQL']),
           Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'MSSQL']),
           Msf::Opt::RHOST(nil, false),
           Msf::Opt::RPORT(1433, false)

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -640,6 +640,14 @@ module Rex
           print_status("Be sure to cleanup #{var_payload}.exe...")
         end
 
+        def address
+          rhost
+        end
+
+        def port
+          rport
+        end
+
         protected
 
         def rhost

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -473,7 +473,6 @@ module Rex
           pkt_hdr[2] = pkt_data.length + 8
 
           pkt = pkt_hdr.pack("CCnnCC") + pkt_data
-
           resp = mssql_send_recv(pkt)
 
           idx = 0

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -473,6 +473,7 @@ module Rex
           pkt_hdr[2] = pkt_data.length + 8
 
           pkt = pkt_hdr.pack("CCnnCC") + pkt_data
+
           resp = mssql_send_recv(pkt)
 
           idx = 0

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -25,14 +25,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     print_status("Running MS SQL Server Enumeration...")
-    if (datastore['SESSION'] && session)
-      set_session(session)
-    end
-
-    unless (datastore['SESSION'] && session) || mssql_login_datastore
-      print_error("Login was unsuccessful. Check your credentials.")
-      disconnect
-      return
+    if session
+      set_session(session.client)
+    else
+      unless mssql_login_datastore
+        print_error("Login was unsuccessful. Check your credentials.")
+        disconnect
+        return
+      end
     end
 
     # Get Version

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -44,9 +44,9 @@ class MetasploitModule < Msf::Auxiliary
       print "[*]\t#{row}"
     end
     vernum = sqlversion.gsub("\n"," ").scan(/SQL Server\s*(200\d)/m)
-    report_note(:host => datastore['RHOST'],
+    report_note(:host => mssql_client.address,
       :proto => 'TCP',
-      :port => datastore['RPORT'],
+      :port => mssql_client.port,
       :type => 'MSSQL_ENUM',
       :data => "Version: #{sqlversion}")
 
@@ -76,16 +76,16 @@ class MetasploitModule < Msf::Auxiliary
     # checking for C2 Audit Mode
     if sysconfig['c2 audit mode'] == 1
       print_status("\tC2 Audit Mode is Enabled")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "C2 Audit Mode is Enabled")
     else
       print_status("\tC2 Audit Mode is Not Enabled")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "C2 Audit Mode is Not Enabled")
     end
@@ -95,16 +95,16 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != "2000"
       if sysconfig['xp_cmdshell'] == 1
         print_status("\txp_cmdshell is Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Enabled")
       else
         print_status("\txp_cmdshell is Not Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Not Enabled")
       end
@@ -112,16 +112,16 @@ class MetasploitModule < Msf::Auxiliary
       xpspexist = mssql_query("select sysobjects.name from sysobjects where name = \'xp_cmdshell\'")[:rows]
       if xpspexist != nil
         print_status("\txp_cmdshell is Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Enabled")
       else
         print_status("\txp_cmdshell is Not Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Not Enabled")
       end
@@ -131,16 +131,16 @@ class MetasploitModule < Msf::Auxiliary
     # check if remote access is enabled
     if sysconfig['remote access'] == 1
       print_status("\tremote access is Enabled")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "remote access is Enabled")
     else
       print_status("\tremote access is Not Enabled")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "remote access is not Enabled")
     end
@@ -149,16 +149,16 @@ class MetasploitModule < Msf::Auxiliary
     #check if updates are allowed
     if sysconfig['allow updates'] == 1
       print_status("\tallow updates is Enabled")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "allow updates is Enabled")
     else
       print_status("\tallow updates is Not Enabled")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "allow updates is not Enabled")
     end
@@ -168,16 +168,16 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != "2000"
       if sysconfig['Database Mail XPs'] == 1
         print_status("\tDatabase Mail XPs is Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is Enabled")
       else
         print_status("\tDatabase Mail XPs is Not Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is not Enabled")
       end
@@ -185,16 +185,16 @@ class MetasploitModule < Msf::Auxiliary
       mailexist = mssql_query("select sysobjects.name from sysobjects where name like \'%mail%\'")[:rows]
       if mailexist != nil
         print_status("\tDatabase Mail XPs is Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is Enabled")
       else
         print_status("\tDatabase Mail XPs is Not Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is not Enabled")
       end
@@ -205,16 +205,16 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != "2000"
       if sysconfig['Ole Automation Procedures'] == 1
         print_status("\tOle Automation Procedures are Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are Enabled")
       else
         print_status("\tOle Automation Procedures are Not Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are not Enabled")
       end
@@ -222,16 +222,16 @@ class MetasploitModule < Msf::Auxiliary
       oleexist = mssql_query("select sysobjects.name from sysobjects where name like \'%sp_OA%\'")[:rows]
       if oleexist != nil
         print_status("\tOle Automation Procedures is Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are Enabled")
       else
         print_status("\tOle Automation Procedures are Not Enabled")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are not Enabled")
       end
@@ -250,9 +250,9 @@ class MetasploitModule < Msf::Auxiliary
           if db_ind_files != nil
             db_ind_files.each do |fn|
               print_status("\t\t#{fn.join}")
-              report_note(:host => datastore['RHOST'],
+              report_note(:host => mssql_client.address,
                 :proto => 'TCP',
-                :port => datastore['RPORT'],
+                :port => mssql_client.port,
                 :type => 'MSSQL_ENUM',
                 :data => "Database: #{dbn.strip} File: #{fn.join}")
             end
@@ -262,9 +262,9 @@ class MetasploitModule < Msf::Auxiliary
           if db_ind_files != nil
             db_ind_files.each do |fn|
               print_status("\t\t#{fn.join.strip}")
-              report_note(:host => datastore['RHOST'],
+              report_note(:host => mssql_client.address,
                 :proto => 'TCP',
-                :port => datastore['RPORT'],
+                :port => mssql_client.port,
                 :type => 'MSSQL_ENUM',
                 :data => "Database: #{dbn.strip} File: #{fn.join}")
             end
@@ -284,17 +284,17 @@ class MetasploitModule < Msf::Auxiliary
     if syslogins != nil
       syslogins.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Database: Master User: #{acc.join}")
       end
     else
       print_error("\tCould not enumerate System Logins!")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "Could not enumerate System Logins")
     end
@@ -307,17 +307,17 @@ class MetasploitModule < Msf::Auxiliary
       if disabledsyslogins != nil
         disabledsyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(:host => datastore['RHOST'],
+          report_note(:host => mssql_client.address,
             :proto => 'TCP',
-            :port => datastore['RPORT'],
+            :port => mssql_client.port,
             :type => 'MSSQL_ENUM',
             :data => "Disabled User: #{acc.join}")
         end
       else
         print_status("\tNo Disabled Logins Found")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "No Disabled Logins Found")
       end
@@ -331,17 +331,17 @@ class MetasploitModule < Msf::Auxiliary
       if nopolicysyslogins != nil
         nopolicysyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(:host => datastore['RHOST'],
+          report_note(:host => mssql_client.address,
             :proto => 'TCP',
-            :port => datastore['RPORT'],
+            :port => mssql_client.port,
             :type => 'MSSQL_ENUM',
             :data => "None Policy Checked User: #{acc.join}")
         end
       else
         print_status("\tAll System Accounts have the Windows Account Policy Applied to them.")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "All System Accounts have the Windows Account Policy Applied to them")
       end
@@ -355,17 +355,17 @@ class MetasploitModule < Msf::Auxiliary
       if passexsyslogins != nil
         passexsyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(:host => datastore['RHOST'],
+          report_note(:host => mssql_client.address,
             :proto => 'TCP',
-            :port => datastore['RPORT'],
+            :port => mssql_client.port,
             :type => 'MSSQL_ENUM',
             :data => "None Password Expiration User: #{acc.join}")
         end
       else
         print_status("\tAll System Accounts are checked for Password Expiration.")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "All System Accounts are checked for Password Expiration")
       end
@@ -382,17 +382,17 @@ class MetasploitModule < Msf::Auxiliary
     if sysadmins != nil
       sysadmins.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Sysdba: #{acc.join}")
       end
     else
       print_error("\tCould not enumerate sysadmin accounts!")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "Could not enumerate sysadmin accounts")
     end
@@ -409,17 +409,17 @@ class MetasploitModule < Msf::Auxiliary
     if winusers != nil
       winusers.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Windows Logins: #{acc.join}")
       end
     else
       print_status("\tNo Windows logins found!")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "No Windows logins found")
     end
@@ -436,17 +436,17 @@ class MetasploitModule < Msf::Auxiliary
     if wingroups != nil
       wingroups.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Windows Groups: #{acc.join}")
       end
     else
       print_status("\tNo Windows Groups where found with permission to login to system.")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "No Windows Groups where found with permission to login to system")
 
@@ -465,17 +465,17 @@ class MetasploitModule < Msf::Auxiliary
     if sameasuser != nil
       sameasuser.each do |up|
         print_status("\t#{up.join}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Username: #{up.join} Password: #{up.join}")
       end
     else
       print_status("\tNo Account with its password being the same as its username was found.")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "No Account with its password being the same as its username was found")
     end
@@ -493,17 +493,17 @@ class MetasploitModule < Msf::Auxiliary
     if blankpass != nil
       blankpass.each do |up|
         print_status("\t#{up.join}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Username: #{up.join} Password: EMPTY ")
       end
     else
       print_status("\tNo Accounts with empty passwords where found.")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "No Accounts with empty passwords where found")
     end
@@ -718,18 +718,18 @@ EOS
       fountsp.each do |strp|
         if dangeroussp.include?(strp.strip)
           print_status("\t#{strp.strip}")
-          report_note(:host => datastore['RHOST'],
+          report_note(:host => mssql_client.address,
             :proto => 'TCP',
-            :port => datastore['RPORT'],
+            :port => mssql_client.port,
             :type => 'MSSQL_ENUM',
             :data => "Stored Procedures with Public Execute Permission #{strp.strip}")
         end
       end
     else
       print_status("\tNo Dangerous Stored Procedure found with Public Execute.")
-      report_note(:host => datastore['RHOST'],
+      report_note(:host => mssql_client.address,
         :proto => 'TCP',
-        :port => datastore['RPORT'],
+        :port => mssql_client.port,
         :type => 'MSSQL_ENUM',
         :data => "No Dangerous Stored Procedure found with Public Execute")
     end
@@ -761,9 +761,9 @@ EOS
       instances.each do |i|
         print_status("\t#{i}")
         instancenames << i.strip
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Instance Name: #{i}")
       end
@@ -778,9 +778,9 @@ EOS
     if privdflt != nil
       privdflt.each do |priv|
         print_status("\t#{priv[1]}")
-        report_note(:host => datastore['RHOST'],
+        report_note(:host => mssql_client.address,
           :proto => 'TCP',
-          :port => datastore['RPORT'],
+          :port => mssql_client.port,
           :type => 'MSSQL_ENUM',
           :data => "Default Instance SQL Server running as: #{priv[1]}")
       end
@@ -797,9 +797,9 @@ EOS
             print_status("Instance #{i} SQL Server Service is running under the privilege of:")
             privinst.each do |p|
               print_status("\t#{p[1]}")
-              report_note(:host => datastore['RHOST'],
+              report_note(:host => mssql_client.address,
                 :proto => 'TCP',
-                :port => datastore['RPORT'],
+                :port => mssql_client.port,
                 :type => 'MSSQL_ENUM',
                 :data => "#{i} Instance SQL Server running as: #{p[1]}")
             end

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -17,14 +18,18 @@ class MetasploitModule < Msf::Auxiliary
         supplied.
       },
       'Author'         => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'   => %w[MSSQL],
     ))
   end
 
   def run
     print_status("Running MS SQL Server Enumeration...")
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
 
-    if !mssql_login_datastore
+    unless (datastore['SESSION'] && session) || mssql_login_datastore
       print_error("Login was unsuccessful. Check your credentials.")
       disconnect
       return

--- a/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
@@ -106,16 +106,16 @@ class MetasploitModule < Msf::Auxiliary
 
     # Create output file
     this_service = report_service(
-      :host  => rhost,
-      :port => rport,
+      :host  => mssql_client.address,
+      :port => mssql_client.port,
       :name => 'mssql',
       :proto => 'tcp'
     )
-    file_name = "#{datastore['RHOST']}-#{datastore['RPORT']}_windows_domain_accounts.csv"
+    file_name = "#{mssql_client.address}-#{mssql_client.port}_windows_domain_accounts.csv"
     path = store_loot(
       'mssql.domain.accounts',
       'text/plain',
-      datastore['RHOST'],
+      mssql_client.address,
       windows_domain_login_table.to_csv,
       file_name,
       'Domain Users enumerated through SQL Server',

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -17,14 +18,19 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => [ 'nullbind <scott.sutherland[at]netspi.com>'],
       'License'        => MSF_LICENSE,
-      'References'     => [[ 'URL','http://technet.microsoft.com/en-us/library/ms188676(v=sql.105).aspx']]
+      'References'     => [[ 'URL','http://technet.microsoft.com/en-us/library/ms188676(v=sql.105).aspx']],
+      'SessionTypes'   => %w[MSSQL]
     ))
   end
 
   def run
     # Check connection and issue initial query
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
+
     print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
-    if mssql_login_datastore
+    if (datastore['SESSION'] && session) || mssql_login_datastore
       print_good('Connected.')
     else
       print_error('Login was unsuccessful. Check your credentials.')

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -25,17 +25,17 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     # Check connection and issue initial query
-    if (datastore['SESSION'] && session)
-      set_session(session)
-    end
-
-    print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
-    if (datastore['SESSION'] && session) || mssql_login_datastore
-      print_good('Connected.')
+    if session
+      set_session(session.client)
     else
-      print_error('Login was unsuccessful. Check your credentials.')
-      disconnect
-      return
+      print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
+      if mssql_login_datastore
+        print_good('Connected.')
+      else
+        print_error("Login was unsuccessful. Check your credentials.")
+        disconnect
+        return
+      end
     end
 
     # Query for sysadmin status

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -24,18 +24,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if (datastore['SESSION'] && session)
-      set_session(session)
-    end
-    # Check connection and issue initial query
-    print_status("Attempting to connect to the database server at #{datastore['RHOST']}:#{datastore['RPORT']} as #{datastore['USERNAME']}...")
-
-    if (datastore['SESSION'] && session) || mssql_login_datastore
-      print_good('Connected.')
+    if session
+      set_session(session.client)
     else
-      print_error('Login was unsuccessful. Check your credentials.')
-      disconnect
-      return
+      print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
+      if mssql_login_datastore
+        print_good('Connected.')
+      else
+        print_error("Login was unsuccessful. Check your credentials.")
+        disconnect
+        return
+      end
     end
 
     # Query for sysadmin status

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -6,6 +6,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -17,14 +18,19 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'      => ['nullbind <scott.sutherland[at]netspi.com>'],
       'License'     => MSF_LICENSE,
-      'References'  => [['URL','http://msdn.microsoft.com/en-us/library/ms178640.aspx']]
+      'References'  => [['URL','http://msdn.microsoft.com/en-us/library/ms178640.aspx']],
+      'SessionTypes' => %w[MSSQL]
     ))
   end
 
   def run
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
     # Check connection and issue initial query
-    print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
-    if mssql_login_datastore
+    print_status("Attempting to connect to the database server at #{datastore['RHOST']}:#{datastore['RPORT']} as #{datastore['USERNAME']}...")
+
+    if (datastore['SESSION'] && session) || mssql_login_datastore
       print_good('Connected.')
     else
       print_error('Login was unsuccessful. Check your credentials.')

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -39,10 +39,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if (datastore['SESSION'] && session)
-      set_session(session)
+    if session
+      set_session(session.client)
+    else
+      return unless mssql_login_datastore
     end
-    return unless (datastore['SESSION'] && session) || mssql_login_datastore
 
     technique = datastore['TECHNIQUE']
     case technique

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(
@@ -26,7 +27,8 @@ class MetasploitModule < Msf::Auxiliary
           [
             [ 'URL', 'http://msdn.microsoft.com/en-us/library/cc448435(PROT.10).aspx'],
             [ 'URL', 'https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-oacreate-transact-sql'],
-          ]
+          ],
+        'SessionTypes' => %w[MSSQL],
       )
     )
 
@@ -37,7 +39,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    return unless mssql_login_datastore
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
+    return unless (datastore['SESSION'] && session) || mssql_login_datastore
 
     technique = datastore['TECHNIQUE']
     case technique

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -339,18 +339,20 @@ class MetasploitModule < Msf::Auxiliary
 
 
     # STATUSING
-    print_line(" ")
-    print_status("Attempting to connect to the SQL Server at #{rhost}:#{rport}...")
 
     # CREATE DATABASE CONNECTION AND SUBMIT QUERY WITH ERROR HANDLING
     begin
-      if (datastore['SESSION'] && session)
-        set_session(session)
+      if session
+        set_session(session.client)
+      else
+        print_line(" ")
+        print_status("Attempting to connect to the SQL Server at #{rhost}:#{rport}...")
+        return unless mssql_login_datastore
+        print_good("Successfully connected to #{rhost}:#{rport}")
       end
-      result = mssql_query(sql, false) if (datastore['SESSION'] && session) || mssql_login_datastore
+      result = mssql_query(sql, false)
 
       column_data = result[:rows]
-      print_good("Successfully connected to #{rhost}:#{rport}")
     rescue
       print_error("Failed to connect to #{rhost}:#{rport}")
     return

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Auxiliary
         print_line(" ")
         print_status("Attempting to connect to the SQL Server at #{rhost}:#{rport}...")
         return unless mssql_login_datastore
-        print_good("Successfully connected to #{rhost}:#{rport}")
+        print_good("Successfully connected to #{mssql_client.address}:#{mssql_client.port}")
       end
       result = mssql_query(sql, false)
 
@@ -444,8 +444,8 @@ class MetasploitModule < Msf::Auxiliary
     this_service = nil
     if framework.db and framework.db.active
       this_service = report_service(
-        :host  => rhost,
-        :port => rport,
+        :host  => mssql_client.address,
+        :port => mssql_client.port,
         :name => 'mssql',
         :proto => 'tcp'
       )
@@ -453,8 +453,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # CONVERT TABLE TO CSV AND WRITE TO FILE
     if (save_loot=="yes")
-      filename= "#{datastore['RHOST']}-#{datastore['RPORT']}_sqlserver_query_results.csv"
-      path = store_loot("mssql.data", "text/plain", datastore['RHOST'], sql_data_tbl.to_csv, filename, "SQL Server query results",this_service)
+      filename= "#{mssql_client.address}-#{mssql_client.port}_sqlserver_query_results.csv"
+      path = store_loot("mssql.data", "text/plain", mssql_client.address, sql_data_tbl.to_csv, filename, "SQL Server query results",this_service)
       print_good("Query results have been saved to: #{path}")
     end
 

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -4,9 +4,10 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::MSSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -27,7 +28,8 @@ class MetasploitModule < Msf::Auxiliary
         'todb'                                               # Help on GitHub
       ],
       'License'        => MSF_LICENSE,
-      'References'     => [[ 'URL', 'http://www.netspi.com/blog/author/ssutherland/' ]]
+      'References'     => [[ 'URL', 'http://www.netspi.com/blog/author/ssutherland/' ]],
+      'SessionTypes'   => %w[MSSQL],
     ))
 
     register_options(
@@ -342,7 +344,11 @@ class MetasploitModule < Msf::Auxiliary
 
     # CREATE DATABASE CONNECTION AND SUBMIT QUERY WITH ERROR HANDLING
     begin
-      result = mssql_query(sql, false) if mssql_login_datastore
+      if (datastore['SESSION'] && session)
+        set_session(session)
+      end
+      result = mssql_query(sql, false) if (datastore['SESSION'] && session) || mssql_login_datastore
+
       column_data = result[:rows]
       print_good("Successfully connected to #{rhost}:#{rport}")
     rescue

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -88,16 +88,15 @@ class MetasploitModule < Msf::Auxiliary
     sql += "DEALLOCATE table_cursor "
 
     begin
-      if (datastore['SESSION'] && session)
-        set_session(session)
-      end
-
-      if (datastore['SESSION'] && session) || mssql_login_datastore
-        result = mssql_query(sql, false)
+      if session
+        set_session(session.client)
       else
-        print_error('Login failed')
-        return
+        unless mssql_login_datastore
+          print_error('Login failed')
+          return
+        end
       end
+      result = mssql_query(sql, false)
     rescue Rex::ConnectionRefused => e
       print_error("Connection failed: #{e}")
       return

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -14,6 +14,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -29,7 +30,8 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://www.digininja.org/metasploit/mssql_idf.php' ],
-        ]
+        ],
+      'SessionTypes'   => %w[MSSQL]
     ))
 
     register_options(
@@ -86,7 +88,11 @@ class MetasploitModule < Msf::Auxiliary
     sql += "DEALLOCATE table_cursor "
 
     begin
-      if mssql_login_datastore
+      if (datastore['SESSION'] && session)
+        set_session(session)
+      end
+
+      if (datastore['SESSION'] && session) || mssql_login_datastore
         result = mssql_query(sql, false)
       else
         print_error('Login failed')

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -5,6 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
+  include Msf::OptionalSession
 
   def initialize(info = {})
     super(update_info(info,
@@ -19,7 +20,8 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'URL', 'http://www.attackresearch.com' ],
           [ 'URL', 'http://msdn.microsoft.com/en-us/library/cc448435(PROT.10).aspx'],
-        ]
+        ],
+      'SessionTypes'   => %w[MSSQL],
     ))
 
     register_options(
@@ -38,7 +40,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    mssql_query(datastore['SQL'], true) if mssql_login_datastore
-    disconnect
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
+
+    mssql_query(datastore['SQL'], true) if (datastore['SESSION'] && session) || mssql_login_datastore
   end
 end

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -40,10 +40,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if (datastore['SESSION'] && session)
-      set_session(session)
+    if session
+      set_session(session.client)
+    else
+      return unless mssql_login_datastore
     end
 
-    mssql_query(datastore['SQL'], true) if (datastore['SESSION'] && session) || mssql_login_datastore
+    mssql_query(datastore['SQL'], true)
   end
 end

--- a/modules/auxiliary/admin/mssql/mssql_sql_file.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql_file.rb
@@ -36,17 +36,22 @@ class MetasploitModule < Msf::Auxiliary
     suffix = datastore['QUERY_SUFFIX']
 
     begin
-      if (datastore['SESSION'] && session)
-        set_session(session)
+      if session
+        set_session(session.client)
+      else
+        unless mssql_login_datastore
+          print_error("#{datastore['RHOST']}:#{datastore['RPORT']} - Invalid SQL Server credentials")
+          return
+        end
       end
       queries.each do |sql_query|
         vprint_status("Executing: #{sql_query}")
-        mssql_query(prefix+sql_query.chomp+suffix,true) if (datastore['SESSION'] && session) || mssql_login_datastore
+        mssql_query(prefix+sql_query.chomp+suffix,true)
       end
     rescue Rex::ConnectionRefused, Rex::ConnectionTimeout
       print_error "Error connecting to server: #{$!}"
     ensure
-      disconnect
+      disconnect unless session
     end
   end
 end

--- a/modules/auxiliary/gather/lansweeper_collector.rb
+++ b/modules/auxiliary/gather/lansweeper_collector.rb
@@ -152,8 +152,8 @@ class MetasploitModule < Msf::Auxiliary
       print_good("Credential name: #{row[0]} | username: #{row[1]} | password: #{pw}")
 
       report_cred(
-        :host => rhost,
-        :port => rport,
+        :host => mssql_client.address,
+        :port => mssql_client.port,
         :creds_name => row[0],
         :user => row[1],
         :password => pw

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -25,11 +25,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    if (datastore['SESSION'] && session)
-      set_session(session)
-    elsif (datastore['SESSION'] && !session)
-      print_error('Unable to connect to session')
-      return
+    if session
+      set_session(session.client)
     elsif !mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
       print_error('Invalid SQL Server credentials')
       return

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
 
     service_data = {
         address: ip,
-        port: rport,
+        port: mssql_client.port,
         service_name: 'mssql',
         protocol: 'tcp',
         workspace_id: myworkspace_id
@@ -102,8 +102,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     this_service = report_service(
-          :host  => datastore['RHOST'],
-          :port => datastore['RPORT'],
+          :host  => mssql_client.address,
+          :port => mssql_client.port,
           :name => 'mssql',
           :proto => 'tcp'
           )
@@ -115,8 +115,8 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     service_data = {
-        address: ::Rex::Socket.getaddress(rhost,true),
-        port: rport,
+        address: ::Rex::Socket.getaddress(mssql_client.address,true),
+        port: mssql_client.port,
         service_name: 'mssql',
         protocol: 'tcp',
         workspace_id: myworkspace_id

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -6,8 +6,8 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
-
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -19,14 +19,19 @@ class MetasploitModule < Msf::Auxiliary
         table names, which can be used to seed the wordlist.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'   => %w[MSSQL],
     )
   end
 
   def run_host(ip)
-
-    if !mssql_login_datastore
-      print_error("Invalid SQL Server credentials")
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    elsif (datastore['SESSION'] && !session)
+      print_error('Unable to connect to session')
+      return
+    elsif !mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
+      print_error('Invalid SQL Server credentials')
       return
     end
 

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("Instance Name: #{instancename.inspect}")
     version = mssql_query(mssql_sql_info())[:rows][0][0]
-    output = "Microsoft SQL Server Schema \n Host: #{datastore['RHOST']} \n Port: #{datastore['RPORT']} \n Instance: #{instancename} \n Version: #{version} \n====================\n\n"
+    output = "Microsoft SQL Server Schema \n Host: #{mssql_client.address} \n Port: #{mssql_client.port} \n Instance: #{instancename} \n Version: #{version} \n====================\n\n"
 
     # Grab all the DB schema and save it as notes
     mssql_schema = get_mssql_schema
@@ -56,19 +56,19 @@ class MetasploitModule < Msf::Auxiliary
         :host  => rhost,
         :type  => "mssql.db.schema",
         :data  => db,
-        :port  => rport,
+        :port  => mssql_client.port,
         :proto => 'tcp',
         :update => :unique_data
       )
     end
     output << YAML.dump(mssql_schema)
     this_service = report_service(
-          :host  => datastore['RHOST'],
-          :port => datastore['RPORT'],
+          :host  => mssql_client.address,
+          :port => mssql_client.port,
           :name => 'mssql',
           :proto => 'tcp'
           )
-    store_loot('mssql_schema', "text/plain", datastore['RHOST'], output, "#{datastore['RHOST']}_mssql_schema.txt", "MS SQL Schema", this_service)
+    store_loot('mssql_schema', "text/plain", mssql_client.address, output, "#{mssql_client.address}_mssql_schema.txt", "MS SQL Schema", this_service)
     print_good output if datastore['DISPLAY_RESULTS']
   end
 

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession
 
   def initialize
     super(
@@ -20,7 +21,8 @@ class MetasploitModule < Msf::Auxiliary
           as loot for easy reading.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'SessionTypes'   => %w[MSSQL],
     )
 
     register_options([
@@ -29,9 +31,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
 
-    if !mssql_login_datastore
-      print_error("#{rhost}:#{rport} - Invalid SQL Server credentials")
+    unless (datastore['SESSION'] && session) || mssql_login_datastore
+      print_error("#{datastore['RHOST']}:#{datastore['RPORT']} - Invalid SQL Server credentials")
       return
     end
 

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -31,13 +31,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    if (datastore['SESSION'] && session)
-      set_session(session)
-    end
-
-    unless (datastore['SESSION'] && session) || mssql_login_datastore
-      print_error("#{datastore['RHOST']}:#{datastore['RPORT']} - Invalid SQL Server credentials")
-      return
+    if session
+      set_session(session.client)
+    else
+      unless mssql_login_datastore
+        print_error("#{datastore['RHOST']}:#{datastore['RPORT']} - Invalid SQL Server credentials")
+        return
+      end
     end
 
     # Grabs the Instance Name and Version of MSSQL(2k,2k5,2k8)

--- a/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
+++ b/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("")
-    print_good("Successfully authenticated to #{rhost}:#{rport} with user 'sa' and password '#{pass}'")
+    print_good("Successfully authenticated to #{mssql_client.address}:#{mssql_client.port} with user 'sa' and password '#{pass}'")
     print_status("")
 
     exe = generate_payload_exe

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -240,8 +240,8 @@ class MetasploitModule < Msf::Exploit::Remote
     this_service = nil
     if framework.db and framework.db.active
       this_service = report_service(
-        :host  => rhost,
-        :port => rport,
+        :host  => mssql_client.address,
+        :port => mssql_client.port,
         :name => 'mssql',
         :proto => 'tcp'
       )
@@ -254,8 +254,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Write log to loot / file
     if (save_loot=="yes")
-      filename= "#{datastore['RHOST']}-#{datastore['RPORT']}_linked_servers.csv"
-      path = store_loot("crawled_links", "text/plain", datastore['RHOST'], linked_server_table.to_csv, filename, "Linked servers",this_service)
+      filename= "#{mssql_client.address}-#{mssql_client.port}_linked_servers.csv"
+      path = store_loot("crawled_links", "text/plain", mssql_client.address, linked_server_table.to_csv, filename, "Linked servers",this_service)
       print_good("Results have been saved to: #{path}")
     end
   end

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::MSSQL
   include Msf::Exploit::CmdStager
+  include Msf::OptionalSession
   #include Msf::Exploit::CmdStagerDebugAsm
   #include Msf::Exploit::CmdStagerDebugWrite
   #include Msf::Exploit::CmdStagerTFTP
@@ -53,6 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Platform'       => 'win',
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'SessionTypes'   => %w[MSSQL],
       'Targets'        =>
         [
           [ 'Automatic', { } ],
@@ -68,7 +70,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    if !mssql_login_datastore
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
+
+    unless (datastore['SESSION'] && session) || mssql_login_datastore
       vprint_status("Invalid SQL Server credentials")
       return Exploit::CheckCode::Detected
     end
@@ -91,7 +97,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    if !mssql_login_datastore
+    if (datastore['SESSION'] && session)
+      set_session(session)
+    end
+
+    unless (datastore['SESSION'] && session) || mssql_login_datastore
       print_status("Invalid SQL Server credentials")
       return
     end

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -70,13 +70,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    if (datastore['SESSION'] && session)
-      set_session(session)
+    if session
+      set_session(session.client)
     end
 
-    unless (datastore['SESSION'] && session) || mssql_login_datastore
+    unless session || mssql_login_datastore
       vprint_status("Invalid SQL Server credentials")
       return Exploit::CheckCode::Detected
+    end
+
+    if session
+      set_session(session.client)
+    else
+      unless mssql_login_datastore
+        vprint_status("Invalid SQL Server credentials")
+        return Exploit::CheckCode::Detected
+      end
     end
 
     mssql_query("select @@version", true)
@@ -97,11 +106,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    if (datastore['SESSION'] && session)
-      set_session(session)
+    if session
+      set_session(session.client)
     end
 
-    unless (datastore['SESSION'] && session) || mssql_login_datastore
+    unless session || mssql_login_datastore
       print_status("Invalid SQL Server credentials")
       return
     end


### PR DESCRIPTION
This pr adds support for running modules with the `session=` option when you already have a session. ie: `run session=1` after successfully running `mssql_login` in accordance with the steps in the above pr.

Modules I skipped and would love feedback on:

`mssql_ntlm_stealer`
This module can be used to help capture or relay the LM/NTLM credentials of the account running the remote SQL Server service. The module will use the supplied credentials to connect to the target SQL Server instance and execute the native "xp_dirtree" or "xp_fileexist" stored procedure. The stored procedures will then force the service account to authenticate to the system defined in the SMBProxy option. In order for the attack to be successful, the SMB capture or relay module must be running on the system defined as the SMBProxy.

`tds_login_corrupt`
This module sends a series of malformed TDS login requests.

`tds_login_username`
This module sends a series of malformed TDS login requests.

`lansweeper_collector`
Lansweeper stores the credentials it uses to scan the computers in its Microsoft SQL database.  The passwords are XTea-encrypted with a 68 character long key, in which the first 8 characters are stored with the password in the database and the other 60 is static. Lansweeper, by default, creates an MSSQL user "lansweeperuser" with the password is "mysecretpassword0*", and stores its data in a database called "lansweeperdb". This module will query the MSSQL database for the credentials.

`mssql_ping`
This module simply queries the MSSQL instance for information.

`lyris_listmanager_weak_pass`
This module exploits a weak password vulnerability in the Lyris ListManager MSDE install. During installation, the 'sa' account password is set to 'lminstall'. Once the install completes, it is set to 'lyris' followed by the process ID of the installer. This module brute forces all possible process IDs that would be used by the installer.

`ms02_039_slammer`
This is an exploit for the SQL Server 2000 resolution service buffer overflow. This overflow is triggered by sending a udp packet to port 1434 which starts with 0x04 and is followed by long string terminating with a colon and a number. This module should work against any vulnerable SQL Server 2000 or MSDE install (pre-SP3).

`ms02_056_hello`
By sending malformed data to TCP port 1433, an unauthenticated remote attacker could overflow a buffer and possibly execute code on the server with SYSTEM level privileges. This module should work against any vulnerable SQL Server 2000 or MSDE install (< SP3).

`ms09_004_sp_replwritetovarbin`
A heap-based buffer overflow can occur when calling the undocumented "sp_replwritetovarbin" extended stored procedure. This vulnerability affects all versions of Microsoft SQL Server 2000 and 2005, Windows Internal Database, and Microsoft Desktop Engine (MSDE) without the updates supplied in MS09-004. Microsoft patched this vulnerability in SP3 for 2005 without any public mention.

`mssql_clr_payload`
This module executes an arbitrary native payload on a Microsoft SQL server by loading a custom SQL CLR Assembly into the target SQL installation, and calling it directly with a base64-encoded payload.

`mssql_linkcrawler`
This module can be used to crawl MS SQL Server database links and deploy Metasploit payloads through links configured with sysadmin privileges using a valid SQL Server Login.
