### PR TITLE
Update SAMR computer and ICPR cert to support SMB sessions

### DIFF
--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::Client::Authenticated
   include Msf::Exploit::Remote::DCERPC
   include Msf::Auxiliary::Report
+  include Msf::OptionalSession::SMB
 
   def initialize(info = {})
     super(
@@ -61,7 +62,24 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_request_cert
-    request_certificate
+    with_ipc_tree do |opts|
+      request_certificate(opts)
+    end
   end
 
+  # @yieldparam options [Hash] If a SMB session is present, a hash with the IPC tree present. Empty hash otherwise.
+  # @return [void]
+  def with_ipc_tree
+    opts = {}
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      opts[:tree] = simple.client.tree_connect("\\\\#{client.dispatcher.tcp_socket.peerhost}\\IPC$")
+    end
+
+    yield opts
+  ensure
+    opts[:tree].disconnect! if opts[:tree]
+  end
 end

--- a/modules/auxiliary/admin/dcerpc/samr_computer.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_computer.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::MsSamr
+  include Msf::OptionalSession::SMB
 
   def initialize(info = {})
     super(
@@ -67,17 +68,38 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_add_computer
-    add_computer
+    with_ipc_tree do |opts|
+      add_computer(opts)
+    end
   end
 
   def action_delete_computer
     fail_with(Failure::BadConfig, 'This action requires COMPUTER_NAME to be specified.') if datastore['COMPUTER_NAME'].blank?
-    delete_computer
+    with_ipc_tree do |opts|
+      delete_computer(opts)
+    end
   end
 
   def action_lookup_computer
     fail_with(Failure::BadConfig, 'This action requires COMPUTER_NAME to be specified.') if datastore['COMPUTER_NAME'].blank?
-    lookup_computer
+    with_ipc_tree do |opts|
+      lookup_computer(opts)
+    end
   end
 
+  # @yieldparam options [Hash] If a SMB session is present, a hash with the IPC tree present. Empty hash otherwise.
+  # @return [void]
+  def with_ipc_tree
+    opts = {}
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      opts[:tree] = simple.client.tree_connect("\\\\#{client.dispatcher.tcp_socket.peerhost}\\IPC$")
+    end
+
+    yield opts
+  ensure
+    opts[:tree].disconnect! if opts[:tree]
+  end
 end


### PR DESCRIPTION
Update SAMR computer and ICPR cert to support SMB sessions

## Verification

Open session

```
msf6 auxiliary(scanner/smb/smb_login) > run 192.168.123.13 username=administrator password=p4$$w0rd8 createsession=true smb::alwaysencrypt=true

[*] 192.168.123.13:445    - 192.168.123.13:445 - Starting SMB login bruteforce
[+] 192.168.123.13:445    - 192.168.123.13:445 - Success: '.\administrator:p4$$w0rd8' Administrator
[!] 192.168.123.13:445    - No active DB -- Credential data will not be saved!
[*] SMB session 1 opened (192.168.123.1:52649 -> 192.168.123.13:445) at 2024-03-01 12:06:45 +0000
[*] 192.168.123.13:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Run SAMR module

```
msf6 auxiliary(admin/dcerpc/samr_computer) > rerun session=-1 action=LOOKUP_COMPUTER COMPUTER_NAME=DESKTOP-A1N30IDK$
[*] Reloading module...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST

[*] Using existing session 1
[*] Connecting to Security Account Manager (SAM) Remote Protocol
[*] Binding to \samr...
[+] Bound to \samr
[*] Using automatically identified domain: ADF3
[+] Found ADF3\DESKTOP-A1N30IDK$ (SID: S-1-5-21-1266190811-2419310613-1856291569-3106)
[*] Auxiliary module execution completed
```

Run ICPR module

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run session=-1 ca=adf3-DC3-CA

[*] Using existing session 3
[*] Connecting to ICertPassage (ICPR) Remote Protocol
[*] Binding to \cert...
[+] Bound to \cert
[*] Requesting a certificate for user  - digest algorithm: SHA256 - template: User
[+] The requested certificate was issued.
[*] Certificate Email: administrator@adf3.local
[*] Certificate UPN: Administrator@adf3.local
[!] No active DB -- Credential data will not be saved!
[*] Certificate stored at: /Users/user/.msf4/loot/20240301124630_default_unknown_windows.ad.cs_667674.pfx
[*] Auxiliary module execution completed
```