### PR TITLE
Add missing '-S' to cmd_notes

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1230,12 +1230,13 @@ class Db
   @@notes_opts = Rex::Parser::Arguments.new(
     [ '-a', '--add' ] => [ false, 'Add a note to the list of addresses, instead of listing.' ],
     [ '-d', '--delete' ] => [ false, 'Delete the notes instead of searching.' ],
-    [ '-n', '--note' ] => [ true, 'Set the data for a new note (only with -a).', '<note>' ],
-    [ '-t', '--type' ] => [ true, 'Search for a list of types, or set single type for add.', '<type1,type2>' ],
     [ '-h', '--help' ] => [ false, 'Show this help information.' ],
-    [ '-R', '--rhosts' ] => [ false, 'Set RHOSTS from the results of the search.' ],
-    [ '-o', '--output' ] => [ true, 'Save the notes to a csv file.', '<filename>' ],
+    [ '-n', '--note' ] => [ true, 'Set the data for a new note (only with -a).', '<note>' ],
     [ '-O', '--order' ] => [ true, 'Order rows by specified column number.', '<column id>' ],
+    [ '-o', '--output' ] => [ true, 'Save the notes to a csv file.', '<filename>' ],
+    [ '-R', '--rhosts' ] => [ false, 'Set RHOSTS from the results of the search.' ],
+    [ '-S', '--search' ] => [ true, 'Search string to filter by.', '<filter>' ],
+    [ '-t', '--type' ] => [ true, 'Search for a list of types, or set single type for add.', '<type1,type2>' ],
     [ '-u', '--update' ] => [ false, 'Update a note. Not officially supported.' ]
   )
 

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "    -O, --order <column id>   Order rows by specified column number.",
           "    -o, --output <filename>   Save the notes to a csv file.",
           "    -R, --rhosts              Set RHOSTS from the results of the search.",
+          "    -S, --search <filter>     Search string to filter by.",
           "    -t, --type <type1,type2>  Search for a list of types, or set single type for add.",
           "    -u, --update              Update a note. Not officially supported.",
           "",


### PR DESCRIPTION
This is a proposed fix for:
https://github.com/rapid7/metasploit-framework/issues/19128

Where '-S' isn't listed in `cmd_notes` making this code:
```
notes -S 'nmap.nse.(http|rtsp)'
```

Doesn't work

Fix includes:
1. Adding of the missing '-S'
2. Sort the options alphabetically

