### PR TITLE
Fix undefined mssql_query method call on mssql client

### DIFF
--- a/lib/rex/post/mssql/ui/console.rb
+++ b/lib/rex/post/mssql/ui/console.rb
@@ -58,7 +58,7 @@ module Rex
 
           # @return [String]
           def database_name
-            session.client.mssql_query('SELECT DB_NAME();')[:rows][0][0]
+            session.client.query('SELECT DB_NAME();')[:rows][0][0]
           end
 
           # @param [Object] val


### PR DESCRIPTION
This PR fixes an issue that I have introduced and didn't catch early enough in my recent SQL consolidation PR.
When aligning the SQL clients to a consistent `client.query()` convention, one line slipped past me which caused issues when interacting with the MSSQL session. MySQL and PostgreSQL were unaffected.
The intended change in the alignment PR was to have a consistent API between client implementations. Calls to `mssql_query` in `remote/mssql.rb` would not change the method signature/results, but the under-the-hood implementation would call to `.query`, thus not being backwards-breaking. The issue fixed in this PR slipped through unexpectedly when looking for `mssql_query` throughout the codebase.

## Before

Broken, `undefined method` on `mssql_query`

```ruby
msf6 auxiliary(scanner/mssql/mssql_login) > run rhost=127.0.0.1 username=sa password=MyMSSQLServerPassword__<>

[*] 127.0.0.1:1433        - 127.0.0.1:1433 - MSSQL - Starting authentication scanner.
[+] 127.0.0.1:1433        - 127.0.0.1:1433 - Login Successful: WORKSTATION\sa:MyMSSQLServerPassword__<>
[*] MSSQL session 1 opened (127.0.0.1:60782 -> 127.0.0.1:1433) at 2024-02-22 16:35:09 +0000
[*] 127.0.0.1:1433        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/mssql/mssql_login) > sessions -i -1
[*] Starting interaction with 1...

[-] Session manipulation failed: undefined method `mssql_query' for #<Rex::Proto::MSSQL::Client:0x00007fc87e84f938
...
more stacktrace
...
```

## After

Working correctly.

```ruby
msf6 auxiliary(scanner/mssql/mssql_login) > run rhost=127.0.0.1 username=sa password=MyMSSQLServerPassword__<>

[*] 127.0.0.1:1433        - 127.0.0.1:1433 - MSSQL - Starting authentication scanner.
[+] 127.0.0.1:1433        - 127.0.0.1:1433 - Login Successful: WORKSTATION\sa:MyMSSQLServerPassword__<>
[*] MSSQL session 1 opened (127.0.0.1:60845 -> 127.0.0.1:1433) at 2024-02-22 16:40:39 +0000
[*] 127.0.0.1:1433        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/mssql/mssql_login) > sessions -i -1
[*] Starting interaction with 1...

MSSQL @ 127.0.0.1:1433 (master) > query -h
Usage: query

Run a raw SQL query on the target.

Examples:

    query select @@version;
    query select user_name();
    query select name from master.dbo.sysdatabases;

MSSQL @ 127.0.0.1:1433 (master) > query select @@version
Response
========

    #  NULL
    -  ----
    0  Microsoft SQL Server 2022 (RTM-CU9) (KB5030731) - 16.0.4085.2 (X64)
        Sep 27 2023 12:05:43
        Copyright (C) 2022 Microsoft Corporation
        Enterprise Evaluation Edition (64-bit) on Linux (Ubuntu 22.04.3 LTS) <X64>

MSSQL @ 127.0.0.1:1433 (master) > exit
[*] Shutting down session: 1
[*] 127.0.0.1 - MSSQL session 1 closed.  Reason: User exit
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get an MSSQL session using mssql_login
- [ ] Interact with the session
- [ ] Confirm you can run queries on it such as `query select @@version`