### PR TITLE
Catch exception when updating non-existing session

### DIFF
--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -227,10 +227,11 @@ module Session
   #
   def cleanup
     if db_record and framework.db.active
-      ::ApplicationRecord.connection_pool.with_connection {
+      ::ApplicationRecord.connection_pool.with_connection do
         framework.db.update_session(id: db_record.id, closed_at: Time.now.utc, close_reason: db_record.close_reason)
-        db_record = nil
-      }
+      rescue ActiveRecord::RecordNotFound
+        nil  # this will fail if the workspace was deleted before the session was closed, see #18561
+      end
     end
   end
 


### PR DESCRIPTION
Fix #18561 by catching `ActiveRecord::RecordNotFound` exceptions to prevent them from being printed to the screen. These exceptions are raised when the workspace is deleted before the session is closed.

It shouldn't be necessary to log the exception because it was already logged by: https://github.com/rapid7/metasploit-framework/blob/9b4d6f12192d7c1a7ef9ba8e3bfbbcd31b9a2ddb/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb#L54

## Testing

- [x] Open a Meterpreter session
- [x] Background the Meterpreter session
- [x] Delete the current workspace by running `workspace -D`
- [x] Kill the session by running `sessions -K`
- [x] Do *not* see an exception that is thrown

## Demo
```
msf6 exploit(windows/smb/psexec) > 
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Executing the payload...
[*] Sending stage (201798 bytes) to 192.168.159.10
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:63450) at 2024-02-13 16:28:08 -0500

msf6 exploit(windows/smb/psexec) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf6 exploit(windows/smb/psexec) > sessions -K
[*] Killing all sessions...
[*] 192.168.159.10 - Meterpreter session 1 closed.
msf6 exploit(windows/smb/psexec) > 
```