### PR TITLE
Extract SMB, PostgreSQL, MySQL and MSSQL optional sessions into their own mixins

### DIFF
--- a/lib/msf/base/sessions/mssql.rb
+++ b/lib/msf/base/sessions/mssql.rb
@@ -53,7 +53,7 @@ class Msf::Sessions::MSSQL
   # Returns the type of session.
   #
   def self.type
-    'MSSQL'
+    'mssql'
   end
 
   def self.can_cleanup_files

--- a/lib/msf/base/sessions/mysql.rb
+++ b/lib/msf/base/sessions/mysql.rb
@@ -49,7 +49,7 @@ class Msf::Sessions::MySQL
 
   # @return [String] The type of the session
   def self.type
-    'MySQL'
+    'mysql'
   end
 
   # @return [Boolean] Can the session clean up after itself

--- a/lib/msf/base/sessions/postgresql.rb
+++ b/lib/msf/base/sessions/postgresql.rb
@@ -57,7 +57,7 @@ class Msf::Sessions::PostgreSQL
   # @return [String] The type of the session
   #
   def self.type
-    'PostgreSQL'
+    'postgresql'
   end
 
   #

--- a/lib/msf/base/sessions/smb.rb
+++ b/lib/msf/base/sessions/smb.rb
@@ -57,7 +57,7 @@ class Msf::Sessions::SMB
   # Returns the type of session.
   #
   def self.type
-    'SMB'
+    'smb'
   end
 
   def self.can_cleanup_files

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -4,63 +4,8 @@
 
 # A mixin used for providing Modules with post-exploitation options and helper methods
 #
-module Msf::OptionalSession
-  include Msf::SessionCompatibility
-
-  def initialize(info = {})
-    super
-
-    if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
-      register_options(
-        [
-          Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
-          Msf::Opt::RHOST(nil, false),
-          Msf::Opt::RPORT(nil, false)
-        ]
-      )
-      add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
-    end
-
-    if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
-      register_options(
-        [
-          Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
-          Msf::Opt::RHOST(nil, false),
-          Msf::Opt::RPORT(3306, false)
-        ]
-      )
-      add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
-    end
-
-    if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
-      register_options(
-        [
-          Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
-          Msf::OptString.new('DATABASE', [ false, 'The database to authenticate against', 'postgres']),
-          Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'postgres']),
-          Msf::Opt::RHOST(nil, false),
-          Msf::Opt::RPORT(5432, false)
-        ]
-      )
-      add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
-    end
-
-    if framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
-      register_options(
-        [
-          Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
-          Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'MSSQL']),
-          Msf::Opt::RHOST(nil, false),
-          Msf::Opt::RPORT(1433, false)
-        ]
-      )
-      add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
-    end
-  end
-
-  def session
-    return nil unless (framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE) || framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE) || framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE) || framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE))
-
-    super
+module Msf
+  module OptionalSession
+    include Msf::SessionCompatibility
   end
 end

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -9,7 +9,7 @@ module Msf
         super(
           update_info(
             info,
-            'SessionTypes' => %w[MSSQL]
+            'SessionTypes' => %w[mssql]
           )
         )
 

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -6,7 +6,13 @@ module Msf
       include Msf::OptionalSession
 
       def initialize(info = {})
-        super
+        super(
+          update_info(
+            info,
+            'SessionTypes' => %w[MSSQL]
+          )
+        )
+
         if framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
           register_options(
             [

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true
-
 module Msf
   module OptionalSession
     module MSSQL

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# frozen_string_literal: true
+
+module Msf
+  module OptionalSession
+    module MSSQL
+      include Msf::OptionalSession
+
+      def initialize(info = {})
+        super
+        if framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
+          register_options(
+            [
+              Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
+              Msf::OptString.new('DATABASE', [ false, 'The database to authenticate against', 'MSSQL']),
+              Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'MSSQL']),
+              Msf::Opt::RHOST(nil, false),
+              Msf::Opt::RPORT(1433, false)
+            ]
+          )
+          add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
+        end
+      end
+
+      def session
+        return nil unless framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/msf/core/optional_session/mysql.rb
+++ b/lib/msf/core/optional_session/mysql.rb
@@ -9,7 +9,7 @@ module Msf
         super(
           update_info(
             info,
-            'SessionTypes' => %w[MySQL]
+            'SessionTypes' => %w[mysql]
           )
         )
 
@@ -18,7 +18,7 @@ module Msf
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
               Msf::Opt::RHOST(nil, false),
