### PR TITLE
Align SQL sessions peerhost and peerport

### DIFF
--- a/lib/msf/core/exploit/remote/mysql.rb
+++ b/lib/msf/core/exploit/remote/mysql.rb
@@ -62,15 +62,17 @@ module Exploit::Remote::MYSQL
       return false
     end
 
-    vprint_good "#{mysql_conn.host}:#{mysql_conn.port} MySQL - Logged in to '#{db}' with '#{user}':'#{pass}'"
+    vprint_good "#{mysql_conn.peerhost}:#{mysql_conn.peerport} MySQL - Logged in to '#{db}' with '#{user}':'#{pass}'"
 
     return true
   end
 
   def mysql_logoff
+    temp_rhost = mysql_conn.peerhost if mysql_conn
+    temp_rport = mysql_conn.peerport if mysql_conn
     mysql_conn.close if mysql_conn
     disconnect if sock
-    vprint_status "#{rhost}:#{rport} MySQL - Disconnected"
+    vprint_status "#{temp_rhost || rhost}:#{temp_rport || rport} MySQL - Disconnected"
   end
 
   def mysql_login_datastore
@@ -95,7 +97,7 @@ module Exploit::Remote::MYSQL
       return nil
     end
 
-    vprint_status "#{mysql_conn.host}:#{mysql_conn.port} MySQL - querying with '#{sql}'"
+    vprint_status "#{mysql_conn.peerhost}:#{mysql_conn.peerport} MySQL - querying with '#{sql}'"
     res
   end
 

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -121,7 +121,7 @@ module Exploit::Remote::Postgres
       return :connection_refused
     end
     if self.postgres_conn
-      print_good "#{self.postgres_conn.address}:#{self.postgres_conn.port} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
+      print_good "#{self.postgres_conn.peerhost}:#{self.postgres_conn.peerport} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
       return :connected
     end
   end
@@ -130,8 +130,8 @@ module Exploit::Remote::Postgres
   #
   # @return [void]
   def postgres_logout
-    ip = self.postgres_conn.address
-    port = self.postgres_conn.port
+    ip = self.postgres_conn.peerhost
+    port = self.postgres_conn.peerport
     verbose = datastore['VERBOSE']
 
     if self.postgres_conn
@@ -158,7 +158,7 @@ module Exploit::Remote::Postgres
 
     if self.postgres_conn
       sql ||= datastore['SQL']
-      vprint_status "#{self.postgres_conn.address}:#{self.postgres_conn.port} Postgres - querying with '#{sql}'"
+      vprint_status "#{self.postgres_conn.peerhost}:#{self.postgres_conn.peerport} Postgres - querying with '#{sql}'"
       begin
         resp = self.postgres_conn.query(sql)
       rescue RuntimeError => e
@@ -196,7 +196,7 @@ module Exploit::Remote::Postgres
     return :error unless resp.kind_of? Connection::Result
 
     if resp.rows and resp.fields
-      print_status "#{postgres_conn.address}:#{postgres_conn.port} Rows Returned: #{resp.rows.size}" if verbose
+      print_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Rows Returned: #{resp.rows.size}" if verbose
       if resp.rows.size > 0
         tbl = Rex::Text::Table.new(
           'Indent' => 4,

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -30,8 +30,6 @@ module Msf::Post::Common
       session.sock.peerhost
     when 'shell', 'powershell'
       session.session_host
-    when 'postgresql', 'mysql'
-      session.address
     end
   rescue
     return nil
@@ -45,8 +43,6 @@ module Msf::Post::Common
       session.sock.peerport
     when 'shell', 'powershell'
       session.session_port
-    when 'postgresql', 'mysql'
-      session.port
     end
   rescue
     return nil

--- a/lib/postgres/postgres-pr/connection.rb
+++ b/lib/postgres/postgres-pr/connection.rb
@@ -121,16 +121,20 @@ class Connection
     end
   end
 
-  def address
+  def peerhost
     @conn.peerhost
   end
 
-  def port
+  def peerport
     @conn.peerport
   end
 
   def current_database
     @params['database']
+  end
+
+  def peerinfo
+    "#{peerhost}:#{peerport}"
   end
 
   def close

--- a/lib/rex/post/mssql/ui/console.rb
+++ b/lib/rex/post/mssql/ui/console.rb
@@ -54,17 +54,6 @@ module Rex
           # @return [MSSQL::Client]
           attr_reader :client
 
-          # @param [Object] val
-          # @return [String]
-          def format_prompt(val)
-            # TODO: Once the client peerhost alignment is landed, extract this out to the generic SQL class.
-            # prompt = "%und#{session.type} @ #{client.peerhost}:#{client.peerport} (#{current_database})%clr > "
-            # or
-            # prompt = "%und#{session.type} @ #{client.peerinfo} (#{current_database})%clr > "
-            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{current_database})%clr > "
-            substitute_colors(prompt, true)
-          end
-
           protected
 
           attr_writer :session, :client # :nodoc:

--- a/lib/rex/post/mysql/ui/console.rb
+++ b/lib/rex/post/mysql/ui/console.rb
@@ -51,13 +51,6 @@ module Rex
           # @return [MySQL::Client]
           attr_reader :client
 
