### PR TITLE
Improves handling of dying SMB and SQL sessions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,7 +474,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.3)
+    ruby_smb (3.3.4)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac

--- a/lib/postgres/postgres-pr/message.rb
+++ b/lib/postgres/postgres-pr/message.rb
@@ -46,7 +46,11 @@ class Message
     type = stream.read_exactly_n_bytes(1) unless startup
     length = stream.read_exactly_n_bytes(4).to_s.unpack('N').first  # FIXME: length should be signed, not unsigned
 
-    raise ParseError if (length.nil? || length < 4)
+    if length.nil?
+      raise EOFError
+    elsif length < 4
+      raise ParseError
+    end
 
     # If we didn't read any bytes and startup was not set, then type will be nil, so don't continue.
     unless startup

--- a/lib/rex/post/mysql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/mysql/ui/console/command_dispatcher/client.rb
@@ -39,6 +39,14 @@ module Rex
             # meaning we don't have that in the Result object.
             { rows: result.entries, columns: result.fields.each.map(&:name), errors: [] }
           end
+
+          def handle_error(e)
+            case e
+            when Mysql::ClientError::ServerLost
+              _close_session
+            end
+            super
+          end
         end
       end
     end

--- a/lib/rex/post/smb/ui/console.rb
+++ b/lib/rex/post/smb/ui/console.rb
@@ -98,6 +98,10 @@ module Rex
             log_error(e.message)
           rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
             session.kill
+          rescue ::RubySMB::Error::CommunicationError => e
+            log_error("Error running command #{method}: #{e.class} #{e}")
+            elog(e)
+            session.alive = false
           rescue ::StandardError => e
             log_error("Error running command #{method}: #{e.class} #{e}")
             elog(e)


### PR DESCRIPTION
> [!note]
This PR is in conjunction with a PR in [ruby_smb](https://github.com/rapid7/ruby_smb/pull/263) . This PR will need to be landed before the framework PR.

This PR improves the handling of dying SMB and SQL sessions. Previously when a session was killed, then interacting with it would return errors but not exit the session. Now the session will close as expected.

## MSSQL
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/2c08f928-cb21-430f-8f8b-ee4eab991edd)

## SMB
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/d8574860-8633-4f9b-a955-f11a1867209a)


# Targets for testing
## PostgreSQL

### Docker command:

```bash
docker run -it -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:16.1
```

### Module commands:

```bash
use postgres_login
run rhost=127.0.0.1 rport=5432 username=postgres password=password database=template1 createsession=true
```

## MSSQL

### Docker command:

```bash
docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=MyMSSQLServerPassword__<>" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04
```

### Module commands:

```bash
use mssql_login
run rhost=127.0.0.1 rport=1433 username=sa password=MyMSSQLServerPassword__<> use_windows_authent=false createsession=true
```

## MySQL

### Docker command:

MariaDB:

```bash
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 4306:3306 mariadb:11.2.2
```

MySQL:

```bash
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 3306:3306 mysql:8.3.0
```

### Module commands:

MariaDB:

```bash
use mysql_login
run rhost=127.0.0.1 rport=4306 username=root password=password createsession=true
```

MySQL

```bash
use mysql_login
run rhost=127.0.0.1 rport=3306 username=root password=password createsession=true
```


# Verification
- [ ] Start `msfconsole`
- [ ] Run `use smb_login`, `use mysql_login`, `use mssql_login`, `use postgres_login`
- [ ] Run `sessions -i -1`
- [ ] Run a remote command (query/share interactions)
- [ ] **Kill** the session - restart docker container or disconnect VM network adapter
- [ ] **Verify** when running the same command the session now exits
