### PR TITLE
Fix broken hosts and services help command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -423,15 +423,6 @@ class Db
     [ '-C', '--columns-until-restart' ] => [ true, 'Only show the given columns until the next restart (see list below)', '<columns>' ],
   )
 
-  def cmd_hosts_help(default_columns)
-    print_line "Usage: hosts [ options ] [addr1 addr2 ...]"
-    print_line
-    print @@hosts_opts.usage
-    print_line
-    print_line "Available columns: #{default_columns.join(", ")}"
-    print_line
-  end
-
   def cmd_hosts(*args)
     return unless active?
     onlyup = false
@@ -487,7 +478,12 @@ class Db
     @@hosts_opts.parse(args) do |opt, idx, val|
       case opt
       when '-h', '--help'
-        cmd_hosts_help(default_columns)
+        print_line "Usage: hosts [ options ] [addr1 addr2 ...]"
+        print_line
+        print @@hosts_opts.usage
+        print_line
+        print_line "Available columns: #{default_columns.join(", ")}"
+        print_line
         return
       when '-a', '--add'
         mode << :add
@@ -698,12 +694,12 @@ class Db
     []
   end
 
-  def cmd_services_help(default_columns)
+  def cmd_services_help
     print_line "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-o <filename>] [addr1 addr2 ...]"
     print_line
     print @@services_opts.usage
     print_line
-    print_line "Available columns: #{default_columns.join(", ")}"
+    print_line "Available columns: #{@@services_columns.join(", ")}"
     print_line
   end
 
@@ -918,7 +914,7 @@ class Db
         search_term = val
         opts[:search_term] = search_term
       when '-h', '--help'
-        cmd_services_help(@@services_columns)
+        cmd_services_help
         return
       else
         # Anything that wasn't an option is a host to search for


### PR DESCRIPTION
Fix the broken `help hosts` and `help services` command

## Verification

These commands should not crash

```
help hosts
hosts -h
help services
services -h
```


### Before

```
msf6 auxiliary(scanner/mssql/mssql_login) > help services
[-] Error while running command help: wrong number of arguments (given 0, expected 1)
```

```
msf6 auxiliary(scanner/mssql/mssql_login) > help hosts
[-] Error while running command help: wrong number of arguments (given 0, expected 1)
```

### After

```
msf6 auxiliary(scanner/mssql/mssql_login) > help services
Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-o <filename>] [addr1 addr2 ...]


OPTIONS:

    -a, --add                  Add the services instead of searching.
    -c, --column <col1,col2>   Only show the given columns.
    -d, --delete               Delete the services instead of searching.
    -h, --help                 Show this help information.
    -O, --order <column id>    Order rows by specified column number.
    -o, --output <filename>    Send output to a file in csv format.
    -p, --port <ports>         Search for a list of ports.
    -r, --protocol <protocol>  Protocol type of the service being added [tcp|udp].
    -R, --rhosts               Set RHOSTS from the results of the search.
    -s, --name <name>          Name of the service to add.
    -S, --search <filter>      Search string to filter by.
    -u, --up                   Only show services which are up.
    -U, --update               Update data for existing service.

Available columns: created_at, info, name, port, proto, state, updated_at
```

```
msf6 auxiliary(scanner/mssql/mssql_login) > help hosts
Usage: hosts [ options ] [addr1 addr2 ...]


OPTIONS:

    -a, --add <host>                       Add the hosts instead of searching
    -c, --columns <columns>                Only show the given columns (see list below)
    -C, --columns-until-restart <columns>  Only show the given columns until the next restart (see list below)
    -d, --delete <hosts>                   Delete the hosts instead of searching
    -h, --help                             Show this help information
    -i, --info <info>                      Change the info of a host
    -m, --comment <comment>                Change the comment of a host
    -n, --name <name>                      Change the name of a host
    -O, --order <column id>                Order rows by specified column number
    -o, --output <filename>                Send output to a file in csv format
    -R, --rhosts                           Set RHOSTS from the results of the search
    -S, --search <filter>                  Search string to filter by
    -T, --delete-tag <tag>                 Remove a tag from a range of hosts
    -t, --tag <tag>                        Add or specify a tag to a range of hosts
    -u, --up                               Only show hosts which are up

Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_family, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags
```