### PR TITLE
Add conditional option validation depending on SESSION/RHOST connection

### DIFF
--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -73,6 +73,7 @@ module Msf::Module::Options
   # @param name [String] Name for the group
   # @param description [String] Description of the group
   # @param option_names [Array<String>] List of datastore option names
+  # @param required_options [Array<String>] List of required datastore option names
   # @param merge [Boolean] whether to merge or overwrite the groups option names
   def register_option_group(name:, description:, option_names: [], required_options: [], merge: true)
     existing_group = options.groups[name]

--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -74,13 +74,16 @@ module Msf::Module::Options
   # @param description [String] Description of the group
   # @param option_names [Array<String>] List of datastore option names
   # @param merge [Boolean] whether to merge or overwrite the groups option names
-  def register_option_group(name:, description:, option_names: [], merge: true)
+  def register_option_group(name:, description:, option_names: [], required_options: [], merge: true)
     existing_group = options.groups[name]
     if merge && existing_group
       existing_group.description = description
       existing_group.add_options(option_names)
     else
-      option_group = Msf::OptionGroup.new(name: name, description: description, option_names: option_names)
+      option_group = Msf::OptionGroup.new(name: name,
+                                          description: description,
+                                          option_names: option_names,
+                                          required_options: required_options)
       options.add_group(option_group)
     end
   end

--- a/lib/msf/core/option_group.rb
+++ b/lib/msf/core/option_group.rb
@@ -9,14 +9,18 @@ module Msf
     attr_accessor :description
     # @return [Array<String>] List of datastore option names
     attr_accessor :option_names
+    # @return [Array<String>] List of options that if present must have a value set
+    attr_accessor :required_options
 
     # @param name [String] Name for the group
     # @param description [String] Description to be displayed to the user
     # @param option_names [Array<String>] List of datastore option names
-    def initialize(name:, description:, option_names: [])
+    # @param required_options [Array<String>] List of options that if present must have a value set
+    def initialize(name:, description:, option_names: [], required_options: [])
       self.name = name
       self.description = description
       self.option_names = option_names
+      self.required_options = required_options
     end
 
     # @param option_name [String] Name of the datastore option to be added to the group
@@ -27,6 +31,20 @@ module Msf
     # @param option_names [Array<String>] List of datastore option names to be added to the group
     def add_options(option_names)
       @option_names.concat(option_names)
+    end
+
+    # Validates that any registered and required options are set
+    #
+    # @param options [Array<Msf::OptBase>] A modules registered options
+    # @param datastore [Msf::DataStore|Msf::DataStoreWithFallbacks] A modules datastore
+    def validate(options, datastore)
+      issues = {}
+      required_options.each do |option_name|
+        if options[option_name] && !datastore[option_name]
+          issues[option_name] = "#{option_name} must be specified"
+        end
+      end
+      raise Msf::OptionValidateError.new(issues.keys.to_a, reasons: issues) unless issues.empty?
     end
   end
 end

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -11,7 +11,7 @@ module Msf
     # Validates options depending on whether we are using  SESSION or an RHOST for our connection
     def validate
       super
-      return unless framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+      return unless optional_session_enabled?
 
       # If the session is set use that by default regardless of rhost being (un)set
       if session
@@ -21,6 +21,12 @@ module Msf
       else
         raise Msf::OptionValidateError.new(message: 'A SESSION or RHOST must be provided')
       end
+    end
+
+    def session
+      return nil unless optional_session_enabled?
+
+      super
     end
 
     protected

--- a/lib/msf/core/optional_session.rb
+++ b/lib/msf/core/optional_session.rb
@@ -7,5 +7,46 @@
 module Msf
   module OptionalSession
     include Msf::SessionCompatibility
