### PR TITLE
Alias `ls` and `dir` commands inside new SMB session type prompt

### DIFF
--- a/lib/rex/post/smb/ui/console/command_dispatcher/shares.rb
+++ b/lib/rex/post/smb/ui/console/command_dispatcher/shares.rb
@@ -55,6 +55,7 @@ module Rex
             cmds = {
               'shares' => 'View the available shares and interact with one',
               'ls' => 'List all files in the current directory',
+              'dir' => 'List all files in the current directory (alias for ls)',
               'pwd' => 'Print the current remote working directory',
               'cd' => 'Change the current remote working directory',
               'cat' => 'Read the file at the given path'
@@ -181,11 +182,30 @@ module Rex
             print_line table.to_s
           end
 
+          def cmd_ls_help
+            print_line 'Usage:'
+            print_line 'ls [options] [path]'
+            print_line
+            print_line 'COMMAND ALIASES:'
+            print_line
+            print_line '    dir'
+            print_line
+            print_line 'Lists contents of directory or file info'
+            print_line @@ls_opts.usage
+          end
+
           def cmd_ls_tabs(_str, words)
             return [] if words.length > 1
 
             @@ls_opts.option_keys
           end
+
+          #
+          # Alias the ls command to dir, for those of us who have windows muscle-memory
+          #
+          alias cmd_dir cmd_ls
+          alias cmd_dir_help cmd_ls_help
+          alias cmd_dir_tabs cmd_ls_tabs
 
           def cmd_pwd_help
             print_line 'Usage: pwd'


### PR DESCRIPTION
This PR adds support for aliasing the `ls` and `dir` commands. In aims to improve workflows for those who have windows muscle-memory.

I also spotted an issue when running the `ls -h` command which return an error:
```
SMB (192.168.175.193\my_share) > ls -h
[-] Error running command ls: NameError undefined local variable or method `cmd_ls_help' for #<Rex::Post::SMB::Ui::Console::CommandDispatcher::Shares:0x00007fbb9e12d750 @shell=#
...
Did you mean?  cmd_bg_help
               cmd_cd_help
               cmd_help
               cmd_pry_help
               cmd_irb_help
               cmd_cat_help
               cmd_pwd_help
               cmd_help_help
```

So I added what I believed was required and tested it and it seems to now be working as intended.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a SMB session via the `smb_login` module
- [ ] Use a share via the following command: `shares -i <share name here>`
- [ ] **Verify** the `dir` and `ls` commands now both work
- [ ] **Verify** the `dir -h` and `ls -h` commands now both work
- [ ] **Verify** the `help dir` and `help ls` commands now both work
- [ ] **Verify** the tab completion for both `dir` and `ls` works as expected 