### PR TITLE
Updates `admin/mysql/mysql_enum` to work with newer versions of MySQL

### DIFF
--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -111,10 +111,17 @@ class MetasploitModule < Msf::Auxiliary
     query = "use mysql"
     mysql_query(query)
 
+    # Starting from MySQL 5.7, the 'password' column was changed to 'authentication_string'.
+    if vparm['version'][0..2].to_f > 5.6
+      password_field = 'authentication_string'
+    else
+      password_field = 'password'
+    end
+
     # Account Enumeration
     # Enumerate all accounts with their password hashes
     print_status("Enumerating Accounts:")
-    query = "select user, host, password from mysql.user"
+    query = "select user, host, #{password_field} from mysql.user"
     res = mysql_query(query)
     if res and res.size > 0
       print_status("\tList of Accounts with Password Hashes:")
@@ -229,7 +236,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Blank Password Check
-    queryblankpass = "select user, host, password from mysql.user where length(password) = 0 or password is null"
+    queryblankpass = "select user, host, #{password_field} from mysql.user where length(#{password_field}) = 0 or #{password_field} is null"
     res = mysql_query(queryblankpass)
     if res and res.size > 0
       print_status("\tThe following accounts have empty passwords:")


### PR DESCRIPTION
> [!NOTE]
Another [PR](https://github.com/rapid7/metasploit-framework/pull/19014) relies on these changes, as it contains fixes that will allow the acceptance tests to pass within that PR.

This PR fixes an issue where MySQL versions before MySQL 5.7 had access to the `password` field. Whereas after MySQL 5.7 this was rename to `authentication_string`. I have updated the module to now check the version and use the appropriate field.

## Testing
- mariadb:latest
- mariadb:5.5.42
- mysql:latest
- mysql:5.5.42

Docker command:
```
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 9000:3306 mysql:latest
```

msfconsole commands
```bash
use mysql_login
run rhost=127.0.0.1 rport=9000 username=root password=password createsession=true
```

## Before
```
msf6 auxiliary(admin/mysql/mysql_enum) > run session=-1

[*] Using existing session 1
[*] Running MySQL Enumerator...
[*] Enumerating Parameters
...
[*] 127.0.0.1:9001 MySQL - querying with 'use mysql'
[*] Enumerating Accounts:
[-] MySQL Error: Mysql::ServerError::BadFieldError Unknown column 'password' in 'field list' <------- ERROR
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host, ssl_type from mysql.user where
        (ssl_type = 'ANY') or
        (ssl_type = 'X509') or
        (ssl_type = 'SPECIFIED')'
...
[*] 	The following accounts have privileges to the mysql database:
[*] 		User: root Host: %
[*] 		User: mysql.infoschema Host: localhost
[*] 		User: root Host: localhost
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where user = '''
[-] MySQL Error: Mysql::ServerError::BadFieldError Unknown column 'password' in 'field list'  <------- ERROR
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where host = "%"'
[*] 	The following accounts are not restricted by source:
[*] 		User: root Host: %
[*] Auxiliary module execution completed
```
## After
```
msf6 auxiliary(admin/mysql/mysql_enum) > run session=6

[*] Using existing session 6
[*] Running MySQL Enumerator...
[*] Enumerating Parameters
...
[*] Enumerating Accounts:
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host, authentication_string from mysql.user'
[*] 	List of Accounts with Password Hashes: <------- NO ERROR
[+] 		User: root Host: % Password Hash: $A$005$I,C24p.WzaVobWTFd6RUersMZ0P6jVKdDQnIU3U3njHCyEOULxDA5We1
[!] No active DB -- Credential data will not be saved!
[+] 		User: mysql.infoschema Host: localhost Password Hash: $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED
[+] 		User: mysql.session Host: localhost Password Hash: $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED
[+] 		User: mysql.sys Host: localhost Password Hash: $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED
[+] 		User: root Host: localhost Password Hash: $A$005$rTdl3),3%+J!89"UrWFABvtyQM1TNcy5Ot1iaYdZ4Jkm1Zf9kcwDKEIqaj4
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host, ssl_type from mysql.user where
        (ssl_type = 'ANY') or
        (ssl_type = 'X509') or
        (ssl_type = 'SPECIFIED')'
...
[*] 	The following accounts have privileges to the mysql database:
[*] 		User: root Host: %
[*] 		User: mysql.infoschema Host: localhost
[*] 		User: root Host: localhost
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where user = '''
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host, authentication_string from mysql.user where <-- NO ERROR
length(authentication_string) = 0 or authentication_string is null'
[*] 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where host = "%"'
[*] 	The following accounts are not restricted by source:
[*] 		User: root Host: %
[*] Auxiliary module execution completed
```

<details>
  <summary>Click me</summary>

### Full output for all 4 test targets

#### mysql:latest
```
msf6 auxiliary(admin/mysql/mysql_enum) > run rhost=127.0.0.1 rport=9001 username=root password=password createsession=true
[*] Running module against 127.0.0.1

[+] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - Logged in to '' with 'root':'password'
[*] 127.0.0.1:9001 - Running MySQL Enumerator...
[*] 127.0.0.1:9001 - Enumerating Parameters
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'show variables'
[*] 127.0.0.1:9001 - 	MySQL Version: 8.3.0
[*] 127.0.0.1:9001 - 	Compiled for the following OS: Linux
[*] 127.0.0.1:9001 - 	Architecture: x86_64
[*] 127.0.0.1:9001 - 	Server Hostname: f12f518d8635
[*] 127.0.0.1:9001 - 	Data Directory: /var/lib/mysql/
[*] 127.0.0.1:9001 - 	Logging of queries and logins: ON
[*] 127.0.0.1:9001 - 	Log Files Location: ON
[*] 127.0.0.1:9001 - 	Old Password Hashing Algorithm
[*] 127.0.0.1:9001 - 	Loading of local files: OFF
[*] 127.0.0.1:9001 - 	Deny logins with old Pre-4.1 Passwords:
[*] 127.0.0.1:9001 - 	Allow Use of symlinks for Database Files: DISABLED
[*] 127.0.0.1:9001 - 	Allow Table Merge:
[*] 127.0.0.1:9001 - 	SSL Connections: Enabled
[*] 127.0.0.1:9001 - 	SSL CA Certificate: ca.pem
[*] 127.0.0.1:9001 - 	SSL Key: server-key.pem
[*] 127.0.0.1:9001 - 	SSL Certificate: server-cert.pem
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'use mysql'
[*] 127.0.0.1:9001 - Enumerating Accounts:
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host, authentication_string from mysql.user'
[*] 127.0.0.1:9001 - 	List of Accounts with Password Hashes:
[+] 127.0.0.1:9001 - 		User: root Host: % Password Hash: $A$005$I,C24p.WzaVobWTFd6RUersMZ0P6jVKdDQnIU3U3njHCyEOULxDA5We1
[+] 127.0.0.1:9001 - 		User: mysql.infoschema Host: localhost Password Hash: $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED
[+] 127.0.0.1:9001 - 		User: mysql.session Host: localhost Password Hash: $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED
[+] 127.0.0.1:9001 - 		User: mysql.sys Host: localhost Password Hash: $A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED
[+] 127.0.0.1:9001 - 		User: root Host: localhost Password Hash: $A$005$rTdl3),3%+J!89"UrWFABvtyQM1TNcy5Ot1iaYdZ4Jkm1Zf9kcwDKEIqaj4
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host, ssl_type from mysql.user where
        (ssl_type = 'ANY') or
        (ssl_type = 'X509') or
        (ssl_type = 'SPECIFIED')'
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where Grant_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have GRANT Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where Create_user_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have CREATE USER Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where Reload_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have RELOAD Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where Shutdown_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have SHUTDOWN Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: mysql.session Host: localhost
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where Super_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have SUPER Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: mysql.session Host: localhost
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where FILE_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have FILE Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where Process_priv = 'Y''
[*] 127.0.0.1:9001 - 	The following users have PROCESS Privilege:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with '       select user, host
        from mysql.user where
        (Select_priv = 'Y') or
        (Insert_priv = 'Y') or
        (Update_priv = 'Y') or
        (Delete_priv = 'Y') or
        (Create_priv = 'Y') or
        (Drop_priv = 'Y')'
[*] 127.0.0.1:9001 - 	The following accounts have privileges to the mysql database:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 		User: mysql.infoschema Host: localhost
[*] 127.0.0.1:9001 - 		User: root Host: localhost
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where user = '''
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host, authentication_string from mysql.user where length(authentication_string) = 0 or authentication_string is null'
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - querying with 'select user, host from mysql.user where host = "%"'
[*] 127.0.0.1:9001 - 	The following accounts are not restricted by source:
[*] 127.0.0.1:9001 - 		User: root Host: %
[*] 127.0.0.1:9001 - 127.0.0.1:9001 MySQL - Disconnected
[*] Auxiliary module execution completed
```

#### mariadb:latest
```
msf6 auxiliary(admin/mysql/mysql_enum) > run rhost=127.0.0.1 rport=9002 username=root password=password createsession=true
[*] Running module against 127.0.0.1

[+] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - Logged in to '' with 'root':'password'
[*] 127.0.0.1:9002 - Running MySQL Enumerator...
[*] 127.0.0.1:9002 - Enumerating Parameters
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'show variables'
[*] 127.0.0.1:9002 - 	MySQL Version: 11.2.2-MariaDB-1:11.2.2+maria~ubu2204
[*] 127.0.0.1:9002 - 	Compiled for the following OS: debian-linux-gnu
[*] 127.0.0.1:9002 - 	Architecture: x86_64
[*] 127.0.0.1:9002 - 	Server Hostname: 483814d22a22
[*] 127.0.0.1:9002 - 	Data Directory: /var/lib/mysql/
[*] 127.0.0.1:9002 - 	Logging of queries and logins: ON
[*] 127.0.0.1:9002 - 	Log Files Location: OFF
[*] 127.0.0.1:9002 - 	Old Password Hashing Algorithm OFF
[*] 127.0.0.1:9002 - 	Loading of local files: ON
[*] 127.0.0.1:9002 - 	Deny logins with old Pre-4.1 Passwords: ON
[*] 127.0.0.1:9002 - 	Skipping of GRANT TABLE: OFF
[*] 127.0.0.1:9002 - 	Allow Use of symlinks for Database Files: YES
[*] 127.0.0.1:9002 - 	Allow Table Merge:
[*] 127.0.0.1:9002 - 	SSL Connections: Enabled
[*] 127.0.0.1:9002 - 	SSL CA Certificate:
[*] 127.0.0.1:9002 - 	SSL Key:
[*] 127.0.0.1:9002 - 	SSL Certificate:
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'use mysql'
[*] 127.0.0.1:9002 - Enumerating Accounts:
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host, authentication_string from mysql.user'
[*] 127.0.0.1:9002 - 	List of Accounts with Password Hashes:
[+] 127.0.0.1:9002 - 		User: mariadb.sys Host: localhost Password Hash:
[+] 127.0.0.1:9002 - 		User: root Host: localhost Password Hash: *2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19
[+] 127.0.0.1:9002 - 		User: root Host: % Password Hash: *2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19
[+] 127.0.0.1:9002 - 		User: healthcheck Host: 127.0.0.1 Password Hash: *648ED762D7DF9345E971BDC57E685B1783CDBE9F
[+] 127.0.0.1:9002 - 		User: healthcheck Host: ::1 Password Hash: *648ED762D7DF9345E971BDC57E685B1783CDBE9F
[+] 127.0.0.1:9002 - 		User: healthcheck Host: localhost Password Hash: *648ED762D7DF9345E971BDC57E685B1783CDBE9F
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host, ssl_type from mysql.user where
        (ssl_type = 'ANY') or
        (ssl_type = 'X509') or
        (ssl_type = 'SPECIFIED')'
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where Grant_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have GRANT Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where Create_user_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have CREATE USER Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where Reload_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have RELOAD Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where Shutdown_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have SHUTDOWN Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where Super_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have SUPER Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where FILE_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have FILE Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where Process_priv = 'Y''
[*] 127.0.0.1:9002 - 	The following users have PROCESS Privilege:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with '       select user, host
        from mysql.user where
        (Select_priv = 'Y') or
        (Insert_priv = 'Y') or
        (Update_priv = 'Y') or
        (Delete_priv = 'Y') or
        (Create_priv = 'Y') or
        (Drop_priv = 'Y')'
[*] 127.0.0.1:9002 - 	The following accounts have privileges to the mysql database:
[*] 127.0.0.1:9002 - 		User: root Host: localhost
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where user = '''
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host, authentication_string from mysql.user where length(authentication_string) = 0 or authentication_string is null'
[*] 127.0.0.1:9002 - 	The following accounts have empty passwords:
[*] 127.0.0.1:9002 - 		User: mariadb.sys Host: localhost
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - querying with 'select user, host from mysql.user where host = "%"'
[*] 127.0.0.1:9002 - 	The following accounts are not restricted by source:
[*] 127.0.0.1:9002 - 		User: root Host: %
[*] 127.0.0.1:9002 - 127.0.0.1:9002 MySQL - Disconnected
[*] Auxiliary module execution completed
```
#### mysql:5.5.42
```
msf6 auxiliary(admin/mysql/mysql_enum) > run rhost=127.0.0.1 rport=9003 username=root password=password createsession=true
[*] Running module against 127.0.0.1

[+] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - Logged in to '' with 'root':'password'
[*] 127.0.0.1:9003 - Running MySQL Enumerator...
[*] 127.0.0.1:9003 - Enumerating Parameters
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'show variables'
[*] 127.0.0.1:9003 - 	MySQL Version: 5.5.42
[*] 127.0.0.1:9003 - 	Compiled for the following OS: linux2.6
[*] 127.0.0.1:9003 - 	Architecture: x86_64
[*] 127.0.0.1:9003 - 	Server Hostname: bebaf2b70399
[*] 127.0.0.1:9003 - 	Data Directory: /var/lib/mysql/
[*] 127.0.0.1:9003 - 	Logging of queries and logins: OFF
[*] 127.0.0.1:9003 - 	Old Password Hashing Algorithm OFF
[*] 127.0.0.1:9003 - 	Loading of local files: ON
[*] 127.0.0.1:9003 - 	Deny logins with old Pre-4.1 Passwords: OFF
[*] 127.0.0.1:9003 - 	Allow Use of symlinks for Database Files: YES
[*] 127.0.0.1:9003 - 	Allow Table Merge:
[*] 127.0.0.1:9003 - 	SSL Connection: DISABLED
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'use mysql'
[*] 127.0.0.1:9003 - Enumerating Accounts:
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host, password from mysql.user'
[*] 127.0.0.1:9003 - 	List of Accounts with Password Hashes:
[+] 127.0.0.1:9003 - 		User: root Host: % Password Hash: *2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where Grant_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have GRANT Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where Create_user_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have CREATE USER Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where Reload_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have RELOAD Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where Shutdown_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have SHUTDOWN Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where Super_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have SUPER Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where FILE_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have FILE Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where Process_priv = 'Y''
[*] 127.0.0.1:9003 - 	The following users have PROCESS Privilege:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with '       select user, host
        from mysql.user where
        (Select_priv = 'Y') or
        (Insert_priv = 'Y') or
        (Update_priv = 'Y') or
        (Delete_priv = 'Y') or
        (Create_priv = 'Y') or
        (Drop_priv = 'Y')'
[*] 127.0.0.1:9003 - 	The following accounts have privileges to the mysql database:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where user = '''
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host, password from mysql.user where length(password) = 0 or password is null'
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - querying with 'select user, host from mysql.user where host = "%"'
[*] 127.0.0.1:9003 - 	The following accounts are not restricted by source:
[*] 127.0.0.1:9003 - 		User: root Host: %
[*] 127.0.0.1:9003 - 127.0.0.1:9003 MySQL - Disconnected
[*] Auxiliary module execution completed
```
#### mariadb:5.5.42
```
msf6 auxiliary(admin/mysql/mysql_enum) > run rhost=127.0.0.1 rport=9004 username=root password=password createsession=true
[*] Running module against 127.0.0.1

[+] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - Logged in to '' with 'root':'password'
[*] 127.0.0.1:9004 - Running MySQL Enumerator...
[*] 127.0.0.1:9004 - Enumerating Parameters
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'show variables'
[*] 127.0.0.1:9004 - 	MySQL Version: 5.5.42-MariaDB-1~wheezy-log
[*] 127.0.0.1:9004 - 	Compiled for the following OS: debian-linux-gnu
[*] 127.0.0.1:9004 - 	Architecture: x86_64
[*] 127.0.0.1:9004 - 	Server Hostname: 69c9c8e8b280
[*] 127.0.0.1:9004 - 	Data Directory: /var/lib/mysql/
[*] 127.0.0.1:9004 - 	Logging of queries and logins: OFF
[*] 127.0.0.1:9004 - 	Old Password Hashing Algorithm OFF
[*] 127.0.0.1:9004 - 	Loading of local files: ON
[*] 127.0.0.1:9004 - 	Deny logins with old Pre-4.1 Passwords: OFF
[*] 127.0.0.1:9004 - 	Allow Use of symlinks for Database Files: YES
[*] 127.0.0.1:9004 - 	Allow Table Merge:
[*] 127.0.0.1:9004 - 	SSL Connection: DISABLED
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'use mysql'
[*] 127.0.0.1:9004 - Enumerating Accounts:
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host, password from mysql.user'
[*] 127.0.0.1:9004 - 	List of Accounts with Password Hashes:
[+] 127.0.0.1:9004 - 		User: root Host: % Password Hash: *2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where Grant_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have GRANT Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where Create_user_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have CREATE USER Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where Reload_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have RELOAD Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where Shutdown_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have SHUTDOWN Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where Super_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have SUPER Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where FILE_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have FILE Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where Process_priv = 'Y''
[*] 127.0.0.1:9004 - 	The following users have PROCESS Privilege:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with '       select user, host
        from mysql.user where
        (Select_priv = 'Y') or
        (Insert_priv = 'Y') or
        (Update_priv = 'Y') or
        (Delete_priv = 'Y') or
        (Create_priv = 'Y') or
        (Drop_priv = 'Y')'
[*] 127.0.0.1:9004 - 	The following accounts have privileges to the mysql database:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where user = '''
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host, password from mysql.user where length(password) = 0 or password is null'
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - querying with 'select user, host from mysql.user where host = "%"'
[*] 127.0.0.1:9004 - 	The following accounts are not restricted by source:
[*] 127.0.0.1:9004 - 		User: root Host: %
[*] 127.0.0.1:9004 - 127.0.0.1:9004 MySQL - Disconnected
[*] Auxiliary module execution completed
```
</details>

## Verification

- [ ] Start `msfconsole`
- [ ] Follow testing steps above to get a MySQL session
- [ ] Verify the errors are no longer appearing
- [ ] Repeat for each target listed within testing section
