### PR TITLE
Improves unknown command handling

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -588,7 +588,15 @@ module DispatcherShell
   # If the command is unknown...
   #
   def unknown_command(method, line)
-    print_error("Unknown command: #{method}")
+    # Map each dispatchers commands to valid_commands
+    valid_commands = dispatcher_stack.flat_map { |dispatcher| dispatcher.commands.keys }
+
+    message = "Unknown command: #{method}."
+    suggestion = DidYouMean::SpellChecker.new(dictionary: valid_commands).correct(method).first
+    message << " Did you mean %grn#{suggestion}%clr?" if suggestion
+    message << ' Run the %grnhelp%clr command for more details.'
+
+    print_error(message)
   end
 
   #


### PR DESCRIPTION
This PR improves the handling of unknown commands within console. Additionally this works for Meterpreter and the new session types - MySQL/PostgreSQL/MSSQL/SMB.

Currently when users get a command wrong, they are given the following error:
```
Unknown command: reloa
```

We now tell users to use the `help` command, and also suggest a potentially close match if one exists.

Scenario when we have a suggestion:
```
Unknown command: reloa. Did you mean reload? Run the help command for more details.
```

Scenario when we do not have a suggestion:
```
Unknown command: foo. Run the help command for more details.
```

Example:
Console top level:
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/5f5f9657-1a87-4207-82d4-0ff5ed7bc8c7)

Meterpreter:
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/f1a44f00-5db9-4b53-9062-aca0731ff2e7)

SMB session type:
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/c8163d9f-ef8e-4286-be65-245ab11e4d6c)

## Verification

- [ ] Start `msfconsole`
- [ ] Run the `help` command.
- [ ] **Verify** that commands listed in the help command work with the new command handling
- [ ] **Verify** that the expected output is returned when there is a suggestion present as well as not
- [ ] **Verify** this also works within Meterpreter and the new session types. Use the help command to see what commands can be ran