### PR TITLE
Add ip to smb session prompt

### DIFF
--- a/lib/rex/post/smb/ui/console.rb
+++ b/lib/rex/post/smb/ui/console.rb
@@ -134,10 +134,12 @@ module Rex
             if active_share
               share_name = active_share.share[/[^\\].*$/, 0]
               cwd = self.cwd.blank? ? '' : "\\#{self.cwd}"
-              return substitute_colors("%undSMB%clr (#{share_name}#{cwd}) > ", true)
+              prompt = "#{share_name}#{cwd}"
+            else
+              prompt = session.address.to_s
             end
 
-            super
+            substitute_colors("%undSMB%clr (#{prompt}) > ", true)
           end
 
           protected


### PR DESCRIPTION
Adds the ip address of the current smb connection when you aren't connected to a share in the smb sessions

Before:
```
msf6 auxiliary(scanner/smb/smb_login) > sessions -1
[*] Starting interaction with 6...

SMB > shares
Shares
======

    #  Name    Type          comment
    -  ----    ----          -------
    0  ADMIN$  DISK|SPECIAL  Remote Admin
    1  C$      DISK|SPECIAL  Default share
    2  foo     DISK
    3  IPC$    IPC|SPECIAL   Remote IPC

SMB > shares -i foo
[+] Successfully connected to foo
SMB (172.16.158.154\foo) >
```

After:
```
msf6 auxiliary(scanner/smb/smb_login) > sessions -1
[*] Starting interaction with 7...

SMB (172.16.158.154) > shares
Shares
======

    #  Name    Type          comment
    -  ----    ----          -------
    0  ADMIN$  DISK|SPECIAL  Remote Admin
    1  C$      DISK|SPECIAL  Default share
    2  foo     DISK
    3  IPC$    IPC|SPECIAL   Remote IPC

SMB (172.16.158.154) > shares -i foo
[+] Successfully connected to foo
SMB (172.16.158.154\foo) >
```

# Verification steps
- [ ] Get an SMB session
- [ ] Interact with the session `sessions -1`
- [ ] Verify the correct ip address is part of the prompt before and after connecting to a share