-          # @param [Object] val
-          # @return [String]
-          def format_prompt(val)
-            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{current_database})%clr > "
-            substitute_colors(prompt, true)
-          end
-
           protected
 
           attr_writer :session, :client # :nodoc:

--- a/lib/rex/post/postgresql/ui/console.rb
+++ b/lib/rex/post/postgresql/ui/console.rb
@@ -53,11 +53,6 @@ module Rex
           # @return [PostgreSQL::Client]
           attr_reader :client # :nodoc:
 
-          def format_prompt(val)
-            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{current_database})%clr > "
-            substitute_colors(prompt, true)
-          end
-
           protected
 
           attr_writer :session, :client # :nodoc:

--- a/lib/rex/post/sql/ui/console.rb
+++ b/lib/rex/post/sql/ui/console.rb
@@ -93,6 +93,13 @@ module Rex
             client.reset_ui
           end
 
+          # @param [Object] val
+          # @return [String]
+          def format_prompt(val)
+            prompt = "%und#{session.type} @ #{client.peerinfo} (#{current_database})%clr > "
+            substitute_colors(prompt, true)
+          end
+
           #
           # Log that an error occurred.
           #

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -661,12 +661,16 @@ module Rex
           self.initial_connection_info[:envs]&.select { |hash| hash[:type] == envchange }&.first || {}
         end
 
-        def address
+        def peerhost
           rhost
         end
 
-        def port
+        def peerport
           rport
+        end
+
+        def peerinfo
+          "#{peerhost}:#{peerport}"
         end
 
         protected

--- a/lib/rex/proto/mysql/client.rb
+++ b/lib/rex/proto/mysql/client.rb
@@ -18,6 +18,11 @@ module Rex
           io.remote_address.ip_port
         end
 
+        # @return [String] The remote peer information containing IP and port
+        def peerinfo
+          "#{peerhost}:#{peerport}"
+        end
+
         # @return [String] The database this client is currently connected to
         def current_database
           # Current database is stored as an array under the type 1 key.

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -43,9 +43,9 @@ class MetasploitModule < Msf::Auxiliary
       print "[*]\t#{row}"
     end
     vernum = sqlversion.gsub("\n"," ").scan(/SQL Server\s*(200\d)/m)
-    report_note(:host => mssql_client.address,
+    report_note(:host => mssql_client.peerhost,
       :proto => 'TCP',
-      :port => mssql_client.port,
+      :port => mssql_client.peerport,
       :type => 'MSSQL_ENUM',
       :data => "Version: #{sqlversion}")
 
@@ -75,16 +75,16 @@ class MetasploitModule < Msf::Auxiliary
     # checking for C2 Audit Mode
     if sysconfig['c2 audit mode'] == 1
       print_status("\tC2 Audit Mode is Enabled")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "C2 Audit Mode is Enabled")
     else
       print_status("\tC2 Audit Mode is Not Enabled")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "C2 Audit Mode is Not Enabled")
     end
@@ -94,16 +94,16 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != "2000"
       if sysconfig['xp_cmdshell'] == 1
         print_status("\txp_cmdshell is Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Enabled")
       else
         print_status("\txp_cmdshell is Not Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Not Enabled")
       end
@@ -111,16 +111,16 @@ class MetasploitModule < Msf::Auxiliary
       xpspexist = mssql_query("select sysobjects.name from sysobjects where name = \'xp_cmdshell\'")[:rows]
       if xpspexist != nil
         print_status("\txp_cmdshell is Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Enabled")
       else
         print_status("\txp_cmdshell is Not Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "xp_cmdshell is Not Enabled")
       end
@@ -130,16 +130,16 @@ class MetasploitModule < Msf::Auxiliary
     # check if remote access is enabled
     if sysconfig['remote access'] == 1
       print_status("\tremote access is Enabled")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "remote access is Enabled")
     else
       print_status("\tremote access is Not Enabled")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "remote access is not Enabled")
     end
@@ -148,16 +148,16 @@ class MetasploitModule < Msf::Auxiliary
     #check if updates are allowed
     if sysconfig['allow updates'] == 1
       print_status("\tallow updates is Enabled")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "allow updates is Enabled")
     else
       print_status("\tallow updates is Not Enabled")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "allow updates is not Enabled")
     end
@@ -167,16 +167,16 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != "2000"
       if sysconfig['Database Mail XPs'] == 1
         print_status("\tDatabase Mail XPs is Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is Enabled")
       else
         print_status("\tDatabase Mail XPs is Not Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is not Enabled")
       end
@@ -184,16 +184,16 @@ class MetasploitModule < Msf::Auxiliary
       mailexist = mssql_query("select sysobjects.name from sysobjects where name like \'%mail%\'")[:rows]
       if mailexist != nil
         print_status("\tDatabase Mail XPs is Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is Enabled")
       else
         print_status("\tDatabase Mail XPs is Not Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Database Mail XPs is not Enabled")
       end
