### PR TITLE
Update the SMB session `pwd` command output to be in line with SMB client output

### DIFF
--- a/lib/rex/post/smb/ui/console/command_dispatcher/shares.rb
+++ b/lib/rex/post/smb/ui/console/command_dispatcher/shares.rb
@@ -225,7 +225,9 @@ module Rex
 
             return print_no_share_selected unless active_share
 
-            print_line shell.cwd || ''
+            share_name = active_share.share[/[^\\].*$/, 0]
+            cwd = shell.cwd.blank? ? '' : "\\#{shell.cwd}"
+            print_line "Current directory is \\\\#{share_name}#{cwd}\\"
           end
 
           def cmd_pwd_tabs(_str, words)


### PR DESCRIPTION
This PR updates the SMB session types `pwd` command to be inline with what the SMB client currently returns:
```
smb: \> pwd
Current directory is \\192.168.123.147\foo\
```

SMB session before:
```
msf6 auxiliary(scanner/smb/smb_login) > sessions -i -1
[*] Starting interaction with 1...

SMB (127.0.0.1\my_share\test) > pwd
\test
SMB (127.0.0.1\my_share) > cd ..
SMB (127.0.0.1\my_share) > pwd

SMB (127.0.0.1\my_share) >
```

SMB session output now:
```
msf6 auxiliary(scanner/smb/smb_login) > sessions -i -1
[*] Starting interaction with 1...

SMB (127.0.0.1\my_share\test) > pwd
Current directory is \\127.0.0.1\my_share\test\
SMB (127.0.0.1\my_share) > cd ..
SMB (127.0.0.1\my_share) > pwd
Current directory is \\127.0.0.1\my_share\
SMB (127.0.0.1\my_share) >
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use the `smb_login` module to get an SMB session
- [ ] Interact with the SMB session
- [ ] run `pwd` in various scenarios and make sure you get the expected output