### PR TITLE
Use HTTPS link for postgres_sql reference

### DIFF
--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'www.postgresql.org' ]
+          [ 'URL', 'https://www.postgresql.org' ]
         ]
     ))
   end


### PR DESCRIPTION
This PR fixes an incorrect reference link in one of the Postgres modules.

## Verification

- [ ] Ensure the link works.