### PR TITLE
Revert "Sql sessions have correct history manager"

### DIFF
--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -228,13 +228,6 @@ class Config < Hash
     self.new.postgresql_session_history
   end
 
-  # Returns the full path to the PostgreSQL interactive query history file
-  #
-  # @return [String] path to the interactive query history file.
-  def self.postgresql_session_history_interactive
-    self.new.postgresql_session_history_interactive
-  end
-
   # Returns the full path to the MSSQL session history file.
   #
   # @return [String] path to the history file.
@@ -242,25 +235,11 @@ class Config < Hash
     self.new.mssql_session_history
   end
 
-  # Returns the full path to the MSSQL interactive query history file
-  #
-  # @return [String] path to the interactive query history file.
-  def self.mssql_session_history_interactive
-    self.new.mssql_session_history_interactive
-  end
-
   # Returns the full path to the MySQL session history file.
   #
   # @return [String] path to the history file.
   def self.mysql_session_history
     self.new.mysql_session_history
-  end
-
-  # Returns the full path to the MySQL interactive query history file
-  #
-  # @return [String] path to the interactive query history file.
-  def self.mysql_session_history_interactive
-    self.new.mysql_session_history_interactive
   end
 
   def self.pry_history
@@ -376,24 +355,12 @@ class Config < Hash
     config_directory + FileSep + "postgresql_session_history"
   end
 
-  def postgresql_session_history_interactive
-    postgresql_session_history + "_interactive"
-  end
-
   def mysql_session_history
     config_directory + FileSep + "mysql_session_history"
   end
 
-  def mysql_session_history_interactive
-    mysql_session_history + "_interactive"
-  end
-
   def mssql_session_history
     config_directory + FileSep + "mssql_session_history"
-  end
-
-  def mssql_session_history_interactive
-    mssql_session_history + "_interactive"
   end
 
   def pry_history

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -67,19 +67,8 @@ module InteractiveSqlClient
 
   # Try getting multi-line input support provided by Reline, fall back to Readline.
   def _multiline_with_fallback
-    name = session.type
-    query = {}
-
-    # Multiline (Reline) and fallback (Readline) have separate history contexts as they are two different libraries.
-    framework.history_manager.with_context(history_file: Msf::Config.send("#{name}_session_history_interactive"), name: name, input_library: :reline) do
-      query = _multiline
-    end
-
-    if query[:status] == :fail
-      framework.history_manager.with_context(history_file: Msf::Config.send("#{name}_session_history_interactive"), name: name, input_library: :readline) do
-        query = _fallback
-      end
-    end
+    query = _multiline
+    query = _fallback if query[:status] == :fail
 
     query
   end
@@ -173,16 +162,6 @@ module InteractiveSqlClient
   end
 
   attr_accessor :on_log_proc, :client_dispatcher
-
-  private
-
-  def framework
-    client_dispatcher.shell.framework
-  end
-
-  def session
-    client_dispatcher.shell.session
-  end
 
 end
 end

--- a/spec/lib/rex/ui/text/shell/history_manager_spec.rb
+++ b/spec/lib/rex/ui/text/shell/history_manager_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'a') do
             expected_contexts = [
-              { history_file: nil, input_library: :readline, name: 'a' },
+              { history_file: nil, name: 'a' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -36,7 +36,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
 
     context 'when there is an existing stack' do
       before(:each) do
-        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
+        subject.send(:push_context, history_file: nil, name: 'a')
       end
 
       it 'continues to have the previous existing stack' do
@@ -44,7 +44,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           # noop
         }
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -53,8 +53,8 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'b') do
             expected_contexts = [
-              { history_file: nil, input_library: :readline, name: 'a' },
-              { history_file: nil, input_library: :readline, name: 'b' },
+              { history_file: nil, name: 'a' },
+              { history_file: nil, name: 'b' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -69,7 +69,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           }
         end.to raise_exception ArgumentError, 'Mock error'
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -79,9 +79,9 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
   describe '#push_context' do
     context 'when the stack is empty' do
       it 'stores the history contexts' do
-        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
+        subject.send(:push_context, history_file: nil, name: 'a')
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' }
+          { history_file: nil, name: 'a' }
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -90,12 +90,12 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     context 'when multiple values are pushed' do
       it 'stores the history contexts' do
         subject.send(:push_context, history_file: nil, name: 'a')
-        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'b')
-        subject.send(:push_context, history_file: nil, input_library: :reline, name: 'c')
+        subject.send(:push_context, history_file: nil, name: 'b')
+        subject.send(:push_context, history_file: nil, name: 'c')
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
-          { history_file: nil, input_library: :readline, name: 'b' },
-          { history_file: nil, input_library: :reline, name: 'c' },
+          { history_file: nil, name: 'a' },
+          { history_file: nil, name: 'b' },
+          { history_file: nil, name: 'c' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -113,12 +113,12 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     end
 
     context 'when the stack is not empty' do
-      it 'continues to have a non-empty stack' do
+      it 'continues to have an empty stack' do
         subject.send(:push_context, history_file: nil, name: 'a')
         subject.send(:push_context, history_file: nil, name: 'b')
         subject.send(:pop_context)
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end


### PR DESCRIPTION
Reverts rapid7/metasploit-framework#18933 - relates to the memory leak spotted here: https://github.com/rapid7/metasploit-framework/issues/19098

Which may be causing memory issues here: https://github.com/rapid7/metasploit-framework/issues/19098