@@ -204,16 +204,16 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != "2000"
       if sysconfig['Ole Automation Procedures'] == 1
         print_status("\tOle Automation Procedures are Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are Enabled")
       else
         print_status("\tOle Automation Procedures are Not Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are not Enabled")
       end
@@ -221,16 +221,16 @@ class MetasploitModule < Msf::Auxiliary
       oleexist = mssql_query("select sysobjects.name from sysobjects where name like \'%sp_OA%\'")[:rows]
       if oleexist != nil
         print_status("\tOle Automation Procedures is Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are Enabled")
       else
         print_status("\tOle Automation Procedures are Not Enabled")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Ole Automation Procedures are not Enabled")
       end
@@ -249,9 +249,9 @@ class MetasploitModule < Msf::Auxiliary
           if db_ind_files != nil
             db_ind_files.each do |fn|
               print_status("\t\t#{fn.join}")
-              report_note(:host => mssql_client.address,
+              report_note(:host => mssql_client.peerhost,
                 :proto => 'TCP',
-                :port => mssql_client.port,
+                :port => mssql_client.peerport,
                 :type => 'MSSQL_ENUM',
                 :data => "Database: #{dbn.strip} File: #{fn.join}")
             end
@@ -261,9 +261,9 @@ class MetasploitModule < Msf::Auxiliary
           if db_ind_files != nil
             db_ind_files.each do |fn|
               print_status("\t\t#{fn.join.strip}")
-              report_note(:host => mssql_client.address,
+              report_note(:host => mssql_client.peerhost,
                 :proto => 'TCP',
-                :port => mssql_client.port,
+                :port => mssql_client.peerport,
                 :type => 'MSSQL_ENUM',
                 :data => "Database: #{dbn.strip} File: #{fn.join}")
             end
@@ -283,17 +283,17 @@ class MetasploitModule < Msf::Auxiliary
     if syslogins != nil
       syslogins.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Database: Master User: #{acc.join}")
       end
     else
       print_error("\tCould not enumerate System Logins!")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "Could not enumerate System Logins")
     end
@@ -306,17 +306,17 @@ class MetasploitModule < Msf::Auxiliary
       if disabledsyslogins != nil
         disabledsyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(:host => mssql_client.address,
+          report_note(:host => mssql_client.peerhost,
             :proto => 'TCP',
-            :port => mssql_client.port,
+            :port => mssql_client.peerport,
             :type => 'MSSQL_ENUM',
             :data => "Disabled User: #{acc.join}")
         end
       else
         print_status("\tNo Disabled Logins Found")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "No Disabled Logins Found")
       end
@@ -330,17 +330,17 @@ class MetasploitModule < Msf::Auxiliary
       if nopolicysyslogins != nil
         nopolicysyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(:host => mssql_client.address,
+          report_note(:host => mssql_client.peerhost,
             :proto => 'TCP',
-            :port => mssql_client.port,
+            :port => mssql_client.peerport,
             :type => 'MSSQL_ENUM',
             :data => "None Policy Checked User: #{acc.join}")
         end
       else
         print_status("\tAll System Accounts have the Windows Account Policy Applied to them.")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "All System Accounts have the Windows Account Policy Applied to them")
       end
@@ -354,17 +354,17 @@ class MetasploitModule < Msf::Auxiliary
       if passexsyslogins != nil
         passexsyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(:host => mssql_client.address,
+          report_note(:host => mssql_client.peerhost,
             :proto => 'TCP',
-            :port => mssql_client.port,
+            :port => mssql_client.peerport,
             :type => 'MSSQL_ENUM',
             :data => "None Password Expiration User: #{acc.join}")
         end
       else
         print_status("\tAll System Accounts are checked for Password Expiration.")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "All System Accounts are checked for Password Expiration")
       end
@@ -381,17 +381,17 @@ class MetasploitModule < Msf::Auxiliary
     if sysadmins != nil
       sysadmins.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Sysdba: #{acc.join}")
       end
     else
       print_error("\tCould not enumerate sysadmin accounts!")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "Could not enumerate sysadmin accounts")
     end
@@ -408,17 +408,17 @@ class MetasploitModule < Msf::Auxiliary
     if winusers != nil
       winusers.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Windows Logins: #{acc.join}")
       end
     else
       print_status("\tNo Windows logins found!")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "No Windows logins found")
     end
@@ -435,17 +435,17 @@ class MetasploitModule < Msf::Auxiliary
     if wingroups != nil
       wingroups.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Windows Groups: #{acc.join}")
       end
     else
       print_status("\tNo Windows Groups where found with permission to login to system.")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "No Windows Groups where found with permission to login to system")
 
@@ -464,17 +464,17 @@ class MetasploitModule < Msf::Auxiliary
     if sameasuser != nil
       sameasuser.each do |up|
         print_status("\t#{up.join}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Username: #{up.join} Password: #{up.join}")
       end
     else
       print_status("\tNo Account with its password being the same as its username was found.")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "No Account with its password being the same as its username was found")
     end
@@ -492,17 +492,17 @@ class MetasploitModule < Msf::Auxiliary
     if blankpass != nil
       blankpass.each do |up|
         print_status("\t#{up.join}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Username: #{up.join} Password: EMPTY ")
       end
     else
       print_status("\tNo Accounts with empty passwords where found.")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "No Accounts with empty passwords where found")
     end
