### PR TITLE
Module to read/write registry key security descriptor remotely

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,7 +475,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.6)
+    ruby_smb (3.3.7)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac

--- a/documentation/modules/auxiliary/admin/registry_security_descriptor.md
+++ b/documentation/modules/auxiliary/admin/registry_security_descriptor.md
@@ -1,0 +1,84 @@
+## Vulnerable Application
+
+This module reads or writes a Windows registry security descriptor remotely.
+
+In READ mode, the `FILE` option can be set to specify where the security
+descriptor should be written to.
+
+The following format is used:
+```
+key: <registry key>
+security_info: <security information>
+sd: <security descriptor as a hex string>
+```
+
+In WRITE mode, the `FILE` option can be used to specify the information needed
+to write the security descriptor to the remote registry. The file must follow
+the same format as described above.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use auxiliary/admin/registry_security_descriptor`
+1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> key=<registry key>`
+1. **Verify** the registry key security descriptor is displayed
+1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> key=<registry key> file=<file path>`
+1. **Verify** the registry key security descriptor is saved to the file
+1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> key=<registry key> action=write sd=<security descriptor as a hex string>`
+1. **Verify** the security descriptor is correctly set on the given registry key
+1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> file=<file path>`
+1. **Verify** the security descriptor taken from the file is correctly set on the given registry key
+
+## Options
+
+### KEY
+Registry key to read or write.
+
+### SD
+Security Descriptor to write as a hex string.
+
+### SECURITY_INFORMATION
+Security Information to read or write (see
+https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/23e75ca3-98fd-4396-84e5-86cd9d40d343
+(default: OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION).
+
+### FILE
+File path to store the security descriptor when reading or source file path used to write the security descriptor when writing
+
+
+## Scenarios
+
+### Read against Windows Server 2019
+
+```
+msf6 auxiliary(admin/registry_security_descriptor) > run verbose=true rhost=192.168.101.124 smbuser=Administrator smbpass=123456 action=READ key='HKLM\SECURITY\Policy\PolEKList'
+[*] Running module against 192.168.101.124
+
+[+] 192.168.101.124:445 - Raw security descriptor for HKLM\SECURITY\Policy\PolEKList: 01000480480000005800000000000000140000000200340002000000000214003f000f0001010000000000051200000000021800000006000102000000000005200000002002000001020000000000052000000020020000010100000000000512000000
+[*] Auxiliary module execution completed
+```
+
+### Write against Windows Server 2019
+Note that the information security has been set to 4 (DACL_SECURITY_INFORMATION) to avoid an access denied error.
+
+```
+msf6 auxiliary(admin/registry_security_descriptor) > run verbose=true rhost=192.168.101.124 smbuser=Administrator smbpass=123456 key='HKLM\SECURITY\Policy\PolEKList' action=WRITE sd=01000480480000005800000000000000140000000200340002000000000214003f000f0001010000000000051200000000021800000006000102000000000005200000002002000001020000000000052000000020020000010100000000000512000000 security_information=4
+[*] Running module against 192.168.101.124
+
+[+] 192.168.101.124:445 - Security descriptor set for HKLM\SECURITY\Policy\PolEKList
+[*] Auxiliary module execution completed
+```
+
+### Write against Windows Server 2019 (from file)
+
+```
+msf6 auxiliary(admin/registry_security_descriptor) > run verbose=true rhost=192.168.101.124 smbuser=Administrator smbpass=123456 action=WRITE file=/tmp/remote_registry_sd_backup.yml
+[*] Running module against 192.168.101.124
+
+[*] 192.168.101.124:445 - Getting security descriptor info from file /tmp/remote_registry_sd_backup.yml
+  key: HKLM\SECURITY\Policy\PolEKList
+  security information: 4
+  security descriptor: 01000480480000005800000000000000140000000200340002000000000214003f000f0001010000000000051200000000021800000006000102000000000005200000002002000001020000000000052000000020020000010100000000000512000000
+[+] 192.168.101.124:445 - Security descriptor set for HKLM\SECURITY\Policy\PolEKList
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/gather/windows_secrets_dump.md
+++ b/documentation/modules/auxiliary/gather/windows_secrets_dump.md
@@ -2,10 +2,15 @@
 ### Description
 The `windows_secrets_dump` auxiliary module dumps SAM hashes and LSA secrets
 (including cached creds) from the remote Windows target without executing any
