### PR TITLE
Fix PASSWORD_SPRAY being ignored for LDAP (and potetnially other modules)

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -233,7 +233,7 @@ module Metasploit::Framework
       additional_publics << public_str
     end
 
-    # When password spraying is enabled, do first passwords then userames
+    # When password spraying is enabled, do first passwords then usernames
     #  i.e.
     #   username1:password1
     #   username2:password1
@@ -243,6 +243,8 @@ module Metasploit::Framework
     #   username2:password2
     #   username3:password2
     # ...
+    # @yieldparam credential [Metasploit::Framework::Credential]
+    # @return [void]
     def each_unfiltered_password_first
       if user_file.present?
         user_fd = File.open(user_file, 'r:binary')
@@ -270,7 +272,7 @@ module Metasploit::Framework
         if user_fd
           user_fd.each_line do |user_from_file|
             user_from_file.chomp!
-            yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(pass_from_file))
+            yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password))
           end
           user_fd.seek(0)
         end
@@ -336,7 +338,7 @@ module Metasploit::Framework
       user_fd.close if user_fd && !user_fd.closed?
     end
 
-    # When password spraying is not enabled, do first usersnames then passwords
+    # When password spraying is not enabled, do first usernames then passwords
     #  i.e.
     #   username1:password1
     #   username1:password2
@@ -345,6 +347,8 @@ module Metasploit::Framework
     #   username2:password1
     #   username2:password2
     #   username2:password3
+    # @yieldparam credential [Metasploit::Framework::Credential]
+    # @return [void]
     def each_unfiltered_username_first
       if pass_file.present?
         pass_fd = File.open(pass_file, 'r:binary')

--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -1,13 +1,8 @@
 require 'metasploit/framework/credential'
 
 module Metasploit::Framework
-  class PrivateCredentialCollection
-    # @!attribute self.built_each_unfiltered
-    #   Stores the {Credential} pairs
-    #
-    #   @return [Array<Credential>]
-    attr_accessor :built_each_unfiltered
 
+  class PrivateCredentialCollection
     # @!attribute additional_privates
     #   Additional private values that should be tried
     #   @return [Array<String>]
@@ -49,11 +44,6 @@ module Metasploit::Framework
     #   A block that can be used to filter credential objects
     attr_accessor :filter
 
-    # @!attribute password_spray
-    #   Whether to use password spraying or not
-    #   @return [Boolean]
-    attr_accessor :password_spray
-
     # @option opts [Boolean] :nil_passwords See {#nil_passwords}
     # @option opts [Boolean] :blank_passwords See {#blank_passwords}
     # @option opts [String] :pass_file See {#pass_file}
@@ -64,7 +54,6 @@ module Metasploit::Framework
     # @option opts [String] :username See {#username}
     # @option opts [String] :userpass_file See {#userpass_file}
     # @option opts [String] :usernames_only See {#usernames_only}
-    # @option opts [String] :password_spray See {#password_spray}
     def initialize(opts = {})
       opts.each do |attribute, value|
         public_send("#{attribute}=", value)
@@ -72,7 +61,6 @@ module Metasploit::Framework
       self.prepended_creds     ||= []
       self.additional_privates ||= []
       self.filter = nil
-      self.built_each_unfiltered = []
     end
 
     # Adds a string as an additional private credential
@@ -94,128 +82,12 @@ module Metasploit::Framework
       self
     end
 
