### PR TITLE
Add extra cves and urls to vuln references when importing OpenVAS.

### DIFF
--- a/lib/rex/parser/nokogiri_doc_mixin.rb
+++ b/lib/rex/parser/nokogiri_doc_mixin.rb
@@ -92,6 +92,10 @@ module Parser
           else
             "#{ref_type}-#{ref_value}"
           end
+        when "CB"
+          ref_value
+        when "DFN-CERT"
+          ref_value
         else # Handle others?
           "#{ref_type}-#{ref_value}"
         end

--- a/lib/rex/parser/openvas_document.rb
+++ b/lib/rex/parser/openvas_document.rb
@@ -25,24 +25,38 @@ module Parser
     when "host"
       @state[:has_text] = true
     when 'ref'
+      ref_type = ''
+      ref_id = ''
+      if defined?(attrs) && attrs.kind_of?(Array)
+        attrs.each do |attr|
+          next if !defined?(attr) || !attr.kind_of?(Array) || attr.length != 2
+          if defined?(attr[0]) && defined?(attr[1]) && attr[0] == 'type'
+            ref_type = attr[1]
+          end
+          if defined?(attr[0]) && defined?(attr[1]) && attr[0] == 'id'
+            ref_id = attr[1]
+          end
+        end
+      end
       if in_tag('result') && in_tag('nvt') && in_tag('refs') &&
-         defined?(attrs[0][0]) && defined?(attrs[0][1]) &&
-         defined?(attrs[1][0]) && defined?(attrs[1][1]) &&
-         attrs[1][0] == 'id' && attrs[0][0] == 'type'
-        case attrs[0][1].upcase
+          !ref_type.empty? && !ref_type.empty?
+        case ref_type.upcase
         when 'CVE'
           @state[:ref_cve] = [] if @state[:ref_cve].nil?
-          @state[:ref_cve].append(attrs[1][1].strip)
+          @state[:ref_cve].append(ref_id.strip)
         when 'URL'
           @state[:ref_url] = [] if @state[:ref_url].nil?
-          @state[:ref_url].append(attrs[1][1].strip)
-        # Uncomment this to import DFN-CERT and CERT-BUND
-        #when 'DFN-CERT'
-          #@state[:ref_dfn] = [] if @state[:ref_dfn].nil?
-          #@state[:ref_dfn].append(attrs[1][1].strip)
-        #when 'CERT-BUND'
-          #@state[:ref_cb] = [] if @state[:ref_cb].nil?
-          #@state[:ref_cb].append(attrs[1][1].strip)
+          @state[:ref_url].append(ref_id.strip)
+        when 'DFN-CERT'
+          if defined?(@args[:options][:openvas_dfn]) && @args[:options][:openvas_dfn]
+            @state[:ref_dfn] = [] if @state[:ref_dfn].nil?
+            @state[:ref_dfn].append(ref_id.strip)
+          end
+        when 'CERT-BUND'
+          if defined?(@args[:options][:openvas_cert]) && @args[:options][:openvas_cert]
+            @state[:ref_cb] = [] if @state[:ref_cb].nil?
+            @state[:ref_cb].append(ref_id.strip)
+          end
         end
       end
     end

--- a/lib/rex/parser/openvas_document.rb
+++ b/lib/rex/parser/openvas_document.rb
@@ -24,6 +24,27 @@ module Parser
     case name
     when "host"
       @state[:has_text] = true
+    when 'ref'
+      if in_tag('result') && in_tag('nvt') && in_tag('refs') &&
+         defined?(attrs[0][0]) && defined?(attrs[0][1]) &&
+         defined?(attrs[1][0]) && defined?(attrs[1][1]) &&
+         attrs[1][0] == 'id' && attrs[0][0] == 'type'
+        case attrs[0][1].upcase
+        when 'CVE'
+          @state[:ref_cve] = [] if @state[:ref_cve].nil?
+          @state[:ref_cve].append(attrs[1][1].strip)
+        when 'URL'
+          @state[:ref_url] = [] if @state[:ref_url].nil?
+          @state[:ref_url].append(attrs[1][1].strip)
+        # Uncomment this to import DFN-CERT and CERT-BUND
+        #when 'DFN-CERT'
+          #@state[:ref_dfn] = [] if @state[:ref_dfn].nil?
+          #@state[:ref_dfn].append(attrs[1][1].strip)
+        #when 'CERT-BUND'
+          #@state[:ref_cb] = [] if @state[:ref_cb].nil?
+          #@state[:ref_cb].append(attrs[1][1].strip)
+        end
+      end
     end
   end
 
@@ -148,6 +169,30 @@ module Parser
       @state[:bid].split(',').each do |bid|
         references.append({ :source => "BID", :value => bid})
       end
+    end
+    if @state[:ref_cve] && @state[:ref_cve].kind_of?(Array)
+      @state[:ref_cve].each do |cve|
+        references.append({ :source => "CVE", :value => cve.dup}) if !cve.empty?
+      end
+      @state[:ref_cve].clear
+    end
+    if @state[:ref_url] && @state[:ref_url].kind_of?(Array)
+      @state[:ref_url].each do |url|
+        references.append({ :source => "URL", :value => url.dup}) if !url.empty?
+      end
+      @state[:ref_url].clear
+    end
+    if @state[:ref_cb] && @state[:ref_cb].kind_of?(Array)
+      @state[:ref_cb].each do |cb|
+        references.append({ :source => "CB", :value => cb.dup}) if !cb.empty?
+      end
+      @state[:ref_cb].clear
+    end
+    if @state[:ref_dfn] && @state[:ref_dfn].kind_of?(Array)
+      @state[:ref_dfn].each do |dfn|
+        references.append({ :source => "DFN-CERT", :value => dfn.dup}) if !dfn.empty?
+      end
+      @state[:ref_dfn].clear
     end
 
     vuln_info = {}


### PR DESCRIPTION
When importing an OpenVAS XML report most of the reference cves/urls/etc are listed as attributes for a reference tag and do not get imported into the vuln references.  This will import those cves and urls but I commented out the lines to import dfn-cert and cert-bund because it reports a ton of them.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `db_import ~/report.xml`
- [ ] `vulns`