-agent locally. First, it reads as much data as possible from the registry and
-then save the hives locally on the target (`%SYSTEMROOT%\\random.tmp`).
-Finally, it downloads the temporary hive files and reads the rest of the data
-from it. These temporary files are removed when it's done.
+agent locally. This is done by remotely updating the registry key security
+descriptor, taking advantage of the WriteDACL privileges held by local
+administrators to set temporary read permissions.
+
+This can be disabled by setting the `INLINE` option to false and the module
+will fallback to the original implementation, which consists in saving the
+registry hives locally on the target (%SYSTEMROOT%\Temp\<random>.tmp),
+downloading the temporary hive files and reading the data from it. This
+temporary files are removed when it's done.
 
 On domain controllers, secrets from Active Directory is extracted using [MS-DRDS]
 DRSGetNCChanges(), replicating the attributes we need to get SIDs, NTLM hashes,
@@ -43,7 +48,10 @@ Windows XP/Server 2003 to Windows 10/Server version 2004.
 14. Verify the notes are there
 
 ## Options
-Apart from the standard SMB options, no other specific options are needed.
+
+### INLINE
+Use inline technique to read protected keys from the registry remotely without
+saving the hives to disk (default: true).
 
 ## Actions
 

--- a/lib/msf/util/windows_registry.rb
+++ b/lib/msf/util/windows_registry.rb
@@ -1,7 +1,7 @@
 module Msf::Util::WindowsRegistry
 
-  def self.parse(hive_data, name: nil)
-    RegistryParser.new(hive_data, name: name)
+  def self.parse(hive_data, name: nil, root: nil)
+    RegistryParser.new(hive_data, name: name, root: root)
   end
 
 end

--- a/lib/msf/util/windows_registry/registry_parser.rb
+++ b/lib/msf/util/windows_registry/registry_parser.rb
@@ -213,6 +213,8 @@ module WindowsRegistry
       when :security
         require_relative 'security'
         extend Security
+      else
+        wlog("[Msf::Util::WindowsRegistry::RegistryParser] Unknown :name argument: #{name}") unless name.blank?
       end
     end
 

--- a/lib/msf/util/windows_registry/registry_parser.rb
+++ b/lib/msf/util/windows_registry/registry_parser.rb
@@ -198,11 +198,14 @@ module WindowsRegistry
 
     # @param hive_data [String] The binary registry data
     # @param name [Symbol] The key name to add specific helpers. Only `:sam`
+    # @param root [String] The root key and subkey corresponding to the hive_data
     #   and `:security` are supported at the moment.
-    def initialize(hive_data, name: nil)
+    def initialize(hive_data, name: nil, root: nil)
       @hive_data = hive_data.b
       @regf = RegRegf.read(@hive_data)
-      @root_key = find_root_key
+      @root_key_block = find_root_key
+      @root = root
+      @root << '\\' unless root.end_with?('\\')
       case name
       when :sam
         require_relative 'sam'
@@ -224,10 +227,10 @@ module WindowsRegistry
       @hive_data.unpack('a4096' * (@hive_data.size / 4096)).each do |data|
         next unless data[0,4] == 'hbin'
         reg_hbin = RegHbin.read(data)
-        root_key = reg_hbin.reg_hbin_blocks.find do |block|
+        root_key_block = reg_hbin.reg_hbin_blocks.find do |block|
           block.data.respond_to?(:magic) && block.data.magic == NK_MAGIC && block.data.nk_type == ROOT_KEY
         end
-        return root_key if root_key
+        return root_key_block if root_key_block
       rescue IOError
         raise StandardError, 'Cannot parse the RegHbin structure'
       end
@@ -265,7 +268,7 @@ module WindowsRegistry
       # only asking for the root node
       key = key[1..-1] if key[0] == '\\' && key.size > 1
 
-      parent_key = @root_key
+      parent_key = @root_key_block
       if key.size > 0 && key[0] != '\\'
         key.split('\\').each do |sub_key|
           res = find_sub_key(parent_key, sub_key)
@@ -450,11 +453,11 @@ module WindowsRegistry
       res = []
       value_list = get_value_blocks(key_obj.data.offset_value_list, key_obj.data.num_values + 1)
       value_list.each do |value|
