### PR TITLE
Fixes WMAP plugin loading failures

### DIFF
--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -229,7 +229,10 @@ class Msf::ModuleSet < Hash
       # Custom filtering
       next if (each_module_filter(opts, name, entry) == true)
 
-      block.call(name, self[name])
+      mod = self[name]
+      next if mod.nil?
+
+      block.call(name, mod)
     end
   end
 


### PR DESCRIPTION
> [!NOTE]  
Fixes #18984

This PR fixes an issue where WMAP plugin module loading was causing failures. Some of this functionality was lost in this [PR](https://github.com/rapid7/metasploit-framework/pull/18704). The functionality that was lost was the ability to filter out any modules that weren't created.

The removal of these [lines](https://github.com/rapid7/metasploit-framework/pull/18704/files#diff-b9b1b8534e09a203ec42386d13190e2ed11330cc1a3785b379dc51d57893c44fL41-L45) meant we were no longer filtering out any modules that weren't created: 
```diff
-    # If there is no module associated with this class, then try to demand load it.
-    if klass.nil? or klass == Msf::SymbolicModule
-      framework.modules.load_cached_module(module_type, reference_name, cache_type: cache_type)
-      klass = fetch(reference_name, nil)
-    end
```

So we have no reintroduced that code without the symbolic modules logic.

Expected output:
```
msf6 exploit(unix/webapp/wp_admin_shell_upload) > wmap_run -t
[*] Testing target:
[*] 	Site: 192.168.175.135 (192.168.175.135)
[*] 	Port: 80 SSL: false
============================================================
[*] Testing started. 2024-03-25 09:47:19 +0000
[*] Loading wmap modules...
/Users/cgranleese/code/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py:104: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
/Users/cgranleese/code/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py:124: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
/Users/cgranleese/code/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py:125: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
/Users/cgranleese/code/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py:198: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
/Users/cgranleese/code/metasploit-framework/modules/auxiliary/scanner/http/rdp_web_login.py:214: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
[*] 39 wmap enabled modules loaded.
[*]
=[ SSL testing ]=
============================================================
[*] Target is not SSL. SSL modules disabled.
[*]
=[ Web Server testing ]=
============================================================
[*] Module auxiliary/scanner/http/http_version
[*] Module auxiliary/scanner/http/open_proxy
[*] Module auxiliary/scanner/http/drupal_views_user_enum
[*] Module auxiliary/scanner/http/frontpage_login
[*] Module auxiliary/scanner/http/host_header_injection
[*] Module auxiliary/scanner/http/options
[*] Module auxiliary/scanner/http/robots_txt
[*] Module auxiliary/scanner/http/scraper
[*] Module auxiliary/scanner/http/svn_scanner
[*] Module auxiliary/scanner/http/trace
[*] Module auxiliary/scanner/http/vhost_scanner
[*] Module auxiliary/scanner/http/webdav_internal_ip
[*] Module auxiliary/scanner/http/webdav_scanner
[*] Module auxiliary/admin/http/tomcat_administration
[*] Module auxiliary/scanner/http/webdav_website_content
[*] Module auxiliary/admin/http/tomcat_utf8_traversal
[*]
=[ File/Dir testing ]=
============================================================
[*] Module auxiliary/scanner/http/verb_auth_bypass
[*] Module auxiliary/scanner/http/brute_dirs
[*] Module auxiliary/scanner/http/copy_of_file
[*] Module auxiliary/scanner/http/dir_listing
[*] Module auxiliary/scanner/http/dir_scanner
[*] Module auxiliary/scanner/http/dir_webdav_unicode_bypass
[*] Module auxiliary/scanner/http/file_same_name_dir
[*] Module auxiliary/scanner/http/files_dir
[*] Module auxiliary/scanner/http/http_put
[*] Module auxiliary/scanner/http/ms09_020_webdav_unicode_bypass
[*] Module auxiliary/scanner/http/prev_dir_same_name_file
[*] Module auxiliary/scanner/http/replace_ext
[*] Module auxiliary/scanner/http/soap_xml
[*] Module auxiliary/scanner/http/trace_axd
[*] Module auxiliary/scanner/http/backup_file
[*]
=[ Unique Query testing ]=
============================================================
[*] Module auxiliary/admin/vmware/vcenter_forge_saml_token
[*] Module auxiliary/scanner/http/blind_sql_query
[*] Module auxiliary/scanner/http/error_sql_injection
[*] Module auxiliary/scanner/http/http_traversal
[*] Module auxiliary/scanner/http/rails_mass_assignment
[*] Module exploit/multi/http/lcms_php_exec
[*]
=[ Query testing ]=
============================================================
[*]
=[ General testing ]=
============================================================
[*] Done.
```

## Verification

- [ ] Start `msfconsole`
- [ ] Run `load wmap`
- [ ] Run `wmap_modules -r`
- [ ] **Verify** the errors mentioned in the linked issue no longer appear