### PR TITLE
SQL sessions consolidation

### DIFF
--- a/lib/msf/base/sessions/mssql.rb
+++ b/lib/msf/base/sessions/mssql.rb
@@ -2,10 +2,7 @@
 
 require 'rex/post/mssql'
 
-class Msf::Sessions::MSSQL
-
-  include Msf::Sessions::Scriptable
-  include Msf::Sessions::Sql
+class Msf::Sessions::MSSQL < Msf::Sessions::Sql
 
   # @return [String] The address MSSQL is running on
   attr_accessor :address

--- a/lib/msf/base/sessions/mssql.rb
+++ b/lib/msf/base/sessions/mssql.rb
@@ -4,19 +4,18 @@ require 'rex/post/mssql'
 
 class Msf::Sessions::MSSQL
 
-  include Msf::Session::Basic
   include Msf::Sessions::Scriptable
+  include Msf::Sessions::Sql
 
-  # @return [Rex::Post::MSSQL::Ui::Console] The interactive console
-  attr_accessor :console
-  # @return [MSSQL::Client] The MSSQL client
-  attr_accessor :client
-  attr_accessor :platform, :arch
+  # @return [String] The address MSSQL is running on
+  attr_accessor :address
+  # @return [Integer] The port MSSQL is running on
+  attr_accessor :port
   attr_reader :framework
 
   def initialize(rstream, opts = {})
     @client = opts.fetch(:client)
-    self.console = Rex::Post::MSSQL::Ui::Console.new(self, opts)
+    self.console = ::Rex::Post::MSSQL::Ui::Console.new(self, opts)
 
     super(rstream, opts)
   end
@@ -26,28 +25,6 @@ class Msf::Sessions::MSSQL
     session.init_ui(user_input, user_output)
 
     @info = "MSSQL #{datastore['USERNAME']} @ #{@peer_info}"
