### PR TITLE
Fix recursive call to `ldap_open`

### DIFF
--- a/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
@@ -258,7 +258,7 @@ class MetasploitModule < Msf::Auxiliary
 
     quota = nil
     begin
-      ldap_open do |ldap|
+      ldap_connection do |ldap|
         ldap_options = {
           filter: Net::LDAP::Filter.eq('objectclass', 'domainDNS'),
           attributes: 'ms-DS-MachineAccountQuota',
@@ -290,7 +290,7 @@ class MetasploitModule < Msf::Auxiliary
     print_error("#{peer} #{msg}")
   end
 
-  def ldap_open
+  def ldap_connection
     ldap_peer = "#{rhost}:#{datastore['LDAP_PORT']}"
     base = datastore['DOMAIN'].split('.').map { |dc| "dc=#{dc}" }.join(',')
     ldap_options = {
@@ -327,7 +327,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def impersonate_dc(computer_name)
-    ldap_open do |ldap|
+    ldap_connection do |ldap|
       dc_dnshostname = get_dnshostname(ldap, datastore['DC_NAME'])
       print_status("Attempting to set the DNS hostname for the computer #{computer_name} to the DNS hostname for the DC: #{datastore['DC_NAME']}")
       domain_to_ldif = datastore['DOMAIN'].split('.').map { |dc| "dc=#{dc}" }.join(',')


### PR DESCRIPTION
The certifried module seems to have been broken since this PR https://github.com/rapid7/metasploit-framework/pull/18197/files#diff-b7c1aff5ecd40aff88dfb3e8186dcf9b5c82c767ffb28cd69d083545a536609bR112

Issue is caused by both the mixin and the module defining `ldap_open` then when `ldap_connect` is called it ends up calling the `ldap_open` in the module rather than in the mixin, this is just a simple name change to avoid that

Before: 
```
msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) > run
[*] Running module against 127.0.0.1

[*] 192.168.176.3:445 - Requesting the ms-DS-MachineAccountQuota value to see if we can add any computer accounts...
[-] 192.168.176.3:445 - Auxiliary failed: ArgumentError wrong number of arguments (given 1, expected 0)
[-] 192.168.176.3:445 - Call stack:
[-] 192.168.176.3:445 -   /Users/dwelch/dev/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb:293:in `ldap_open'
[-] 192.168.176.3:445 -   /Users/dwelch/dev/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:99:in `ldap_connect'
[-] 192.168.176.3:445 -   /Users/dwelch/dev/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb:305:in `ldap_open'
[-] 192.168.176.3:445 -   /Users/dwelch/dev/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb:261:in `can_add_computer?'
[-] 192.168.176.3:445 -   /Users/dwelch/dev/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb:100:in `run'
[*] Auxiliary module execution completed
```

After:
```
msf6 auxiliary(admin/dcerpc/cve_2022_26923_certifried) > run
[*] Running module against 127.0.0.1

[*] 127.0.0.1:445 - Requesting the ms-DS-MachineAccountQuota value to see if we can add any computer accounts...
[-] 127.0.0.1:445 - 127.0.0.1:445 LDAP error 49: Invalid Credentials - 8009030C: LdapErr: DSID-0C0904DC, comment: AcceptSecurityContext error, data 51f, v1db1
[!] 127.0.0.1:445 - Received no result when trying to obtain ms-DS-MachineAccountQuota. Adding a computer account may not work.
[*] 127.0.0.1:445 - Connecting SMB with vagrant.windomain.local:vagrant
[-] 127.0.0.1:445 - Auxiliary aborted due to failure: unreachable: The connection was refused by the remote host (127.0.0.1:445).
[*] Auxiliary module execution completed
```

# Verification Steps:
- [ ] Run the certifried module
- [ ] Verify we no longer get the `ArgumentError` exception
