### PR TITLE
add mssql_version module

### DIFF
--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -53,6 +53,10 @@ module Exploit::Remote::MSSQL
     @mssql_client = client
   end
 
+  def mssql_get_version
+    @mssql_client ||= Rex::Proto::MSSQL::Client.new(self, framework, datastore['RHOST'], datastore['RPORT'])
+    @mssql_client.mssql_get_version
+  end
   #
   # This method sends a UDP query packet to the server and
   # parses out the reply packet into a hash

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -19,6 +19,11 @@ module Exploit::Remote::MSSQL
 
   attr_accessor :mssql_client
 
+  ENCRYPT_OFF     = 0x00 #Encryption is available but off.
+  ENCRYPT_ON      = 0x01 #Encryption is available and on.
+  ENCRYPT_NOT_SUP = 0x02 #Encryption is not available.
+  ENCRYPT_REQ     = 0x03 #Encryption is required.
+
   #
   # Creates an instance of a MSSQL exploit module.
   #
@@ -48,15 +53,15 @@ module Exploit::Remote::MSSQL
     register_autofilter_services(%W{ ms-sql-s ms-sql2000 sybase })
   end
 
-  def set_session(client)
+  def set_mssql_session(client)
     print_status("Using existing session #{session.sid}")
     @mssql_client = client
   end
 
-  def mssql_get_version
+  def create_mssql_client
     @mssql_client ||= Rex::Proto::MSSQL::Client.new(self, framework, datastore['RHOST'], datastore['RPORT'])
-    @mssql_client.mssql_get_version
   end
+
   #
   # This method sends a UDP query packet to the server and
   # parses out the reply packet into a hash

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -485,10 +485,10 @@ module Rex
           idx = 0
           data = parse_prelogin_response(resp)
 
-          unless data['Encryption']
+          unless data[:encryption]
             framework_module.print_error("Unable to parse encryption req " \
               "during pre-login, this may not be a MSSQL server")
-            data['Encryption'] = ENCRYPT_NOT_SUP
+            data[:encryption] = ENCRYPT_NOT_SUP
           end
 
           ##########################################################
@@ -506,7 +506,7 @@ module Rex
           #
           ##########################################################
 
-          if data['Encryption'] == ENCRYPT_REQ
+          if data[:encryption] == ENCRYPT_REQ
             # restart prelogin process except that we tell SQL Server
             # than we are now able to encrypt
             disconnect if self.sock
@@ -521,10 +521,10 @@ module Rex
             resp = mssql_send_recv(pkt)
             data = parse_prelogin_response(resp)
 
-            unless data['Encryption']
+            unless data[:encryption]
               framework_module.print_error("Unable to parse encryption req " \
                 "during pre-login, this may not be a MSSQL server")
-                data['Encryption'] = ENCRYPT_NOT_SUP
+              data[:encryption] = ENCRYPT_NOT_SUP
             end
           end
           data

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -477,64 +477,7 @@ module Rex
         #this method send a prelogin packet and check if encryption is off
         #
         def mssql_prelogin(enc_error=false)
-          pkt = ""
-          pkt_hdr = ""
-          pkt_data_token = ""
-          pkt_data = ""
-
-
-          pkt_hdr = [
-              TYPE_PRE_LOGIN_MESSAGE, #type
-              STATUS_END_OF_MESSAGE, #status
-              0x0000, #length
-              0x0000, # SPID
-              0x00, # PacketID
-              0x00 #Window
-          ]
-
-          version = [0x55010008, 0x0000].pack("Vv")
-
-          # if manually set, we will honour
-          if tdsencryption == true
-            encryption = ENCRYPT_ON
-          else
-            encryption = ENCRYPT_NOT_SUP
-          end
-
-          instoptdata = "MSSQLServer\0"
-
-          threadid = "\0\0" + Rex::Text.rand_text(2)
-
-          idx = 21 # size of pkt_data_token
-          pkt_data_token << [
-              0x00, # Token 0 type Version
-              idx , # VersionOffset
-              version.length, # VersionLength
-
-              0x01, # Token 1 type Encryption
-              idx = idx + version.length, # EncryptionOffset
-              0x01, # EncryptionLength
-
-              0x02, # Token 2 type InstOpt
-              idx = idx + 1, # InstOptOffset
-              instoptdata.length, # InstOptLength
-
-              0x03, # Token 3 type Threadid
-              idx + instoptdata.length, # ThreadIdOffset
-              0x04, # ThreadIdLength
-
-              0xFF
-          ].pack("CnnCnnCnnCnnC")
-
-          pkt_data << pkt_data_token
-          pkt_data << version
-          pkt_data << encryption
-          pkt_data << instoptdata
-          pkt_data << threadid
-
-          pkt_hdr[2] = pkt_data.length + 8
-
-          pkt = pkt_hdr.pack("CCnnCC") + pkt_data
+          pkt = mssql_prelogin_packet
 
           resp = mssql_send_recv(pkt)
 

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -129,8 +129,7 @@ module Rex
         #
 
         def mssql_login(user='sa', pass='', db='', domain_name='')
