### PR TITLE
Jsherwood0 update apache_rocketmq_update_config.rb to eliminate hang on check

### DIFF
--- a/modules/exploits/multi/http/apache_rocketmq_update_config.rb
+++ b/modules/exploits/multi/http/apache_rocketmq_update_config.rb
@@ -71,14 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      ::Timeout.timeout(datastore['ConnectTimeout']) do
-        @version_request_response = send_version_request
-      end
-    rescue => e
-      @version_request_response = nil
-      return Exploit::CheckCode::Unknown('Error #{e.message}')
+    ::Timeout.timeout(datastore['ConnectTimeout']) do
+      @version_request_response = send_version_request
     end
+
     @parsed_data = parse_rocketmq_data(@version_request_response)
     return Exploit::CheckCode::Unknown('RocketMQ did not respond to the request for version information') unless @parsed_data['version']
 

--- a/modules/exploits/multi/http/apache_rocketmq_update_config.rb
+++ b/modules/exploits/multi/http/apache_rocketmq_update_config.rb
@@ -71,7 +71,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    @version_request_response = send_version_request
+    begin
+      ::Timeout.timeout(datastore['ConnectTimeout']) do
+        @version_request_response = send_version_request
+      end
+    rescue => e
+      @version_request_response = nil
+      return Exploit::CheckCode::Unknown('Error #{e.message}')
+    end
     @parsed_data = parse_rocketmq_data(@version_request_response)
     return Exploit::CheckCode::Unknown('RocketMQ did not respond to the request for version information') unless @parsed_data['version']
 


### PR DESCRIPTION
Add a timeout to eliminate the hang in the check method

This fix is to ensure that if all else fails, the check will timeout and allow progress to continue instead of hanging on a host that does not reply as expected. This addresses Issue #19035.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/apache_rocketmq_update_config`
- [ ] Set RHOSTS and RPORT to host/port that is not responding as RocketMQ should (e.g., it's down or its not RocketMQ)
- [ ] `check`
- [ ] **Verify** that the check will eventually time out even if it does not receive an expected RocketMQ response.
- [ ] **Verify** that the check does not hang on servers that fail to respond as expected.
