### PR TITLE
DNS Changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,5 +53,3 @@ group :test do
   gem 'timecop'
 end
 
-# remove after https://github.com/rapid7/rex-socket/pull/65 is landed
-gem 'rex-socket', git: 'https://github.com/zeroSteiner/rex-socket', branch: 'feat/util-is-name'

--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ group :test do
   gem 'timecop'
 end
 
+# remove after https://github.com/rapid7/rex-socket/pull/65 is landed
+gem 'rex-socket', git: 'https://github.com/zeroSteiner/rex-socket', branch: 'feat/util-is-name'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/zeroSteiner/rex-socket
+  revision: 764718bf3dd397c0a5ecc41ee0874d826e9c9144
+  branch: feat/util-is-name
+  specs:
+    rex-socket (0.1.56)
+      rex-core
+
 PATH
   remote: .
   specs:
@@ -419,8 +427,6 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.55)
-      rex-core
     rex-sslscan (0.1.10)
       rex-core
       rex-socket
@@ -562,6 +568,7 @@ DEPENDENCIES
   pry-byebug
   rake
   redcarpet
+  rex-socket!
   rspec-rails
   rspec-rerun
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/zeroSteiner/rex-socket
-  revision: 764718bf3dd397c0a5ecc41ee0874d826e9c9144
-  branch: feat/util-is-name
-  specs:
-    rex-socket (0.1.56)
-      rex-core
-
 PATH
   remote: .
   specs:
@@ -427,6 +419,8 @@ GEM
       metasm
       rex-core
       rex-text
+    rex-socket (0.1.56)
+      rex-core
     rex-sslscan (0.1.10)
       rex-core
       rex-socket
@@ -568,7 +562,6 @@ DEPENDENCIES
   pry-byebug
   rake
   redcarpet
-  rex-socket!
   rspec-rails
   rspec-rerun
   rubocop

--- a/lib/msf/core/exploit/remote/dns/enumeration.rb
+++ b/lib/msf/core/exploit/remote/dns/enumeration.rb
@@ -183,7 +183,7 @@ module Enumeration
   end
 
   def dns_get_ptr(ip)
-    resp = dns_query(ip, nil)
+    resp = dns_query(ip, 'PTR')
     return if resp.blank? || resp.answer.blank?
 
     records = []
@@ -227,7 +227,7 @@ module Enumeration
     srv_record_types.each do |srv_record_type|
       srv_protos.each do |srv_proto|
         srv_record = "_#{srv_record_type}._#{srv_proto}.#{domain}"
-        resp = dns_query(srv_record, Net::DNS::SRV)
+        resp = dns_query(srv_record, 'SRV')
         next if resp.blank? || resp.answer.blank?
         srv_record_data = []
         resp.answer.each do |r|

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -532,9 +532,7 @@ class DNS
     if should_confirm
       print("Are you sure you want to reset the DNS configuration? [y/N]: ")
       response = gets.downcase.chomp
-      unless response.present? && 'yes'.start_with?(response)
-        return
-      end
+      return unless response =~ /^y/i
     end
 
     resolver.reinit

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -449,6 +449,10 @@ class DNS
       end
     end
 
+    if remove_ids.empty?
+      raise ::ArgumentError.new('At least one index to remove must be provided')
+    end
+
     removed = resolver.remove_ids(remove_ids)
     print_warning('Some entries were not removed') unless removed.length == remove_ids.length
     if removed.length > 0
@@ -465,7 +469,7 @@ class DNS
     print_line "  Delete the DNS resolution rule #3"
     print_line "    dns remove -i 3"
     print_line
-    print_line "  Delete multiple entries in one command"
+    print_line "  Delete multiple rules in one command"
     print_line "    dns remove -i 3 -i 4 -i 5"
     print_line
   end

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -247,7 +247,7 @@ class DNS
     difference = remove_ids.difference(removed.map { |entry| entry[:id] })
     print_warning("Some entries were not removed: #{difference.join(', ')}") unless difference.empty?
     if removed.length > 0
-      print_good("#{removed.length} DNS #{removed.length > 1 ? 'entries' : 'entry'} removed") 
+      print_good("#{removed.length} DNS #{removed.length > 1 ? 'entries' : 'entry'} removed")
       print_dns_set('Deleted entries', removed)
     end
   end
@@ -264,7 +264,26 @@ class DNS
   # Display the user-configured DNS settings
   #
   def print_dns
-    results = driver.framework.dns_resolver.nameserver_entries
+    default_domain = 'N/A'
+    if resolver.defname? && resolver.domain.present?
+      default_domain = resolver.domain
+    end
+    print_line("Default search domain: #{default_domain}")
+
+    searchlist = resolver.searchlist
+    case searchlist.length
+    when 0
+      print_line('Default search list:   N/A')
+    when 1
+      print_line("Default search list:   #{searchlist.first}")
+    else
+      print_line('Default search list:')
+      searchlist.each do |entry|
+        print_line("  * #{entry}")
+      end
+    end
+
+    results = resolver.nameserver_entries
     print_dns_set('Custom nameserver rules', results[0])
 
     # Default nameservers don't include a rule

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -76,7 +76,7 @@ class DNS
       if words.length > 2
         words[2..-1].each do |word|
           if tag_is_expected && !word.start_with?('-')
-            return # They're trying to specify a DNS server - we can't help them from here on out
+            return
           end
           tag_is_expected = !tag_is_expected
         end

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -338,11 +338,16 @@ class DNS
     end
 
     hostname = args.shift
-    if (ip_address = args.find { |a| !Rex::Socket.is_ip_addr?(a) })
+    if !Rex::Proto::DNS::StaticHostnames.is_valid_hostname?(hostname)
+      raise ::ArgumentError.new("Invalid hostname: #{hostname}")
+    end
+
+    ip_addresses = args
+    if (ip_address = ip_addresses.find { |a| !Rex::Socket.is_ip_addr?(a) })
       raise ::ArgumentError.new("Invalid IP address: #{ip_address}")
     end
 
-    args.each do |ip_address|
+    ip_addresses.each do |ip_address|
       resolver.static_hostnames.add(hostname, ip_address)
       print_status("Added static hostname mapping #{hostname} to #{ip_address}")
     end
@@ -482,8 +487,11 @@ class DNS
     end
 
     hostname = args.shift
-    ip_addresses = args
+    if !Rex::Proto::DNS::StaticHostnames.is_valid_hostname?(hostname)
+      raise ::ArgumentError.new("Invalid hostname: #{hostname}")
+    end
 
+    ip_addresses = args
     if ip_addresses.empty?
       ip_addresses = resolver.static_hostnames.get(hostname, Dnsruby::Types::A) + resolver.static_hostnames.get(hostname, Dnsruby::Types::AAAA)
       if ip_addresses.empty?

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -433,6 +433,7 @@ class DNS
         print_line("  * #{entry}")
       end
     end
+    print_line("Current cache size:    #{resolver.cache.records.length}")
 
     upstream_entries = resolver.upstream_entries
     print_dns_set('Resolver rule entries', upstream_entries)

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -191,9 +191,10 @@ class DNS
     args << 'print' if args.length == 0
     # Short-circuit help
     if args.delete("-h") || args.delete("--help")
-      if respond_to?("#{args.first.gsub('-', '_')}_dns_help")
+      subcommand = args.first
+      if subcommand && respond_to?("#{subcommand.gsub('-', '_')}_dns_help")
         # if it is a valid command with dedicated help information
-        send("#{args.first.gsub('-', '_')}_dns_help")
+        send("#{subcommand.gsub('-', '_')}_dns_help")
       else
         # otherwise print the top-level help information
         cmd_dns_help

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -381,7 +381,7 @@ class DNS
     print_dns_set(
       'Default nameservers',
       # name servers loaded from the system environment are appended to the end
-      results[1] + resolver.nameservers.map { |ns| { id: '[system]', dns_server: ns } }
+      results[1] + resolver.nameservers.map { |ns| { id: '', server: ns } }
     )
 
     if results[0].length + results[1].length + resolver.nameservers.length == 0
@@ -428,9 +428,9 @@ class DNS
         )
     result_set.each do |hash|
       if columns.size == 4
-        tbl << [hash[:id], hash[:wildcard_rules].join(','), hash[:dns_server], prettify_comm(hash[:comm], hash[:dns_server])]
+        tbl << [hash[:id], hash[:wildcard_rules].join(','), hash[:server], prettify_comm(hash[:comm], hash[:server])]
       else
-        tbl << [hash[:id], hash[:dns_server], prettify_comm(hash[:comm], hash[:dns_server])]
+        tbl << [hash[:id], hash[:server], prettify_comm(hash[:comm], hash[:server])]
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -287,10 +287,12 @@ class DNS
     comm_obj = nil
 
     unless comm.nil?