-          mssql_prelogin
-
+          prelogin_data = mssql_prelogin
           if auth == Msf::Exploit::Remote::AuthOption::KERBEROS
             idx = 0
             pkt = ''
@@ -234,6 +233,7 @@ module Rex
             info = {:errors => []}
             info = mssql_parse_reply(resp, info)
             self.initial_connection_info = info
+            self.initial_connection_info[:prelogin_data] = prelogin_data
 
             return false if not info
             return info[:login_ack] ? true : false
@@ -466,6 +466,7 @@ module Rex
           info = {:errors => []}
           info = mssql_parse_reply(resp, info)
           self.initial_connection_info = info
+          self.initial_connection_info[:prelogin_data] = prelogin_data
 
           return false if not info
           info[:login_ack] ? true : false

--- a/lib/rex/proto/mssql/client_mixin.rb
+++ b/lib/rex/proto/mssql/client_mixin.rb
@@ -86,9 +86,7 @@ module ClientMixin
     end
   end
 
-  def mssql_get_version
-    disconnect if self.sock
-    connect
+  def mssql_prelogin_packet
     pkt = ""
     pkt_hdr = ""
     pkt_data_token = ""
@@ -147,6 +145,14 @@ module ClientMixin
     pkt_hdr[2] = pkt_data.length + 8
 
     pkt = pkt_hdr.pack("CCnnCC") + pkt_data
+    pkt
+  end
+
+  def mssql_get_version
+    disconnect if self.sock
+    connect
+
+    pkt = mssql_prelogin_packet
 
     resp = mssql_send_recv(pkt)
     while resp

--- a/lib/rex/proto/mssql/client_mixin.rb
+++ b/lib/rex/proto/mssql/client_mixin.rb
@@ -86,6 +86,86 @@ module ClientMixin
     end
   end
 
+  def mssql_get_version
+    disconnect if self.sock
+    connect
+    pkt = ""
+    pkt_hdr = ""
+    pkt_data_token = ""
+    pkt_data = ""
+
+
+    pkt_hdr = [
+        TYPE_PRE_LOGIN_MESSAGE, #type
+        STATUS_END_OF_MESSAGE, #status
+        0x0000, #length
+        0x0000, # SPID
+        0x00, # PacketID
+        0x00 #Window
+    ]
+
+    version = [0x55010008, 0x0000].pack("Vv")
+
+    # if manually set, we will honour
+    if tdsencryption == true
+      encryption = ENCRYPT_ON
+    else
+      encryption = ENCRYPT_NOT_SUP
+    end
+
+    instoptdata = "MSSQLServer\0"
+
+    threadid = "\0\0" + Rex::Text.rand_text(2)
+
+    idx = 21 # size of pkt_data_token
+    pkt_data_token << [
+        0x00, # Token 0 type Version
+        idx , # VersionOffset
+        version.length, # VersionLength
+
+        0x01, # Token 1 type Encryption
+        idx = idx + version.length, # EncryptionOffset
+        0x01, # EncryptionLength
+
+        0x02, # Token 2 type InstOpt
+        idx = idx + 1, # InstOptOffset
+        instoptdata.length, # InstOptLength
+
+        0x03, # Token 3 type Threadid
+        idx + instoptdata.length, # ThreadIdOffset
+        0x04, # ThreadIdLength
+
+        0xFF
+    ].pack("CnnCnnCnnCnnC")
+
+    pkt_data << pkt_data_token
+    pkt_data << version
+    pkt_data << encryption
+    pkt_data << instoptdata
+    pkt_data << threadid
+
+    pkt_hdr[2] = pkt_data.length + 8
+
+    pkt = pkt_hdr.pack("CCnnCC") + pkt_data
+
+    resp = mssql_send_recv(pkt)
+    while resp
+      token = resp.slice!(0, 1)
+      if token.unpack('C')[0] == 255
+        major =  resp.slice!(0, 1).unpack('C')[0]
+        minor =  resp.slice!(0, 1).unpack('C')[0]
+        build = resp.slice!(0, 2).unpack('n')[0]
+        break
+      end
+    end
+
+    if major && minor && build
+      return "#{major}.#{minor}.#{build}"
+    else
+      return nil
+    end
+  end
+
   def mssql_send_recv(req, timeout=15, check_status = true)
     sock.put(req)
 

