### PR TITLE
Downgrade unf ext

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,7 +520,7 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.9.1)
+    unf_ext (0.0.8.2)
     unicode-display_width (2.5.0)
     unix-crypt (1.3.1)
     uuid (2.3.9)


### PR DESCRIPTION
Revert `unf_ext` for now, which fails to compile on centos6:

```
14:10:46 Installing railties 7.0.8.1
14:10:46 
14:10:46 Error:
14:10:46 
14:10:46     Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
14:10:46 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
14:10:46 
14:10:46 current directory:
14:10:46 /opt/metasploit-framework/embedded/lib/ruby/gems/3.1.0/gems/unf_ext-0.0.9.1/ext/unf_ext
14:10:46 /opt/metasploit-framework/embedded/bin/ruby -I
14:10:46 /opt/metasploit-framework/embedded/lib/ruby/site_ruby/3.1.0 -r
14:10:46 ./siteconf20240425-5724-ezvumc.rb extconf.rb
14:10:46 checking for -lstdc++... yes
14:10:46 creating Makefile
14:10:46 
14:10:46 current directory:
14:10:46 /opt/metasploit-framework/embedded/lib/ruby/gems/3.1.0/gems/unf_ext-0.0.9.1/ext/unf_ext
14:10:46 make -j4 DESTDIR\= clean
14:10:46 
14:10:46 current directory:
14:10:46 /opt/metasploit-framework/embedded/lib/ruby/gems/3.1.0/gems/unf_ext-0.0.9.1/ext/unf_ext
14:10:46 make -j4 DESTDIR\=
14:10:46 compiling unf.cc
14:10:46 unf.cc:34: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:35: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:36: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:37: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:38: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:39: warning: extended initializer lists only available with -std=c++0x or
14:10:46 -std=gnu++0x
14:10:46 unf.cc:40: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:41: error: expected primary-expression before ‘.’ token
14:10:46 unf.cc:42: error: expected primary-expression before ‘.’ token
14:10:46 make: *** [unf.o] Error 1
14:10:46 
14:10:46 make failed, exit code 2
14:10:46 
14:10:46 Gem files will remain installed in
14:10:46 /opt/metasploit-framework/embedded/lib/ruby/gems/3.1.0/gems/unf_ext-0.0.9.1 for
14:10:46 inspection.
14:10:46 Results logged to
14:10:46 /opt/metasploit-framework/embedded/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/unf_ext-0.0.9.1/gem_make.out
14:10:46 
14:10:46 An error occurred while installing unf_ext (0.0.9.1), and Bundler cannot
14:10:46 continue.
14:10:46 Make sure that `gem install unf_ext -v '0.0.9.1' --source
14:10:46 'https://rubygems.org/'` succeeds before bundling.
14:10:46 
14:10:46 In Gemfile:
14:10:46   metasploit-framework was resolved to 6.4.7, which depends on
14:10:46     dnsruby was resolved to 1.72.1, which depends on
14:10:46       simpleidn was resolved to 0.2.1, which depends on
14:10:46         unf was resolved to 0.1.4, which depends on
14:10:46           unf_ext
```

Caused by:

https://github.com/knu/ruby-unf_ext/blame/c72a36d0a5ea9fe3950611b0f289fc68a2595fcf/ext/unf_ext/unf.cc#L33-L43

I've just raised an issue with the gem - https://github.com/knu/ruby-unf_ext/issues/80 - it might be a small fix that we could contribute, but just wanted to get a sanity check from the maintainers first ✅

## Verification

- Verify CI passes