-      raise ::ArgumentError.new("Not a valid number: #{comm}") unless comm =~ /^\d+$/
-      comm_int = comm.to_i
-      raise ::ArgumentError.new("Session does not exist: #{comm}") unless driver.framework.sessions.include?(comm_int)
-      comm_obj = driver.framework.sessions[comm_int]
+      raise ::ArgumentError.new("Not a valid session: #{comm}") unless comm =~ /\A-?[0-9]+\Z/
+
+      comm_obj = driver.framework.sessions.get(comm.to_i)
+      raise ::ArgumentError.new("Session does not exist: #{comm}") unless comm_obj
+      raise ::ArgumentError.new("Socket Comm (Session #{comm}) does not implement Rex::Socket::Comm") unless comm_obj.is_a? ::Rex::Socket::Comm
+
       if resolvers.any? { |resolver| SPECIAL_RESOLVERS.include?(resolver.downcase) }
         print_warning("The session argument will be ignored for the system resolver")
       end

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -540,14 +540,14 @@ class DNS
 
     if add_system_resolver
       # if the user requested that we add the system resolver
-      system_resolver = Rex::Proto::DNS::UpstreamResolver.new_system
+      system_resolver = Rex::Proto::DNS::UpstreamResolver.create_system
       # first find the default, catch-all rule
       default_rule = resolver.upstream_rules.find { |ur| ur.matches_all? }
       if default_rule.nil?
         resolver.add_upstream_rule([ system_resolver ])
       else
         # if the first resolver is for static hostnames, insert after that one
-        if default_rule.resolvers.first&.type == Rex::Proto::DNS::UpstreamResolver::TYPE_STATIC
+        if default_rule.resolvers.first&.type == Rex::Proto::DNS::UpstreamResolver::Type::STATIC
           index = 1
         else
           index = 0
@@ -650,8 +650,8 @@ class DNS
   private
 
   SPECIAL_RESOLVERS = [
-    Rex::Proto::DNS::UpstreamResolver::TYPE_BLACK_HOLE.to_s.downcase,
-    Rex::Proto::DNS::UpstreamResolver::TYPE_SYSTEM.to_s.downcase
+    Rex::Proto::DNS::UpstreamResolver::Type::BLACK_HOLE.to_s.downcase,
+    Rex::Proto::DNS::UpstreamResolver::Type::SYSTEM.to_s.downcase
   ].freeze
 
   # XXX: By default rex-text tables strip preceding whitespace:

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -265,14 +265,18 @@ class DNS
   #
   def print_dns
     results = driver.framework.dns_resolver.nameserver_entries
-    columns = ['ID','Rule(s)', 'DNS Server', 'Comm channel']
     print_dns_set('Custom nameserver rules', results[0])
 
     # Default nameservers don't include a rule
-    columns = ['ID', 'DNS Server', 'Comm channel']
-    print_dns_set('Default nameservers', results[1])
+    print_dns_set(
+      'Default nameservers',
+      # name servers loaded from the system environment are appended to the end
+      results[1] + resolver.nameservers.map { |ns| { id: '[system]', dns_server: ns } }
+    )
 
-    print_line('No custom DNS nameserver entries configured') if results[0].length + results[1].length == 0
+    if results[0].length + results[1].length + resolver.nameservers.length == 0
+      print_error('No DNS nameserver entries configured')
+    end
   end
 
   private
@@ -299,7 +303,7 @@ class DNS
 
   def print_dns_set(heading, result_set)
     return if result_set.length == 0
-    if result_set[0][:wildcard_rules].any?
+    if result_set[0][:wildcard_rules]&.any?
       columns = ['ID', 'Rules(s)', 'DNS Server', 'Comm channel']
     else
       columns = ['ID', 'DNS Server', 'Commm channel']

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -85,6 +85,8 @@ class Driver < Msf::Ui::Driver
     if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS_FEATURE)
       dns_resolver = Rex::Proto::DNS::CachedResolver.new
       dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+      dns_resolver.purge
+      dns_resolver.static_hostnames.flush
       dns_resolver.load_config
 
       # Defer loading of modules until paths from opts can be added below

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -85,9 +85,7 @@ class Driver < Msf::Ui::Driver
     if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS_FEATURE)
       dns_resolver = Rex::Proto::DNS::CachedResolver.new
       dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-      dns_resolver.purge
-      dns_resolver.static_hostnames.flush
-      dns_resolver.load_config
+      dns_resolver.load_config if dns_resolver.has_config?
 
       # Defer loading of modules until paths from opts can be added below
       framework_create_options = framework_create_options.merge({ 'CustomDnsResolver' => dns_resolver })

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -253,7 +253,7 @@ module Net # :nodoc:
       #     #=> ["example.com","a.example.com","b.example.com"]
       #
       def searchlist
-        @config[:searchlist].inspect
+        @config[:searchlist].deep_dup
       end
 
       # Set the resolver searchlist.
@@ -350,7 +350,7 @@ module Net # :nodoc:
       # Return a string with the default domain
       #
       def domain
-        @config[:domain].inspect
+        @config[:domain].dup
       end
 
       # Set the domain for the query

--- a/lib/net/dns/resolver/timeouts.rb
+++ b/lib/net/dns/resolver/timeouts.rb
@@ -21,27 +21,31 @@ end
 class DnsTimeout # :nodoc: all
 
   include SecondsHandle
-  
+
   def initialize(seconds)
     if seconds.is_a? Numeric and seconds >= 0
       @timeout = seconds
     else
       raise DnsTimeoutArgumentError, "Invalid value for tcp timeout"
-    end    
+    end
   end
-  
+
+  def to_i
+    @timeout
+  end
+
   def to_s
-    if @timeout == 0 
+    if @timeout == 0
       @output
     else
       @timeout.to_s
     end
   end
-  
+
   def pretty_to_s
     transform(@timeout)
   end
-  
+
   def timeout
     unless block_given?
       raise DnsTimeoutArgumentError, "Block required but missing"

--- a/lib/rex/proto/dns/cache.rb
+++ b/lib/rex/proto/dns/cache.rb
@@ -57,25 +57,6 @@ module DNS
     end
 
     #
-    # Add static record to cache
-    #
-    # @param name [String] Name of record
-    # @param address [String] Address of record
-    # @param type [Dnsruby::Types] Record type to add
-    # @param replace [TrueClass, FalseClass] Replace existing records
-    def add_static(name, address, type = Dnsruby::Types::A, replace = false)
-      if Rex::Socket.is_ip_addr?(address.to_s) and
-      ( name.to_s.match(MATCH_HOSTNAME) or name == '*')
-        find(name, type).each do |found|
-          delete(found)
-        end if replace
-        add(Dnsruby::RR.create(name: name, type: type, address: address),0)
-      else
-        raise "Invalid parameters for static entry - #{name}, #{address}, #{type}"
-      end
-    end
-
-    #
     # Delete all cache entries, this is different from pruning because the
     # record's expiration is ignored
     #

--- a/lib/rex/proto/dns/cache.rb
+++ b/lib/rex/proto/dns/cache.rb
@@ -76,6 +76,14 @@ module DNS
     end
 
     #
+    # Delete all cache entries, this is different from pruning because the
+    # record's expiration is ignored
+    #
+    def flush
+      self.records.each {|rec, _| delete(rec)}
+    end
+
+    #
     # Prune cache entries
     #
     # @param before [Fixnum] Time in seconds before which records are evicted

--- a/lib/rex/proto/dns/cached_resolver.rb
+++ b/lib/rex/proto/dns/cached_resolver.rb
@@ -24,55 +24,6 @@ module DNS
       dns_cache_no_start = config.delete(:dns_cache_no_start)
       super(config)
       self.cache = Rex::Proto::DNS::Cache.new
-      # Read hostsfile into cache
-      hf = Rex::Compat.is_windows ? '%WINDIR%/system32/drivers/etc/hosts' : '/etc/hosts'
-      entries = begin
-        File.read(hf).lines.map(&:strip).select do |entry|
-          Rex::Socket.is_ip_addr?(entry.gsub(/\s+/,' ').split(' ').first) and
-          not entry.match(/::.*ip6-/) # Ignore Debian/Ubuntu-specific notation for IPv6 hosts
-        end.map do |entry|
-          entry.gsub(/\s+/,' ').split(' ')
-        end
-      rescue => e
-        @logger.error(e)
-        []
-      end
-      entries.each do |ent|
-        next if ent.first =~ /^127\./
-        # Deal with multiple hostnames per address
-        while ent.length > 2
-          hostname = ent.pop
-          next unless MATCH_HOSTNAME.match hostname
-          begin
-            if Rex::Socket.is_ipv4?(ent.first)
-              self.cache.add_static(hostname, ent.first, Dnsruby::Types::A)
-            elsif Rex::Socket.is_ipv6?(ent.first)
-              self.cache.add_static(hostname, ent.first, Dnsruby::Types::AAAA)
-            else
-              raise "Unknown IP address format #{ent.first} in hosts file!"
-            end
-          rescue => e
-            # Deal with edge-cases in users' hostsfile
-            @logger.error(e)
-          end
-        end
-        hostname = ent.pop
-        begin
-          if MATCH_HOSTNAME.match hostname
-            if Rex::Socket.is_ipv4?(ent.first)
-              self.cache.add_static(hostname, ent.first, Dnsruby::Types::A)
-            elsif Rex::Socket.is_ipv6?(ent.first)
-              self.cache.add_static(hostname, ent.first, Dnsruby::Types::AAAA)
-            else
-              raise "Unknown IP address format #{ent.first} in hosts file!"
-            end
-          end
-        rescue => e
-          # Deal with edge-cases in users' hostsfile
-          @logger.error(e)
-        end
-      end
-      # TODO: inotify or similar on hostsfile for live updates? Easy-button functionality
       self.cache.start unless dns_cache_no_start
       return
     end

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -50,6 +50,7 @@ module DNS
       nil
     end
 
