### PR TITLE
Update sql prompt on db change

### DIFF
--- a/lib/postgres/postgres-pr/connection.rb
+++ b/lib/postgres/postgres-pr/connection.rb
@@ -129,6 +129,10 @@ class Connection
     @conn.peerport
   end
 
+  def current_database
+    @params['database']
+  end
+
   def close
     raise "connection already closed" if @conn.nil?
     @conn.shutdown

--- a/lib/rex/post/mssql/ui/console.rb
+++ b/lib/rex/post/mssql/ui/console.rb
@@ -54,15 +54,14 @@ module Rex
           # @return [MSSQL::Client]
           attr_reader :client
 
-          # @return [String]
-          def database_name
-            session.client.query('SELECT DB_NAME();')[:rows][0][0]
-          end
-
           # @param [Object] val
           # @return [String]
           def format_prompt(val)
-            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{database_name})%clr > "
+            # TODO: Once the client peerhost alignment is landed, extract this out to the generic SQL class.
+            # prompt = "%und#{session.type} @ #{client.peerhost}:#{client.peerport} (#{current_database})%clr > "
+            # or
+            # prompt = "%und#{session.type} @ #{client.peerinfo} (#{current_database})%clr > "
+            prompt = "%undMSSQL @ #{client.sock.peerinfo} (#{current_database})%clr > "
             substitute_colors(prompt, true)
           end
 

--- a/lib/rex/post/mysql/ui/console.rb
+++ b/lib/rex/post/mysql/ui/console.rb
@@ -26,7 +26,7 @@ module Rex
             self.session = session
             self.client = session.client
             self.client.socket ||= self.client.io
-            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{database_name})%clr"
+            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{current_database})%clr"
             history_manager = Msf::Config.mysql_session_history
             super(prompt, '>', history_manager, nil, :mysql)
 
@@ -51,15 +51,10 @@ module Rex
           # @return [MySQL::Client]
           attr_reader :client
 
-          # @return [String]
-          def database_name
-            client.database
-          end
-
           # @param [Object] val
           # @return [String]
           def format_prompt(val)
-            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{database_name})%clr > "
+            prompt = "%undMySQL @ #{client.socket.peerinfo} (#{current_database})%clr > "
             substitute_colors(prompt, true)
           end
 

--- a/lib/rex/post/postgresql/ui/console.rb
+++ b/lib/rex/post/postgresql/ui/console.rb
@@ -28,7 +28,7 @@ module Rex
             # The postgresql client context
             self.session = session
             self.client = session.client
-            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{database_name})%clr"
+            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{current_database})%clr"
             history_manager = Msf::Config.postgresql_session_history
             super(prompt, '>', history_manager, nil, :postgresql)
 
@@ -53,13 +53,8 @@ module Rex
           # @return [PostgreSQL::Client]
           attr_reader :client # :nodoc:
 
-          # @return [String]
-          def database_name
-            client.params['database']
-          end
-
           def format_prompt(val)
-            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{database_name})%clr > "
+            prompt = "%undPostgreSQL @ #{client.conn.peerinfo} (#{current_database})%clr > "
             substitute_colors(prompt, true)
           end
 

--- a/lib/rex/post/sql/ui/console.rb
+++ b/lib/rex/post/sql/ui/console.rb
@@ -95,6 +95,10 @@ module Rex
 
             dlog("Call stack:\n#{$ERROR_POSITION.join("\n")}", session.type)
           end
+
+          def current_database
+            client.current_database
+          end
         end
       end
     end

--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -137,11 +137,31 @@ module Rex
                 end
 
                 result = run_query(args.join(' '))
+                case result[:status]
+                when :success
+                  # When changing a database in MySQL, we get a nil result back.
+                  # When changing a database in MSSQL, we get a result, but it doesn't contain colnames or rows.
+                  normalised_result = normalise_sql_result(result[:result])
 
