### PR TITLE
Add Proxies support to creating a session with mssql_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -77,7 +77,7 @@ module Metasploit
           }
 
           begin
-            client = Rex::Proto::MSSQL::Client.new(framework_module, framework, host, port)
+            client = Rex::Proto::MSSQL::Client.new(framework_module, framework, host, port, proxies)
             if client.mssql_login(credential.public, credential.private, '', credential.realm)
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
               if use_client_as_proof

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -43,7 +43,7 @@ module Rex
         #   @return [Integer] The delay between sending packets
         attr_accessor :send_delay
 
-        def initialize(framework_module, framework, rhost, rport = 1433)
+        def initialize(framework_module, framework, rhost, rport = 1433, proxies = nil)
           @framework_module       = framework_module
           @framework              = framework
           @connection_timeout     = framework_module.datastore['ConnectTimeout']      || 30
@@ -60,6 +60,7 @@ module Rex
           @domain_controller_rhost = framework_module.datastore['DomainControllerRhost'] || ''
           @rhost = rhost
           @rport = rport
+          @proxies = proxies
         end
 
         #

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -33,6 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         }
     )
     register_options([
+      Opt::Proxies,
       OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
       OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
     ])

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
         scanner = Metasploit::Framework::LoginScanner::MySQL.new(
             host: ip,
             port: rport,
-            proxies: datastore['PROXIES'],
+            proxies: datastore['Proxies'],
             cred_details: cred_collection,
             stop_on_success: datastore['STOP_ON_SUCCESS'],
             bruteforce_speed: datastore['BRUTEFORCE_SPEED'],


### PR DESCRIPTION
This PR allows `mssql_login` to correctly works with over a provided Socks proxy.

## Setup

Ubuntu VM, MacOS Host running two instanced of Framework:
- Instance 1
  - Has a Meterpreter session running on the Ubuntu VM
  - Has added routes to the private Docker IP ranges using `routes add x.x.x.x/32 -1`
  - Has a `socks_proxy` module running on port 1080
- Instance 2
  - Runs the `mssql_login` module
  - Uses the first instance as a proxy to access Ubuntu VM's private Docker IP ranges

## Before

```ruby
msf6 auxiliary(scanner/mssql/mssql_login) > run proxies=socks5:192.168.112.1:1080 rhost=172.17.0.4 rport=1433 stop_on_success=true CreateSession=true username=sa password=MyMSSQLServerPassword__<> verbose=true

[*] 172.17.0.4:1433       - 172.17.0.4:1433 - MSSQL - Starting authentication scanner.
[-] 172.17.0.4:1433       - 172.17.0.4:1433 - LOGIN FAILED: WORKSTATION\sa:MyMSSQLServerPassword__<> (Unable to Connect: The connection with (172.17.0.4:1433) timed out.)
[-] 172.17.0.4:1433       - 172.17.0.4:1433 - LOGIN FAILED: WORKSTATION\sa: (Unable to Connect: The connection with (172.17.0.4:1433) timed out.)
[*] 172.17.0.4:1433       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## After

```ruby
msf6 auxiliary(scanner/mssql/mssql_login) > run proxies=socks5:192.168.112.1:1080 rhost=172.17.0.4 rport=1433 stop_on_success=true CreateSession=true username=sa password=MyMSSQLServerPassword__<> verbose=true

[*] 172.17.0.4:1433       - 172.17.0.4:1433 - MSSQL - Starting authentication scanner.
[+] 172.17.0.4:1433       - 172.17.0.4:1433 - Login Successful: WORKSTATION\sa:MyMSSQLServerPassword__<>
[*] MSSQL session 1 opened (192.168.112.1:52867 -> 192.168.112.1:1080) at 2024-02-17 01:30:01 +0000
[*] 172.17.0.4:1433       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/mssql/mssql_login) > sessions -i -1
[*] Starting interaction with 1...

MSSQL @ 192.168.112.1:1080 (master) > query select @@version;

[*] 172.17.0.4:1433       - SQL Query: select @@version;
[*] 172.17.0.4:1433       - Row Count: 1 (Status: 16 Command: 193)
Response
========

 NULL
 ----
 Microsoft SQL Server 2022 (RTM-CU9) (KB5030731) - 16.0.4085.2 (X64)
        Sep 27 2023 12:05:43
        Copyright (C) 2022 Microsoft C
 orporation
        Enterprise Evaluation Edition (64-bit) on Linux (Ubuntu 22.04.3 LTS) <X64>
```

### Wireshark

![image](https://github.com/rapid7/metasploit-framework/assets/85949464/d306531f-f524-4018-900d-420a1b644138)

The above screenshot shows no leaked destination IP (Private Docker IP Range in the Ubuntu VM)

![image](https://github.com/rapid7/metasploit-framework/assets/85949464/162f45d9-634b-4226-85c0-e659b615bf04)

The above screenshot shows an encrypted TCP stream when executing `query select @@version;` in the mssql session.

## Verification

You might want to ensure that on your host, you have no Docker containers running so that false positives with the same IP on the host and VM are avoided.

- [x] Start `msfconsole` on your host
- [x] Have Docker installed on your Ubuntu VM
- [x] Set up an MSSQL container
- [x] Get a meterpreter x64 session on your Ubuntu VM
- [x] in the Framework Console, do `route add` to add the internal Docker IP from Ubuntu to the routing table (you may be able to call `route add 172.17.0.1/24 -1`)
- [x] Set up a socks proxy on the first instance using `use socks_proxy`
- [x] Run a second framework instance on your host
- [x] `use mssql_login`
- [x] pass in the `proxies=` option pointing to your IP and port used by the socks_proxy
- [x] `run proxies=socks5:your_ip:1080 rhost=ubuntu_vm_internal_docker_ip rport=1433 stop_on_success=true CreateSession=true username=sa password=whatever_password_you_picked verbose=true`
