### PR TITLE
Handle correct openvas error

### DIFF
--- a/plugins/openvas.rb
+++ b/plugins/openvas.rb
@@ -186,7 +186,7 @@ module Msf
           rescue OpenVASOMP::OMPAuthError => e
             print_error("Authentication failed: #{e.reason}")
             return
-          rescue OpenVASOMP::OMPConnectionError => e
+          rescue OpenVASOMP::OMPError => e
             print_error("Connection failed: #{e.reason}")
             return
           end


### PR DESCRIPTION
resolves #18958

Fixes an issue with the openvas plugin that was trying to as far as I can tell rescue a non-existant error

Before:
```
msf6 auxiliary(scanner/smb/smb_login) > openvas_connect msfconsole msfconsole 127.0.0.1 9392 ok
[*] Connecting to OpenVAS instance at 127.0.0.1:9392 with username msfconsole...
[-] Error while running command openvas_connect: uninitialized constant OpenVASOMP::OMPConnectionError

Call stack:
/Users/dwelch/dev/metasploit-framework/plugins/openvas.rb:189:in `rescue in cmd_openvas_connect'
/Users/dwelch/dev/metasploit-framework/plugins/openvas.rb:183:in `cmd_openvas_connect'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:582:in `run_command'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:531:in `block in run_single'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `each'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_single'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:165:in `block in run'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:309:in `block in with_history_manager_context'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:33:in `with_context'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:306:in `with_history_manager_context'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:133:in `run'
/Users/dwelch/dev/metasploit-framework/lib/metasploit/framework/command/console.rb:54:in `start'
/Users/dwelch/dev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

After:
```
msf6 auxiliary(scanner/smb/smb_login) > openvas_connect msfconsole msfconsole 127.0.0.1 9392 ok
[*] Connecting to OpenVAS instance at 127.0.0.1:9392 with username msfconsole...
[-] Error while running command openvas_connect: Connection refused - connect(2) for "127.0.0.1" port 9392

Call stack:
/Users/dwelch/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/openvas-omp-0.0.4/lib/openvas-omp.rb:160:in `initialize'
/Users/dwelch/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/openvas-omp-0.0.4/lib/openvas-omp.rb:160:in `open'
/Users/dwelch/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/openvas-omp-0.0.4/lib/openvas-omp.rb:160:in `connect'
/Users/dwelch/.rvm/gems/ruby-3.0.5@metasploit-framework/gems/openvas-omp-0.0.4/lib/openvas-omp.rb:136:in `initialize'
/Users/dwelch/dev/metasploit-framework/plugins/openvas.rb:185:in `new'
/Users/dwelch/dev/metasploit-framework/plugins/openvas.rb:185:in `cmd_openvas_connect'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:582:in `run_command'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:531:in `block in run_single'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `each'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_single'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:165:in `block in run'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:309:in `block in with_history_manager_context'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:33:in `with_context'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:306:in `with_history_manager_context'
/Users/dwelch/dev/metasploit-framework/lib/rex/ui/text/shell.rb:133:in `run'
/Users/dwelch/dev/metasploit-framework/lib/metasploit/framework/command/console.rb:54:in `start'
/Users/dwelch/dev/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

Still getting an error because I wasn't pointing it at a real openvas system but the uninitialized constant error is gone now