-              Msf::Opt::RPORT(nil, false)
+              Msf::Opt::RPORT(3306, false)
             ]
           )
           add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')

--- a/lib/msf/core/optional_session/mysql.rb
+++ b/lib/msf/core/optional_session/mysql.rb
@@ -6,7 +6,13 @@ module Msf
       include Msf::OptionalSession
 
       def initialize(info = {})
-        super
+        super(
+          update_info(
+            info,
+            'SessionTypes' => %w[MySQL]
+          )
+        )
+
         if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
           register_options(
             [

--- a/lib/msf/core/optional_session/mysql.rb
+++ b/lib/msf/core/optional_session/mysql.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Msf
+  module OptionalSession
+    module MySQL
+      include Msf::OptionalSession
+
+      def initialize(info = {})
+        super
+        if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
+          register_options(
+            [
+              Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
+              Msf::Opt::RHOST(nil, false),
+              Msf::Opt::RPORT(nil, false)
+            ]
+          )
+          add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
+
+        end
+      end
+
+      def session
+        return nil unless framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/msf/core/optional_session/postgresql.rb
+++ b/lib/msf/core/optional_session/postgresql.rb
@@ -9,7 +9,7 @@ module Msf
         super(
           update_info(
             info,
-            'SessionTypes' => %w[PostgreSQL]
+            'SessionTypes' => %w[postgresql]
           )
         )
         if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
@@ -19,7 +19,7 @@ module Msf
               Msf::OptString.new('DATABASE', [ false, 'The database to authenticate against', 'postgres']),
               Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'postgres']),
               Msf::Opt::RHOST(nil, false),
-              Msf::Opt::RPORT(nil, false)
+              Msf::Opt::RPORT(5432, false)
             ]
           )
           add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')

--- a/lib/msf/core/optional_session/postgresql.rb
+++ b/lib/msf/core/optional_session/postgresql.rb
@@ -6,7 +6,12 @@ module Msf
       include Msf::OptionalSession
 
       def initialize(info = {})
-        super
+        super(
+          update_info(
+            info,
+            'SessionTypes' => %w[PostgreSQL]
+          )
+        )
         if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
           register_options(
             [

--- a/lib/msf/core/optional_session/postgresql.rb
+++ b/lib/msf/core/optional_session/postgresql.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Msf
+  module OptionalSession
+    module PostgreSQL
+      include Msf::OptionalSession
+
+      def initialize(info = {})
+        super
+        if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
+          register_options(
+            [
+              Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
+              Msf::OptString.new('DATABASE', [ false, 'The database to authenticate against', 'postgres']),
+              Msf::OptString.new('USERNAME', [ false, 'The username to authenticate as', 'postgres']),
+              Msf::Opt::RHOST(nil, false),
+              Msf::Opt::RPORT(nil, false)
+            ]
+          )
+          add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
+        end
+      end
+
+      def session
+        return nil unless framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/msf/core/optional_session/smb.rb
+++ b/lib/msf/core/optional_session/smb.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Msf
+  module OptionalSession
+    module SMB
+      include Msf::OptionalSession
+
+      def initialize(info = {})
+        super
+        if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+          register_options(
+            [
+              Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
+              Msf::Opt::RHOST(nil, false),
+              Msf::Opt::RPORT(nil, false)
+            ]
+          )
+          add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
+        end
+      end
+
+      def session
+        return nil unless framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/msf/core/optional_session/smb.rb
+++ b/lib/msf/core/optional_session/smb.rb
@@ -9,7 +9,7 @@ module Msf
         super(
           update_info(
             info,
-            'SessionTypes' => %w[SMB]
+            'SessionTypes' => %w[smb]
           )
         )
 
@@ -19,7 +19,7 @@ module Msf
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
               Msf::Opt::RHOST(nil, false),
-              Msf::Opt::RPORT(nil, false)
+              Msf::Opt::RPORT(443, false)
             ]
           )
           add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')

--- a/lib/msf/core/optional_session/smb.rb
+++ b/lib/msf/core/optional_session/smb.rb
@@ -6,7 +6,14 @@ module Msf
       include Msf::OptionalSession
 
       def initialize(info = {})
