### PR TITLE
AD CS Updates for ESC13

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -224,6 +224,7 @@ queries:
       - adminCount
       - managedBy
       - groupAttributes
+      - objectSID
     references:
       - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
   - action: ENUM_GROUP_POLICY_OBJECTS

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,7 +32,7 @@ exclude:
 # just-the-docs config
 mermaid_enabled: true
 mermaid:
-  version: "9.2.2"
+  version: "10.8.0"
 heading_anchors: true
 aux_links_new_tab: true
 aux_links:

--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -53,12 +53,22 @@ module Msf
         tbl = Rex::Text::Table.new(
           'Header' => entry[:dn].first,
           'Indent' => 1,
-          'Columns' => %w[Name Attributes]
+          'Columns' => %w[Name Attributes],
+          'ColProps' => { 'Name' => { 'Strip' => false } },
+          'SortIndex' => -1,
+          'WordWrap' => false
         )
 
-        entry.each_key do |attr|
+        entry.keys.sort.each do |attr|
           if format == 'table'
-            tbl << [attr, entry[attr].join(' || ')] unless attr == :dn # Skip over DN entries for tables since DN information is shown in header.
+            next if attr == :dn # Skip over DN entries for tables since DN information is shown in header.
+
+            tbl << [attr, entry[attr].first]
+            if entry[attr].length > 1
+              entry[attr][1...].each do |additional_attr|
+                tbl << [ '  \\_', additional_attr]
+              end
+            end
           else
             tbl << [attr, entry[attr].join(' || ')] # DN information is not shown in CSV output as a header so keep DN entries in.
           end

--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -51,7 +51,7 @@ module Msf
 
       def generate_rex_tables(entry, format)
         tbl = Rex::Text::Table.new(
-          'Header' => entry[:dn][0].split(',').join(' '),
+          'Header' => entry[:dn].first,
           'Indent' => 1,
           'Columns' => %w[Name Attributes]
         )

