### PR TITLE
Fix typo in SASL supported mechanisms

### DIFF
--- a/lib/rex/proto/ldap/auth.rb
+++ b/lib/rex/proto/ldap/auth.rb
@@ -5,7 +5,7 @@ module Rex
   module Proto
     module LDAP
       class Auth
-        SUPPORTS_SASL = %w[GSS-SPNEGO NLTM]
+        SUPPORTS_SASL = %w[GSS-SPNEGO NTLM]
         NTLM_CONST = Rex::Proto::NTLM::Constants
         NTLM_CRYPT = Rex::Proto::NTLM::Crypt
         MESSAGE = Rex::Proto::NTLM::Message


### PR DESCRIPTION
A typo in #18678 causes failure to complete NTLM auth attempts,

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use capture/ldap`
- [ ] `run`
- [ ] **Verify** ldapsearch reports attempt `NTLM` attempt
`ldapsearch -H ldap://127.0.0.1 -Y ntlm -U admin -b 'dc=example,dc=com'`