+    # Reinitialize the configuration to its original state.
     def reinit
       parse_config_file
       parse_environment_variables
@@ -64,6 +65,7 @@ module DNS
       nil
     end
 
+    # Check whether or not there is configuration data in Metasploit's configuration file which is persisted on disk.
     def has_config?
       Msf::Config.load.keys.any? { |group| group == CONFIG_KEY_BASE || group.starts_with?("#{CONFIG_KEY_BASE}/") }
     end

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -11,7 +11,7 @@ module DNS
 
     #
     # A Comm implementation that always reports as dead, so should never
-    # be used. This is used to prevent DNS leaks of saved DNS rules that 
+    # be used. This is used to prevent DNS leaks of saved DNS rules that
     # were attached to a specific channel.
     ##
     class CommSink
@@ -222,7 +222,6 @@ module DNS
     def valid_rule?(rule)
       rule =~ /^(\*\.)?([a-z\d][a-z\d-]*[a-z\d]\.)+[a-z]+$/
     end
-
 
     def matches(domain, pattern)
       if pattern.start_with?('*.')

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -199,9 +199,8 @@ module DNS
 
       static_hostnames.flush
       config.fetch("#{CONFIG_KEY_BASE}/static_hostnames", {}).each do |_name, value|
-        values = value.split(';')
-        hostname = values.shift
-        values.each do |ip_address|
+        hostname, ip_addresses = value.split(';', 2)
+        ip_addresses.split(',').each do |ip_address|
           next if ip_address.blank?
 
           unless Rex::Socket.is_ip_addr?(ip_address)
@@ -233,8 +232,7 @@ module DNS
       static_hostnames.each_with_index do |(hostname, addresses), index|
         val = [
           hostname,
-          addresses[Dnsruby::Types::A],
-          addresses[Dnsruby::Types::AAAA]
+          (addresses.fetch(Dnsruby::Types::A, []) + addresses.fetch(Dnsruby::Types::AAAA, [])).join(',')
         ].join(';')
         new_config["##{index}"] = val
       end

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -139,7 +139,8 @@ module DNS
     def remove_ids(ids)
       removed = []
       ids.sort.reverse.each do |id|
-        removed << @upstream_rules.delete_at(id)
+        upstream_rule = @upstream_rules.delete_at(id)
+        removed << upstream_rule if upstream_rule
       end
 
       removed.reverse

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -36,10 +36,10 @@ module DNS
     def init
       @upstream_rules = []
 
-      resolvers = [UpstreamResolver.new_static]
+      resolvers = [UpstreamResolver.create_static]
       if @config[:nameservers].empty?
         # if no nameservers are specified, fallback to the system
-        resolvers << UpstreamResolver.new_system
+        resolvers << UpstreamResolver.create_system
       else
         # migrate the originally configured name servers
         resolvers += @config[:nameservers].map(&:to_s)
@@ -248,7 +248,7 @@ module DNS
         val = [
           entry.wildcard,
           entry.resolvers.map do |resolver|
-            resolver.type == Rex::Proto::DNS::UpstreamResolver::TYPE_DNS_SERVER ? resolver.destination : resolver.type.to_s
+            resolver.type == Rex::Proto::DNS::UpstreamResolver::Type::DNS_SERVER ? resolver.destination : resolver.type.to_s
           end.join(','),
           (!entry.comm.nil?).to_s
         ].join(';')

--- a/lib/rex/proto/dns/exceptions.rb
+++ b/lib/rex/proto/dns/exceptions.rb
@@ -1,0 +1,14 @@
+# -*- coding: binary -*-
+
+module Rex
+module Proto
+module DNS
+module Exceptions
+
+  class ConfigError < Rex::RuntimeError
+  end
+
+end
+end
+end
+end

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -18,7 +18,7 @@ module DNS
       :log_file => File::NULL, # formerly $stdout, should be tied in with our loggers
       :port => 53,
       :searchlist => [],
-      :nameservers => [IPAddr.new("127.0.0.1")],
+      :nameservers => [],
       :domain => "",
       :source_port => 0,
       :source_address => IPAddr.new("0.0.0.0"),

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -14,7 +14,7 @@ module DNS
   class Resolver < Net::DNS::Resolver
 
     Defaults = {
-      :config_file => "/etc/resolv.conf",
+      :config_file => nil,
       :log_file => File::NULL, # formerly $stdout, should be tied in with our loggers
       :port => 53,
       :searchlist => [],
@@ -40,11 +40,12 @@ module DNS
     #
     # Provide override for initializer to use local Defaults constant
     #
-    # @param config [Hash] Configuration options as conusumed by parent class
+    # @param config [Hash] Configuration options as consumed by parent class
     def initialize(config = {})
       raise ResolverArgumentError, "Argument has to be Hash" unless config.kind_of? Hash
       # config.key_downcase!
       @config = Defaults.merge config
+      @config[:config_file] ||= self.class.default_config_file
       @raw = false
       # New logger facility
       @logger = Logger.new(@config[:log_file])
@@ -398,6 +399,15 @@ module DNS
 
       return send(name,type,cls)
 
+    end
+
+    def self.default_config_file
+      %w[
+        /etc/resolv.conf
+        /data/data/com.termux/files/usr/etc/resolv.conf
+      ].find do |path|
+        File.file?(path) && File.readable?(path)
+      end
     end
 
     private

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -124,7 +124,9 @@ module DNS
 
     def upstream_resolvers_for_query(name, type = Dnsruby::Types::A, cls = Dnsruby::Classes::IN)
       name, type, cls = preprocess_query_arguments(name, type, cls)
-      packet = make_query_packet(name, type, cls)
+      net_packet = make_query_packet(name, type, cls)
+      # This returns a Net::DNS::Packet. Convert to Dnsruby::Message for consistency
+      packet = Rex::Proto::DNS::Packet.encode_drb(net_packet)
       upstream_resolvers_for_packet(packet)
     end
 

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -120,7 +120,7 @@ module DNS
     #
     def upstream_resolvers_for_packet(_dns_message)
       @config[:nameservers].map do |ns|
-        UpstreamResolver.new(UpstreamResolver::TYPE_DNS_SERVER, destination: ns.to_s)
+        UpstreamResolver.new_dns_server(ns.to_s)
       end
     end
 

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -441,6 +441,12 @@ module DNS
       ans
     end
 
+    def send_blackhole(upstream_resolver, packet, type, cls)
+      # do not just return nil because that will cause the next resolver to be used
+      @logger.info "No response from upstream resolvers: blackholed"
+      raise NoResponseError
+    end
+
     def send_system(upstream_resolver, packet, type, cls)
       # This system resolver will use host operating systems `getaddrinfo` (or equivalent function) to perform name
       # resolution. This is primarily useful if that functionality is hooked or modified by an external application such

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -30,8 +30,8 @@ module DNS
       :use_tcp => false,
       :ignore_truncated => false,
       :packet_size => 512,
-      :tcp_timeout => 30,
-      :udp_timeout => 30,
+      :tcp_timeout => TcpTimeout.new(5),
+      :udp_timeout => UdpTimeout.new(5),
       :context => {},
       :comm => nil
     }

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -458,8 +458,7 @@ module DNS
 
    def send_static(upstream_resolver, packet, type, cls)
       simple_name_lookup(upstream_resolver, packet, type, cls) do |name, _family|
-        ip_address = static_hostnames.get(name, type)
-        ip_address ? [ip_address] : nil
+        static_hostnames.get(name, type)
       end
    end
 

--- a/lib/rex/proto/dns/static_hostnames.rb
+++ b/lib/rex/proto/dns/static_hostnames.rb
@@ -78,7 +78,7 @@ module DNS
     # @param [IPAddr, String] ip_address The IP address that is being defined for the hostname. If this value is a
     #   string, it will be converted to an IPAddr instance.
     def add(hostname, ip_address)
-      ip_address = IPAddr.new(ip_address) if Rex::Socket.is_ip_addr?(ip_address)
+      ip_address = IPAddr.new(ip_address) if ip_address.is_a?(String) && Rex::Socket.is_ip_addr?(ip_address)
 
       hostname = hostname.downcase
       this_host = @hostnames.fetch(hostname, {})
@@ -100,7 +100,7 @@ module DNS
     # @param [IPAddr, String] ip_address The IP address that is being undefined. If this value is a string, it will be
     #   converted to an IPAddr instance.
     def delete(hostname, ip_address)
-      ip_address = IPAddr.new(ip_address) if Rex::Socket.is_ip_addr?(ip_address)
+      ip_address = IPAddr.new(ip_address) if ip_address.is_a?(String) && Rex::Socket.is_ip_addr?(ip_address)
       if ip_address.family == ::Socket::AF_INET
         type = Dnsruby::Types::A
       else