+        # TODO: use #to_s to make sure value.data.name is a String
         res << (value.data.flag > 0 ? value.data.name : nil)
       end
       res
     end
-
   end
 
 end

--- a/lib/msf/util/windows_registry/remote_registry.rb
+++ b/lib/msf/util/windows_registry/remote_registry.rb
@@ -1,0 +1,167 @@
+module Msf
+module Util
+module WindowsRegistry
+
+  class RemoteRegistry
+    # Constants
+    ROOT_KEY        = 0x2c
+    REG_NONE        = 0x00
+    REG_SZ          = 0x01
+    REG_EXPAND_SZ   = 0x02
+    REG_BINARY      = 0x03
+    REG_DWORD       = 0x04
+    REG_MULTISZ     = 0x07
+    REG_QWORD       = 0x0b
+
+    LOCAL_GROUP_ADMINS_SID = 'S-1-5-32-544'
+
+    def initialize(winreg, name: nil, inline: false)
+      @winreg = winreg
+      @inline = inline
+      case name
+      when :sam
+        require_relative 'sam'
+        extend Sam
+      when :security
+        require_relative 'security'
+        extend Security
+      end
+    end
+
+    def create_ace(sid)
+      access_mask = RubySMB::Dcerpc::Winreg::Regsam.new({
+        write_dac: 1,
+        read_control: 1,
+        key_enumerate_sub_keys: 1,
+        key_query_value: 1
+      })
+      Rex::Proto::MsDtyp::MsDtypAce.new({
+        header: {
+          ace_type: Rex::Proto::MsDtyp::MsDtypAceType::ACCESS_ALLOWED_ACE_TYPE,
+          ace_flags: { container_inherit_ace: 1 }
+        },
+        body: {
+          access_mask: Rex::Proto::MsDtyp::MsDtypAccessMask.read(access_mask.to_binary_s),
+          sid: sid
+        }
+      })
+    end
+
+    def backup_file_path
+      return @backup_file_path if @backup_file_path
+
+      if ! File.directory?(Msf::Config.local_directory)
+        FileUtils.mkdir_p(Msf::Config.local_directory)
+      end
+      remote_host = @winreg.tree.client.dns_host_name
+      remote_host = @winreg.tree.client.dispatcher.tcp_socket.peerhost if remote_host.blank?
+      path = File.join(Msf::Config.local_directory, "remote_registry_sd_backup_#{remote_host}_#{Time.now.strftime("%Y%m%d%H%M%S")}.#{Rex::Text.rand_text_alpha(6)}.yml")
+      @backup_file_path = File.expand_path(path)
+    end
+
+    def save_to_file(key, security_descriptor, security_information, path = backup_file_path)
+      sd_info = {
+        'key' => key,
+        'security_info' => security_information,
+        'sd' => security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join
+      }
+      File.open(path, 'w') do |fd|
+        fd.write(sd_info.to_yaml)
+      end
+    end
+
+    def read_from_file(filepath)
+      sd_info = YAML.safe_load_file(filepath)
+      sd_info['security_info'] = sd_info['security_info'].to_i
+      sd_info
+    end
+
+    def delete_backup_file(path = backup_file_path)
+      File.delete(path) if File.file?(path)
+    end
+
+    def change_dacl(key, sid)
+      security_information =
+        RubySMB::Field::SecurityDescriptor::OWNER_SECURITY_INFORMATION |
+        RubySMB::Field::SecurityDescriptor::GROUP_SECURITY_INFORMATION |
+        RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION
+
+      security_descriptor = @winreg.get_key_security_descriptor(key, security_information, bind: false)
+      dlog("Security descriptor for #{key}: #{security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join}")
+      save_to_file(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION)
+
+      parsed_sd = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.read(security_descriptor)
+      ace = create_ace(sid)
+      parsed_sd.dacl.aces << ace
+      parsed_sd.dacl.acl_count += 1
+      parsed_sd.dacl.acl_size += ace.num_bytes
+      dlog("New security descriptor for #{key}: #{parsed_sd.to_binary_s.b.bytes.map { |c| '%02x' % c.ord }.join}")
+
+      @winreg.set_key_security_descriptor(key, parsed_sd.to_binary_s, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
+
+      security_descriptor.dup
+    rescue RubySMB::Dcerpc::Error::WinregError => e
+      elog("Error while changing DACL on key `#{key}`: #{e}")
+    end
+
+    def restore_dacl(key, security_descriptor)
+      begin
+        dlog("Restoring DACL on key `#{key}`")
+        @winreg.set_key_security_descriptor(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
+      rescue StandardError => e
+        elog(
+          "Error while restoring DACL on key `#{key}`: #{e}\n"\
+          "The original security descriptor has been saved in `#{backup_file_path}`. "\
+          "The auxiliary module `admin/registry_security_descriptor` can be used to "\
+          "restore the security descriptor from this file."
+        )
+        # Reset the `backup_file_path` instance variable to make sure a new
+        # backup filename will be generated. This way, this backup file won't
+        # be deleted the next time `#restore_dacl` is called.
+        @backup_file_path = nil
+        return
+      end
+      delete_backup_file
+    end
+
+    def enum_values(key)
+      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      @winreg.enum_registry_values(key, bind: false).map do |value|
+        value.to_s.encode(::Encoding::ASCII_8BIT)
+      end
+    ensure
+      restore_dacl(key, sd_backup) if @inline
+    end
+
+    def enum_key(key)
+      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      @winreg.enum_registry_key(key, bind: false).map do |key|
+        key.to_s.encode(::Encoding::ASCII_8BIT)
+      end
+    ensure
+      restore_dacl(key, sd_backup) if @inline
+    end
+
+    def get_value(key, value_name = nil)
+      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      root_key, sub_key = key.gsub(/\//, '\\').split('\\', 2)
+      root_key_handle = @winreg.open_root_key(root_key)
+      subkey_handle = @winreg.open_key(root_key_handle, sub_key)
+      begin
+        type, value = @winreg.query_value(subkey_handle, value_name.nil? ? '' : value_name, type: true)
+        [type.to_i, value.to_s.b]
+      rescue RubySMB::Dcerpc::Error::WinregError
+        nil
+      end
+    ensure
+      @winreg.close_key(subkey_handle) if subkey_handle
+      @winreg.close_key(root_key_handle) if root_key_handle
+      restore_dacl(key, sd_backup) if @inline
+    end
+
+  end
+end
+end
+end
+
+

--- a/lib/msf/util/windows_registry/remote_registry.rb
+++ b/lib/msf/util/windows_registry/remote_registry.rb
@@ -13,8 +13,6 @@ module WindowsRegistry
     REG_MULTISZ     = 0x07
     REG_QWORD       = 0x0b
 
-    LOCAL_GROUP_ADMINS_SID = 'S-1-5-32-544'
-
     def initialize(winreg, name: nil, inline: false)
       @winreg = winreg
       @inline = inline
@@ -25,6 +23,8 @@ module WindowsRegistry
       when :security
         require_relative 'security'
         extend Security
+      else
+        wlog("[Msf::Util::WindowsRegistry::RemoteRegistry] Unknown :name argument: #{name}") unless name.blank?
       end
     end
 
@@ -87,7 +87,7 @@ module WindowsRegistry
         RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION
 
       security_descriptor = @winreg.get_key_security_descriptor(key, security_information, bind: false)
-      dlog("Security descriptor for #{key}: #{security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join}")
+      dlog("[Msf::Util::WindowsRegistry::RemoteRegistry] Security descriptor for #{key}: #{security_descriptor.b.bytes.map { |c| '%02x' % c.ord }.join}")
       save_to_file(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION)
 
       parsed_sd = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.read(security_descriptor)
@@ -95,22 +95,22 @@ module WindowsRegistry
       parsed_sd.dacl.aces << ace
       parsed_sd.dacl.acl_count += 1
       parsed_sd.dacl.acl_size += ace.num_bytes
-      dlog("New security descriptor for #{key}: #{parsed_sd.to_binary_s.b.bytes.map { |c| '%02x' % c.ord }.join}")
+      dlog("[Msf::Util::WindowsRegistry::RemoteRegistry] New security descriptor for #{key}: #{parsed_sd.to_binary_s.b.bytes.map { |c| '%02x' % c.ord }.join}")
 
       @winreg.set_key_security_descriptor(key, parsed_sd.to_binary_s, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
 
-      security_descriptor.dup
+      security_descriptor
     rescue RubySMB::Dcerpc::Error::WinregError => e
-      elog("Error while changing DACL on key `#{key}`: #{e}")
+      elog("[Msf::Util::WindowsRegistry::RemoteRegistry] Error while changing DACL on key `#{key}`: #{e}")
     end
 
     def restore_dacl(key, security_descriptor)
       begin
-        dlog("Restoring DACL on key `#{key}`")
+        dlog("[Msf::Util::WindowsRegistry::RemoteRegistry] Restoring DACL on key `#{key}`")
         @winreg.set_key_security_descriptor(key, security_descriptor, RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION, bind: false)
       rescue StandardError => e
         elog(
-          "Error while restoring DACL on key `#{key}`: #{e}\n"\
+          "[Msf::Util::WindowsRegistry::RemoteRegistry] Error while restoring DACL on key `#{key}`: #{e}\n"\
           "The original security descriptor has been saved in `#{backup_file_path}`. "\
           "The auxiliary module `admin/registry_security_descriptor` can be used to "\
           "restore the security descriptor from this file."
@@ -125,38 +125,38 @@ module WindowsRegistry
     end
 
     def enum_values(key)
-      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
       @winreg.enum_registry_values(key, bind: false).map do |value|
         value.to_s.encode(::Encoding::ASCII_8BIT)
       end
     ensure
-      restore_dacl(key, sd_backup) if @inline
+      restore_dacl(key, sd_backup) if @inline && sd_backup
     end
 
     def enum_key(key)
-      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
       @winreg.enum_registry_key(key, bind: false).map do |key|
         key.to_s.encode(::Encoding::ASCII_8BIT)
       end
     ensure
-      restore_dacl(key, sd_backup) if @inline
+      restore_dacl(key, sd_backup) if @inline && sd_backup
     end
 
     def get_value(key, value_name = nil)
-      sd_backup = change_dacl(key, LOCAL_GROUP_ADMINS_SID) if @inline
+      sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
       root_key, sub_key = key.gsub(/\//, '\\').split('\\', 2)
       root_key_handle = @winreg.open_root_key(root_key)
       subkey_handle = @winreg.open_key(root_key_handle, sub_key)
       begin
-        type, value = @winreg.query_value(subkey_handle, value_name.nil? ? '' : value_name, type: true)
-        [type.to_i, value.to_s.b]
+        reg_value = @winreg.query_value(subkey_handle, value_name.nil? ? '' : value_name)
+        [reg_value.type.to_i, reg_value.data.to_s.b]
       rescue RubySMB::Dcerpc::Error::WinregError
         nil
       end
     ensure
       @winreg.close_key(subkey_handle) if subkey_handle
       @winreg.close_key(root_key_handle) if root_key_handle
-      restore_dacl(key, sd_backup) if @inline
+      restore_dacl(key, sd_backup) if @inline && sd_backup
     end
 
   end

--- a/modules/auxiliary/admin/registry_security_descriptor.rb
+++ b/modules/auxiliary/admin/registry_security_descriptor.rb
@@ -1,0 +1,171 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+  include Msf::OptionalSession::SMB
+  include Msf::Util::WindowsRegistry
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Registry Security Descriptor Utility',
+        'Description' => %q{
+          Read or write a Windows registry security descriptor remotely.
+
+          In READ mode, the `FILE` option can be set to specify where the
+          security descriptor should be written to.
+
+          The following format is used:
+          ```
+          key: <registry key>
+          security_info: <security information>
+          sd: <security descriptor as a hex string>
+          ```
+
+          In WRITE mode, the `FILE` option can be used to specify the information
+          needed to write the security descriptor to the remote registry. The file must
+          follow the same format as described above.
+        },
+        'Author' => [
+          'Christophe De La Fuente'
+        ],
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          [ 'READ', { 'Description' => 'Read a Windows registry security descriptor' } ],
+          [ 'WRITE', { 'Description' => 'Write a Windows registry security descriptor' } ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [CONFIG_CHANGES]
+        },
+        'DefaultAction' => 'READ'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('KEY', [ false, 'Registry key to read or write' ]),
+        OptString.new('SD', [ false, 'Security Descriptor to write as a hex string' ], conditions: %w[ACTION == WRITE]),
+        OptInt.new('SECURITY_INFORMATION', [
+          true,
+          'Security Information to read or write (see '\
+          'https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/23e75ca3-98fd-4396-84e5-86cd9d40d343 '\
+          '(default: OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION)',
+          RubySMB::Field::SecurityDescriptor::OWNER_SECURITY_INFORMATION |
+            RubySMB::Field::SecurityDescriptor::GROUP_SECURITY_INFORMATION |
+            RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION
+        ]),
+        OptString.new('FILE', [
+          false,
+          'File path to store the security descriptor when reading or source file path used to write the security descriptor when writing'
+        ])
+      ]
+    )
+  end
+
+  def run
+    if session
+      print_status("Using existing session #{session.sid}")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      simple.connect("\\\\#{simple.address}\\IPC$")
+    else
+      connect
+      begin
+        smb_login
+      rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
+        fail_with(Module::Failure::NoAccess, "Unable to authenticate ([#{e.class}] #{e}).")
+      end
+    end
+
+    report_service(
+      host: simple.address,
+      port: simple.port,
+      host_name: simple.client.default_name,
+      proto: 'tcp',
+      name: 'smb',
+      info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
+    )
+
+    begin
+      @tree = simple.client.tree_connect("\\\\#{simple.address}\\IPC$")
+    rescue RubySMB::Error::RubySMBError => e
+      fail_with(Module::Failure::Unreachable, "Unable to connect to the remote IPC$ share ([#{e.class}] #{e}).")
+    end
+
+    begin
+      @winreg = @tree.open_file(filename: 'winreg', write: true, read: true)
+      @winreg.bind(endpoint: RubySMB::Dcerpc::Winreg)
+    rescue RubySMB::Error::RubySMBError => e
+      fail_with(Module::Failure::Unreachable, "Error when connecting to 'winreg' interface ([#{e.class}] #{e}).")
+    end
+
+    case action.name
+    when 'READ'
+      cmd_read
+    when 'WRITE'
+      cmd_write
+    else
+      print_error("Unknown action #{action.name}")
+    end
+  ensure
+    @winreg.close if @winreg
+    @tree.disconnect! if @tree
+    # Don't disconnect the client if it's coming from the session so it can be reused
+    unless session
+      simple.client.disconnect! if simple&.client.is_a?(RubySMB::Client)
+      disconnect
+    end
+  end
+
+  def auxiliary_commands
+    {
+      'read' => 'Read a Windows registry security descriptor',
+      'write' => 'Write a Windows registry security descriptor'
+    }
+  end
+
+  def cmd_read
+    fail_with(Failure::BadConfig, 'Unknown registry key, please set the `KEY` option') if datastore['KEY'].blank?
+
+    sd = @winreg.get_key_security_descriptor(datastore['KEY'], datastore['SECURITY_INFORMATION'], bind: false)
+    print_good("Raw security descriptor for #{datastore['KEY']}: #{sd.bytes.map { |c| '%02x' % c.ord }.join}")
+
+    unless datastore['FILE'].blank?
+      remote_reg = Msf::Util::WindowsRegistry::RemoteRegistry.new(@winreg, name: :sam)
+      remote_reg.backup_to_file(datastore['KEY'], sd, datastore['SECURITY_INFORMATION'], datastore['FILE'])
+      print_good("Saved to file #{datastore['FILE']}")
+    end
+  end
+
+  def cmd_write
+    if datastore['FILE'].blank?
+      fail_with(Failure::BadConfig, 'Unknown security descriptor, please set the `SD` option') if datastore['SD'].blank?
+      fail_with(Failure::BadConfig, 'Unknown registry key, please set the `KEY` option') if datastore['KEY'].blank?
+      sd = datastore['SD']
+      key = datastore['KEY']
+      security_info = datastore['SECURITY_INFORMATION']
+    else
+      print_status("Getting security descriptor info from file #{datastore['FILE']}")
+      remote_reg = Msf::Util::WindowsRegistry::RemoteRegistry.new(@winreg, name: :sam)
+      sd_info = remote_reg.read_from_file(datastore['FILE'])
+      sd = sd_info['sd']
+      key = sd_info['key']
+      security_info = sd_info['security_info']
+      vprint_line("  key: #{key}")
+      vprint_line("  security information: #{security_info}")
+      vprint_line("  security descriptor: #{sd}")
+    end
+
+    sd = sd.chars.each_slice(2).map { |c| c.join.to_i(16).chr }.join
+    @winreg.set_key_security_descriptor(key, sd, security_info, bind: false)
+    print_good("Security descriptor set for #{key}")
+  rescue RubySMB::Dcerpc::Error::WinregError => e
+    fail_with(Failure::Unknown, "Unable to set the security descriptor for #{key}: #{e}")
+  end
+end

--- a/modules/auxiliary/admin/registry_security_descriptor.rb
+++ b/modules/auxiliary/admin/registry_security_descriptor.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('KEY', [ false, 'Registry key to read or write' ]),
-        OptString.new('SD', [ false, 'Security Descriptor to write as a hex string' ], conditions: %w[ACTION == WRITE]),
+        OptString.new('SD', [ false, 'Security Descriptor to write as a hex string' ], conditions: %w[ACTION == WRITE], regex: /^([a-fA-F0-9]{2})+$/),
         OptInt.new('SECURITY_INFORMATION', [
           true,
           'Security Information to read or write (see '\
@@ -111,9 +111,9 @@ class MetasploitModule < Msf::Auxiliary
 
     case action.name
     when 'READ'
-      cmd_read
+      action_read
     when 'WRITE'
-      cmd_write
+      action_write
     else
       print_error("Unknown action #{action.name}")
     end
@@ -127,9 +127,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def cmd_read
-    do_connect unless @winreg
-
+  def action_read
     fail_with(Failure::BadConfig, 'Unknown registry key, please set the `KEY` option') if datastore['KEY'].blank?
 
     sd = @winreg.get_key_security_descriptor(datastore['KEY'], datastore['SECURITY_INFORMATION'], bind: false)
@@ -142,9 +140,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def cmd_write
-    do_connect unless @winreg
-
+  def action_write
     if datastore['FILE'].blank?
       fail_with(Failure::BadConfig, 'Unknown security descriptor, please set the `SD` option') if datastore['SD'].blank?
       fail_with(Failure::BadConfig, 'Unknown registry key, please set the `KEY` option') if datastore['KEY'].blank?

--- a/modules/auxiliary/example.rb
+++ b/modules/auxiliary/example.rb
@@ -42,12 +42,9 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Running the simple auxiliary module with action #{action.name}")
   end
 
-  # auxiliary modules can register new commands, they all call cmd_* to
-  # dispatch them
-  def auxiliary_commands
-    { 'aux_extra_command' => 'Run this auxiliary test commmand' }
-  end
-
+  # Framework automatically registers `cmd_*` methods to be dispatched when the
+  # corresponding command is used. For example, here this method will be called
+  # when entering the `aux_extra_command` command in the console.
   def cmd_aux_extra_command(*args)
     print_status("Running inside aux_extra_command(#{args.join(' ')})")
   end

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -860,7 +860,8 @@ class MetasploitModule < Msf::Auxiliary
     dc_infos = dcerpc_client.drs_domain_controller_info(ph_drs, domain_name)
     user_info = {}
     dc_infos.each do |dc_info|
-      users.each_key do |sid|
+      users.each do |user|
+        sid = user[0]
         crack_names = dcerpc_client.drs_crack_names(ph_drs, rp_names: [sid])
         crack_names.each do |crack_name|
           user_record = dcerpc_client.drs_get_nc_changes(

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -33,11 +33,17 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'Windows Secrets Dump',
         'Description' => %q{
           Dumps SAM hashes and LSA secrets (including cached creds) from the
-          remote Windows target without executing any agent locally. First, it
-          reads as much data as possible from the registry and then save the
-          hives locally on the target (%SYSTEMROOT%\Temp\random.tmp). Finally, it
-          downloads the temporary hive files and reads the rest of the data
-          from it. This temporary files are removed when it's done.
+          remote Windows target without executing any agent locally. This is
+          done by remotely updating the registry key security descriptor,
+          taking advantage of the WriteDACL privileges held by local
+          administrators to set temporary read permissions.
+
+          This can be disabled by setting the `INLINE` option to false and the
+          module will fallback to the original implementation, which consists
+          in saving the registry hives locally on the target
+          (%SYSTEMROOT%\Temp\<random>.tmp), downloading the temporary hive
+          files and reading the data from it. This temporary files are removed
+          when it's done.
 
           On domain controllers, secrets from Active Directory is extracted
           using [MS-DRDS] DRSGetNCChanges(), replicating the attributes we need
@@ -57,6 +63,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [
           'Alberto Solino', # Original Impacket code
           'Christophe De La Fuente', # MSF module
+          'antuache' # Inline technique
         ],
         'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py'],


### PR DESCRIPTION
This module reads or writes a Windows registry security descriptor remotely.

In READ mode, the `FILE` option can be set to specify where the security descriptor should be written to.

The following format is used:
```
key: <registry key>
security_info: <security information>
sd: <security descriptor as a hex string>
```

In WRITE mode, the `FILE` option can be used to specify the information needed to write the security descriptor to the remote registry. The file must follow the same format as described above.

:warning: **Important** :warning:
DO NOT MERGE YET.
This module is based on this [branch](https://github.com/cdelafuente-r7/metasploit-framework/tree/feat/mod/enh/secrets_dump) will need this [PR](https://github.com/rapid7/metasploit-framework/pull/19048) landed first. This PR only adds two files:
- modules/auxiliary/admin/registry_security_descriptor.rb
- documentation/modules/auxiliary/admin/registry_security_descriptor.md


## Verification Steps

1. Start msfconsole
1. Do: `use auxiliary/admin/registry_security_descriptor`
1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> key=<registry key>`
1. **Verify** the registry key security descriptor is displayed
1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> key=<registry key> file=<file path>`
1. **Verify** the registry key security descriptor is saved to the file
1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> key=<registry key> action=write sd=<security descriptor as a hex string>`
1. **Verify** the security descriptor is correctly set on the given registry key
1. Do: `run verbose=true rhost=<host> smbuser=<username> smbpass=<password> file=<file path>`
1. **Verify** the security descriptor taken from the file is correctly set on the given registry key

## Scenarios

### Read against Windows Server 2019

```
msf6 auxiliary(admin/registry_security_descriptor) > run verbose=true rhost=192.168.101.124 smbuser=Administrator smbpass=123456 action=READ key='HKLM\SECURITY\Policy\PolEKList'
[*] Running module against 192.168.101.124

[+] 192.168.101.124:445 - Raw security descriptor for HKLM\SECURITY\Policy\PolEKList: 01000480480000005800000000000000140000000200340002000000000214003f000f0001010000000000051200000000021800000006000102000000000005200000002002000001020000000000052000000020020000010100000000000512000000
[*] Auxiliary module execution completed
```

### Write against Windows Server 2019
Note that the information security has been set to 4 (DACL_SECURITY_INFORMATION) to avoid an access denied error.

```
msf6 auxiliary(admin/registry_security_descriptor) > run verbose=true rhost=192.168.101.124 smbuser=Administrator smbpass=123456 key='HKLM\SECURITY\Policy\PolEKList' action=WRITE sd=01000480480000005800000000000000140000000200340002000000000214003f000f0001010000000000051200000000021800000006000102000000000005200000002002000001020000000000052000000020020000010100000000000512000000 security_information=4
[*] Running module against 192.168.101.124

[+] 192.168.101.124:445 - Security descriptor set for HKLM\SECURITY\Policy\PolEKList
[*] Auxiliary module execution completed
```

### Write against Windows Server 2019 (from file)

```
msf6 auxiliary(admin/registry_security_descriptor) > run verbose=true rhost=192.168.101.124 smbuser=Administrator smbpass=123456 action=WRITE file=/tmp/remote_registry_sd_backup.yml
[*] Running module against 192.168.101.124

[*] 192.168.101.124:445 - Getting security descriptor info from file /tmp/remote_registry_sd_backup.yml
  key: HKLM\SECURITY\Policy\PolEKList
  security information: 4
  security descriptor: 01000480480000005800000000000000140000000200340002000000000214003f000f0001010000000000051200000000021800000006000102000000000005200000002002000001020000000000052000000020020000010100000000000512000000
[+] 192.168.101.124:445 - Security descriptor set for HKLM\SECURITY\Policy\PolEKList
[*] Auxiliary module execution completed
```