+
+    # Validates options depending on whether we are using  SESSION or an RHOST for our connection
+    def validate
+      super
+      return unless framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+
+      # If the session is set use that by default regardless of rhost being (un)set
+      if session
+        validate_session
+      elsif rhost
+        validate_rhost
+      else
+        raise Msf::OptionValidateError.new(message: 'A SESSION or RHOST must be provided')
+      end
+    end
+
+    protected
+
+    # Used to validate options when RHOST has been set
+    def validate_rhost
+      validate_group('RHOST')
+    end
+
+    # Used to validate options when SESSION has been set
+    def validate_session
+      issues = {}
+      if session_types && !session_types.include?(session.type)
+        issues['SESSION'] = "Incompatible session type: #{session.type}. This module works with: #{session_types.join(', ')}."
+      end
+      raise Msf::OptionValidateError.new(issues.keys.to_a, reasons: issues) unless issues.empty?
+
+      validate_group('SESSION')
+    end
+
+    # Validates the options within an option group
+    #
+    # @param group_name [String] Name of the option group
+    def validate_group(group_name)
+      option_group = options.groups[group_name]
+      option_group.validate(options, datastore) if option_group
+    end
   end
 end

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -21,7 +21,8 @@ module Msf
                                 option_names: ['SESSION'])
           register_option_group(name: 'RHOST',
                                 description: 'Used when making a new connection via RHOSTS',
-                                option_names: RHOST_GROUP_OPTIONS)
+                                option_names: RHOST_GROUP_OPTIONS,
+                                required_options: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),

--- a/lib/msf/core/optional_session/mssql.rb
+++ b/lib/msf/core/optional_session/mssql.rb
@@ -15,7 +15,7 @@ module Msf
           )
         )
 
-        if framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
+        if optional_session_enabled?
           register_option_group(name: 'SESSION',
                                 description: 'Used when connecting via an existing SESSION',
                                 option_names: ['SESSION'])
@@ -37,10 +37,8 @@ module Msf
         end
       end
 
-      def session
-        return nil unless framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
-
-        super
+      def optional_session_enabled?
+        framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
       end
     end
   end

--- a/lib/msf/core/optional_session/mysql.rb
+++ b/lib/msf/core/optional_session/mysql.rb
@@ -15,7 +15,7 @@ module Msf
           )
         )
 
-        if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
+        if optional_session_enabled?
           register_option_group(name: 'SESSION',
                                 description: 'Used when connecting via an existing SESSION',
                                 option_names: ['SESSION'])
@@ -35,10 +35,8 @@ module Msf
         end
       end
 
-      def session
-        return nil unless framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
-
-        super
+      def optional_session_enabled?
+        framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
       end
     end
   end

--- a/lib/msf/core/optional_session/mysql.rb
+++ b/lib/msf/core/optional_session/mysql.rb
@@ -21,7 +21,8 @@ module Msf
                                 option_names: ['SESSION'])
           register_option_group(name: 'RHOST',
                                 description: 'Used when making a new connection via RHOSTS',
-                                option_names: RHOST_GROUP_OPTIONS)
+                                option_names: RHOST_GROUP_OPTIONS,
+                                required_options: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),

--- a/lib/msf/core/optional_session/postgresql.rb
+++ b/lib/msf/core/optional_session/postgresql.rb
@@ -21,7 +21,8 @@ module Msf
                                 option_names: ['SESSION'])
           register_option_group(name: 'RHOST',
                                 description: 'Used when making a new connection via RHOSTS',
-                                option_names: RHOST_GROUP_OPTIONS)
+                                option_names: RHOST_GROUP_OPTIONS,
+                                required_options: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),

--- a/lib/msf/core/optional_session/postgresql.rb
+++ b/lib/msf/core/optional_session/postgresql.rb
@@ -15,7 +15,7 @@ module Msf
           )
         )
 
-        if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
+        if optional_session_enabled?
           register_option_group(name: 'SESSION',
                                 description: 'Used when connecting via an existing SESSION',
                                 option_names: ['SESSION'])
@@ -37,10 +37,8 @@ module Msf
         end
       end
 
-      def session
-        return nil unless framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
-
-        super
+      def optional_session_enabled?
+        framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
       end
     end
   end

--- a/lib/msf/core/optional_session/smb.rb
+++ b/lib/msf/core/optional_session/smb.rb
@@ -21,7 +21,8 @@ module Msf
                                 option_names: ['SESSION'])
           register_option_group(name: 'RHOST',
                                 description: 'Used when making a new connection via RHOSTS',
-                                option_names: RHOST_GROUP_OPTIONS)
+                                option_names: RHOST_GROUP_OPTIONS,
+                                required_options: RHOST_GROUP_OPTIONS)
           register_options(
             [
               Msf::OptInt.new('SESSION', [ false, 'The session to run this module on' ]),

--- a/lib/msf/core/optional_session/smb.rb
+++ b/lib/msf/core/optional_session/smb.rb
@@ -15,7 +15,7 @@ module Msf
           )
         )
 
-        if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
+        if optional_session_enabled?
           register_option_group(name: 'SESSION',
                                 description: 'Used when connecting via an existing SESSION',
                                 option_names: ['SESSION'])
