### PR TITLE
Remove all references to `Msf::SymbolicModule`

### DIFF
--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -154,7 +154,7 @@ module Msf::ModuleManager::Cache
 
   # Return a module info from Msf::Modules::Metadata::Obj.
   #
-  # @note Also sets module_set(module_type)[module_reference_name] to Msf::SymbolicModule if it is not already set.
+  # @note Also sets module_set(module_type)[module_reference_name] to nil if it is not already set.
   #
   # @return [Hash{String => Hash{Symbol => Object}}] Maps path (Mdm::Module::Detail#file) to module information.  Module
   #   information is a Hash derived from Mdm::Module::Detail.  It includes :modification_time, :parent_path, :type,
@@ -193,7 +193,7 @@ module Msf::ModuleManager::Cache
       # which would potentially call {Msf::ModuleSet#create}.
       next unless typed_module_set
       unless typed_module_set.has_key?(reference_name)
-        typed_module_set[reference_name] = Msf::SymbolicModule
+        typed_module_set[reference_name] = nil
       end
     end
 

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -1,12 +1,6 @@
 # -*- coding: binary -*-
 require 'pathname'
 
-#
-# Define used for a place-holder module that is used to indicate that the
-# module has not yet been demand-loaded. Soon to go away.
-#
-Msf::SymbolicModule = '__SYMBOLIC__'
-
 ###
 #
 # A module set contains zero or more named module classes of an arbitrary
@@ -23,7 +17,7 @@ class Msf::ModuleSet < Hash
   # @return [Msf::Module] Class of the of the Msf::Module with the given reference name
   def [](name)
     module_class = super
-    if module_class == Msf::SymbolicModule || module_class.nil?
+    if module_class.nil?
       load_module_class(name)
     end
 
@@ -39,7 +33,7 @@ class Msf::ModuleSet < Hash
     klass = load_module_class(reference_name, cache_type: cache_type)
     instance = nil
     # If the klass is valid for this reference_name, try to create it
-    unless klass.nil? or klass == Msf::SymbolicModule
+    unless klass.nil?
       instance = klass.new
     end
 
@@ -180,7 +174,7 @@ class Msf::ModuleSet < Hash
     # don't want to trigger a create, so use fetch
     cached_module = self.fetch(reference_name, nil)
 
-    if (cached_module and cached_module != Msf::SymbolicModule)
+    if cached_module
       ambiguous_module_reference_name_set.add(reference_name)
 
       # TODO this isn't terribly helpful since the refnames will always match, that's why they are ambiguous.
@@ -287,7 +281,7 @@ class Msf::ModuleSet < Hash
     klass = fetch(reference_name, nil)
 
     # If there is no module associated with this class, then try to demand load it.
-    if klass.nil? || klass == Msf::SymbolicModule
+    if klass.nil?
       framework.modules.load_cached_module(module_type, reference_name, cache_type: cache_type)
       klass = fetch(reference_name, nil)
     end

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -119,8 +119,7 @@ class PayloadSet < ModuleSet
 
     # Blow away anything that was cached but didn't exist during the
     # recalculation
-    self.delete_if do |k, v|
-      next if v == SymbolicModule
+    self.delete_if do |k, _v|
       !!(old_keys.include?(k) and not new_keys.include?(k))
     end
 

--- a/spec/lib/msf/core/module_set_spec.rb
+++ b/spec/lib/msf/core/module_set_spec.rb
@@ -34,93 +34,7 @@ RSpec.describe Msf::ModuleSet do
       }
     end
 
