### PR TITLE
Don't run check modules in the background

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -71,7 +71,8 @@ module Auxiliary
     run_uuid = Rex::Text.rand_text_alphanumeric(24)
     job_listener.waiting run_uuid
     ctx = [mod, run_uuid, job_listener]
-    if(mod.passive? or opts['RunAsJob'])
+    run_as_job = opts['RunAsJob'].nil? ? mod.passive? : opts['RunAsJob']
+    if run_as_job
       mod.job_id = mod.framework.jobs.start_bg_job(
         "Auxiliary: #{mod.refname}",
         ctx,
@@ -240,4 +241,3 @@ end
 
 end
 end
-

--- a/lib/msf/core/exploit/remote/auto_check.rb
+++ b/lib/msf/core/exploit/remote/auto_check.rb
@@ -41,35 +41,27 @@ module Exploit::Remote::AutoCheck
     warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
     error_msg = '"set ForceExploit true" to override check result.'
 
-    case (checkcode = check)
+    check_code = check
+    case check_code
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
-      print_good(checkcode.message)
-      yield
+      print_good(check_code.message)
+      return yield
     when Exploit::CheckCode::Detected
-      print_warning(checkcode.message)
-      yield
+      print_warning(check_code.message)
+      return yield
     when Exploit::CheckCode::Safe
-      if datastore['ForceExploit']
-        print_warning("#{checkcode.message} #{warning_msg}")
-        return yield
-      end
-
-      fail_with(Module::Failure::NotVulnerable, "#{checkcode.message} #{error_msg}")
+      failure_type = Module::Failure::NotVulnerable
     when Exploit::CheckCode::Unsupported
-      if datastore['ForceExploit']
-        print_warning("#{checkcode.message} #{warning_msg}")
-        return yield
-      end
-
-      fail_with(Module::Failure::BadConfig, "#{checkcode.message} #{error_msg}")
+      failure_type = Module::Failure::BadConfig
     else
-      if datastore['ForceExploit']
-        print_warning("#{checkcode.message} #{warning_msg}")
-        return yield
-      end
-
-      fail_with(Module::Failure::Unknown, "#{checkcode.message} #{error_msg}")
+      failure_type = Module::Failure::Unknown
     end
+
+    if datastore['ForceExploit']
+      print_warning("#{check_code.message} #{warning_msg}")
+      return yield
+    end
+    fail_with(failure_type, "#{check_code.message} #{error_msg}")
   end
 
 end

--- a/lib/msf/core/exploit/remote/check_module.rb
+++ b/lib/msf/core/exploit/remote/check_module.rb
@@ -49,7 +49,8 @@ module Exploit::Remote::CheckModule
     res = mod.run_simple(
       'LocalInput'  => user_input,
       'LocalOutput' => user_output,
-      'Options'     => datastore.merge(check_options)
+      'Options'     => datastore.merge(check_options),
+      'RunAsJob'    => false
     )
 
     # Ensure return value is a CheckCode

--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -3,8 +3,8 @@ module Msf::Module::ModuleInfo
   # CONSTANTS
   #
 
-  # The list of options that support merging in an information hash.
-  UpdateableOptions = [ "Name", "Description", "Alias", "PayloadCompat" ]
+  # The list of options that don't support merging in an information hash.
+  UpdateableOptions = [ "Name", "Description", "Alias", "PayloadCompat" , "Stance"]
 
   #
   # Instance Methods
@@ -224,20 +224,20 @@ module Msf::Module::ModuleInfo
   # platforms, and options.
   #
   def update_info(info, opts)
-    opts.each_pair { |name, val|
+    opts.each_pair do |name, val|
       # If the supplied option name is one of the ones that we should
       # override by default
-      if (UpdateableOptions.include?(name) == true)
+      if UpdateableOptions.include?(name)
         # Only if the entry is currently nil do we use our value
-        if (info[name] == nil)
+        if info[name].nil?
           info[name] = val
         end
-      # Otherwise, perform the merge operation like normal
+        # Otherwise, perform the merge operation like normal
       else
         merge_check_key(info, name, val)
       end
-    }
+    end
 
-    return info
+    info
   end
 end

--- a/spec/support/shared/examples/msf/module/module_info.rb
+++ b/spec/support/shared/examples/msf/module/module_info.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for 'Msf::Module::ModuleInfo' do
         described_class::UpdateableOptions
       }
 
-      it { is_expected.to match_array(%w{Name Description Alias PayloadCompat})}
+      it { is_expected.to match_array(%w{Name Description Alias PayloadCompat Stance})}
     end
   end
 


### PR DESCRIPTION
Resolves #18836 

We're doing two things here, enforcing modules to have a single stance (no more passive aggressive modules) and when running a check module we force it not to run as a job

# Verification steps
- [ ] start msfconsole
- [ ] `use exploit/multi/http/log4shell_header_injection`
- [ ] Verify the linked issue is resolved