### PR TITLE
Adds support for searching by session types

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -34,6 +34,7 @@ module Msf::Modules::Metadata::Search
       reference
       references
       rport
+      session_type
       stage
       stager
       target
@@ -213,6 +214,8 @@ module Msf::Modules::Metadata::Search
               match = [keyword, search_term] if module_metadata.stager_refname =~ regex
             when 'adapter'
               match = [keyword, search_term] if module_metadata.adapter_refname =~ regex
+            when 'session_type'
+              match = [keyword, search_term] if module_metadata.session_types && module_metadata.session_types.any? { |session_type| session_type =~ regex }
             when 'port', 'rport'
               match = [keyword, search_term] if module_metadata.rport.to_s =~ regex
             when 'rank'

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -399,6 +399,7 @@ module Msf
               'rank'        => 'Modules with a matching rank (Can be descriptive (ex: \'good\') or numeric with comparison operators (ex: \'gte400\'))',
               'ref'         => 'Modules with a matching ref',
               'reference'   => 'Modules with a matching reference',
+              'session_type' => 'Modules with a matching session type (SMB, MySQL, Meterpreter, etc)',
               'stage'       => 'Modules with a matching stage reference name',
               'stager'      => 'Modules with a matching stager reference name',
               'target'      => 'Modules affecting this target',

--- a/lib/rex/post/session_compatible_modules.rb
+++ b/lib/rex/post/session_compatible_modules.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Post
+    ###
+    #
+    # This module provides a list of modules that are compatible with the current session
+    #
+    ###
+    module SessionCompatibleModules
+
+      # @return [Array<String>]
+      def session_compatible_modules
+        # Use the built in search command functionality to get a list of search results
+        search_params = { 'session_type' => [[self.session.type], []] }
+        Msf::Modules::Metadata::Cache.instance.find(search_params)
+      end
+
+      # @return [String]
+      def format_session_compatible_modules
+        <<~EOF
+          This session also works with the following modules:
+
+            #{session_compatible_modules.flat_map(&:fullname).join("\n  ")}
+
+        EOF
+      end
+    end
+  end
+end

--- a/lib/rex/post/smb/ui/console.rb
+++ b/lib/rex/post/smb/ui/console.rb
@@ -1,6 +1,8 @@
 # -*- coding: binary -*-
 
 require 'English'
+require 'rex/post/session_compatible_modules'
+
 module Rex
   module Post
     module SMB
@@ -13,6 +15,7 @@ module Rex
         class Console
 
           include Rex::Ui::Text::DispatcherShell
+          include Rex::Post::SessionCompatibleModules
 
           # Dispatchers
           require 'rex/post/smb/ui/console/command_dispatcher'
@@ -96,6 +99,12 @@ module Rex
           rescue ::StandardError => e
             log_error("Error running command #{method}: #{e.class} #{e}")
             elog(e)
+          end
+
+          # @param [Hash] opts
+          # @return [String]
+          def help_to_s(opts = {})
+            super + format_session_compatible_modules
           end
 
           #

--- a/lib/rex/post/sql/ui/console.rb
+++ b/lib/rex/post/sql/ui/console.rb
@@ -1,5 +1,6 @@
 require 'rex/post/sql/ui/console/command_dispatcher'
 require 'rex/post/sql/ui/console/interactive_sql_client'
+require 'rex/post/session_compatible_modules'
 
 module Rex
   module Post
@@ -12,6 +13,7 @@ module Rex
         module Console
 
           include Rex::Ui::Text::DispatcherShell
+          include Rex::Post::SessionCompatibleModules
 
           # Called when someone wants to interact with an SQL client.  It's
           # assumed that init_ui has been called prior.
@@ -67,6 +69,12 @@ module Rex
               log_error("Error running command #{method}: #{e.class} #{e}")
               elog(e)
             end
