### PR TITLE
Add Proxies support to creating a session with postgres_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/postgres.rb
+++ b/lib/metasploit/framework/login_scanner/postgres.rb
@@ -45,7 +45,7 @@ module Metasploit
           pg_conn = nil
 
           begin
-            pg_conn = Msf::Db::PostgresPR::Connection.new(db_name,credential.public,credential.private,uri)
+            pg_conn = Msf::Db::PostgresPR::Connection.new(db_name,credential.public,credential.private,uri,proxies)
           rescue ::RuntimeError => e
             case e.to_s.split("\t")[1]
               when "C3D000"

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -94,6 +94,7 @@ module Exploit::Remote::Postgres
     password = opts[:password] || datastore['PASSWORD']
     ip = opts[:server]         || datastore['RHOST']
     port = opts[:port]         || datastore['RPORT']
+    proxies = opts[:proxies]   || datastore['Proxies']
     uri = "tcp://#{ip}:#{port}"
 
     if Rex::Socket.is_ipv6?(ip)
@@ -102,7 +103,7 @@ module Exploit::Remote::Postgres
 
     verbose = opts[:verbose] || datastore['VERBOSE']
     begin
-      self.postgres_conn = Connection.new(db,username,password,uri)
+      self.postgres_conn = Connection.new(db,username,password,uri,proxies)
     rescue RuntimeError => e
       case e.to_s.split("\t")[1]
       when "C3D000"

--- a/lib/postgres/postgres-pr/connection.rb
+++ b/lib/postgres/postgres-pr/connection.rb
@@ -56,12 +56,12 @@ class Connection
     end
   end
 
-  def initialize(database, user, password=nil, uri = nil)
+  def initialize(database, user, password=nil, uri = nil, proxies = nil)
     uri ||= DEFAULT_URI
 
     @transaction_status = nil
     @params = { 'username' => user, 'database' => database }
-    establish_connection(uri)
+    establish_connection(uri, proxies)
 
     # Check if the password supplied is a Postgres-style md5 hash
     md5_hash_match = password.match(/^md5([a-f0-9]{32})$/)
@@ -243,14 +243,15 @@ class Connection
 
   # tcp://localhost:5432
   # unix:/tmp/.s.PGSQL.5432
-  def establish_connection(uri)
+  def establish_connection(uri, proxies)
     u = URI.parse(uri)
     case u.scheme
     when 'tcp'
       @conn = Rex::Socket.create(
       'PeerHost' => (u.host || DEFAULT_HOST).gsub(/[\[\]]/, ''),  # Strip any brackets off (IPv6)
       'PeerPort' => (u.port || DEFAULT_PORT),
-      'proto' => 'tcp'
+      'proto' => 'tcp',
+      'Proxies' => proxies
     )
     when 'unix'
       @conn = UNIXSocket.new(u.path)

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     scanner = Metasploit::Framework::LoginScanner::Postgres.new(
       host: ip,
       port: rport,
-      proxies: datastore['PROXIES'],
+      proxies: datastore['Proxies'],
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],

--- a/spec/lib/metasploit/framework/login_scanner/postgres_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/postgres_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Postgres do
 
     context 'when there is no realm on the credential' do
       it 'uses template1 as the default realm' do
-        expect(Msf::Db::PostgresPR::Connection).to receive(:new).with('template1', 'root', 'toor', 'tcp://:')
+        expect(Msf::Db::PostgresPR::Connection).to receive(:new).with('template1', 'root', 'toor', 'tcp://:', nil)
         login_scanner.attempt_login(cred_no_realm)
       end
     end


### PR DESCRIPTION
This PR allows the `postgres_login` module to work with proxies.
This was tested using MacOS host and an Ubuntu VM running Docker.
The MacOS host was running two framework consoles. One for setting up a meterpreter session on the Ubuntu VM and the socks proxy job, and the second instance was using the socks proxy to connect to the internal Docker IP.

## Before
```ruby
msf6 auxiliary(scanner/postgres/postgres_login) > run proxies=socks5:192.168.112.1:1080 rhost=172.17.0.3 rport=5432 stop_on_success=true CreateSession=true username=postgres password=password verbose=true

[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:password@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:tiger@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:postgres@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:password@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:admin@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: :password@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: :@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: :tiger@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: :postgres@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: :password@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: :admin@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:password@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:tiger@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:postgres@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:password@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
[-] 172.17.0.3:5432 - LOGIN FAILED: postgres:admin@template1 (Incorrect: The connection with (172.17.0.3:5432) timed out.)
...
You get the point
...
^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
```

## After
```ruby
msf6 auxiliary(scanner/postgres/postgres_login) > run proxies=socks5:192.168.112.1:1080 rhost=172.17.0.3 rport=5432 stop_on_success=true CreateSession=true username=postgres password=password verbose=true

[+] 172.17.0.3:5432 - Login Successful: postgres:password@template1
[*] PostgreSQL session 1 opened (192.168.112.1:52583 -> 192.168.112.1:1080) at 2024-02-17 01:11:24 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/postgres/postgres_login) > sessions

Active sessions
===============

  Id  Name  Type        Information                               Connection
  --  ----  ----        -----------                               ----------
  1         postgresql  PostgreSQL postgres @ 192.168.112.1:1080  192.168.112.1:52583 -> 192.168.112.1:1080 (172.17.0.3)

msf6 auxiliary(scanner/postgres/postgres_login) > sessions -i -1
[*] Starting interaction with 1...

PostgreSQL @ 192.168.112.1:1080 (template1) > query select version()
[*] SELECT 1

Query
=====

    #  version
    -  -------
    0  PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
```

### Wireshark

![image](https://github.com/rapid7/metasploit-framework/assets/85949464/151720c0-c0a4-4927-9d70-3f5bf1543b2b)

This shows us that the PostgreSQL session is routed through the Ubuntu VM (192.168.112.132), and the host is isolated from that VM's Docker IP address range.

![image](https://github.com/rapid7/metasploit-framework/assets/85949464/44f74639-67a7-4946-a2fc-0bf8db0fc348)

The above screenshot shows the query `select version()` being executed. This TCP stream is encrypted, and we are routing it correctly 👍 

## Verification

You might want to ensure that on your host, you have no Docker containers running so that false positives with the same IP on the host and VM are avoided.

- [x] Start `msfconsole` on your host
- [x] Have Docker installed on your Ubuntu VM
- [x] Set up a Postgres container
- [x] Get a meterpreter x64 session on your Ubuntu VM
- [x] in the Framework Console, do `route add` to add the internal Docker IP from Ubuntu to the routing table (you may be able to call `route add 172.17.0.1/24 -1`)
- [x] Set up a socks proxy on the first instance using `use socks_proxy`
- [x] Run a second framework instance on your host
- [x] `use postgres_login`
- [x] pass in the `proxies=` option pointing to your IP and port used by the socks_proxy
- [x] `run proxies=socks5:your_ip:1080 rhost=ubuntu_vm_internal_docker_ip rport=5432 stop_on_success=true CreateSession=true username=postgres password=whatever_password_you_picked verbose=true`
