### PR TITLE
make session query/shares help menu more explicit

### DIFF
--- a/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/sql/ui/console/command_dispatcher/client.rb
@@ -134,19 +134,30 @@ module Rex
               end
 
               def cmd_query(*args)
-                @@query_opts.parse(args) do |opt, idx, val|
+                show_help = false
+                call_interactive = false
+
+                @@query_opts.parse(args) do |opt, _idx, val|
                   case opt
+                  when nil
+                    show_help = true if val == 'help'
+                    break
                   when '-h', '--help'
-                    cmd_query_help
-                    return
+                    show_help = true
+                    break
                   when '-i', '--interact'
-                    cmd_query_interactive
-                    return
+                    call_interactive = true
+                    break
                   end
                 end
 
-                if args.empty?
+                if args.empty? || show_help
                   cmd_query_help
+                  return
+                end
+
+                if call_interactive
+                  cmd_query_interactive
                   return
                 end
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -663,7 +663,7 @@ module DispatcherShell
       str << dispatcher.help_to_s(opts.merge({ command_width: [max_command_length, 12].max }))
     }
 
-    return str
+    return str << "For more info on a specific command, use %grn<command> -h%clr or %grnhelp <command>%clr.\n\n"
   end
 
 


### PR DESCRIPTION
Paired with @ekalinichev-r7 
In response to user acceptance testing, this pr does a couple things:
1) adds references to shares/session -h commands in each session type's `help` command
2) allows use of 'help' with query

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <smb/mssql/postgres/mysql>_login`
- [ ] run CreateSession=true ...
- [ ] Interact with a session you get
- [ ] verify each session's `help` has a reference to `-h` for query/shares and the formatting looks good
- [ ] verify `query help` works the same as `query -h` for SQL sessions