@@ -35,10 +35,8 @@ module Msf
         end
       end
 
-      def session
-        return nil unless framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
-
-        super
+      def optional_session_enabled?
+        framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
       end
     end
   end

--- a/lib/msf/ui/formatter/option_validate_error.rb
+++ b/lib/msf/ui/formatter/option_validate_error.rb
@@ -13,7 +13,11 @@ module Msf
           raise ArgumentError, "invalid error type #{error.class}, expected ::Msf::OptionValidateError" unless error.is_a?(::Msf::OptionValidateError)
 
           if error.reasons.empty?
-            mod.print_error("#{error.class} The following options failed to validate: #{error.options.join(', ')}")
+            if error.message
+              mod.print_error("#{error.class} #{error.message}")
+            else
+              mod.print_error("#{error.class} The following options failed to validate: #{error.options.join(', ')}")
+            end
           else
             mod.print_error("#{error.class} The following options failed to validate:")
             error.options.sort.each do |option_name|

--- a/spec/lib/msf/core/option_group_spec.rb
+++ b/spec/lib/msf/core/option_group_spec.rb
@@ -47,4 +47,92 @@ RSpec.describe Msf::OptionGroup do
       end
     end
   end
+
+  describe '#validate' do
+    let(:required_option_name) { 'required_name' }
+    let(:option_names) { ['not_required_name', required_option_name] }
+    let(:required_names) { [required_option_name] }
+    let(:options) { instance_double(Msf::OptionContainer) }
+    let(:datastore) { instance_double(Msf::DataStoreWithFallbacks) }
+
+    context 'when there are no required options' do
+      subject { described_class.new(name: 'name', description: 'description', option_names: option_names) }
+
+      context 'when no values are set for the options' do
+
+        before(:each) do
+          allow(options).to receive(:[]).and_return(instance_double(Msf::OptBase))
+          allow(datastore).to receive(:[]).and_return(nil)
+        end
+
+        it 'validates the options in the group' do
+          expect { subject.validate(options, datastore) }.not_to raise_error(Msf::OptionValidateError)
+        end
+      end
+
+      context 'when values are set for the options' do
+
+        before(:each) do
+          allow(options).to receive(:[]).and_return(instance_double(Msf::OptBase))
+          allow(datastore).to receive(:[]).and_return('OptionValue')
+        end
+
+        it 'validates the options in the group' do
+          expect { subject.validate(options, datastore) }.not_to raise_error(Msf::OptionValidateError)
+        end
+      end
+
+      context 'when the options have not been registered' do
+
+        before(:each) do
+          allow(options).to receive(:[]).and_return(nil)
+        end
+
+        it 'does not attempt to validate the options' do
+          expect { subject.validate(options, datastore) }.not_to raise_error(Msf::OptionValidateError)
+        end
+      end
+    end
+
+    context 'when there is a required option' do
+      subject { described_class.new(name: 'name', description: 'description', option_names: option_names, required_options: required_names) }
+      let(:error_message) { "The following options failed to validate: #{required_option_name}." }
+
+      context 'when no values are set for the options' do
+
+        before(:each) do
+          allow(options).to receive(:[]).and_return(instance_double(Msf::OptBase))
+          allow(datastore).to receive(:[]).and_return(nil)
+        end
+
+        it 'raises an error only for the required option' do
+          expect { subject.validate(options, datastore) }.to raise_error(Msf::OptionValidateError).with_message(error_message)
+        end
+      end
+
+      context 'when values are set for the options' do
+
+        before(:each) do
+          allow(options).to receive(:[]).and_return(instance_double(Msf::OptBase))
+          allow(datastore).to receive(:[]).and_return('OptionValue')
+        end
+
+        it 'validates the options in the group' do
+          expect { subject.validate(options, datastore) }.not_to raise_error(Msf::OptionValidateError)
+        end
+      end
+
+      context 'when the options have not been registered' do
+
+        before(:each) do
+          allow(options).to receive(:[]).and_return(nil)
+        end
+
+        it 'does not attempt to validate the options' do
+          expect { subject.validate(options, datastore) }.not_to raise_error(Msf::OptionValidateError)
+        end
+      end
+    end
+
+  end
 end

--- a/spec/lib/msf/core/optional_session/mssql_spec.rb
+++ b/spec/lib/msf/core/optional_session/mssql_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptionalSession::MSSQL do
+  subject(:mod) do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  it_behaves_like Msf::OptionalSession
+end

