### PR TITLE
Fix smb session autorun

### DIFF
--- a/lib/msf/base/sessions/smb.rb
+++ b/lib/msf/base/sessions/smb.rb
@@ -45,8 +45,8 @@ class Msf::Sessions::SMB
       next if datastore[key].nil? || datastore[key].empty?
 
       args = Shellwords.shellwords(datastore[key])
-      print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-      session.execute_script(args.shift, *args)
+      print_status("Session ID #{sid} (#{tunnel_to_s}) processing #{key} '#{datastore[key]}'")
+      execute_script(args.shift, *args)
     end
   end
 


### PR DESCRIPTION
This PR fixes an issue with the autorun scripts within an smb session

`rc_file` contents:
```
help
```

Before:
```msf6 auxiliary(scanner/smb/smb_login) > set autorunscript rc_file
autorunscript => rc_file
msf6 auxiliary(scanner/smb/smb_login) > run

[*] 172.16.158.154:445    - 172.16.158.154:445 - Starting SMB login bruteforce
[+] 172.16.158.154:445    - 172.16.158.154:445 - Success: 'windomain.local\vagrant:vagrant' Administrator
[-] 172.16.158.154:445    - Failed to setup the session - NameError undefined local variable or method `session' for #<Session:smb 172.16.158.154:445 (172.16.158.154) "SMB vagrant @ 172.16.158.154:445">
Did you mean?  session_host
[*] 172.16.158.154:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

After:
```
msf6 auxiliary(scanner/smb/smb_login) > run

[*] 172.16.158.154:445    - 172.16.158.154:445 - Starting SMB login bruteforce
[+] 172.16.158.154:445    - 172.16.158.154:445 - Success: 'windomain.local\vagrant:vagrant' Administrator
[*] Session ID 6 (172.16.158.1:61774 -> 172.16.158.154:445) processing AutoRunScript 'rc_file'
[*] Processing rc_file for ERB directives.
resource (rc_file)> help

Core Commands
=============

    Command       Description
    -------       -----------
    ?             Help menu
    background    Backgrounds the current session
    bg            Alias for background
    exit          Terminate the SMB session
    help          Help menu
    irb           Open an interactive Ruby shell on the current session
    pry           Open the Pry debugger on the current session
    sessions      Quickly switch to another session


Shares Commands
===============

    Command       Description
    -------       -----------
    cat           Read the file at the given path
    cd            Change the current remote working directory
    dir           List all files in the current directory (alias for ls)
    ls            List all files in the current directory
    pwd           Print the current remote working directory
    shares        View the available shares and interact with one

This session also works with the following modules:

  auxiliary/admin/dcerpc/icpr_cert
  auxiliary/admin/dcerpc/samr_computer
  auxiliary/admin/smb/delete_file
  auxiliary/admin/smb/download_file
  auxiliary/admin/smb/psexec_ntdsgrab
  auxiliary/admin/smb/upload_file
  auxiliary/gather/windows_secrets_dump
  auxiliary/scanner/smb/pipe_auditor
  auxiliary/scanner/smb/pipe_dcerpc_auditor
  auxiliary/scanner/smb/smb_enum_gpp
  auxiliary/scanner/smb/smb_enumshares
  auxiliary/scanner/smb/smb_enumusers
  auxiliary/scanner/smb/smb_enumusers_domain
  auxiliary/scanner/smb/smb_lookupsid
  exploit/windows/smb/psexec

[*] SMB session 6 opened (172.16.158.1:61774 -> 172.16.158.154:445) at 2024-03-05 15:07:04 +0000
[*] 172.16.158.154:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

# Verification Steps
- [ ] Get an smb session
- [ ] `set AutoRunScript <some_rc_file>`
- [ ] Verify the rc script runs
- [ ] Repeat for SQL session types (just to be sure)
