### PR TITLE
Nameservers from resolv.conf must be IP addresses

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1094,7 +1094,17 @@ module Net # :nodoc:
               when /^\s*search\s+(.*)/
                 self.searchlist = $1.split(" ")
               when /^\s*nameserver\s+(.*)/
-                self.nameservers += $1.split(" ")
+                $1.split(/\s+/).each do |nameserver|
+                  # per https://man7.org/linux/man-pages/man5/resolv.conf.5.html nameserver values must be IP addresses
+                  begin
+                    ip_addr = IPAddr.new(nameserver)
+                  rescue IPAddr::InvalidAddressError
+                    @logger.warn "Ignoring invalid name server '#{nameserver}' from configuration file"
+                    next
+                  else
+                    self.nameservers += [ip_addr]
+                  end
+                end
               end
             end
           rescue => e


### PR DESCRIPTION
Fixes an infinite recursion error where Metasploit would attempt to resolve a nameserver specified as a hostname in /etc/resolv.conf while initializing.

Values for the namserver key in the resolv.conf file must be IP addresses per the man page while the Resolver class in theory allows them to be added by hostname however an existing one must be defined by which it will be resolved.

This notably prevents IPv6 addresses with a scope ID from being allowed in Ruby versions < 3.1. See this GitHub issue for the discussion. https://github.com/ruby/ipaddr/issues/52. In Ruby 3.0 and earlier, an IPv6 address with a scope is not considered to be a valid IP address, so when it fails the `IPAddr` initialization, it's treated as a hostname and now ignored. We could strip the scope ID, but it's possible that it's required to contact the specified nameserver. I'm also not 100% certain the scope ID is honored even when it's included in the IP address and passed through the socket stack. It's _probably_ used when the underlying socket is the native Ruby socket for a connection originating from the local host. 🤷🏻  It wouldn't make any sense to use a scope from the host's perspective if the DNS server is being contacted over a pivot for example.

Fixes #19135 

## Verification

List the steps needed to make sure this thing works

- [ ] Edit your `/etc/resolv.conf` file and add a invalid nameserver, something like `nameserver 127.0.0.1 bad.lan 127.0.0.2`
- [ ] Start `msfconsole` without any configuration file, use fresh defaults
- [ ] Do not see a stack trace
- [ ] Run the `dns` command, see that the two nameservers defined by IP address are present and configured