--- a/lib/rex/proto/dns/static_hostnames.rb
+++ b/lib/rex/proto/dns/static_hostnames.rb
@@ -21,9 +21,17 @@ module DNS
     end
 
     def parse_hosts_file
-      path = '/etc/hosts'
-      return unless File.file?(path) && File.readable?(path)
+      path = %w[
+        %WINDIR%\system32\drivers\etc\hosts
+        /etc/hosts
+        /data/data/com.termux/files/usr/etc/hosts
+      ].find do |path|
+        path = File.expand_path(path)
+        File.file?(path) && File.readable?(path)
+      end
+      return unless path
 
+      path = File.expand_path(path)
       hostnames = {}
       ::IO.foreach(path) do |line|
         words = line.split

--- a/lib/rex/proto/dns/static_hostnames.rb
+++ b/lib/rex/proto/dns/static_hostnames.rb
@@ -1,0 +1,88 @@
+# -*- coding: binary -*-
+
+require 'rex/socket'
+require 'forwardable'
+
+module Rex
+module Proto
+module DNS
+  class StaticHostnames
+    extend Forwardable
+
+    def_delegators :@hostnames, :each, :length, :empty?
+
+    def initialize(hostnames: nil)
+      @hostnames = {}
+      if hostnames
+        hostnames.each do |hostname, ip_address|
+          add(hostname, ip_address)
+        end
+      end
+    end
+
+    def parse_hosts_file
+      path = '/etc/hosts'
+      return unless File.file?(path) && File.readable?(path)
+
+      hostnames = {}
+      ::IO.foreach(path) do |line|
+        words = line.split
+        next unless words.length > 1 && Rex::Socket.is_ip_addr?(words.first)
+
+        ip_address = IPAddr.new(words.shift)
+        words.each do |hostname|
+          hostname = hostname.downcase
+          this_host = hostnames.fetch(hostname, {})
+          if ip_address.family == ::Socket::AF_INET
+            type = Dnsruby::Types::A
+          else
+            type = Dnsruby::Types::AAAA
+          end
+          next if this_host.key?(type) # only honor the first definition
+
+          this_host[type] = ip_address
+          hostnames[hostname] = this_host
+        end
+      end
+      @hostnames.merge!(hostnames)
+    end
+
+    def get(hostname, type = Dnsruby::Types::A)
+      hostname = hostname.downcase
+      @hostnames.fetch(hostname, {}).fetch(type, nil)
+    end
+
+    def add(hostname, ip_address)
+      hostname = hostname.downcase
+      ip_address = IPAddr.new(ip_address) if Rex::Socket.is_ip_addr?(ip_address)
+
+      addresses = @hostnames.fetch(hostname, {})
+      if ip_address.family == ::Socket::AF_INET
+        addresses[Dnsruby::Types::A] = ip_address
+      elsif ip_address.family == ::Socket::AF_INET6
+        addresses[Dnsruby::Types::AAAA] = ip_address
+      end
+      @hostnames[hostname] = addresses
+      nil
+    end
+
+    def delete(hostname, type = Dnsruby::Types::A)
+      hostname = hostname.downcase
+      addresses = @hostnames.fetch(hostname, {})
+      addresses.delete(type)
+      if addresses.length == 0
+        @hostnames.delete(hostname)
+      else
+        @hostnames[hostname] = addresses
+      end
+
+      nil
+    end
+
+    def flush
+      @hostnames.clear
+    end
+  end
+end
+end
+end

--- a/lib/rex/proto/dns/static_hostnames.rb
+++ b/lib/rex/proto/dns/static_hostnames.rb
@@ -9,7 +9,7 @@ module DNS
   class StaticHostnames
     extend Forwardable
 
-    def_delegators :@hostnames, :each, :length, :empty?
+    def_delegators :@hostnames, :each, :each_with_index, :length, :empty?
 
     def initialize(hostnames: nil)
       @hostnames = {}

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+
+require 'rex/socket'
+
+module Rex
+module Proto
+module DNS
+  class UpstreamResolver
+    TYPE_SYSTEM = :system
+    TYPE_DNS_SERVER = :dns_server
+
+    attr_reader :type, :destination, :socket_options
+    def initialize(type, destination: nil, socket_options: {})
+      @type = type
+      @destination = destination
+      @socket_options = socket_options
+    end
+  end
+end
+end
+end

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -3,6 +3,9 @@
 module Rex
 module Proto
 module DNS
+  ##
+  # This represents a single upstream DNS resolver target of one of the predefined types.
+  ##
   class UpstreamResolver
     TYPE_BLACK_HOLE = %s[black-hole]
     TYPE_DNS_SERVER = %s[dns-server]
@@ -10,16 +13,26 @@ module DNS
     TYPE_SYSTEM = :system
 
     attr_reader :type, :destination, :socket_options
+
+    # @param [Symbol] type The resolver type.
+    # @param [String] destination An optional destination, as used by some resolver types.
+    # @param [Hash] socket_options Options to use for sockets when connecting to the destination, as used by some
+    #   resolver types.
     def initialize(type, destination: nil, socket_options: {})
       @type = type
       @destination = destination
       @socket_options = socket_options
     end
 
+    # Initialize a new black-hole resolver.
     def self.new_black_hole
       self.new(TYPE_BLACK_HOLE)
     end
 
+    # Initialize a new dns-server resolver.
+    #
+    # @param [String] destination The IP address of the upstream DNS server.
+    # @param [Hash] socket_options Options to use when connecting to the upstream DNS server.
     def self.new_dns_server(destination, socket_options: {})
       self.new(
         TYPE_DNS_SERVER,
@@ -28,10 +41,12 @@ module DNS
       )
     end
 
+    # Initialize a new static resolver.
     def self.new_static
       self.new(TYPE_STATIC)
     end
 
+    # Initialize a new system resolver.
     def self.new_system
       self.new(TYPE_SYSTEM)
     end

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -8,6 +8,7 @@ module DNS
   class UpstreamResolver
     TYPE_SYSTEM = :system
     TYPE_DNS_SERVER = :dns_server
+    TYPE_BLACKHOLE = :blackhole
 
     attr_reader :type, :destination, :socket_options
     def initialize(type, destination: nil, socket_options: {})

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'rex/socket'
-
 module Rex
 module Proto
 module DNS
@@ -15,6 +13,17 @@ module DNS
       @type = type
       @destination = destination
       @socket_options = socket_options
+    end
+
+    def to_s
+      case type
+      when TYPE_BLACKHOLE
+        'blackhole'
+      when TYPE_SYSTEM
+        'system'
+      else
+        destination.to_s
+      end
     end
   end
 end

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -4,9 +4,10 @@ module Rex
 module Proto
 module DNS
   class UpstreamResolver
+    TYPE_BLACK_HOLE = %s[black-hole]
+    TYPE_DNS_SERVER = %s[dns-server]
+    TYPE_STATIC = :static
     TYPE_SYSTEM = :system
-    TYPE_DNS_SERVER = :dns_server
-    TYPE_BLACKHOLE = :blackhole
 
     attr_reader :type, :destination, :socket_options
     def initialize(type, destination: nil, socket_options: {})
@@ -16,13 +17,10 @@ module DNS
     end
 
     def to_s
-      case type
-      when TYPE_BLACKHOLE
-        'blackhole'
-      when TYPE_SYSTEM
-        'system'
-      else
+      if type == TYPE_DNS_SERVER
         destination.to_s
+      else
+        type.to_s
       end
     end
 

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -7,10 +7,12 @@ module DNS
   # This represents a single upstream DNS resolver target of one of the predefined types.
   ##
   class UpstreamResolver
-    TYPE_BLACK_HOLE = %s[black-hole]
-    TYPE_DNS_SERVER = %s[dns-server]
-    TYPE_STATIC = :static
-    TYPE_SYSTEM = :system
+    module Type
+      BLACK_HOLE = :"black-hole"
+      DNS_SERVER = :"dns-server"
+      STATIC = :static
+      SYSTEM = :system
+    end
 
     attr_reader :type, :destination, :socket_options
 
@@ -25,34 +27,34 @@ module DNS
     end
 
     # Initialize a new black-hole resolver.
-    def self.new_black_hole
-      self.new(TYPE_BLACK_HOLE)
+    def self.create_black_hole
+      self.new(Type::BLACK_HOLE)
     end
 
     # Initialize a new dns-server resolver.
     #
     # @param [String] destination The IP address of the upstream DNS server.
     # @param [Hash] socket_options Options to use when connecting to the upstream DNS server.
-    def self.new_dns_server(destination, socket_options: {})
+    def self.create_dns_server(destination, socket_options: {})
       self.new(
-        TYPE_DNS_SERVER,
+        Type::DNS_SERVER,
         destination: destination,
         socket_options: socket_options
       )
     end
 
     # Initialize a new static resolver.
-    def self.new_static
-      self.new(TYPE_STATIC)
+    def self.create_static
+      self.new(Type::STATIC)
     end
 
     # Initialize a new system resolver.
