### PR TITLE
change bloodhound OutputDirectory to OptString

### DIFF
--- a/modules/post/windows/gather/bloodhound.rb
+++ b/modules/post/windows/gather/bloodhound.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Post
       # OptString.new('LDAPUsername', [false, 'User to connect to LDAP with', 'Default']),
       # OptString.new('LDAPPassword', [false, 'Password for user you are connecting to LDAP with']),
       # OptString.new('DisableKerbSigning', [false, 'Disables Kerberos Signing on requests', false]),
-      OptPath.new('OutputDirectory', [false, 'Folder to write json output to.  Default is Windows temp']),
+      OptString.new('OutputDirectory', [false, 'Folder to write json output to.  Default is Windows temp']),
       OptEnum.new('Method', [true, 'Method to run Sharphound with', 'download', ['download', 'disk']]),
       OptBool.new('EncryptZip', [false, 'If the zip should be password protected', true]),
       OptBool.new('NoSaveCache', [false, 'Dont save the cache file to disk', true]),


### PR DESCRIPTION
OptPath is intended for a local path and performs validation. Attempting to set it to a target path that doesn't exist on the local fails.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use windows/gather/bloodhound`
- [ ] `set session 1`
- [ ] `set outputdirectory c:\\windows\\tasks`
- [ ] `run`

<img width="1652" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/5640233/9cef5e92-d42e-4604-ae1e-e5b6444c0b03">
