### PR TITLE
Add ':' for split of PATH in backup_file.rb

### DIFF
--- a/modules/auxiliary/scanner/http/backup_file.rb
+++ b/modules/auxiliary/scanner/http/backup_file.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('PATH', [ true,  "The path/file to identify backups", '/index.asp'])
+        OptString.new('PATH', [ true,  "The path/file to identify backups, use ':' as a delimiter for multi-path/file input", '/index.asp'])
       ])
 
   end
@@ -41,13 +41,17 @@ class MetasploitModule < Msf::Auxiliary
       '~'
     ]
 
-    bakextensions.each do |ext|
-      file = normalize_uri(datastore['PATH'])+ext
-      check_for_file(file, ip)
-    end
-    if datastore['PATH'] =~ %r#(.*)(/.+$)#
-      file = $1 + $2.sub('/', '/.') + '.swp'
-      check_for_file(file, ip)
+    # If there is ':' use it as a delimiter
+    pathes = datastore['PATH'].split(":")
+    pathes.each do |path|
+      bakextensions.each do |ext|
+        file = normalize_uri(path)+ext
+        check_for_file(file, ip)
+      end
+      if path =~ %r#(.*)(/.+$)#
+        file = $1 + $2.sub('/', '/.') + '.swp'
+        check_for_file(file, ip)
+      end
     end
   end
   def check_for_file(file, ip)


### PR DESCRIPTION
At the moment `backup_file.rb` support single path lookup, by adding the ability to use `:` delimiter you can now use the module with multiple paths at one 'run'

Step to recreate (the web server target I use, returns 200 OK on everything):
```
use scanner/http/backup_file
set PATH "/index.asp:/something.asp:/other.asp"
set RHOSTS 10.0.0.243

[+] Found http://10.0.0.243:80/index.asp.backup
[+] Found http://10.0.0.243:80/index.asp.bak
[+] Found http://10.0.0.243:80/index.asp.copy
[+] Found http://10.0.0.243:80/index.asp.copia
[+] Found http://10.0.0.243:80/index.asp.old
[+] Found http://10.0.0.243:80/index.asp.orig
[+] Found http://10.0.0.243:80/index.asp.temp
[+] Found http://10.0.0.243:80/index.asp.txt
[+] Found http://10.0.0.243:80/index.asp~
[+] Found http://10.0.0.243:80/.index.asp.swp
[+] Found http://10.0.0.243:80/something.asp.backup
[+] Found http://10.0.0.243:80/something.asp.bak
[+] Found http://10.0.0.243:80/something.asp.copy
[+] Found http://10.0.0.243:80/something.asp.copia
[+] Found http://10.0.0.243:80/something.asp.old
[+] Found http://10.0.0.243:80/something.asp.orig
[+] Found http://10.0.0.243:80/something.asp.temp
[+] Found http://10.0.0.243:80/something.asp.txt
[+] Found http://10.0.0.243:80/something.asp~
[+] Found http://10.0.0.243:80/.something.asp.swp
[+] Found http://10.0.0.243:80/other.asp.backup
[+] Found http://10.0.0.243:80/other.asp.bak
[+] Found http://10.0.0.243:80/other.asp.copy
[+] Found http://10.0.0.243:80/other.asp.copia
[+] Found http://10.0.0.243:80/other.asp.old
[+] Found http://10.0.0.243:80/other.asp.orig
[+] Found http://10.0.0.243:80/other.asp.temp
[+] Found http://10.0.0.243:80/other.asp.txt
[+] Found http://10.0.0.243:80/other.asp~
[+] Found http://10.0.0.243:80/.other.asp.swp
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```