### PR TITLE
Update kerberos/inspect_ticket

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -477,8 +477,8 @@ class Creds
         else
           private_val = ''
         end
-        if truncate && private_val.to_s.length > 87
-          private_val = "#{private_val[0,87]} (TRUNCATED)"
+        if truncate && private_val.to_s.length > 88
+          private_val = "#{private_val[0,76]} (TRUNCATED)"
         end
         realm_val = core.realm ? core.realm.value : ''
         human_val = core.private ? core.private.class.model_name.human : ''

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -250,6 +250,17 @@ module Rex::Proto::Kerberos::CredentialCache
       output.join("\n")
     end
 
+    def present_credential_info(credential_info)
+      output = []
+
+      output << 'Credential Information:'
+      output << "Version: #{credential_info.version}".indent(2)
+      output << "Encryption Type: #{credential_info.encryption_type} (#{Rex::Proto::Kerberos::Crypto::Encryption.const_name(credential_info.encryption_type)})".indent(2)
+      output << "Serialized Data: #{credential_info.serialized_data.map { |x| x.to_i.to_s(16).rjust(2, '0').to_s }.join}".indent(2)
+
+      output.join("\n")
+    end
+
     # @param [Rex::Proto::Kerberos::Pac::Krb5ClientInfo] client_info
     # @return [String] A human readable representation of a Client Info
     def present_client_info(client_info)
@@ -349,6 +360,8 @@ module Rex::Proto::Kerberos::CredentialCache
       case ul_type
       when Rex::Proto::Kerberos::Pac::Krb5PacElementType::LOGON_INFORMATION
         present_logon_info(pac_element)
+      when Rex::Proto::Kerberos::Pac::Krb5PacElementType::CREDENTIAL_INFORMATION
+        present_credential_info(pac_element)
       when Rex::Proto::Kerberos::Pac::Krb5PacElementType::CLIENT_INFORMATION
         present_client_info(pac_element)
       when Rex::Proto::Kerberos::Pac::Krb5PacElementType::SERVER_CHECKSUM

--- a/lib/rex/proto/kerberos/crypto/des_cbc_md5.rb
+++ b/lib/rex/proto/kerberos/crypto/des_cbc_md5.rb
@@ -94,6 +94,9 @@ module Rex
 
 
             cipher = OpenSSL::Cipher.new('des-cbc')
+            if key.length != cipher.key_len
+              raise Rex::Proto::Kerberos::Model::Error::KerberosError, "Decryption key length must be #{cipher.key_len} for des-cbc"
+            end
             cipher.decrypt
             cipher.padding = 0
             cipher.key = key
@@ -137,6 +140,9 @@ module Rex
             plaintext = confounder + checksum + padded_data
 
             cipher = OpenSSL::Cipher.new('des-cbc')
+            if key.length != cipher.key_len
+              raise Rex::Proto::Kerberos::Model::Error::KerberosError, "Encryption key length must be #{cipher.key_len} for des-cbc"
+            end
             cipher.encrypt
             cipher.padding = 0
             cipher.key = key

--- a/lib/rex/proto/kerberos/crypto/rc4_hmac.rb
+++ b/lib/rex/proto/kerberos/crypto/rc4_hmac.rb
@@ -25,7 +25,7 @@ module Rex
             unicode_password = password.encode('utf-16le')
             password_digest = OpenSSL::Digest.digest('MD4', unicode_password)
           end
-          
+
           # Use this class's encryption routines to create a checksum of the data based on the key and message type
           #
           # @param key [String] the key to use to generate the checksum
@@ -261,7 +261,7 @@ module Rex
 
           def usage_str(msg_type)
             usage_table = {
-              Rex::Proto::Kerberos::Crypto::KeyUsage::AS_REP_ENCPART => Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY, 
+              Rex::Proto::Kerberos::Crypto::KeyUsage::AS_REP_ENCPART => Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY,
               Rex::Proto::Kerberos::Crypto::KeyUsage::GSS_ACCEPTOR_SIGN => Rex::Proto::Kerberos::Crypto::KeyUsage::KRB_PRIV_ENCPART
             }
             usage_mapped = usage_table.fetch(msg_type) { msg_type }

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
 
     context 'when the decryption key is invalid' do
       it 'raises an exception' do
