### PR TITLE
msftidy_docs.rb update: add TARGETURI to universal option list

### DIFF
--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -245,8 +245,8 @@ class MsftidyDoc
       end
 
       # this will catch either bold or h2/3 universal options.  Defaults aren't needed since they're not unique to this exploit
-      if in_options && ln =~ /^\s*[\*#]{2,3}\s*(rhost|rhosts|rport|lport|lhost|srvhost|srvport|ssl|uripath|session|proxies|payload)\*{0,2}$/i
-        warn('Universal options such as rhost(s), rport, lport, lhost, srvhost, srvport, ssl, uripath, session, proxies, payload can be removed.', idx)
+      if in_options && ln =~ /^\s*[\*#]{2,3}\s*(rhost|rhosts|rport|lport|lhost|srvhost|srvport|ssl|uripath|session|proxies|payload|targeturi)\*{0,2}$/i
+        warn('Universal options such as rhost(s), rport, lport, lhost, srvhost, srvport, ssl, uripath, session, proxies, payload, targeturi can be removed.', idx)
       end
       # find spaces at EOL not in a code block which is ``` or starts with four spaces
       if !in_codeblock && ln =~ /[ \t]$/ && !(ln =~ /^    /)


### PR DESCRIPTION
This adds the TARGETURI option to the universal option list in `msftidy_docs.rb`. This option is used by almost every web-based modules and should be largely be understood by users. It is usually redefined in modules to customize its description text, which should not require to be documented.