### PR TITLE
Move CreateSession from advanced into basic options

### DIFF
--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -15,9 +15,14 @@ module CommandShellOptions
   def initialize(info = {})
     super(info)
 
+    register_options(
+      [
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', true])
+      ]
+    )
+
     register_advanced_options(
       [
-        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', true]),
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),
         OptString.new('AutoRunScript', "A script to run automatically on session creation."),
         OptString.new('CommandShellCleanupCommand', "A command to run before the session is closed"),

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options([
       OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+      OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
     ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -38,7 +38,9 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]
-    unless framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
+    if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
+      add_info('New in Metasploit 6.4 - The %grnCreateSession%clr option within this module can open an interactive session')
+    else
       options_to_deregister << 'CreateSession'
     end
     deregister_options(*options_to_deregister)

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -33,7 +33,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::Proxies
+        Opt::Proxies,
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false]),
         OptPath.new('USERPASS_FILE',  [ false, "File containing (space-separated) users and passwords, one pair per line",
           File.join(Msf::Config.data_directory, "wordlists", "postgres_default_userpass.txt") ]),
         OptPath.new('USER_FILE',      [ false, "File containing users, one per line",

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false]),
         OptBool.new('ABORT_ON_LOCKOUT', [ true, 'Abort the run when an account lockout is detected', false ]),
         OptBool.new('PRESERVE_DOMAINS', [ false, 'Respect a username that contains a domain name.', true ]),
         OptBool.new('RECORD_GUEST', [ false, 'Record guest-privileged random logins to the database', false ]),


### PR DESCRIPTION
This PR moves the `CreateSession` option from advanced into basic options, in order to increase discoverability.
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/20e1fd13-bfd5-4b45-a3cb-2ad0deb5c0d5)

I have left have the default as `true` within the mixin, but added an option within each session types login module to override this options to be false: 
- `auxiliary/scanner/smb/smb_login`
- `auxiliary/scanner/mssql/mssql_login`
- `auxiliary/scanner/postgres/postgres_login`
- `auxiliary/scanner/mysql/mysql_login`

As part of the ticket I was asked to do data mining to get a list of other modules that made use of this options. So it can be reviewed at module hacking or similar, just to get more input on potentially unexpected issues with this change:

- [modules/auxiliary/cloud/aws/enum_ssm.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/cloud/aws/enum_ssm.rb)
- [modules/auxiliary/scanner/mysql/mysql_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/mysql/mysql_login.rb)
- [modules/auxiliary/scanner/postgres/postgres_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/postgres/postgres_login.rb)
- [modules/auxiliary/scanner/rservices/rexec_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/rservices/rexec_login.rb)
- [modules/auxiliary/scanner/rservices/rlogin_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/rservices/rlogin_login.rb)
- [modules/auxiliary/scanner/rservices/rsh_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/rservices/rsh_login.rb)
- [modules/auxiliary/scanner/smb/smb_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/smb/smb_login.rb)
- [modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb)
- [modules/auxiliary/scanner/ssh/fortinet_backdoor.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb)
- [modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb)
- [modules/auxiliary/scanner/ssh/ssh_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/ssh/ssh_login.rb)
- [modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb)
- [modules/auxiliary/scanner/telnet/brocade_enable_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/telnet/brocade_enable_login.rb)
- [modules/auxiliary/scanner/telnet/telnet_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/telnet/telnet_login.rb)
- [modules/auxiliary/scanner/winrm/winrm_login.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/winrm/winrm_login.rb)
- [modules/exploits/windows/smb/smb_relay.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/smb/smb_relay.rb)


## Verification

- [ ] Start `msfconsole`
- [ ] Use each new session type login module - `use scanner/postgres/postgres_login` 
- [ ] **Verify** the `CreateSession` option is now present when running the `options` command.
- [ ] **Verify** the `CreateSession` option is no longer present when running the `advanced` command.
- [ ] **Verify** the login modules still function as expected
- [ ] **Verify** the module in the list of other modules that make use of the `CreateSession` options still have access to it and it defaults to `true`