### PR TITLE
Improve options display optional session types

### DIFF
--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -67,4 +67,28 @@ module Msf::Module::Options
     self.options.add_options(options, owner)
     import_defaults(false)
   end
+
+  # Registers a new option group, merging options by default
+  #
+  # @param name [String] Name for the group
+  # @param description [String] Description of the group
+  # @param option_names [Array<String>] List of datastore option names
+  # @param merge [Boolean] whether to merge or overwrite the groups option names
+  def register_option_group(name:, description:, option_names: [], merge: true)
+    existing_group = options.groups[name]
+    if merge && existing_group
+      existing_group.description = description
+      existing_group.add_options(option_names)
+    else
+      option_group = Msf::OptionGroup.new(name: name, description: description, option_names: option_names)
+      options.add_group(option_group)
+    end
+  end
+
+  # De-registers an option group by name
+  #
+  # @param name [String] Name for the group
+  def deregister_option_group(name:)
+    options.remove_group(name)
+  end
 end

--- a/lib/msf/core/opt_condition.rb
+++ b/lib/msf/core/opt_condition.rb
@@ -3,9 +3,10 @@
 module Msf
   module OptCondition
     # Check a condition's result
-    # @param [Msf::Module] mod The module module
-    # @param [Msf::OptBase] opt the option which has conditions present
-    # @return [String]
+    # @param [String] left_value The left hand side of the condition
+    # @param [String] operator The conditions comparison operator
+    # @param [String] right_value The right hand side of the condition
+    # @return [Boolean]
     def self.eval_condition(left_value, operator, right_value)
       case operator.to_sym
       when :==
@@ -16,6 +17,8 @@ module Msf
         right_value.include?(left_value)
       when :nin
         !right_value.include?(left_value)
+      else
+        raise ArgumentError("Operator: #{operator} is invalid")
       end
     end
 

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -49,6 +49,7 @@ module Msf
     #
     def initialize(opts = {})
       self.sorted = []
+      self.groups = {}
 
       add_options(opts)
     end
@@ -313,14 +314,33 @@ module Msf
       result.sort
     end
 
+    # Adds an option group to the container
+    #
+    # @param option_group [Msf::OptionGroup]
+    def add_group(option_group)
+      groups[option_group.name] = option_group
+    end
+
+    # Removes an option group from the container by name
+    #
+    # @param group_name [String]
+    def remove_group(group_name)
+      groups.delete(group_name)
+    end
+
     #
     # The sorted array of options.
     #
     attr_reader :sorted
 
+    # @return [Hash<String, Msf::OptionGroup>]
+    attr_reader :groups
+
     protected
 
     attr_writer :sorted # :nodoc:
+
+    attr_writer :groups
   end
 
 end

--- a/lib/msf/core/option_group.rb
+++ b/lib/msf/core/option_group.rb
@@ -1,0 +1,32 @@
+# -*- coding: binary -*-
+
+module Msf
+  class OptionGroup
+
+    # @return [String] Name for the group
+    attr_accessor :name
+    # @return [String] Description to be displayed to the user
+    attr_accessor :description
+    # @return [Array<String>] List of datastore option names
+    attr_accessor :option_names
+
+    # @param name [String] Name for the group
+    # @param description [String] Description to be displayed to the user
+    # @param option_names [Array<String>] List of datastore option names
+    def initialize(name:, description:, option_names: [])
+      self.name = name
+      self.description = description
+      self.option_names = option_names
+    end
+
+    # @param option_name [String] Name of the datastore option to be added to the group
+    def add_option(option_name)
+      @option_names << option_name
+    end
+
+    # @param option_names [Array<String>] List of datastore option names to be added to the group
+    def add_options(option_names)
+      @option_names.concat(option_names)
+    end
+  end
+end

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -5,6 +5,8 @@ module Msf
     module MSSQL
       include Msf::OptionalSession
 
+      RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT DATABASE USERNAME PASSWORD THREADS]
+
       def initialize(info = {})
         super(
           update_info(
@@ -14,6 +16,12 @@ module Msf
         )
 
         if framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
+          register_option_group(name: 'SESSION',
+                                description: 'Used when connecting via an existing SESSION',
+                                option_names: ['SESSION'])
+          register_option_group(name: 'RHOST',
+                                description: 'Used when making a new connection via RHOSTS',
+                                option_names: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
@@ -23,6 +31,7 @@ module Msf
               Msf::Opt::RPORT(1433, false)
             ]
           )
+
           add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
         end
       end

--- a/lib/msf/core/optional_session/mysql.rb
+++ b/lib/msf/core/optional_session/mysql.rb
@@ -5,6 +5,8 @@ module Msf
     module MySQL
       include Msf::OptionalSession
 
+      RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT DATABASE USERNAME PASSWORD THREADS]
+
       def initialize(info = {})
         super(
           update_info(
@@ -14,6 +16,12 @@ module Msf
         )
 
         if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
+          register_option_group(name: 'SESSION',
+                                description: 'Used when connecting via an existing SESSION',
+                                option_names: ['SESSION'])
+          register_option_group(name: 'RHOST',
+                                description: 'Used when making a new connection via RHOSTS',
+                                option_names: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
@@ -21,8 +29,8 @@ module Msf
               Msf::Opt::RPORT(3306, false)
             ]
           )
