### PR TITLE
Modularise the Softing login code

### DIFF
--- a/lib/metasploit/framework/login_scanner/softing_sis.rb
+++ b/lib/metasploit/framework/login_scanner/softing_sis.rb
@@ -34,17 +34,11 @@ module Metasploit
           false
         end
 
-        # the actual login method, called by #attempt_login
+        # get the authentication token
         #
-        # @param user [String] The username to try
-        # @param pass [String] The password to try
-        # @return [Hash]
-        #   * status [Metasploit::Model::Login::Status]
-        #   * proof [String] the HTTP response body
-        def do_login(user, pass)
-          # prep the data needed for login
-          protocol = ssl ? 'https' : 'http'
-          # attempt to get an authentication token
+        # @param user [String] The username
+        # @return [String] The authentication token
+        def get_auth_token(user)
           auth_token_uri = normalize_uri("#{uri}/runtime/core/user/#{user}/authentication-token")
 
           # send the request to get an authentication token
@@ -79,9 +73,35 @@ module Metasploit
             return { status: LOGIN_STATUS::INCORRECT, proof: auth_res.body.to_s }
           end
 
+          auth_token
+        end
+
+        # generate a signature from the authentication token, username, and password
+        #
+        # @param auth_token [String] The authentication token retrieved by calling get_auth_token
+        # @param user [String] The username
+        # @param pass [String] The password
+        # @return [String] A hexadecimal string representation of the signature
+        def generate_signature(auth_token, user, pass)
+          Digest::MD5.hexdigest(auth_token + pass + auth_token + user + auth_token)
+        end
+
+        # the actual login method, called by #attempt_login
+        #
+        # @param user [String] The username to try
+        # @param pass [String] The password to try
+        # @return [Hash]
+        #   * status [Metasploit::Model::Login::Status]
+        #   * proof [String] the HTTP response body
+        def do_login(user, pass)
+          # prep the data needed for login
+          protocol = ssl ? 'https' : 'http'
+          # attempt to get an authentication token
+          auth_token = get_auth_token(user)
+
           login_uri = normalize_uri("#{uri}/runtime/core/user/#{user}/authentication")
           # calculate signature to use when logging in
-          signature = Digest::MD5.hexdigest(auth_token + pass + auth_token + user + auth_token)
+          signature = generate_signature(auth_token, user, pass)
           # GET parameters for login
           vars_get = {
             'Signature' => signature,


### PR DESCRIPTION
No functional change.

This PR modularises some of the code for the Softing Secure Integration Server (SIS) login. I was writing an exploit module for Softing SIS that required authentication, and had to move some of the code in `lib/metasploit/framework/login_scanner/softing_sis.rb` to their own methods to make it reusable.