### PR TITLE
Update smb login to support additional configuration

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -96,7 +96,7 @@ module Msf
       # @return (see Exploit::Remote::Tcp#connect)
       def connect(global=true, versions: [], backend: nil)
         if versions.nil? || versions.empty?
-          versions = datastore['SMB::ProtocolVersion'].split(',').map(&:to_i)
+          versions = datastore['SMB::ProtocolVersion'].split(',').map(&:strip).reject(&:blank?).map(&:to_i)
           # if the user explicitly set the protocol version to 1, still use ruby_smb
           backend ||= :ruby_smb if versions == [1]
         end

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -16,6 +16,8 @@ class SimpleClient
   XCEPT = Rex::Proto::SMB::Exceptions
   EVADE = Rex::Proto::SMB::Evasions
 
+  DEFAULT_VERSIONS = [1, 2, 3].freeze
+
   # Public accessors
   attr_accessor :last_error, :server_max_buffer_size, :address, :port
 
@@ -23,7 +25,7 @@ class SimpleClient
   attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
 
   # Pass the socket object and a boolean indicating whether the socket is netbios or cifs
-  def initialize(socket, direct = false, versions = [1, 2, 3], always_encrypt: true, backend: nil, client: nil)
+  def initialize(socket, direct = false, versions = DEFAULT_VERSIONS, always_encrypt: true, backend: nil, client: nil)
     self.socket = socket
     self.direct = direct
     self.versions = versions

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -128,6 +128,8 @@ class MetasploitModule < Msf::Auxiliary
       send_delay: datastore['TCP::send_delay'],
       framework: framework,
       framework_module: self,
+      always_encrypt: datastore['SMB::AlwaysEncrypt'],
+      versions: datastore['SMB::ProtocolVersion'].split(',').map(&:strip).reject(&:blank?).map(&:to_i),
       kerberos_authenticator_factory: kerberos_authenticator_factory,
       use_client_as_proof: create_session?
     )


### PR DESCRIPTION
Updates the `smb_login` module to support configuring the negotiated SMB protocol versions and whether encryption is negotiated.

## Verification

Create samba target:

```
docker run -it --rm -p 139:139 -p 445:445 ubuntu:16.04 /bin/bash
mkdir -p /tmp/foo
apt update
apt install -y samba

samba --version
# Version 4.3.11-Ubuntu

cat << EOF >> /etc/samba/smb.conf
[foo_share]
    comment = Foo samba share
    path = /tmp/foo
    read only = no
    browsable = yes
    valid users = root
EOF


# Allow root access
passwd -u root
echo 'root:admin' | chpasswd

service smbd restart
```

Run Metasploit module:

```
use scanner/smb/smb_login
run rhost=127.0.0.1 username=root password=admin createsession=true smb::alwaysencrypt=false smb::protocolversion=2
```

### Before

SMB configuration is ignored, and wireshark shows encryption is present

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/db126eda-c65f-45b5-9828-72ea84d57a7d)


### After

SMB configuration is honored, and wireshark shows encryption is now disabled

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/819ec165-aa17-4561-bcd6-ce97094951b9)