--- a/lib/rex/proto/mssql/client_mixin.rb
+++ b/lib/rex/proto/mssql/client_mixin.rb
@@ -158,15 +158,12 @@ module ClientMixin
       build = resp.slice(version_index+2, 2).unpack('n')[0]
 
       enc_index = resp.slice(6, 2).unpack('n')[0]
-      data['Encryption'] = resp.slice(enc_index, 1).unpack('C')[0]
+      data[:encryption] = resp.slice(enc_index, 1).unpack('C')[0]
     end
 
     if major && minor && build
-      data['Version'] = "#{major}.#{minor}.#{build}"
+      data[:version] = "#{major}.#{minor}.#{build}"
     end
-
-
-    data['Status'] = 'open' if data['Version'] || data['Encryption']
 
     return data
   end

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     print_status("Running MS SQL Server Enumeration...")
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       unless mssql_login_datastore
         print_error("Login was unsuccessful. Check your credentials.")

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     # Check connection and issue initial query
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
       if mssql_login_datastore

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
       if mssql_login_datastore

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       unless mssql_login_datastore
         print_error("Error with mssql_login call")

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -342,7 +342,7 @@ class MetasploitModule < Msf::Auxiliary
     # CREATE DATABASE CONNECTION AND SUBMIT QUERY WITH ERROR HANDLING
     begin
       if session
-        set_session(session.client)
+        set_mssql_session(session.client)
       else
         print_line(" ")
         print_status("Attempting to connect to the SQL Server at #{rhost}:#{rport}...")

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       if session
-        set_session(session.client)
+        set_mssql_session(session.client)
       else
         unless mssql_login_datastore
           print_error('Login failed')

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       unless mssql_login_datastore
         print_error("Error with mssql_login call")

--- a/modules/auxiliary/admin/mssql/mssql_sql_file.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql_file.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       if session
-        set_session(session.client)
+        set_mssql_session(session.client)
       else
         unless mssql_login_datastore
           print_error("#{datastore['RHOST']}:#{datastore['RPORT']} - Invalid SQL Server credentials")

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     elsif !mssql_login(datastore['USERNAME'], datastore['PASSWORD'])
       info = self.mssql_client.initial_connection_info
       if info[:errors] && !info[:errors].empty?

--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'           => 'MSSQL Ping Utility',
-      'Description'    => 'This module simply queries the MSSQL instance for information.',
+      'Description'    => 'This module simply queries the MSSQL Browser service for server information.',
       'Author'         => 'MC',
       'License'        => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       unless mssql_login_datastore
         print_error("#{datastore['RHOST']}:#{datastore['RPORT']} - Invalid SQL Server credentials")

--- a/modules/auxiliary/scanner/mssql/mssql_version.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_version.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
 
     data = mssql_prelogin
 
-    if data.nil? || data.empty?
+    if data.blank?
       print_error("Unable to retrieve version information for #{mssql_client.address}")
       return
     end