-    def self.new_system
-      self.new(TYPE_SYSTEM)
+    def self.create_system
+      self.new(Type::SYSTEM)
     end
 
     def to_s
-      if type == TYPE_DNS_SERVER
+      if type == Type::DNS_SERVER
         destination.to_s
       else
         type.to_s

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -16,6 +16,26 @@ module DNS
       @socket_options = socket_options
     end
 
+    def self.new_black_hole
+      self.new(TYPE_BLACK_HOLE)
+    end
+
+    def self.new_dns_server(destination, socket_options: {})
+      self.new(
+        TYPE_DNS_SERVER,
+        destination: destination,
+        socket_options: socket_options
+      )
+    end
+
+    def self.new_static
+      self.new(TYPE_STATIC)
+    end
+
+    def self.new_system
+      self.new(TYPE_SYSTEM)
+    end
+
     def to_s
       if type == TYPE_DNS_SERVER
         destination.to_s

--- a/lib/rex/proto/dns/upstream_resolver.rb
+++ b/lib/rex/proto/dns/upstream_resolver.rb
@@ -25,6 +25,16 @@ module DNS
         destination.to_s
       end
     end
+
+   def eql?(other)
+      return false unless other.is_a?(self.class)
+      return false unless other.type == type
+      return false unless other.destination == destination
+      return false unless other.socket_options == socket_options
+      true
+    end
+
+    alias == eql?
   end
 end
 end

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -23,18 +23,14 @@ module DNS
         when UpstreamResolver
           resolver
         when UpstreamResolver::TYPE_BLACK_HOLE
-          UpstreamResolver.new(UpstreamResolver::TYPE_BLACK_HOLE)
+          UpstreamResolver.new_black_hole
         when UpstreamResolver::TYPE_STATIC
-          UpstreamResolver.new(UpstreamResolver::TYPE_STATIC)
+          UpstreamResolver.new_static
         when UpstreamResolver::TYPE_SYSTEM
-          UpstreamResolver.new(UpstreamResolver::TYPE_SYSTEM)
+          UpstreamResolver.new_system
         else
           if Rex::Socket.is_ip_addr?(resolver)
-            UpstreamResolver.new(
-              UpstreamResolver::TYPE_DNS_SERVER,
-              destination: resolver,
-              socket_options: socket_options
-            )
+            UpstreamResolver.new_dns_server(resolver, socket_options: socket_options)
           else
             raise ::ArgumentError.new("Invalid upstream DNS resolver: #{resolver}")
           end

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -1,0 +1,71 @@
+# -*- coding: binary -*-
+
+require 'json'
+require 'rex/socket'
+
+module Rex
+module Proto
+module DNS
+  class UpstreamRule
+
+    attr_reader :id, :wildcard, :resolvers, :comm
+    def initialize(id: nil, wildcard: '*', resolvers: [], comm: nil)
+      @id = id
+      ::ArgumentError.new("Invalid wildcard text: #{wildcard}") unless self.class.valid_wildcard?(wildcard)
+      @wildcard = wildcard
+      socket_options = {}
+      socket_options['Comm'] = comm unless comm.nil?
+      @resolvers = resolvers.map do |resolver|
+        if resolver.is_a?(String) && !Rex::Socket.is_ip_addr?(resolver)
+          resolver = resolver.downcase.to_sym
+        end
+
+        case resolver
+        when UpstreamResolver
+          resolver
+        when UpstreamResolver::TYPE_BLACKHOLE
+          UpstreamResolver.new(UpstreamResolver::TYPE_BLACKHOLE)
+        when UpstreamResolver::TYPE_SYSTEM
+          UpstreamResolver.new(UpstreamResolver::TYPE_SYSTEM)
+        else
+          if Rex::Socket.is_ip_addr?(resolver)
+            UpstreamResolver.new(
+              UpstreamResolver::TYPE_DNS_SERVER,
+              destination: resolver,
+              socket_options: socket_options
+            )
+          else
+            raise ::ArgumentError.new("Invalid upstream DNS resolver: #{resolver}")
+          end
+        end
+      end
+      @comm = comm
+    end
+
+    def self.valid_resolver?(resolver)
+      return true if Rex::Socket.is_ip_addr?(resolver)
+
+      resolver = resolver.downcase.to_sym
+      [
+        UpstreamResolver::TYPE_BLACKHOLE,
+        UpstreamResolver::TYPE_SYSTEM
+      ].include?(resolver)
+    end
+
+    def self.valid_wildcard?(wildcard)
+      wildcard == '*' || wildcard =~ /^(\*\.)?([a-z\d][a-z\d-]*[a-z\d]\.)+[a-z]+$/
+    end
+
+    def matches_name?(name)
+      if wildcard == '*'
+        true
+      elsif wildcard.start_with?('*.')
+        name.downcase.end_with?(wildcard[1..-1].downcase)
+      else
+        name.casecmp?(wildcard)
+      end
+    end
+  end
+end
+end
+end

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -29,15 +29,15 @@ module DNS
         case resolver
         when UpstreamResolver
           resolver
-        when UpstreamResolver::TYPE_BLACK_HOLE
-          UpstreamResolver.new_black_hole
-        when UpstreamResolver::TYPE_STATIC
-          UpstreamResolver.new_static
-        when UpstreamResolver::TYPE_SYSTEM
-          UpstreamResolver.new_system
+        when UpstreamResolver::Type::BLACK_HOLE
+          UpstreamResolver.create_black_hole
+        when UpstreamResolver::Type::STATIC
+          UpstreamResolver.create_static
+        when UpstreamResolver::Type::SYSTEM
+          UpstreamResolver.create_system
         else
           if Rex::Socket.is_ip_addr?(resolver)
-            UpstreamResolver.new_dns_server(resolver, socket_options: socket_options)
+            UpstreamResolver.create_dns_server(resolver, socket_options: socket_options)
           else
             raise ::ArgumentError.new("Invalid upstream DNS resolver: #{resolver}")
           end
@@ -55,9 +55,9 @@ module DNS
 
       resolver = resolver.downcase.to_sym
       [
-        UpstreamResolver::TYPE_BLACK_HOLE,
-        UpstreamResolver::TYPE_STATIC,
-        UpstreamResolver::TYPE_SYSTEM
+        UpstreamResolver::Type::BLACK_HOLE,
+        UpstreamResolver::Type::STATIC,
+        UpstreamResolver::Type::SYSTEM
       ].include?(resolver)
     end
 

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -22,8 +22,10 @@ module DNS
         case resolver
         when UpstreamResolver
           resolver
-        when UpstreamResolver::TYPE_BLACKHOLE
-          UpstreamResolver.new(UpstreamResolver::TYPE_BLACKHOLE)
+        when UpstreamResolver::TYPE_BLACK_HOLE
+          UpstreamResolver.new(UpstreamResolver::TYPE_BLACK_HOLE)
+        when UpstreamResolver::TYPE_STATIC
+          UpstreamResolver.new(UpstreamResolver::TYPE_STATIC)
         when UpstreamResolver::TYPE_SYSTEM
           UpstreamResolver.new(UpstreamResolver::TYPE_SYSTEM)
         else
@@ -46,7 +48,8 @@ module DNS
 
       resolver = resolver.downcase.to_sym
       [
-        UpstreamResolver::TYPE_BLACKHOLE,
+        UpstreamResolver::TYPE_BLACK_HOLE,
+        UpstreamResolver::TYPE_STATIC,
         UpstreamResolver::TYPE_SYSTEM
       ].include?(resolver)
     end

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -6,9 +6,16 @@ require 'rex/socket'
 module Rex
 module Proto
 module DNS
+  ##
+  # This represents a configuration rule for how names should be resolved. It matches a single wildcard which acts as a
+  # matching condition and maps it to 0 or more resolvers to use for lookups.
+  ##
   class UpstreamRule
 
     attr_reader :wildcard, :resolvers, :comm
+    # @param [String] wildcard The wildcard pattern to use for conditionally matching hostnames.
+    # @param [Array] resolvers The resolvers to use when this rule is applied.
+    # @param [Msf::Session::Comm] comm The communication channel to use when creating network connections.
     def initialize(wildcard: '*', resolvers: [], comm: nil)
       ::ArgumentError.new("Invalid wildcard text: #{wildcard}") unless self.class.valid_wildcard?(wildcard)
       @wildcard = wildcard
@@ -39,6 +46,10 @@ module DNS
       @comm = comm
     end
 
+    # Check whether or not the defined resolver is valid.
+    #
+    # @param [String] resolver The resolver string to check.
+    # @rtype Boolean
     def self.valid_resolver?(resolver)
       return true if Rex::Socket.is_ip_addr?(resolver)
 
@@ -50,14 +61,24 @@ module DNS
       ].include?(resolver)
     end
 
+    # Check whether or not the defined wildcard is a valid pattern.
+    #
+    # @param [String] wildcard The wildcard text to check.
+    # @rtype Boolean
     def self.valid_wildcard?(wildcard)
       wildcard == '*' || wildcard =~ /^(\*\.)?([a-z\d][a-z\d-]*[a-z\d]\.)+[a-z]+$/
     end
 