--- a/spec/lib/msf/core/optional_session/mssql_spec.rb
+++ b/spec/lib/msf/core/optional_session/mssql_spec.rb
@@ -10,5 +10,10 @@ RSpec.describe Msf::OptionalSession::MSSQL do
     mod
   end
 
+  before(:each) do
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).and_call_original
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).with(Msf::FeatureManager::MSSQL_SESSION_TYPE).and_return(true)
+  end
+
   it_behaves_like Msf::OptionalSession
 end

--- a/spec/lib/msf/core/optional_session/mysql_spec.rb
+++ b/spec/lib/msf/core/optional_session/mysql_spec.rb
@@ -10,5 +10,10 @@ RSpec.describe Msf::OptionalSession::MySQL do
     mod
   end
 
+  before(:each) do
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).and_call_original
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).with(Msf::FeatureManager::MYSQL_SESSION_TYPE).and_return(true)
+  end
+
   it_behaves_like Msf::OptionalSession
 end

--- a/spec/lib/msf/core/optional_session/mysql_spec.rb
+++ b/spec/lib/msf/core/optional_session/mysql_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptionalSession::MySQL do
+  subject(:mod) do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  it_behaves_like Msf::OptionalSession
+end

--- a/spec/lib/msf/core/optional_session/postgresql_spec.rb
+++ b/spec/lib/msf/core/optional_session/postgresql_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptionalSession::PostgreSQL do
+  subject(:mod) do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  it_behaves_like Msf::OptionalSession
+end

--- a/spec/lib/msf/core/optional_session/postgresql_spec.rb
+++ b/spec/lib/msf/core/optional_session/postgresql_spec.rb
@@ -10,5 +10,10 @@ RSpec.describe Msf::OptionalSession::PostgreSQL do
     mod
   end
 
+  before(:each) do
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).and_call_original
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).with(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE).and_return(true)
+  end
+
   it_behaves_like Msf::OptionalSession
 end

--- a/spec/lib/msf/core/optional_session/smb_spec.rb
+++ b/spec/lib/msf/core/optional_session/smb_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptionalSession::SMB do
+  subject(:mod) do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  it_behaves_like Msf::OptionalSession
+end

--- a/spec/lib/msf/core/optional_session/smb_spec.rb
+++ b/spec/lib/msf/core/optional_session/smb_spec.rb
@@ -10,5 +10,10 @@ RSpec.describe Msf::OptionalSession::SMB do
     mod
   end
 
+  before(:each) do
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).and_call_original
+    allow(Msf::FeatureManager.instance).to receive(:enabled?).with(Msf::FeatureManager::SMB_SESSION_TYPE).and_return(true)
+  end
+
   it_behaves_like Msf::OptionalSession
 end

--- a/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         subject.cmd_check
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -296,7 +296,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_check
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -397,7 +397,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -508,7 +508,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -609,7 +609,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_check
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -243,7 +243,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = nil
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -255,7 +255,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = ''
         subject.cmd_run
         expected_output = [
-          'Msf::OptionValidateError The following options failed to validate: RHOSTS'
+          'Msf::OptionValidateError One or more options failed to validate: RHOSTS.'
         ]
 
         expect(@combined_output).to match_array(expected_output)
@@ -284,7 +284,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         subject.cmd_run
         expected_output = [
           'Exploit completed, but no session was created.',
-          'Msf::OptionValidateError The following options failed to validate: REQUIRED_PAYLOAD_OPTION'
+          'Msf::OptionValidateError One or more options failed to validate: REQUIRED_PAYLOAD_OPTION.'
         ]
 
         expect(@combined_output).to match_array(expected_output)