-                normalised_result = result[:status] == :success ? normalise_sql_result(result[:result]) : result[:result]
-                formatted_result = format_result(normalised_result)
+                  # MSSQL returns :success, even if the query failed due to wrong syntax.
+                  if normalised_result[:errors].any?
+                    print_error "Query has failed. Reasons: #{normalised_result[:errors].join(', ')}"
+                    return
+                  end
 
-                normalised_result[:errors].any? ? print_error(formatted_result.to_s) : print_line(formatted_result.to_s)
+                  if normalised_result[:rows].nil? || normalised_result[:columns].nil? # Should this be AND?
+                    print_status 'Query executed successfully'
+                    return
+                  end
+
+                  formatted_result = format_result(normalised_result)
+                  print_line(formatted_result.to_s)
+                when :error
+                  print_error "Query has failed. Reasons: #{result[:result][:errors].join(', ')}"
+                else
+                  elog "Unknown query status: #{result[:status]}"
+                  print_error "Unknown query status: #{result[:status]}"
+                end
               end
 
               def process_query(query: '')

--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -116,7 +116,7 @@ module Rex
                   return { status: :error, result: { errors: [e] } }
                 end
 
-                if result.respond_to? :cmd_tag
+                if result.respond_to?(:cmd_tag) && result.cmd_tag
                   print_status result.cmd_tag
                   print_line
                 end
@@ -140,7 +140,11 @@ module Rex
                 case result[:status]
                 when :success
                   # When changing a database in MySQL, we get a nil result back.
-                  # When changing a database in MSSQL, we get a result, but it doesn't contain colnames or rows.
+                  if result[:result].nil?
+                    print_status 'Query executed successfully'
+                    return
+                  end
+
                   normalised_result = normalise_sql_result(result[:result])
 
                   # MSSQL returns :success, even if the query failed due to wrong syntax.
@@ -149,7 +153,8 @@ module Rex
                     return
                   end
 
-                  if normalised_result[:rows].nil? || normalised_result[:columns].nil? # Should this be AND?
+                  # When changing a database in MSSQL, we get a result, but it doesn't contain colnames or rows.
+                  if normalised_result[:rows].nil? || normalised_result[:columns].nil?
                     print_status 'Query executed successfully'
                     return
                   end

--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -136,6 +136,11 @@ module Rex
                   end
                 end
 
+                if args.empty?
+                  cmd_query_help
+                  return
+                end
+
                 result = run_query(args.join(' '))
                 case result[:status]
                 when :success

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -46,6 +46,9 @@ module Rex
         #   @return [Hash] Key-value pairs received from the server during the initial MSSQL connection.
         # See the spec here: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/b46a581a-39de-4745-b076-ec4dbb7d13ec
         attr_accessor :initial_connection_info
+        # @!attribute current_database
+        #   @return [String] The database name this client is currently connected to.
+        attr_accessor :current_database
 
         def initialize(framework_module, framework, rhost, rport = 1433, proxies = nil)
           @framework_module       = framework_module

--- a/lib/rex/proto/mssql/client_mixin.rb
+++ b/lib/rex/proto/mssql/client_mixin.rb
@@ -420,6 +420,9 @@ module ClientMixin
 
     info[:envs] ||= []
     info[:envs] << { :type => type, :old => oval, :new => nval }
+
+    self.current_database = nval if type == ENVCHANGE::DATABASE
+
     info
   end
 

--- a/spec/lib/msf/base/sessions/mysql_spec.rb
+++ b/spec/lib/msf/base/sessions/mysql_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe Msf::Sessions::MySQL do
   let(:address) { '192.0.2.1' }
   let(:port) { '3306' }
   let(:peerinfo) { "#{address}:#{port}" }
-  let(:database) { 'database_name' }
+  let(:current_database) { 'database_name' }
 
   before(:each) do
     allow(user_input).to receive(:output=)
     allow(user_input).to receive(:intrinsic_shell?).and_return(true)
     allow(rstream).to receive(:peerinfo).and_return(peerinfo)
     allow(client).to receive(:socket).and_return(rstream)
-    allow(client).to receive(:database).and_return(database)
+    allow(client).to receive(:current_database).and_return(current_database)
     allow(::Rex::Proto::MySQL::Client).to receive(:connect).and_return(client)
   end
 