-          add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
 
+          add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
         end
       end
 

--- a/lib/msf/core/optional_session/postgresql.rb
+++ b/lib/msf/core/optional_session/postgresql.rb
@@ -5,6 +5,8 @@ module Msf
     module PostgreSQL
       include Msf::OptionalSession
 
+      RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT DATABASE USERNAME PASSWORD THREADS]
+
       def initialize(info = {})
         super(
           update_info(
@@ -12,7 +14,14 @@ module Msf
             'SessionTypes' => %w[postgresql]
           )
         )
+
         if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
+          register_option_group(name: 'SESSION',
+                                description: 'Used when connecting via an existing SESSION',
+                                option_names: ['SESSION'])
+          register_option_group(name: 'RHOST',
+                                description: 'Used when making a new connection via RHOSTS',
+                                option_names: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
@@ -22,6 +31,7 @@ module Msf
               Msf::Opt::RPORT(5432, false)
             ]
           )
+
           add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
         end
       end

--- a/lib/msf/core/optional_session/smb.rb
+++ b/lib/msf/core/optional_session/smb.rb
@@ -5,6 +5,8 @@ module Msf
     module SMB
       include Msf::OptionalSession
 
+      RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT SMBDomain SMBUser SMBPass THREADS]
+
       def initialize(info = {})
         super(
           update_info(
@@ -13,15 +15,21 @@ module Msf
           )
         )
 
-
         if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+          register_option_group(name: 'SESSION',
+                                description: 'Used when connecting via an existing SESSION',
+                                option_names: ['SESSION'])
+          register_option_group(name: 'RHOST',
+                                description: 'Used when making a new connection via RHOSTS',
+                                option_names: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),
               Msf::Opt::RHOST(nil, false),
-              Msf::Opt::RPORT(443, false)
+              Msf::Opt::RPORT(445, false)
             ]
           )
+
           add_info('New in Metasploit 6.4 - This module can target a %grnSESSION%clr or an %grnRHOST%clr')
         end
       end

--- a/spec/lib/msf/core/module/options_spec.rb
+++ b/spec/lib/msf/core/module/options_spec.rb
@@ -1,0 +1,59 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Module::Options do
+  subject(:mod) do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  describe '#register_option_group' do
+    let(:name) { 'name' }
+    let(:description) { 'description' }
+    let(:option_names) { %w[option1 option2] }
+
+    context 'there are no registered option groups' do
+      it 'registers a new option group' do
+        subject.send(:register_option_group, name: name, description: description, option_names: option_names)
+        expect(subject.options.groups.length).to eq(1)
+        expect(subject.options.groups.keys).to include(name)
+      end
+    end
+
+    context 'there is a registered option group' do
+      let(:existing_name) { 'existing_name' }
+      let(:existing_options) { ['existing_option_names'] }
+      let(:existing_description) { 'existing_description' }
+      before(:each) do
+        subject.send(:register_option_group, name: existing_name, description: existing_description, option_names: existing_options)
+      end
+
+      it 'registers a an additional option group' do
+        subject.send(:register_option_group, name: name, description: description, option_names: option_names)
+        expect(subject.options.groups.length).to eq(2)
+        expect(subject.options.groups.keys).to include(name, existing_name)
+      end
+
+      context 'when adding a group with the same name' do
+        it 'merges the option groups together' do
+          subject.send(:register_option_group, name: existing_name, description: description, option_names: option_names)
+          expect(subject.options.groups.length).to eq(1)
+          expect(subject.options.groups.keys).to include(existing_name)
+          expect(subject.options.groups[existing_name].option_names).to include(*existing_options, *option_names)
+          expect(subject.options.groups[existing_name].description).to eq(description)
+        end
+
+        it 'overwrites the existing option group' do
+          subject.send(:register_option_group, name: existing_name, description: description, option_names: option_names, merge: false)
+          expect(subject.options.groups.length).to eq(1)
+          expect(subject.options.groups.keys).to include(existing_name)
+          expect(subject.options.groups[existing_name].option_names).to include(*option_names)
+          expect(subject.options.groups[existing_name].description).to eq(description)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/option_container_spec.rb
+++ b/spec/lib/msf/core/option_container_spec.rb
@@ -181,4 +181,60 @@ RSpec.describe Msf::OptionContainer do
       end
     end
   end
