### PR TITLE
Allow selecting auxiliary modules in RPC

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -350,6 +350,8 @@ class RPC_Module < RPC_Base
   def rpc_compatible_sessions(mname)
     if mname.start_with? 'exploit/'
       m = _find_module('exploit',mname)
+    elsif mname.start_with? 'auxiliary/'
+      m = _find_module('auxiliary', mname)
     else
       m = _find_module('post',mname)
     end


### PR DESCRIPTION
This PR is a second in the series to fix some functionality broken in Pro.

## Verification

To test this, I had a Pro instance, and made sure I could execute auxiliary modules against the new SQL session types.