### PR TITLE
Add Proxies support to creating a session with mysql_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -37,9 +37,9 @@ module Metasploit
           begin
             # manage our behind the scenes socket. Close any existing one and open a new one
             disconnect if self.sock
-            connect
+            self.sock = connect
 
-            mysql_conn = ::Mysql.connect(host, credential.public, credential.private, '', port, sock)
+            mysql_conn = ::Mysql.connect(host, credential.public, credential.private, '', port, io: self.sock)
 
           rescue ::SystemCallError, Rex::ConnectionError => e
             result_options.merge!({

--- a/lib/rex/post/mysql/ui/console.rb
+++ b/lib/rex/post/mysql/ui/console.rb
@@ -23,6 +23,7 @@ module Rex
             # The mysql client context
             self.session = session
             self.client = session.client
+            self.client.socket ||= self.client.io
             prompt = "%undMySQL @ #{client.socket.peerinfo} (#{database_name})%clr"
             history_manager = Msf::Config.mysql_session_history
             super(prompt, '>', history_manager, nil, :mysql)

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
         scanner = Metasploit::Framework::LoginScanner::MySQL.new(
             host: ip,
             port: rport,
-            proxies: datastore['PROXIES'],
+            proxies: datastore['Proxies'],
             cred_details: cred_collection,
             stop_on_success: datastore['STOP_ON_SUCCESS'],
             bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Auxiliary
   def session_setup(result, client)
     return unless (result && client)
 
-    rstream = client.socket
+    rstream = client.socket || client.io
 
     my_session = Msf::Sessions::MySQL.new(rstream, { client: client })
     merging = {


### PR DESCRIPTION
This PR adds in proxy support for getting a mysql session using `mysql_login`.

## Before

```ruby
msf6 auxiliary(scanner/mysql/mysql_login) > run proxies=socks5:192.168.112.1:1080 rhost=172.17.0.2 rport=3306 stop_on_success=true CreateSession=true username=root password=password verbose=true

[+] 172.17.0.2:3306       - 172.17.0.2:3306 - Found remote MySQL version 8.3.0
[-] 172.17.0.2:3306       - 172.17.0.2:3306 - LOGIN FAILED: root:password (Unable to Connect: connection timeout)
[-] 172.17.0.2:3306       - 172.17.0.2:3306 - LOGIN FAILED: root: (Unable to Connect: connection timeout)
[*] 172.17.0.2:3306       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## After

```ruby
msf6 auxiliary(scanner/mysql/mysql_login) > run proxies=socks5:192.168.112.1:1080 rhost=172.17.0.2 rport=3306 stop_on_success=true CreateSession=true username=root password=password verbose=true

[+] 172.17.0.2:3306       - 172.17.0.2:3306 - Found remote MySQL version 8.3.0
[+] 172.17.0.2:3306       - 172.17.0.2:3306 - Success: 'root:password'
[*] MySQL session 1 opened (192.168.112.1:54174 -> 192.168.112.1:1080) at 2024-02-17 03:10:05 +0000
[*] 172.17.0.2:3306       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/mysql/mysql_login) > sessions -i -1
[*] Starting interaction with 1...

MySQL @ 192.168.112.1:1080 () > query 'select version()'
[*] Sending statement: 'select version()'...
Query Result
============

    #  version()
    -  ---------
    0  8.3.0
```

### Wireshark

![image](https://github.com/rapid7/metasploit-framework/assets/85949464/44f051d9-2398-4848-b113-b11372a4e8a0)

The above screenshot shows the initial session setup using the proxy. No internal Docker IP is ever exposed as the host has no access to the Ubuntu VM Docker IP range.

![image](https://github.com/rapid7/metasploit-framework/assets/85949464/80579e46-475e-4425-af21-cbad954c0f6f)

The above Wireshark capture shows the result of running `query 'select version()'` on the session.

## Verification

You might want to ensure that on your host, you have no Docker containers running so that false positives with the same IP on the host and VM are avoided.

- [ ] Start `msfconsole` on your host
- [ ] Have Docker installed on your Ubuntu VM
- [ ] Set up a MySQL container
- [ ] Get a meterpreter x64 session on your Ubuntu VM
- [ ] in the Framework Console, do `route add` to add the internal Docker IP from Ubuntu to the routing table (you may be able to call `route add 172.17.0.1/24 -1`)
- [ ] Set up a socks proxy on the first instance using `use socks_proxy`
- [ ] Run a second framework instance on your host
- [ ] `use mysql_login`
- [ ] pass in the `proxies=` option pointing to your IP and port used by the socks_proxy
- [ ] `run proxies=socks5:your_ip:1080 rhost=ubuntu_vm_internal_docker_ip rport=3306 stop_on_success=true CreateSession=true username=root password=whatever_password_you_picked verbose=true`