### PR TITLE
Fix persistent jobs

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -1061,7 +1061,7 @@ class ReadableText
         persist_list.each do |e|
           handler_ctx = framework.jobs[job_id.to_s].ctx[1]
           if handler_ctx && handler_ctx.respond_to?(:datastore)
-             row[7] = 'true' if e['mod_options']['Options'] == handler_ctx.datastore
+            row[7] = 'true' if e['mod_options']['Options'] == handler_ctx.datastore.user_defined.to_h
           end
         end
 

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -134,7 +134,7 @@ module Msf
                 job_list = build_range_array(val)
                 kill_job = true
               when "-K"
-                print_line("Stopping all jobs...")
+                print_status("Stopping all jobs...")
                 framework.jobs.each_key do |i|
                   framework.jobs.stop_job(i)
                 end
@@ -154,7 +154,7 @@ module Msf
                   add_persist_job(job_id)
                 end
               when "-P"
-                print_line("Making all jobs persistent ...")
+                print_status("Making all jobs persistent...")
                 job_list = framework.jobs.map do |k,v|
                   v.jid.to_s
                 end
@@ -257,7 +257,7 @@ module Msf
 
               payload_opts = {
                 'Payload'        => payload.refname,
-                'Options'        => payload.datastore,
+                'Options'        => payload.datastore.user_defined.to_h,
                 'RunAsJob'       => true
               }
 
@@ -275,9 +275,9 @@ module Msf
               File.open(Msf::Config.persist_file,"w") do |file|
                 file.puts(JSON.pretty_generate(persist_list))
               end
-              print_line("Added persistence to job #{job_id}.")
+              print_good("Added persistence to job #{job_id}.")
             else
-              print_line("Invalid Job ID")
+              print_error("Invalid Job ID")
             end
           end
 

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -217,7 +217,7 @@ module Msf
                 if framework.jobs.key?(job)
                   ctx_1 = framework.jobs[job.to_s].ctx[1]
                   next if ctx_1.nil? || !ctx_1.respond_to?(:datastore)  # next if no payload context in the job
-                  payload_option = ctx_1.datastore
+                  payload_option = ctx_1.datastore.user_defined.to_h
                   persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
                 end
               end


### PR DESCRIPTION
The persistent job handler dumps datastore as a string and does not correctly load or start the job.  This commit will dump and load the datastore as a hash for the user_defined values only because it was throwing error for "MeterpreterDebugLogging".

I created an issue yesterday here https://github.com/rapid7/metasploit-framework/issues/18995
## Verification
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set payload linux/x64/meterpreter/reverse_tcp`
- [ ] `set lhost ip`
- [ ] `run -j`
- [ ] `jobs -p job_id`
- [ ] `exit`
- [ ] Start `msfconsole`
- [ ] `jobs`