### PR TITLE
Revert change to `each_module` for compatible nops

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -342,7 +342,7 @@ class EncodedPayload
         wlog("#{pinst.refname}: Failed to find preferred nop #{reqs['Nop']}")
       end
 
-      nops.each_module { |nopname, nopmod|
+      nops.each { |nopname, nopmod|
         # Create an instance of the nop module
         self.nop = nopmod.new
 


### PR DESCRIPTION
Resolves #18822

I accidentally replaced an `each` with an `each_module` in #18704 that shouldn't have been switched, I thought `nops` was a module set but it's just the return value of `compatible_nops` 

# Verification Steps
- [ ] `use multi/browser/chrome_cve_2021_21220_v8_insufficient_validation`
- [ ] `run`

Before:
```
msf6 > use multi/browser/chrome_cve_2021_21220_v8_insufficient_validation
[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > run

[-] Exploit failed: undefined method `each_module' for [["x64/simple", Msf::Modules::Nop__X64__Simple::MetasploitModule]]:Array
Did you mean?  each_slice
[*] Exploit completed, but no session was created.
```

After:
```
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > [*] Using URL: http://127.0.0.1:8080/gl9BOaXq
[*] Server started.
```