### PR TITLE
add support for boolean datatypes on mssql

### DIFF
--- a/lib/rex/proto/mssql/client_mixin.rb
+++ b/lib/rex/proto/mssql/client_mixin.rb
@@ -202,6 +202,13 @@ module ClientMixin
         col[:id] = :int
         col[:int_size] = data.slice!(0, 1).unpack('C')[0]
 
+      when 50
+        col[:id] = :bit
+
+      when 104
+        col[:id] = :bitn
+        col[:int_size] = data.slice!(0, 1).unpack('C')[0]
+
       when 127
         col[:id] = :bigint
 
@@ -314,6 +321,17 @@ module ClientMixin
         row << [data.slice!(0, 3)].pack("Z4").unpack("V")[0]
 
       when :tinyint
+        row << data.slice!(0, 1).unpack("C")[0]
+
+      when :bitn
+        has_value = data.slice!(0, 1).unpack("C")[0]
+        if has_value == 0
+          row << nil
+        else
+          row << data.slice!(0, 1).unpack("C")[0]
+        end
+
+      when :bit
         row << data.slice!(0, 1).unpack("C")[0]
 
       when :image


### PR DESCRIPTION
In newer TDS Protocol versions, two different bit datatypes were added, one that allows null and one that doesn't, to allow for boolean support. To this point, our MSSQL code does not support these values, and causes "unknown column type" errors.

## Verification

List the steps needed to make sure this thing works

- [ ] change `mssql_query` to `query` in `lib/rex/post/mssql/ui/console.rb` (PR incoming)
- [ ] Start `msfconsole`
- [ ] spin up an mssql instance in your vm
- [ ] create a table with two different columns of type bit, one with not null enforcement, and populate it with different values
- [ ] `use mssql_login` `run CreateSession=true ...` to get a session
- [ ] `sessions -i -1`
- [ ] run queries against this table in both sqlcmd in your mssql instance and via your msf mssql client, verify that the output is the same and there are no unknown column type errors with values 50 or 104.

## Setting up MSSQL Table

in your mssql instance, run the following steps:
- [ ] `create table your_table (nullable_bit bit);`
- [ ] `grant select on your_table to public;`
- [ ] `alter table your_table add strict_bit bit not null default 0;`
- [ ] `insert into your_table (nullable_bit, strict_bit) values (0, 0);`
- [ ] `insert into your_table (nullable_bit, strict_bit) values (0, 1);`
- [ ] `insert into your_table (nullable_bit, strict_bit) values (1, 0);`
- [ ] `insert into your_table (nullable_bit, strict_bit) values (1, 1);`
- [ ] `insert into your_table (nullable_bit, strict_bit) values (NULL, 0);`
- [ ] `insert into your_table (nullable_bit, strict_bit) values (NULL, 1);`

previously, running `select * from your_table;` would break this if run from your mssql client in metasploit framework. This now should look like:

```
msf6 auxiliary(scanner/mssql/mssql_login) > sessions -i -1
[*] Starting interaction with 1...

MSSQL @ 192.168.2.227:1433 (master) > query "select * from your_table;"

[*] 192.168.2.227:1433    - SQL Query: select * from your_table;
[*] 192.168.2.227:1433    - Row Count: 6 (Status: 16 Command: 193)
Response
========

 nullable_bit  strict_bit
 ------------  ----------
 0             0
 0             1
 1             0
 1             1
 NULL          0
 NULL          1
```
or from modules:
```
msf6 auxiliary(admin/mssql/mssql_sql) > run SESSION=2 SQL="select * from your_table;"

[*] Using existing session 2
[*] 192.168.2.227:1433    - SQL Query: select * from your_table;
[*] 192.168.2.227:1433    - Row Count: 6 (Status: 16 Command: 193)
Response
========

 nullable_bit  strict_bit
 ------------  ----------
 0             0
 0             1
 1             0
 1             1
 NULL          0
 NULL          1
```

