### PR TITLE
Resolve deprecation warnings from actions/checkout in Github actions

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: always()
 
       - name: Install system dependencies (Linux)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Required to checkout HEAD^ and 3a046f01dae340c124dd3895e670983aef5fe0c5 for the msftidy script
         # https://github.com/actions/checkout/tree/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f#checkout-head
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,7 +33,7 @@ jobs:
     name: Docker Build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: docker-compose build
         run: |
@@ -93,7 +93,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         env:


### PR DESCRIPTION
Like #18896, this PR resolves deprecation warnings from `actions/checkout` in Github actions.

These warnings are caused because v3 and below ran on Node.js 16, which is deprecated by Github.

Example of the warnings: https://github.com/rapid7/metasploit-framework/actions/runs/8116715670

Example of the same action, now with the warnings cleared: https://github.com/rapid7/metasploit-framework/actions/runs/8123598724