-        super
+        super(
+          update_info(
+            info,
+            'SessionTypes' => %w[SMB]
+          )
+        )
+
+
         if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
           register_options(
             [

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -35,17 +35,17 @@ class MsfAutoload
         'PowerShell'
       elsif basename == 'ui' && abspath.end_with?("#{__dir__}/msf/core/module/ui", "#{__dir__}/msf/core/module/ui.rb", "#{__dir__}/rex/post/ui", "#{__dir__}/rex/post/ui.rb", "#{__dir__}/rex/post/meterpreter/extensions/stdapi/ui.rb")
         'UI'
+      elsif basename == 'mysql' && abspath.end_with?("#{__dir__}/msf/core/exploit/remote/mysql.rb")
+        'MySQL'
       elsif basename == 'ssh' && abspath.end_with?("#{__dir__}/rex/proto/ssh")
         'Ssh'
       elsif basename == 'http' && abspath.end_with?("#{__dir__}/rex/proto/http")
         'Http'
       elsif basename == 'rftransceiver' && abspath.end_with?("#{__dir__}/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb")
         'RFtransceiver'
-      elsif basename == 'mysql' && abspath.end_with?("#{__dir__}/msf/base/sessions/mysql.rb")
-        'MySQL'
       else
-       super
-    end
+        super
+      end
     end
   end
 
@@ -145,7 +145,7 @@ class MsfAutoload
       'dcerpc_lsa' => 'DCERPC_LSA',
       'wdbrpc_client' => 'WDBRPC_Client',
       'sunrpc' => 'SunRPC',
-      'mysql' => 'MYSQL',
+      'mysql' => 'MySQL',
       'ldap' => 'LDAP',
       'sqli' => 'SQLi',
       'dhcp_server' => 'DHCPServer',

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -36,7 +36,7 @@ class MsfAutoload
       elsif basename == 'ui' && abspath.end_with?("#{__dir__}/msf/core/module/ui", "#{__dir__}/msf/core/module/ui.rb", "#{__dir__}/rex/post/ui", "#{__dir__}/rex/post/ui.rb", "#{__dir__}/rex/post/meterpreter/extensions/stdapi/ui.rb")
         'UI'
       elsif basename == 'mysql' && abspath.end_with?("#{__dir__}/msf/core/exploit/remote/mysql.rb")
-        'MySQL'
+        'MYSQL'
       elsif basename == 'ssh' && abspath.end_with?("#{__dir__}/rex/proto/ssh")
         'Ssh'
       elsif basename == 'http' && abspath.end_with?("#{__dir__}/rex/proto/http")

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -6,7 +6,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -18,8 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'      => ['nullbind <scott.sutherland[at]netspi.com>'],
       'License'     => MSF_LICENSE,
-      'References'  => [['URL','http://msdn.microsoft.com/en-us/library/ms178640.aspx']],
-      'SessionTypes' => %w[MSSQL]
+      'References'  => [['URL','http://msdn.microsoft.com/en-us/library/ms178640.aspx']]
     ))
   end
 

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Auxiliary
             [ 'URL', 'http://msdn.microsoft.com/en-us/library/cc448435(PROT.10).aspx'],
             [ 'URL', 'https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-oacreate-transact-sql'],
           ],
-        'SessionTypes' => %w[MSSQL],
       )
     )
 

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -14,7 +14,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mssql/mssql_sql_file.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql_file.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::MYSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -16,7 +16,6 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'		=> [ 'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>' ],
       'License'		=> MSF_LICENSE,
-      'SessionTypes' => %w[MySQL]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Postgres
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -18,8 +18,7 @@ class MetasploitModule < Msf::Auxiliary
           as well as read privileges to the target file.
       },
       'Author'         => [ 'todb' ],
-      'License'        => MSF_LICENSE,
-      'SessionTypes' => %w[PostgreSQL]
+      'License'        => MSF_LICENSE
     ))
 
     register_options(

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Postgres
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -19,8 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'www.postgresql.org' ]
-        ],
-      'SessionTypes' => %w[PostgreSQL]
+        ]
     ))
   end
 

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Auxiliary
           'mubix' # copied from hdm upload_file module
         ],
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
       )
 
     register_options([

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::RemotePaths
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::RemotePaths
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Auxiliary
           'mubix' # copied from hdm upload_file module
         ],
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
     )
 
     register_options([

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   # Exploit mixins should be called first
   include Msf::Exploit::Remote::SMB::Client::Psexec
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://sourceforge.net/projects/smbexec' ],
         [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ]
       ],
-      'SessionTypes' => %w[SMB]
     ))
 
     register_options([

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
         [
         ],
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
     )
 
     register_options([

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::RemotePaths
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -74,8 +74,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'LSA', { 'Description' => 'Dump LSA secrets' } ],
           [ 'DOMAIN', { 'Description' => 'Dump domain secrets (credentials, password history, Kerberos keys, etc.)' } ]
         ],
-        'DefaultAction' => 'ALL',
-        'SessionTypes' => %w[SMB]
+        'DefaultAction' => 'ALL'
       )
     )
 

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Util::WindowsRegistry
   include Msf::Util::WindowsCryptoHelpers
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   # Mapping of MS-SAMR encryption keys to IANA Kerberos Parameter values
   #

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -16,8 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         Enumerates the version of MySQL servers.
       },
       'Author'      => 'kris katterjohn',
