### PR TITLE
Add MySQL Arch & Platform detection by query

### DIFF
--- a/lib/msf/base/sessions/mysql.rb
+++ b/lib/msf/base/sessions/mysql.rb
@@ -8,6 +8,8 @@ class Msf::Sessions::MySQL < Msf::Sessions::Sql
   # @param [Hash] opts
   def initialize(rstream, opts = {})
     @client = opts.fetch(:client)
+    self.platform = opts.fetch(:platform)
+    self.arch = opts.fetch(:arch)
     self.console = ::Rex::Post::MySQL::Ui::Console.new(self)
     super(rstream, opts)
   end

--- a/lib/rex/proto/mysql/client.rb
+++ b/lib/rex/proto/mysql/client.rb
@@ -28,6 +28,67 @@ module Rex
           # Current database is stored as an array under the type 1 key.
           session_track.fetch(1, ['']).first
         end
+
+        # List of supported MySQL platforms & architectures:
+        # https://www.mysql.com/support/supportedplatforms/database.html
+        def map_compile_os_to_platform(compile_os)
+          return Msf::Platform::Unknown.realname if compile_os.blank?
+
+          compile_os = compile_os.downcase.encode(::Encoding::BINARY)
+
+          if compile_os.match?('linux')
+            platform = Msf::Platform::Linux
+          elsif compile_os.match?('unix')
+            platform = Msf::Platform::Unix
+          elsif compile_os.match?(/(darwin|mac|osx)/)
+            platform = Msf::Platform::OSX
+          elsif compile_os.match?('win')
+            platform = Msf::Platform::Windows
+          elsif compile_os.match?('solaris')
+            platform = Msf::Platform::Solaris
+          else
+            platform = Msf::Platform::Unknown
+          end
+
+          platform.realname
+        end
+
+        def map_compile_arch_to_architecture(compile_arch)
+          return '' if compile_arch.blank?
+
+          compile_arch = compile_arch.downcase.encode(::Encoding::BINARY)
+
+          if compile_arch.match?('sparc')
+            if compile_arch.include?('64')
+              arch = ARCH_SPARC64
+            else
+              arch = ARCH_SPARC
+            end
+          elsif compile_arch.match?('arm')
+            arch = ARCH_AARCH64
+          elsif compile_arch.match?('64')
+            arch = ARCH_X86_64
+          elsif compile_arch.match?('86') || compile_arch.match?('i686')
+            arch = ARCH_X86
+          else
+            arch = ''
+          end
+
+          arch
+        end
+
+        # @return [Hash] Detect the platform and architecture of the MySQL server:
+        #  * :arch [String] The server architecture.
+        #  * :platform [String] The server platform.
+        def detect_platform_and_arch
+          result = {}
+
+          server_vars = query("show variables where variable_name in ('version_compile_machine', 'version_compile_os')").entries.to_h
+          result[:arch] = map_compile_arch_to_architecture(server_vars['version_compile_machine'])
+          result[:platform] = map_compile_os_to_platform(server_vars['version_compile_os'])
+
+          result
+        end
       end
     end
   end

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Auxiliary
   def session_setup(result)
     return unless (result.connection && result.proof)
 
-    my_session = Msf::Sessions::MySQL.new(result.connection, { client: result.proof })
+    my_session = Msf::Sessions::MySQL.new(result.connection, { client: result.proof, **result.proof.detect_platform_and_arch })
     merge_me = {
       'USERPASS_FILE' => nil,
       'USER_FILE'     => nil,

--- a/spec/lib/msf/base/sessions/mysql_spec.rb
+++ b/spec/lib/msf/base/sessions/mysql_spec.rb
@@ -5,7 +5,7 @@ require 'rex/proto/mysql/client'
 
 RSpec.describe Msf::Sessions::MySQL do
   let(:client) { instance_double(::Rex::Proto::MySQL::Client) }
-  let(:opts) { { client: client } }
+  let(:opts) { { client: client, platform: Msf::Platform::Linux.realname, arch: ARCH_X86_64 } }
   let(:console_class) { Rex::Post::MySQL::Ui::Console }
   let(:user_input) { instance_double(Rex::Ui::Text::Input::Readline) }
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }

--- a/spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mysql/ui/console/command_dispatcher/core_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Rex::Post::MySQL::Ui::Console::CommandDispatcher::Core do
   let(:address) { '192.0.2.1' }
   let(:port) { '3306' }
   let(:peerinfo) { "#{address}:#{port}" }
-  let(:session) { Msf::Sessions::MySQL.new(nil, { client: client }) }
+  let(:session) { Msf::Sessions::MySQL.new(nil, { client: client, platform: Msf::Platform::Linux.realname, arch: ARCH_X86_64 }) }
   let(:console) do
     console = Rex::Post::MySQL::Ui::Console.new(session)
     console.disable_output = true

--- a/spec/lib/rex/proto/mysql/client_spec.rb
+++ b/spec/lib/rex/proto/mysql/client_spec.rb
@@ -32,4 +32,49 @@ RSpec.describe Rex::Proto::MySQL::Client do
       end
     end
   end
