### PR TITLE
Use database_name for SQL sessions

### DIFF
--- a/lib/rex/post/mssql/ui/console.rb
+++ b/lib/rex/post/mssql/ui/console.rb
@@ -26,8 +26,7 @@ module Rex
             # The mssql client context
             self.session = session
             self.client = session.client
-            self.cwd = session.client.mssql_query('SELECT DB_NAME();')[:rows][0][0]
-            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{cwd})%clr"
+            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{database_name})%clr"
             history_manager = Msf::Config.mssql_session_history
             super(prompt, '>', history_manager, nil, :mssql)
 
@@ -126,13 +125,14 @@ module Rex
           attr_reader :client
 
           # @return [String]
-          attr_accessor :cwd
+          def database_name
+            session.client.mssql_query('SELECT DB_NAME();')[:rows][0][0]
+          end
 
           # @param [Object] val
           # @return [String]
           def format_prompt(val)
-            self.cwd ||= ''
-            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{@cwd})%clr > "
+            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{database_name})%clr > "
             substitute_colors(prompt, true)
           end
 

--- a/lib/rex/post/mysql/ui/console.rb
+++ b/lib/rex/post/mysql/ui/console.rb
@@ -23,8 +23,7 @@ module Rex
             # The mysql client context
             self.session = session
             self.client = session.client
-            self.cwd = client.database
-            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{cwd})%clr"
+            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{database_name})%clr"
             history_manager = Msf::Config.mysql_session_history
             super(prompt, '>', history_manager, nil, :mysql)
 
@@ -119,13 +118,14 @@ module Rex
           attr_reader :client
 
           # @return [String]
-          attr_accessor :cwd
+          def database_name
+            client.database
+          end
 
           # @param [Object] val
           # @return [String]
           def format_prompt(val)
-            @cwd ||= client.database
-            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{@cwd})%clr > "
+            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{database_name})%clr > "
             substitute_colors(prompt, true)
           end
 

--- a/lib/rex/post/postgresql/ui/console.rb
+++ b/lib/rex/post/postgresql/ui/console.rb
@@ -30,8 +30,7 @@ module Rex
             # The postgresql client context
             self.session = session
             self.client = session.client
-            self.cwd = client.params['database']
-            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{cwd})%clr"
+            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{database_name})%clr"
             history_manager = Msf::Config.postgresql_session_history
             super(prompt, '>', history_manager, nil, :postgresql)
 
@@ -136,11 +135,12 @@ module Rex
           attr_reader :client # :nodoc:
 
           # @return [String]
-          attr_accessor :cwd
+          def database_name
+            client.params['database']
+          end
 
           def format_prompt(val)
-            cwd ||= client.params['database']
-            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{cwd})%clr > "
+            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{database_name})%clr > "
             substitute_colors(prompt, true)
           end
 

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
   def session_setup(result, client)
     return unless (result && client)
     rstream = client.sock
-    my_session = Msf::Sessions::MSSQL.new(rstream, { client: client }) # is cwd right?
+    my_session = Msf::Sessions::MSSQL.new(rstream, { client: client })
     merging = {
       'USERPASS_FILE' => nil,
       'USER_FILE'     => nil,

--- a/spec/lib/msf/base/sessions/mssql_spec.rb
+++ b/spec/lib/msf/base/sessions/mssql_spec.rb
@@ -6,7 +6,7 @@ require 'rex/post/mssql/ui/console/command_dispatcher/core'
 RSpec.describe Msf::Sessions::MSSQL do
   let(:rstream) { instance_double(::Rex::Socket) }
   let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
-  let(:opts) { { client: client, cwd: 'name' } }
+  let(:opts) { { client: client } }
   let(:console_class) { Rex::Post::MSSQL::Ui::Console }
   let(:user_input) { instance_double(Rex::Ui::Text::Input::Readline) }
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }

--- a/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rex::Post::MSSQL::Ui::Console::CommandDispatcher::Core do
   let(:query_result) do
     { rows: [['mssql']]}
   end
-  let(:session) { Msf::Sessions::MSSQL.new(nil, { client: client, cwd: 'mssql' }) }
+  let(:session) { Msf::Sessions::MSSQL.new(nil, { client: client }) }
   let(:address) { '192.0.2.1' }
   let(:port) { '1433' }
   let(:peer_info) { "#{address}:#{port}" }


### PR DESCRIPTION
This PR removes the `cwd` convention from SQL-based sessions, and instead uses a more appropriate `def database_name` computed value rather than a cached variable.

## Verification

### Run Docker
```
docker run -it -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:16.1
docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=MyMSSQLServerPassword__<>" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 3306:3306 mysql:8.3.0
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 4306:3306 mariadb:11.2.2
```

Get all the shells:
```
use mysql_login
run rhost=127.0.0.1 rport=3306 username=root password=password
run rhost=127.0.0.1 rport=4306 username=root password=password

use postgres_login
run rhost=127.0.0.1 rport=5432 username=postgres password=password database=template1

use mssql_login
run rhost=127.0.0.1 rport=1433 username=sa password=MyMSSQLServerPassword__<> use_windows_authent=false
```
- [ ] Confirm the above script works and gets you sessions
- [ ] Confirm the sessions have the correct database names in the prompt