### PR TITLE
Don't close sockets that we're using for sessions

### DIFF
--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -82,6 +82,7 @@ module Metasploit
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
               if use_client_as_proof
                 result_options[:proof] = client
+                result_options[:connection] = client.sock
               else
                 client.disconnect
               end

--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -37,7 +37,7 @@ module Metasploit
           begin
             # manage our behind the scenes socket. Close any existing one and open a new one
             disconnect if self.sock
-            self.sock = connect
+            connect
 
             mysql_conn = ::Rex::Proto::MySQL::Client.connect(host, credential.public, credential.private, '', port, io: self.sock)
 
@@ -75,7 +75,8 @@ module Metasploit
             # Additionally assign values to nil to avoid closing the socket etc automatically
             if use_client_as_proof
               result_options[:proof] = mysql_conn
-              nil
+              result_options[:connection] = self.sock
+              self.sock = nil
             else
               mysql_conn.close
             end

--- a/lib/metasploit/framework/login_scanner/postgres.rb
+++ b/lib/metasploit/framework/login_scanner/postgres.rb
@@ -80,7 +80,7 @@ module Metasploit
             # Additionally assign values to nil to avoid closing the socket etc automatically
             if use_client_as_proof
               result_options[:proof] = pg_conn
-              pg_conn = nil
+              result_options[:connection] = pg_conn.conn
             else
               pg_conn.close
             end

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -152,6 +152,7 @@ module Metasploit
               # Additionally assign values to nil to avoid closing the socket etc automatically
               if use_client_as_proof
                 proof = client
+                connection = self.sock
                 client = nil
                 self.sock = nil
                 self.dispatcher = nil
@@ -184,7 +185,11 @@ module Metasploit
             access_level ||= AccessLevels::GUEST
           end
 
-          result = Result.new(credential: credential, status: status, proof: proof, access_level: access_level)
+          result = Result.new(credential: credential,
+                              status: status,
+                              proof: proof,
+                              access_level: access_level,
+                              connection: connection)
           result.host = host
           result.port = port
           result.protocol = 'tcp'


### PR DESCRIPTION
Spotted an issue where when targeting a single host with multiple user/pass combinations that if a session was created then the next login attempt would close the socket being used by the newly created session. I've fixed this by explicitly setting the socket to `nil` in the login scanner. 
There were also some issues with the error handling where we were trying to access a clients socket incorrectly so I've addressed that in here too by passing the socket in as part of the result object so all error handling is the same across implementations.

# Verification Steps
- [x] boot up `msfconsole`
- [x] create a set of user/pass combos
- [x] use each of the login modules with the set of credentials
- [x] ensure a session is generated for each of `mysql_login`, `postgresql_login`, `mssql_login` and `smb_login`
- [x] interact with the session(s) to make sure they remain valid after more attempted logins
