### PR TITLE
Add `-i` option to `Msf::Ui::Console::CommandDispatcher::Session` mixin's `sessions` command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/session.rb
+++ b/lib/msf/ui/console/command_dispatcher/session.rb
@@ -136,23 +136,36 @@ module Msf
           end
 
           def cmd_sessions_help
-            print_line('Usage: sessions <id>')
+            print_line('Usage: sessions <id> or sessions -i <id>')
             print_line
             print_line('Interact with a different session Id.')
-            print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
             print_line
           end
 
           def cmd_sessions(*args)
-            if args.empty? || args[0].to_i == 0
+            if args.empty? ||
+               (args.length == 1 && args[0].to_i == 0) ||
+               (args.length == 2 && args[1].to_i == 0)
               cmd_sessions_help
-            elsif args[0].to_s == session.name.to_s
+              return
+            end
+
+            if args.length == 1 && args[0] =~ /-?\d+/
+              sid = args[0].to_i
+            elsif args.length == 2 && args[0] == '-i' && args[1] =~ /-?\d+/
+              sid = args[1].to_i
+            else
+              cmd_sessions_help
+              return
+            end
+
+            if sid.to_s == session.name.to_s
               print_status("Session #{session.name} is already interactive.")
             else
               print_status("Backgrounding session #{session.name}...")
               # store the next session id so that it can be referenced as soon
               # as this session is no longer interacting
-              session.next_session = args[0]
+              session.next_session = sid
               session.interacting = false
             end
           end

--- a/spec/support/shared/examples/msf/ui/console/command_dispatcher/session.rb
+++ b/spec/support/shared/examples/msf/ui/console/command_dispatcher/session.rb
@@ -73,6 +73,14 @@ RSpec.shared_examples_for 'session command dispatcher' do
           expect(session).to have_received(:interacting=).with(false)
           expect(session).to have_received(:next_session=).with(new_session_id.to_i)
         end
+
+        let(:new_session_id) { '1' }
+
+        it 'backgrounds the session and switches to the new session' do
+          subject.cmd_sessions(new_session_id)
+          expect(session).to have_received(:interacting=).with(false)
+          expect(session).to have_received(:next_session=).with(new_session_id.to_i)
+        end
       end
     end
 

--- a/spec/support/shared/examples/msf/ui/console/command_dispatcher/session.rb
+++ b/spec/support/shared/examples/msf/ui/console/command_dispatcher/session.rb
@@ -66,12 +66,12 @@ RSpec.shared_examples_for 'session command dispatcher' do
           allow(session).to receive(:next_session=)
         end
 
-        let(:new_session_id) { 2 }
+        let(:new_session_id) { '2' }
 
         it 'backgrounds the session and switches to the new session' do
-          subject.cmd_sessions(new_session_id)
+          subject.cmd_sessions('-i', new_session_id)
           expect(session).to have_received(:interacting=).with(false)
-          expect(session).to have_received(:next_session=).with(new_session_id)
+          expect(session).to have_received(:next_session=).with(new_session_id.to_i)
         end
       end
     end


### PR DESCRIPTION
Fixes #18811 

This PR adds a `-i` option to `Msf::Ui::Console::CommandDispatcher::Session` mixin's `sessions` command. This change would affect `meterpreter`, `smb`, `sql` consoles.

I've also updated the spec tests for the same

## Verification

- [ ] Get 2 or more `meterpreter` sessions
- [ ] use the `-i` option to interact with different sessions

```
msf6 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                   Information            Connection
  --  ----  ----                   -----------            ----------
  1         meterpreter x64/linux  errorxyz @ linome.xyz  127.0.0.1:4444 -> 127.0.0.1:52652 (127.0.0.1)
  2         meterpreter x64/linux  errorxyz @ linome.xyz  127.0.0.1:4444 -> 127.0.0.1:33242 (127.0.0.1)

msf6 exploit(multi/handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sessions -i 2
[*] Backgrounding session 1...
[*] Starting interaction with 2...

meterpreter > sessions -i 1
[*] Backgrounding session 2...
[*] Starting interaction with 1...

meterpreter > sessions -i -1
[*] Backgrounding session 1...
[*] Starting interaction with 2...

meterpreter > sessions -i 2
[*] Session 2 is already interactive.

```