### PR TITLE
Update create session default values

### DIFF
--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -36,7 +36,8 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options([
       Opt::Proxies,
-      OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false])
+      OptBool.new('TDSENCRYPTION', [ true, 'Use TLS/SSL for TDS data "Force Encryption"', false]),
+      OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
     ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ])
 
     options_to_deregister = %w[PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "postgres_default_user.txt") ]),
         OptPath.new('PASS_FILE',      [ false, "File containing passwords, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "postgres_default_pass.txt") ]),
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ])
 
     options_to_deregister = %w[SQL PASSWORD_SPRAY]

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -61,7 +61,8 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('PRESERVE_DOMAINS', [ false, 'Respect a username that contains a domain name.', true ]),
         OptBool.new('RECORD_GUEST', [ false, 'Record guest-privileged random logins to the database', false ]),
         OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', false]),
-        OptBool.new('DETECT_ANY_DOMAIN', [false, 'Detect if domain is required for the specified user', false])
+        OptBool.new('DETECT_ANY_DOMAIN', [false, 'Detect if domain is required for the specified user', false]),
+        OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ]
     )
 


### PR DESCRIPTION
Updates the Metasploit RPC functionality to not open new SMB, Postgres, MySQL, MSSQL sessions by default.

The issue is caused by Metasploit's RPC exposing an `options` API with a default CreateSession value of `true`. The RPC functionality does not take into consideration the Module's `DefaultOptions` key:

```ruby
      # some overrides from authbrute since there is a default username and a blank password
      'DefaultOptions' =>
        {
          'USERNAME' => 'sa',
          'BLANK_PASSWORDS' => true,
          'CreateSession' => false
        }
```

There will be a separate effort to update the RPC layer to expose the default options to users correctly, but for now let's swap the default value in the module options itself

## Verification

- Ensure tests pass
- Ensure the module's option metadata still shows the `CreateSession` option as `false`