### PR TITLE
Add user affordance for scanner modules that can create a new session

### DIFF
--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -60,9 +60,9 @@ class MetasploitModule < Msf::Auxiliary
     results = super
     logins = results.flat_map { |_k, v| v[:successful_logins] }
     sessions = results.flat_map { |_k, v| v[:successful_sessions] }
-    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    print_status("Bruteforce completed, #{logins.size} #{logins.size == 1 ? 'credential was' : 'credentials were'} successful.")
     if datastore['CreateSession']
-      print_status("#{sessions.size} MSSQL sessions were opened successfully.")
+      print_status("#{sessions.size} MSSQL #{sessions.size == 1 ? 'session was' : 'sessions were'} opened successfully.")
     else
       print_status('You can open an MSSQL session with these credentials and %grnCreateSession%clr set to true')
     end

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -56,6 +56,19 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def run
+    results = super
+    logins = results.flat_map { |_k, v| v[:successful_logins] }
+    sessions = results.flat_map { |_k, v| v[:successful_sessions] }
+    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    if datastore['CreateSession']
+      print_status("#{sessions.size} MSSQL sessions were opened successfully.")
+    else
+      print_status('You can open an MSSQL session with these credentials and CreateSession set to true')
+    end
+    results
+  end
+
   def run_host(ip)
     print_status("#{rhost}:#{rport} - MSSQL - Starting authentication scanner.")
 
@@ -102,7 +115,8 @@ class MetasploitModule < Msf::Auxiliary
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
     )
-
+    successful_logins = []
+    successful_sessions = []
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -114,11 +128,12 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        successful_logins << result
 
         if create_session?
           begin
             mssql_client = result.proof
-            session_setup(result, mssql_client)
+            successful_sessions << session_setup(result, mssql_client)
           rescue ::StandardError => e
             elog('Failed: ', error: e)
             print_error(e)
@@ -130,6 +145,7 @@ class MetasploitModule < Msf::Auxiliary
         vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
       end
     end
+    { successful_logins: successful_logins, successful_sessions: successful_sessions }
   end
 
   def session_setup(result, client)

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['CreateSession']
       print_status("#{sessions.size} MSSQL sessions were opened successfully.")
     else
-      print_status('You can open an MSSQL session with these credentials and CreateSession set to true')
+      print_status('You can open an MSSQL session with these credentials and %grnCreateSession%clr set to true')
     end
     results
   end

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Auxiliary
     results = super
     logins = results.flat_map { |_k, v| v[:successful_logins] }
     sessions = results.flat_map { |_k, v| v[:successful_sessions] }
-    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    print_status("Bruteforce completed, #{logins.size} #{logins.size == 1 ? 'credential was' : 'credentials were'} successful.")
     if datastore['CreateSession']
-      print_status("#{sessions.size} MySQL sessions were opened successfully.")
+      print_status("#{sessions.size} MySQL #{sessions.size == 1 ? 'session was' : 'sessions were'} opened successfully.")
     else
       print_status('You can open an MySQL session with these credentials and %grnCreateSession%clr set to true')
     end

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -60,6 +60,18 @@ class MetasploitModule < Msf::Auxiliary
     [rhost,rport].join(":")
   end
 
+  def run
+    results = super
+    logins = results.flat_map { |_k, v| v[:successful_logins] }
+    sessions = results.flat_map { |_k, v| v[:successful_sessions] }
+    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    if datastore['CreateSession']
+      print_status("#{sessions.size} MySQL sessions were opened successfully.")
+    else
+      print_status('You can open an MySQL session with these credentials and CreateSession set to true')
+    end
+    results
+  end
 
   def run_host(ip)
     begin
@@ -90,6 +102,8 @@ class MetasploitModule < Msf::Auxiliary
             local_host: datastore['CHOST']
         )
 
+        successful_logins = []
+        successful_sessions = []
         scanner.scan! do |result|
           credential_data = result.to_h
           credential_data.merge!(
@@ -102,11 +116,12 @@ class MetasploitModule < Msf::Auxiliary
             create_credential_login(credential_data)
 
             print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}'"
+            successful_logins << result
 
             if create_session?
               begin
                 mysql_client = result.proof
-                session_setup(result, mysql_client)
+                successful_sessions << session_setup(result, mysql_client)
               rescue ::StandardError => e
                 elog('Failed: ', error: e)
                 print_error(e)
@@ -125,6 +140,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionError, ::EOFError => e
       vprint_error "#{target} - Unable to connect: #{e.to_s}"
     end
+    { successful_logins: successful_logins, successful_sessions: successful_sessions }
   end
 
   # Tmtm's rbmysql is only good for recent versions of mysql, according

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['CreateSession']
       print_status("#{sessions.size} MySQL sessions were opened successfully.")
     else
-      print_status('You can open an MySQL session with these credentials and CreateSession set to true')
+      print_status('You can open an MySQL session with these credentials and %grnCreateSession%clr set to true')
     end
     results
   end

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -68,9 +68,9 @@ class MetasploitModule < Msf::Auxiliary
     results = super
     logins = results.flat_map { |_k, v| v[:successful_logins] }
     sessions = results.flat_map { |_k, v| v[:successful_sessions] }
-    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    print_status("Bruteforce completed, #{logins.size} #{logins.size == 1 ? 'credential was' : 'credentials were'} successful.")
     if datastore['CreateSession']
