### PR TITLE
Sql sessions have correct history manager

### DIFF
--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -228,6 +228,13 @@ class Config < Hash
     self.new.postgresql_session_history
   end
 
+  # Returns the full path to the PostgreSQL interactive query history file
+  #
+  # @return [String] path to the interactive query history file.
+  def self.postgresql_session_history_interactive
+    self.new.postgresql_session_history_interactive
+  end
+
   # Returns the full path to the MSSQL session history file.
   #
   # @return [String] path to the history file.
@@ -235,11 +242,25 @@ class Config < Hash
     self.new.mssql_session_history
   end
 
+  # Returns the full path to the MSSQL interactive query history file
+  #
+  # @return [String] path to the interactive query history file.
+  def self.mssql_session_history_interactive
+    self.new.mssql_session_history_interactive
+  end
+
   # Returns the full path to the MySQL session history file.
   #
   # @return [String] path to the history file.
   def self.mysql_session_history
     self.new.mysql_session_history
+  end
+
+  # Returns the full path to the MySQL interactive query history file
+  #
+  # @return [String] path to the interactive query history file.
+  def self.mysql_session_history_interactive
+    self.new.mysql_session_history_interactive
   end
 
   def self.pry_history
@@ -355,12 +376,24 @@ class Config < Hash
     config_directory + FileSep + "postgresql_session_history"
   end
 
+  def postgresql_session_history_interactive
+    postgresql_session_history + "_interactive"
+  end
+
   def mysql_session_history
     config_directory + FileSep + "mysql_session_history"
   end
 
+  def mysql_session_history_interactive
+    mysql_session_history + "_interactive"
+  end
+
   def mssql_session_history
     config_directory + FileSep + "mssql_session_history"
+  end
+
+  def mssql_session_history_interactive
+    mssql_session_history + "_interactive"
   end
 
   def pry_history

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -28,8 +28,8 @@ class HistoryManager
   # @param [Proc] block
   # @return [nil]
   def with_context(history_file: nil, name: nil, input_library: nil, &block)
-    input_library ||= :readline # Default to Readline for backwards compatibility.
-    push_context(history_file: history_file, name: name, input_library: input_library)
+    # Default to Readline for backwards compatibility.
+    push_context(history_file: history_file, name: name, input_library: input_library || :readline)
 
     begin
       block.call
@@ -69,7 +69,7 @@ class HistoryManager
 
   def push_context(history_file: nil, name: nil, input_library: nil)
     $stderr.puts("Push context before\n#{JSON.pretty_generate(_contexts)}") if debug?
-    new_context = { history_file: history_file, name: name, input_library: input_library }
+    new_context = { history_file: history_file, name: name, input_library: input_library || :readline }
 
     switch_context(new_context, @contexts.last)
     @contexts.push(new_context)

--- a/spec/lib/rex/ui/text/shell/history_manager_spec.rb
+++ b/spec/lib/rex/ui/text/shell/history_manager_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'a') do
             expected_contexts = [
-              { history_file: nil, name: 'a' },
+              { history_file: nil, input_library: :readline, name: 'a' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -36,7 +36,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
 
     context 'when there is an existing stack' do
       before(:each) do
-        subject.send(:push_context, history_file: nil, name: 'a')
+        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
       end
 
       it 'continues to have the previous existing stack' do
@@ -44,7 +44,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           # noop
         }
         expected_contexts = [
-          { history_file: nil, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -53,8 +53,8 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'b') do
             expected_contexts = [
-              { history_file: nil, name: 'a' },
-              { history_file: nil, name: 'b' },
+              { history_file: nil, input_library: :readline, name: 'a' },
+              { history_file: nil, input_library: :readline, name: 'b' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -69,7 +69,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           }
         end.to raise_exception ArgumentError, 'Mock error'
         expected_contexts = [
-          { history_file: nil, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -79,9 +79,9 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
   describe '#push_context' do
     context 'when the stack is empty' do
       it 'stores the history contexts' do
-        subject.send(:push_context, history_file: nil, name: 'a')
+        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
         expected_contexts = [
-          { history_file: nil, name: 'a' }
+          { history_file: nil, input_library: :readline, name: 'a' }
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -90,12 +90,12 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     context 'when multiple values are pushed' do
       it 'stores the history contexts' do
         subject.send(:push_context, history_file: nil, name: 'a')
-        subject.send(:push_context, history_file: nil, name: 'b')
-        subject.send(:push_context, history_file: nil, name: 'c')
+        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'b')
+        subject.send(:push_context, history_file: nil, input_library: :reline, name: 'c')
         expected_contexts = [
-          { history_file: nil, name: 'a' },
-          { history_file: nil, name: 'b' },
-          { history_file: nil, name: 'c' },
+          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'b' },
+          { history_file: nil, input_library: :reline, name: 'c' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -113,12 +113,12 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     end
 
     context 'when the stack is not empty' do
-      it 'continues to have an empty stack' do
+      it 'continues to have a non-empty stack' do
         subject.send(:push_context, history_file: nil, name: 'a')
         subject.send(:push_context, history_file: nil, name: 'b')
         subject.send(:pop_context)
         expected_contexts = [
-          { history_file: nil, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end


### PR DESCRIPTION
This PR addresses the interactive query mode not having correctly separated input history between various SQL session types.
Now, each session type will have its own input history for normal `query` input in the session, as well as the interactive query mode. This support is provided for Reline and Readline as fallback.

## Verification

- [ ] Get a session for MySQL, MSSQL, and PostgreSQL
- [ ] Run some queries in the context of the session by using `query SELECT ...` etc.
- [ ] Confirm that the above `query` calls are not shared between session types.
- [ ] Run some queries in the context of the interactive query mode (`query -i`) by using `select version();` etc.
- [ ] Confirm that the above interactive query calls are not shared between session types.
- [ ] Confirm that the history persists between framework reboots.
- [ ] Confirm that multi-line input in the interactive query prompt works as expected.