### PR TITLE
Fixes pry-byebug functionality when running `credential_collection_spec.rb`

### DIFF
--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
     )
   end
 
+  before(:each) do
+    # The test suite overrides File.open(...) calls; fall back to the normal behavior for any File.open calls that aren't explicitly mocked
+    allow(File).to receive(:open).with(anything).and_call_original
+    allow(File).to receive(:open).with(anything, anything).and_call_original
+    allow(File).to receive(:open).with(anything, anything, anything).and_call_original
+  end
+
   let(:nil_passwords) { nil }
   let(:blank_passwords) { nil }
   let(:username) { "user" }


### PR DESCRIPTION
This PR fixes an issue where trying to debug tests that were opening files 

```
allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
```

### Before
When attempting to debug the tests file were being interpreted as random files. Whereas now it will honour the values set by the tests when debugging:
```
Error: #<File (class)> received :open with unexpected arguments
  expected: ("user_file", /^r/)
       got: ("/Users/cgranleese/.inputrc")
Diff:
@@ -1 +1 @@
-["user_file", /^r/]
+["/Users/cgranleese/.inputrc"]
```

### After
Now the tests will allow debugging as expected:
```
Run options:
  include {:focus=>true, :locations=>{"./spec/lib/metasploit/framework/credential_collection_spec.rb"=>[128]}}
  exclude {:acceptance=>true}

Randomized with seed 33905
Metasploit::Framework::CredentialCollection
From: /Users/cgranleese/code/metasploit-framework/lib/metasploit/framework/credential_collection.rb:248 Metasploit::Framework::CredentialCollection#each_unfiltered_password_first:

    243:     #   username2:password2
    244:     #   username3:password2
    245:     # ...
    246:     def each_unfiltered_password_first
    247:       require 'pry-byebug'; binding.pry
 => 248:       if user_file.present?
    249:         user_fd = File.open(user_file, 'r:binary')
    250:       end
    251:
    252:       prepended_creds.each { |c| yield c }
    253:

[1] pry(#<Metasploit::Framework::CredentialCollection>)>
```



## Verification
Example of where a `pry` could be added to test these changes:
https://github.com/rapid7/metasploit-framework/blob/13a79ab536b560f7aeb749afcb365f878794f170/lib/metasploit/framework/credential_collection.rb#L98

- [ ] Attempt to run the tests will debugging
- [ ] Verify the tests return the error above and doesn't hit the `pry`
- [ ] Checkout this branch and confirm the `pry` can now be hit