+
+  describe '#map_compile_os_to_platform' do
+    [
+      { info: 'linux', expected: Msf::Platform::Linux.realname },
+      { info: 'linux2.6', expected: Msf::Platform::Linux.realname },
+      { info: 'debian-linux-gnu', expected: Msf::Platform::Linux.realname },
+      { info: 'win', expected: Msf::Platform::Windows.realname },
+      { info: 'windows', expected: Msf::Platform::Windows.realname },
+      { info: 'darwin', expected: Msf::Platform::OSX.realname },
+      { info: 'osx', expected: Msf::Platform::OSX.realname },
+      { info: 'macos', expected: Msf::Platform::OSX.realname },
+      { info: 'unix', expected: Msf::Platform::Unix.realname },
+      { info: 'solaris', expected: Msf::Platform::Solaris.realname },
+      { info: '', expected: Msf::Platform::Unknown.realname },
+      { info: 'blank', expected: Msf::Platform::Unknown.realname },
+      { info: nil, expected: Msf::Platform::Unknown.realname },
+    ].each do |test|
+      it "correctly identifies '#{test[:info]}' as '#{test[:expected]}'" do
+        expect(subject.map_compile_os_to_platform(test[:info])).to eq(test[:expected])
+      end
+    end
+  end
+
+  describe '#map_compile_arch_to_architecture' do
+    [
+      { info: 'x86_64', expected: ARCH_X86_64 },
+      { info: 'x86_x64', expected: ARCH_X86_64 },
+      { info: 'x64', expected: ARCH_X86_64 },
+      { info: '64', expected: ARCH_X86_64 },
+      { info: 'x86', expected: ARCH_X86 },
+      { info: '86', expected: ARCH_X86 },
+      { info: 'i686', expected: ARCH_X86 },
+      { info: 'arm64', expected: ARCH_AARCH64 },
+      { info: 'arm', expected: ARCH_AARCH64 },
+      { info: 'sparc', expected: ARCH_SPARC },
+      { info: 'sparc64', expected: ARCH_SPARC64 },
+      { info: '', expected: '' },
+      { info: 'blank', expected: '' },
+      { info: nil, expected: '' },
+    ].each do |test|
+      it "correctly identifies '#{test[:info]}' as '#{test[:expected]}'" do
+        expect(subject.map_compile_arch_to_architecture(test[:info])).to eq(test[:expected])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds in the ability to detect the MySQL server's host's platform and arch by running a query.

In the future, this should instead be gathered from the initial server connection info similar to MSSQL's ENVCHANGE and `initial_connection_info`. However I wasn't able to verify this information in WireShark as the data is encrypted, even if the `SSL` option is set to false:
<img width="1546" alt="image" src="https://github.com/rapid7/metasploit-framework/assets/85949464/8c3cc6cc-2b90-4bc9-8109-4b01a26dbd1c">
In the above image, the initial MySQL connection receives an error 1158, `Got an error reading communication packets`. The second connection request is successful, but encrypted using TLS.

## Before
```
msf6 auxiliary(scanner/mysql/mysql_login) > sessions

Active sessions
===============

  Id  Name  Type   Information                  Connection
  --  ----  ----   -----------                  ----------
  1         mysql  MySQL root @ 127.0.0.1:3306  127.0.0.1:64696 -> 127.0.0.1:3306 (127.0.0.1)
  2         mysql  MySQL root @ 127.0.0.1:4306  127.0.0.1:64698 -> 127.0.0.1:4306 (127.0.0.1)
```

## After
```
msf6 auxiliary(scanner/mysql/mysql_login) > sessions

Active sessions
===============

  Id  Name  Type                           Information                  Connection
  --  ----  ----                           -----------                  ----------
  8         mysql x86_64/Linux             MySQL root @ 127.0.0.1:3306  127.0.0.1:64569 -> 127.0.0.1:3306 (127.0.0.1)
  9         mysql x86_64/debian-linux-gnu  MySQL root @ 127.0.0.1:4306  127.0.0.1:64631 -> 127.0.0.1:4306 (127.0.0.1)

```

Confirming we get the correct platform from the string:
```ruby
>> framework.sessions[1].platform
=> "debian-linux-gnu"
>> Msf::Platform.find_platform(framework.sessions[1].platform)
=> Msf::Module::Platform::Linux
```

## Verification

Get yourself a MySQL Docker container:
```
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 3306:3306 mysql:8.3.0
```
and MariaDB:
```
docker run -it --rm -e MYSQL_ROOT_PASSWORD='password' -p 4306:3306 mariadb:11.2.2
```

- [x] Start `msfconsole`
- [x] `use mysql_login`
- [x] `run rhost={...} etc.`
- [x] **Verify** that `sessions` returns you a MySQL Linux x86_64 session.
- [x] **Verify** that targeting a MariaDB server results in an x86_64 debian-linux-gnu platform, but you can call `Msf::Module::Platform.find_platform(framework.sessions[session_id_here].platform)` and that it returns Linux.