### PR TITLE
add EVENT_DEPENDENT to vcenter vmon priv esc

### DIFF
--- a/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
+++ b/modules/exploits/linux/local/vcenter_java_wrapper_vmon_priv_esc.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Stability' => [CRASH_SERVICE_DOWN],
-          'Reliability' => [REPEATABLE_SESSION],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
           'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS],
           'AKA' => ['vScalation']
         }

--- a/spec/module_validation_spec.rb
+++ b/spec/module_validation_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ModuleValidation::Validator do
       end
 
       it 'has errors' do
-        expect(subject.errors.full_messages).to eq ['Reliability contains invalid values ["FIRST_ATTEMPT_FAIL"] - only ["first-attempt-fail", "repeatable-session", "unreliable-session"] is allowed']
+        expect(subject.errors.full_messages).to eq ['Reliability contains invalid values ["FIRST_ATTEMPT_FAIL"] - only ["first-attempt-fail", "repeatable-session", "unreliable-session", "event-dependent"] is allowed']
       end
     end
 

--- a/spec/support/lib/module_validation.rb
+++ b/spec/support/lib/module_validation.rb
@@ -66,7 +66,8 @@ module ModuleValidation
     VALID_RELIABILITY_VALUES = [
       Msf::FIRST_ATTEMPT_FAIL,
       Msf::REPEATABLE_SESSION,
-      Msf::UNRELIABLE_SESSION
+      Msf::UNRELIABLE_SESSION,
+      Msf::EVENT_DEPENDENT
     ]
 
     #


### PR DESCRIPTION
Now that #17294 has landed, add the new `EVENT_DEPENDENT` to one of the modules which needed it.


## Verification

- [ ] Start `msfconsole`
- [ ] `use vcenter_java_wrapper`
- [ ] `info`
- [ ] **Verify** `event-dependent` is in reliability list
