### PR TITLE
Make it possible to provide a non-default RPORT

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('RPORT', 'SMBDIRECT', 'SMB::ProtocolVersion')
+    deregister_options('SMBDIRECT', 'SMB::ProtocolVersion')
   end
 
   def rport
@@ -189,7 +189,11 @@ class MetasploitModule < Msf::Auxiliary
   # Fingerprint a single host
   #
   def run_host(ip)
-    smb_ports = [445, 139]
+    # Use a set, rather than an array, so that we can add the user provided
+    #  RPORTS
+    smb_ports = Set[445, 139]
+    smb_ports.add(datastore['RPORT'])
+
     lines = [] # defer status output to the very end to group lines together by host
     smb_ports.each do |pnum|
       @smb_port = pnum

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -199,8 +199,12 @@ class MetasploitModule < Msf::Auxiliary
     #  RPORTS
     smb_ports = [['smb', 445], ['rpc', 139]]
 
+    if datastore['RPORT'] != 0
+      smb_ports = [['smb', datastore['RPORT']]]
+    end
+
     if datastore['SMB_RPORT'] != 0
-      smb_ports = [['smb', datastore['SMB_RPORT']]]
+      smb_ports = [['smb', datastore['RPORT']]]
     end
 
     if datastore['RPC_RPORT'] != 0


### PR DESCRIPTION
Related to: https://github.com/rapid7/metasploit-framework/issues/19072

Make it possible to add a non-default (139, 445) port to the SMB test, by using `Set` rather than `list/array` and adding the datastore RPORT to the mix