--- a/spec/lib/msf/base/sessions/postgresql_spec.rb
+++ b/spec/lib/msf/base/sessions/postgresql_spec.rb
@@ -18,14 +18,15 @@ RSpec.describe Msf::Sessions::PostgreSQL do
   let(:address) { '192.0.2.1' }
   let(:port) { '5432' }
   let(:peer_info) { "#{address}:#{port}" }
-  let(:postgres_db) { 'template1' }
+  let(:current_database) { 'template1' }
 
   before(:each) do
     allow(user_input).to receive(:intrinsic_shell?).and_return(true)
     allow(user_input).to receive(:output=)
     allow(rstream).to receive(:peerinfo).and_return(peer_info)
     allow(client).to receive(:conn).and_return(rstream)
-    allow(client).to receive(:params).and_return({ 'database' => postgres_db })
+    allow(client).to receive(:params).and_return({ 'database' => current_database })
+    allow(client).to receive(:current_database).and_return(current_database)
   end
 
   subject(:session) do

--- a/spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb
@@ -7,7 +7,7 @@ require 'rex/proto/mysql/client'
 RSpec.describe Rex::Post::MySQL::Ui::Console::CommandDispatcher::Core do
   let(:rstream) { instance_double(::Rex::Socket) }
   let(:client) { instance_double(::Rex::Proto::MySQL::Client) }
-  let(:database) { 'database_name' }
+  let(:current_database) { 'database_name' }
   let(:address) { '192.0.2.1' }
   let(:port) { '3306' }
   let(:peerinfo) { "#{address}:#{port}" }
@@ -20,7 +20,7 @@ RSpec.describe Rex::Post::MySQL::Ui::Console::CommandDispatcher::Core do
 
   before(:each) do
     allow(rstream).to receive(:peerinfo).and_return(peerinfo)
-    allow(client).to receive(:database).and_return(database)
+    allow(client).to receive(:current_database).and_return(current_database)
     allow(client).to receive(:socket).and_return(rstream)
     allow(session).to receive(:console).and_return(console)
     allow(session).to receive(:name).and_return('test client name')

--- a/spec/lib/rex/post/postgresql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/postgresql/ui/console/command_dispatcher/core_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Core do
   let(:client) { instance_double(Msf::Db::PostgresPR::Connection) }
   let(:address) { '192.0.2.1' }
   let(:port) { '5432' }
-  let(:postgres_db) { 'template1' }
+  let(:current_database) { 'template1' }
   let(:peer_info) { "#{address}:#{port}" }
   let(:session) { Msf::Sessions::PostgreSQL.new(nil, { client: client }) }
   let(:console) do
@@ -20,7 +20,8 @@ RSpec.describe Rex::Post::PostgreSQL::Ui::Console::CommandDispatcher::Core do
 
   before(:each) do
     allow(client).to receive(:conn).and_return(rstream)
-    allow(client).to receive(:params).and_return({ 'database' => postgres_db })
+    allow(client).to receive(:params).and_return({ 'database' => current_database })
+    allow(client).to receive(:current_database).and_return(current_database)
     allow(rstream).to receive(:peerinfo).and_return(peer_info)
     allow(session).to receive(:client).and_return(client)
     allow(session).to receive(:console).and_return(console)


### PR DESCRIPTION
This PR is a UX improvement. It adds the correct handling for changing of databases in the context of a MySQL or MSSQL session. The prompt now gets updated with an up-to-date value.
This PR also aligns the SQL clients to use the `current_database` method.

## MySQL

### Before
```ruby
MySQL @ 127.0.0.1:3306 () > query show databases
Response
========

    #  Database
    -  --------
    0  information_schema
    1  my_docker_db
    2  my_new_db
    3  mysql
    4  performance_schema
    5  sys

MySQL @ 127.0.0.1:3306 () > query use mysql
[-] Error running command query: NoMethodError undefined method `entries' for nil:NilClass
MySQL @ 127.0.0.1:3306 () > query use garbage
[-] Query has failed. Reasons: Unknown database 'garbage'
```

### After
```ruby
MySQL @ 127.0.0.1:3306 () > query show databases
Response
========

    #  Database
    -  --------
    0  information_schema
    1  my_docker_db
    2  my_new_db
    3  mysql
    4  performance_schema
    5  sys

