### PR TITLE
rename shell to query_interactive for sql session types, add -i flag

### DIFF
--- a/lib/rex/post/mssql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/mssql/ui/console/command_dispatcher/client.rb
@@ -24,8 +24,8 @@ module Rex
           def cmd_query_help
             print_line 'Usage: query'
             print_line
-            print_line 'Run a raw SQL query on the target.'
-            print_line
+            print_line 'Run a single SQL query on the target.'
+            print_line @@query_opts.usage
             print_line 'Examples:'
             print_line
             print_line '    query select @@version;'
@@ -34,7 +34,7 @@ module Rex
             print_line
           end
 
-          # @param [Hash] result The MSQQL query result
+          # @param [Hash] result The MSSQL query result
           # @return [Hash] Hash containing rows, columns and errors.
           def normalise_sql_result(result)
             { rows: result[:rows], columns: result[:colnames], errors: result[:errors] }

--- a/lib/rex/post/mysql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/mysql/ui/console/command_dispatcher/client.rb
@@ -21,8 +21,8 @@ module Rex
           def cmd_query_help
             print_line 'Usage: query'
             print_line
-            print_line 'Run a raw SQL query on the target.'
-            print_line
+            print_line 'Run a single SQL query on the target.'
+            print_line @@query_opts.usage
             print_line 'Examples:'
             print_line
             print_line '    query SHOW DATABASES;'

--- a/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/postgresql/ui/console/command_dispatcher/client.rb
@@ -25,8 +25,8 @@ module Rex
           def cmd_query_help
             print_line 'Usage: query'
             print_line
-            print_line 'Run a raw SQL query on the target.'
-            print_line
+            print_line 'Run a single SQL query on the target.'
+            print_line @@query_opts.usage
             print_line 'Examples:'
             print_line
             print_line '    query SELECT user;'

--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -16,6 +16,11 @@ module Rex
 
               include Rex::Post::Sql::Ui::Console::CommandDispatcher
 
+              @@query_opts = Rex::Parser::Arguments.new(
+                ['-h', '--help'] => [false, 'Help menu.'],
+                ['-i', '--interact'] => [false,  'Enter an interactive prompt for running multiple SQL queries'],
+                )
+
               #
               # Initializes an instance of the core command set using the supplied console
               # for interactivity.
@@ -32,8 +37,8 @@ module Rex
               #
               def commands
                 cmds = {
-                  'query'   => 'Run a raw SQL query',
-                  'shell'   => 'Enter a raw shell where SQL queries can be executed',
+                  'query'   => 'Run a single SQL query',
+                  'query_interactive'   => 'Enter an interactive prompt for running multiple SQL queries',
                 }
 
                 reqs = {}
@@ -54,17 +59,17 @@ module Rex
                 args.include?('-h') || args.include?('--help')
               end
 
-              def cmd_shell_help
-                print_line 'Usage: shell'
+              def cmd_query_interactive_help
+                print_line 'Usage: query_interactive'
                 print_line
-                print_line 'Go into a raw SQL shell where SQL queries can be executed.'
+                print_line 'Go into an interactive SQL shell where SQL queries can be executed.'
                 print_line "To exit, type 'exit', 'quit', 'end' or 'stop'."
                 print_line
               end
 
-              def cmd_shell(*args)
+              def cmd_query_interactive(*args)
                 if help_args?(args)
-                  cmd_shell_help
+                  cmd_query_interactive_help
                   return
                 end
 
@@ -120,9 +125,15 @@ module Rex
               end
 
               def cmd_query(*args)
-                if help_args?(args)
-                  cmd_query_help
-                  return
+                @@query_opts.parse(args) do |opt, idx, val|
+                  case opt
+                  when '-h', '--help'
+                    cmd_query_help
+                    return
+                  when '-i', '--interact'
+                    cmd_query_interactive
+                    return
+                  end
                 end
 
                 result = run_query(args.join(' '))

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -101,7 +101,7 @@ module InteractiveSqlClient
 
     if finished
       self.interacting = false
