### PR TITLE
Extra ',' is causing ruby issues

### DIFF
--- a/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
+++ b/modules/exploits/multi/http/apache_couchdb_erlang_rce.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
         }
-      ),
+      )
     )
 
     register_options(


### PR DESCRIPTION
The rb file has an extra `,` between two `)...)` - newer versions of Ruby treat this as an error