### PR TITLE
Adds a help command within the interactive query prompt

### DIFF
--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -71,6 +71,7 @@ module Rex
                 print_line 'Interactive SQL prompt'
                 print_line
                 print_line 'You are in an interactive SQL shell where SQL queries can be executed.'
+                print_line 'SQL commands ending with ; will be executed on the remote server.'
                 print_line "To exit, type 'exit', 'quit', 'end' or 'stop'."
                 print_line
               end

--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -67,6 +67,14 @@ module Rex
                 print_line
               end
 
+              def query_interactive_help
+                print_line 'Interactive SQL prompt'
+                print_line
+                print_line 'You are in an interactive SQL shell where SQL queries can be executed.'
+                print_line "To exit, type 'exit', 'quit', 'end' or 'stop'."
+                print_line
+              end
+
               def cmd_query_interactive(*args)
                 if help_args?(args)
                   cmd_query_interactive_help

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -114,8 +114,7 @@ module InteractiveSqlClient
           help = help_words.include?(multiline_input.split.last)
         end
 
-        finished || multiline_input.split.last&.end_with?(';')
-        help || multiline_input.split.last&.end_with?(';')
+        finished || help || multiline_input.split.last&.end_with?(';')
       end
     rescue ::StandardError => e
       elog('Failed to get multi-line SQL query from user', e)

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -22,6 +22,11 @@ module InteractiveSqlClient
     while self.interacting
       sql_input = _multiline_with_fallback
       self.interacting = (sql_input[:status] != :exit)
+
+      if sql_input[:status] == :help
+        client_dispatcher.query_interactive_help
+      end
+
       # We need to check that the user is still interacting, i.e. if ctrl+z is triggered when requesting user input
       break unless (self.interacting && sql_input[:result])
 
@@ -77,8 +82,10 @@ module InteractiveSqlClient
     end
 
     stop_words = %w[stop s exit e end quit q].freeze
+    help_words = %w[help h].freeze
 
     finished = false
+    help = false
     begin
       result = nil
       prompt_proc_before = ::Reline.prompt_proc
@@ -100,10 +107,15 @@ module InteractiveSqlClient
           next true
         end
 
-        # In the case only a stop word was input, exit out of the REPL shell
-        finished = (multiline_input.split.count == 1 && stop_words.include?(multiline_input.split.last))
+        if multiline_input.split.count == 1
+          # In the case only a stop word was input, exit out of the REPL shell
+          finished = stop_words.include?(multiline_input.split.last)
+          # In the case when only a help word was input call the help command
+          help = help_words.include?(multiline_input.split.last)
+        end
 
         finished || multiline_input.split.last&.end_with?(';')
+        help || multiline_input.split.last&.end_with?(';')
       end
     rescue ::StandardError => e
       elog('Failed to get multi-line SQL query from user', e)
@@ -113,6 +125,10 @@ module InteractiveSqlClient
 
     if result
       return result
+    end
+
+    if help
+      return { status: :help, result: nil }
     end
 
     if finished


### PR DESCRIPTION
Adds the ability to run a `help` command from within the interactive SQL prompt

before:
```
SQL >> help
SQL *>
```

After:
```
SQL >> help
Interactive SQL prompt

You are in an interactive SQL shell where SQL queries can be executed.
To exit, type 'exit', 'quit', 'end' or 'stop'.
```

# Verification Steps
- [ ] boot msfconsole
- [ ] Get a SQL type session
- [ ] drop into an interactive prompt `query_interactive`
- [ ] run the `help` command
