### PR TITLE
feat(ziglang): add buffer/comment support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.4)
-    rex-text (0.2.56)
+    rex-text (0.2.57)
     rex-zip (0.1.5)
       rex-text
     rexml (3.2.6)

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -69,6 +69,8 @@ module Buffer
         buf = Rex::Text.to_nim(buf)
       when 'rust', 'rustlang'
         buf = Rex::Text.to_rust(buf)
+      when 'zig','ziglang'
+        buf = Rex::Text.to_zig(buf)
       when 'octal'
         buf = Rex::Text.to_octal(buf)
       else
@@ -112,6 +114,8 @@ module Buffer
         buf = Rex::Text.to_nim_comment(buf)
       when 'rust', 'rustlang'
         buf = Rex::Text.to_rust_comment(buf)
+      when 'zig','ziglang'
+        buf = Rex::Text.to_zig_comment(buf)
       else
         raise BufferFormatError, "Unsupported buffer format: #{fmt}", caller
     end
@@ -155,7 +159,8 @@ module Buffer
       'rustlang',
       'sh',
       'vbapplication',
-      'vbscript'
+      'vbscript',
+      'zig'
     ]
   end
 


### PR DESCRIPTION
Adding support for Ziglang output with msfvenom

Requires https://github.com/rapid7/rex-text/pull/69

## Verification

List the steps needed to make sure this thing works

```bash
msfvenom -p linux/x64/meterpreter/reverse_tcp -f zig
```