### PR TITLE
Resolve deprecation warnings from setup-python in Github actions

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ matrix.meterpreter.name == 'python' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.meterpreter.runtime_version }}
 


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

---

This PR resolves deprecation warnings in Github actions from `setup-python`, by upversioning it from v4 to v5. These warnings are caused because v4 ran on Node.js 16, which is deprecated by Github.

Example of the warnings: https://github.com/rapid7/metasploit-framework/actions/runs/8069157916

Example to show the setup-python warning has been resolved: https://github.com/KanchiMoe/metasploit-framework/actions/runs/8070209807

