### PR TITLE
Add rex proto mysql client wrapper

### DIFF
--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -2,6 +2,7 @@ require 'metasploit/framework/tcp/client'
 require 'mysql'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'rex/proto/mysql/client'
 
 module Metasploit
   module Framework
@@ -39,7 +40,7 @@ module Metasploit
             disconnect if self.sock
             self.sock = connect
 
-            mysql_conn = ::Mysql.connect(host, credential.public, credential.private, '', port, io: self.sock)
+            mysql_conn = ::Rex::Proto::MySQL::Client.connect(host, credential.public, credential.private, '', port, io: self.sock)
 
           rescue ::SystemCallError, Rex::ConnectionError => e
             result_options.merge!({

--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -1,5 +1,4 @@
 require 'metasploit/framework/tcp/client'
-require 'mysql'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
 require 'rex/proto/mysql/client'
@@ -47,22 +46,22 @@ module Metasploit
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e
             })
-          rescue Mysql::ClientError => e
+          rescue Rex::Proto::MySQL::Client::ClientError => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e
             })
-          rescue Mysql::HostNotPrivileged => e
+          rescue Rex::Proto::MySQL::Client::HostNotPrivileged => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e
             })
-          rescue Mysql::AccessDeniedError => e
+          rescue Rex::Proto::MySQL::Client::AccessDeniedError => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::INCORRECT,
               proof: e
             })
-          rescue Mysql::HostIsBlocked => e
+          rescue Rex::Proto::MySQL::Client::HostIsBlocked => e
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
               proof: e

--- a/lib/msf/core/exploit/remote/mysql.rb
+++ b/lib/msf/core/exploit/remote/mysql.rb
@@ -20,7 +20,7 @@ module Exploit::Remote::MYSQL
   include Exploit::Remote::Tcp
 
   # @!attribute [rw] mysql_conn
-  # @return [::Mysql]
+  # @return [::Rex::Proto::MySQL::Client]
   attr_accessor :mysql_conn
 
   def initialize(info = {})
@@ -48,16 +48,16 @@ module Exploit::Remote::MYSQL
     rescue Errno::ECONNREFUSED
       print_error("Connection refused")
       return false
-    rescue ::Mysql::ClientError
+    rescue ::Rex::Proto::MySQL::Client::ClientError
       print_error("Connection timedout")
       return false
     rescue Errno::ETIMEDOUT
       print_error("Operation timedout")
       return false
-    rescue ::Mysql::HostNotPrivileged
+    rescue ::Rex::Proto::MySQL::Client::HostNotPrivileged
       print_error("Unable to login from this host due to policy")
       return false
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       print_error("Access denied")
       return false
     end
@@ -87,7 +87,7 @@ module Exploit::Remote::MYSQL
   def mysql_query(sql)
     begin
       res = mysql_conn.query(sql)
-    rescue ::Mysql::Error => e
+    rescue ::Rex::Proto::MySQL::Client::Error => e
       print_error("MySQL Error: #{e.class} #{e.to_s}")
       return nil
     rescue Rex::ConnectionTimeout => e

--- a/lib/msf/core/exploit/remote/mysql.rb
+++ b/lib/msf/core/exploit/remote/mysql.rb
@@ -12,7 +12,7 @@
 ###
 
 
-require 'mysql'
+require 'rex/proto/mysql/client'
 
 module Msf
 module Exploit::Remote::MYSQL
@@ -38,10 +38,10 @@ module Exploit::Remote::MYSQL
 
   def mysql_login(user='root', pass='', db=nil)
     disconnect if sock
-    connect
+    self.sock = connect
 
     begin
-      self.mysql_conn = ::Mysql.connect(rhost, user, pass, db, rport, io: sock)
+      self.mysql_conn = ::Rex::Proto::MySQL::Client.connect(rhost, user, pass, db, rport, io: self.sock)
       # Deprecating this in favor off `mysql_conn`
       @mysql_handle = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :mysql_conn, :@mysql_handle, ActiveSupport::Deprecation.new)
 

--- a/lib/rex/proto/mysql/client.rb
+++ b/lib/rex/proto/mysql/client.rb
@@ -1,0 +1,29 @@
+require 'mysql'
+
+module Rex
+  module Proto
+    module MySQL
+
+      # This is a Rex Proto wrapper around the ::Mysql client which is currently coming from the 'ruby-mysql' gem.
+      # The purpose of this wrapper is to provide 'peerhost' and 'peerport' methods to ensure the client interfaces
+      # are consistent between various SQL implementations/protocols.
+      class Client < ::Mysql
+        # @return [String] The remote IP address that the Mysql server is running on
+        def peerhost
+          io.remote_address.ip_address
+        end
+
+        # @return [Integer] The remote port that the Mysql server is running on
+        def peerport
+          io.remote_address.ip_port
+        end
+
+        # @return [String] The database this client is currently connected to
+        def current_database
+          # Current database is stored as an array under the type 1 key.
+          session_track.fetch(1, ['']).first
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'rex/proto/mysql/client'
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MYSQL
   include Msf::Auxiliary::Report