-        expect { subject.present(key: 'Invalid key') }.to raise_error(ArgumentError)
+        expect { subject.present(key: 'key length must be') }.to raise_error(Rex::Proto::Kerberos::Model::Error::KerberosError)
       end
     end
 


### PR DESCRIPTION
This makes three updates to the `auxiliary/admin/kerberos/inspect_ticket` module.

1. It adds credential information to the presenter so it can be displayed instead of leaking the BinData representation to the user.
2. It raises a clear `KerberosError` when the encryption key is not the correct size instead of deferring to OpenSSL's `ArgumentError`
3. It adjusts the truncation logic in the `creds` command to:
    a. Increase the truncation size from 87 character to 88. 87 was the *exact* length to trim off the last byte of an AES256 key, and the resulting string would be appended with ` (TRUNCATED)` making the displayed string longer than the untrucated one.
    b. When a private is truncated now, trim it at 76 characters instead of 88 so the resulting value is 88 characters once ` (TRUNCATED)` is appended. This guarantees that if we truncate a string, the resulting value will not be larger than the original.

## Verification

- [ ] Use the secrets dump module or some other means to get an AES 256 kerberos key from a target server
- [ ] Use the `creds -u krbtgt` command to show the full AES-256 key (no truncation)
- [ ] Issue a kerberos ticket from a server (my target was a Server 2022 instance)
- [ ] Use the `auxiliary/admin/kerberos/inspect_ticket` module
- [ ] Give it an AES-128 key and run the module. See it fail with an error that the encryption key must be 32 bytes long for AES-256.
- [ ] Give it an AES-256 key and run the module. See that the credential information is nicely printed.


### Demo (AES Key Length Error)
Before:
```
[*] Credentials cache: File:/home/smcintyre/.msf4/loot/20240222163404_default_3.19.108.211_mit.kerberos.cca_039453.bin
[-] Auxiliary failed: ArgumentError key must be 32 bytes
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/crypto/aes_block_cipher_base.rb:39:in `key='
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/crypto/aes_block_cipher_base.rb:39:in `encrypt_basic'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/crypto/block_cipher_base.rb:187:in `derive'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/crypto/block_cipher_base.rb:50:in `decrypt'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:395:in `present_encrypted_ticket_part'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:110:in `present_cred'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:54:in `block in present'
[-]   /home/smcintyre/.rvm/gems/ruby-3.1.2@metasploit-framework/gems/bindata-2.4.15/lib/bindata/array.rb:220:in `block in each'
[-]   /home/smcintyre/.rvm/gems/ruby-3.1.2@metasploit-framework/gems/bindata-2.4.15/lib/bindata/array.rb:220:in `each'
[-]   /home/smcintyre/.rvm/gems/ruby-3.1.2@metasploit-framework/gems/bindata-2.4.15/lib/bindata/array.rb:220:in `each'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:53:in `map'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:53:in `with_index'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb:53:in `present'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/kerberos/ticket.rb:308:in `print_ccache_contents'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/kerberos/ticket.rb:295:in `print_contents'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/kerberos/inspect_ticket.rb:49:in `run'
[*] Auxiliary module execution completed
```

After:
```
[*] Credentials cache: File:/home/smcintyre/.msf4/loot/20240222163404_default_3.19.108.211_mit.kerberos.cca_039453.bin
[-] Auxiliary aborted due to failure: unknown: Could not print ticket contents (Encryption key length must be 32 for aes-256-cbc)
[*] Auxiliary module execution completed
```

