### PR TITLE
Updates to the AutoCheck mixin

### DIFF
--- a/lib/msf/core/exploit/remote/auto_check.rb
+++ b/lib/msf/core/exploit/remote/auto_check.rb
@@ -6,6 +6,7 @@ module Exploit::Remote::AutoCheck
   AUTO_CHECK_LEVEL_OPTIONAL = 0   # the check itself can be ignored by the user
   AUTO_CHECK_LEVEL_BYPASSABLE = 1 # the check must be run but the result can be ignored by the user
   AUTO_CHECK_LEVEL_REQUIRED = 2   # nothing can be ignored by the user
+  AUTO_CHECK_LEVEL_DEFAULT = AUTO_CHECK_LEVEL_OPTIONAL
 
   def self.included(_base)
     raise NotImplementedError, "#{name} should not be included, it should be prepended"
@@ -15,7 +16,7 @@ module Exploit::Remote::AutoCheck
     super(
       update_info(
         info,
-        'AutoCheckLevel' => AUTO_CHECK_LEVEL_OPTIONAL
+        'AutoCheckLevel' => AUTO_CHECK_LEVEL_DEFAULT
       )
     )
 
@@ -47,7 +48,7 @@ module Exploit::Remote::AutoCheck
   private
 
   def auto_check_level
-    module_info['AutoCheckLevel']
+    module_info['AutoCheckLevel'] || AUTO_CHECK_LEVEL_DEFAULT
   end
 
   def with_prepended_auto_check

--- a/lib/msf/core/exploit/remote/auto_check.rb
+++ b/lib/msf/core/exploit/remote/auto_check.rb
@@ -3,17 +3,33 @@
 module Msf
 module Exploit::Remote::AutoCheck
 
+  AUTO_CHECK_LEVEL_OPTIONAL = 0   # the check itself can be ignored by the user
+  AUTO_CHECK_LEVEL_BYPASSABLE = 1 # the check must be run but the result can be ignored by the user
+  AUTO_CHECK_LEVEL_REQUIRED = 2   # nothing can be ignored by the user
+
   def self.included(_base)
     raise NotImplementedError, "#{name} should not be included, it should be prepended"
   end
 
   def initialize(info = {})
-    super
+    super(
+      update_info(
+        info,
+        'AutoCheckLevel' => AUTO_CHECK_LEVEL_OPTIONAL
+      )
+    )
 
-    register_advanced_options([
-      OptBool.new('AutoCheck', [false, 'Run check before exploit', true]),
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
+
+    if auto_check_level <= AUTO_CHECK_LEVEL_BYPASSABLE
+      register_advanced_options([
+          OptBool.new('ForceExploit', [false, 'Override check result', false])
+      ])
+      if auto_check_level <= AUTO_CHECK_LEVEL_OPTIONAL
+        register_advanced_options([
+          OptBool.new('AutoCheck', [false, 'Run check before exploit', true])
+        ])
+      end
+    end
   end
 
   def run
@@ -30,16 +46,21 @@ module Exploit::Remote::AutoCheck
 
   private
 
+  def auto_check_level
+    module_info['AutoCheckLevel']
+  end
+
   def with_prepended_auto_check
-    unless datastore['AutoCheck']
+    if auto_check_level <= AUTO_CHECK_LEVEL_OPTIONAL && !datastore['AutoCheck']
       print_warning('AutoCheck is disabled, proceeding with exploitation')
       return yield
     end
 
-    print_status('Running automatic check ("set AutoCheck false" to disable)')
-
-    warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
-    error_msg = '"set ForceExploit true" to override check result.'
+    if auto_check_level <= AUTO_CHECK_LEVEL_OPTIONAL
+      print_status('Running automatic check. Run "set AutoCheck false" to disable.')
+    else
+      print_status('Running automatic check.')
+    end
 
     check_code = check
     case check_code
@@ -57,11 +78,20 @@ module Exploit::Remote::AutoCheck
       failure_type = Module::Failure::Unknown
     end
 
-    if datastore['ForceExploit']
-      print_warning("#{check_code.message} #{warning_msg}")
+    if auto_check_level <= AUTO_CHECK_LEVEL_BYPASSABLE && datastore['ForceExploit']
+      print_warning("#{check_code.message} ForceExploit is enabled, proceeding with exploitation.")
       return yield
     end
-    fail_with(failure_type, "#{check_code.message} #{error_msg}")
+
+    if auto_check_level <= AUTO_CHECK_LEVEL_BYPASSABLE
+      fail_with(failure_type, "#{check_code.message} Run \"set ForceExploit true\" to override check result.")
+    else
+      fail_with(failure_type, check_code.message)
+    end
+  end
+
+  def merge_info_autochecklevel(info, val)
+    info['AutoCheckLevel'] = val
   end
 
 end

--- a/modules/exploits/windows/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/exploits/windows/dcerpc/cve_2021_1675_printnightmare.rb
@@ -46,6 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'SRVHOST' => Rex::Socket.source_address
         },
         'Stance' => Msf::Exploit::Stance::Aggressive,
+        'AutoCheckLevel' => AUTO_CHECK_LEVEL_REQUIRED,
         'Targets' => [
           [
             'Windows', {

--- a/spec/lib/msf/core/exploit/remote/auto_check_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check_spec.rb
@@ -100,17 +100,17 @@ RSpec.shared_examples "An AutoChecked method" do |opts|
     it_behaves_like "An AutoCheck module which can be overridden",
                     method: opts[:method],
                     check_code: ::Msf::Exploit::CheckCode::Safe,
-                    expected_error: 'The target is not exploitable. "set ForceExploit true" to override check result.'
+                    expected_error: 'The target is not exploitable. Run "set ForceExploit true" to override check result.'
 
     it_behaves_like "An AutoCheck module which can be overridden",
                     method: opts[:method],
                     check_code: ::Msf::Exploit::CheckCode::Unsupported,
-                    expected_error: 'This module does not support check. "set ForceExploit true" to override check result.'
+                    expected_error: 'This module does not support check. Run "set ForceExploit true" to override check result.'
 
     it_behaves_like "An AutoCheck module which can be overridden",
                     method: opts[:method],
                     check_code: ::Msf::Exploit::CheckCode::Unknown,
-                    expected_error: 'Cannot reliably check exploitability. "set ForceExploit true" to override check result.'
+                    expected_error: 'Cannot reliably check exploitability. Run "set ForceExploit true" to override check result.'
   end
 end
 


### PR DESCRIPTION
This updates the AutoCheck mixin to allow the module author to rely on some guarantees regarding it's execution. It adds a new `AutoCheckLevel` module info option which the module author can use to reliably ensure that the `check` method at least runs (LEVEL_BYPASSABLE) or runs and returns a result implying that the target is vulnerable (LEVEL_REQUIRED). This makes it a lot easier to rely on module instance state set within the check method. If the connection is established in the check method, and required in the exploit, it might make sense to use LEVEL_BYPASSABLE, which guarantees that at least the check method ran and presumably connected. If the exploit's check method maybe gathers a sensitive token that's then used in the exploit and determines the vulnerable state based on whether it could leak the token, then it makes sense for the check method to be a hard requirement and abort execution if the required token couldn't be leaked.

This fixes the stack trace in #19123 by preventing the user from bypassing the check method which as failing due to a connection error. The check method in printnight makes sense to be a requirement. There's a fair bit of setup to access the DCERPC interface and the response to the method can be used to reliably fingerprint whether or not the target is vulnerable.

## Verification


- [ ] `Use the new printnightmare exploit
- [ ] See that the check method can no longer be disabled (via AutoCheck) or bypassed (via ForceExploit)