-    def build_each_unfiltered
-      if pass_file.present?
-        pass_fd = File.open(pass_file, 'r:binary')
-      end
-
-      prepended_creds.each { |c| yield c }
-
-      if anonymous_login
-        self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: '', private: '', realm: realm, private_type: :password))
-      end
-
-      if username.present?
-        if nil_passwords
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: username, private: nil, realm: realm, private_type: :password))
-        end
-        if password.present?
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: username, private: password, realm: realm, private_type: private_type(password)))
-        end
-        if user_as_pass
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: username, private: username, realm: realm, private_type: :password))
-        end
-        if blank_passwords
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: username, private: "", realm: realm, private_type: :password))
-        end
-        if pass_fd
-          pass_fd.each_line do |pass_from_file|
-            pass_from_file.chomp!
-            self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: username, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file)))
-          end
-          pass_fd.seek(0)
-        end
-        additional_privates.each do |add_private|
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: username, private: add_private, realm: realm, private_type: private_type(add_private)))
-        end
-      end
-
-      if user_file.present?
-        File.open(user_file, 'r:binary') do |user_fd|
-          user_fd.each_line do |user_from_file|
-            user_from_file.chomp!
-            if nil_passwords
-              self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user_from_file, private: nil, realm: realm, private_type: :password))
-            end
-            if password.present?
-              self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password)))
-            end
-            if user_as_pass
-              self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user_from_file, private: user_from_file, realm: realm, private_type: :password))
-            end
-            if blank_passwords
-              self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user_from_file, private: "", realm: realm, private_type: :password))
-            end
-            if pass_fd
-              pass_fd.each_line do |pass_from_file|
-                pass_from_file.chomp!
-                self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user_from_file, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file)))
-              end
-              pass_fd.seek(0)
-            end
-            additional_privates.each do |add_private|
-              self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user_from_file, private: add_private, realm: realm, private_type: private_type(add_private)))
-            end
-          end
-        end
-      end
-
-      if userpass_file.present?
-        File.open(userpass_file, 'r:binary') do |userpass_fd|
-          userpass_fd.each_line do |line|
-            user, pass = line.split(" ", 2)
-            if pass.blank?
-              pass = ''
-            else
-              pass.chomp!
-            end
-            self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm))
-          end
-        end
-      end
-
-      additional_publics.each do |add_public|
-        if password.present?
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: add_public, private: password, realm: realm, private_type: private_type(password)))
-        end
-        if user_as_pass
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: add_public, private: user_from_file, realm: realm, private_type: :password))
-        end
-        if blank_passwords
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: add_public, private: "", realm: realm, private_type: :password))
-        end
-        if pass_fd
-          pass_fd.each_line do |pass_from_file|
-            pass_from_file.chomp!
-            self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: add_public, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file)))
-          end
-          pass_fd.seek(0)
-        end
-        additional_privates.each do |add_private|
-          self.built_each_unfiltered.push(Metasploit::Framework::Credential.new(public: add_public, private: add_private, realm: realm, private_type: private_type(add_private)))
-        end
-      end
-
-      # If we are doing password spray, the sorting needs to be by password, rather than by user (which is the)
-      #  default
-      if password_spray
-        # Sorted by 'password'
-        built_each_unfiltered_private = self.built_each_unfiltered.sort_by { |obj| [obj.private] }
-        self.built_each_unfiltered = built_each_unfiltered_private
-      end
-
-    ensure
-      pass_fd.close if pass_fd && !pass_fd.closed?
-    end
-
     def each_filtered
-      build_each_unfiltered
+      each_unfiltered do |credential|
+        next unless self.filter.nil? || self.filter.call(credential)
 
-      self.built_each_unfiltered.each { |credential|
-          next unless self.filter.nil? || self.filter.call(credential)
-  
-          yield credential
-      }
+        yield credential
+      end
     end
 
     # Combines all the provided credential sources into a stream of {Credential}
@@ -292,6 +164,7 @@ module Metasploit::Framework
   end
 
   class CredentialCollection < PrivateCredentialCollection
+
     # @!attribute additional_publics
     #   Additional public values that should be tried
     #
@@ -395,7 +268,7 @@ module Metasploit::Framework
               yield Metasploit::Framework::Credential.new(public: user_from_file, private: nil, realm: realm, private_type: :password)
             end
             if password.present?
-              yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password))
+              yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password) )
             end
             if user_as_pass
               yield Metasploit::Framework::Credential.new(public: user_from_file, private: user_from_file, realm: realm, private_type: :password)
@@ -433,7 +306,7 @@ module Metasploit::Framework
 
       additional_publics.each do |add_public|
         if password.present?
-          yield Metasploit::Framework::Credential.new(public: add_public, private: password, realm: realm, private_type: private_type(password))
+          yield Metasploit::Framework::Credential.new(public: add_public, private: password, realm: realm, private_type: private_type(password) )
         end
         if user_as_pass
           yield Metasploit::Framework::Credential.new(public: add_public, private: user_from_file, realm: realm, private_type: :password)

--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -82,11 +82,24 @@ module Metasploit::Framework
       self
     end
 
+    # Combines all the provided credential sources into a stream of {Credential}
+    # objects, yielding them one at a time
+    #
+    # @yieldparam credential [Metasploit::Framework::Credential]
+    # @return [void]
     def each_filtered