-      print_status("#{sessions.size} Postgres sessions were opened successfully.")
+      print_status("#{sessions.size} Postgres #{sessions.size == 1 ? 'session was' : 'sessions were'} opened successfully.")
     else
       print_status('You can open a Postgres session with these credentials and %grnCreateSession%clr set to true')
     end

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -64,6 +64,19 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def run
+    results = super
+    logins = results.flat_map { |_k, v| v[:successful_logins] }
+    sessions = results.flat_map { |_k, v| v[:successful_sessions] }
+    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    if datastore['CreateSession']
+      print_status("#{sessions.size} Postgres sessions were opened successfully.")
+    else
+      print_status('You can open a Postgres session with these credentials and CreateSession set to true')
+    end
+    results
+  end
+
   # Loops through each host in turn. Note the current IP address is both
   # ip and datastore['RHOST']
   def run_host(ip)
@@ -85,7 +98,8 @@ class MetasploitModule < Msf::Auxiliary
       framework_module: self,
       use_client_as_proof: create_session?
     )
-
+    successful_logins = []
+    successful_sessions = []
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -98,11 +112,12 @@ class MetasploitModule < Msf::Auxiliary
         create_credential_login(credential_data)
 
         print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        successful_logins << result
 
         if create_session?
           begin
             postgresql_client = result.proof
-            session_setup(result, postgresql_client)
+            successful_sessions << session_setup(result, postgresql_client)
           rescue ::StandardError => e
             elog('Failed: ', error: e)
             print_error(e)
@@ -114,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
         vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
       end
     end
-
+    { successful_logins: successful_logins, successful_sessions: successful_sessions }
   end
 
   # Alias for RHOST

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['CreateSession']
       print_status("#{sessions.size} Postgres sessions were opened successfully.")
     else
-      print_status('You can open a Postgres session with these credentials and CreateSession set to true')
+      print_status('You can open a Postgres session with these credentials and %grnCreateSession%clr set to true')
     end
     results
   end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -88,6 +88,19 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def run
+    results = super
+    logins = results.flat_map { |_k, v| v[:successful_logins] }
+    sessions = results.flat_map { |_k, v| v[:successful_sessions] }
+    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    if datastore['CreateSession']
+      print_status("#{sessions.size} SMB sessions were opened successfully.")
+    else
+      print_status('You can open an SMB session with these credentials and CreateSession set to true')
+    end
+    results
+  end
+
   def run_host(ip)
     print_brute(level: :vstatus, ip: ip, msg: 'Starting SMB login bruteforce')
 
@@ -156,7 +169,8 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = prepend_db_hashes(cred_collection)
 
     @scanner.cred_details = cred_collection
-
+    successful_logins = []
+    successful_sessions = []
     @scanner.scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::LOCKED_OUT
@@ -173,11 +187,12 @@ class MetasploitModule < Msf::Auxiliary
         :next_user
       when Metasploit::Model::Login::Status::SUCCESSFUL
         print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}' #{result.access_level}"
+        successful_logins << result
         report_creds(ip, rport, result)
         if create_session?
           begin
             smb_client = result.proof
-            session_setup(result, smb_client)
+            successful_sessions << session_setup(result, smb_client)
           rescue StandardError => e
             elog('Failed to setup the session', error: e)
             print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
@@ -217,6 +232,7 @@ class MetasploitModule < Msf::Auxiliary
         )
       end
     end
+    { successful_logins: successful_logins, successful_sessions: successful_sessions }
   end
 
   # This logic is not universal ie a local account will not care about workgroup

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -92,9 +92,9 @@ class MetasploitModule < Msf::Auxiliary
     results = super
     logins = results.flat_map { |_k, v| v[:successful_logins] }
     sessions = results.flat_map { |_k, v| v[:successful_sessions] }
-    print_status("Bruteforce completed, #{logins.size} credentials were successful.")
+    print_status("Bruteforce completed, #{logins.size} #{logins.size == 1 ? 'credential was' : 'credentials were'} successful.")
     if datastore['CreateSession']
-      print_status("#{sessions.size} SMB sessions were opened successfully.")
+      print_status("#{sessions.size} SMB #{sessions.size == 1 ? 'session was' : 'sessions were'} opened successfully.")
     else
       print_status('You can open an SMB session with these credentials and %grnCreateSession%clr set to true')
     end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['CreateSession']
       print_status("#{sessions.size} SMB sessions were opened successfully.")
     else
-      print_status('You can open an SMB session with these credentials and CreateSession set to true')
+      print_status('You can open an SMB session with these credentials and %grnCreateSession%clr set to true')
     end
     results
   end


### PR DESCRIPTION
Adding some messaging to the end of scans to tell the user how many credentials and/or sessions were successful
We can potentially flesh this out further in the future by printing out a table of the good creds/created sessions and extending this more broadly to all scanner types but we've limited the scope to just the login modules for the new SMB, and SQL session types for now

# Verification Steps
- [x] Boot up framework
- [x] Use the `smb_login` module
- [x] Perform a single run against a set of hosts with `CreateSession` set to false
- [x] Repeat above but for `CreateSession` set to true
- [x] Verify the output messages are correct (correct number of good creds/sessions etc)
- [x] Repeat for `postgres_login`, `mssql_login` and `mysql_login` 
