### PR TITLE
Fix incorrectly named shared example file

### DIFF
--- a/spec/lib/msf/base/sessions/mssql_spec.rb
+++ b/spec/lib/msf/base/sessions/mssql_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Msf::Sessions::MSSQL do
     allow(user_input).to receive(:intrinsic_shell?).and_return(true)
     allow(user_input).to receive(:output=)
     allow(client).to receive(:sock).and_return(rstream)
-    allow(client).to receive(:mssql_query).and_return(query_result)
+    allow(client).to receive(:mssql_query).with('SELECT DB_NAME();').and_return(query_result)
     allow(rstream).to receive(:peerinfo).and_return(peer_info)
   end
 

--- a/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
@@ -6,6 +6,9 @@ require 'rex/post/mssql/ui/console/command_dispatcher/core'
 RSpec.describe Rex::Post::MSSQL::Ui::Console::CommandDispatcher::Core do
   let(:rstream) { instance_double(::Rex::Socket) }
   let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
+  let(:query_result) do
+    { rows: [['mssql']]}
+  end
   let(:session) { Msf::Sessions::MSSQL.new(nil, { client: client, cwd: 'mssql' }) }
   let(:address) { '192.0.2.1' }
   let(:port) { '1433' }
@@ -18,6 +21,7 @@ RSpec.describe Rex::Post::MSSQL::Ui::Console::CommandDispatcher::Core do
 
   before(:each) do
     allow(client).to receive(:sock).and_return(rstream)
+    allow(client).to receive(:mssql_query).and_return(query_result)
     allow(rstream).to receive(:peerinfo).and_return(peer_info)
     allow(session).to receive(:client).and_return(client)
     allow(session).to receive(:console).and_return(console)

--- a/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Rex::Post::MSSQL::Ui::Console::CommandDispatcher::Core do
 
   before(:each) do
     allow(client).to receive(:sock).and_return(rstream)
-    allow(client).to receive(:mssql_query).and_return(query_result)
+    allow(client).to receive(:mssql_query).with('SELECT DB_NAME();').and_return(query_result)
     allow(rstream).to receive(:peerinfo).and_return(peer_info)
     allow(session).to receive(:client).and_return(client)
     allow(session).to receive(:console).and_return(console)

--- a/spec/support/shared/examples/msf/ui/console/command_dispatcher/session.rb
+++ b/spec/support/shared/examples/msf/ui/console/command_dispatcher/session.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.shared_examples_for 'session command dispatcher' do
   include_context 'Msf::Simple::Framework'
 


### PR DESCRIPTION
There was an issue with the incorrectly named `session_spec` file that was causing test failures not to cause the CI tests to fail correctly, this resolves that issue and fixes some failing tests that snuck in because of it

# Verification Steps
- [ ] CI passes
- [ ] Actually open up the CI tests and verify that nothing failed