-      each_unfiltered do |credential|
-        next unless self.filter.nil? || self.filter.call(credential)
+      if password_spray
+        each_unfiltered_password_first do |credential|
+          next unless self.filter.nil? || self.filter.call(credential)
 
-        yield credential
+          yield credential
+        end
+      else
+        each_unfiltered_username_first do |credential|
+          next unless self.filter.nil? || self.filter.call(credential)
+
+          yield credential
+        end
       end
     end
 
@@ -164,6 +177,7 @@ module Metasploit::Framework
   end
 
   class CredentialCollection < PrivateCredentialCollection
+    attr_accessor :password_spray
 
     # @!attribute additional_publics
     #   Additional public values that should be tried
@@ -219,12 +233,119 @@ module Metasploit::Framework
       additional_publics << public_str
     end
 
-    # Combines all the provided credential sources into a stream of {Credential}
-    # objects, yielding them one at a time
-    #
-    # @yieldparam credential [Metasploit::Framework::Credential]
-    # @return [void]
-    def each_unfiltered
+    # When password spraying is enabled, do first passwords then userames
+    #  i.e.
+    #   username1:password1
+    #   username2:password1
+    #   username3:password1
+    # ...
+    #   username1:password2
+    #   username2:password2
+    #   username3:password2
+    # ...
+    def each_unfiltered_password_first
+      if user_file.present?
+        user_fd = File.open(user_file, 'r:binary')
+      end
+
+      prepended_creds.each { |c| yield c }
+
+      if anonymous_login
+        yield Metasploit::Framework::Credential.new(public: '', private: '', realm: realm, private_type: :password)
+      end
+
+      if password.present?
+        if nil_passwords
+          yield Metasploit::Framework::Credential.new(public: username, private: nil, realm: realm, private_type: :password)
+        end
+        if username.present?
+          yield Metasploit::Framework::Credential.new(public: username, private: password, realm: realm, private_type: private_type(password))
+        end
+        if user_as_pass
+          yield Metasploit::Framework::Credential.new(public: username, private: username, realm: realm, private_type: :password)
+        end
+        if blank_passwords
+          yield Metasploit::Framework::Credential.new(public: username, private: "", realm: realm, private_type: :password)
+        end
+        if user_fd
+          user_fd.each_line do |user_from_file|
+            user_from_file.chomp!
+            yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(pass_from_file))
+          end
+          user_fd.seek(0)
+        end
+      end
+
+      if pass_file.present?
+        File.open(pass_file, 'r:binary') do |pass_fd|
+          pass_fd.each_line do |pass_from_file|
+            pass_from_file.chomp!
+            if user_as_pass
+              yield Metasploit::Framework::Credential.new(public: pass_from_file, private: pass_from_file, realm: realm, private_type: :password)
+            end
+            if user_fd
+              user_fd.each_line do |user_from_file|
+                user_from_file.chomp!
+                yield Metasploit::Framework::Credential.new(public: user_from_file, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+              end
+              user_fd.seek(0)
+            end
+            additional_privates.each do |add_private|
+              yield Metasploit::Framework::Credential.new(public: user_from_file, private: add_private, realm: realm, private_type: private_type(add_private))
+            end
+          end
+        end
+      end
+
+      if userpass_file.present?
+        File.open(userpass_file, 'r:binary') do |userpass_fd|
+          userpass_fd.each_line do |line|
+            user, pass = line.split(" ", 2)
+            if pass.blank?
+              pass = ''
+            else
+              pass.chomp!
+            end
+            yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm)
+          end
+        end
+      end
+
+      additional_publics.each do |add_public|
+        if password.present?
+          yield Metasploit::Framework::Credential.new(public: add_public, private: password, realm: realm, private_type: private_type(password) )
+        end
+        if user_as_pass
+          yield Metasploit::Framework::Credential.new(public: add_public, private: user_from_file, realm: realm, private_type: :password)
+        end
+        if blank_passwords
+          yield Metasploit::Framework::Credential.new(public: add_public, private: "", realm: realm, private_type: :password)
+        end
+        if user_fd
+          user_fd.each_line do |user_from_file|
+            user_from_file.chomp!
+            yield Metasploit::Framework::Credential.new(public: add_public, private: user_from_file, realm: realm, private_type: private_type(user_from_file))
+          end
+          user_fd.seek(0)
+        end
+        additional_privates.each do |add_private|
+          yield Metasploit::Framework::Credential.new(public: add_public, private: add_private, realm: realm, private_type: private_type(add_private))
+        end
+      end
+    ensure
+      user_fd.close if user_fd && !user_fd.closed?
+    end
+
+    # When password spraying is not enabled, do first usersnames then passwords
+    #  i.e.
+    #   username1:password1
+    #   username1:password2
+    #   username1:password3
+    # ...
+    #   username2:password1
+    #   username2:password2
+    #   username2:password3
+    def each_unfiltered_username_first
       if pass_file.present?
         pass_fd = File.open(pass_file, 'r:binary')
       end
