### PR TITLE
Better enforce types to prevent nil values from causing stack traces

### DIFF
--- a/lib/metasploit/framework/ldap/client.rb
+++ b/lib/metasploit/framework/ldap/client.rb
@@ -82,8 +82,8 @@ module Metasploit
         def ldap_auth_opts_ntlm(opts)
           auth_opts = {}
           ntlm_client = RubySMB::NTLM::Client.new(
-            opts[:username],
-            opts[:password],
+            (opts[:username].nil? ? '' : opts[:username]),
+            (opts[:password].nil? ? '' : opts[:password]),
             workstation: 'WORKSTATION',
             domain: opts[:domain].blank? ? '.' : opts[:domain],
             flags:

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -390,7 +390,7 @@ module Exploit::Remote::MsIcpr
   # @param [OpenSSL::X509::Certificate] cert
   # @return [Array<String>] The UPNs if any were found.
   def get_cert_msext_upn(cert)
-    return unless (san = get_cert_san(cert))
+    return [] unless (san = get_cert_san(cert))
 
     san[:GeneralNames].value.select do |gn|
       gn[:otherName][:type_id]&.value == OID_NT_PRINCIPAL_NAME
@@ -415,7 +415,7 @@ module Exploit::Remote::MsIcpr
   # @param [OpenSSL::X509::Certificate] cert
   # @return [Array<String>] The DNS names if any were found.
   def get_cert_san_dns(cert)
-    return unless (san = get_cert_san(cert))
+    return [] unless (san = get_cert_san(cert))
 
     san[:GeneralNames].value.select do |gn|
       gn[:dNSName].value?
@@ -430,7 +430,7 @@ module Exploit::Remote::MsIcpr
   # @param [OpenSSL::X509::Certificate] cert
   # @return [Array<String>] The E-mail addresses if any were found.
   def get_cert_san_email(cert)
-    return unless (san = get_cert_san(cert))
+    return [] unless (san = get_cert_san(cert))
 
     san[:GeneralNames].value.select do |gn|
       gn[:rfc822Name].value?

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -140,9 +140,6 @@ class MetasploitModule < Msf::Auxiliary
     returned_entries = @ldap.search(base: full_base_dn, filter: filter, attributes: attributes, controls: controls)
     query_result_table = @ldap.get_operation_result.table
     validate_query_result!(query_result_table, filter)
-
-    return nil if returned_entries.empty?
-
     returned_entries
   end
 
@@ -184,8 +181,8 @@ class MetasploitModule < Msf::Auxiliary
       attributes = ['sAMAccountName', 'name']
       base_prefix = 'CN=Configuration'
       sid_entry = query_ldap_server(raw_filter, attributes, base_prefix: base_prefix) # First try with prefix to find entries that may be group specific.
-      sid_entry = query_ldap_server(raw_filter, attributes) if sid_entry.blank? # Retry without prefix if blank.
-      if sid_entry.blank?
+      sid_entry = query_ldap_server(raw_filter, attributes) if sid_entry.empty? # Retry without prefix if blank.
+      if sid_entry.empty?
         print_warning("Could not find any details on the LDAP server for SID #{sid}!")
         output << [sid, nil, nil] # Still want to print out the SID even if we couldn't get additional information.
       elsif sid_entry[0][:samaccountname][0]
@@ -350,7 +347,7 @@ class MetasploitModule < Msf::Auxiliary
       attributes = ['cn', 'dnsHostname', 'ntsecuritydescriptor']
       base_prefix = 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
       enrollment_ca_data = query_ldap_server(certificate_enrollment_raw_filter, attributes, base_prefix: base_prefix)
-      next if enrollment_ca_data.blank?
+      next if enrollment_ca_data.empty?
 
       enrollment_ca_data.each do |ca_server|
         begin


### PR DESCRIPTION
This PR fixes a number of nil-type related stack traces that crept in as we were adding features to our LDAP work.

1. This fixes the return value of a few methods in the MsIcpr mixin to return an empty array instead of nil as the documentation states it should.

This fixes an exception reported to me by @bwatters-r7 

```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.108.211

[+] 3.19.108.211:445 - The requested certificate was issued.
[-] 3.19.108.211:445 - Auxiliary failed: NoMethodError undefined method `empty?' for nil:NilClass
[-] 3.19.108.211:445 - Call stack:
[-] 3.19.108.211:445 -   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:214:in `do_request_cert'
[-] 3.19.108.211:445 -   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:97:in `request_certificate'
[-] 3.19.108.211:445 -   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:68:in `block in action_request_cert'
[-] 3.19.108.211:445 -   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:83:in `with_ipc_tree'
[-] 3.19.108.211:445 -   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:67:in `action_request_cert'
[-] 3.19.108.211:445 -   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:53:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) >
```

2. This fixes `query_ldap_server` to return an empty array rather than nil in `ldap_esc_vulnerable_cert_finder`
```
[-] Auxiliary failed: NoMethodError undefined method `empty?' for nil:NilClass
[-] Call stack:
[-]   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:297:in `find_esc13_vuln_cert_templates'
[-]   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:474:in `block in run'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:644:in `block in open'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:716:in `block in open'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:711:in `open'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:644:in `open'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:114:in `ldap_open'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:98:in `ldap_connect'
[-]   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:457:in `run'
[*] Auxiliary module execution completed

```

3. This fixes an issue in `gather/ldap_esc_vulnerable_cert_finder` because the module did not require a password value, but when the `nil` password was sent on to `ruby_smb`, it crashed:
```
[-] Auxiliary failed: NoMethodError undefined method `force_encoding' for nil:NilClass
[-] Call stack:
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/ruby_smb-3.3.5/lib/ruby_smb/ntlm/custom/string_encoder.rb:14:in `encode_utf16le'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/rubyntlm-0.6.3/lib/net/ntlm/client/session.rb:187:in `oem_or_unicode_str'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/rubyntlm-0.6.3/lib/net/ntlm/client/session.rb:172:in `password'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/ruby_smb-3.3.5/lib/ruby_smb/ntlm/client.rb:55:in `ntlmv2_hash'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/ruby_smb-3.3.5/lib/ruby_smb/ntlm/client.rb:63:in `calculate_user_session_key!'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/ruby_smb-3.3.5/lib/ruby_smb/ntlm/client.rb:20:in `authenticate!'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/ruby_smb-3.3.5/lib/ruby_smb/ntlm/client.rb:74:in `init_context'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/metasploit/framework/ldap/client.rb:104:in `block in ldap_auth_opts_ntlm'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/auth_adapter/sasl.rb:54:in `block in bind'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/auth_adapter/sasl.rb:38:in `loop'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/auth_adapter/sasl.rb:38:in `bind'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/connection.rb:281:in `block in bind'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/connection.rb:278:in `bind'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:715:in `block in open'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:711:in `open'
[-]   /home/tmoose/.rvm/gems/ruby-3.0.2/gems/net-ldap-0.18.0/lib/net/ldap.rb:644:in `open'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:114:in `ldap_open'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:98:in `ldap_connect'
[-]   /home/tmoose/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:455:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > 

```

