### PR TITLE
add arch and platform detection for mssql sessions

### DIFF
--- a/lib/msf/base/sessions/mssql.rb
+++ b/lib/msf/base/sessions/mssql.rb
@@ -8,6 +8,8 @@ class Msf::Sessions::MSSQL < Msf::Sessions::Sql
 
   def initialize(rstream, opts = {})
     @client = opts.fetch(:client)
+    self.platform = opts.fetch(:platform)
+    self.arch = opts.fetch(:arch)
     self.console = ::Rex::Post::MSSQL::Ui::Console.new(self, opts)
 
     super(rstream, opts)

--- a/lib/rex/proto/mysql/client.rb
+++ b/lib/rex/proto/mysql/client.rb
@@ -32,25 +32,25 @@ module Rex
         # List of supported MySQL platforms & architectures:
         # https://www.mysql.com/support/supportedplatforms/database.html
         def map_compile_os_to_platform(compile_os)
-          return Msf::Platform::Unknown.realname if compile_os.blank?
+          return '' if compile_os.blank?
 
           compile_os = compile_os.downcase.encode(::Encoding::BINARY)
 
           if compile_os.match?('linux')
-            platform = Msf::Platform::Linux
+            platform = Msf::Platform::Linux.realname
           elsif compile_os.match?('unix')
-            platform = Msf::Platform::Unix
+            platform = Msf::Platform::Unix.realname
           elsif compile_os.match?(/(darwin|mac|osx)/)
-            platform = Msf::Platform::OSX
+            platform = Msf::Platform::OSX.realname
           elsif compile_os.match?('win')
-            platform = Msf::Platform::Windows
+            platform = Msf::Platform::Windows.realname
           elsif compile_os.match?('solaris')
-            platform = Msf::Platform::Solaris
+            platform = Msf::Platform::Solaris.realname
           else
-            platform = Msf::Platform::Unknown
+            platform = compile_os
           end
 
-          platform.realname
+          platform
         end
 
         def map_compile_arch_to_architecture(compile_arch)
@@ -71,7 +71,7 @@ module Rex
           elsif compile_arch.match?('86') || compile_arch.match?('i686')
             arch = ARCH_X86
           else
-            arch = ''
+            arch = compile_arch
           end
 
           arch

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
   def session_setup(result)
     return unless (result.connection && result.proof)
 
-    my_session = Msf::Sessions::MSSQL.new(result.connection, { client: result.proof })
+    my_session = Msf::Sessions::MSSQL.new(result.connection, { client: result.proof, **result.proof.detect_platform_and_arch })
     merge_me = {
       'USERPASS_FILE' => nil,
       'USER_FILE'     => nil,

--- a/spec/lib/msf/base/sessions/mssql_spec.rb
+++ b/spec/lib/msf/base/sessions/mssql_spec.rb
@@ -5,7 +5,7 @@ require 'rex/post/mssql'
 
 RSpec.describe Msf::Sessions::MSSQL do
   let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
-  let(:opts) { { client: client } }
+  let(:opts) { { client: client, platform: Msf::Platform::Linux.realname, arch: ARCH_X86_64 } }
   let(:console_class) { Rex::Post::MSSQL::Ui::Console }
   let(:user_input) { instance_double(Rex::Ui::Text::Input::Readline) }
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }

--- a/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/rex/post/mssql/ui/console/command_dispatcher/core_spec.rb
@@ -5,7 +5,7 @@ require 'rex/post/mssql'
 
 RSpec.describe Rex::Post::MSSQL::Ui::Console::CommandDispatcher::Core do
   let(:client) { instance_double(Rex::Proto::MSSQL::Client) }
-  let(:session) { Msf::Sessions::MSSQL.new(nil, { client: client }) }
+  let(:session) { Msf::Sessions::MSSQL.new(nil, { client: client, platform: Msf::Platform::Linux.realname, arch: ARCH_X86_64 }) }
   let(:address) { '192.0.2.1' }
   let(:port) { '1433' }
   let(:peer_info) { "#{address}:#{port}" }

--- a/spec/lib/rex/proto/mssql/client_spec.rb
+++ b/spec/lib/rex/proto/mssql/client_spec.rb
@@ -18,6 +18,46 @@ RSpec.describe Rex::Proto::MSSQL::Client do
 
   it_behaves_like 'session compatible SQL client'
 
