### PR TITLE
Add support for newer sqlcmd versions

### DIFF
--- a/lib/msf/core/post/windows/mssql.rb
+++ b/lib/msf/core/post/windows/mssql.rb
@@ -99,7 +99,7 @@ module Msf
         # @return [Boolean] true if sqlcmd is present
         def check_sqlcmd
           result = run_cmd('sqlcmd -?')
-          result =~ /SQL Server Command Line Tool/i
+          result =~ /SQL Server Command Line Tool|Version v\d+/i
         end
 
         # Runs a SQL query using the identified command line tool

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('DB_USERNAME', [true, 'New sysadmin login', '']),
-        OptString.new('DB_PASSWORD', [true, 'Password for new sysadmin login', '']),
+        OptString.new('DB_USERNAME', [true, 'New sysadmin login', nil]),
+        OptString.new('DB_PASSWORD', [true, 'Password for new sysadmin login', nil]),
         OptString.new('INSTANCE', [false, 'Name of target SQL Server instance', nil]),
         OptBool.new('REMOVE_LOGIN', [true, 'Remove DB_USERNAME login from database', false])
       ]


### PR DESCRIPTION
Updates `post/windows/gather/credentials/mssql_local_hashdump` and `post/windows/manage/mssql_local_auth_bypass` to work with newer versions of sqlcmd

## Verification

Ensure that these post modules work