### PR TITLE
Fixes `password_spray` not using `additional_privates` and default `username`'s

### DIFF
--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -159,6 +159,91 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       end
     end
 
+    context 'when given a username and password' do
+      let(:password) { 'password' }
+      let(:username) { 'root' }
+
+      specify do
+        expected = [
+          Metasploit::Framework::Credential.new(public: 'root', private: 'password'),
+        ]
+        expect { |b| collection.each(&b) }.to yield_successive_args(*expected)
+      end
+    end
+
+    context 'when given a pass_file, user_file, password spray and a default username' do
+      let(:password) { nil }
+      let(:username) { 'root' }
+      let(:password_spray) { true }
+      let(:pass_file) do
+        filename = "pass_file"
+        stub_file = StringIO.new("password1\npassword2\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
+
+        filename
+      end
+      let(:user_file) do
+        filename = "user_file"
+        stub_file = StringIO.new("user1\nuser2\nuser3\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
+
+        filename
+      end
+
+      specify do
+        expected = [
+          Metasploit::Framework::Credential.new(public: "root", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user1", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "root", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user1", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "password2"),
+        ]
+        expect { |b| collection.each(&b) }.to yield_successive_args(*expected)
+      end
+    end
+
+    context 'when given a pass_file, user_file, password spray and additional privates' do
+      let(:password) { nil }
+      let(:username) { 'root' }
+      let(:password_spray) { true }
+      let(:additional_privates) { ['foo'] }
+      let(:pass_file) do
+        filename = "pass_file"
+        stub_file = StringIO.new("password1\npassword2\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_yield stub_file
+
+        filename
+      end
+      let(:user_file) do
+        filename = "user_file"
+        stub_file = StringIO.new("user1\nuser2\nuser3\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
+
+        filename
+      end
+
+      specify do
+        expected = [
+          Metasploit::Framework::Credential.new(public: "root", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user1", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "password1"),
+          Metasploit::Framework::Credential.new(public: "root", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user1", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "password2"),
+          Metasploit::Framework::Credential.new(public: "root", private: "foo"),
+          Metasploit::Framework::Credential.new(public: "user1", private: "foo"),
+          Metasploit::Framework::Credential.new(public: "user2", private: "foo"),
+          Metasploit::Framework::Credential.new(public: "user3", private: "foo"),
+        ]
+        expect { |b| collection.each(&b) }.to yield_successive_args(*expected)
+      end
+    end
+
     context 'when given a username, user_file and pass_file' do
       let(:password) { nil }
       let(:username) { 'my_username' }


### PR DESCRIPTION
This PR fixes some issue that were found while working on another ticket.

The `password_spray` datastore option was not considering `additional_privates` or default `usernames`.

I have fixed these issues and added tests.

## Verification
Currently a lot of the login modules have the `password_spray` datastore is currently being deregistered. (This is the ticket I am working on to change this)
- [ ] Start `msfconsole`
- [ ] Can look at removing the deregistering the `password_spray` from `smb_login` and test that way
- [ ] **Verify** the tests make sense and now pass
- [ ] Ensure code changes are sane