### PR TITLE
Fix saving and loading DNS rules from the config

### DIFF
--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -202,7 +202,7 @@ module DNS
       config = Msf::Config.load
 
       with_rules = []
-      config.fetch("#{CONFIG_KEY_BASE}/entries", {}).each do |_name, value|
+      config.fetch("#{CONFIG_KEY_BASE}/rules", {}).each do |_name, value|
         wildcard, resolvers, uses_comm = value.split(';')
         wildcard = '*' if wildcard.blank?
         resolvers = resolvers.split(',')
@@ -254,7 +254,7 @@ module DNS
         ].join(';')
         new_config["##{index}"] = val
       end
-      Msf::Config.save("#{CONFIG_KEY_BASE}/upstream_rules" => new_config)
+      Msf::Config.save("#{CONFIG_KEY_BASE}/rules" => new_config)
     end
 
     def save_config_static_hostnames


### PR DESCRIPTION
This fixes a bug I noticed in the new DNS changes from #18809. Basically two different key names were being used to save and load the resolver rules. This meant that the rules were saved under one name and loaded under another which meant the rules wouldn't be loaded and DNS would be broken.

- [ ] Make sure there's at least one DNS resolver rule (run `dns reset-config` and at least one should be populated)
- [ ] Save the configuration with the `save` command
- [ ] Restart msfconsole and run the `dns` command, see that the rule was loaded