+    # Check whether or not the currently configured wildcard pattern will match all names.
+    #
+    # @rtype Boolean
     def matches_all?
       wildcard == '*'
     end
 
+    # Check whether or not the specified name matches the currently configured wildcard pattern.
+    #
+    # @rtype Boolean
     def matches_name?(name)
       if matches_all?
         true

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -54,8 +54,12 @@ module DNS
       wildcard == '*' || wildcard =~ /^(\*\.)?([a-z\d][a-z\d-]*[a-z\d]\.)+[a-z]+$/
     end
 
+    def matches_all?
+      wildcard == '*'
+    end
+
     def matches_name?(name)
-      if wildcard == '*'
+      if matches_all?
         true
       elsif wildcard.start_with?('*.')
         name.downcase.end_with?(wildcard[1..-1].downcase)

--- a/lib/rex/proto/dns/upstream_rule.rb
+++ b/lib/rex/proto/dns/upstream_rule.rb
@@ -8,9 +8,8 @@ module Proto
 module DNS
   class UpstreamRule
 
-    attr_reader :id, :wildcard, :resolvers, :comm
-    def initialize(id: nil, wildcard: '*', resolvers: [], comm: nil)
-      @id = id
+    attr_reader :wildcard, :resolvers, :comm
+    def initialize(wildcard: '*', resolvers: [], comm: nil)
       ::ArgumentError.new("Invalid wildcard text: #{wildcard}") unless self.class.valid_wildcard?(wildcard)
       @wildcard = wildcard
       socket_options = {}
@@ -65,6 +64,16 @@ module DNS
         name.casecmp?(wildcard)
       end
     end
+
+    def eql?(other)
+      return false unless other.is_a?(self.class)
+      return false unless other.wildcard == wildcard
+      return false unless other.resolvers == resolvers
+      return false unless other.comm == comm
+      true
+    end
+
+    alias == eql?
   end
 end
 end

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
       packet = packet_for('subdomain.metasploit.com')
       ns = dns_resolver.upstream_resolvers_for_packet(packet)
       expect(ns).to eq([
-        Rex::Proto::DNS::UpstreamResolver.new_dns_server(metasploit_nameserver)
+        Rex::Proto::DNS::UpstreamResolver.create_dns_server(metasploit_nameserver)
       ])
     end
   end
@@ -59,8 +59,8 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
       packet = packet_for('subdomain.test.lan')
       ns = dns_resolver.upstream_resolvers_for_packet(packet)
       expect(ns).to eq([
-        Rex::Proto::DNS::UpstreamResolver.new_static,
-        Rex::Proto::DNS::UpstreamResolver.new_dns_server(default_nameserver)
+        Rex::Proto::DNS::UpstreamResolver.create_static,
+        Rex::Proto::DNS::UpstreamResolver.create_dns_server(default_nameserver)
       ])
     end
   end

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
 
   subject(:dns_resolver) do
     dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
-    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
     dns_resolver.nameservers = [default_nameserver]
-    dns_resolver.add_upstream_entry([metasploit_nameserver], wildcard: '*.metasploit.com')
+    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
+    dns_resolver.add_upstream_entry([metasploit_nameserver], wildcard: '*.metasploit.com', position: 0)
     dns_resolver.set_framework(framework_with_dns_enabled)
     dns_resolver
   end
@@ -48,7 +48,9 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     it 'The correct resolver is returned' do
       packet = packet_for('subdomain.metasploit.com')
       ns = dns_resolver.upstream_resolvers_for_packet(packet)
-      expect(ns).to eq([Rex::Proto::DNS::UpstreamResolver.new_dns_server(metasploit_nameserver)])
+      expect(ns).to eq([
+        Rex::Proto::DNS::UpstreamResolver.new_dns_server(metasploit_nameserver)
+      ])
     end
   end
 
@@ -56,7 +58,10 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     it 'The default resolver is returned' do
       packet = packet_for('subdomain.test.lan')
       ns = dns_resolver.upstream_resolvers_for_packet(packet)
-      expect(ns).to eq([Rex::Proto::DNS::UpstreamResolver.new_dns_server(default_nameserver)])
+      expect(ns).to eq([
+        Rex::Proto::DNS::UpstreamResolver.new_static,
+        Rex::Proto::DNS::UpstreamResolver.new_dns_server(default_nameserver)
+      ])
     end
   end
 end

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -9,24 +9,12 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     Rex::Proto::DNS::Packet.encode_drb(packet)
   end
 
-  let(:base_nameserver) do
-    '1.2.3.4'
+  let(:default_nameserver) do
+    '192.0.2.10'
   end
 
-  let(:ruleless_nameserver) do
-    '1.2.3.5'
-  end
-
-  let(:ruled_nameserver) do
-    '1.2.3.6'
-  end
-
-  let(:ruled_nameserver2) do
-    '1.2.3.7'
-  end
-
-  let(:ruled_nameserver3) do
-    '1.2.3.8'
+  let(:metasploit_nameserver) do
+    '192.0.2.20'
   end
 
   let (:config) do
@@ -47,96 +35,28 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     framework
   end
 
-  subject(:many_ruled_provider) do
+  subject(:dns_resolver) do
     dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
     dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    dns_resolver.nameservers = [base_nameserver]
-    dns_resolver.add_nameserver([], ruleless_nameserver, nil)
-    dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver, nil)
-    dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver2, nil)
-    dns_resolver.add_nameserver(['*.notmetasploit.com'], ruled_nameserver3, nil)
+    dns_resolver.nameservers = [default_nameserver]
+    dns_resolver.add_upstream_entry([metasploit_nameserver], wildcard: '*.metasploit.com')
     dns_resolver.set_framework(framework_with_dns_enabled)
-
     dns_resolver
   end
 
-  subject(:ruled_provider) do
-    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
-    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    dns_resolver.nameservers = [base_nameserver]
-    dns_resolver.add_nameserver([], ruleless_nameserver, nil)
-    dns_resolver.add_nameserver(['*.metasploit.com'], ruled_nameserver, nil)
-    dns_resolver.set_framework(framework_with_dns_enabled)
-
-    dns_resolver
-  end
-
-  subject(:ruleless_provider) do
-    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
-    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    dns_resolver.nameservers = [base_nameserver]
-    dns_resolver.add_nameserver([], ruleless_nameserver, nil)
-    dns_resolver.set_framework(framework_with_dns_enabled)
-
-    dns_resolver
-  end
-
-  subject(:empty_provider) do
-    dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
-    dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    dns_resolver.nameservers = [base_nameserver]
-    dns_resolver.set_framework(framework_with_dns_enabled)
-
-    dns_resolver
-  end
-
-  context 'When no nameserver is configured' do
-   it 'The resolver base is returned' do
-     packet = packet_for('subdomain.metasploit.com')
-     ns = empty_provider.nameservers_for_packet(packet)
-     expect(ns).to eq([[base_nameserver, {}]])
-   end
-  end
-
-  context 'When a base nameserver is configured' do
-   it 'The base nameserver is returned' do
-     packet = packet_for('subdomain.metasploit.com')
-     ns = ruleless_provider.nameservers_for_packet(packet)
-     expect(ns).to eq([[ruleless_nameserver, {}]])
-   end
-  end
-
-  context 'When a nameserver rule is configured and a rule entry matches' do
-   it 'The correct nameserver is returned' do
-     packet = packet_for('subdomain.metasploit.com')
-     ns = ruled_provider.nameservers_for_packet(packet)
-     expect(ns).to eq([[ruled_nameserver, {}]])
+  context 'When a condition matches' do
+    it 'The correct resolver is returned' do
+      packet = packet_for('subdomain.metasploit.com')
+      ns = dns_resolver.upstream_resolvers_for_packet(packet)
+      expect(ns).to eq([Rex::Proto::DNS::UpstreamResolver.new_dns_server(metasploit_nameserver)])
     end
   end
 
-  context 'When a nameserver rule is configured and no rule entry is applicable' do
-   it 'The base nameserver is returned when no rule entry' do
-     packet = packet_for('subdomain.notmetasploit.com')
-     ns = ruled_provider.nameservers_for_packet(packet)
-     expect(ns).to eq([[ruleless_nameserver, {}]])
-   end
-  end
-
-  context 'When many rules are configured' do
-   it 'Returns multiple entries if multiple rules match' do
-     packet = packet_for('subdomain.metasploit.com')
-     ns = many_ruled_provider.nameservers_for_packet(packet)
-     expect(ns).to eq([[ruled_nameserver, {}], [ruled_nameserver2, {}]])
-   end
-  end
-
-  context 'When a packet contains multiple questions that have different nameserver results' do
-   it 'Throws an error' do
-     packet = packet_for('subdomain.metasploit.com')
-     q = Dnsruby::Question.new('subdomain.notmetasploit.com', Dnsruby::Types::A, Dnsruby::Classes::IN)
-
-     packet.question.append(q)
-     expect {many_ruled_provider.nameservers_for_packet(packet)}.to raise_error(ResolverError)
-   end
+  context 'When no conditions match' do
+    it 'The default resolver is returned' do
+      packet = packet_for('subdomain.test.lan')
+      ns = dns_resolver.upstream_resolvers_for_packet(packet)
+      expect(ns).to eq([Rex::Proto::DNS::UpstreamResolver.new_dns_server(default_nameserver)])
+    end
   end
 end

