### PR TITLE
Fix to make arguments not use regex when parsing

### DIFF
--- a/lib/rex/parser/arguments.rb
+++ b/lib/rex/parser/arguments.rb
@@ -175,7 +175,7 @@ module Rex
         short_args.sort_by! { |value| value.downcase }.reverse!
         short_args.each do |short_arg|
           break if compare_arg.empty?
-          if compare_arg.include? short_arg
+          if compare_arg == short_arg
             found_args[arg.index(short_arg)] = short_arg
             compare_arg.gsub!(short_arg, '')
           end


### PR DESCRIPTION
When parsing arguments with Rex::Parser::Arguments it uses a .include? on the string argument so -x would match -mx or anything with a x in the argument as an example.

Attached plugin to demonstrate.

- [ ] Start `msfconsole`
- [ ] `load arg_test`
- [ ] `arg_test -mx -x 555 -md d`


In this example the -mx takes no arguments and -x does.  While parsing the -mx key it matches for the -x key and expects an argument so it uses -x as the argument and the next parse thinks 555 is supposed to be a key.

- [ ] `argtest -md dd -x 555 -mx 666`
This will set the argument for -x to 666 and not set mx.

[arg_test.txt](https://github.com/rapid7/metasploit-framework/files/14623164/arg_test.txt)
.