@@ -62,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       socket = connect(false)
       close_required = true
-      mysql_client = ::Mysql.connect(rhost, username, password, nil, rport, io: socket)
+      mysql_client = ::Rex::Proto::MySQL::Client.connect(rhost, username, password, nil, rport, io: socket)
       results << mysql_client
       close_required = false
 
@@ -118,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
             # Create our socket and make the connection
             close_required = true
             s = connect(false)
-            mysql_client = ::Mysql.connect(rhost, username, password, nil, rport, io: s)
+            mysql_client = ::Rex::Proto::MySQL::Client.connect(rhost, username, password, nil, rport, io: s)
 
             print_good "#{rhost}:#{rport} Successfully bypassed authentication after #{count} attempts. URI: mysql://#{username}:#{password}@#{rhost}:#{rport}"
             results << mysql_client

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Auxiliary
 
       print_good "#{rhost}:#{rport} The server accepted our first login as #{username} with a bad password. URI: mysql://#{username}:#{password}@#{rhost}:#{rport}"
 
-    rescue ::Mysql::HostNotPrivileged
+    rescue ::Rex::Proto::MySQL::Client::HostNotPrivileged
       print_error "#{rhost}:#{rport} Unable to login from this host due to policy (may still be vulnerable)"
       return
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       print_good "#{rhost}:#{rport} The server allows logins, proceeding with bypass test"
     rescue ::Interrupt
       raise $!
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
             print_good "#{rhost}:#{rport} Successfully bypassed authentication after #{count} attempts. URI: mysql://#{username}:#{password}@#{rhost}:#{rport}"
             results << mysql_client
             close_required = false
-          rescue ::Mysql::AccessDeniedError
+          rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
           rescue ::Exception => e
             print_bad "#{rhost}:#{rport} Thread #{count}] caught an unhandled exception: #{e}"
           ensure

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       mysql_query_no_handle("USE " + datastore['DATABASE_NAME'])
-    rescue ::Mysql::Error => e
+    rescue ::Rex::Proto::MySQL::Client::Error => e
       vprint_error("MySQL Error: #{e.class} #{e.to_s}")
       return
     rescue Rex::ConnectionTimeout => e
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
   def check_dir dir
     begin
       res = mysql_query_no_handle("LOAD DATA INFILE '" + dir + "' INTO TABLE " + datastore['TABLE_NAME'])
-    rescue ::Mysql::TextfileNotReadable
+    rescue ::Rex::Proto::MySQL::Client::TextfileNotReadable
       print_good("#{dir} is a directory and exists")
       report_note(
         :host  => mysql_conn.host,
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :update => :unique_data
       )
-    rescue ::Mysql::DataTooLong, ::Mysql::TruncatedWrongValueForField
+    rescue ::Rex::Proto::MySQL::Client::DataTooLong, ::Rex::Proto::MySQL::Client::TruncatedWrongValueForField
       print_good("#{dir} is a file and exists")
       report_note(
         :host  => mysql_conn.host,
@@ -107,9 +107,9 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :update => :unique_data
       )
-    rescue ::Mysql::ServerError
+    rescue ::Rex::Proto::MySQL::Client::ServerError
       vprint_warning("#{dir} does not exist")
-    rescue ::Mysql::Error => e
+    rescue ::Rex::Proto::MySQL::Client::Error => e
       vprint_error("MySQL Error: #{e.class} #{e.to_s}")
       return
     rescue Rex::ConnectionTimeout => e

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   # @param [Metasploit::Framework::LoginScanner::Result] result
-  # @param [::Mysql] client
+  # @param [::Rex::Proto::MySQL::Client] client
   # @return [Msf::Sessions::MySQL]
   def session_setup(result, client)
     return unless (result && client)

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       print_status("Checking #{dir}...")
       res = mysql_query_no_handle("SELECT _utf8'test' INTO DUMPFILE '#{dir}/" + datastore['FILE_NAME'] + "'")
-    rescue ::Mysql::ServerError => e
+    rescue ::Rex::Proto::MySQL::Client::ServerError => e
       print_warning(e.to_s)
     rescue Rex::ConnectionTimeout => e
       print_error("Timeout: #{e.message}")

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res.each_hash do |row|
         rows << row
       end