-      'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[MySQL],
+      'License'     => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Postgres
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -18,7 +18,6 @@ class MetasploitModule < Msf::Auxiliary
       ),
       'Author' => ['theLightCosine'],
       'License' => MSF_LICENSE,
-      'SessionTypes' => %w[PostgreSQL]
     )
     register_options([
       OptBool.new('DISPLAY_RESULTS', [true, 'Display the Results to the Screen', true]),

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Postgres
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Postgres
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   # Creates an instance of this module.
   def initialize(info = {})

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -21,8 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'https://www.postgresql.org/' ]
-        ],
-        'SessionTypes' => %w[PostgreSQL]
+        ]
     ))
 
     register_options([ ]) # None needed.

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Determine what named pipes are accessible over SMB',
       'Author'      => 'hdm',
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
     )
 
     deregister_options('RPORT', 'SMBDirect')

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Determine what DCERPC services are accessible over a SMB pipe',
       'Author'      => 'hdm',
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
     )
 
     deregister_options('RPORT')

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::Authenticated
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::Client

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://labs.portcullis.co.uk/blog/are-you-considering-using-microsoft-group-policy-preferences-think-again/']
         ],
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
     )
     register_options([
       OptString.new('SMBSHARE', [true, 'The name of the share on the server', 'SYSVOL']),

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Auxiliary
         'DefaultOptions' => {
           'DCERPC::fake_bind_multi' => false
         },
-        'SessionTypes' => %w[SMB]
       )
     )
 

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultOptions' => {
         'DCERPC::fake_bind_multi' => false
       },
-      'SessionTypes' => %w[SMB]
     )
 
     register_options(

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://docs.microsoft.com/en-us/windows/win32/api/lmwksta/nf-lmwksta-netwkstauserenum' ]
         ],
       'License'     => MSF_LICENSE,
-      'SessionTypes' => %w[SMB]
     )
 
     deregister_options('RPORT')

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Auxiliary
           ['DOMAIN', { 'Description' => 'Enumerate domain accounts' } ]
         ],
       'DefaultAction' => 'LOCAL',
-      'SessionTypes' => %w[SMB]
     )
 
     register_options(

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize
     super(

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Postgres
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   # Creates an instance of this module.
   def initialize(info = {})

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -67,8 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => '2007-06-05',
-      'SessionTypes' => %w[PostgreSQL]
+      'DisclosureDate' => '2007-06-05'
       ))
 
     deregister_options('SQL', 'RETURN_ROWSET')

--- a/modules/exploits/multi/mysql/mysql_udf_payload.rb
+++ b/modules/exploits/multi/mysql/mysql_udf_payload.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::MYSQL
   include Msf::Exploit::CmdStager
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
+++ b/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Postgres
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
+++ b/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
@@ -73,8 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-      'DisclosureDate' => '2019-03-20',
-      'SessionTypes' => %w[PostgreSQL]
+      'DisclosureDate' => '2019-03-20'
     ))
 
     register_options([

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -47,8 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Automatic', {}]
       ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => '2016-01-01',
-      'SessionTypes' => %w[PostgreSQL]
+      'DisclosureDate' => '2016-01-01'
     ))
 
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Postgres
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::MSSQL
   include Msf::Exploit::CmdStager
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MSSQL
   #include Msf::Exploit::CmdStagerDebugAsm
   #include Msf::Exploit::CmdStagerDebugWrite
   #include Msf::Exploit::CmdStagerTFTP

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::WbemExec
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::MYSQL
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
-  include Msf::OptionalSession
+  include Msf::OptionalSession::MySQL
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Report
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
-  include Msf::OptionalSession
+  include Msf::OptionalSession::PostgreSQL
 
   # Creates an instance of this module.
   def initialize(info = {})

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2009-04-10', # Date of Bernardo's BH Europe paper.
-      'SessionTypes' => %w[PostgreSQL]
     ))
 
     deregister_options('SQL', 'RETURN_ROWSET')

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -69,7 +69,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Command', { 'Arch' => [ARCH_CMD], 'Payload' => { 'Space' => 8191 } } ]
         ],
       'DefaultTarget'  => 0,
