### PR TITLE
adds help command to basic shells

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -203,6 +203,7 @@ Shell Banner:
     end
 
     print(tbl.to_s)
+    print("For more info on a specific command, use %grn<command> -h%clr or %grnhelp <command>%clr.\n\n")
   end
 
   def cmd_background_help


### PR DESCRIPTION
In following with https://github.com/rapid7/metasploit-framework/pull/18973 adds context to basic shell help menu describing how to get help with commands.

To test:

- [ ] get a basic shell session
- [ ] interact with the session
- [ ] `help`
- [ ] make sure it looks nice