--- a/lib/rex/proto/crypto_asn1/o_i_ds.rb
+++ b/lib/rex/proto/crypto_asn1/o_i_ds.rb
@@ -1,0 +1,78 @@
+# -*- coding: binary -*-
+require 'rasn1'.freeze
+require 'rex/proto/crypto_asn1/types'
+
+module Rex::Proto::CryptoAsn1
+  class ObjectId < OpenSSL::ASN1::ObjectId
+    attr_reader :label, :name
+    def initialize(*args, label: nil, name: nil)
+      @label = label
+      @name = name
+      super(*args)
+    end
+
+   def eql?(other)
+      return false unless other.is_a?(self.class)
+      return false unless other.value == value
+      true
+    end
+
+    alias == eql?
+
+    # Returns whether or not this OID is one of Microsoft's
+    def microsoft?
+      @value.start_with?('1.3.6.1.4.1.311.') || @value == '1.3.6.1.4.1.311'
+    end
+  end
+
+  class OIDs
+    # see: https://learn.microsoft.com/en-us/windows/win32/api/certenroll/nn-certenroll-ix509extensionenhancedkeyusage
+    # see: https://www.pkisolutions.com/object-identifiers-oid-in-pki/
+    OID_ANY_APPLICATION_POLICY = ObjectId.new('1.3.6.1.4.1.311.10.12.1', name: 'OID_ANY_APPLICATION_POLICY')
+    OID_AUTO_ENROLL_CTL_USAGE = ObjectId.new('1.3.6.1.4.1.311.20.1', name: 'OID_AUTO_ENROLL_CTL_USAGE', label: 'CTL Usage')
+    OID_DRM = ObjectId.new('1.3.6.1.4.1.311.10.5.1', name: 'OID_DRM', label: 'Digital Rights')
+    OID_DS_EMAIL_REPLICATION = ObjectId.new('1.3.6.1.4.1.311.21.19', name: 'OID_DS_EMAIL_REPLICATION', label: 'Directory Service Email Replication')
+    OID_EFS_RECOVERY = ObjectId.new('1.3.6.1.4.1.311.10.3.4.1', name: 'OID_EFS_RECOVERY', label: 'File Recovery')
+    OID_EMBEDDED_NT_CRYPTO = ObjectId.new('1.3.6.1.4.1.311.10.3.8', name: 'OID_EMBEDDED_NT_CRYPTO', label: 'Embedded Windows System Component Verification')
+    OID_ENROLLMENT_AGENT = ObjectId.new('1.3.6.1.4.1.311.20.2.1', name: 'OID_ENROLLMENT_AGENT', label: 'Certificate Request Agent')
+    OID_IPSEC_KP_IKE_INTERMEDIATE = ObjectId.new('1.3.6.1.5.5.8.2.2', name: 'OID_IPSEC_KP_IKE_INTERMEDIATE', label: 'IP Security IKE Intermediate')
+    OID_KP_CA_EXCHANGE = ObjectId.new('1.3.6.1.4.1.311.21.5', name: 'OID_KP_CA_EXCHANGE', label: 'Private Key Archival')
+    OID_KP_CTL_USAGE_SIGNING = ObjectId.new('1.3.6.1.4.1.311.10.3.1', name: 'OID_KP_CTL_USAGE_SIGNING', label: 'Microsoft Trust List Signing')
+    OID_KP_DOCUMENT_SIGNING = ObjectId.new('1.3.6.1.4.1.311.10.3.12', name: 'OID_KP_DOCUMENT_SIGNING', label: 'Document Signing')
+    OID_KP_EFS = ObjectId.new('1.3.6.1.4.1.311.10.3.4', name: 'OID_KP_EFS', label: 'Encrypting File System')
+    OID_KP_KEY_RECOVERY = ObjectId.new('1.3.6.1.4.1.311.10.3.11', name: 'OID_KP_KEY_RECOVERY', label: 'Key Recovery')
+    OID_KP_KEY_RECOVERY_AGENT = ObjectId.new('1.3.6.1.4.1.311.21.6', name: 'OID_KP_KEY_RECOVERY_AGENT', label: 'Key Recovery Agent')
+    OID_KP_LIFETIME_SIGNING = ObjectId.new('1.3.6.1.4.1.311.10.3.13', name: 'OID_KP_LIFETIME_SIGNING', label: 'Lifetime Signing')
+    OID_KP_QUALIFIED_SUBORDINATION = ObjectId.new('1.3.6.1.4.1.311.10.3.10', name: 'OID_KP_QUALIFIED_SUBORDINATION', label: 'Qualified Subordination')
+    OID_KP_SMARTCARD_LOGON = ObjectId.new('1.3.6.1.4.1.311.20.2.2', name: 'OID_KP_SMARTCARD_LOGON', label: 'Smart Card Logon')
+    OID_KP_TIME_STAMP_SIGNING = ObjectId.new('1.3.6.1.4.1.311.10.3.2', name: 'OID_KP_TIME_STAMP_SIGNING', label: 'Microsoft Time Stamping')
+    OID_LICENSE_SERVER = ObjectId.new('1.3.6.1.4.1.311.10.6.2', name: 'OID_LICENSE_SERVER', label: 'License Server Verification')
+    OID_LICENSES = ObjectId.new('1.3.6.1.4.1.311.10.6.1', name: 'OID_LICENSES', label: 'Key Pack Licenses')
+    OID_NT5_CRYPTO = ObjectId.new('1.3.6.1.4.1.311.10.3.7', name: 'OID_NT5_CRYPTO', label: 'OEM Windows System Component Verification')
+    OID_OEM_WHQL_CRYPTO = ObjectId.new('1.3.6.1.4.1.311.10.3.7', name: 'OID_OEM_WHQL_CRYPTO', label: 'OEM Windows System Component Verification')
+    OID_PKIX_KP_CLIENT_AUTH = ObjectId.new('1.3.6.1.5.5.7.3.2', name: 'OID_PKIX_KP_CLIENT_AUTH', label: 'Client Authentication')
+    OID_PKIX_KP_CODE_SIGNING = ObjectId.new('1.3.6.1.5.5.7.3.3', name: 'OID_PKIX_KP_CODE_SIGNING', label: 'Code Signing')
+    OID_PKIX_KP_EMAIL_PROTECTION = ObjectId.new('1.3.6.1.5.5.7.3.4', name: 'OID_PKIX_KP_EMAIL_PROTECTION', label: 'Secure Email')
+    OID_PKIX_KP_IPSEC_END_SYSTEM = ObjectId.new('1.3.6.1.5.5.7.3.5', name: 'OID_PKIX_KP_IPSEC_END_SYSTEM', label: 'IP Security End System')
+    OID_PKIX_KP_IPSEC_TUNNEL = ObjectId.new('1.3.6.1.5.5.7.3.6', name: 'OID_PKIX_KP_IPSEC_TUNNEL', label: 'IP Security Tunnel Termination')
+    OID_PKIX_KP_IPSEC_USER = ObjectId.new('1.3.6.1.5.5.7.3.7', name: 'OID_PKIX_KP_IPSEC_USER', label: 'IP Security User')
+    OID_PKIX_KP_OCSP_SIGNING = ObjectId.new('1.3.6.1.5.5.7.3.9', name: 'OID_PKIX_KP_OCSP_SIGNING', label: 'OCSP Signing')
+    OID_PKIX_KP_SERVER_AUTH = ObjectId.new('1.3.6.1.5.5.7.3.1', name: 'OID_PKIX_KP_SERVER_AUTH', label: 'Server Authentication')
+    OID_PKIX_KP_TIMESTAMP_SIGNING = ObjectId.new('1.3.6.1.5.5.7.3.8', name: 'OID_PKIX_KP_TIMESTAMP_SIGNING', label: 'Time Stamping')
+    OID_ROOT_LIST_SIGNER = ObjectId.new('1.3.6.1.4.1.311.10.3.9', name: 'OID_ROOT_LIST_SIGNER', label: 'Root List Signer')
+    OID_WHQL_CRYPTO = ObjectId.new('1.3.6.1.4.1.311.10.3.5', name: 'OID_WHQL_CRYPTO', label: 'Windows Hardware Driver Verification')
+
+    def self.name(value)
+      value = ObjectId.new(value) if value.is_a?(String)
+
+      constants.select { |c| c.start_with?('OID_') }.find{ |c| const_get(c) == value }
+    end
+
+    def self.value(value)
+      name = self.name(value)
+      return nil unless name
+
+      const_get(name)
+    end
+  end
+end

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def get_certificate_template
     obj = ldap_get(
-      "(&(cn=#{datastore['CERT_TEMPLATE']})(objectClass=pkicertificatetemplate))",
+      "(&(cn=#{datastore['CERT_TEMPLATE']})(objectClass=pKICertificateTemplate))",
       base: "CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,#{@base_dn}",
       controls: [ms_security_descriptor_control(DACL_SECURITY_INFORMATION)]
     )
