### PR TITLE
Fix Rex MySQL wrapper test to have correct method symbol

### DIFF
--- a/spec/lib/rex/proto/mysql/client_spec.rb
+++ b/spec/lib/rex/proto/mysql/client_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rex::Proto::MySQL::Client do
   [
     { method: :peerhost, return_type: String },
     { method: :peerport, return_type: Integer },
-    { method: :database_name, return_type: String }
+    { method: :current_database, return_type: String }
   ].each do |method_hash|
     it { is_expected.to respond_to method_hash[:method] }
   end


### PR DESCRIPTION
This PR fixes an incorrect test I've introduced in a previous PR, and got caught up in renaming/aligning of method names.

## Verification

- [x] `bundle exec rspec spec/lib/rex/proto/mysql/client_spec.rb`
- [x] Ensure CI passes