+          end
+
+          # @param [Hash] opts
+          # @return [String]
+          def help_to_s(opts = {})
+            super + format_session_compatible_modules
           end
 
           #

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("stage:linux/x64/meterpreter ")).to eq({"stage"=>[["linux/x64/meterpreter"], []]}) }
     it { expect(described_class.parse_search_string("stager:linux/x64/reverse_tcp ")).to eq({"stager"=>[["linux/x64/reverse_tcp"], []]}) }
     it { expect(described_class.parse_search_string("adapter:cmd/linux/http/mips64 ")).to eq({"adapter"=>[["cmd/linux/http/mips64"], []]}) }
+    it { expect(described_class.parse_search_string("session_type:PostgreSQL ")).to eq({"session_type"=>[["postgresql"], []]}) }
+    it { expect(described_class.parse_search_string("session_type:MSSQL ")).to eq({"session_type"=>[["mssql"], []]}) }
+    it { expect(described_class.parse_search_string("session_type:MySQL ")).to eq({"session_type"=>[["mysql"], []]}) }
+    it { expect(described_class.parse_search_string("session_type:SMB ")).to eq({"session_type"=>[["smb"], []]}) }
+    it { expect(described_class.parse_search_string("session_type:Meterpreter ")).to eq({"session_type"=>[["meterpreter"], []]}) }
+    it { expect(described_class.parse_search_string("session_type:shell ")).to eq({"session_type"=>[["shell"], []]}) }
     it { expect(described_class.parse_search_string("action:forge_golden ")).to eq({"action"=>[["forge_golden"], []]}) }
   end
 
@@ -181,6 +187,48 @@ RSpec.describe Msf::Modules::Metadata::Search do
       let(:opts) { { 'adapter_refname' => 'linux/x64/meterpreter_reverse_https' } }
       accept = %w[adapter:linux/x64/meterpreter_reverse_http adapter:linux/x64/meterpreter_reverse_https]
       reject = %w[adapter:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #session_type of ["postgresql"]' do
+      let(:opts) { { 'session_types' => ['postgresql'] } }
+      accept = %w[session_type:postgresql]
+      accept_mis_spelt = %w[session_type:postgre]
+      reject = %w[session_type:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+      it_should_behave_like 'search_filter', accept: accept_mis_spelt, reject: reject
+    end
+
+    context 'on a module with a #session_types of ["postgresql"]' do
+      let(:opts) { { 'session_types' => ['postgresql'] } }
+      accept = %w[session_type:postgre]
+      reject = %w[session_type:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #session_type of ["mysql"]' do
+      let(:opts) { { 'session_types' => ['mysql'] } }
+      accept = %w[session_type:mysql]
+      reject = %w[session_type:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #session_type of ["smb"]' do
+      let(:opts) { { 'session_types' => ['smb'] } }
+      accept = %w[session_type:SMB]
+      reject = %w[session_type:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #session_type of ["mssql"]' do
+      let(:opts) { { 'session_types' => ['mssql'] } }
+      accept = %w[session_type:mssql]
+      reject = %w[session_type:unrelated]
 
       it_should_behave_like 'search_filter', accept: accept, reject: reject
     end


### PR DESCRIPTION
This PR adds support to the existing `search` command functionality to now also search by session type. 

The idea is to allow users to search by a specific session type and then a list of modules that support that session type will be output.

![image](https://github.com/rapid7/metasploit-framework/assets/69522014/14295453-f33c-4f5f-a540-709ad49c2d0c)

Tests were also updated for the new search functionality.

> [!note]
This PR also adds support to the `help` command within sessions (MySQL, MSSQL, PostgreSQL and SMB) to now return a list off modules the current session type is compatible with.
Meterpreter was excluded from this, as it's list would be much too long for this to work.

![image](https://github.com/rapid7/metasploit-framework/assets/69522014/9c7243e4-3cb2-4c19-a174-3bc2d163a6e7)



## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Test the new search functionality - `search session_type:MySQL`
- [ ] Repeat for each session type - MSSQL/SMB/PostgreSQL/Meterpreter/shell
- [ ] Get a session for each session type and **verify** that the help command now returns a list of compatible modules for MSSQL/SMB/PostgreSQL/MySQL
- [ ] **Verify** that Meterpreter and shell session still function as expected and don't return a list of compatible modules