### PR TITLE
RPC will now expose the default_options struc

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -333,6 +333,10 @@ module Msf
       false
     end
 
+    def default_options
+      self.module_info['DefaultOptions']
+    end
+
     def required_cred_options
       @required_cred_options ||= lambda {
         self.options.select { |name, opt|
@@ -454,6 +458,8 @@ module Msf
     attr_writer   :platform, :references # :nodoc:
     attr_writer   :privileged # :nodoc:
     attr_writer   :license # :nodoc:
+
+
 
   end
 

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -225,6 +225,7 @@ class RPC_Module < RPC_Base
     res['authors'] = m.author.map { |a| a.to_s }
     res['privileged'] = m.privileged?
     res['check'] = m.has_check?
+    res['default_options'] = m.default_options
 
     res['references'] = []
     m.references.each do |r|

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -238,7 +238,7 @@ class RPC_Module < RPC_Base
         res['targets'][i] = m.targets[i].name
       end
 
-      if (m.default_target)
+      if m.default_target
         res['default_target'] = m.default_target
       end
 


### PR DESCRIPTION
Expose the default_options struct so that it can be sent via RPC and allow better integration (mainly related to default PAYLOAD selection)

At the moment `default_options` is not exposed, causing several modules like `linux/http/opennms_horizon_authenticated_rce` to not expose their preferred payload as the `DefaultOptions`:
```
'DefaultOptions' => {
          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
          'RPORT' => 8980,
          'SRVPORT' => 8080,
          'FETCH_COMMAND' => 'CURL',
          'FETCH_FILENAME' => Rex::Text.rand_text_alpha(2..4),
          'FETCH_WRITABLE_DIR' => '/tmp',
          'FETCH_SRVPORT' => 8081,
          'WfsDelay' => 15 # It takes a while for the payload to execute
        },
```

Doesn't get sent back via RPC

This small modification allows exposing this to the RPC client user
 