### PR TITLE
Adds pattern to catch other arch and platform values

### DIFF
--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -115,10 +115,12 @@ module Rex
         def detect_platform_and_arch
           result = {}
 
-          server_vars = query('select @@version')[:rows][0][0]
+          version_string = query('select @@version')[:rows][0][0]
+          arch = version_string[/\b\d+\.\d+\.\d+\.\d+\s\(([^)]*)\)/, 1] || version_string
+          plat = version_string[/\bon\b\s+(\w+)/, 1] || version_string
 
-          result[:arch]     = map_compile_arch_to_architecture(server_vars)
-          result[:platform] = map_compile_os_to_platform(server_vars)
+          result[:arch]     = map_compile_arch_to_architecture(arch)
+          result[:platform] = map_compile_os_to_platform(plat)
           result
         end
 

--- a/spec/lib/rex/proto/mssql/client_spec.rb
+++ b/spec/lib/rex/proto/mssql/client_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Rex::Proto::MSSQL::Client do
     [
       { version: 'Microsoft SQL Server 2022 (RTM-CU12) (KB5033663) - 16.0.4115.5 (X64) Mar  4 2024 08:56:10 Copyright (C) 2022 Microsoft Corporation Developer Edition (64-bit) on Linux (Ubuntu 22.04.4 LTS) <X64>', expected: { arch: 'x86_64', platform: 'Linux' } },
       { version: 'Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64) Oct  8 2022 05:58:25 Copyright (C) 2022 Microsoft Corporation Developer Edition (64-bit) on Windows Server 2022 Standard 10.0 <X64> (Build 20348: ) (Hypervisor)', expected: { arch: 'x86_64', platform: 'Windows' } },
+      { version: 'Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (32) Oct  8 2022 05:58:25 Copyright (C) 2022 Microsoft Corporation Developer Edition (2-bit) on Mac Standard 10.0 <??> (Build 20348: ) (Hypervisor)', expected: { arch: '32', platform: 'mac' } },
+      { version: 'unknown', expected: { arch: 'unknown', platform: 'unknown' } },
     ].each do |test|
       context "when the database is version #{test[:version]}" do
         it "returns #{test[:expected]}" do


### PR DESCRIPTION
We noticed that thte mssql platform/arch detection would return the full `@@version` query result for both arch and platform, and have a very noisy result:
![Screenshot 2024-04-19 at 2 28 01 PM](https://github.com/rapid7/metasploit-framework/assets/106169455/9ff74416-073f-4e1c-be8d-9ccc94dcd1e6)
To test this, I'm not sure how to actually return a string that doesn't match the existing patterns, but just create a session (`mssql_login` `createsession=true`), and list them `sessions` and make sure the arch/platform looks right. You can also pry in to the method and change the string, or just make sure the tests actually look good & add/suggest more if it's not covered. 