### PR TITLE
Expose module metadata over RPC

### DIFF
--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -1,4 +1,12 @@
 module Msf::Module::ModuleInfo
+
+  #
+  # Attributes
+  #
+
+  # @!attribute module_info
+  attr_accessor :module_info
+
   #
   # CONSTANTS
   #
@@ -48,13 +56,6 @@ module Msf::Module::ModuleInfo
   end
 
   protected
-
-  #
-  # Attributes
-  #
-
-  # @!attribute module_info
-  attr_accessor :module_info
 
   #
   # Instance Methods

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -470,6 +470,24 @@ class RPC_Module < RPC_Base
     res
   end
 
+  # Returns the module's information metadata.
+  #
+  # @param [String] mtype Module type. Supported types include (case-sensitive):
+  #                       * exploit
+  #                       * auxiliary
+  #                       * post
+  #                       * nop
+  #                       * payload
+  # @param [String] mname Module name. For example: 'windows/wlan/wlan_profile'.
+  # @raise [Msf::RPC::Exception] Module not found (either wrong type or name).
+  # @return [Hash] The module's info metadata.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.module_metadata', 'exploit', 'windows/smb/ms08_067_netapi')
+  def rpc_module_metadata(mtype, mname)
+    m = _find_module(mtype,mname)
+    m.module_info
+  end
+
   # Executes a module.
   #
   # @param [String] mtype Module type. Supported types include (case-sensitive):


### PR DESCRIPTION
This PR adds the ability to query a module's information metadata over RPC.
This allows us to extract a module's `DefaultOptions` hash and more, used for populating module run options correctly.

## Verification

- [ ] Checkout the relevant Pro PR that adds in the RPC call definition
- [ ] Start Metasploit Pro
- [ ] Verify that you can query the metadata over RPC with `Pro::Client.get.module_metadata(@type, fullname)`