### PR TITLE
remove db_create mention

### DIFF
--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -197,7 +197,7 @@ module Msf
 
       def nessus_verify_db
         if !(framework.db && framework.db.active)
-          print_error('No database has been configured, please use db_create/db_connect first')
+          print_error('No database has been configured, please use db_connect first')
           return false
         end
         true

--- a/plugins/nexpose.rb
+++ b/plugins/nexpose.rb
@@ -40,7 +40,7 @@ module Msf
 
       def nexpose_verify_db
         if !(framework.db && framework.db.usable && framework.db.active)
-          print_error('No database has been configured, please use db_create/db_connect first')
+          print_error('No database has been configured, please use db_connect first')
           return false
         end
 


### PR DESCRIPTION
db_create was deprecated but still appears in some moments. With this pull request, we remove db_create references from all command responses.

## Verification

- [ ] Start `msfconsole`
- [ ] `db_create`
- [ ] **Verify** db_create is not mentioned