### PR TITLE
Fixes the create session datastore option from appearing for payloads

### DIFF
--- a/documentation/modules/auxiliary/cloud/aws/enum_ssm.md
+++ b/documentation/modules/auxiliary/cloud/aws/enum_ssm.md
@@ -4,7 +4,7 @@ Provided AWS credentials, this module will call the authenticated API of Amazon 
 instances accessible to the account. Once enumerated as SSM-enabled, the instances can be controlled using out-of-band
 WebSocket sessions provided by the AWS API (nominally, privileged out of the box). This module provides not only the API
 enumeration identifying EC2 instances accessible via SSM with given credentials, but enables session initiation for all
-identified targets (without requiring target-level credentials) using the CreateSession mixin option. The module also
+identified targets (without requiring target-level credentials) using the CreateSession datastore option. The module also
 provides an EC2 ID filter and a limiting throttle to prevent session stampedes or expensive messes.
 
 ## Verification Steps

--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -15,12 +15,6 @@ module CommandShellOptions
   def initialize(info = {})
     super(info)
 
-    register_options(
-      [
-        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', true])
-      ]
-    )
-
     register_advanced_options(
       [
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),

--- a/lib/msf/base/sessions/create_session_options.rb
+++ b/lib/msf/base/sessions/create_session_options.rb
@@ -1,0 +1,25 @@
+# -*- coding: binary -*-
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# https://metasploit.com/framework/
+##
+
+
+module Msf
+  module Sessions
+    module CreateSessionOptions
+      def initialize(info = {})
+        super(info)
+
+        register_options(
+          [
+            OptBool.new('CreateSession', [false, 'Create a new session for every successful login', true])
+          ]
+        )
+      end
+    end
+  end
+end

--- a/modules/auxiliary/cloud/aws/enum_ssm.rb
+++ b/modules/auxiliary/cloud/aws/enum_ssm.rb
@@ -10,6 +10,8 @@ class MetasploitModule < Msf::Auxiliary
   include Rex::Proto::Http::WebSocket::AmazonSsm
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
+
   def initialize(info = {})
     super(
       update_info(
@@ -24,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           This module provides not only the API enumeration identifying EC2
           instances accessible via SSM with given credentials, but enables
           session initiation for all identified targets (without requiring
-          target-level credentials) using the CreateSession mixin option.
+          target-level credentials) using the CreateSession datastore option.
           The module also provides an EC2 ID filter and a limiting throttle
           to prevent session stampedes or expensive messes.
         },

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -14,6 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(
@@ -29,13 +30,13 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultOptions' =>
         {
           'USERNAME' => 'sa',
-          'BLANK_PASSWORDS' => true
+          'BLANK_PASSWORDS' => true,
+          'CreateSession' => false
         }
     )
     register_options([
       Opt::Proxies,
-      OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
-      OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
+      OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false])
     ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Scanner
+  include Msf::Sessions::CreateSessionOptions
   include Msf::Auxiliary::CommandShell
 
   def initialize(info = {})
@@ -27,14 +28,14 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultOptions' =>
         {
           'USERNAME' => 'root',
-          'BLANK_PASSWORDS' => true
+          'BLANK_PASSWORDS' => true,
+          'CreateSession'  => false
         }
     ))
 
     register_options(
       [
         Opt::Proxies,
-        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   # Creates an instance of this module.
   def initialize(info = {})
@@ -26,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => [ 'todb' ],
       'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'CreateSession' => false },
       'References'     =>
         [
           [ 'URL', 'https://www.postgresql.org/' ],
@@ -37,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false]),
         OptPath.new('USERPASS_FILE',  [ false, "File containing (space-separated) users and passwords, one pair per line",
           File.join(Msf::Config.data_directory, "wordlists", "postgres_default_userpass.txt") ]),
         OptPath.new('USER_FILE',      [ false, "File containing users, one per line",

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Login
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::RServices
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -15,6 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   Aliases = [
     'auxiliary/scanner/smb/login'
@@ -46,7 +47,8 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultOptions' => {
         'DB_ALL_CREDS' => false,
         'BLANK_PASSWORDS' => false,
-        'USER_AS_PASS' => false
+        'USER_AS_PASS' => false,
+        'CreateSession' => false
       }
     )
 
@@ -55,7 +57,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false]),
         OptBool.new('ABORT_ON_LOCKOUT', [ true, 'Abort the run when an account lockout is detected', false ]),
         OptBool.new('PRESERVE_DOMAINS', [ false, 'Respect a username that contains a domain name.', true ]),
         OptBool.new('RECORD_GUEST', [ false, 'Record guest-privileged random logins to the database', false ]),

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Report
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SSH
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
   include Msf::Auxiliary::Report
 
   def initialize(info = {})

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Report
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -14,6 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::SSH::Options
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -15,6 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::SSH::Options
+  include Msf::Sessions::CreateSessionOptions
 
   attr_accessor :ssh_socket, :good_key
 

--- a/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
+++ b/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -15,6 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Sessions::CreateSessionOptions
 
   def initialize
     super(

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     deregister_options(
-      'RPORT', 'RHOSTS', 'SMBPass', 'SMBUser', 'CommandShellCleanupCommand', 'AutoVerifySession', 'CreateSession'
+      'RPORT', 'RHOSTS', 'SMBPass', 'SMBUser', 'CommandShellCleanupCommand', 'AutoVerifySession'
     )
     if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCREATE_SMB_SESSION%clr action within this module can open an interactive session')


### PR DESCRIPTION
In a a previous [PR](https://github.com/rapid7/metasploit-framework/pull/18795) the `CreateSession` options was moved from the advanced options into the basic options. Previously it was not as apparent an issue as it was hidden with the advanced options, whereas now it was being displayed with the module options.

The fix is to update how the create session options is being include in modules. Previously `Msf::Auxiliary::CommandShell` mixin would include `include Msf::Sessions::CommandShellOptions` which added the `CreateSession` option, which caused the `CreateSession` option to appear in the payload options. 

This has now been moved into it's own mxin, so we have more control over where it is added.
 
## Verification

- [ ] Start `msfconsole`
- [ ] Check modules that have the new mixin now display the `CreateSession` in the module options
- [ ] Verify payloads that make use of `Msf::Auxiliary::CommandShell` no longer have the `CreateSession` options appearing with the payload options.
- [ ] Make sure code changes are sane