### PR TITLE
Fixes store_valid_credential conditional logic for `unix/webapp/wp_admin_shell_upload` module

### DIFF
--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -42,10 +42,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     cookie = wordpress_login(username, password)
     if cookie.nil?
-      store_valid_credential(user: username, private: password, proof: cookie)
       return CheckCode::Safe
     end
 
+    store_valid_credential(user: username, private: password, proof: cookie)
     CheckCode::Appears
   end
 


### PR DESCRIPTION
> [!NOTE]  
This PR fixes https://github.com/rapid7/metasploit-framework/issues/18916

This PR updates the conditional logic for `unix/webapp/wp_admin_shell_upload` module. Previously `store_valid_credential` was added to the wrong conditional branch in https://github.com/rapid7/metasploit-framework/commit/d69bfd509f5822d1d2c3ec3fb5bdc48cbffb9bd4.

The new fix will now return `return CheckCode::Safe` when an invalid login (cookie returns `nil`) is used by the module. `CheckCode::Safe` is return when a target is safe and is therefore not exploitable.
https://github.com/rapid7/metasploit-framework/blob/d64ed33cdf908d0512595a019560e9475cb43c83/lib/msf/core/exploit.rb#L124

When a valid login is used by the module, the module will now store the creds to the database and return `CheckCode::Appears`. `CheckCode::Appears` is return when the target appears to be vulnerable.
https://github.com/rapid7/metasploit-framework/blob/d64ed33cdf908d0512595a019560e9475cb43c83/lib/msf/core/exploit.rb#L136

## Example
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/3cda68cf-f76f-414f-a61d-2fc16150598e)


## Target
Guide I followed: https://github.com/docker/awesome-compose/tree/master/wordpress-mysql
Example file when targeting Wordpress version 4.8.2:

File name: `compose.yaml`

```docker
services:
  db:
    # We use a mariadb image which supports both amd64 & arm64 architecture
    image: mariadb:10.6.4-focal
    # If you really want to use MySQL, uncomment the following line
    #image: mysql:8.0.27
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:4.8.2
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
volumes:
  db_data:
```

Command to run that Docker compose image:
```bash
docker compose up
```

## Verification

- [x] Start `msfconsole`
- [x] `use unix/webapp/wp_admin_shell_upload`
- [x] Get a Wordpress target - see Target section above for setup steps
- [x] **Verify** when a valid login is used that the module returns `The target appears to be vulnerable.` and the creds are added to the DB via the `creds` command
- [x] **Verify** when an invalid login is used that it returns `The target is not exploitable.`
