### PR TITLE
Add missing Platform to osx/local/persistence module

### DIFF
--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultTarget' => 0,
         'SessionTypes' => [ 'shell', 'meterpreter' ],
-        'DisclosureDate' => '2012-04-01'
+        'DisclosureDate' => '2012-04-01',
+        'Platform' => [ 'osx', 'python', 'unix' ]
       )
     )
 


### PR DESCRIPTION
This PR adds in the missing Platform data to the osx/local/persistence module.
This fixes a small issue I've encountered in Pro where the module was incorrectly suggested for a Windows Meterpreter session, as the `session_compatible?` was only checking for a compatible session `type` (`'meterpreter'`), ignoring the specified platforms in the `Targets` field.

I have used the following session for testing:
```ruby
msf6 exploit(osx/local/persistence) > sessions

Active sessions
===============

  Id  Name  Type                     Information             Connection
  --  ----  ----                     -----------             ----------
  1         meterpreter x64/windows  my_private_account @ DC1  192.168.x.1:8888 -> 192.168.x.3:61577 (192.168.x.3)
```

## Before
```ruby
msf6 exploit(osx/local/persistence) > irb
[*] Starting IRB shell...
[*] You are in exploit/osx/local/persistence

irb: warn: can't alias ls from irb_ls.
>> session_compatible?(1)
=> true
```

## After
```ruby
msf6 payload(windows/x64/meterpreter/reverse_tcp) >
[*] Sending stage (261198 bytes) to 192.168.x.3
[*] Meterpreter session 1 opened (192.168.x.1:8888 -> 192.168.x.3:61577) at 2024-03-25 16:06:06 +0000

msf6 payload(windows/x64/meterpreter/reverse_tcp) > use osx/local/persistence
[*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
msf6 exploit(osx/local/persistence) > irb
[*] Starting IRB shell...
[*] You are in exploit/osx/local/persistence

irb: warn: can't alias ls from irb_ls.
>> session_compatible?(1)
=> false
```

## Verification

- [ ] Start `msfconsole`
- [ ] Get a Windows Meterpreter session
- [ ] `use osx/local/persistence`
- [ ] Go into `irb`
- [ ] Type `session_compatible?(session_id)` where session_id is the id of your Windows Meterpreter session
- [ ] **Verify** it now says false.