--- a/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
+++ b/spec/lib/rex/proto/dns/custom_nameserver_provider_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Rex::Proto::DNS::CustomNameserverProvider do
     dns_resolver = Rex::Proto::DNS::CachedResolver.new(config)
     dns_resolver.nameservers = [default_nameserver]
     dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
-    dns_resolver.add_upstream_entry([metasploit_nameserver], wildcard: '*.metasploit.com', position: 0)
+    dns_resolver.add_upstream_rule([metasploit_nameserver], wildcard: '*.metasploit.com', index: 0)
     dns_resolver.set_framework(framework_with_dns_enabled)
     dns_resolver
   end

--- a/spec/lib/rex/proto/dns/static_hostnames_spec.rb
+++ b/spec/lib/rex/proto/dns/static_hostnames_spec.rb
@@ -1,0 +1,78 @@
+# -*- coding:binary -*-
+require 'dnsruby'
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::DNS::StaticHostnames do
+  describe '#parse_hosts_file' do
+    context 'when parsing a file' do
+      let(:subject) { described_class.new }
+      let(:hosts_file) {
+        <<~CONTENT
+          # this is a comment
+
+          127.0.0.1 localhost localhost4
+          ::1       localhost localhost6
+          127.1.1.1 localhost
+          thisIsInvalid
+        CONTENT
+      }
+
+      before(:each) do
+        expect(File).to receive(:file?).and_return(true)
+        expect(File).to receive(:readable?).and_return(true)
+        expect(::IO).to receive(:foreach) do |_, &block|
+          hosts_file.split("\n").each do |line|
+            block.call(line)
+          end
+        end
+        subject.parse_hosts_file
+      end
+
+      it 'is not empty' do
+        expect(subject.empty?).to be_falsey
+      end
+
+      context 'when no type is specified' do
+        it 'returns an IPv4 address' do
+          expect(subject.get('localhost')).to eq ['127.0.0.1', '127.1.1.1']
+        end
+      end
+
+      it 'defines an IPv4 address for localhost' do
+        expect(subject.get('localhost', Dnsruby::Types::A)).to eq ['127.0.0.1', '127.1.1.1']
+      end
+
+      it 'defines an IPv6 address for localhost' do
+        expect(subject.get('localhost', Dnsruby::Types::AAAA)).to eq ['::1']
+      end
+    end
+  end
+
+  context 'when no hosts are defined' do
+    let(:subject) { described_class.new }
+
+    describe '#empty?' do
+      it 'is true' do
+        expect(subject.empty?).to be_truthy
+      end
+    end
+
+    describe '#get' do
+      it 'returns an empty array' do
+        expect(subject.get('localhost')).to eq []
+      end
+    end
+
+    describe '#get1' do
+      it 'returns nil' do
+        expect(subject.get1('localhost')).to be_nil
+      end
+    end
+
+    describe '#length' do
+      it 'is zero' do
+        expect(subject.length).to eq 0
+      end
+    end
+  end
+end

--- a/spec/lib/rex/proto/dns/upstream_resolver_spec.rb
+++ b/spec/lib/rex/proto/dns/upstream_resolver_spec.rb
@@ -1,0 +1,90 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+
+RSpec.describe Rex::Proto::DNS::UpstreamResolver do
+  context 'when type is black-hole' do
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_BLACK_HOLE }
+    let(:resolver) { described_class.new_black_hole }
+
+    describe '.new_black_hole' do
+      it 'is expected to set the type correctly' do
+        expect(resolver.type).to eq type
+      end
+
+      it 'is expected to set the destination correctly' do
+        expect(resolver.destination).to be_nil
+      end
+    end
+
+    describe '#to_s' do
+      it 'is expected to return the type as a string' do
+        expect(resolver.to_s).to eq type.to_s
+      end
+    end
+  end
+
+  context 'when type is dns-server' do
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_DNS_SERVER }
+    let(:destination) { '192.0.2.10' }
+    let(:resolver) { described_class.new_dns_server(destination) }
+
+    describe '.new_dns_server' do
+      it 'is expected to set the type correctly' do
+        expect(resolver.type).to eq type
+      end
+
+      it 'is expected to set the destination correctly' do
+        expect(resolver.destination).to eq destination
+      end
+    end
+
+    describe '#to_s' do
+      it 'is expected to return the nameserver IP address as a string' do
+        expect(resolver.to_s).to eq destination
+      end
+    end
+  end
+
+  context 'when type is static' do
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_STATIC }
+    let(:resolver) { described_class.new_static }
+
+    describe '.new_static' do
+      it 'is expected to set the type correctly' do
+        expect(resolver.type).to eq type
+      end
+
+      it 'is expected to set the destination correctly' do
+        expect(resolver.destination).to be_nil
+      end
+    end
+
+    describe '#to_s' do
+      it 'is expected to return the type as a string' do
+        expect(resolver.to_s).to eq type.to_s
+      end
+    end
+  end
+
+  context 'when type is system' do
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_SYSTEM }
+    let(:resolver) { described_class.new_system }
+
+    describe '.new_system' do
+      it 'is expected to set the type correctly' do
+        expect(resolver.type).to eq type
+      end
+
+      it 'is expected to set the destination correctly' do
+        expect(resolver.destination).to be_nil
+      end
+    end
+
+    describe '#to_s' do
+      it 'is expected to return the type as a string' do
+        expect(resolver.to_s).to eq type.to_s
+      end
+    end
+  end
+end

--- a/spec/lib/rex/proto/dns/upstream_resolver_spec.rb
+++ b/spec/lib/rex/proto/dns/upstream_resolver_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 RSpec.describe Rex::Proto::DNS::UpstreamResolver do
   context 'when type is black-hole' do
-    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_BLACK_HOLE }
-    let(:resolver) { described_class.new_black_hole }
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::Type::BLACK_HOLE }
+    let(:resolver) { described_class.create_black_hole }
 
     describe '.new_black_hole' do
       it 'is expected to set the type correctly' do
@@ -25,9 +25,9 @@ RSpec.describe Rex::Proto::DNS::UpstreamResolver do
   end
 
   context 'when type is dns-server' do
-    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_DNS_SERVER }
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::Type::DNS_SERVER }
     let(:destination) { '192.0.2.10' }
-    let(:resolver) { described_class.new_dns_server(destination) }
+    let(:resolver) { described_class.create_dns_server(destination) }
 
     describe '.new_dns_server' do
       it 'is expected to set the type correctly' do
@@ -47,8 +47,8 @@ RSpec.describe Rex::Proto::DNS::UpstreamResolver do
   end
 
   context 'when type is static' do
-    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_STATIC }
-    let(:resolver) { described_class.new_static }
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::Type::STATIC }
+    let(:resolver) { described_class.create_static }
 
     describe '.new_static' do
       it 'is expected to set the type correctly' do
@@ -68,8 +68,8 @@ RSpec.describe Rex::Proto::DNS::UpstreamResolver do
   end
 
   context 'when type is system' do
-    let(:type) { Rex::Proto::DNS::UpstreamResolver::TYPE_SYSTEM }
-    let(:resolver) { described_class.new_system }
+    let(:type) { Rex::Proto::DNS::UpstreamResolver::Type::SYSTEM }
+    let(:resolver) { described_class.create_system }
 
     describe '.new_system' do
       it 'is expected to set the type correctly' do

--- a/spec/lib/rex/proto/dns/upstream_rule_spec.rb
+++ b/spec/lib/rex/proto/dns/upstream_rule_spec.rb
@@ -40,33 +40,51 @@ RSpec.describe Rex::Proto::DNS::UpstreamRule do
   context 'when using a wildcard condition' do
     let(:subject) { described_class.new(wildcard: '*.metasploit.com') }
 
-    it 'returns true for subdomains' do
-      expect(subject.matches_name?('www.metasploit.com')).to be_truthy
+    describe '#matches_all?' do
+      it 'does not return true for everything' do
+        expect(subject.matches_all?).to be_falsey
+      end
     end
 
-    it 'returns true for subsubdomains' do
-      expect(subject.matches_name?('one.two.metasploit.com')).to be_truthy
-    end
+    describe '#matches_name?' do
+      it 'returns true for subdomains' do
+        expect(subject.matches_name?('www.metasploit.com')).to be_truthy
+      end
 
-    it 'returns false for the domain' do
-      expect(subject.matches_name?('metasploit.com')).to be_falsey
-    end
+      it 'returns true for subsubdomains' do
+        expect(subject.matches_name?('one.two.metasploit.com')).to be_truthy
+      end
+
+      it 'returns false for the domain' do
+        expect(subject.matches_name?('metasploit.com')).to be_falsey
+      end
 
 
-    it 'returns false for other domains' do
-      expect(subject.matches_name?('notmetasploit.com')).to be_falsey
+      it 'returns false for other domains' do
+        expect(subject.matches_name?('notmetasploit.com')).to be_falsey
+      end
     end
   end
 
   context 'when not using a wildcard condition' do
     let(:subject) { described_class.new }
 
