### PR TITLE
Fixed output of db_import command in spec

### DIFF
--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "    Nikto XML",
           "    Nmap XML",
           "    OpenVAS Report",
-          "    OpenVAS XML",
+          "    OpenVAS XML (optional arguments -cert -dfn)",
           "    Outpost24 XML",
           "    Qualys Asset XML",
           "    Qualys Scan XML",


### PR DESCRIPTION
This should fix this issue:
https://github.com/rapid7/metasploit-framework/actions/runs/8793235928/job/24130785304

We updated the output of `db_import -h` [here](https://github.com/rapid7/metasploit-framework/pull/18914/files#diff-b6d3d884f6817f2037924f100cc29d81cf107f9821998849d3e6c6ee99b68badL1715-R1715), but didn't update the spec with it.

## Verification
Ensure tests pass.



