### PR TITLE
Fresh SQL prompt when pressing enter if no input was provided

### DIFF
--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -84,9 +84,16 @@ module InteractiveSqlClient
       ::Reline.prompt_proc = proc { |line_buffer| line_buffer.each_with_index.map { |_line, i| i > 0 ? 'SQL *> ' : 'SQL >> ' } }
 
       # We want to do this in a loop
+      # multiline_input is the whole string that the user has input, not just the current line.
       raw_query = ::Reline.readmultiline('SQL >> ', use_history = true) do |multiline_input|
         # The user pressed ctrl + c or ctrl + z and wants to background our SQL prompt
         return { status: :exit, result: nil } unless self.interacting
+        # When the user has pressed the enter key with no input, don't run any queries;
+        # simply give them a new prompt on a new line.
+        if multiline_input.chomp.empty?
+          print_blank_line
+          return { status: :success, result: nil }
+        end
 
         # In the case only a stop word was input, exit out of the REPL shell
         finished = (multiline_input.split.count == 1 && stop_words.include?(multiline_input.split.last))


### PR DESCRIPTION
This PR changes how the `enter` key is handled when there is no user input present in the multiline SQL prompt.

This PR also removes the early return calls from within the Reline context. This was causing issues. Now, this is handled by calling `next true`, causing the `readmultiline` proc to give us back control cleanly, whilst also tidying up any Reline things behind the scenes. This was not happening when early returns were used. No `print_empty_line` hacks are necessary; it just works™️ 

## Before

Multi-line input when we want only a new line. You can press backspace to clear the previous multi-line inputs.
```ruby
PostgreSQL @ 127.0.0.1:5432 (template1) > shell
SQL >>
SQL *>
SQL *>
SQL *>
SQL *>
SQL *> exit

[*] Exiting Shell mode.
```

## After

The user can now press `enter` multiple times, each time getting a fresh prompt.
Also, the blank `enter` presses are not stored in the history, which is nice.
```ruby
PostgreSQL @ 127.0.0.1:5432 (template1) > shell
SQL >>
SQL >>
SQL >>
SQL >>
SQL >> exit
[*] Exiting Shell mode.
```

## Verification

- [ ] Start `msfconsole`
- [ ] Get an SQL session (MySQL, PostgreSQL, MSSQL)
- [ ] `sessions -i -1`
- [ ] `shell`
- [ ] **Verify** that pressing `enter` with no user input gives you a new line
- [ ] Ensure you can input multi-line and single-line queries that end in `;`
- [ ] Ensure that pressing enter multiple times when there is user input results in multiple lines