### PR TITLE
Add https prefix to module URL references

### DIFF
--- a/modules/exploits/linux/http/ipfire_proxy_exec.rb
+++ b/modules/exploits/linux/http/ipfire_proxy_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References'  =>
           [
             [ 'EDB', '39765' ],
-            [ 'URL', 'www.ipfire.org/news/ipfire-2-19-core-update-101-released']
+            [ 'URL', 'https://www.ipfire.org/news/ipfire-2-19-core-update-101-released']
           ],
         'License'        => MSF_LICENSE,
         'Platform'       => 'unix',

--- a/modules/exploits/windows/http/geutebrueck_gcore_x64_rce_bo.rb
+++ b/modules/exploits/windows/http/geutebrueck_gcore_x64_rce_bo.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         ['EDB','41153'],
         ['CVE', '2017-11517'],
-        ['URL','www.geutebrueck.com']
+        ['URL','https://www.geutebrueck.com']
       ],
       'Platform' => 'win',
       'Targets' =>


### PR DESCRIPTION
Quick win, this PR adds in the https prefix to module references that were missing them (only two), similar to the PR here: https://github.com/rapid7/metasploit-framework/pull/18923

Fixes an issue where the module couldn't be selected in Pro.

## Testing
```ruby
require 'URI'
ref = 'www.geutebrueck.com'
URI.parse(ref).host
ref = 'https://www.geutebrueck.com'
URI.parse(ref).host
```

## Verification

- [ ] Run the code snippet above
- [ ] Ensure the host is not `nil`