### Demo (PAC Credential Information)
Before:
```
              Logon Server: 'SRV-ADDS01'
              Logon Domain Name: 'collalabs1'
            Credential information:
              {:ul_type=>2, :cb_buffer_size=>148, :offset=>624, :buffer=>{:pac_element=>{:ul_type=>2, :version=>0, :encryption_type=>18, :serialized_data=>[155, 99, 26, 96, 192, 252, 176, 71, 142, 131, 117, 251, 20, 232, 227, 41, 7, 19, 82, 33, 72, 225, 118, 178, 208, 90, 29, 118, 33, 247, 10, 94, 100, 237, 136, 159, 234, 191, 120, 240, 174, 200, 151, 199, 223, 210, 72, 78, 134, 122, 40, 182, 239, 58, 156, 249, 88, 5, 229, 84, 140, 236, 2, 159, 195, 37, 179, 48, 99, 20, 102, 61, 99, 141, 233, 243, 76, 203, 195, 173, 172, 126, 86, 173, 233, 192, 45, 229, 143, 81, 125, 184, 243, 185, 175, 44, 172, 118, 11, 214, 201, 127, 159, 146, 249, 155, 163, 125, 125, 126, 6, 165, 253, 169, 246, 246, 65, 155, 160, 252, 233, 70, 255, 169, 145, 122, 250, 4, 226, 45, 13, 112, 221, 80, 140, 209, 95, 68, 64, 62]}, :padding=>"\x00\x00\x00\x00"}}
            Pac Server Checksum:
              Signature: 7ae6baa4cbbc700dcfb5a6d3
```

After:
```
...
              Logon Server: 'SRV-ADDS01'
              Logon Domain Name: 'collalabs1'
            Credential Information:
              Version: 0
              Encryption Type: 18 (AES256)
              Serialized Data: 9b631a60c0fcb0478e8375fb14e8e3290713522148e176b2d05a1d7621f70a5e64ed889feabf78f0aec897c7dfd2484e867a28b6ef3a9cf95805e5548cec029fc325b3306314663d638de9f34ccbc3adac7e56ade9c02de58f517db8f3b9af2cac760bd6c97f9f92f99ba37d7d7e06a5fda9f6f6419ba0fce946ffa9917afa04e22d0d70dd508cd15f44403e
            Pac Server Checksum:
              Signature: 7ae6baa4cbbc700dcfb5a6d3
...
```

### Demo (AES Key Truncation)
Before:
```
msf6 auxiliary(admin/kerberos/inspect_ticket) > creds -u krbtgt
Credentials
===========

host          origin        service        public  private                                                                                              realm             private_type  JtR Format  cracked_password
----          ------        -------        ------  -------                                                                                              -----             ------------  ----------  ----------------
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  00000000000000000000000000000000:00000000000000000000000000000000                                    collalabs1.local  NTLM hash     nt,lm       
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  aes256-cts-hmac-sha1-96:000000000000000000000000000000000000000000000000a8dc1b699c6521c (TRUNCATED)  collalabs1.local  Krb enc key               
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  aes128-cts-hmac-sha1-96:00000000000000000000000000000000                                             collalabs1.local  Krb enc key               
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  des-cbc-md5:0000000000000000                                                                         collalabs1.local  Krb enc key               

msf6 auxiliary(admin/kerberos/inspect_ticket) >
```

After:
```
msf6 auxiliary(admin/kerberos/inspect_ticket) > creds -u krbtgt
Credentials
===========
host          origin        service        public  private                                                                                   realm             private_type  JtR Format  cracked_password
----          ------        -------        ------  -------                                                                                   -----             ------------  ----------  ----------------
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  00000000000000000000000000000000:000000000000000028f7af8f8350e41                          collalabs1.local  NTLM hash     nt,lm       
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  aes256-cts-hmac-sha1-96:0000000000000000000000000000000000000000000000000000000000000000  collalabs1.local  Krb enc key               
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  aes128-cts-hmac-sha1-96:00000000000000000000000000000000                                  collalabs1.local  Krb enc key               
192.0.2.211   192.0.2.211   445/tcp (smb)  krbtgt  des-cbc-md5:0000000000000000                                                              collalabs1.local  Krb enc key               

msf6 auxiliary(admin/kerberos/inspect_ticket) >
```
```