+  describe '#map_compile_os_to_platform' do
+    [
+      { info: 'linux', expected: Msf::Platform::Linux.realname },
+      { info: 'windows', expected: Msf::Platform::Windows.realname },
+      { info: 'win', expected: Msf::Platform::Windows.realname },
+    ].each do |test|
+      it "correctly identifies '#{test[:info]}' as '#{test[:expected]}'" do
+        expect(subject.map_compile_os_to_platform(test[:info])).to eq(test[:expected])
+      end
+    end
+  end
+
+  describe '#map_compile_arch_to_architecture' do
+    [
+      { info: 'x64', expected: ARCH_X86_64 },
+      { info: 'x86', expected: ARCH_X86 },
+      { info: '64', expected: ARCH_X86_64 },
+      { info: '32-bit', expected: ARCH_X86 },
+    ].each do |test|
+      it "correctly identifies '#{test[:info]}' as '#{test[:expected]}'" do
+        expect(subject.map_compile_arch_to_architecture(test[:info])).to eq(test[:expected])
+      end
+    end
+  end
+
+  describe '#detect_platform_and_arch' do
+    [
+      { version: 'Microsoft SQL Server 2022 (RTM-CU12) (KB5033663) - 16.0.4115.5 (X64) Mar  4 2024 08:56:10 Copyright (C) 2022 Microsoft Corporation Developer Edition (64-bit) on Linux (Ubuntu 22.04.4 LTS) <X64>', expected: { arch: 'x86_64', platform: 'Linux' } },
+      { version: 'Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64) Oct  8 2022 05:58:25 Copyright (C) 2022 Microsoft Corporation Developer Edition (64-bit) on Windows Server 2022 Standard 10.0 <X64> (Build 20348: ) (Hypervisor)', expected: { arch: 'x86_64', platform: 'Windows' } },
+    ].each do |test|
+      context "when the database is version #{test[:version]}" do
+        it "returns #{test[:expected]}" do
+          mock_query_result = { rows: [[test[:version]]] }
+          allow(subject).to receive(:query).with('select @@version').and_return(mock_query_result)
+
+          expect(subject.detect_platform_and_arch).to eq test[:expected]
+        end
+      end
+    end
+  end
   describe '#current_database' do
     context 'we have not selected a database yet' do
       subject do

--- a/spec/lib/rex/proto/mysql/client_spec.rb
+++ b/spec/lib/rex/proto/mysql/client_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Rex::Proto::MySQL::Client do
       { info: 'macos', expected: Msf::Platform::OSX.realname },
       { info: 'unix', expected: Msf::Platform::Unix.realname },
       { info: 'solaris', expected: Msf::Platform::Solaris.realname },
-      { info: '', expected: Msf::Platform::Unknown.realname },
-      { info: 'blank', expected: Msf::Platform::Unknown.realname },
-      { info: nil, expected: Msf::Platform::Unknown.realname },
+      { info: '', expected: '' },
+      { info: 'blank', expected: 'blank' },
+      { info: nil, expected: '' },
     ].each do |test|
       it "correctly identifies '#{test[:info]}' as '#{test[:expected]}'" do
         expect(subject.map_compile_os_to_platform(test[:info])).to eq(test[:expected])
@@ -69,7 +69,7 @@ RSpec.describe Rex::Proto::MySQL::Client do
       { info: 'sparc', expected: ARCH_SPARC },
       { info: 'sparc64', expected: ARCH_SPARC64 },
       { info: '', expected: '' },
-      { info: 'blank', expected: '' },
+      { info: 'blank', expected: 'blank' },
       { info: nil, expected: '' },
     ].each do |test|
       it "correctly identifies '#{test[:info]}' as '#{test[:expected]}'" do


### PR DESCRIPTION
This adds platform and arch detection to MSSQL

To test:

- [ ] create a session using `mssql_login` module with `createsession=true`
- [ ] list sessions with `sessions` command
- [ ] ensure platform and arch is correctly listed
- [ ] ensure tests pass

Before:
![Screenshot 2024-04-18 at 3 54 39 PM](https://github.com/rapid7/metasploit-framework/assets/106169455/c9e79bb2-e39c-49ff-8a90-ee8c81679775)


After:
![Screenshot 2024-04-18 at 3 53 43 PM](https://github.com/rapid7/metasploit-framework/assets/106169455/c6fd57c6-36ee-4100-a561-b6d18f330776)