@@ -325,7 +446,6 @@ module Metasploit::Framework
           yield Metasploit::Framework::Credential.new(public: add_public, private: add_private, realm: realm, private_type: private_type(add_private))
         end
       end
-
     ensure
       pass_fd.close if pass_fd && !pass_fd.closed?
     end

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -61,6 +61,7 @@ module Auxiliary::AuthBrute
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
       user_as_pass: datastore['USER_AS_PASS'],
+      password_spray: datastore['PASSWORD_SPRAY']
     }.merge(opts))
 
     if framework.db.active

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -58,7 +58,8 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['PASSWORD'],
       realm: datastore['DOMAIN'],
       anonymous_login: datastore['ANONYMOUS_LOGIN'],
-      blank_passwords: false
+      blank_passwords: false,
+      password_spray: datastore['PASSWORD_SPRAY']
     )
 
     opts = {

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -128,14 +128,14 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       let(:pass_file) do
         filename = "pass_file"
         stub_file = StringIO.new("password1\npassword2\n")
-        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
+        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
 
         filename
       end
       let(:user_file) do
         filename = "user_file"
         stub_file = StringIO.new("user1\nuser2\nuser3\n")
-        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
+        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
 
         filename
       end

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -125,17 +125,17 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       let(:password) { nil }
       let(:username) { nil }
       let(:password_spray) { true }
-      let(:user_file) do
-        filename = "user_file"
-        stub_file = StringIO.new("user1\nuser2\nuser3\n")
-        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
-
-        filename
-      end
       let(:pass_file) do
         filename = "pass_file"
         stub_file = StringIO.new("password1\npassword2\n")
         allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
+
+        filename
+      end
+      let(:user_file) do
+        filename = "user_file"
+        stub_file = StringIO.new("user1\nuser2\nuser3\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
 
         filename
       end

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       userpass_file: userpass_file,
       prepended_creds: prepended_creds,
       additional_privates: additional_privates,
-      additional_publics: additional_publics
+      additional_publics: additional_publics,
+      password_spray: password_spray
     )
   end
 
@@ -30,6 +31,7 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
   let(:prepended_creds) { [] }
   let(:additional_privates) { [] }
   let(:additional_publics) { [] }
+  let(:password_spray) { false }
 
   describe "#each" do
     specify do
@@ -71,7 +73,6 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
         )
       end
     end
-
 
     context "when given a userspass_file" do
       let(:username) { nil }
@@ -116,6 +117,37 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
           Metasploit::Framework::Credential.new(public: "asdf", private: "jkl"),
           Metasploit::Framework::Credential.new(public: "jkl", private: "asdf"),
           Metasploit::Framework::Credential.new(public: "jkl", private: "jkl"),
+        )
+      end
+    end
+
+    context "when given a pass_file and user_file and password spray" do
+      let(:password) { nil }
+      let(:username) { nil }
+      let(:password_spray) { true }
+      let(:user_file) do
+        filename = "user_file"
+        stub_file = StringIO.new("user1\nuser2\nuser3\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
+
+        filename
+      end
+      let(:pass_file) do
+        filename = "pass_file"
+        stub_file = StringIO.new("password1\npassword2\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
+
+        filename
+      end
+
+      specify  do
+        expect { |b| collection.each(&b) }.to yield_successive_args(
+          Metasploit::Framework::Credential.new(public: "user1", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user1", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "password2"),
         )
       end
     end

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       let(:user_file) do
         filename = "user_file"
         stub_file = StringIO.new("user1\nuser2\nuser3\n")
-        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
+        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
 
         filename
       end


### PR DESCRIPTION
Fixes #18994 which will fix the PASSWORD_SPRAY (unhandling) issue whenever the code is still using `each` for credentials rather than newer functions

I am unable to test it for all modules that use this - I did test it for LDAP