### PR TITLE
Bugfix Msf::Exploit::FileDropper.file_dropper_exist? for Windows sessions

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -173,9 +173,9 @@ module Exploit::FileDropper
       stat.file? || stat.directory?
     else
       if session.platform == 'windows'
-        f = shell_command_token("cmd.exe /C IF exist \"#{normalized}\" ( echo true )")
+        f = session.shell_command_token("cmd.exe /C IF exist \"#{normalized}\" ( echo true )")
         if f =~ /true/
-          f = shell_command_token("cmd.exe /C IF exist \"#{normalized}\\\\\" ( echo false ) ELSE ( echo true )")
+          f = session.shell_command_token("cmd.exe /C IF exist \"#{normalized}\\\\\" ( echo false ) ELSE ( echo true )")
         end
       else
         f = session.shell_command_token("test -f \"#{normalized}\" -o -d \"#{normalized}\" && echo true")

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -174,9 +174,6 @@ module Exploit::FileDropper
     else
       if session.platform == 'windows'
         f = session.shell_command_token("cmd.exe /C IF exist \"#{normalized}\" ( echo true )")
-        if f =~ /true/
-          f = session.shell_command_token("cmd.exe /C IF exist \"#{normalized}\\\\\" ( echo false ) ELSE ( echo true )")
-        end
       else
         f = session.shell_command_token("test -f \"#{normalized}\" -o -d \"#{normalized}\" && echo true")
       end


### PR DESCRIPTION
When using the `FileDropper` mixin for a shell session on the windows platform, it appears the function `file_dropper_exist?` may have been broken for [~9 years](https://github.com/rapid7/metasploit-framework/commit/ea8e62f0fb3ae8b44c36ccab08c957d8d08be5bb#diff-a5e083471f27844ba10ba2c087cdd3440f966d061bf91a3e72dcdfd7587304adR120), preventing files and directories from being deleted if they exist. The function `shell_command_token` was being called, but it should be `session.shell_command_token`. 

```rb
      if session.platform == 'windows'
        f = shell_command_token("cmd.exe /C IF exist \"#{normalized}\" ( echo true )")
        if f =~ /true/
          f = shell_command_token("cmd.exe /C IF exist \"#{normalized}\\\\\" ( echo false ) ELSE ( echo true )")
        end
      else
        f = session.shell_command_token("test -f \"#{normalized}\" -o -d \"#{normalized}\" && echo true")
      end
```

An exception was being thrown when the function `shell_command_token` could not be found, and swallowed (silently unless you have debug logging enabled) in `Msf::Payload::on_session`:

```rb
  def on_session(session)

    # If this payload is associated with an exploit, inform the exploit
    # that a session has been created and potentially shut down any
    # open sockets. This allows active exploits to continue hammering
    # on a service until a session is created.
    if (assoc_exploit)

      # Signal that a new session is created by calling the exploit's
      # on_new_session handler. The default behavior is to set an
      # instance variable, which the exploit will have to check.
      begin
        assoc_exploit.on_new_session(session)
      rescue ::Exception => e
        dlog("#{assoc_exploit.refname}: on_new_session handler triggered exception: #{e.class} #{e} #{e.backtrace}", 'core', LEV_1)	rescue nil
      end
```

Additionally, the logic in the `file_dropper_exist?` function for windows shell sessions is wrong. The function should test if a path is either a file _or_ a directory, the logic current only tests is a path is a file and return false if it is a directory. This does not match how the test is done on either meterpreter sessions or non windows shell sessions. (I think the code was copied from the File post modules back when FileDropper only supported cleaning up files, but now FileDropper supports directories, so `file_dropper_exist?` must test for either. the Windows shell command IF EXIST will test for both implicitly)

So with the 2 fixes mentioned in this pull request, the following works as expected in my testing:

```rb
      if session.platform == 'windows'
        f = session.shell_command_token("cmd.exe /C IF exist \"#{normalized}\" ( echo true )")
      else
        f = session.shell_command_token("test -f \"#{normalized}\" -o -d \"#{normalized}\" && echo true")
      end
```
