### PR TITLE
Update Windows 11 Mimikatz support - update metasploit-payloads gem to 2.0.166

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.165)
+      metasploit-payloads (= 2.0.166)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.26)
       mqtt
@@ -279,7 +279,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.165)
+    metasploit-payloads (2.0.166)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -82,7 +82,7 @@ metasploit-concern, 5.0.2, "New BSD"
 metasploit-credential, 6.0.7, "New BSD"
 metasploit-framework, 6.3.57, "New BSD"
 metasploit-model, 5.0.2, "New BSD"
-metasploit-payloads, 2.0.165, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.166, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.3, "New BSD"
 metasploit_payloads-mettle, 1.0.26, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.165'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.166'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.26'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Includes changes from:
* rapid7/metasploit-payloads#698

