### PR TITLE
The DNS feature requires a restart, so flag it

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-Configure-DNS.md
+++ b/docs/metasploit-framework.wiki/How-to-Configure-DNS.md
@@ -15,8 +15,8 @@ control over the process of DNS queries.
 
 ## The DNS command
 Metasploit's DNS configuration is controlled by the `dns` command which has multiple subcommands. This command is only
-available when the `dns_feature` is enabled (`features set dns_feature true`). Once enabled, the current configuration
-can be printed by running `dns print`.
+available when the `dns` feature is enabled (`features set dns true`). Once enabled, the current configuration can be
+printed by running `dns print`.
 
 ```
 msf6 > dns print

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -20,7 +20,7 @@ module Msf
     MANAGER_COMMANDS = 'manager_commands'
     METASPLOIT_PAYLOAD_WARNINGS = 'metasploit_payload_warnings'
     DEFER_MODULE_LOADS = 'defer_module_loads'
-    DNS_FEATURE = 'dns_feature'
+    DNS = 'dns'
     HIERARCHICAL_SEARCH_TABLE = 'hierarchical_search_table'
     SMB_SESSION_TYPE = 'smb_session_type'
     POSTGRESQL_SESSION_TYPE = 'postgresql_session_type'
@@ -91,15 +91,15 @@ module Msf
         default_value: false
       }.freeze,
       {
-        name: DNS_FEATURE,
-        description: 'When enabled, allows configuration of DNS resolution behaviour in Metasploit',
-        requires_restart: false,
+        name: DNS,
+        description: 'When enabled allows configuration of DNS resolution behaviour in Metasploit',
+        requires_restart: true,
         default_value: false,
         developer_notes: 'Planned for default enablement in: Metasploit 6.4.x'
       }.freeze,
       {
         name: HIERARCHICAL_SEARCH_TABLE,
-        description: 'When enabled, the search table is enhanced to show details on module actions and targets',
+        description: 'When enabled the search table is enhanced to show details on module actions and targets',
         requires_restart: false,
         default_value: false,
         developer_notes: 'Planned for default enablement in: Metasploit 6.4.x'

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -82,7 +82,7 @@ class Framework
     require 'msf/core/cert_provider'
     Rex::Socket::Ssl.cert_provider = Msf::Ssl::CertProvider
 
-    if options.include?('CustomDnsResolver') && Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS_FEATURE)
+    if options.include?('CustomDnsResolver') && Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS)
       self.dns_resolver = options['CustomDnsResolver']
       self.dns_resolver.set_framework(self)
       Rex::Socket._install_global_resolver(self.dns_resolver)

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -48,7 +48,7 @@ class DNS
   def commands
     commands = {}
 
-    if framework.features.enabled?(Msf::FeatureManager::DNS_FEATURE)
+    if framework.features.enabled?(Msf::FeatureManager::DNS)
       commands = {
         'dns' => "Manage Metasploit's DNS resolving behaviour"
       }
@@ -186,7 +186,10 @@ class DNS
   # Manage Metasploit's DNS resolution rules
   #
   def cmd_dns(*args)
-    return if driver.framework.dns_resolver.nil?
+    if driver.framework.dns_resolver.nil?
+      print_warning("Run the #{Msf::Ui::Tip.highlight("save")} command and restart the console for this feature to take effect.")
+      return
+    end
 
     args << 'print' if args.length == 0
     # Short-circuit help

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -70,7 +70,7 @@ class Driver < Msf::Ui::Driver
 
     begin
       FeatureManager.instance.load_config
-    rescue StandardException => e
+    rescue StandardError => e
       elog(e)
     end
 
@@ -82,7 +82,7 @@ class Driver < Msf::Ui::Driver
 
     framework_create_options = opts.merge({ 'DeferModuleLoads' => true })
 
-    if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS_FEATURE)
+    if Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::DNS)
       dns_resolver = Rex::Proto::DNS::CachedResolver.new
       dns_resolver.extend(Rex::Proto::DNS::CustomNameserverProvider)
       dns_resolver.load_config if dns_resolver.has_config?

--- a/lib/rex/proto/dns/custom_nameserver_provider.rb
+++ b/lib/rex/proto/dns/custom_nameserver_provider.rb
@@ -156,7 +156,7 @@ module DNS
     # @return [Array<Array>] A list of nameservers, each with Rex::Socket options
     #
     def upstream_resolvers_for_packet(packet)
-      unless feature_set.enabled?(Msf::FeatureManager::DNS_FEATURE)
+      unless feature_set.enabled?(Msf::FeatureManager::DNS)
         return super
       end
       # Leaky abstraction: a packet could have multiple question entries,


### PR DESCRIPTION
This updates the DNS feature definition in the feature manager to:

1. Mark that it requires the framework to be restarted in order for it to be activated (because the resolver attribute on the framework instance needs to be set)
2. Rename it from DNS_FEATURE to DNS because the FEATURE suffix is redundant in this case and inconsistent with the other names

Fixes #18948

## Verification

- [ ] Follow the steps from #18948 and see that the issue is now fixed

## Demo

![image](https://github.com/rapid7/metasploit-framework/assets/2058303/4e4b9077-9d21-4260-8f99-977d7718e856)