-    context 'with Msf::SymbolicModule' do
-      before(:example) do
-        module_set['a'] = Msf::SymbolicModule
-        module_set['b'] = Msf::SymbolicModule
-        module_set['c'] = Msf::SymbolicModule
-      end
-
-      describe '#create' do
-        #
-        # lets
-        #
-
-        let(:b_class) do
-          Class.new
-        end
-
-        let(:c_class) do
-          Class.new
-        end
-
-        context 'returns nil' do
-          before(:example) do
-            allow(module_metadata_a).to receive(:rank).and_return(nil)
-            allow(module_metadata_b).to receive(:rank).and_return(Msf::AverageRanking)
-            allow(module_metadata_c).to receive(:rank).and_return(Msf::GoodRanking)
-            allow(Msf::Modules::Metadata::Cache.instance).to receive(:module_metadata).with(anything).and_return(module_metadata)
-          end
-
-          specify do
-            expect do
-              rank_modules
-            end.not_to raise_error
-          end
-
-          it 'is ranked as Normal' do
-            expect(rank_modules).to eq(
-              [
-                ['c', module_metadata_c],
-                ['a', module_metadata_a],
-                ['b', module_metadata_b]
-              ]
-            )
-          end
-        end
-
-        context 'does not return nil' do
-          #
-          # lets
-          #
-
-          let(:a_class) do
-            Class.new
-          end
-
-          #
-          # Callbacks
-          #
-
-          before(:example) do
-            allow(module_set).to receive(:create).with('a').and_return(a_class.new)
-            allow(module_set).to receive(:create).with('b').and_return(b_class.new)
-            allow(module_set).to receive(:create).with('c').and_return(c_class.new)
-          end
-
-          context 'with Rank' do
-            before(:example) do
-              allow(module_metadata_a).to receive(:rank).and_return(Msf::LowRanking)
-              allow(module_metadata_b).to receive(:rank).and_return(Msf::AverageRanking)
-              allow(module_metadata_c).to receive(:rank).and_return(Msf::GoodRanking)
-              allow(Msf::Modules::Metadata::Cache.instance).to receive(:module_metadata).with(anything).and_return(module_metadata)
-            end
-
-            it 'is ranked using Rank' do
-              expect(rank_modules).to eq(
-                [
-                  ['c', module_metadata_c],
-                  ['b', module_metadata_b],
-                  ['a', module_metadata_a]
-                ]
-              )
-            end
-          end
-        end
-      end
-    end
-
-    context 'without Msf::SymbolicModule' do
+    context 'with loaded modules' do
       #
       # lets
       #
@@ -229,7 +143,7 @@ RSpec.describe Msf::ModuleSet do
 
     context 'when the module set has symbolic modules' do
       before(:each) do
-        subject[module_refname] = Msf::SymbolicModule
+        subject[module_refname] = nil
       end
       it 'attempts to create the module' do
         subject[module_refname]

--- a/spec/support/shared/examples/msf/db_manager/update_all_module_details_refresh.rb
+++ b/spec/support/shared/examples/msf/db_manager/update_all_module_details_refresh.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples_for 'Msf::DBManager#update_all_module_details refresh' do
     end
 
     before(:example) do
-      module_set[module_detail.refname] = Msf::SymbolicModule
+      module_set[module_detail.refname] = nil
 
       framework.modules.send(:module_info_by_path)[module_detail.file] = {
           :parent_path => Metasploit::Framework.root.join('modules').to_path,

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -436,12 +436,12 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
         end
 
         context 'without reference_name' do
-          it 'should set reference_name value to Msf::SymbolicModule' do
+          it 'should set reference_name value to nil' do
             module_info_by_path_from_database!
 
             # have to use fetch because [] will trigger de-symbolization and
             # instantiation.
-            expect(typed_module_set.fetch(reference_name)).to eq Msf::SymbolicModule
+            expect(typed_module_set.fetch(reference_name)).to eq nil
           end
         end
       end


### PR DESCRIPTION
Resolves #18791

Fixes a bug introduced in #18704 that caused msfconsole to error when attempting to set a modules payload to some invalid payload (i.e. the encrypted payloads when not supported by the system)

The issue appeared when I refactored the module sets a little bit to not `create` a module when all we needed was the modules class to be loaded into the module set. Unfortunately I missed a side effect of the `create` function which deleted the modules entry into the module set if an instance wasn't able to be created.

Removing the references to `Msf::SymbolicModule` made the most sense to me here rather than adding in additional checks since `Msf::SymbolicModule` isn't used for anything useful and was intended to be temporary when it was originally added anyway. Now that we have the on demand loading it was just causing issues.

# Verification steps
- [ ] Boot up `msfconsole` and set `features set defer_module_loads false`, save and restart `msfconsole
- [ ] `use exploit/multi/handler` and then `set payload cmd/windows/http/x64/encrypted_shell_reverse_tcp`
- [ ] You get a stacktrace printed out to console (Note: this will only fail if your system doesn't meet the pre-requisites for encrypted payloads)
- [ ] Switch to this PR
- [ ] `use exploit/multi/handler` and then `set payload cmd/windows/http/x64/encrypted_shell_reverse_tcp` again
- [ ] expected output should be `[-] The value specified for payload is not valid.` with no stacktrace
