### PR TITLE
Improve error message for incompatible sessions

### DIFF
--- a/lib/msf/core/session_compatibility.rb
+++ b/lib/msf/core/session_compatibility.rb
@@ -188,7 +188,7 @@ module Msf
 
       # Can't be compatible if it's the wrong type
       if session_types && !session_types.include?(s.type)
-        issues << "incompatible session type: #{s.type}"
+        issues << "incompatible session type: #{s.type}. This module works with: #{session_types.join(', ')}."
       end
 
       # Check to make sure architectures match
@@ -208,9 +208,9 @@ module Msf
 
       if platform && platform.is_a?(Msf::Module::PlatformList) && !platform.empty?
         if s.platform.blank?
-          issues << 'Unknown session platform'
+          issues << "Unknown session platform. This module works with: #{platform.names.join(', ')}."
         elsif !platform.supports?(Msf::Module::PlatformList.transform(s.platform))
-          issues << "incompatible session platform: #{s.platform}"
+          issues << "incompatible session platform: #{s.platform}. This module works with: #{platform.names.join(', ')}."
         end
       end
 


### PR DESCRIPTION
This PR adds better error message when interacting with a module and passing a session that is not compatible.

Example - using a MSSQL session when the module expects a Meterpreter session.

Now the error message will reach into the module and return the modules expected session types and platfrom.

## Before
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/6f3950e7-9377-48c9-addc-dd8f246962d3)

## After
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/402bd6ea-ff5e-4666-9a11-87f2e52ff004)


## Verification

- [ ] Start `msfconsole`
- [ ] Choose a module that takes a session as an option
- [ ] Get a session that is incompatible with the module
- [ ] Run the module while using the incompatible session
- [ ] **Verify** the error message is now updated to include the expected session type and platform