### PR TITLE
Fix edgecase in Meterpreter job persistence

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -1061,7 +1061,7 @@ class ReadableText
         persist_list.each do |e|
           handler_ctx = framework.jobs[job_id.to_s].ctx[1]
           if handler_ctx && handler_ctx.respond_to?(:datastore)
-             row[7] = 'true' if e['mod_options']['Options'] == handler_ctx.datastore
+             row[7] = 'true' if e['mod_options']['Options'] == handler_ctx.datastore.to_h
           end
         end
 

--- a/lib/msf/base/simple/module.rb
+++ b/lib/msf/base/simple/module.rb
@@ -18,10 +18,14 @@ module Module
   def _import_extra_options(opts)
     # If options were supplied, import them into the payload's
     # datastore
-    if (opts['Options'])
-      self.datastore.import_options_from_hash(opts['Options'])
-    elsif (opts['OptionStr'])
-      self.datastore.import_options_from_s(opts['OptionStr'])
+    if (value = opts['Options'])
+      if value.is_a?(String)
+        self.datastore.import_options_from_s(value)
+      else
+        self.datastore.import_options_from_hash(value)
+      end
+    elsif (value = opts['OptionStr'])
+      self.datastore.import_options_from_s(value)
     end
   end
 

--- a/lib/msf/core/opt_meterpreter_debug_logging.rb
+++ b/lib/msf/core/opt_meterpreter_debug_logging.rb
@@ -39,9 +39,9 @@ module Msf
       result = {}
       errors = []
 
-      return result if value.nil?
+      value = value.to_s.strip
+      return result if value.empty?
 
-      value = value.strip
       # Match 'rpath:./file', 'rpath:/file', and drive letters e.g. 'rpath:C:/file'
       rpath_regex = %r{^rpath:((\.?/\p{ASCII}+)|(\p{ASCII}:/\p{ASCII}+))}i
 

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -213,12 +213,13 @@ module Msf
               end
 
               # Remove persistence by job id.
-              job_list.map(&:to_s).each do |job|
-                if framework.jobs.key?(job)
-                  ctx_1 = framework.jobs[job.to_s].ctx[1]
+              job_list.map(&:to_s).each do |job_id|
+                job_id = job_id.to_i < 0 ? framework.jobs.keys[job_id.to_i] : job_id
+                if framework.jobs.key?(job_id)
+                  ctx_1 = framework.jobs[job_id.to_s].ctx[1]
                   next if ctx_1.nil? || !ctx_1.respond_to?(:datastore)  # next if no payload context in the job
                   payload_option = ctx_1.datastore
-                  persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
+                  persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option.to_h}
                 end
               end
               # Write persist job back to config file.
@@ -257,7 +258,7 @@ module Msf
 
               payload_opts = {
                 'Payload'        => payload.refname,
-                'Options'        => payload.datastore,
+                'Options'        => payload.datastore.to_h,
                 'RunAsJob'       => true
               }
 

--- a/spec/lib/msf/core/opt_meterpreter_debug_logging_spec.rb
+++ b/spec/lib/msf/core/opt_meterpreter_debug_logging_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Msf::OptMeterpreterDebugLogging do
     { value: 'rpath:C:/log.txt', normalized: 'rpath:C:/log.txt' },
     { value: 'rpath:/tmp/log.txt', normalized: 'rpath:/tmp/log.txt' },
     { value: 'rpath:./log.log', normalized: 'rpath:./log.log' },
-    { value: ' rpath:./log.log ', normalized: ' rpath:./log.log ' }
+    { value: ' rpath:./log.log ', normalized: ' rpath:./log.log ' },
+    { value: '', normalized: '' },
+    { value: '  ', normalized: '  ' }
   ]
   invalid_values = [
     { value: 'rpath', normalized: 'rpath' },
@@ -17,4 +19,18 @@ RSpec.describe Msf::OptMeterpreterDebugLogging do
   ]
 
   it_behaves_like 'an option', valid_values, invalid_values, 'meterpreterdebuglogging'
+
+  describe '.parse_logging_options' do
+    [
+      { value: nil, expected: {} },
+      { value: '', expected: {} },
+      { value: '  ', expected: {} },
+      { value: 'rpath:./file', expected: { rpath: './file' } },
+      { value: '  rpath:C:/file  ', expected: { rpath: 'C:/file' } },
+    ].each do |test|
+      it "parses #{test[:value]} as #{test[:expected]}" do
+        expect(described_class.parse_logging_options(test[:value])).to eq test[:expected]
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/18995

## Verification

1. Verify jobs can be persisted

```
use exploit/multi/handler
set payload linux/x64/meterpreter/reverse_tcp
setg lhost ip
run -j
jobs -p job_id
exit
msfconsole
jobs
```

Ensure the job is available on console boot `jobs`

2.  Verify that `jobs -v` correctly detects when a job is persisted
3. Verify that the job is removed from being persisted when using `jobs -k 1` and with a negative index `jobs -k -1`