-      'SessionTypes' => %w[SMB],
       # For the CVE, PsExec was first released around February or March 2001
       'DisclosureDate' => '1999-01-01'
     ))

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::EXE
   include Msf::Exploit::WbemExec
   include Msf::Auxiliary::Report
-  include Msf::OptionalSession
+  include Msf::OptionalSession::SMB
 
   def initialize(info = {})
     super(update_info(info,

--- a/spec/lib/msf/base/sessions/mssql_spec.rb
+++ b/spec/lib/msf/base/sessions/mssql_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Msf::Sessions::MSSQL do
     { rows: [['mssql']]}
   end
   let(:log_source) { "session_#{name}" }
-  let(:type) { 'MSSQL' }
+  let(:type) { 'mssql' }
   let(:description) { 'MSSQL' }
   let(:can_cleanup_files) { false }
   let(:address) { '192.0.2.1' }

--- a/spec/lib/msf/base/sessions/mysql_spec.rb
+++ b/spec/lib/msf/base/sessions/mysql_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Msf::Sessions::MySQL do
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }
   let(:name) { 'mysql' }
   let(:log_source) { "session_#{name}" }
-  let(:type) { 'MySQL' }
+  let(:type) { 'mysql' }
   let(:description) { 'MySQL' }
   let(:can_cleanup_files) { false }
   let(:address) { '192.0.2.1' }

--- a/spec/lib/msf/base/sessions/postgresql_spec.rb
+++ b/spec/lib/msf/base/sessions/postgresql_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Msf::Sessions::PostgreSQL do
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }
   let(:name) { 'postgresql' }
   let(:log_source) { "session_#{name}" }
-  let(:type) { 'PostgreSQL' }
+  let(:type) { 'postgresql' }
   let(:description) { 'PostgreSQL' }
   let(:can_cleanup_files) { false }
   let(:address) { '192.0.2.1' }

--- a/spec/lib/msf/base/sessions/smb_spec.rb
+++ b/spec/lib/msf/base/sessions/smb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Msf::Sessions::SMB do
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }
   let(:name) { 'name' }
   let(:log_source) { "session_#{name}" }
-  let(:type) { 'SMB' }
+  let(:type) { 'smb' }
   let(:description) { 'SMB' }
   let(:can_cleanup_files) { false }
   let(:address) { '192.0.2.1' }


### PR DESCRIPTION
Spotted an issue where having _any_ of the new SMB/MySQL/PostgreSQL/MSSQL session type features enabled would end up enabling the new feature for each which was unintended, also fixes an issue where if the postgres session feature is enabled it starts registering postgres specific datastore options in the included other session type modules, this PR resolves both of these issues by splitting the `Msf::OptionalSession` out into individual mixins for each session type.

The `Msf::OptionalSession` mixin is left quite bare at the minute, but it will fill up in the near future with stuff common to all sessions (like the `SESSION` datastore option as an example) once the sessions are no longer behind individual feature flags 

# Verification steps
- [x] with `features set smb_session_type false` and `features set postgresql_session_type false`
  - [x] check that the `SESSION` datastore option is not available in the smb/postgres modules 
  - [x] check that the smb modules do not have the `DATABASE` datastore option registered
  - [x] Run a few modules to make sure they still work as expected
- [x] with `features set smb_session_type true` and `features set postgresql_session_type false`
  - [x] check that the `SESSION` datastore option is not available in the postgres modules 
  - [x] check that the `SESSION` datastore option is available in the SMB modules 
  - [x] check that the smb modules do not have the `DATABASE` datastore option registered
  - [x] Run a few SMB modules with a session to make sure they still work as expected
- [x] with `features set smb_session_type false` and `features set postgresql_session_type true`
  - [x] check that the `SESSION` datastore option is not available in the SMB modules 
  - [x] check that the `SESSION` datastore option is available in the postgres modules 
  - [x] check that the smb modules do not have the `DATABASE` datastore option registered
  - [x] Run the postgres schema dump module with a session to make sure it still works as expected
- [x] with `features set smb_session_type true` and `features set postgresql_session_type true`
  - [x] check that the `SESSION` datastore option is available in the postgres/SMB modules 
  - [x] check that the smb modules do not have the `DATABASE` datastore option registered
  - [x] Run a few modules to make sure they still work as expected

**_Continue the above steps for each new session type_**