-    rescue ::Mysql::ParseError
+    rescue ::Rex::Proto::MySQL::Client::ParseError
       return rows
     end
 
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
         m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
         return unless m
       end
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       print_error("Access denied.")
       return
     end
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       upload_file(exe, dest)
       register_file_for_cleanup("#{exe_name}")
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       print_error("No permission to write. I blame kc :-)")
       return
     end
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       upload_file(mof, dest)
       register_file_for_cleanup("wbem\\mof\\good\\#{mof_name}")
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       print_error("No permission to write. Bail!")
       return
     end

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res.each_hash do |row|
         rows << row
       end
-    rescue ::Mysql::ParseError
+    rescue ::Rex::Proto::MySQL::Client::ParseError
       return rows
     end
 
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
         m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
         return unless m
       end
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       fail_with(Failure::NoAccess, "#{peer} - Access denied")
     end
 
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       drive = get_drive_letter
-    rescue ::Mysql::ParseError
+    rescue ::Rex::Proto::MySQL::Client::ParseError
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not determine drive name")
     end
 
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Uploading to '#{dest}'")
     begin
       upload_file(exe, dest)
-    rescue ::Mysql::AccessDeniedError
+    rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
       fail_with(Failure::NotVulnerable, "#{peer} - No permission to write. I blame kc :-)")
     end
     register_file_for_cleanup("#{dest}")

--- a/spec/lib/metasploit/framework/login_scanner/mysql_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mysql_spec.rb
@@ -4,7 +4,7 @@ require 'metasploit/framework/login_scanner/mysql'
 RSpec.describe Metasploit::Framework::LoginScanner::MySQL do
   let(:public) { 'root' }
   let(:private) { 'toor' }
-  let(:client) { instance_double(::Mysql) }
+  let(:client) { instance_double(::Rex::Proto::MySQL::Client) }
   let(:pub_blank) {
     Metasploit::Framework::Credential.new(
         paired: true,
@@ -42,7 +42,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::MySQL do
 
     context 'when the attempt is successful' do
       it 'returns a result object with a status of Metasploit::Model::Login::Status::SUCCESSFUL' do
-        expect(::Mysql).to receive(:connect).and_return(client)
+        expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_return(client)
         expect(login_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::SUCCESSFUL
       end
     end
@@ -50,61 +50,61 @@ RSpec.describe Metasploit::Framework::LoginScanner::MySQL do
     context 'when the attempt is unsuccessful' do
       context 'due to connection refused' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::Mysql).to receive(:connect).and_raise Errno::ECONNREFUSED
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Errno::ECONNREFUSED
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::Mysql).to receive(:connect).and_raise Errno::ECONNREFUSED
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Errno::ECONNREFUSED
           expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Errno::ECONNREFUSED)
         end
       end
 
       context 'due to connection timeout' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::Mysql).to receive(:connect).and_raise Mysql::ClientError, "Client Error"
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise ::Rex::Proto::MySQL::Client::ClientError, "Client Error"
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::Mysql).to receive(:connect).and_raise Mysql::ClientError, "Client Error"
-          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Mysql::ClientError)
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise ::Rex::Proto::MySQL::Client::ClientError, "Client Error"
+          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(::Rex::Proto::MySQL::Client::ClientError)
         end
       end
 
       context 'due to operation timeout' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::Mysql).to receive(:connect).and_raise Errno::ETIMEDOUT
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Errno::ETIMEDOUT
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::Mysql).to receive(:connect).and_raise Errno::ETIMEDOUT
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Errno::ETIMEDOUT
           expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Errno::ETIMEDOUT)
         end
       end
 
       context 'due to not being allowed to connect from this host' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-          expect(::Mysql).to receive(:connect).and_raise Mysql::HostNotPrivileged, "Host not privileged"
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Rex::Proto::MySQL::Client::HostNotPrivileged, "Host not privileged"
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::Mysql).to receive(:connect).and_raise Mysql::HostNotPrivileged, "Host not privileged"
-          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Mysql::HostNotPrivileged)
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Rex::Proto::MySQL::Client::HostNotPrivileged, "Host not privileged"
+          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Rex::Proto::MySQL::Client::HostNotPrivileged)
         end
       end
 
       context 'due to access denied' do
         it 'returns a result with a status of Metasploit::Model::Login::Status::INCORRECT' do
-          expect(::Mysql).to receive(:connect).and_raise Mysql::AccessDeniedError, "Access Denied"
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Rex::Proto::MySQL::Client::AccessDeniedError, "Access Denied"
           expect(login_scanner.attempt_login(pub_pub).status).to eq Metasploit::Model::Login::Status::INCORRECT
         end
 
         it 'returns a result with the proof containing an appropriate error message' do
-          expect(::Mysql).to receive(:connect).and_raise Mysql::AccessDeniedError, "Access Denied"
-          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Mysql::AccessDeniedError)
+          expect(::Rex::Proto::MySQL::Client).to receive(:connect).and_raise Rex::Proto::MySQL::Client::AccessDeniedError, "Access Denied"
+          expect(login_scanner.attempt_login(pub_pub).proof).to be_a(Rex::Proto::MySQL::Client::AccessDeniedError)
         end
       end
     end