-      print_status 'Exiting Shell mode.'
+      print_status 'Exiting Interactive mode.'
       return { status: :exit, result: nil }
     end
 
@@ -116,7 +116,7 @@ module InteractiveSqlClient
 
       if stop_words.include? line.chomp.downcase
         self.interacting = false
-        print_status 'Exiting Shell mode.'
+        print_status 'Exiting Interactive mode.'
         return { status: :exit, result: nil }
       end
 


### PR DESCRIPTION
For clarity, renames 'shell' command for sql session types to 'query_interactive', as well as adds a `-i` flag to `query` so users have options.

## Verification

- [ ] Start `msfconsole`
- [ ] Open up a `sql` session type. (i.e. `use mssql_login` and `run CreateSession=true ...other_args`)
- [ ] `sessions -i -1`
- [ ] try out the new commands and verify that things look good and still work
- [ ] Example commands to run: `help`, `query`, `query -h`, `query -i -h`, `query -h -i`, `query_interactive`, `query_interactive -h`

```
 ./msfconsole -q
[*] New in Metasploit 6.4 - The CreateSession option within this module can open an interactive session
msf6 auxiliary(scanner/mssql/mssql_login) > run CreateSession=true RPORT=1433 RHOSTS=192.168.2.230 USERNAME=.. PASSWORD=..

[*] 192.168.2.230:1433    - 192.168.2.230:1433 - MSSQL - Starting authentication scanner.
[+] 192.168.2.230:1433    - 192.168.2.230:1433 - Login Successful: WORKSTATION\test:ASDqwe123
[*] MSSQL session 1 opened (192.168.2.1:57262 -> 192.168.2.230:1433) at 2024-02-26 11:31:37 -0600
[*] 192.168.2.230:1433    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/mssql/mssql_login) > sessions -i -1
[*] Starting interaction with 1...

MSSQL @ 192.168.2.230:1433 (master) > help

Core Commands
=============

    Command       Description
    -------       -----------
    ?             Help menu
    background    Backgrounds the current session
    bg            Alias for background
    exit          Terminate the PostgreSQL session
    help          Help menu
    irb           Open an interactive Ruby shell on the current session
    pry           Open the Pry debugger on the current session
    sessions      Quickly switch to another session


MSSQL Client Commands
=====================

    Command       Description
    -------       -----------
    query         Run a single SQL query
    query_intera  Enter an interactive prompt for running multiple SQL queries
    ctive

MSSQL @ 192.168.2.230:1433 (master) > query -h
Usage: query

Run a single SQL query on the target.

Examples:

    query select @@version;
    query select user_name();
    query select name from master.dbo.sysdatabases;

MSSQL @ 192.168.2.230:1433 (master) > query -i -h
Usage: query_interactive, query -i

Go into an interactive SQL shell where SQL queries can be executed.
To exit, type 'exit', 'quit', 'end' or 'stop'.

MSSQL @ 192.168.2.230:1433 (master) > query -h -i
Usage: query_interactive, query -i

Go into an interactive SQL shell where SQL queries can be executed.
To exit, type 'exit', 'quit', 'end' or 'stop'.

MSSQL @ 192.168.2.230:1433 (master) > query -i
SQL >> exit

[*] Exiting Interactive mode.
MSSQL @ 192.168.2.230:1433 (master) > query_interactive
SQL >> select @@version;

[*] Executing query: select @@version;
Response
========

    #  NULL
    -  ----
    0  Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64)
	Oct  8 2022 05:58:25
	Copyright (C) 202
       2 Microsoft Corporation
	Developer Edition (64-bit) on Windows Server 2022 Standard 10.0 <X64>
        (Build 20348: ) (Hypervisor)

SQL >> exit
[*] Exiting Interactive mode.
MSSQL @ 192.168.2.230:1433 (master) > query_interactive -h
Usage: query_interactive, query -i

Go into an interactive SQL shell where SQL queries can be executed.
To exit, type 'exit', 'quit', 'end' or 'stop'.
```