--- a/modules/auxiliary/scanner/mssql/mssql_version.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_version.rb
@@ -11,20 +11,53 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name' => 'MSSQL Version Utility',
-      'Description' => 'This module simply queries the MSSQL instance for version information.',
-      'Author' => 'MC',
+      'Description' => 'Executes a TDS7 pre-login request against the MSSQL instance to query for version information.',
+      'Author' => 'Zach Goldman',
       'License' => MSF_LICENSE
     )
+
+    register_options([
+      Opt::RPORT(1433)
+    ])
   end
 
   def run
     if session
       set_session(session.client)
     end
-    version = mssql_get_version
-    if version && !version.empty?
-      print_status("SQL Server for #{mssql_client.address}:")
-      print_good("Version: #{version}")
+
+    data = mssql_get_version
+    if data.nil? || data.empty?
+      print_error("Unable to retrieve version information for #{mssql_client.address}")
+      return
     end
+
+    print_status("SQL Server for #{mssql_client.address}:")
+    if data['Version'] && !data['Version'].empty?
+      print_good("Version: #{data['Version']}")
+    else
+      print_error('Unknown Version')
+    end
+    if data['Encryption'] && !data['Encryption'].empty?
+      print_good("Encryption is #{data['Encryption']}")
+    else
+      print_error('Unknown encryption status')
+    end
+
+    report_mssql_service(mssql_client.address, data)
+  end
+
+  def report_mssql_service(ip, data)
+    mssql_info = 'Version: %<version>s, Encryption: %<encryption>s' % [
+      version: data['Version'] || 'unknown',
+      encryption: data['Encryption'] || 'unknown'
+    ]
+    report_service(
+      host: ip,
+      port: mssql_client.port,
+      name: 'mssql',
+      info: mssql_info,
+      state: (data['Status'].nil? ? 'closed' : data['Status'])
+    )
   end
 end

--- a/modules/auxiliary/scanner/mssql/mssql_version.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_version.rb
@@ -6,20 +6,24 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Scanner
+  include Msf::OptionalSession::MSSQL
 
   def initialize
     super(
       'Name' => 'MSSQL Version Utility',
-      'Description' => 'This module simply queries the MSSQL instance for information.',
+      'Description' => 'This module simply queries the MSSQL instance for version information.',
       'Author' => 'MC',
       'License' => MSF_LICENSE
     )
   end
 
-  def run_host(ip)
+  def run
+    if session
+      set_session(session.client)
+    end
     version = mssql_get_version
     if version && !version.empty?
-      print_status("SQL Server for #{ip}:")
+      print_status("SQL Server for #{mssql_client.address}:")
       print_good("Version: #{version}")
     end
   end

--- a/modules/auxiliary/scanner/mssql/mssql_version.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_version.rb
@@ -1,0 +1,26 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::MSSQL
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name' => 'MSSQL Version Utility',
+      'Description' => 'This module simply queries the MSSQL instance for information.',
+      'Author' => 'MC',
+      'License' => MSF_LICENSE
+    )
+  end
+
+  def run_host(ip)
+    version = mssql_get_version
+    if version && !version.empty?
+      print_status("SQL Server for #{ip}:")
+      print_good("Version: #{version}")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/mssql/mssql_version.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_version.rb
@@ -35,26 +35,28 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
+    data[:status] = 'open' if data[:version] || data[:encryption]
+
     print_status("SQL Server for #{mssql_client.address}:")
-    if data['Version']
-      print_good("Version: #{data['Version']}")
+    if data[:version]
+      print_good("Version: #{data[:version]}")
     else
       print_error('Unknown Version')
     end
-    if data['Encryption']
-      case data['Encryption']
+    if data[:encryption]
+      case data[:encryption]
       when ENCRYPT_OFF
-        data['Encryption'] = 'off'
+        data[:encryption] = 'off'
       when ENCRYPT_ON
-        data['Encryption'] = 'on'
+        data[:encryption] = 'on'
       when ENCRYPT_NOT_SUP
