### PR TITLE
add better logging for failed logins

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -41,7 +41,16 @@ class MetasploitModule < Msf::Auxiliary
     if session
       set_session(session.client)
     else
-      return unless mssql_login_datastore
+      unless mssql_login_datastore
+        print_error("Error with mssql_login call")
+        info = self.mssql_client.initial_connection_info
+        if info[:errors] && !info[:errors].empty?
+          info[:errors].each do |err|
+            print_error(err)
+          end
+        end
+        return
+      end
     end
 
     technique = datastore['TECHNIQUE']

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -42,7 +42,16 @@ class MetasploitModule < Msf::Auxiliary
     if session
       set_session(session.client)
     else
-      return unless mssql_login_datastore
+      unless mssql_login_datastore
+        print_error("Error with mssql_login call")
+        info = self.mssql_client.initial_connection_info
+        if info[:errors] && !info[:errors].empty?
+          info[:errors].each do |err|
+            print_error(err)
+          end
+        end
+        return
+      end
     end
 
     mssql_query(datastore['SQL'], true)


### PR DESCRIPTION
This adds more detailed error logging to failed runs of mssql_sql and mssql_exec modules, as previously it would just give a generic failed login error without providing the specific issue.
To reproduce, use `mssql_sql` module and try to connect with the `database` option set to something that isn't a real database.
New error:
```
[-] 192.168.2.131:1433 - Error with mssql_login call
[-] 192.168.2.131:1433 - SQL Server Error #4060 (State:1 Severity:11): Cannot open database "MSSQL" requested by the login. The login failed.
[-] 192.168.2.131:1433 - SQL Server Error #18456 (State:1 Severity:14): Login failed for user 'test'.
```

old:
```
[*] Running module against 192.168.2.131
[*] Auxiliary module execution completed
```