@@ -717,18 +717,18 @@ EOS
       fountsp.each do |strp|
         if dangeroussp.include?(strp.strip)
           print_status("\t#{strp.strip}")
-          report_note(:host => mssql_client.address,
+          report_note(:host => mssql_client.peerhost,
             :proto => 'TCP',
-            :port => mssql_client.port,
+            :port => mssql_client.peerport,
             :type => 'MSSQL_ENUM',
             :data => "Stored Procedures with Public Execute Permission #{strp.strip}")
         end
       end
     else
       print_status("\tNo Dangerous Stored Procedure found with Public Execute.")
-      report_note(:host => mssql_client.address,
+      report_note(:host => mssql_client.peerhost,
         :proto => 'TCP',
-        :port => mssql_client.port,
+        :port => mssql_client.peerport,
         :type => 'MSSQL_ENUM',
         :data => "No Dangerous Stored Procedure found with Public Execute")
     end
@@ -760,9 +760,9 @@ EOS
       instances.each do |i|
         print_status("\t#{i}")
         instancenames << i.strip
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Instance Name: #{i}")
       end
@@ -777,9 +777,9 @@ EOS
     if privdflt != nil
       privdflt.each do |priv|
         print_status("\t#{priv[1]}")
-        report_note(:host => mssql_client.address,
+        report_note(:host => mssql_client.peerhost,
           :proto => 'TCP',
-          :port => mssql_client.port,
+          :port => mssql_client.peerport,
           :type => 'MSSQL_ENUM',
           :data => "Default Instance SQL Server running as: #{priv[1]}")
       end
@@ -796,9 +796,9 @@ EOS
             print_status("Instance #{i} SQL Server Service is running under the privilege of:")
             privinst.each do |p|
               print_status("\t#{p[1]}")
-              report_note(:host => mssql_client.address,
+              report_note(:host => mssql_client.peerhost,
                 :proto => 'TCP',
-                :port => mssql_client.port,
+                :port => mssql_client.peerport,
                 :type => 'MSSQL_ENUM',
                 :data => "#{i} Instance SQL Server running as: #{p[1]}")
             end

--- a/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
@@ -106,16 +106,16 @@ class MetasploitModule < Msf::Auxiliary
 
     # Create output file
     this_service = report_service(
-      :host  => mssql_client.address,
-      :port => mssql_client.port,
+      :host  => mssql_client.peerhost,
+      :port => mssql_client.peerport,
       :name => 'mssql',
       :proto => 'tcp'
     )
-    file_name = "#{mssql_client.address}-#{mssql_client.port}_windows_domain_accounts.csv"
+    file_name = "#{mssql_client.peerhost}-#{mssql_client.peerport}_windows_domain_accounts.csv"
     path = store_loot(
       'mssql.domain.accounts',
       'text/plain',
-      mssql_client.address,
+      mssql_client.peerhost,
       windows_domain_login_table.to_csv,
       file_name,
       'Domain Users enumerated through SQL Server',

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -347,7 +347,7 @@ class MetasploitModule < Msf::Auxiliary
         print_line(" ")
         print_status("Attempting to connect to the SQL Server at #{rhost}:#{rport}...")
         return unless mssql_login_datastore
-        print_good("Successfully connected to #{mssql_client.address}:#{mssql_client.port}")
+        print_good("Successfully connected to #{mssql_client.peerhost}:#{mssql_client.peerport}")
       end
       result = mssql_query(sql, false)
 
@@ -443,8 +443,8 @@ class MetasploitModule < Msf::Auxiliary
     this_service = nil
     if framework.db and framework.db.active
       this_service = report_service(
-        :host  => mssql_client.address,
-        :port => mssql_client.port,
+        :host  => mssql_client.peerhost,
+        :port => mssql_client.peerport,
         :name => 'mssql',
         :proto => 'tcp'
       )
@@ -452,8 +452,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # CONVERT TABLE TO CSV AND WRITE TO FILE
     if (save_loot=="yes")
-      filename= "#{mssql_client.address}-#{mssql_client.port}_sqlserver_query_results.csv"
-      path = store_loot("mssql.data", "text/plain", mssql_client.address, sql_data_tbl.to_csv, filename, "SQL Server query results",this_service)
+      filename= "#{mssql_client.peerhost}-#{mssql_client.peerport}_sqlserver_query_results.csv"
+      path = store_loot("mssql.data", "text/plain", mssql_client.peerhost, sql_data_tbl.to_csv, filename, "SQL Server query results",this_service)
       print_good("Query results have been saved to: #{path}")
     end
 

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -121,8 +121,8 @@ class MetasploitModule < Msf::Auxiliary
       res.each do |row|
         print_good("\t\tUser: #{row[0]} Host: #{row[1]} Password Hash: #{row[2]}")
         report_cred(
-          ip: mysql_conn.host,
-          port: mysql_conn.port,
+          ip: mysql_conn.peerhost,
+          port: mysql_conn.peerport,
           user: row[0],
           password: row[2],
           service_name: 'mysql',

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -47,13 +47,13 @@ class MetasploitModule < Msf::Auxiliary
     when :sql_error
       case ret[:sql_error]
       when /^C58P01/
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} Postgres - No such file or directory."
-        vprint_status "#{postgres_conn.address}:#{postgres_conn.port} Postgres - #{ret[:sql_error]}"
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - No such file or directory."
+        vprint_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{ret[:sql_error]}"
       when /^C42501/
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Insufficient file permissions."
-        vprint_status "#{postgres_conn.address}:#{postgres_conn.port} Postgres - #{ret[:sql_error]}"
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Insufficient file permissions."
+        vprint_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{ret[:sql_error]}"
       else
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} Postgres - #{ret[:sql_error]}"
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{ret[:sql_error]}"
       end
     when :complete
       loot = ''
@@ -62,9 +62,9 @@ class MetasploitModule < Msf::Auxiliary
         loot << row.first
       }
       # No idea what the actual ctype will be, text/plain is just a guess
-      path = store_loot('postgres.file', 'text/plain', postgres_conn.address, loot, datastore['RFILE'])
-      print_good("#{postgres_conn.address}:#{postgres_conn.port} Postgres - #{datastore['RFILE']} saved in #{path}")
-      vprint_good  "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Command complete."
+      path = store_loot('postgres.file', 'text/plain', postgres_conn.peerhost, loot, datastore['RFILE'])
+      print_good("#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{datastore['RFILE']} saved in #{path}")
+      vprint_good  "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Command complete."
     end
     postgres_logout if self.postgres_conn && session.blank?
   end

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -47,9 +47,9 @@ class MetasploitModule < Msf::Auxiliary
     when :conn_error
       print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
     when :sql_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} Postgres - #{ret[:sql_error]}"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{ret[:sql_error]}"
     when :complete
-      vprint_good "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Command complete."
+      vprint_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Command complete."
     end
     postgres_logout if self.postgres_conn && session.blank?
   end

--- a/modules/auxiliary/gather/lansweeper_collector.rb
+++ b/modules/auxiliary/gather/lansweeper_collector.rb
@@ -152,8 +152,8 @@ class MetasploitModule < Msf::Auxiliary
       print_good("Credential name: #{row[0]} | username: #{row[1]} | password: #{pw}")
 
       report_cred(
-        :host => mssql_client.address,
-        :port => mssql_client.port,
+        :host => mssql_client.peerhost,
+        :port => mssql_client.peerport,
         :creds_name => row[0],
         :user => row[1],
         :password => pw

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
 
     service_data = {
         address: ip,
-        port: mssql_client.port,
+        port: mssql_client.peerport,
         service_name: 'mssql',
         protocol: 'tcp',
         workspace_id: myworkspace_id
@@ -101,8 +101,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     this_service = report_service(
-          :host  => mssql_client.address,
-          :port => mssql_client.port,
+          :host  => mssql_client.peerhost,
+          :port => mssql_client.peerport,
           :name => 'mssql',
           :proto => 'tcp'
           )
@@ -114,8 +114,8 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     service_data = {
-        address: ::Rex::Socket.getaddress(mssql_client.address,true),
-        port: mssql_client.port,
+        address: ::Rex::Socket.getaddress(mssql_client.peerhost,true),
+        port: mssql_client.peerport,
         service_name: 'mssql',
         protocol: 'tcp',
         workspace_id: myworkspace_id

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -45,29 +45,29 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("Instance Name: #{instancename.inspect}")
     version = mssql_query(mssql_sql_info())[:rows][0][0]
-    output = "Microsoft SQL Server Schema \n Host: #{mssql_client.address} \n Port: #{mssql_client.port} \n Instance: #{instancename} \n Version: #{version} \n====================\n\n"
+    output = "Microsoft SQL Server Schema \n Host: #{mssql_client.peerhost} \n Port: #{mssql_client.peerport} \n Instance: #{instancename} \n Version: #{version} \n====================\n\n"
 
     # Grab all the DB schema and save it as notes
     mssql_schema = get_mssql_schema
     return nil if mssql_schema.nil? or mssql_schema.empty?
     mssql_schema.each do |db|
       report_note(
-        :host  => rhost,
+        :host  => mssql_client.peerhost,
         :type  => "mssql.db.schema",
         :data  => db,
-        :port  => mssql_client.port,
+        :port  => mssql_client.peerport,
         :proto => 'tcp',
         :update => :unique_data
       )
     end
     output << YAML.dump(mssql_schema)
     this_service = report_service(
-          :host  => mssql_client.address,
-          :port => mssql_client.port,
+          :host  => mssql_client.peerhost,
+          :port => mssql_client.peerport,
           :name => 'mssql',
           :proto => 'tcp'
           )
-    store_loot('mssql_schema', "text/plain", mssql_client.address, output, "#{mssql_client.address}_mssql_schema.txt", "MS SQL Schema", this_service)
+    store_loot('mssql_schema', "text/plain", mssql_client.peerhost, output, "#{mssql_client.peerhost}_mssql_schema.txt", "MS SQL Schema", this_service)
     print_good output if datastore['DISPLAY_RESULTS']
   end
 

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -90,20 +90,20 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::Proto::MySQL::Client::TextfileNotReadable
       print_good("#{dir} is a directory and exists")
       report_note(
-        :host  => mysql_conn.host,
+        :host  => mysql_conn.peerhost,
         :type  => "filesystem.dir",
         :data  => "#{dir} is a directory and exists",
-        :port  => mysql_conn.port,
+        :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
       )
     rescue ::Rex::Proto::MySQL::Client::DataTooLong, ::Rex::Proto::MySQL::Client::TruncatedWrongValueForField
       print_good("#{dir} is a file and exists")
       report_note(
-        :host  => mysql_conn.host,
+        :host  => mysql_conn.peerhost,
         :type  => "filesystem.file",
         :data  => "#{dir} is a file and exists",
-        :port  => mysql_conn.port,
+        :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
       )
@@ -118,10 +118,10 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_good("#{dir} is a file and exists")
       report_note(
-        :host  => mysql_conn.host,
+        :host  => mysql_conn.peerhost,
         :type  => "filesystem.file",
         :data  => "#{dir} is a file and exists",
-        :port  => mysql_conn.port,
+        :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
       )

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     service_data = {
-      address: ip,
-      port: mysql_conn.port,
+      address: mysql_conn.peerhost,
+      port: mysql_conn.peerport,
       service_name: 'mysql',
       protocol: 'tcp',
       workspace_id: myworkspace_id
@@ -81,8 +81,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     service_data = {
-      address: ::Rex::Socket.getaddress(mysql_conn.host, true),
-      port: mysql_conn.port,
+      address: ::Rex::Socket.getaddress(mysql_conn.peerhost, true),
+      port: mysql_conn.peerport,
       service_name: 'mysql',
       protocol: 'tcp',
       workspace_id: myworkspace_id

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -41,23 +41,23 @@ class MetasploitModule < Msf::Auxiliary
     mysql_schema = get_schema
     mysql_schema.each do |db|
       report_note(
-        :host  => mysql_conn.host,
+        :host  => mysql_conn.peerhost,
         :type  => "mysql.db.schema",
         :data  => db,
-        :port  => mysql_conn.port,
+        :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
       )
     end
-    output = "MySQL Server Schema \n Host: #{mysql_conn.host} \n Port: #{mysql_conn.port} \n ====================\n\n"
+    output = "MySQL Server Schema \n Host: #{mysql_conn.peerhost} \n Port: #{mysql_conn.peerport} \n ====================\n\n"
     output << YAML.dump(mysql_schema)
     this_service = report_service(
-          :host  => mysql_conn.host,
-          :port => mysql_conn.port,
+          :host  => mysql_conn.peerhost,
+          :port => mysql_conn.peerport,
           :name => 'mysql',
           :proto => 'tcp'
           )
-    p = store_loot('mysql_schema', "text/plain", mysql_conn.host, output, "#{mysql_conn.host}_mysql_schema.txt", "MySQL Schema", this_service)
+    p = store_loot('mysql_schema', "text/plain", mysql_conn.peerhost, output, "#{mysql_conn.peerhost}_mysql_schema.txt", "MySQL Schema", this_service)
     print_good("Schema stored in: #{p}")
     print_good output if datastore['DISPLAY_RESULTS']
   end

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -30,10 +30,10 @@ class MetasploitModule < Msf::Auxiliary
       if session
         sql_conn = session.client
         version = sql_conn.server_info
-        print_good("#{sql_conn.host}:#{sql_conn.port} is running MySQL #{version}")
+        print_good("#{sql_conn.peerhost}:#{sql_conn.peerport} is running MySQL #{version}")
         report_service(
-          :host => sql_conn.host,
-          :port => sql_conn.port,
+          :host => sql_conn.peerhost,
+          :port => sql_conn.peerport,
           :name => "mysql",
           :info => version
         )

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_good("#{dir} is writeable")
       report_note(
-        :host  => mysql_conn.host,
+        :host  => mysql_conn.peerhost,
         :type  => "filesystem.file",
         :data  => "#{dir} is writeable",
-        :port  => mysql_conn.port,
+        :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
       )

--- a/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
@@ -42,8 +42,8 @@ class MetasploitModule < Msf::Auxiliary
     res = postgres_query('SELECT usename, passwd FROM pg_shadow',false)
 
     service_data = {
-        address: postgres_conn.address,
-        port: postgres_conn.port,
+        address: postgres_conn.peerhost,
+        port: postgres_conn.peerport,
         service_name: 'postgres',
         protocol: 'tcp',
         workspace_id: myworkspace_id
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Auxiliary
 
       case res[:sql_error]
       when /^C42501/
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Insufficient permissions."
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Insufficient permissions."
         return
       else
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} Postgres - #{res[:sql_error]}"
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{res[:sql_error]}"
         return
       end
     when :complete
@@ -107,8 +107,8 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     service_data = {
-        address: postgres_conn.address,
-        port: postgres_conn.port,
+        address: postgres_conn.peerhost,
+        port: postgres_conn.peerport,
         service_name: 'postgres',
         protocol: 'tcp',
         workspace_id: myworkspace_id

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -26,6 +26,14 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
   end
 
+  def rhost
+    self.postgres_conn.peerhost
+  end
+
+  def rport
+    self.postgres_conn.peerport
+  end
+
   def run_host(_ip)
     if session
       print_status 'When targeting a session, only the current database can be dumped.'

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -85,27 +85,27 @@ class MetasploitModule < Msf::Auxiliary
         :password => password
       )
       if result[:auth]
-        vprint_good "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Logged in to '#{database}' with '#{user}':'#{password}'" unless session
-        print_status "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Version #{result[:auth]} (Post-Auth)"
+        vprint_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Logged in to '#{database}' with '#{user}':'#{password}'" unless session
+        print_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Version #{result[:auth]} (Post-Auth)"
       elsif result[:preauth]
-        print_good "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Version #{result[:preauth]} (Pre-Auth)"
+        print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Version #{result[:preauth]} (Pre-Auth)"
       else # It's something we don't know yet
-        vprint_status "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Authentication Error Fingerprint: #{result[:unknown]}"
-        print_status "#{postgres_conn.address}:#{postgres_conn.port} Postgres - Version Unknown (Pre-Auth)"
+        vprint_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Authentication Error Fingerprint: #{result[:unknown]}"
+        print_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - Version Unknown (Pre-Auth)"
       end
 
       # Reporting
       report_service(
-        :host => postgres_conn.address,
-        :port => postgres_conn.port,
+        :host => postgres_conn.peerhost,
+        :port => postgres_conn.peerport,
         :name => "postgres",
         :info => result.values.first
       )
 
       if self.postgres_conn
         report_cred(
-          ip: postgres_conn.address,
-          port: postgres_conn.port,
+          ip: postgres_conn.peerhost,
+          port: postgres_conn.peerport,
           service_name: 'postgres',
           user: user,
           password: password,
@@ -115,10 +115,10 @@ class MetasploitModule < Msf::Auxiliary
 
       if result[:unknown]
         report_note(
-          :host => postgres_conn.address,
+          :host => postgres_conn.peerhost,
           :proto => 'tcp',
           :sname => 'postgres',
-          :port => postgres_conn.port,
+          :port => postgres_conn.peerport,
           :ntype => 'postgresql.fingerprint',
           :data => "Unknown Pre-Auth fingerprint: #{result[:unknown]}"
         )

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :noauth; print_error "Authentication failed"; return
     when :noconn; print_error "Connection failed"; return
     else
-      print_status("#{postgres_conn.address}:#{postgres_conn.port} - #{version}")
+      print_status("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{version}")
     end
 
     fname = "/tmp/#{Rex::Text.rand_text_alpha(8)}.so"
@@ -131,8 +131,8 @@ class MetasploitModule < Msf::Exploit::Remote
       )
       if result[:auth]
         report_service(
-          :host => postgres_conn.address,
-          :port => postgres_conn.port,
+          :host => postgres_conn.peerhost,
+          :port => postgres_conn.peerport,
           :name => "postgres",
           :info => result.values.first
         )

--- a/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
+++ b/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
@@ -123,15 +123,15 @@ class MetasploitModule < Msf::Exploit::Remote
     drop_query = postgres_query(query)
     case drop_query.keys[0]
     when :conn_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
       return false
     when :sql_error
-      print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+      print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
       return false
     when :complete
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{tablename} dropped successfully"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{tablename} dropped successfully"
     else
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
       return false
     end
 
@@ -140,15 +140,15 @@ class MetasploitModule < Msf::Exploit::Remote
     create_query = postgres_query(query)
     case create_query.keys[0]
     when :conn_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
       return false
     when :sql_error
-      print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+      print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
       return false
     when :complete
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{tablename} created successfully"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{tablename} created successfully"
     else
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
       return false
     end
 
@@ -158,24 +158,24 @@ class MetasploitModule < Msf::Exploit::Remote
     copy_query = postgres_query(query)
     case copy_query.keys[0]
     when :conn_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
       return false
     when :sql_error
       if copy_query[:sql_error].match? 'execution expired'
         print_warning 'Timed out. The function was potentially executed.'
         return true
       end
-      print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+      print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
       if copy_query[:sql_error] =~ /must be superuser to COPY to or from an external program/
         print_error 'Insufficient permissions, User must be superuser or in pg_read_server_files group'
         return false
       end
-      print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+      print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
       return false
     when :complete
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{tablename} copied successfully(valid syntax/command)"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{tablename} copied successfully(valid syntax/command)"
     else
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
       return false
     end
 
@@ -185,16 +185,16 @@ class MetasploitModule < Msf::Exploit::Remote
       select_query = postgres_query(query)
       case select_query.keys[0]
       when :conn_error
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
         return false
       when :sql_error
-        print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+        print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
         return false
       when :complete
-        print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{tablename} contents:\n#{select_query}"
+        print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{tablename} contents:\n#{select_query}"
         return true
       else
-        print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+        print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
         return false
       end
     end
@@ -203,15 +203,15 @@ class MetasploitModule < Msf::Exploit::Remote
     drop_query = postgres_query(query)
     case drop_query.keys[0]
     when :conn_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
       return false
     when :sql_error
-      print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+      print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
       return false
     when :complete
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{tablename} dropped successfully(Cleaned)"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{tablename} dropped successfully(Cleaned)"
     else
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
       return false
     end
   end

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error "#{peer} - Connection failed"
       return false
     else
-      print_status "#{postgres_conn.address}:#{postgres_conn.port} - #{status}"
+      print_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{status}"
       return true
     end
   end
@@ -87,16 +87,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def load_extension?(language)
     case load_procedural_language(language, 'LANGUAGE')
     when :exists
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{language} is already loaded, continuing"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{language} is already loaded, continuing"
       return true
     when :loaded
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - #{language} was successfully loaded, continuing"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{language} was successfully loaded, continuing"
       return true
     when :not_exists
-      print_status "#{postgres_conn.address}:#{postgres_conn.port} - #{language} could not be loaded"
+      print_status "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{language} could not be loaded"
       return false
     else
-      vprint_error "#{postgres_conn.address}:#{postgres_conn.port} - error occurred loading #{language}"
+      vprint_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - error occurred loading #{language}"
       return false
     end
   end
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case select_query.keys[0]
     when :conn_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
       return false
     when :sql_error
       elog(select_query[:sql_error])
@@ -123,13 +123,13 @@ class MetasploitModule < Msf::Exploit::Remote
         return true
       end
 
-      print_warning "#{postgres_conn.address}:#{postgres_conn.port} - Unable to execute query: #{query}"
+      print_warning "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}"
       return false
     when :complete
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - Exploit successful"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Exploit successful"
       return true
     else
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
       return false
     end
   end
@@ -152,16 +152,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case load_func.keys[0]
     when :conn_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Connection error"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error"
       return false
     when :sql_error
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} Exploit failed"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Exploit failed"
       return false
     when :complete
-      print_good "#{postgres_conn.address}:#{postgres_conn.port} - Loaded UDF (exec_#{func_name})"
+      print_good "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Loaded UDF (exec_#{func_name})"
       return true
     else
-      print_error "#{postgres_conn.address}:#{postgres_conn.port} - Unknown"
+      print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown"
       return false
     end
   end

--- a/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
+++ b/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("")
-    print_good("Successfully authenticated to #{mssql_client.address}:#{mssql_client.port} with user 'sa' and password '#{pass}'")
+    print_good("Successfully authenticated to #{mssql_client.peerhost}:#{mssql_client.peerport} with user 'sa' and password '#{pass}'")
     print_status("")
 
     exe = generate_payload_exe

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -240,8 +240,8 @@ class MetasploitModule < Msf::Exploit::Remote
     this_service = nil
     if framework.db and framework.db.active
       this_service = report_service(
-        :host  => mssql_client.address,
-        :port => mssql_client.port,
+        :host  => mssql_client.peerhost,
+        :port => mssql_client.peerport,
         :name => 'mssql',
         :proto => 'tcp'
       )
@@ -254,8 +254,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Write log to loot / file
     if (save_loot=="yes")
-      filename= "#{mssql_client.address}-#{mssql_client.port}_linked_servers.csv"
-      path = store_loot("crawled_links", "text/plain", mssql_client.address, linked_server_table.to_csv, filename, "Linked servers",this_service)
+      filename= "#{mssql_client.peerhost}-#{mssql_client.peerport}_linked_servers.csv"
+      path = store_loot("crawled_links", "text/plain", mssql_client.peerhost, linked_server_table.to_csv, filename, "Linked servers",this_service)
       print_good("Results have been saved to: #{path}")
     end
   end

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :noauth; print_error "Authentication failed"; return
     when :noconn; print_error "Connection failed"; return
     else
-      print_status("#{postgres_conn.address}:#{postgres_conn.port} - #{version}")
+      print_status("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - #{version}")
     end
 
     fname = "#{Rex::Text.rand_text_alpha(8)}.dll"
@@ -124,8 +124,8 @@ class MetasploitModule < Msf::Exploit::Remote
       )
       if result[:auth]
         report_service(
-          :host => postgres_conn.address,
-          :port => postgres_conn.port,
+          :host => postgres_conn.peerhost,
+          :port => postgres_conn.peerport,
           :name => "postgres",
           :info => result.values.first
         )


### PR DESCRIPTION
This PR aligns the `client`'s `peerhost` and `peerport` API for the recently added SQL-based sessions (postgres, mssql, mysql).

## Verification

- [x] Start `msfconsole`
- [x] Get a session for each SQL protocol using `postgres_login`, `mssql_login`, `mysql_login`
- [x] Confirm the session prompts work as expected and have correct IP and port
- [x] Confirm that in IRB, `session.client.peerhost` and `session.client.peerport` have the correct values
- [x] Confirm that the values are correct over a socks proxy
- [x] Confirm that the MSSQL, MySQL and PostgreSQL modules continue to work