-    it 'defaults to *' do
-      expect(subject.wildcard).to eq '*'
+    describe '#wildcard' do
+      it 'defaults to *' do
+        expect(subject.wildcard).to eq '*'
+      end
     end
 
-    it 'returns true for everything' do
-      expect(subject.matches_name?("#{Rex::Text.rand_text_alphanumeric(10)}.#{Rex::Text.rand_text_alphanumeric(3)}")).to be_truthy
+    describe '#matches_all?' do
+      it 'returns true for everything' do
+        expect(subject.matches_all?).to be_truthy
+      end
+    end
+
+    describe '#matches_name?' do
+      it 'returns true for everything' do
+        expect(subject.matches_name?("#{Rex::Text.rand_text_alphanumeric(10)}.#{Rex::Text.rand_text_alphanumeric(3)}")).to be_truthy
+      end
     end
   end
 end

--- a/spec/lib/rex/proto/dns/upstream_rule_spec.rb
+++ b/spec/lib/rex/proto/dns/upstream_rule_spec.rb
@@ -1,0 +1,72 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Rex::Proto::DNS::UpstreamRule do
+  describe '.valid_resolver?' do
+    it 'returns true for "black-hole"' do
+      expect(described_class.valid_resolver?('black-hole')).to be_truthy
+      expect(described_class.valid_resolver?('Black-Hole')).to be_truthy
+      expect(described_class.valid_resolver?(%s[black-hole])).to be_truthy
+    end
+
+    it 'returns true for IPv4 addresses' do
+      address = Rex::Socket.addr_ntoa(Random.new.bytes(4))
+      expect(described_class.valid_resolver?(address)).to be_truthy
+    end
+
+    it 'returns true for IPv6 addresses' do
+      address = Rex::Socket.addr_ntoa(Random.new.bytes(16))
+      expect(described_class.valid_resolver?(address)).to be_truthy
+    end
+
+    it 'returns true for "static"' do
+      expect(described_class.valid_resolver?('static')).to be_truthy
+      expect(described_class.valid_resolver?('Static')).to be_truthy
+      expect(described_class.valid_resolver?(:static)).to be_truthy
+    end
+
+    it 'returns true for "system"' do
+      expect(described_class.valid_resolver?('system')).to be_truthy
+      expect(described_class.valid_resolver?('System')).to be_truthy
+      expect(described_class.valid_resolver?(:system)).to be_truthy
+    end
+
+    it 'raises returns false for invalid resolvers' do
+      expect(described_class.valid_resolver?('fake')).to be_falsey
+    end
+  end
+
+  context 'when using a wildcard condition' do
+    let(:subject) { described_class.new(wildcard: '*.metasploit.com') }
+
+    it 'returns true for subdomains' do
+      expect(subject.matches_name?('www.metasploit.com')).to be_truthy
+    end
+
+    it 'returns true for subsubdomains' do
+      expect(subject.matches_name?('one.two.metasploit.com')).to be_truthy
+    end
+
+    it 'returns false for the domain' do
+      expect(subject.matches_name?('metasploit.com')).to be_falsey
+    end
+
+
+    it 'returns false for other domains' do
+      expect(subject.matches_name?('notmetasploit.com')).to be_falsey
+    end
+  end
+
+  context 'when not using a wildcard condition' do
+    let(:subject) { described_class.new }
+
+    it 'defaults to *' do
+      expect(subject.wildcard).to eq '*'
+    end
+
+    it 'returns true for everything' do
+      expect(subject.matches_name?("#{Rex::Text.rand_text_alphanumeric(10)}.#{Rex::Text.rand_text_alphanumeric(3)}")).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
# Overview
This makes a number of changes to how Metasploit handles DNS requests internally. The intention is to keep the handling intuitive, functional and safe from leaks in scenarios where the operator is pivoting.

## Rule Consolidation
The original implementation utilized two arrays for matching names to resolvers. One array contained conditions defined as wildcard patterns to match names against while the other did not. Both arrays defined a single upstream DNS server to use for resolution. When resolution took place, a matcher would find all resolvers that matched a particular condition.

This pattern has been consolidated into a single array where *every* rule has a conditional wildcard pattern to match names against and the default wildcard pattern simply matches everything, effectively being a catch all. Entries, here after referred to as rules and represented in code in the `UpstreamRule` class associate a wildcard pattern for conditionally matching names to an array of resolvers. This means that for each name that is being resolved, it will match exactly 0 or 1 rules. The rule in turn defines the resolvers, in order that are to be used for resolving the query.

In the UI, rules are now managed by index instead of a unique numeric ID as they were previously. This pattern emulates how `iptables` handles it's rules in a particular chain (e.g. `INPUT`). Rules are indexed starting at 1, so to insert a rule into the first position of the chain, the syntax for the `add` command would use the `-i 1` argument.

## New Resolvers
The original implementation supported two types of name resolution. Names that were statically defined in the host operating systems `/etc/hosts` (or equivalent) file and traditional, network-attached DNS servers. In addition to these two techniques, operators can now also define system and black-hole resolvers.

Rules now contain an array of resolvers and the resolvers will be attempted in order until one is able to fulfill the request. In a standard configuration, users will most likely want to define the 'static' resolver as the first entry.

### system Resolver
The system resolver is capable of handling A/AAAA records to resolve queries for hostnames to IPv4 and IPv6 addresses. It does so by using the `getaddrinfo` API provided by Ruby. This will eventually invoke the operating systems standard API which may be hooked by external applications such as proxy chains.

Queries for PTR, NS, SRV and other unsupported records are unable to be handled by this resolver and the next resolver defined in the parent rule will be used. Supposedly, IP addresses can be mapped to hostnames using the `AI_CANONNAME` flag, however this behavior was not able to be replicated using the following Ruby snippet where the IP address has a PTR record.

```
::Socket.getaddrinfo(ip_address, 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM, ::Socket::IPPROTO_TCP, ::Socket::AI_CANONNAME).first
```

### black-hole Resolver
This resolver will simply deny any queries and can be used as a stop gap if desired. Once invoked, subsequent resolvers that are defined in the parent rule will be ignored.

## Static Hostnames
Commands to add, delete and flush all statically defined hostname to IP address mappings were added. Furthermore, statically defined hostnames are now persisted to the Metasploit configuration file when the `save` command is used. These static hostnames are shared among all instances of 'static' resolvers.

## Inspection Updates
The `dns print` output was updated to display additional information, not just the configured rules. It will now also show:

* The default search domain
* The default search list
* The number of entries that are currently cached
* The currently configured static hostnames

Additionally, the new `dns resolve` command will show the rule that was used for DNS resolution which should help with debugging. It does not show the exact resolver that was able to fulfill the query at this time because that level of control is not currently implemented.

## New Reset Command
A new `dns reset-config` command has been added that will reset the currently running configuration to sane default values as specified by the host operating system. This only affects the running configuration; the user will need to use the `save` command to make the changes persistent.

This implementation also altered the default state of the DNS resolver that will be used when no configuration is present, e.g. because it is being used for the very first time. These changes include loading the name servers from the host operating systems configuration file, typically `/etc/resolv.conf` and converting those to upstream rules. This rule will have the 'static' resolver defined as the first entry to ensure that statically defined hostnames are used before the upstream nameserver is contacted to emulate normal behaviors.

## Configuration Changes
The DNS configuration that is persisted to Metasploit's INI file now uses multiple sections. There's a section for upstream rules and a dedicated section for static hostnames. Additionally, the top-level DNS configuration section now includes a version number that can be used to identify whether or not the configuration data is compatible and can be loaded. This means we can make changes in the future without worrying about restructuring the data.

> [!WARNING]  
> Each time changes from the pull request are pulled down, the tester should delete the DNS section from their configuration file. The version will be finalized once the PR is landed but between now and then, changes to the persisted format may occur that are not accompanied by a version bump.

## Additional Miscellaneous Changes

* Changed the time out for TCP and UDP to 5 seconds to make scanner modules more responsive
  * Updated the `DnsTimeout` class to add a `#to_i` method, making it compatible with rex-socket's `Timeout` parameter
* Updated `lib/msf/core/exploit/remote/dns/enumeration.rb` to consistently define the record type as a string value   (Fixes #18794)
* Added a search order for locating the `resolv.conf` file to load configuration information from (fixes an issue with Termux).

# Testing

- [ ] Enable the internal DNS system by running `features set dns_feature true`
- [ ] View the initial rules (they should be in a default state as defined by the host)
- [ ] Make sure that DNS works with the default rules (use the `dns resolve` command)
- [ ] Add new DNS rule(s)
- [ ] Delete existing DNS rule(s)
- [ ] Test DNS resolution changes based on the rule changes
- [ ] Run the `save` command, restart Metasploit and see that the configuration was persisted
- [ ] Manage statically defined hostnames
  - [ ] Create statically defined hostnames
  - [ ] See that they are used by the 'static' resolver (there must be a 'static' resolver for the name)
- [ ] See that the cache can be flushed
- [ ] See that the configuration can be reset
