### PR TITLE
clean up code duplication

### DIFF
--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -72,15 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     if session
       set_session(session.client)
-    end
-
-    unless session || mssql_login_datastore
-      vprint_status("Invalid SQL Server credentials")
-      return Exploit::CheckCode::Detected
-    end
-
-    if session
-      set_session(session.client)
     else
       unless mssql_login_datastore
         vprint_status("Invalid SQL Server credentials")
@@ -105,14 +96,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     if session
       set_session(session.client)
-    end
-
-    unless session || mssql_login_datastore
-      print_status("Invalid SQL Server credentials")
-      return
+    else
+      unless mssql_login_datastore
+        print_status("Invalid SQL Server credentials")
+        return
+      end
     end
 
     method = datastore['METHOD'].downcase


### PR DESCRIPTION
Follow on to https://github.com/rapid7/metasploit-framework/pull/18763

Removes redundant code from recent change. 
To test:
`./msfconsole -q` 
`features set mssql_session_type true`
`save`
`exit`
`use mssql_login`
get a session with `run CreateSession=true`
`use mssql_payload`
make sure that still works as expected