### PR TITLE
Consistently refer to black hole as two words

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -325,7 +325,7 @@ class DNS
     print_line @@add_opts.usage
     print_line "RESOLVERS:"
     print_line "  ipv4 / ipv6 address - The IP address of an upstream DNS server to resolve from"
-    print_line "  blackhole           - Drop all queries"
+    print_line "  black-hole          - Drop all queries"
     print_line "  static              - Reply with statically configured addresses (only for A/AAAA records)"
     print_line "  system              - Use the host operating systems DNS resolution functionality (only for A/AAAA records)"
     print_line

--- a/lib/msf/ui/console/command_dispatcher/dns.rb
+++ b/lib/msf/ui/console/command_dispatcher/dns.rb
@@ -270,6 +270,7 @@ class DNS
 
         comm = val
       when nil
+        val = 'black-hole' if val.casecmp?('blackhole')
         resolvers << val
       else
         raise ::ArgumentError.new("Unknown flag: #{opt}")
@@ -325,9 +326,9 @@ class DNS
     print_line @@add_opts.usage
     print_line "RESOLVERS:"
     print_line "  ipv4 / ipv6 address - The IP address of an upstream DNS server to resolve from"
-    print_line "  black-hole          - Drop all queries"
-    print_line "  static              - Reply with statically configured addresses (only for A/AAAA records)"
-    print_line "  system              - Use the host operating systems DNS resolution functionality (only for A/AAAA records)"
+    print_line "  #{Rex::Proto::DNS::UpstreamResolver::Type::BLACK_HOLE.to_s.ljust(19)} - Drop all queries"
+    print_line "  #{Rex::Proto::DNS::UpstreamResolver::Type::STATIC.to_s.ljust(19)    } - Reply with statically configured addresses (only for A/AAAA records)"
+    print_line "  #{Rex::Proto::DNS::UpstreamResolver::Type::SYSTEM.to_s.ljust(19)    } - Use the host operating systems DNS resolution functionality (only for A/AAAA records)"
     print_line
     print_line "EXAMPLES:"
     print_line "  Set the DNS server(s) to be used for *.metasploit.com to 192.168.1.10"

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -162,7 +162,7 @@ module DNS
       upstream_resolvers.each do |upstream_resolver|
         case upstream_resolver.type
         when UpstreamResolver::Type::BLACK_HOLE
-          ans = resolve_via_blackhole(upstream_resolver, packet, type, cls)
+          ans = resolve_via_black_hole(upstream_resolver, packet, type, cls)
         when UpstreamResolver::Type::DNS_SERVER
           ans = resolve_via_dns_server(upstream_resolver, packet, type, cls)
         when UpstreamResolver::Type::STATIC
@@ -450,9 +450,9 @@ module DNS
       ans
     end
 
-    def resolve_via_blackhole(upstream_resolver, packet, type, cls)
+    def resolve_via_black_hole(upstream_resolver, packet, type, cls)
       # do not just return nil because that will cause the next resolver to be used
-      @logger.info "No response from upstream resolvers: blackholed"
+      @logger.info "No response from upstream resolvers: black-hole"
       raise NoResponseError
     end
 


### PR DESCRIPTION
Fix a typo in the help menu of the `dns` command.