--- a/spec/support/shared/examples/msf/core/optional_session.rb
+++ b/spec/support/shared/examples/msf/core/optional_session.rb
@@ -1,0 +1,110 @@
+# -*- coding:binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.shared_examples_for Msf::OptionalSession do
+  include_context 'Msf::Simple::Framework'
+
+  let(:options) { instance_double(Msf::OptionContainer) }
+  let(:datastore) { instance_double(Msf::DataStoreWithFallbacks) }
+  let(:session) { instance_double(Msf::Sessions::SMB) }
+  let(:session_group) { instance_double(Msf::OptionGroup) }
+  let(:rhost_group) { instance_double(Msf::OptionGroup) }
+  let(:groups) do
+    {
+      'SESSION' => session_group,
+      'RHOST' => rhost_group
+    }
+  end
+  describe '#validate' do
+    before(:each) do
+      allow(options).to receive(:validate)
+      allow(options).to receive(:[]).and_return(instance_double(Msf::OptBase))
+      allow(options).to receive(:groups).and_return(groups)
+      allow(mod).to receive(:options).and_return(options)
+      allow(mod).to receive(:datastore).and_return(datastore)
+      allow(mod).to receive(:framework).and_return(framework)
+      allow(session_group).to receive(:validate)
+      allow(rhost_group).to receive(:validate)
+    end
+
+    context 'when neither SESSION or RHOST are set' do
+      before(:each) do
+        allow(mod).to receive(:rhost).and_return(nil)
+        allow(mod).to receive(:session).and_return(nil)
+      end
+
+      it 'raises an error' do
+        expect { mod.validate }.to raise_error(Msf::OptionValidateError).with_message('A SESSION or RHOST must be provided')
+      end
+    end
+
+    context 'when both SESSION and RHOST are set' do
+      before(:each) do
+        allow(datastore).to receive(:[]).with('SESSION').and_return('SESSION_ID')
+        allow(datastore).to receive(:[]).with('RHOST').and_return('RHOST_VALUE')
+        allow(mod).to receive(:session).and_return(session)
+        allow(mod).to receive(:rhost).and_return('RHOST_VALUE')
+      end
+
+      it 'validates the SESSION only' do
+        mod.validate
+        expect(session_group).to have_received(:validate).once
+        expect(rhost_group).not_to have_received(:validate)
+      end
+    end
+
+    context 'when only RHOST is set' do
+      before(:each) do
+        allow(datastore).to receive(:[]).with('RHOST').and_return('RHOST_VALUE')
+        allow(datastore).to receive(:[]).with('SESSION').and_return(nil)
+        allow(mod).to receive(:rhost).and_return('RHOST_VALUE')
+        allow(mod).to receive(:session).and_return(nil)
+      end
+
+      it 'only validates the RHOST group' do
+        mod.validate
+        expect(rhost_group).to have_received(:validate).once
+        expect(session_group).not_to have_received(:validate)
+      end
+    end
+
+    context 'when only SESSION is set' do
+      before(:each) do
+        allow(datastore).to receive(:[]).with('SESSION').and_return('SESSION_ID')
+        allow(datastore).to receive(:[]).with('RHOST').and_return(nil)
+        allow(mod).to receive(:session).and_return(session)
+        allow(mod).to receive(:rhost).and_return(nil)
+      end
+
+      it 'validates the SESSION only' do
+        mod.validate
+        expect(session_group).to have_received(:validate).once
+        expect(rhost_group).not_to have_received(:validate)
+      end
+
+      context 'when the session is not the correct type' do
+        before(:each) do
+          allow(mod).to receive(:session_types).and_return(['correct_session_type'])
+          allow(session).to receive(:type).and_return('wrong_session_type')
+        end
+
+        it 'should raise an error about the wrong session type' do
+          expect { mod.validate }.to raise_error(Msf::OptionValidateError) { |error| expect(error.options).to eq ['SESSION'] }
+        end
+      end
+
+      context 'when the session is the correct type' do
+        before(:each) do
+          allow(mod).to receive(:session_types).and_return(['correct_session_type'])
+          allow(session).to receive(:type).and_return('correct_session_type')
+        end
+
+        it 'should raise an error about the wrong session type' do
+          expect { mod.validate }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The new session types allows certain modules to connect over either `RHOST` or an existing `SESSION` but this meant when normally the `RHOST` option was required the be set that could no longer be the case leading to a compromised user experience since we were no longer communicating _which_ options needed to be set 

This PR resolves that by adding conditional validation of options depending on the chosen connection type so for example if you want to connect via `RHOST` we also check (where applicable) that `RPORT` or the `USERNAME` is set. Then when a connection is made over an existing `SESSION` we can still allow the user to only set `SESSION` and not worry about the missing values only required for a new `RHOST` connection

# Validation Steps
- [x] Use a module that supports the new session types
- [x] Check that when `SESSION` is set no option related to `RHOST` are forced to be set
- [x] Check that `SESSION` doesn't need to be set when connecting via `RHOST`
- [x] When attempting to connect over `RHOST` and RPORT/USERNAME/etc aren't set the user is notified of _all_ missing required options
- [x] When neither `SESSION` nor `RHOST` is set there is a warning telling the user this

Note: Some options can be an empty string so if you `unset OPTION` and don't get the expected outcome you may need to do `set --clear OPTION` 