### PR TITLE
Ensure modules honor spooler settings

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1421,10 +1421,14 @@ class Core
     color = driver.output.config[:color]
 
     if args[0] == "off"
-      driver.init_ui(driver.input, Rex::Ui::Text::Output::Stdio.new)
+      stdout = Rex::Ui::Text::Output::Stdio.new
+      driver.init_ui(driver.input, stdout)
+      active_module.init_ui(driver.input, stdout) if defined?(active_module) && active_module
       msg = "Spooling is now disabled"
     else
-      driver.init_ui(driver.input, Rex::Ui::Text::Output::Tee.new(args[0]))
+      stdout = Rex::Ui::Text::Output::Tee.new(args[0])
+      driver.init_ui(driver.input, stdout)
+      active_module.init_ui(driver.input, stdout) if defined?(active_module) && active_module
       msg = "Spooling to file #{args[0]}..."
     end
 


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/18953

## Verification

```
msfconsole
use auxiliary/scanner/ftp/ftp_version
run
```

### Before

No error logs are output in the spooler file:

```
$ tail /tmp/example.txt
msf6 auxiliary(scanner/ftp/ftp_login) > run

[-] Msf::OptionValidateError One or more options failed to validate: RHOSTS.
msf6 auxiliary(scanner/ftp/ftp_login) >
```

### After

Error logs are output to the spooler filter:

```
$ tail /tmp/example.txt
msf6 auxiliary(scanner/ftp/ftp_login) > run
msf6 auxiliary(scanner/ftp/ftp_login) >
```