@@ -147,6 +147,35 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::NotFound, 'The domain SID was not found!') unless obj&.fetch('objectsid', nil)
 
     Rex::Proto::MsDtyp::MsDtypSid.read(obj['objectsid'].first)
+  end
+
+  def get_pki_oids
+    return @pki_oids if @pki_oids.present?
+
+    raw_objs = @ldap.search(
+      base: "CN=OID,CN=Public Key Services,CN=Services,CN=Configuration,#{@base_dn}",
+      filter: '(objectClass=msPKI-Enterprise-OID)'
+    )
+    validate_query_result!(@ldap.get_operation_result.table)
+    return nil unless raw_objs
+
+    @pki_oids = []
+    raw_objs.each do |raw_obj|
+      obj = {}
+      raw_obj.attribute_names.each do |attr|
+        obj[attr.to_s] = raw_obj[attr].map(&:to_s)
+      end
+
+      @pki_oids << obj
+    end
+    @pki_oids
+  end
+
+  def get_pki_oid_displayname(oid)
+    oid_obj = get_pki_oids.find { |o| o['mspki-cert-template-oid'].first == oid }
+    return nil unless oid_obj && oid_obj['displayname'].present?
+
+    oid_obj['displayname'].first
   end
 
   def dump_to_json(template)
@@ -403,11 +432,19 @@ class MetasploitModule < Msf::Auxiliary
 
     if obj['mspki-certificate-policy'].present?
       if obj['mspki-certificate-policy'].length == 1
-        print_status("  msPKI-Certificate-Policy: #{obj['mspki-certificate-policy'].first}")
+        if (oid_name = get_pki_oid_displayname(obj['mspki-certificate-policy'].first)).present?
+          print_status("  msPKI-Certificate-Policy: #{obj['mspki-certificate-policy'].first} (#{oid_name})")
+        else
+          print_status("  msPKI-Certificate-Policy: #{obj['mspki-certificate-policy'].first}")
+        end
       else
         print_status('  msPKI-Certificate-Policy:')
         obj['mspki-certificate-policy'].each do |value|
-          print_status("    * #{value}")
+          if (oid_name = get_pki_oid_displayname(value)).present?
+            print_status("    * #{value} (#{oid_name})")
+          else
+            print_status("    * #{value}")
+          end
         end
       end
     end

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -393,7 +393,22 @@ class MetasploitModule < Msf::Auxiliary
     if obj['pkiextendedkeyusage'].present?
       print_status('  pKIExtendedKeyUsage:')
       obj['pkiextendedkeyusage'].each do |value|
-        print_status("    * #{value}")
+        if (oid = Rex::Proto::CryptoAsn1::OIDs.value(value)) && oid.label.present?
+          print_status("    * #{value} (#{oid.label})")
+        else
+          print_status("    * #{value}")
+        end
+      end
+    end
+
+    if obj['mspki-certificate-policy'].present?
+      if obj['mspki-certificate-policy'].length == 1
+        print_status("  msPKI-Certificate-Policy: #{obj['mspki-certificate-policy'].first}")
+      else
+        print_status('  msPKI-Certificate-Policy:')
+        obj['mspki-certificate-policy'].each do |value|
+          print_status("    * #{value}")
+        end
       end
     end
   end


### PR DESCRIPTION
This makes some changes necessary for users to leverage the latest ESC technique, [ESC13](https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53). Actually exploiting ESC13 did not require any code changes to the icpr_cert module so the changes contained within this PR are related to the identification of misconfigured certificate templates and workflow documentation.

The `ldap_esc_vulnerable_cert_finder` module was also updated to establish an authenticated LDAP connection exactly once.

The `ldap_query` module was also updated with the new changes to Rex::Text that allow tables to more clearly print nested rows (see #18849). Also the DN is now printed with the commas, which means the value can just be copied and pasted into a location where a DN is expected. DNs are supposed to have commas AFAIK so I'm not sure why they were removed at first.

## Verification

For steps, you can basically follow along with the blog starting at the "ESC13 Demo" section.

- [x] Use the ldap_query module to identify the group RID (this is why the objectSID is added to the default queries)
- [x] Use the `ldap_esc_vulnerable_cert_finder` module to find the vulnerable certificate
- [x] Issue the certificate with `icpr_cert`
- [x] Use `kerberos/get_ticket` to obtain a TGT
- [x] Use `kerberos/inspect_ticket` to decrypt the PAC and see the group RID from step 1 in the ticket