-  end
-
-  def execute_file(full_path, args)
-    if File.extname(full_path) == '.rb'
-      Rex::Script::Shell.new(self, full_path).run(args)
-    else
-      console.load_resource(full_path)
-    end
-  end
-
-  def process_autoruns(datastore)
-    ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
-      next if datastore[key].nil? || datastore[key].empty?
-
-      args = Shellwords.shellwords(datastore[key])
-      print_status("Session ID #{self.sid} (#{self.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-      self.execute_script(args.shift, *args)
-    end
-  end
-
-  def type
-    self.class.type
   end
 
   # Returns the type of session.
@@ -80,64 +57,4 @@ class Msf::Sessions::MSSQL
     @address, @port = client.sock.peerinfo.split(':')
     @port
   end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  # Initializes the console's I/O handles.
-  #
-  def init_ui(input, output)
-    self.user_input = input
-    self.user_output = output
-    console.init_ui(input, output)
-    console.set_log_source(log_source)
-
-    super
-  end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  # Resets the console's I/O handles.
-  #
-  def reset_ui
-    console.unset_log_source
-    console.reset_ui
-  end
-
-  def exit
-    console.stop
-  end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  # Override the basic session interaction to use shell_read and
-  # shell_write instead of operating on rstream directly.
-  def _interact
-    framework.events.on_session_interact(self)
-    framework.history_manager.with_context(name: type.to_sym) do
-      _interact_stream
-    end
-  end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  def _interact_stream
-    framework.events.on_session_interact(self)
-
-    console.framework = framework
-    # Call the console interaction of the MSSQL client and
-    # pass it a block that returns whether or not we should still be
-    # interacting.  This will allow the shell to abort if interaction is
-    # canceled.
-    console.interact { interacting != true }
-    console.framework = nil
-
-    # If the stop flag has been set, then that means the user exited.  Raise
-    # the EOFError so we can drop this handle like a bad habit.
-    raise EOFError if (console.stopped? == true)
-  end
-
 end

--- a/lib/msf/base/sessions/mysql.rb
+++ b/lib/msf/base/sessions/mysql.rb
@@ -4,15 +4,8 @@ require 'rex/post/mysql'
 
 class Msf::Sessions::MySQL
 
-  # This interface supports basic interaction.
-  include Msf::Session::Basic
   include Msf::Sessions::Scriptable
-
-  # @return [Rex::Post::MySQL::Ui::Console] The interactive console
-  attr_accessor :console
-  # @return [MySQL::Client]
-  attr_accessor :client
-  attr_accessor :platform, :arch
+  include Msf::Sessions::Sql
 
   # @param[Rex::IO::Stream] rstream
   # @param [Hash] opts
@@ -30,21 +23,6 @@ class Msf::Sessions::MySQL
     session.init_ui(user_input, user_output)
 
     @info = "MySQL #{datastore['USERNAME']} @ #{client.socket.peerinfo}"
-  end
-
-  def process_autoruns(datastore)
-    ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
-      next if datastore[key].nil? || datastore[key].empty?
-
-      args = Shellwords.shellwords(datastore[key])
-      print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-      execute_script(args.shift, *args)
-    end
-  end
-
-  # @return [String]
-  def type
-    self.class.type
   end
 
   # @return [String] The type of the session
@@ -76,61 +54,5 @@ class Msf::Sessions::MySQL
 
     @address, @port = @client.socket.peerinfo.split(':')
     @port
-  end
-
-  # Initializes the console's I/O handles.
-  #
-  # @param [Object] input
-  # @param [Object] output
-  # @return [String]
-  def init_ui(input, output)
-    super(input, output)
-
-    console.init_ui(input, output)
-    console.set_log_source(log_source)
-  end
-
-  # Resets the console's I/O handles.
-  #
-  # @return [Object]
-  def reset_ui
-    console.unset_log_source
-    console.reset_ui
-  end
-
-
-  # Exit the console
-  #
-  # @return [TrueClass]
-  def exit
-    console.stop
-  end
-
-  protected
-
-  # Override the basic session interaction to use shell_read and
-  # shell_write instead of operating on rstream directly.
-  #
-  # @return [Object]
-  def _interact
-    framework.events.on_session_interact(self)
-    framework.history_manager.with_context(name: type.to_sym) { _interact_stream }
-  end
-
-  # @return [Object]
-  def _interact_stream
-    framework.events.on_session_interact(self)
-
-    console.framework = framework
-    # Call the console interaction of the mysql client and
-    # pass it a block that returns whether or not we should still be
-    # interacting.  This will allow the shell to abort if interaction is
-    # canceled.
-    console.interact { interacting != true }
-    console.framework = nil
-
-    # If the stop flag has been set, then that means the user exited.  Raise
-    # the EOFError so we can drop this handle like a bad habit.
-    raise ::EOFError if (console.stopped? == true)
   end
 end

--- a/lib/msf/base/sessions/mysql.rb
+++ b/lib/msf/base/sessions/mysql.rb
@@ -2,10 +2,7 @@
 
 require 'rex/post/mysql'
 
-class Msf::Sessions::MySQL
-
-  include Msf::Sessions::Scriptable
-  include Msf::Sessions::Sql
+class Msf::Sessions::MySQL < Msf::Sessions::Sql
 
   # @param[Rex::IO::Stream] rstream
   # @param [Hash] opts

--- a/lib/msf/base/sessions/postgresql.rb
+++ b/lib/msf/base/sessions/postgresql.rb
@@ -3,17 +3,9 @@
 require 'rex/post/postgresql'
 
 class Msf::Sessions::PostgreSQL
-  #
-  # This interface supports basic interaction.
-  #
-  include Msf::Session::Basic
-  include Msf::Sessions::Scriptable
 
-  # @return [Rex::Post::PostgreSQL::Ui::Console] The interactive console
-  attr_accessor :console
-  # @return [PostgreSQL::Client]
-  attr_accessor :client
-  attr_accessor :platform, :arch
+  include Msf::Sessions::Scriptable
+  include Msf::Sessions::Sql
 
   # @param[Rex::IO::Stream] rstream
   # @param [Hash] opts
@@ -29,28 +21,6 @@ class Msf::Sessions::PostgreSQL
     session.init_ui(user_input, user_output)
 
     @info = "PostgreSQL #{datastore['USERNAME']} @ #{@peer_info}"
-  end
-
-  def execute_file(full_path, args)
-    if File.extname(full_path) == '.rb'
-      Rex::Script::Shell.new(self, full_path).run(args)
-    else
-      console.load_resource(full_path)
-    end
-  end
-
-  def process_autoruns(datastore)
-    ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
-      next if datastore[key].nil? || datastore[key].empty?
-
-      args = Shellwords.shellwords(datastore[key])
-      print_status("Session ID #{self.sid} (#{self.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-      self.execute_script(args.shift, *args)
-    end
-  end
-
-  def type
-    self.class.type
   end
 
   #
@@ -85,63 +55,5 @@ class Msf::Sessions::PostgreSQL
 
     @address, @port = @client.conn.peerinfo.split(':')
     @port
-  end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  # Initializes the console's I/O handles.
-  #
-  def init_ui(input, output)
-    super(input, output)
-
-    console.init_ui(input, output)
-    console.set_log_source(self.log_source)
-  end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  # Resets the console's I/O handles.
-  #
-  def reset_ui
-    console.unset_log_source
-    console.reset_ui
-  end
-
-  def exit
-    console.stop
-  end
-
-  protected
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  # Override the basic session interaction to use shell_read and
-  # shell_write instead of operating on rstream directly.
-  def _interact
-    framework.events.on_session_interact(self)
-    framework.history_manager.with_context(name: type.to_sym) { _interact_stream }
-  end
-
-  ##
-  # :category: Msf::Session::Interactive implementors
-  #
-  def _interact_stream
-    framework.events.on_session_interact(self)
-
-    console.framework = framework
-
-    # Call the console interaction of the PostgreSQL client and
-    # pass it a block that returns whether or not we should still be
-    # interacting.  This will allow the shell to abort if interaction is
-    # canceled.
-    console.interact { interacting != true }
-    console.framework = nil
-
-    # If the stop flag has been set, then that means the user exited.  Raise
-    # the EOFError so we can drop this handle like a bad habit.
-    raise ::EOFError if (console.stopped? == true)
   end
 end

--- a/lib/msf/base/sessions/postgresql.rb
+++ b/lib/msf/base/sessions/postgresql.rb
@@ -2,10 +2,7 @@
 
 require 'rex/post/postgresql'
 
-class Msf::Sessions::PostgreSQL
-
-  include Msf::Sessions::Scriptable
-  include Msf::Sessions::Sql
+class Msf::Sessions::PostgreSQL < Msf::Sessions::Sql
 
   # @param[Rex::IO::Stream] rstream
   # @param [Hash] opts

--- a/lib/msf/base/sessions/sql.rb
+++ b/lib/msf/base/sessions/sql.rb
@@ -1,9 +1,10 @@
 # -*- coding: binary -*-
 
-module Msf::Sessions::Sql
+class Msf::Sessions::Sql
 
   # This interface supports basic interaction.
   include Msf::Session::Basic
+  include Msf::Sessions::Scriptable
 
   # @return console The interactive console
   attr_accessor :console

--- a/lib/msf/base/sessions/sql.rb
+++ b/lib/msf/base/sessions/sql.rb
@@ -1,0 +1,139 @@
+# -*- coding: binary -*-
+
+module Msf::Sessions::Sql
+
+  # This interface supports basic interaction.
+  include Msf::Session::Basic
+
+  # @return console The interactive console
+  attr_accessor :console
+  # @return client The underlying client object used to make SQL queries
+  attr_accessor :client
+  attr_accessor :platform, :arch
+
+  def process_autoruns(datastore)
+    ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
+      next if datastore[key].nil? || datastore[key].empty?
+
+      args = ::Shellwords.shellwords(datastore[key])
+      print_status("Session ID #{sid} (#{tunnel_to_s}) processing #{key} '#{datastore[key]}'")
+      execute_script(args.shift, *args)
+    end
+  end
+
+  def execute_file(full_path, args)
+    if File.extname(full_path) == '.rb'
+      Rex::Script::Shell.new(self, full_path).run(args)
+    else
+      console.load_resource(full_path)
+    end
+  end
+
+  # @param [String] cmd The command to execute in the context of a session using the '-c' flag.
+  # @param [IO] output_object The IO where output should be written to
+  # For example, 'query select version()' for a PostgreSQL session.
+  def run_cmd(cmd, output_object=nil)
+    # This implementation is taken from Meterpreter.
+    stored_output_state = nil
+    # If the user supplied an Output IO object, then we tell
+    # the console to use that, while saving it's previous output/
+    if output_object
+      stored_output_state = console.output
+      console.send(:output=, output_object)
+    end
+    success = console.run_single(cmd)
+    # If we stored the previous output object of the channel
+    # we restore it here to put everything back the way we found it
+    # We re-use the conditional above, because we expect in many cases for
+    # the stored state to actually be nil here.
+    if output_object
+      console.send(:output=, stored_output_state)
+    end
+    success
+  end
+
+  # @return [String]
+  def type
+    self.class.type
+  end
+
+  # @return [String] The type of the session
+  def self.type
+    raise ::NotImplementedError
+  end
+
+  # @return [Boolean] Can the session clean up after itself
+  def self.can_cleanup_files
+    raise ::NotImplementedError
+  end
+
+  # @return [String] The session description
+  def desc
+    raise ::NotImplementedError
+  end
+
+  # @return [Object] The peer address
+  def address
+    raise ::NotImplementedError
+  end
+
+  # @return [Object] The peer host
+  def port
+    raise ::NotImplementedError
+  end
+
+  # Initializes the console's I/O handles.
+  #
+  # @param [Object] input
+  # @param [Object] output
+  # @return [String]
+  def init_ui(input, output)
+    super(input, output)
+
+    console.init_ui(input, output)
+    console.set_log_source(log_source)
+  end
+
+  # Resets the console's I/O handles.
+  #
+  # @return [Object]
+  def reset_ui
+    console.unset_log_source
+    console.reset_ui
+  end
+
+  # Exit the console
+  #
+  # @return [TrueClass]
+  def exit
+    console.stop
+  end
+
+  protected
+
+  # Override the basic session interaction to use shell_read and
+  # shell_write instead of operating on rstream directly.
+  #
+  # @return [Object]
+  def _interact
+    framework.events.on_session_interact(self)
+    framework.history_manager.with_context(name: type.to_sym) { _interact_stream }
+  end
+
+  # @return [Object]
+  def _interact_stream
+    framework.events.on_session_interact(self)
+
+    console.framework = framework
+    # Call the console interaction of the mysql client and
+    # pass it a block that returns whether or not we should still be
+    # interacting.  This will allow the shell to abort if interaction is
+    # canceled.
+    console.interact { interacting != true }
+    console.framework = nil
+
+    # If the stop flag has been set, then that means the user exited.  Raise
+    # the EOFError so we can drop this handle like a bad habit.
+    raise ::EOFError if (console.stopped? == true)
+  end
+end

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -205,7 +205,7 @@ module Exploit::Remote::MSSQL
   # Issue a SQL query using the TDS protocol
   #
   def mssql_query(sqla, doprint=false, opts={})
-    @mssql_client.mssql_query(sqla, doprint, opts)
+    @mssql_client.query(sqla, doprint, opts)
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1602,7 +1602,8 @@ class Core
           end
 
           begin
-            if session.type == 'meterpreter'
+            case session.type.downcase
+            when 'meterpreter'
               # If session.sys is nil, dont even try..
               unless session.sys
                 print_error("Session #{s} does not have stdapi loaded, skipping...")
@@ -1619,12 +1620,14 @@ class Core
                 print_line(data) unless data.blank?
               rescue ::Rex::Post::Meterpreter::RequestError
                 print_error("Failed: #{$!.class} #{$!}")
-              rescue Rex::TimeoutError
+              rescue ::Rex::TimeoutError
                 print_error("Operation timed out. Timeout currently #{session.response_timeout} seconds, you can configure this with %grnsessions -c <cmd> --timeout <value>%clr")
               end
-            elsif session.type == 'shell' || session.type == 'powershell'
+            when 'shell', 'powershell'
               output = session.shell_command(cmd)
               print_line(output) if output
+            when 'mssql', 'postgresql', 'mysql'
+              session.run_cmd(cmd, driver.output)
             end
           ensure
             # Restore timeout for each session

--- a/lib/rex/post/mssql/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/mssql/ui/console/command_dispatcher.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/ui/text/dispatcher_shell'
+require 'rex/post/sql/ui/console/command_dispatcher'
 
 module Rex
   module Post
@@ -12,63 +13,7 @@ module Rex
         #
         ###
         module Console::CommandDispatcher
-          include Msf::Ui::Console::CommandDispatcher::Session
-
-          #
-          # Initializes an instance of the core command set using the supplied session and client
-          # for interactivity.
-          #
-          # @param [Rex::Post::MSSQL::Ui::Console] console
-          def initialize(console)
-            super
-            @msf_loaded = nil
-            @filtered_commands = []
-          end
-
-          #
-          # Returns the MSSQL client context.
-          #
-          # @return [MSSQL::Client]
-          def client
-            console = shell
-            console.client
-          end
-
-          #
-          # Returns the MSSQL session context.
-          #
-          # @return [Msf::Sessions::MSSQL]
-          def session
-            console = shell
-            console.session
-          end
-
-          #
-          # Returns the commands that meet the requirements
-          #
-          # @param [Object] all
-          # @param [Object] reqs
-          # @return [Object]
-          def filter_commands(all, reqs)
-            all.delete_if do |cmd, _desc|
-              if reqs[cmd]&.any? { |req| !client.commands.include?(req) }
-                @filtered_commands << cmd
-                true
-              end
-            end
-          end
-
-          # @param [Object] cmd
-          # @param [Object] line
-          # @return [Symbol, nil]
-          def unknown_command(cmd, line)
-            if @filtered_commands.include?(cmd)
-              print_error("The \"#{cmd}\" command is not supported by this session type (#{session.session_type})")
-              return :handled
-            end
-
-            super
-          end
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher
 
           #
           # Return the subdir of the `documentation/` directory that should be used
@@ -77,34 +22,6 @@ module Rex
           # @return [String]
           def docs_dir
             ::File.join(super, 'mssql_session')
-          end
-
-          #
-          # Returns true if the client has a framework object.
-          #
-          # Used for firing framework session events
-          #
-          # @return [TrueClass, FalseClass]
-          def msf_loaded?
-            return @msf_loaded unless @msf_loaded.nil?
-
-            # if we get here we must not have initialized yet
-
-            @msf_loaded = !session.framework.nil?
-            @msf_loaded
-          end
-
-          #
-          # Log that an error occurred.
-          #
-          # @param [Object] msg
-          # @return [Object]
-          def log_error(msg)
-            print_error(msg)
-
-            elog(msg, 'mssql')
-
-            dlog("Call stack:\n#{$ERROR_POSITION.join("\n")}", 'mssql')
           end
         end
       end

--- a/lib/rex/post/mssql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/mssql/ui/console/command_dispatcher/client.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
-require 'pathname'
-require 'reline'
+require 'rex/post/sql/ui/console/command_dispatcher/client'
 
 module Rex
   module Post
@@ -13,91 +12,12 @@ module Rex
         #
         ###
         class Console::CommandDispatcher::Client
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Client
           include Rex::Post::MSSQL::Ui::Console::CommandDispatcher
-
-          #
-          # Initializes an instance of the core command set using the supplied console
-          # for interactivity.
-          #
-          # @param [Rex::Post::MSSQL::Ui::Console] console
-          def initialize(console)
-            super
-
-            @db_search_results = []
-          end
-
-          #
-          # List of supported commands.
-          #
-          # @return [Hash{String->String}]
-          def commands
-            cmds = {
-              'query'   => 'Run a raw SQL query',
-              'shell'   => 'Enter a raw shell where SQL queries can be executed',
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
 
           # @return [String]
           def name
             'MSSQL Client'
-          end
-
-          # @param [Object] args
-          # @return [FalseClass, TrueClass]
-          def help_args?(args)
-            return false unless args.instance_of?(::Array)
-
-            args.include?('-h') || args.include?('--help')
-          end
-
-          # @return [Object]
-          def cmd_shell_help
-            print_line 'Usage: shell'
-            print_line
-            print_line 'Go into a raw SQL shell where SQL queries can be executed.'
-            print_line 'To exit, type `exit`, `quit`, `end` or `stop`.'
-            print_line
-          end
-
-          # @param [Array] args
-          # @return [Object]
-          def cmd_shell(*args)
-            cmd_shell_help && return if help_args?(args)
-
-            prompt_proc_before = ::Reline.prompt_proc
-
-            ::Reline.prompt_proc = proc { |line_buffer| line_buffer.each_with_index.map { |_line, i| i > 0 ? 'SQL *> ' : 'SQL >> ' } }
-
-            stop_words = %w[stop s exit e end quit q].freeze
-
-            finished = false
-            loop do
-              begin
-                raw_query = ::Reline.readmultiline('SQL >> ', use_history = true) do |multiline_input|
-                  finished = stop_words.include?(multiline_input.split.last)
-                  finished || (multiline_input.split.last && !multiline_input.split.last.end_with?('\\'))
-                end
-              rescue ::Interrupt
-                finished = true
-              ensure
-                ::Reline.prompt_proc = prompt_proc_before
-              end
-
-              if finished
-                print_status 'Exiting Shell mode.'
-                return
-              end
-
-              formatted_query = raw_query.split.map { |word| word.chomp('\\') }.reject(&:empty?).compact.join(' ')
-
-              print_status "Running SQL Command: '#{formatted_query}'"
-              cmd_query(formatted_query)
-            end
           end
 
           # @return [Object]
@@ -105,6 +25,7 @@ module Rex
             print_line 'Usage: query'
             print_line
             print_line 'Run a raw SQL query on the target.'
+            print_line
             print_line 'Examples:'
             print_line
             print_line '    query select @@version;'
@@ -113,32 +34,10 @@ module Rex
             print_line
           end
 
-          # @param [Array] result The result of an SQL query to format.
-          def format_result(result)
-            columns = ['#']
-
-            unless result.is_a?(Array)
-              result.fields.each { |field| columns.append(field.name) }
-
-              ::Rex::Text::Table.new(
-                'Header' => 'Query Result',
-                'Indent' => 4,
-                'Columns' => columns,
-                'Rows' => result.map.each.with_index { |row, i| [i, row].flatten }
-              )
-            end
-          end
-
-          # @param [Array] args SQL query
-          # @return [Object]
-          def cmd_query(*args)
-            if help_args?(args)
-              cmd_query_help
-              return
-            end
-
-            query = args.join(' ').to_s
-            client.mssql_query(query, true) || []
+          # @param [Hash] result The MSQQL query result
+          # @return [Hash] Hash containing rows, columns and errors.
+          def normalise_sql_result(result)
+            { rows: result[:rows], columns: result[:colnames], errors: result[:errors] }
           end
         end
       end

--- a/lib/rex/post/mssql/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/mssql/ui/console/command_dispatcher/core.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 
-require 'rex/post/mssql'
+require 'rex/post/sql/ui/console/command_dispatcher/core'
 
 module Rex
   module Post
@@ -12,48 +12,8 @@ module Rex
         #
         ###
         class Console::CommandDispatcher::Core
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Core
           include Rex::Post::MSSQL::Ui::Console::CommandDispatcher
-
-          #
-          # Initializes an instance of the core command set using the supplied session and client
-          # for interactivity.
-          #
-          # @param [Rex::Post::MSSQL::Ui::Console] console
-
-          #
-          # List of supported commands.
-          #
-          def commands
-            cmds = {
-              '?' => 'Help menu',
-              'background' => 'Backgrounds the current session',
-              'bg' => 'Alias for background',
-              'exit' => 'Terminate the MSSQL session',
-              'help' => 'Help menu',
-              'irb' => 'Open an interactive Ruby shell on the current session',
-              'pry' => 'Open the Pry debugger on the current session',
-              'sessions' => 'Quickly switch to another session'
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
-          #
-          # Core
-          #
-          def name
-            'Core'
-          end
-
-          def unknown_command(cmd, line)
-            status = super
-
-            status
-          end
-
         end
       end
     end

--- a/lib/rex/post/mssql/ui/console/command_dispatcher/modules.rb
+++ b/lib/rex/post/mssql/ui/console/command_dispatcher/modules.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 
-require 'pathname'
+require 'rex/post/sql/ui/console/command_dispatcher/modules'
 
 module Rex
   module Post
@@ -12,81 +12,19 @@ module Rex
         #
         ###
         class Console::CommandDispatcher::Modules
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Modules
           include Rex::Post::MSSQL::Ui::Console::CommandDispatcher
 
-
-          #
-          # List of supported commands.
-          #
-          def commands
-            cmds = {
-              'run' => 'Run a module'
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
-          #
-          # Modules
-          #
-          def name
-            'Modules'
-          end
-
           def cmd_run_help
-            print_line 'Usage: Modules'
+            print_line 'Usage: run'
             print_line
-            print_line 'Run a module.'
+            print_line 'Run a module or script against the current session.'
             print_line
-          end
-
-          #
-          # Executes a module/script in the context of the mssql session.
-          #
-          def cmd_run(*args)
-            if args.empty? || args.first == '-h' || args.first == '--help'
-              cmd_run_help
-              return true
-            end
-
-            # Get the script name
-            begin
-              script_name = args.shift
-              # First try it as a module if we have access to the Metasploit
-              # Framework instance.  If we don't, or if no such module exists,
-              # fall back to using the scripting interface.
-              if msf_loaded? && (mod = session.framework.modules.create(script_name))
-                original_mod = mod
-                reloaded_mod = session.framework.modules.reload_module(original_mod)
-
-                unless reloaded_mod
-                  error = session.framework.modules.module_load_error_by_path[original_mod.file_path]
-                  print_error("Failed to reload module: #{error}")
-
-                  return
-                end
-
-                opts = ''
-
-                opts << (args + [ "SESSION=#{session.sid}" ]).join(',')
-                result = reloaded_mod.run_simple(
-                  'LocalInput' => shell.input,
-                  'LocalOutput' => shell.output,
-                  'OptionStr' => opts
-                )
-
-                print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
-              else
-                # the rest of the arguments get passed in through the binding
-                session.execute_script(script_name, args)
-              end
-            rescue StandardError => e
-              print_error("Error in script: #{script_name}")
-              elog("Error in script: #{script_name}", error: e)
-            end
+            print_line '    run auxiliary/scanner/mssql/mssql_schemadump'
+            print_line '    run auxiliary/scanner/mssql/mssql_hashdump'
+            print_line '    run auxiliary/admin/mssql/mssql_enum'
+            print_line '    run my_erb_script.rc'
+            print_line
           end
         end
       end

--- a/lib/rex/post/mysql/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/mysql/ui/console/command_dispatcher.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/ui/text/dispatcher_shell'
+require 'rex/post/sql/ui/console/command_dispatcher'
 
 module Rex
   module Post
@@ -9,59 +10,7 @@ module Rex
 
         # Base class for all command dispatchers within the MySQL console user interface.
         module Console::CommandDispatcher
-          include Msf::Ui::Console::CommandDispatcher::Session
-
-          # Initializes an instance of the core command set using the supplied session and client
-          # for interactivity.
-          #
-          # @param [Rex::Post::MySQL::Ui::Console] console
-          def initialize(console)
-            super
-            @msf_loaded = nil
-            @filtered_commands = []
-          end
-
-          # Returns the MySQL client context.
-          #
-          # @return [MySQL::Client]
-          def client
-            console = shell
-            console.client
-          end
-
-          # Returns the MySQL session context.
-          #
-          # @return [Msf::Sessions::MySQL]
-          def session
-            console = shell
-            console.session
-          end
-
-          # Returns the commands that meet the requirements
-          #
-          # @param [Object] all
-          # @param [Object] reqs
-          # @return [Object]
-          def filter_commands(all, reqs)
-            all.delete_if do |cmd, _desc|
-              if reqs[cmd]&.any? { |req| !client.commands.include?(req) }
-                @filtered_commands << cmd
-                true
-              end
-            end
-          end
-
-          # @param [Object] cmd
-          # @param [Object] line
-          # @return [Symbol, nil]
-          def unknown_command(cmd, line)
-            if @filtered_commands.include?(cmd)
-              print_error("The \"#{cmd}\" command is not supported by this session type (#{session.session_type})")
-              return :handled
-            end
-
-            super
-          end
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher
 
           # Return the subdir of the `documentation/` directory that should be used
           # to find usage documentation
@@ -69,31 +18,6 @@ module Rex
           # @return [String]
           def docs_dir
             ::File.join(super, 'mysql_session')
-          end
-
-          # Returns true if the client has a framework object.
-          # Used for firing framework session events
-          #
-          # @return [TrueClass, FalseClass]
-          def msf_loaded?
-            return @msf_loaded unless @msf_loaded.nil?
-
-            # if we get here we must not have initialized yet
-
-            @msf_loaded = !session.framework.nil?
-            @msf_loaded
-          end
-
-          # Log that an error occurred.
-          #
-          # @param [Object] msg
-          # @return [Object]
-          def log_error(msg)
-            print_error(msg)
-
-            elog(msg, 'mysql')
-
-            dlog("Call stack:\n#{$ERROR_POSITION.join("\n")}", 'mysql')
           end
         end
       end

--- a/lib/rex/post/mysql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/mysql/ui/console/command_dispatcher/client.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
-require 'pathname'
-require 'reline'
+require 'rex/post/sql/ui/console/command_dispatcher/client'
 
 module Rex
   module Post
@@ -10,99 +9,12 @@ module Rex
 
         # Core MySQL client commands
         class Console::CommandDispatcher::Client
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Client
           include Rex::Post::MySQL::Ui::Console::CommandDispatcher
-
-          # Initializes an instance of the core command set using the supplied console
-          # for interactivity.
-          #
-          # @param [Rex::Post::MySQL::Ui::Console] console
-          def initialize(console)
-            super
-
-            @db_search_results = []
-          end
-
-          # List of supported commands.
-          #
-          # @return [Hash{String->String}]
-          def commands
-            cmds = {
-              'query'   => 'Run a raw SQL query',
-              'shell'   => 'Enter a raw shell where SQL queries can be executed',
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
 
           # @return [String]
           def name
             'MySQL Client'
-          end
-
-          # @param [Object] args
-          # @return [FalseClass, TrueClass]
-          def help_args?(args)
-            return false unless args.instance_of?(::Array)
-
-            args.include?('-h') || args.include?('--help')
-          end
-
-          # @return [Object]
-          def cmd_shell_help
-            print_line 'Usage: shell'
-            print_line
-            print_line 'Go into a raw SQL shell where SQL queries can be executed.'
-            print_line 'To exit, type `exit`, `quit`, `end` or `stop`.'
-            print_line
-          end
-
-          # @param [Array] args
-          # @return [Object]
-          def cmd_shell(*args)
-            if help_args?(args)
-              cmd_shell_help
-              return
-            end
-
-            stop_words = %w[stop s exit e end quit q].freeze
-
-            # Allow the user to query the DB in a loop.
-            finished = false
-            until finished
-              begin
-                # This needs to be here, otherwise the `ensure` block would reset it to the previous
-                # value after a single query, meaning future queries would have the default prompt_block.
-                prompt_proc_before = ::Reline.prompt_proc
-                ::Reline.prompt_proc = proc { |line_buffer| line_buffer.each_with_index.map { |_line, i| i > 0 ? 'SQL *> ' : 'SQL >> ' } }
-
-                # This will loop until it receives `true`.
-                raw_query = ::Reline.readmultiline('SQL >> ', use_history = true) do |multiline_input|
-                  # In the case only a stop word was input, exit out of the REPL shell
-                  finished = multiline_input.split.count == 1 && stop_words.include?(multiline_input.split.last)
-                  # Accept the input until the current line does not end with '\', similar to a shell
-                  finished || multiline_input.split.empty? || !multiline_input.split.last&.end_with?('\\')
-                end
-              rescue ::Interrupt => _e
-                finished = true
-              ensure
-                ::Reline.prompt_proc = prompt_proc_before
-              end
-
-              if finished
-                print_status 'Exiting Shell mode.'
-                return
-              end
-
-              formatted_query = process_query(query: raw_query)
-
-              unless formatted_query.empty?
-                print_status "Running SQL Command: '#{formatted_query}'"
-                cmd_query(formatted_query)
-              end
-            end
           end
 
           # @return [Object]
@@ -110,49 +22,22 @@ module Rex
             print_line 'Usage: query'
             print_line
             print_line 'Run a raw SQL query on the target.'
+            print_line
             print_line 'Examples:'
-            print_line "\tquery SHOW DATABASES;"
-            print_line "\tquery USE information_schema;"
-            print_line "\tquery SELECT * FROM SQL_FUNCTIONS;"
-            print_line "\tquery SELECT version();"
+            print_line
+            print_line '    query SHOW DATABASES;'
+            print_line '    query USE information_schema;'
+            print_line '    query SELECT * FROM SQL_FUNCTIONS;'
+            print_line '    query SELECT version();'
             print_line
           end
 
-          # @param [Array] result The result of an SQL query to format.
-          def format_result(result)
-            columns = ['#']
-
-            unless result.is_a?(Array)
-              result.fields.each { |field| columns.append(field.name) }
-
-              ::Rex::Text::Table.new(
-                'Header' => 'Query Result',
-                'Indent' => 4,
-                'Columns' => columns,
-                'Rows' => result.map.each.with_index { |row, i| [i, row].flatten }
-              )
-            end
-          end
-
-          # @param [Array] args SQL query
-          # @return [Object]
-          def cmd_query(*args)
-            cmd_query_help && return if help_args?(args)
-
-            query = args.join(' ').to_s
-            print_status("Sending statement: '#{query}'...")
-            result = client.query(query) || []
-
-            table = format_result(result)
-            print_line(table.to_s)
-          end
-
-          # @param [String] query
-          # @return [String]
-          def process_query(query: '')
-            return '' if query.empty?
-
-            query.lines.each.map { |line| line.chomp("\\\n").strip }.reject(&:empty?).compact.join(' ')
+          # @param [Mysql::Result] result The MySQL query result
+          # @return [Hash] Hash containing rows, columns and errors.
+          def normalise_sql_result(result)
+            # MySQL errors are handled by raising an exception when querying,
+            # meaning we don't have that in the Result object.
+            { rows: result.entries, columns: result.fields.each.map(&:name), errors: [] }
           end
         end
       end

--- a/lib/rex/post/mysql/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/mysql/ui/console/command_dispatcher/core.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'rex/post/sql/ui/console/command_dispatcher/core'
+
 module Rex
   module Post
     module MySQL
@@ -7,42 +9,8 @@ module Rex
 
         # Core MySQL client commands
         class Console::CommandDispatcher::Core
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Core
           include Rex::Post::MySQL::Ui::Console::CommandDispatcher
-
-          # List of supported commands.
-          #
-          # @return [Hash{String->String}]
-          def commands
-            cmds = {
-              '?'                        => 'Help menu',
-              'background'               => 'Backgrounds the current session',
-              'bg'                       => 'Alias for background',
-              'exit'                     => 'Terminate the MySQL session',
-              'help'                     => 'Help menu',
-              'irb'                      => 'Open an interactive Ruby shell on the current session',
-              'pry'                      => 'Open the Pry debugger on the current session',
-              'sessions'                 => 'Quickly switch to another session',
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
-          # @return [String]
-          def name
-            'Core'
-          end
-
-          # @param [Object] cmd
-          # @param [Object] line
-          # @return [Symbol, nil]
-          def unknown_command(cmd, line)
-            status = super
-
-            status
-          end
         end
       end
     end

--- a/lib/rex/post/mysql/ui/console/command_dispatcher/modules.rb
+++ b/lib/rex/post/mysql/ui/console/command_dispatcher/modules.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 
-require 'pathname'
+require 'rex/post/sql/ui/console/command_dispatcher/modules'
 
 module Rex
   module Post
@@ -9,89 +9,19 @@ module Rex
 
         # MySQL client commands for running modules
         class Console::CommandDispatcher::Modules
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Modules
           include Rex::Post::MySQL::Ui::Console::CommandDispatcher
 
-          # List of supported commands.
-          #
-          # @return [Hash{String->String}]
-          def commands
-            cmds = {
-              'run' => 'Run a module'
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
-          # Modules
-          #
-          # @return [String]
-          def name
-            'Modules'
-          end
-
-          # @return [Object]
           def cmd_run_help
             print_line 'Usage: run'
             print_line
             print_line 'Run a module or script against the current session.'
             print_line
-            print_line 'Example:'
-            print_line "\trun auxiliary/admin/mysql/mysql_enum"
-            print_line "\trun my_erb_script.rc"
+            print_line '    run auxiliary/scanner/mysql/mysql_schemadump'
+            print_line '    run auxiliary/scanner/mysql/mysql_hashdump'
+            print_line '    run auxiliary/scanner/mysql/mysql_file_enum'
+            print_line '    run my_erb_script.rc'
             print_line
-          end
-
-          # Executes a module/script in the context of the MySQL session.
-          #
-          # @param [Array] args
-          # @return [TrueClass]
-          def cmd_run(*args)
-            if args.empty? || args.first == '-h' || args.first == '--help'
-              cmd_run_help
-              return true
-            end
-
-            # Get the script name
-            begin
-              script_name = args.shift
-              # First try it as a module if we have access to the Metasploit
-              # Framework instance.  If we don't, or if no such module exists,
-              # fall back to using the scripting interface.
-              if msf_loaded? && (mod = session.framework.modules.create(script_name))
-                original_mod = mod
-                reloaded_mod = session.framework.modules.reload_module(original_mod)
-
-                unless reloaded_mod
-                  error = session.framework.modules.module_load_error_by_path[original_mod.file_path]
-                  print_error("Failed to reload module: #{error}")
-
-                  return
-                end
-
-                opts = ''
-
-                opts << (args + [ "SESSION=#{session.sid}" ]).join(',')
-                result = reloaded_mod.run_simple(
-                  'LocalInput' => shell.input,
-                  'LocalOutput' => shell.output,
-                  'OptionStr' => opts
-                )
-
-                print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
-              else
-                # the rest of the arguments get passed in through the binding
-                session.execute_script(script_name, args)
-              end
-            rescue Msf::OptionValidateError => e
-              print_error(e.message)
-              elog('Option validation error:', error: e)
-            rescue StandardError => e
-              print_error("Error in script: #{script_name}")
-              elog("Error in script: #{script_name}", error: e)
-            end
           end
         end
       end

--- a/lib/rex/post/postgresql.rb
+++ b/lib/rex/post/postgresql.rb
@@ -1,3 +1,4 @@
 # -*- coding: binary -*-
 
+require 'rex/post/sql'
 require 'rex/post/postgresql/ui'

--- a/lib/rex/post/postgresql/ui/console.rb
+++ b/lib/rex/post/postgresql/ui/console.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'rex/post/sql/ui/console'
+
 module Rex
   module Post
     module PostgreSQL
@@ -10,6 +12,7 @@ module Rex
         #
         ###
         class Console
+          include Rex::Post::Sql::Ui::Console
           include Rex::Ui::Text::DispatcherShell
 
           # Dispatchers
@@ -17,10 +20,6 @@ module Rex
           require 'rex/post/postgresql/ui/console/command_dispatcher/core'
           require 'rex/post/postgresql/ui/console/command_dispatcher/client'
           require 'rex/post/postgresql/ui/console/command_dispatcher/modules'
-
-          # Interactive channel, required for the REPL shell interaction and correct CTRL + Z handling.
-          # Zeitwerk ignored `rex/post` files so we need to `require` this file here.
-          require 'rex/post/postgresql/ui/console/interactive_sql_client'
 
           #
           # Initialize the PostgreSQL console.
@@ -48,84 +47,6 @@ module Rex
             if ! $dispatcher['postgresql']
               $dispatcher['postgresql'] = $dispatcher['core']
             end
-          end
-
-          #
-          # Called when someone wants to interact with the postgresql client.  It's
-          # assumed that init_ui has been called prior.
-          #
-          def interact(&block)
-            # Run queued commands
-            commands.delete_if do |ent|
-              run_single(ent)
-              true
-            end
-
-            # Run the interactive loop
-            run do |line|
-              # Run the command
-              run_single(line)
-
-              # If a block was supplied, call it, otherwise return false
-              if block
-                block.call
-              else
-                false
-              end
-            end
-          end
-
-          #
-          # Queues a command to be run when the interactive loop is entered.
-          #
-          def queue_cmd(cmd)
-            self.commands << cmd
-          end
-
-          #
-          # Runs the specified command wrapper in something to catch meterpreter
-          # exceptions.
-          #
-          def run_command(dispatcher, method, arguments)
-            begin
-              super
-            rescue ::Timeout::Error
-              log_error('Operation timed out.')
-            rescue ::Rex::InvalidDestination => e
-              log_error(e.message)
-            rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
-              self.session.kill
-            rescue ::StandardError => e
-              log_error("Error running command #{method}: #{e.class} #{e}")
-              elog(e)
-            end
-          end
-
-          #
-          # Logs that an error occurred and persists the callstack.
-          #
-          def log_error(msg)
-            print_error(msg)
-
-            elog(msg, 'postgresql')
-
-            dlog("Call stack:\n#{$@.join("\n")}", 'postgresql')
-          end
-
-          #
-          # Interacts with the supplied client.
-          #
-          def interact_with_client(client_dispatcher: nil)
-            return unless client_dispatcher
-
-            client.extend(InteractiveSqlClient) unless (client.kind_of?(InteractiveSqlClient) == true)
-            client.on_command_proc = self.on_command_proc if self.on_command_proc
-            client.on_print_proc   = self.on_print_proc if self.on_print_proc
-            client.on_log_proc = method(:log_output) if self.respond_to?(:log_output, true)
-            client.client_dispatcher = client_dispatcher
-
-            client.interact(input, output)
-            client.reset_ui
           end
 
           # @return [Msf::Sessions::PostgreSQL]

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/ui/text/dispatcher_shell'
+require 'rex/post/sql/ui/console/command_dispatcher'
 
 module Rex
   module Post
@@ -12,57 +13,7 @@ module Rex
         #
         ###
         module Console::CommandDispatcher
-          include Msf::Ui::Console::CommandDispatcher::Session
-
-          #
-          # Initializes an instance of the core command set using the supplied session and client
-          # for interactivity.
-          #
-          # @param [Rex::Post::PostgreSQL::Ui::Console] console
-          def initialize(console)
-            super
-            @msf_loaded = nil
-            @filtered_commands = []
-          end
-
-          #
-          # Returns the PostgreSQL client context.
-          #
-          # @return [PostgreSQL::Client]
-          def client
-            console = shell
-            console.client
-          end
-
-          #
-          # Returns the PostgreSQL session context.
-          #
-          # @return [Msf::Sessions::PostgreSQL]
-          def session
-            console = shell
-            console.session
-          end
-
-          #
-          # Returns the commands that meet the requirements
-          #
-          def filter_commands(all, reqs)
-            all.delete_if do |cmd, _desc|
-              if reqs[cmd]&.any? { |req| !client.commands.include?(req) }
-                @filtered_commands << cmd
-                true
-              end
-            end
-          end
-
-          def unknown_command(cmd, line)
-            if @filtered_commands.include?(cmd)
-              print_error("The \"#{cmd}\" command is not supported by this session type (#{session.session_type})")
-              return :handled
-            end
-
-            super
-          end
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher
 
           #
           # Return the subdir of the `documentation/` directory that should be used
@@ -70,31 +21,6 @@ module Rex
           #
           def docs_dir
             ::File.join(super, 'postgresql_session')
-          end
-
-          #
-          # Returns true if the client has a framework object.
-          #
-          # Used for firing framework session events
-          #
-          def msf_loaded?
-            return @msf_loaded unless @msf_loaded.nil?
-
-            # if we get here we must not have initialized yet
-
-            @msf_loaded = !session.framework.nil?
-            @msf_loaded
-          end
-
-          #
-          # Log that an error occurred.
-          #
-          def log_error(msg)
-            print_error(msg)
-
-            elog(msg, 'postgresql')
-
-            dlog("Call stack:\n#{$ERROR_POSITION.join("\n")}", 'postgresql')
           end
         end
       end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
-require 'pathname'
-require 'reline'
+require 'rex/post/sql/ui/console/command_dispatcher/client'
 
 module Rex
   module Post
@@ -14,119 +13,34 @@ module Rex
         #
         ###
         class Console::CommandDispatcher::Client
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Client
           include Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher
 
-          #
-          # Initializes an instance of the core command set using the supplied console
-          # for interactivity.
-          #
-          # @param [Rex::Post::PostgreSQL::Ui::Console] console
-          def initialize(console)
-            super
-
-            @db_search_results = []
-          end
-
-          #
-          # List of supported commands.
-          #
-          def commands
-            cmds = {
-              'query'   => 'Run a raw SQL query',
-              'shell'   => 'Enter a raw shell where SQL queries can be executed',
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
+          # @return [String]
           def name
             'PostgreSQL Client'
           end
 
-          def help_args?(args)
-            return false unless args.instance_of?(::Array)
-
-            args.include?('-h') || args.include?('--help')
-          end
-
-          def cmd_shell_help
-            print_line 'Usage: shell'
-            print_line
-            print_line 'Go into a raw SQL shell where SQL queries can be executed.'
-            print_line 'To exit, type `exit`, `quit`, `end` or `stop`.'
-            print_line
-          end
-
-          def cmd_shell(*args)
-            if help_args?(args)
-              cmd_shell_help
-              return
-            end
-
-            console = shell
-            # Pass in self so that we can call cmd_query in subsequent calls
-            console.interact_with_client(client_dispatcher: self)
-          end
-
+          # @return [Object]
           def cmd_query_help
             print_line 'Usage: query'
             print_line
             print_line 'Run a raw SQL query on the target.'
             print_line
             print_line 'Examples:'
-            print_line "\tquery SELECT user;"
-            print_line "\tquery SELECT version();"
-            print_line "\tquery SELECT * FROM pg_catalog.pg_tables;"
+            print_line
+            print_line '    query SELECT user;'
+            print_line '    query SELECT version();'
+            print_line '    query SELECT * FROM pg_catalog.pg_tables;'
             print_line
           end
 
-          #
-          # @param [::Msf::Db::PostgresPR::Connection::Result] result The result of an SQL query to format.
-          def format_result(result)
-            columns = ['#']
-            columns.append(result.fields.map.each { |field| field[:name] })
-            flat_columns = columns.flatten
-
-            ::Rex::Text::Table.new(
-              'Header' => 'Query',
-              'Indent' => 4,
-              'Columns' => flat_columns,
-              'Rows' => result.rows.map.each.with_index do |row, i|
-                [i, row].flatten
-              end
-            )
-          end
-
-          def cmd_query(*args)
-            if help_args?(args)
-              cmd_query_help
-              return
-            end
-
-            begin
-              result = client.query(args.join(' ').to_s)
-            rescue ::RuntimeError => e
-              print_error "Query result: #{e}"
-              print_line
-              return
-            end
-
-            print_status result.cmd_tag
-            print_line
-
-            unless result.rows.empty?
-              table = format_result(result)
-              print_line(table.to_s)
-            end
-          end
-
-          def process_query(query: '')
-            return '' if query.empty?
-
-            query.lines.each.map { |line| line.chomp.chomp('\\').strip }.reject(&:empty?).compact.join(' ')
+          # @param [Msf::Db::PostgresPR::Connection] result The PostgreSQL query result
+          # @return [Hash] Hash containing rows, columns and errors.
+          def normalise_sql_result(result)
+            # PostgreSQL errors are handled by raising an exception when querying,
+            # meaning we don't have that in the Result object.
+            { rows: result.rows, columns: result.fields.each.map(&:name), errors: [] }
           end
         end
       end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/core.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'rex/post/sql/ui/console/command_dispatcher/core'
+
 module Rex
   module Post
     module PostgreSQL
@@ -11,38 +13,8 @@ module Rex
         #
         ###
         class Console::CommandDispatcher::Core
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Core
           include Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher
-
-          #
-          # List of supported commands.
-          #
-          def commands
-            cmds = {
-              '?'                        => 'Help menu',
-              'background'               => 'Backgrounds the current session',
-              'bg'                       => 'Alias for background',
-              'exit'                     => 'Terminate the PostgreSQL session',
-              'help'                     => 'Help menu',
-              'irb'                      => 'Open an interactive Ruby shell on the current session',
-              'pry'                      => 'Open the Pry debugger on the current session',
-              'sessions'                 => 'Quickly switch to another session',
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
-          def name
-            'Core'
-          end
-
-          def unknown_command(cmd, line)
-            status = super
-
-            status
-          end
         end
       end
     end

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/modules.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/modules.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 
-require 'pathname'
+require 'rex/post/sql/ui/console/command_dispatcher/modules'
 
 module Rex
   module Post
@@ -12,85 +12,19 @@ module Rex
         #
         ###
         class Console::CommandDispatcher::Modules
-
+          include Rex::Post::Sql::Ui::Console::CommandDispatcher::Modules
           include Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher
-
-
-          #
-          # List of supported commands.
-          #
-          def commands
-            cmds = {
-              'run' => 'Run a module'
-            }
-
-            reqs = {}
-
-            filter_commands(cmds, reqs)
-          end
-
-          #
-          # Modules
-          #
-          def name
-            'Modules'
-          end
 
           def cmd_run_help
             print_line 'Usage: run'
             print_line
             print_line 'Run a module or script against the current session.'
             print_line
-            print_line 'Example:'
-            print_line "\trun auxiliary/scanner/postgres/postgres_schemadump"
-            print_line "\trun my_erb_script.rc"
+            print_line '    run auxiliary/scanner/postgres/postgres_schemadump'
+            print_line '    run auxiliary/scanner/postgres/postgres_hashdump'
+            print_line '    run auxiliary/admin/postgres/postgres_readfile'
+            print_line '    run my_erb_script.rc'
             print_line
-          end
-
-          #
-          # Executes a module/script in the context of the PostgreSQL session.
-          #
-          def cmd_run(*args)
-            if args.empty? || args.first == '-h' || args.first == '--help'
-              cmd_run_help
-              return true
-            end
-
-            # Get the script name
-            begin
-              script_name = args.shift
-              # First try it as a module if we have access to the Metasploit
-              # Framework instance.  If we don't, or if no such module exists,
-              # fall back to using the scripting interface.
-              if msf_loaded? && (mod = session.framework.modules.create(script_name))
-                original_mod = mod
-                reloaded_mod = session.framework.modules.reload_module(original_mod)
-
-                unless reloaded_mod
-                  error = session.framework.modules.module_load_error_by_path[original_mod.file_path]
-                  print_error("Failed to reload module: #{error}")
-
-                  return
-                end
-
-                opts = ''
-
-                opts << (args + [ "SESSION=#{session.sid}" ]).join(',')
-                result = reloaded_mod.run_simple(
-                  'LocalInput' => shell.input,
-                  'LocalOutput' => shell.output,
-                  'OptionStr' => opts
-                )
-
-                print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
-              else
-                # the rest of the arguments get passed in through the binding
-                session.execute_script(script_name, args)
-              end
-            rescue StandardError => e
-              print_error("Error in script: #{script_name}")
-              elog("Error in script: #{script_name}", error: e)
-            end
           end
         end
       end

--- a/lib/rex/post/sql.rb
+++ b/lib/rex/post/sql.rb
@@ -1,0 +1,3 @@
+# -*- coding: binary -*-
+
+require 'rex/post/sql/ui'

--- a/lib/rex/post/sql/ui.rb
+++ b/lib/rex/post/sql/ui.rb
@@ -1,0 +1,3 @@
+# -*- coding: binary -*-
+
+require 'rex/post/sql/ui/console'

--- a/lib/rex/post/sql/ui/console.rb
+++ b/lib/rex/post/sql/ui/console.rb
@@ -1,0 +1,102 @@
+require 'rex/post/sql/ui/console/command_dispatcher'
+require 'rex/post/sql/ui/console/interactive_sql_client'
+
+module Rex
+  module Post
+    module Sql
+      module Ui
+
+        #
+        # Base console class for Generic SQL consoles
+        #
+        module Console
+
+          include Rex::Ui::Text::DispatcherShell
+
+          # Called when someone wants to interact with an SQL client.  It's
+          # assumed that init_ui has been called prior.
+          #
+          # @param [Proc] block
+          # @return [Integer]
+          def interact(&block)
+            # Run queued commands
+            commands.delete_if do |ent|
+              run_single(ent)
+              true
+            end
+
+            # Run the interactive loop
+            run do |line|
+              # Run the command
+              run_single(line)
+
+              # If a block was supplied, call it, otherwise return false
+              if block
+                block.call
+              else
+                false
+              end
+            end
+          end
+
+          # Queues a command to be run when the interactive loop is entered.
+          #
+          # @param [Object] cmd
+          # @return [Object]
+          def queue_cmd(cmd)
+            self.commands << cmd
+          end
+
+          # Runs the specified command wrapper in something to catch meterpreter
+          # exceptions.
+          #
+          # @param [Object] dispatcher
+          # @param [Object] method
+          # @param [Object] arguments
+          # @return [FalseClass]
+          def run_command(dispatcher, method, arguments)
+            begin
+              super
+            rescue ::Timeout::Error
+              log_error('Operation timed out.')
+            rescue ::Rex::InvalidDestination => e
+              log_error(e.message)
+            rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
+              self.session.kill
+            rescue ::StandardError => e
+              log_error("Error running command #{method}: #{e.class} #{e}")
+              elog(e)
+            end
+          end
+
+          #
+          # Interacts with the supplied client.
+          #
+          def interact_with_client(client_dispatcher: nil)
+            return unless client_dispatcher
+
+            client.extend(InteractiveSqlClient) unless client.is_a?(InteractiveSqlClient)
+            client.on_command_proc = self.on_command_proc if self.on_command_proc && client.respond_to?(:on_command_proc)
+            client.on_print_proc   = self.on_print_proc if self.on_print_proc && client.respond_to?(:on_print_proc)
+            client.on_log_proc = method(:log_output) if self.respond_to?(:log_output, true) && client.respond_to?(:on_log_proc)
+            client.client_dispatcher = client_dispatcher
+
+            client.interact(input, output)
+            client.reset_ui
+          end
+
+          #
+          # Log that an error occurred.
+          #
+          def log_error(msg)
+            print_error(msg)
+
+            elog(msg, session.type)
+
+            dlog("Call stack:\n#{$ERROR_POSITION.join("\n")}", session.type)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/sql/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher.rb
@@ -1,0 +1,89 @@
+# -*- coding: binary -*-
+
+require 'rex/post/sql/ui/console/command_dispatcher/client'
+require 'rex/post/sql/ui/console/command_dispatcher/core'
+require 'rex/post/sql/ui/console/command_dispatcher/modules'
+
+module Rex
+  module Post
+    module Sql
+      module Ui
+        module Console
+
+          ###
+          #
+          # Base class for all command dispatchers within the Generic SQL console user interface.
+          #
+          ###
+          module CommandDispatcher
+
+            include Msf::Ui::Console::CommandDispatcher::Session
+
+            #
+            # Initializes an instance of the core command set using the supplied session and client
+            # for interactivity.
+            #
+            # @param [Rex::Post::PostgreSQL::Ui::Console] console
+            def initialize(console)
+              super
+              @msf_loaded = nil
+              @filtered_commands = []
+            end
+
+            #
+            # Returns the SQL client context.
+            # @return [Object]
+            def client
+              console = shell
+              console.client
+            end
+
+            #
+            # Returns the PostgreSQL session context.
+            #
+            # @return [Msf::Sessions::PostgreSQL]
+            def session
+              console = shell
+              console.session
+            end
+
+            #
+            # Returns the commands that meet the requirements
+            #
+            def filter_commands(all, reqs)
+              all.delete_if do |cmd, _desc|
+                if reqs[cmd]&.any? { |req| !client.commands.include?(req) }
+                  @filtered_commands << cmd
+                  true
+                end
+              end
+            end
+
+            def unknown_command(cmd, line)
+              if @filtered_commands.include?(cmd)
+                print_error("The \"#{cmd}\" command is not supported by this session type (#{session.session_type})")
+                return :handled
+              end
+
+              super
+            end
+
+            #
+            # Returns true if the client has a framework object.
+            #
+            # Used for firing framework session events
+            #
+            def msf_loaded?
+              return @msf_loaded unless @msf_loaded.nil?
+
+              # if we get here we must not have initialized yet
+
+              @msf_loaded = !session.framework.nil?
+              @msf_loaded
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -1,0 +1,147 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    module Sql
+      module Ui
+        module Console
+          module CommandDispatcher
+
+            ###
+            #
+            # Core Generic SQL client commands
+            #
+            ###
+            module Client
+
+              include Rex::Post::Sql::Ui::Console::CommandDispatcher
+
+              #
+              # Initializes an instance of the core command set using the supplied console
+              # for interactivity.
+              #
+              # @param console The protocol-specific Rex Ui Console
+              def initialize(console)
+                super
+
+                @db_search_results = []
+              end
+
+              #
+              # List of supported commands.
+              #
+              def commands
+                cmds = {
+                  'query'   => 'Run a raw SQL query',
+                  'shell'   => 'Enter a raw shell where SQL queries can be executed',
+                }
+
+                reqs = {}
+
+                filter_commands(cmds, reqs)
+              end
+
+              # @return [String] The name of the client
+              def name
+                raise ::NotImplementedError
+              end
+
+              # @param [Array] args An array of arguments passed in to a command
+              # @return [TrueClass, FalseClass] True if the array contains '-h' or '--help', else false.
+              def help_args?(args)
+                return false unless args.instance_of?(::Array)
+
+                args.include?('-h') || args.include?('--help')
+              end
+
+              def cmd_shell_help
+                print_line 'Usage: shell'
+                print_line
+                print_line 'Go into a raw SQL shell where SQL queries can be executed.'
+                print_line "To exit, type 'exit', 'quit', 'end' or 'stop'."
+                print_line
+              end
+
+              def cmd_shell(*args)
+                if help_args?(args)
+                  cmd_shell_help
+                  return
+                end
+
+                console = shell
+                # Pass in self so that we can call cmd_query in subsequent calls
+                console.interact_with_client(client_dispatcher: self)
+              end
+
+              def normalise_sql_result(result)
+                raise ::NotImplementedError
+              end
+
+              # Take in a normalised SQL result and print it.
+              # If there are any errors, print those instead.
+              # @param [Hash {Symbol => Array, Symbol => Array, Symbol => Array}] result A hash of 'rows', 'columns' and 'errors'
+              def format_result(result)
+                if result[:errors].any?
+                  return "Query has failed. Reasons: #{result[:errors].join(', ')}"
+                end
+
+                number_column = ['#']
+                columns = [number_column, result[:columns]].flatten
+                rows = result[:rows].map.each_with_index do |row, i|
+                  [i, row].flatten
+                end
+
+                ::Rex::Text::Table.new(
+                  'Header' => 'Response',
+                  'Indent' => 4,
+                  'Columns' => columns,
+                  'Rows' => rows
+                )
+              end
+
+              def cmd_query_help
+                raise ::NotImplementedError
+              end
+
+              def run_query(query)
+                begin
+                  result = client.query(query)
+                rescue ::RuntimeError, ::StandardError => e
+                  elog("Running query '#{query}' failed on session #{self.inspect}", error: e)
+                  return { status: :error, result: { errors: [e] } }
+                end
+
+                if result.respond_to? :cmd_tag
+                  print_status result.cmd_tag
+                  print_line
+                end
+
+                { status: :success, result: result }
+              end
+
+              def cmd_query(*args)
+                if help_args?(args)
+                  cmd_query_help
+                  return
+                end
+
+                result = run_query(args.join(' '))
+
+                normalised_result = result[:status] == :success ? normalise_sql_result(result[:result]) : result[:result]
+                formatted_result = format_result(normalised_result)
+
+                normalised_result[:errors].any? ? print_error(formatted_result.to_s) : print_line(formatted_result.to_s)
+              end
+
+              def process_query(query: '')
+                return '' if query.empty?
+
+                query.lines.each.map { |line| line.chomp.chomp('\\').strip }.reject(&:empty?).compact.join(' ')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/sql/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/core.rb
@@ -1,0 +1,53 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    module Sql
+      module Ui
+        module Console
+          module CommandDispatcher
+
+            #
+            # Generic SQL Core commands
+            #
+            module Core
+
+              include Rex::Post::Sql::Ui::Console::CommandDispatcher
+
+              #
+              # List of supported commands.
+              #
+              def commands
+                cmds = {
+                  '?'                        => 'Help menu',
+                  'background'               => 'Backgrounds the current session',
+                  'bg'                       => 'Alias for background',
+                  'exit'                     => 'Terminate the PostgreSQL session',
+                  'help'                     => 'Help menu',
+                  'irb'                      => 'Open an interactive Ruby shell on the current session',
+                  'pry'                      => 'Open the Pry debugger on the current session',
+                  'sessions'                 => 'Quickly switch to another session',
+                }
+
+                reqs = {}
+
+                filter_commands(cmds, reqs)
+              end
+
+              # @param [String]
+              def name
+                'Core'
+              end
+
+              def unknown_command(cmd, line)
+                status = super
+
+                status
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/sql/ui/console/command_dispatcher/modules.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/modules.rb
@@ -1,0 +1,93 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    module Sql
+      module Ui
+        module Console
+          module CommandDispatcher
+
+            ###
+            #
+            # Generic SQL client commands for running modules
+            #
+            ###
+            module Modules
+              include Rex::Post::Sql::Ui::Console::CommandDispatcher
+
+              #
+              # List of supported commands.
+              #
+              def commands
+                cmds = {
+                  'run' => 'Run a module or script'
+                }
+
+                reqs = {}
+
+                filter_commands(cmds, reqs)
+              end
+
+              #
+              # Modules
+              #
+              def name
+                'Modules'
+              end
+
+              def cmd_run_help
+                raise ::NotImplementedError
+              end
+
+              #
+              # Executes a module/script in the context of the SQL session.
+              #
+              def cmd_run(*args)
+                if args.empty? || help_args?(args)
+                  cmd_run_help
+                  return true
+                end
+
+                # Get the script name
+                begin
+                  script_name = args.shift
+                  # First try it as a module if we have access to the Metasploit
+                  # Framework instance.  If we don't, or if no such module exists,
+                  # fall back to using the scripting interface.
+                  if msf_loaded? && (mod = session.framework.modules.create(script_name))
+                    original_mod = mod
+                    reloaded_mod = session.framework.modules.reload_module(original_mod)
+
+                    unless reloaded_mod
+                      error = session.framework.modules.module_load_error_by_path[original_mod.file_path]
+                      print_error("Failed to reload module: #{error}")
+
+                      return
+                    end
+
+                    opts = ''
+
+                    opts << (args + [ "SESSION=#{session.sid}" ]).join(',')
+                    result = reloaded_mod.run_simple(
+                      'LocalInput' => shell.input,
+                      'LocalOutput' => shell.output,
+                      'OptionStr' => opts
+                    )
+
+                    print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
+                  else
+                    # the rest of the arguments get passed in through the binding
+                    session.execute_script(script_name, args)
+                  end
+                rescue ::StandardError => e
+                  print_error("Error in script: #{script_name}")
+                  elog("Error in script: #{script_name}", error: e)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -1,8 +1,9 @@
 # -*- coding: binary -*-
 module Rex
 module Post
-module PostgreSQL
+module Sql
 module Ui
+module Console
 
 ###
 #
@@ -10,7 +11,7 @@ module Ui
 # manner that adds interactive capabilities.
 #
 ###
-module Console::InteractiveSqlClient
+module InteractiveSqlClient
 
   include Rex::Ui::Interactive
 
@@ -100,6 +101,7 @@ module Console::InteractiveSqlClient
 
     if finished
       self.interacting = false
+      print_status 'Exiting Shell mode.'
       return { status: :exit, result: nil }
     end
 
@@ -114,6 +116,7 @@ module Console::InteractiveSqlClient
 
       if stop_words.include? line.chomp.downcase
         self.interacting = false
+        print_status 'Exiting Shell mode.'
         return { status: :exit, result: nil }
       end
 
@@ -130,7 +133,7 @@ module Console::InteractiveSqlClient
   attr_accessor :on_log_proc, :client_dispatcher
 
 end
-
+end
 end
 end
 end

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -558,7 +558,7 @@ module Rex
           tdsproxy.send_recv(req)
         end
 
-        def mssql_query(sqla, doprint=false, opts={})
+        def query(sqla, doprint=false, opts={})
           info = { :sql => sqla }
           opts[:timeout] ||= 15
           pkts = []

--- a/lib/rex/proto/mssql/client_mixin.rb
+++ b/lib/rex/proto/mssql/client_mixin.rb
@@ -132,7 +132,7 @@ module ClientMixin
   def mssql_xpcmdshell(cmd, doprint=false, opts={})
     force_enable = false
     begin
-      res = mssql_query("EXEC master..xp_cmdshell '#{cmd}'", false, opts)
+      res = query("EXEC master..xp_cmdshell '#{cmd}'", false, opts)
       if res[:errors] && !res[:errors].empty?
         if res[:errors].join =~ /xp_cmdshell/
           if force_enable
@@ -140,7 +140,7 @@ module ClientMixin
             raise RuntimeError, "Failed to execute command"
           else
             print_status("The server may have xp_cmdshell disabled, trying to enable it...")
-            mssql_query(mssql_xpcmdshell_enable())
+            query(mssql_xpcmdshell_enable())
             raise RuntimeError, "xp_cmdshell disabled"
           end
         end

--- a/spec/lib/msf/base/sessions/mssql_spec.rb
+++ b/spec/lib/msf/base/sessions/mssql_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'rex/post/mssql/ui/console/command_dispatcher/core'
+require 'rex/post/mssql'
 
 RSpec.describe Msf::Sessions::MSSQL do
   let(:rstream) { instance_double(::Rex::Socket) }

--- a/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'rex/post/mssql/ui/console/command_dispatcher/core'
+require 'rex/post/mssql'
 
 RSpec.describe Rex::Post::MSSQL::Ui::Console::CommandDispatcher::Core do
   let(:rstream) { instance_double(::Rex::Socket) }


### PR DESCRIPTION
This PR gets rid of a lot of the copy-pasted code for the recently-added SQL-based session types (PostgreSQL, MSSQL & MySQL).

This PR:
- Aligns the underlying SQL clients to now use the `def query` convention for consistency. Wrappers such as `mssql_query` and `mysql_query` are unaffected and modules relying on that wrapper should still work as expected.
- Adds in `sessions -i x -c` command support for sessions that `include` the generic SQL session type mixin.
- Implements correct CTRL+Z/C handling for `shell` mode for all SQL-based session types. This code is now in a single place only.
- Working Autoruns for SQL-based sessions
- Working `run` command for running modules/scripts in the context of the SQL-based session
- Replaced backticks with single-quotes based on the feedback here: https://github.com/rapid7/metasploit-framework/pull/18747#discussion_r1484241528
- Uses the `Response` header for SQL query results table
- Allows for normalising SQL results from all three SQL-based session types to now provide a consistent result defined as `{ columns: [], rows: [], errors: [] }`

## Verification

### Docker Setup
```bash
docker run -it -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:16.1

docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=MyMSSQLServerPassword__<>" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04

docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 3306:3306 mysql:8.3.0

docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 4306:3306 mariadb:11.2.2
```

### MSSQL Server Setup
This is set up on a Windows Server box, and also allows for Kerberos Auth to be used. For Kerberos Auth, use the docs here: https://docs.metasploit.com/docs/pentesting/metasploit-guide-mssql.html#kerberos-authentication

### Getting Sessions
I used the following script to get sessions against all targets easily. Remember to adapt the IPs and the MSSQL Server username & password for your environment. It should give you seven (7) sessions.

```ruby
use mysql_login
run rhost=127.0.0.1 rport=3306 username=root password=password
run rhost=127.0.0.1 rport=4306 username=root password=password

use postgres_login
run rhost=127.0.0.1 rport=5432 username=postgres password=password database=template1

use mssql_login
run rhost=192.168.x.3 rport=1433 username=mssql-user password=mssql-password1 use_windows_authent=false
run rhosts=192.168.x.3 domaincontrollerrhost=192.168.x.3 username=windows_admin_user password=windows_admin_password mssql::auth=kerberos mssql::rhostname=domain_controller_hostname mssqldomain=domain_name
run rhost=192.168.x.3 rport=1433 username=windows_admin_user password=windows_admin_password use_windows_authent=true
run rhost=127.0.0.1 rport=1433 username=sa password=MyMSSQLServerPassword__<> use_windows_authent=false
```

### Scripts
I've used an example autorun script, `autoruns.rc`:
```erb
<ruby>
$stderr.puts "hello world from autoruns"
$stderr.puts self
</ruby>
```

For some testing, you can use the following script. Make sure you change the relevant IPs and passwords/usernames.

```ruby
<ruby>

run_single "use auxiliary/scanner/postgres/postgres_login"
run_single "run rhost=127.0.0.1 rport=5432 username=postgres password=password CreateSession=true stop_on_success=true autorunscript=autoruns.rc"

run_single "use auxiliary/scanner/postgres/postgres_schemadump"
run_single "run session=-1"

run_single "sessions -i -1 -c 'query -h'"
run_single "sessions -i -1 -c 'query select version()'"

run_single "use mysql_login"
run_single "run rhost=127.0.0.1 rport=3306 username=root password=password CreateSession=true stop_on_success=true autorunscript=autoruns.rc"

run_single "use mysql_schemadump"
run_single "run session=-1"

run_single "sessions -i -1 -c 'query -h'"
run_single "sessions -i -1 -c 'query SHOW DATABASES'"

run_single "use mssql_login"
run_single "run rhost=127.0.0.1 username=sa password=MyMSSQLServerPassword__<> CreateSesion=true stop_on_success=true autorunscript=autoruns.rc"

run_single "use auxiliary/scanner/mssql/mssql_schemadump"
run_single "run session=-1"

run_single "sessions -i -1 -c 'query -h'"
run_single "sessions -i -1 -c 'query select @@version'"

</ruby>
```

- [ ] Ensure you can interact with each session type
- [ ] Ensure the commands `run` etc. work from inside the context of interacting with a session
- [ ] Ensure you can use `sessions -i x -c 'query your_query'` correctly and errors & results are handled
- [ ] Ensure you can use the `shell` command and correctly CTRL+Z & CTRL+C out of the shell context for each session type
- [ ] Ensure CI & tests pass
- [ ] Ensure MSSQL can be used with Kerberos
- [ ] Ensure MySQL, MSSQL & PostgreSQL modules continue to work