### PR TITLE
Update smb_version.rb: Re-enable `RPORT`

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -47,15 +47,10 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('RPORT', 'SMBDIRECT', 'SMB::ProtocolVersion')
-  end
-
-  def rport
-    @smb_port
   end
 
   def smb_direct
-    (@smb_port == 445)
+    @smbdirect || datastore['SMBDirect']
   end
 
   def seconds_to_timespan(seconds)

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -47,6 +47,8 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
+    deregister_options('SMB::ProtocolVersion')
+
   end
 
   def smb_direct


### PR DESCRIPTION
Fixes #19072. 

I updated the `smb_direct` option to match https://github.com/rapid7/metasploit-framework/blob/397781f2b1a51b9d8766918f9f7e6ab613f4b8b5/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb#L93.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/smb_version`
- [ ] `show options`
- [ ] **Verify** that `RPORT` is now an available and functional option