### PR TITLE
Allow static DNS hostnames ending in a . to be queried

### DIFF
--- a/lib/rex/proto/dns/static_hostnames.rb
+++ b/lib/rex/proto/dns/static_hostnames.rb
@@ -86,7 +86,7 @@ module DNS
 
       ip_address = IPAddr.new(ip_address) if ip_address.is_a?(String) && Rex::Socket.is_ip_addr?(ip_address)
 
-      hostname = hostname.downcase
+      hostname = hostname.downcase.delete_suffix('.')
       this_host = @hostnames.fetch(hostname, {})
       if ip_address.family == ::Socket::AF_INET
         type = Dnsruby::Types::A


### PR DESCRIPTION
Since #19012 was landed, static hostnames that end in a `.` can be defined which fixed an issue that could prevent Metasploit from starting. Since the query mechanism that static hostnames uses operates on a packet object though, the name will never end in a dot meaning these hostnames can't be queried. This fixes that by deleting any `.` suffix that could be in place as part of the normalization (downcasing).

# Testing

- [ ] Add a static hostname ending in a `.` (e.g. `dns add-static test. 127.1.1.1`)
- [ ] See that it can be queried now, run `dns query test.`
- [ ] See that it can also be queried without the ending `.`, run `dns query test`