--- a/spec/lib/msf/base/sessions/mysql_spec.rb
+++ b/spec/lib/msf/base/sessions/mysql_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'mysql'
+require 'rex/proto/mysql/client'
 
 RSpec.describe Msf::Sessions::MySQL do
   let(:rstream) { instance_double(::Rex::Socket) }
-  let(:client) { instance_double(::Mysql) }
+  let(:client) { instance_double(::Rex::Proto::MySQL::Client) }
   let(:opts) { { client: client } }
   let(:console_class) { Rex::Post::MySQL::Ui::Console }
   let(:user_input) { instance_double(Rex::Ui::Text::Input::Readline) }
@@ -26,7 +26,7 @@ RSpec.describe Msf::Sessions::MySQL do
     allow(rstream).to receive(:peerinfo).and_return(peerinfo)
     allow(client).to receive(:socket).and_return(rstream)
     allow(client).to receive(:database).and_return(database)
-    allow(::Mysql).to receive(:connect).and_return(client)
+    allow(::Rex::Proto::MySQL::Client).to receive(:connect).and_return(client)
   end
 
   subject(:session) do

--- a/spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb
@@ -2,11 +2,11 @@
 
 require 'spec_helper'
 require 'rex/post/mysql/ui/console'
-require 'mysql'
+require 'rex/proto/mysql/client'
 
 RSpec.describe Rex::Post::MySQL::Ui::Console::CommandDispatcher::Core do
   let(:rstream) { instance_double(::Rex::Socket) }
-  let(:client) { instance_double(::Mysql) }
+  let(:client) { instance_double(::Rex::Proto::MySQL::Client) }
   let(:database) { 'database_name' }
   let(:address) { '192.0.2.1' }
   let(:port) { '3306' }

--- a/spec/lib/rex/proto/mysql/client_spec.rb
+++ b/spec/lib/rex/proto/mysql/client_spec.rb
@@ -1,0 +1,16 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+require 'rex/proto/mysql/client'
+
+RSpec.describe Rex::Proto::MySQL::Client do
+  it { is_expected.to be_a ::Mysql }
+
+  [
+    { method: :peerhost, return_type: String },
+    { method: :peerport, return_type: Integer },
+    { method: :database_name, return_type: String }
+  ].each do |method_hash|
+    it { is_expected.to respond_to method_hash[:method] }
+  end
+end


### PR DESCRIPTION
This PR is a pre-requisite to the peerhost alignment and the upcoming PR that will address having the correct database name being shown in the SQL session prompts.

This wrapper allows for a consistent client API - currently, the Mysql client we use comes from the ruby-mysql gem. Making changes to it would require monkey-patching in multiple places. Having this wrapper allows us to patch it in one place.

The line of code in `lib/rex/post/mysql/ui/console/command_dispatcher/client.rb`:
```ruby
# @param [Mysql::Result] result The MySQL query result
# @return [Hash] Hash containing rows, columns and errors.
```
has been left alone. The result object is still of class `Mysql::Result`.

## Docker
To test `modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb` you need to find the vulhub MySQL 5.5.23:
```bash
docker run -it -p 5306:3306 vulhub/mysql:5.5.23
```

Ensure you also test the following modules & session with incorrect username and/or password, e.g.:
```ruby
msf6 auxiliary(scanner/mysql/mysql_login) > run password=bogus

[+] 127.0.0.1:3306        - 127.0.0.1:3306 - Found remote MySQL version 8.3.0
[-] 127.0.0.1:3306        - 127.0.0.1:3306 - LOGIN FAILED: root:bogus (Incorrect: Access denied for user 'root'@'192.168.x.1' (using password: YES))
[-] 127.0.0.1:3306        - 127.0.0.1:3306 - LOGIN FAILED: root: (Incorrect: Access denied for user 'root'@'192.168.x.1' (using password: NO))
[*] 127.0.0.1:3306        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

- [ ] Start `msfconsole`
- [ ] `use mysql_login`
- [ ] `run {options_here...}`
- [ ] Ensure you can get and interact with a MySQL session
- [ ] `sessions -i -1`
- [ ] `query SHOW DATABASES`
- [ ] `bg`
- [ ] `use auxiliary/scanner/mysql/mysql_authbypass_hashdump`
- [ ] `run rhost=127.0.0.1 rport=5306`
- [ ] `bundle exec rspec spec/lib/rex/proto/mysql/client_spec.rb`
- [ ] `bundle exec rspec spec/lib/metasploit/framework/login_scanner/mysql_spec.rb`
- [ ] `bundle exec rspec spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb`
- [ ] `bundle exec rspec spec/lib/msf/base/sessions/mysql_spec.rb`