### PR TITLE
Fix source location tracking for Ruby kernel patches

### DIFF
--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -98,15 +98,15 @@ require 'rex/sslscan/result'
 require 'rex/version'
 
 # Overload the Kernel.sleep() function to be thread-safe
-Kernel.class_eval("
+Kernel.class_eval(<<-EOF, __FILE__, __LINE__ + 1)
   def sleep(seconds=nil)
     Rex::ThreadSafe.sleep(seconds)
   end
-")
+EOF
 
 # Overload the Kernel.select function to be thread-safe
-Kernel.class_eval("
+Kernel.class_eval(<<-EOF, __FILE__, __LINE__ + 1)
   def select(rfd = nil, wfd = nil, efd = nil, to = nil)
     Rex::ThreadSafe.select(rfd, wfd, efd, to)
   end
-")
+EOF


### PR DESCRIPTION
Fix source location tracking for Ruby kernel patches

## Verification

### Before

```
msf6 auxiliary(admin/kerberos/forge_ticket) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/admin/kerberos/forge_ticket

>> 
>> method(:sleep).source_location
=> ["(eval)", 2]
>> 
```

### After

```
msf6 auxiliary(admin/kerberos/forge_ticket) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/admin/kerberos/forge_ticket

>> method(:sleep).source_location
=> ["/Users/user/Documents/code/metasploit-framework/lib/rex.rb", 102]
>> 
```