### PR TITLE
Removes SessionType values from modules with OptionalSession mixin

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -18,8 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         supplied.
       },
       'Author'         => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'   => %w[MSSQL],
+      'License'        => MSF_LICENSE
     ))
   end
 

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -18,8 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => [ 'nullbind <scott.sutherland[at]netspi.com>'],
       'License'        => MSF_LICENSE,
-      'References'     => [[ 'URL','http://technet.microsoft.com/en-us/library/ms188676(v=sql.105).aspx']],
-      'SessionTypes'   => %w[MSSQL]
+      'References'     => [[ 'URL','http://technet.microsoft.com/en-us/library/ms188676(v=sql.105).aspx']]
     ))
   end
 

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -28,8 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         'todb'                                               # Help on GitHub
       ],
       'License'        => MSF_LICENSE,
-      'References'     => [[ 'URL', 'http://www.netspi.com/blog/author/ssutherland/' ]],
-      'SessionTypes'   => %w[MSSQL],
+      'References'     => [[ 'URL', 'http://www.netspi.com/blog/author/ssutherland/' ]]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -30,8 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://www.digininja.org/metasploit/mssql_idf.php' ],
-        ],
-      'SessionTypes'   => %w[MSSQL]
+        ]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -20,8 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'URL', 'http://www.attackresearch.com' ],
           [ 'URL', 'http://msdn.microsoft.com/en-us/library/cc448435(PROT.10).aspx'],
-        ],
-      'SessionTypes'   => %w[MSSQL],
+        ]
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mssql/mssql_sql_file.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql_file.rb
@@ -16,8 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         the appropriate credentials.
       },
       'Author'         => [ 'j0hn__f : <jf[at]tinternet.org.uk>' ],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'   => %w[MSSQL]
+      'License'        => MSF_LICENSE
     ))
 
     register_options(

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -17,7 +17,6 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
         'License'       => MSF_LICENSE,
-        'SessionTypes'  => %w[MySQL],
         'References'    =>
         [
           [ 'URL', 'https://cisecurity.org/benchmarks.html' ]

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -19,8 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         table names, which can be used to seed the wordlist.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'   => %w[MSSQL],
+      'License'        => MSF_LICENSE
     )
   end
 

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -21,8 +21,7 @@ class MetasploitModule < Msf::Auxiliary
           as loot for easy reading.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'   => %w[MSSQL],
+      'License'        => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -23,8 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://pauldotcom.com/2013/01/mysql-file-system-enumeration.html' ],
         [ 'URL', 'http://www.digininja.org/projects/mysql_file_enum.php' ]
       ],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'  => %w[MySQL]
+      'License'        => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -17,8 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         hashes from a MySQL server and stores them for later cracking.
       ),
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'  => %w[MySQL]
+      'License'        => MSF_LICENSE
     )
   end
 

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -19,8 +19,7 @@ class MetasploitModule < Msf::Auxiliary
           MySQL DB server.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'  => %w[MySQL]
+      'License'        => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -21,8 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'  => [
         [ 'URL', 'https://dev.mysql.com/doc/refman/5.7/en/select-into.html' ]
       ],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'  => %w[MySQL]
+      'License'        => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
@@ -17,8 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         hashes from a Postgres server and stores them for later cracking.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE,
-      'SessionTypes'   => %w[PostgreSQL]
+      'License'        => MSF_LICENSE
     )
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
 

--- a/modules/exploits/multi/mysql/mysql_udf_payload.rb
+++ b/modules/exploits/multi/mysql/mysql_udf_payload.rb
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'http://bernardodamele.blogspot.com/2009/01/command-execution-with-mysql-udf.html' ]
           ],
         'Platform'       => ['win', 'linux'],
-        'SessionTypes'   => %w[MySQL],
         'Targets'        =>
           [
             [ 'Windows', {'CmdStagerFlavor' => 'vbs'} ], # Confirmed on MySQL 4.1.22, 5.5.9, and 5.1.56 (64bit)

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -54,7 +54,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Platform'       => 'win',
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'SessionTypes'   => %w[MSSQL],
       'Targets'        =>
         [
           [ 'Automatic', { } ],

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://seclists.org/fulldisclosure/2012/Dec/13']
         ],
       'Platform'       => 'win',
-      'SessionTypes'   => %w[MySQL],
       'Targets'        =>
         [
           [ 'MySQL on Windows prior to Vista', { } ]

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://seclists.org/fulldisclosure/2012/Dec/13']
         ],
       'Platform'       => 'win',
-      'SessionTypes'   => %w[MySQL],
       'Targets'        =>
         [
           [ 'MySQL on Windows', { } ]


### PR DESCRIPTION
This PR removes `SessionTypes` from modules that have the new `include Msf::OptionalSession::<SessionType>` mixin present. The mixin is use to set the `SessionType` values.

## Verification

- [ ] Verify the code changes are sane
- [ ] Use a few of the modules to ensure they still function as expect.