MySQL @ 127.0.0.1:3306 () > query use mysql
[*] Query executed successfully
MySQL @ 127.0.0.1:3306 (mysql) > query use sys
[*] Query executed successfully
MySQL @ 127.0.0.1:3306 (sys) > query use garbage
[-] Query has failed. Reasons: Unknown database 'garbage'
```

## MSSQL

### Before
```ruby
MSSQL @ 192.168.112.3:1433 (master) > query select name from master.dbo.sysdatabases
Response
========

    #  name
    -  ----
    0  master
    1  tempdb
    2  model
    3  msdb

MSSQL @ 192.168.112.3:1433 (master) > query use msdb
[-] Error running command query: NoMethodError undefined method `map' for nil:NilClass
MSSQL @ 192.168.112.3:1433 (msdb) > query use master
[-] Error running command query: NoMethodError undefined method `map' for nil:NilClass
MSSQL @ 192.168.112.3:1433 (master) > query use garbage
[-] Query has failed. Reasons: SQL Server Error #911 (State:1 Severity:16): Database 'garbage' does not exist. Make sure that the name is entered correctly.
```

## After
```ruby
MSSQL @ 192.168.112.3:1433 (master) > query select name from master.dbo.sysdatabases
Response
========

    #  name
    -  ----
    0  master
    1  tempdb
    2  model
    3  msdb

MSSQL @ 192.168.112.3:1433 (master) > query use msdb
[*] Query executed successfully
MSSQL @ 192.168.112.3:1433 (msdb) > query use master
[*] Query executed successfully
MSSQL @ 192.168.112.3:1433 (master) > query use garbage
[-] Query has failed. Reasons: SQL Server Error #911 (State:1 Severity:16): Database 'garbage' does not exist. Make sure that the name is entered correctly.
```

## Bogus & Correct Queries
The following ensures we get the correct output for good and bogus queries:

```ruby
MSSQL @ 192.168.112.3:1433 (master) > query use hello
[-] Query has failed. Reasons: SQL Server Error #911 (State:1 Severity:16): Database 'hello' does not exist. Make sure that the name is entered correctly.
MSSQL @ 192.168.112.3:1433 (master) > query use msdb
[*] Query executed successfully
MSSQL @ 192.168.112.3:1433 (msdb) > query select @@version
Response
========

    #  NULL
    -  ----
    0  Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64)
        Oct  8 2022 05:58:25
        Copyright (C) 2022 Microsoft Corporation
        Express Edition (64-bit) on Windows Server 2022 Standard 10.0 <X64> (Build 20348: ) (Hypervisor)

...

MySQL @ 127.0.0.1:3306 (sys) > query use hello
[-] Query has failed. Reasons: Unknown database 'hello'
MySQL @ 127.0.0.1:3306 (sys) > query show databases
Response
========

    #  Database
    -  --------
    0  information_schema
    1  my_docker_db
    2  my_new_db
    3  mysql
    4  performance_schema
    5  sys

...

PostgreSQL @ 127.0.0.1:5432 (template1) > query select version
[-] Query has failed. Reasons: ERROR    VERROR  C42703  Mcolumn "version" does not exist        P8      Fparse_relation.c       L3713   RerrorMissingColumn
PostgreSQL @ 127.0.0.1:5432 (template1) > query select version()
[*] SELECT 1

Response
========

    #  version
    -  -------
    0  PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
```

## Verification

- [ ] Get a PostgreSQL, MSSQL and MySQL session
- [ ] **Verify** you can change the database by typing in `query use ....`
- [ ] Ensure typing in correct queries results in the expected output with no errors
- [ ] Ensure typing in bogus queries results in errors being output
