### PR TITLE
Use #compatible_payloads in #validate

### DIFF
--- a/lib/msf/core/evasion_driver.rb
+++ b/lib/msf/core/evasion_driver.rb
@@ -38,8 +38,7 @@ class EvasionDriver
   # current evasion module.  Assumes that target_idx is valid.
   #
   def compatible_payload?(payload)
-    evasion_platform = evasion.targets[target_idx].platform || evasion.platform
-    return ((payload.platform & evasion_platform).empty? == false)
+    !evasion.compatible_payloads.find { |refname, _| refname == payload.refname }.nil?
   end
 
   def validate
@@ -48,7 +47,7 @@ class EvasionDriver
     end
 
     # Make sure the payload is compatible after all
-    if (compatible_payload?(payload) == false)
+    unless compatible_payload?(payload)
       raise IncompatiblePayloadError.new(payload.refname), "#{payload.refname} is not a compatible payload.", caller
     end
 

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -52,10 +52,7 @@ class ExploitDriver
   # current exploit.  Assumes that target_idx is valid.
   #
   def compatible_payload?(payload)
-    # Try to use the target's platform in preference of the exploit's
-    exp_platform = exploit.targets[target_idx].platform || exploit.platform
-
-    return ((payload.platform & exp_platform).empty? == false)
+    !exploit.compatible_payloads.find { |refname, _| refname == payload.refname }.nil?
   end
 
   ##
@@ -83,9 +80,8 @@ class ExploitDriver
     end
 
     # Make sure the payload is compatible after all
-    if (compatible_payload?(payload) == false)
-      raise IncompatiblePayloadError.new(payload.refname),
-        "#{payload.refname} is not a compatible payload.", caller
+    unless compatible_payload?(payload)
+      raise IncompatiblePayloadError.new(payload.refname), "#{payload.refname} is not a compatible payload.", caller
     end
 
     unless exploit.respond_to?(:allow_no_cleanup) && exploit.allow_no_cleanup

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
     allow(subject).to receive(:mod).and_return(current_mod)
 
     framework.modules.add_module_path(File.join(FILE_FIXTURES_PATH, 'modules'))
+    framework.modules.refresh_cache_from_module_files
   end
 
   describe '#cmd_check' do


### PR DESCRIPTION
This updates the exploit and evasion module drivers to use `#compatible_payloads` to ensure that the selected payload is compatible with the module before running it. The previous check would only inspect the platform and not the architecture. This also means that only payloads that can be tab completed can be selected, making the behavior more consistent.

Also, this means that as an exploit author now, when the target is defined to a particular platform and architecture combination, there's a guarantee that the payload instance matches what was defined. If there are instances where the user needed to select other values, then it's likely that the module's target definition is incorrect.

## Verification

In both of these test cases, the payload module name must be fully specified and can not be tab completed.

- [ ] Test an exploit module such as `exploit/windows/rdp/cve_2019_0708_bluekeep_rce` with a payload that matches the platform but is of an incorrect architecture (ARCH_X86 in this case). See that the module fails stating that the payload is incompatible.
- [ ] Test an evasion module such as `evasion/windows/process_herpaderping` with a payload that matches the platform but is of an incorrect architecture for the target. See that the module fails, stating that the payload is incompatible.


