### PR TITLE
Remove empty () when no DB selected for sql session prompts

### DIFF
--- a/lib/rex/post/sql/ui/console.rb
+++ b/lib/rex/post/sql/ui/console.rb
@@ -92,7 +92,7 @@ module Rex
           #
           # @return [String]
           def sql_prompt
-            "#{session.type} @ #{client.peerinfo} (#{current_database})"
+            "#{session.type} @ #{client.peerinfo}#{current_database.blank? ? '' : " (#{current_database})"}"
           end
 
           #


### PR DESCRIPTION
Minor improvement to the SQL session prompts that no longer displays empty () when not connected to a specific DB

Before:
```
mysql @ 127.0.0.1:3306 () > query USE information_schema;
[*] Query executed successfully
mysql @ 127.0.0.1:3306 (information_schema) >
```

After:
```
mysql @ 127.0.0.1:3306 > query USE information_schema;
[*] Query executed successfully
mysql @ 127.0.0.1:3306 (information_schema) >
```

# Verification Steps
- [ ] Get a mysql/mssql session
- [ ] verify the prompt doesn't have an empty () in it
- [ ] `use` a db and the prompt should update to have the db name inside the ()'s
- [ ] verify this doesn't affect the prompt of postgres sessions (since they are always connected so should never have a blank database name)