+
+  describe '#add_group' do
+    subject { described_class.new }
+    let(:group) { Msf::OptionGroup.new(name: 'name', description: 'description') }
+
+    context 'when the container has no groups' do
+      it 'adds the group to the container' do
+        subject.add_group(group)
+        expect(subject.groups[group.name]).to be(group)
+      end
+    end
+
+    context 'when the container has existing groups' do
+      let(:existing_group) { Msf::OptionGroup.new(name: 'existing', description: 'existing') }
+      before(:each) do
+        subject.add_group(existing_group)
+      end
+      it 'adds an additional group to the container' do
+        subject.add_group(group)
+        expect(subject.groups.length).to eql(2)
+        expect(subject.groups[group.name]).to be(group)
+      end
+
+      context 'when adding a new group with an existing groups name' do
+        let(:group) { Msf::OptionGroup.new(name: existing_group.name, description: 'description') }
+        it 'overwrites the existing group' do
+          expect(subject.groups[group.name]).to be(existing_group)
+          subject.add_group(group)
+          expect(subject.groups.length).to eql(1)
+          expect(subject.groups[group.name]).to be(group)
+        end
+      end
+    end
+  end
+
+  describe '#remove_group' do
+    subject { described_class.new }
+
+    context 'when the container has no groups' do
+      it 'has no effect' do
+        expect { subject.remove_group('name') }.not_to raise_error
+      end
+    end
+
+    context 'when the container has existing groups' do
+      let(:existing_group) { Msf::OptionGroup.new(name: 'existing', description: 'existing') }
+      before(:each) do
+        subject.add_group(existing_group)
+      end
+
+      it 'removes the group' do
+        subject.remove_group(existing_group.name)
+        expect(subject.groups).to be_empty
+      end
+    end
+  end
 end

--- a/spec/lib/msf/core/option_group_spec.rb
+++ b/spec/lib/msf/core/option_group_spec.rb
@@ -1,0 +1,50 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptionGroup do
+  subject { described_class.new(name: 'name', description: 'description') }
+
+  describe '#add_option' do
+    let(:option_name) { 'option_name' }
+    context 'when the option group is empty' do
+      it 'adds the option' do
+        subject.add_option(option_name)
+        expect(subject.option_names.length).to eql(1)
+        expect(subject.option_names).to include(option_name)
+      end
+    end
+
+    context 'when the option group contains options' do
+      subject { described_class.new(name: 'name', description: 'description', option_names: ['existing_option']) }
+
+      it 'adds the option' do
+        subject.add_option(option_name)
+        expect(subject.option_names.length).to eql(2)
+        expect(subject.option_names).to include(option_name)
+      end
+    end
+  end
+
+  describe '#add_options' do
+    let(:option_names) { %w[option_name1 option_name2] }
+    context 'when the option group is empty' do
+      it 'adds the option' do
+        subject.add_options(option_names)
+        expect(subject.option_names.length).to eql(2)
+        expect(subject.option_names).to include(*option_names)
+      end
+    end
+
+    context 'when the option group contains options' do
+      subject { described_class.new(name: 'name', description: 'description', option_names: ['existing_option']) }
+
+      it 'adds the option' do
+        subject.add_options(option_names)
+        expect(subject.option_names.length).to eql(3)
+        expect(subject.option_names).to include(*option_names)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Merge after #18770 

This PR splits up the output of the `options` command for modules that support either an `rhost` or a `session` connection to show that only one _or_ the other is required as this was ambiguous before

Before:
```
msf6 auxiliary(scanner/smb/smb_enumshares) > options

Module options (auxiliary/scanner/smb/smb_enumshares):

   Name                    Current Setting                         Required  Description
   ----                    ---------------                         --------  -----------
   HIGHLIGHT_NAME_PATTERN  username|password|user|pass|Groups.xml  yes       PCRE regex of resource names to highlight
   LogSpider               3                                       no        0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt) (Accepted: 0, 1, 2, 3)
   MaxDepth                999                                     yes       Max number of subdirectories to spider
   RHOSTS                  172.16.158.159                          no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   SESSION                 1                                       no        The session to run this module on
   SMBDomain               .                                       no        The Windows domain to use for authentication
   SMBPass                 vagrant                                 no        The password for the specified username
   SMBUser                 vagrant                                 no        The username to authenticate as
   Share                                                           no        Show only the specified share
   ShowFiles               false                                   yes       Show detailed information when spidering
   SpiderProfiles          true                                    no        Spider only user profiles when share is a disk share
   SpiderShares            false                                   no        Spider shares recursively
   THREADS                 1                                       yes       The number of concurrent threads (max one per host)
```

After:
```
msf6 auxiliary(scanner/smb/smb_enumshares) > options

Module options (auxiliary/scanner/smb/smb_enumshares):

   Name                    Current Setting                         Required  Description
   ----                    ---------------                         --------  -----------
   HIGHLIGHT_NAME_PATTERN  username|password|user|pass|Groups.xml  yes       PCRE regex of resource names to highlight
   LogSpider               3                                       no        0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt) (Accepted: 0, 1, 2, 3)
   MaxDepth                999                                     yes       Max number of subdirectories to spider
   Share                                                           no        Show only the specified share
   ShowFiles               false                                   yes       Show detailed information when spidering
   SpiderProfiles          true                                    no        Spider only user profiles when share is a disk share
   SpiderShares            false                                   no        Spider shares recursively


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     172.16.158.159   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass    vagrant          no        The password for the specified username
   SMBUser    vagrant          no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  1                no        The session to run this module on
```

# Verification Steps
- [ ] CI passes
- [ ] Check that modules with new session type support have their relevant options grouped in the output of `options`
- [ ] Check other modules look as they did before
