### PR TITLE
Temporarily remove PHP github action testing

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -63,10 +63,10 @@ jobs:
           # Java - newer versions of Java are not supported currently: https://github.com/rapid7/metasploit-payloads/issues/647
           - { name: java, runtime_version: 8 }
 
-          # PHP
-          - { name: php, runtime_version: 5.3 }
-          - { name: php, runtime_version: 7.4 }
-          - { name: php, runtime_version: 8.2 }
+          # PHP - Temporarily removed as tests are timing out on Github actions
+          # - { name: php, runtime_version: 5.3 }
+          # - { name: php, runtime_version: 7.4 }
+          # - { name: php, runtime_version: 8.2 }
         include:
           # Windows Meterpreter
           - { meterpreter: { name: windows_meterpreter }, os: windows-2019 }


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/18779

We're seeing that the PHP github actions are currently timing out. Let's remove them for now to not mark CI as failing.

## Verification

- Ensure CI passes