### PR TITLE
Use timed reads in the apache_activemq_rce_cve_2023_46604 check method 

### DIFF
--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -80,15 +80,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
 
-    res = sock.get_once
+    len = sock.timed_read(4)&.unpack1('N')
+
+    return CheckCode::Unknown if len.nil? || len > 0x1000 # upper limit in case the service isn't ActiveMQ
+
+    res = sock.timed_read(len)
 
     disconnect
 
     return CheckCode::Unknown unless res
 
-    len, _, magic = res.unpack('NCZ*')
-
-    return CheckCode::Unknown unless res.length == len + 4
+    _, magic = res.unpack('CZ*')
 
     return CheckCode::Unknown unless magic == 'ActiveMQ'
 
@@ -110,6 +112,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     Exploit::CheckCode::Safe("Apache ActiveMQ #{version}")
+  rescue ::Timeout::Error
+    CheckCode::Unknown
   end
 
   def exploit


### PR DESCRIPTION
Fixes #19036 by using #timed_read in the check method so it doesn't hang for 60 seconds when targeting an HTTPS service.

`#timed_read` uses the socket's read timeout which defaults to 10 seconds. The current implementation uses a default read timeout of 60 seconds which makes scanning services that don't immediately return data on connection (such as HTTPS servers) very slow.

Supersedes #19037 which was repurposing the connection timeout for the purposes of a read timeout.

## Verification

List the steps needed to make sure this thing works

- [ ] Run `time check https://metasploit.com/`
- [ ] See that the check method took a reasonable amount of time


## Demo

```
metasploit-framework (S:0 J:0) exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > time check https://zerosteiner.com/
[*] 192.168.249.3:443 - Cannot reliably check exploitability.
[+] Command "check https://zerosteiner.com/" completed in 10.248666797000169 seconds
# still works when targeting a real server
metasploit-framework (S:0 J:0) exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > check ubuntu.labs1collabu0.local
[*] 18.220.174.0:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.18.2
metasploit-framework (S:0 J:0) exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > 
```