-        data['Encryption'] = 'unsupported'
+        data[:encryption] = 'unsupported'
       when ENCRYPT_REQ
-        data['Encryption'] = 'required'
+        data[:encryption] = 'required'
       else
-        data['Encryption'] = 'unknown'
+        data[:encryption] = 'unknown'
       end
-      print_good("Encryption is #{data['Encryption']}")
+      print_good("Encryption is #{data[:encryption]}")
     else
       print_error('Unknown encryption status')
     end
@@ -65,8 +67,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def report_mssql_service(ip, data)
     mssql_info = 'Version: %<version>s, Encryption: %<encryption>s' % [
-      version: data['Version'] || 'unknown',
-      encryption: data['Encryption'] || 'unknown'
+      version: data[:version] || 'unknown',
+      encryption: data[:encryption] || 'unknown'
     ]
     report_service(
       host: ip,

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -70,12 +70,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if session
-      set_session(session.client)
-    else
-      unless mssql_login_datastore
-        vprint_status("Invalid SQL Server credentials")
-        return Exploit::CheckCode::Detected
-      end
+      set_mssql_session(session.client)
+    end
+
+    unless session || mssql_login_datastore
+      vprint_status("Invalid SQL Server credentials")
+      return Exploit::CheckCode::Detected
     end
 
     mssql_query("select @@version", true)

--- a/spec/acceptance/mssql_spec.rb
+++ b/spec/acceptance/mssql_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
           }
         },
         {
+          name: "auxiliary/scanner/mssql/mssql_version",
+          platforms: [:linux, :osx, :windows],
+          targets: [:session, :rhost],
+          skipped: false,
+          lines: {
+            all: {
+              required: [
+                /Version: \d+.\d+.\d+/,
+                /Encryption: (?:on|off|unsupported|required|unknown)/
+              ]
+            },
+          }
+        },
+        {
           name: "auxiliary/admin/mssql/mssql_enum",
           platforms: [:linux, :osx, :windows],
           targets: [:session, :rhost],

--- a/spec/lib/rex/proto/mssql/client_spec.rb
+++ b/spec/lib/rex/proto/mssql/client_spec.rb
@@ -69,4 +69,14 @@ RSpec.describe Rex::Proto::MSSQL::Client do
       end
     end
   end
+
+  context '#parse_prelogin_response' do
+    let(:buf) { "\x00\x00\x15\x00\x06\x01\x00\e\x00\x01\x02\x00\x1C\x00\x01\x03\x00\x1D\x00\x00\xFF\x10\x00\x03\xE8\x00\x00\x02\x00" }
+    let(:client) { Rex::Proto::MSSQL::Client.allocate }
+
+    it 'correctly parses a prelogin response' do
+      result = client.parse_prelogin_response(buf)
+      expect(result).to eq({ version: '16.0.1000', encryption: 2 })
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/rapid7/metasploit-framework/issues/18684
`mssql_ping` relies on the SQL Server Browser UDP service at 1434 to be running, so we want another way to get some information on the server. This adds the `mssql_version` module which attempts to connect directly to mssql and retrieve some information surrounding the version number and whether encryption is supported.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start a sql server instance
- [ ] `use mssql_version`
- [ ] `run rhosts=YOUR_RHOST_HERE`


```
msf6 auxiliary(scanner/mssql/mssql_version) > run rhosts=192.168.2.230

[*] 192.168.2.230:1433    - SQL Server for 192.168.2.230:
[+] 192.168.2.230:1433    - Version: 16.0.1000
[+] 192.168.2.230:1433    - Encryption is unsupported
[*] 192.168.2.230:1433    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

This also works with a session instead of rhost

- [ ] Start `msfconsole`
- [ ] Start a sql server instance
- [ ] `use mssql_login`
- [ ] `run CreateSession=true [rest of args here]`
- [ ] `use mssql_version`
- [ ] `run rhosts=YOUR_RHOST_HERE`

```
run sessions=-1
[*] Using existing session 1
[*] SQL Server for 192.168.2.233:
[+] Version: 16.0.1000
[+] Encryption is unsupported
[*] Auxiliary module execution completed
```
