### PR TITLE
Rex Table command column width based on longest dispatcher command

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -232,6 +232,7 @@ module DispatcherShell
     #
     # Return a pretty, user-readable table of commands provided by this
     # dispatcher.
+    # The command column width can be modified by passing in :command_width.
     #
     def help_to_s(opts={})
       # If this dispatcher has no commands, we can't do anything useful.
@@ -250,7 +251,7 @@ module DispatcherShell
           {
             'Command' =>
               {
-                'Width' => 12
+                'Width' => opts[:command_width]
               }
           })
 
@@ -656,8 +657,10 @@ module DispatcherShell
   def help_to_s(opts = {})
     str = ''
 
+    max_command_length = dispatcher_stack.flat_map { |dispatcher| dispatcher.commands.to_a }.map { |(name, _description)| name.length }.max
+
     dispatcher_stack.reverse.each { |dispatcher|
-      str << dispatcher.help_to_s
+      str << dispatcher.help_to_s(opts.merge({ command_width: [max_command_length, 12].max }))
     }
 
     return str


### PR DESCRIPTION
This PR adds in the ability to change the previously hard-coded command column width for the dispatcher's `help_to_s` method. This can be changed by passing in `{ command_width: x }` as an option. This defaults to 12, which was the previously used value.

## Before

```ruby
msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > ?

Core Commands
=============

    Command       Description
    -------       -----------
    ?             Help menu
    background    Backgrounds the current session
    bg            Alias for background
    bgkill        Kills a background meterpreter script
    bglist        Lists running background scripts
    bgrun         Executes a meterpreter script as a background thread
    channel       Displays information or control active channels
    close         Closes a channel
    detach        Detach the meterpreter session (for http/https)
    disable_unic  Disables encoding of unicode strings
    ode_encoding
    enable_unico  Enables encoding of unicode strings
    de_encoding
    exit          Terminate the meterpreter session
    get_timeouts  Get the current session timeout values
    guid          Get the session GUID
    help          Help menu
    ...
    ...
```

## After

All dispatchers now have the same command column width for consistency.

```ruby
meterpreter > ?

Core Commands
=============

    Command                   Description
    -------                   -----------
    ?                         Help menu
    background                Backgrounds the current session
    bg                        Alias for background
    bgkill                    Kills a background meterpreter script
    bglist                    Lists running background scripts
    bgrun                     Executes a meterpreter script as a background thread
    channel                   Displays information or control active channels
    close                     Closes a channel
    detach                    Detach the meterpreter session (for http/https)
    disable_unicode_encoding  Disables encoding of unicode strings
    enable_unicode_encoding   Enables encoding of unicode strings
    exit                      Terminate the meterpreter session
    get_timeouts              Get the current session timeout values
    guid                      Get the session GUID
    help                      Help menu
    info                      Displays information about a Post module
    irb                       Open an interactive Ruby shell on the current session
    load                      Load one or more meterpreter extensions
    machine_id                Get the MSF ID of the machine attached to the session
    migrate                   Migrate the server to another process
    pivot                     Manage pivot listeners
    pry                       Open the Pry debugger on the current session
    quit                      Terminate the meterpreter session
    read                      Reads data from a channel
    resource                  Run the commands stored in a file
    run                       Executes a meterpreter script or Post module
    secure                    (Re)Negotiate TLV packet encryption on the session
    sessions                  Quickly switch to another session
    set_timeouts              Set the current session timeout values
    sleep                     Force Meterpreter to go quiet, then re-establish session
    ssl_verify                Modify the SSL certificate verification setting
    transport                 Manage the transport mechanisms
    use                       Deprecated alias for "load"
    uuid                      Get the UUID for the current session
    write                     Writes data to a channel


Stdapi: File system Commands
============================

    Command                   Description
    -------                   -----------
    cat                       Read the contents of a file to the screen
    cd                        Change directory
    checksum                  Retrieve the checksum of a file
    cp                        Copy source to destination
    del                       Delete the specified file
    dir                       List files (alias for ls)
    download                  Download a file or directory
    edit                      Edit a file
    getlwd                    Print local working directory
    getwd                     Print working directory
    lcat                      Read the contents of a local file to the screen
    lcd                       Change local working directory
    lls                       List local files
    lmkdir                    Create new directory on local machine
    lpwd                      Print local working directory
    ls                        List files
    mkdir                     Make directory
    mv                        Move source to destination
    pwd                       Print working directory
    rm                        Delete the specified file
    rmdir                     Remove directory
    search                    Search for files
    show_mount                List all mount points/logical drives
    upload                    Upload a file or directory
    ...
    ...
```

## Verification

- [ ] Start `msfconsole`
- [ ] Get a Meterpreter session
- [ ] `?` or `help`
- [ ] **Verify** that the `disable_unicode_encoding` and other long commands are preset on one line