### PR TITLE
Fix crash in exim4_deliver_message_priv_esc

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -340,6 +340,8 @@ autoload :RubySMB, 'ruby_smb'
 autoload :MetasploitPayloads, 'metasploit-payloads'
 
 require 'rexml/document'
+# Load IO#expect moneypatch
+require 'expect'
 
 # XXX: Should be removed once the `lib/metasploit` folder is loaded by Zeitwerk
 require 'metasploit/framework/hashes'


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/19067

## Verification

### Before

Method not available

```
>> Socket.instance_method(:expect)
(irb):1:in `instance_method': undefined method `expect' for class `Socket' (NameError)
...
```

### After

Method available

```
>> Socket.instance_method(:expect)
=> #<UnboundMethod: Socket(IO)#expect(pat, timeout=...) /Users/user/metasploit-framework/lib/expect.rb:36>
```