### PR TITLE
Reimplement password_spray into login modules

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -9,6 +9,8 @@ module Msf
 
 module Auxiliary::AuthBrute
 
+  include Msf::Auxiliary::LoginScanner
+
   def initialize(info = {})
     super
 

--- a/lib/msf/core/auxiliary/login_scanner.rb
+++ b/lib/msf/core/auxiliary/login_scanner.rb
@@ -1,0 +1,31 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Auxiliary
+    ###
+    #
+    # This module provides a base configure scanner method for binding common datastore options to the login scanners
+    #
+    ###
+    module LoginScanner
+      #
+      # Converts datastore options into configuration parameters for the
+      # Msf::Auxiliary::LoginScanner. Any parameters passed into
+      # this method will override the defaults.
+      #
+      def configure_login_scanner(conf)
+        {
+          host: datastore['RHOST'],
+          port: datastore['RPORT'],
+          proxies: datastore['Proxies'],
+          stop_on_success: datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          framework: framework,
+          framework_module: self,
+          local_port: datastore['CPORT'],
+          local_host: datastore['CHOST'],
+        }.merge(conf)
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -14,6 +14,7 @@ module Msf
 module Exploit::Remote::HttpClient
 
   include Msf::Auxiliary::Report
+  include Msf::Auxiliary::LoginScanner
 
   #
   # Initializes an exploit module that exploits a vulnerability in an HTTP
@@ -152,7 +153,7 @@ module Exploit::Remote::HttpClient
     client_password = opts['password'] || datastore['HttpPassword'] || ''
 
     http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
-    
+
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,
       (opts['rport'] || rport).to_i,
@@ -270,44 +271,39 @@ module Exploit::Remote::HttpClient
   # this method will override the defaults.
   #
   def configure_http_login_scanner(conf)
-    {
-      host:                          rhost,
-      port:                          rport,
-      ssl:                           ssl,
-      ssl_version:                   ssl_version,
-      proxies:                       datastore['PROXIES'],
-      framework:                     framework,
-      framework_module:              self,
-      vhost:                         vhost,
-      user_agent:                    datastore['UserAgent'],
-      evade_uri_encode_mode:         datastore['HTTP::uri_encode_mode'],
-      evade_uri_full_url:            datastore['HTTP::uri_full_url'],
-      evade_pad_method_uri_count:    datastore['HTTP::pad_method_uri_count'],
-      evade_pad_uri_version_count:   datastore['HTTP::pad_uri_version_count'],
-      evade_pad_method_uri_type:     datastore['HTTP::pad_method_uri_type'],
-      evade_pad_uri_version_type:    datastore['HTTP::pad_uri_version_type'],
-      evade_method_random_valid:     datastore['HTTP::method_random_valid'],
-      evade_method_random_invalid:   datastore['HTTP::method_random_invalid'],
-      evade_method_random_case:      datastore['HTTP::method_random_case'],
-      evade_version_random_valid:    datastore['HTTP::version_random_valid'],
-      evade_version_random_invalid:  datastore['HTTP::version_random_invalid'],
-      evade_uri_dir_self_reference:  datastore['HTTP::uri_dir_self_reference'],
-      evade_uri_dir_fake_relative:   datastore['HTTP::uri_dir_fake_relative'],
-      evade_uri_use_backslashes:     datastore['HTTP::uri_use_backslashes'],
-      evade_pad_fake_headers:        datastore['HTTP::pad_fake_headers'],
-      evade_pad_fake_headers_count:  datastore['HTTP::pad_fake_headers_count'],
-      evade_pad_get_params:          datastore['HTTP::pad_get_params'],
-      evade_pad_get_params_count:    datastore['HTTP::pad_get_params_count'],
-      evade_pad_post_params:         datastore['HTTP::pad_post_params'],
-      evade_pad_post_params_count:   datastore['HTTP::pad_post_params_count'],
-      evade_shuffle_get_params:      datastore['HTTP::shuffle_get_params'],
-      evade_shuffle_post_params:     datastore['HTTP::shuffle_post_params'],
-      evade_uri_fake_end:            datastore['HTTP::uri_fake_end'],
-      evade_uri_fake_params_start:   datastore['HTTP::uri_fake_params_start'],
-      evade_header_folding:          datastore['HTTP::header_folding'],
-      ntlm_domain:                   datastore['DOMAIN'],
-      digest_auth_iis:               datastore['DigestAuthIIS']
-    }.merge(conf)
+    configure_login_scanner(
+      {
+        vhost:                         vhost,
+        user_agent:                    datastore['UserAgent'],
+        evade_uri_encode_mode:         datastore['HTTP::uri_encode_mode'],
+        evade_uri_full_url:            datastore['HTTP::uri_full_url'],
+        evade_pad_method_uri_count:    datastore['HTTP::pad_method_uri_count'],
+        evade_pad_uri_version_count:   datastore['HTTP::pad_uri_version_count'],
+        evade_pad_method_uri_type:     datastore['HTTP::pad_method_uri_type'],
+        evade_pad_uri_version_type:    datastore['HTTP::pad_uri_version_type'],
+        evade_method_random_valid:     datastore['HTTP::method_random_valid'],
+        evade_method_random_invalid:   datastore['HTTP::method_random_invalid'],
+        evade_method_random_case:      datastore['HTTP::method_random_case'],
+        evade_version_random_valid:    datastore['HTTP::version_random_valid'],
+        evade_version_random_invalid:  datastore['HTTP::version_random_invalid'],
+        evade_uri_dir_self_reference:  datastore['HTTP::uri_dir_self_reference'],
+        evade_uri_dir_fake_relative:   datastore['HTTP::uri_dir_fake_relative'],
+        evade_uri_use_backslashes:     datastore['HTTP::uri_use_backslashes'],
+        evade_pad_fake_headers:        datastore['HTTP::pad_fake_headers'],
+        evade_pad_fake_headers_count:  datastore['HTTP::pad_fake_headers_count'],
+        evade_pad_get_params:          datastore['HTTP::pad_get_params'],
+        evade_pad_get_params_count:    datastore['HTTP::pad_get_params_count'],
+        evade_pad_post_params:         datastore['HTTP::pad_post_params'],
+        evade_pad_post_params_count:   datastore['HTTP::pad_post_params_count'],
+        evade_shuffle_get_params:      datastore['HTTP::shuffle_get_params'],
+        evade_shuffle_post_params:     datastore['HTTP::shuffle_post_params'],
+        evade_uri_fake_end:            datastore['HTTP::uri_fake_end'],
+        evade_uri_fake_params_start:   datastore['HTTP::uri_fake_params_start'],
+        evade_header_folding:          datastore['HTTP::header_folding'],
+        ntlm_domain:                   datastore['DOMAIN'],
+        digest_auth_iis:               datastore['DigestAuthIIS'],
+      }.merge(conf)
+    )
   end
 
   #

--- a/modules/auxiliary/scanner/acpp/login.rb
+++ b/modules/auxiliary/scanner/acpp/login.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Auxiliary
       'DB_ALL_USERS',
       'DB_ALL_CREDS',
       'DB_SKIP_EXISTING',
-      'PASSWORD_SPRAY',
       'USERNAME',
       'USERPASS_FILE',
       'USER_FILE',
@@ -61,23 +60,25 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = prepend_db_passwords(cred_collection)
 
     scanner = Metasploit::Framework::LoginScanner::ACPP.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: datastore['ConnectTimeout'],
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      ssl: datastore['SSL'],
-      ssl_version: datastore['SSLVersion'],
-      ssl_verify_mode: datastore['SSLVerifyMode'],
-      ssl_cipher: datastore['SSLCipher'],
-      local_port: datastore['CPORT'],
-      local_host: datastore['CHOST']
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        proxies: datastore['PROXIES'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: datastore['ConnectTimeout'],
+        max_send_size: datastore['TCP::max_send_size'],
+        send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('RECORD_GUEST', [ false, "Record guest login to the database", false]),
         OptBool.new('CHECK_GUEST', [ false, "Check for guest login", true])
       ], self)
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)
@@ -49,6 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::AFP.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         proxies: datastore['PROXIES'],
@@ -66,6 +65,7 @@ class MetasploitModule < Msf::Auxiliary
         ssl_cipher: datastore['SSLCipher'],
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "db2_default_pass.txt") ]),
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)
@@ -48,6 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::DB2.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         proxies: datastore['PROXIES'],
@@ -65,6 +64,7 @@ class MetasploitModule < Msf::Auxiliary
         ssl_cipher: datastore['SSLCipher'],
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('FTPUSER','FTPPASS', 'PASSWORD_SPRAY') # Can use these, but should use 'username' and 'password'
+    deregister_options('FTPUSER','FTPPASS') # Can use these, but should use 'username' and 'password'
     @accepts_all_logins = {}
   end
 
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::FTP.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         proxies: datastore['PROXIES'],
@@ -82,6 +83,7 @@ class MetasploitModule < Msf::Auxiliary
         ssl_cipher: datastore['SSLCipher'],
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
+++ b/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
@@ -31,8 +31,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The base path to Advantech WebAccess', '/']),
         OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:[empty]', false])
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options(
         'USERNAME', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING',
         'NTLM::SendLM', 'NTLM::SendNTLM', 'NTLM::SendSPN', 'NTLM::UseLMKey', 'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2',
-        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername', 'PASSWORD_SPRAY'
+        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername'
     )
   end
 
@@ -124,4 +124,3 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 end
-

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -38,8 +38,6 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(8080),
       OptString.new('TARGETURI', [false, 'Path to the Apache Axis Administration page', '/axis2/axis2-admin/login']),
     ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   # For print_* methods

--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('PASSWORD_SPRAY', 'VHOST', 'USER_AS_PASS',
+    deregister_options('VHOST', 'USER_AS_PASS',
                        'USERPASS_FILE', 'STOP_ON_SUCCESS', 'Proxies',
                        'DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_ALL_USERS',
                        'BLANK_PASSWORDS', 'RHOSTS')

--- a/modules/auxiliary/scanner/http/bavision_cam_login.rb
+++ b/modules/auxiliary/scanner/http/bavision_cam_login.rb
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:123456', false])
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -27,8 +27,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80)
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
 
     # caidao does not have an username, there's only password
-    deregister_options('HttpUsername', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS', 'PASSWORD_SPRAY')
+    deregister_options('HttpUsername', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
   end
 
   def scanner(ip)

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -38,8 +38,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [false, 'The password to specify for authentication', '']),
         OptString.new('TARGETURI', [ true,  'The path to the Chef Web UI application', '/']),
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   #

--- a/modules/auxiliary/scanner/http/cisco_firepower_login.rb
+++ b/modules/auxiliary/scanner/http/cisco_firepower_login.rb
@@ -34,8 +34,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The base path to Cisco Firepower Management console', '/']),
         OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:Admin123', false])
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/directadmin_login.rb
+++ b/modules/auxiliary/scanner/http/directadmin_login.rb
@@ -32,8 +32,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [false, 'The username to specify for authentication', '']),
         OptString.new('PASSWORD', [false, 'The password to specify for authentication', '']),
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -32,8 +32,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'The path to GitLab', '/'])
       ])
 
-    deregister_options('PASSWORD_SPRAY')
-
     register_autofilter_ports([ 80, 443 ])
   end
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -41,8 +41,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(4848),
         OptString.new('USERNAME',[true, 'A specific username to authenticate as','admin']),
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   #

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('CPQLOGIN', [true, 'The homepage of the login', '/cpqlogin.htm']),
       OptString.new('LOGIN_REDIRECT', [true, 'The URL to redirect to', '/cpqlogin'])
     ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def get_version(res)
@@ -199,4 +197,3 @@ class MetasploitModule < Msf::Auxiliary
     bruteforce(ip)
   end
 end
-

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('USERNAME', 'PASSWORD', 'PASSWORD_SPRAY')
+    deregister_options('USERNAME', 'PASSWORD')
   end
 
   def to_uri(uri)

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -26,8 +26,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
         OptString.new('TARGETURI', [true, "The directory of the IP Board install", "/forum/"]),
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [ false, 'The path to the Jenkins-CI application'])
       ])
 
-    deregister_options('PASSWORD_SPRAY')
-
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000 ])
   end
 

--- a/modules/auxiliary/scanner/http/jupyter_login.rb
+++ b/modules/auxiliary/scanner/http/jupyter_login.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
 
     deregister_options(
       'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING',
-      'HttpUsername', 'PASSWORD_SPRAY', 'STOP_ON_SUCCESS', 'USERNAME', 'USERPASS_FILE', 'USER_AS_PASS', 'USER_FILE'
+      'HttpUsername', 'STOP_ON_SUCCESS', 'USERNAME', 'USERPASS_FILE', 'USER_AS_PASS', 'USER_FILE'
     )
 
     register_autofilter_ports([ 80, 443, 8888 ])

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -22,8 +22,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'DefaultOptions' => { 'RPORT' => 8020}
     ))
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
 

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
     # username is hardcoded into application
     deregister_options(
       'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING',
-      'USERNAME', 'USER_FILE', 'USER_AS_PASS', 'PASSWORD_SPRAY')
+      'USERNAME', 'USER_FILE', 'USER_AS_PASS')
   end
 
   def setup

--- a/modules/auxiliary/scanner/http/octopusdeploy_login.rb
+++ b/modules/auxiliary/scanner/http/octopusdeploy_login.rb
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(80),
         OptString.new('TARGETURI', [true, 'URI for login. Default is /api/users/login', '/api/users/login'])
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -34,8 +34,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [false, 'The password to PhpMyAdmin', '']),
         OptString.new('TARGETURI', [true, 'The path to PhpMyAdmin', '/index.php'])
       ])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def scanner(ip)

--- a/modules/auxiliary/scanner/http/softing_sis_login.rb
+++ b/modules/auxiliary/scanner/http/softing_sis_login.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
-    deregister_options('PASSWORD_SPRAY')
-
     # credentials are "admin:admin" by default
     register_options(
       [

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -27,8 +27,6 @@ class MetasploitModule < Msf::Auxiliary
         }
     ))
 
-    deregister_options('PASSWORD_SPRAY')
-
     register_options(
       [
         OptString.new('USERNAME', [false, 'The username to specify for authentication', '']),

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -43,8 +43,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [false, 'The path to Syncovery', '/'])
       ]
     )
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def scanner(ip)

--- a/modules/auxiliary/scanner/http/syncovery_linux_token_cve_2022_36536.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_token_cve_2022_36536.rb
@@ -60,8 +60,8 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options(
       'USERNAME', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING',
       'NTLM::SendLM', 'NTLM::SendNTLM', 'NTLM::SendSPN', 'NTLM::UseLMKey', 'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2',
-      'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername', 'PASSWORD_SPRAY', 'BLANK_PASSWORDS',
-      'USER_FILE', 'USERPASS_FILE', 'PASS_FILE', 'PASSWORD'
+      'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername', 'BLANK_PASSWORDS', 'USER_FILE',
+      'USERPASS_FILE', 'PASS_FILE', 'PASSWORD'
     )
   end
 
@@ -124,11 +124,13 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("#{peer.strip} - Starting Brute-Forcer")
     scanner = Metasploit::Framework::LoginScanner::SyncoveryFileSyncBackup.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      stop_on_success: true, # this will have no effect due to the scanner behaviour when scanning without username
-      connection_timeout: 10
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: true, # this will have no effect due to the scanner behaviour when scanning without username
+        connection_timeout: 10
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -67,8 +67,6 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "tomcat_mgr_default_pass.txt") ]),
       ])
 
-    deregister_options('PASSWORD_SPRAY')
-
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000, 8008, 8443, 8444, 8880, 8888, 9080, 19300 ])
   end
 

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     # Not supporting these options, because we are not actually letting the API to process the
     # password list for us. We are doing that in Metasploit::Framework::LoginScanner::WordpressRPC.
     deregister_options(
-      'BLANK_PASSWORDS', 'PASSWORD', 'USERPASS_FILE', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_SKIP_EXISTING', 'PASSWORD_SPRAY'
+      'BLANK_PASSWORDS', 'PASSWORD', 'USERPASS_FILE', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_SKIP_EXISTING'
       )
   end
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
           Opt::RPORT(80),
         ])
 
-    deregister_options('BLANK_PASSWORDS', 'PASSWORD_SPRAY') # we don't need these options
+    deregister_options('BLANK_PASSWORDS') # we don't need these options
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -27,8 +27,6 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
-    deregister_options('PASSWORD_SPRAY')
-
     register_options(
       [
         Opt::RPORT(80),

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -58,8 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['PASSWORD'],
       realm: datastore['DOMAIN'],
       anonymous_login: datastore['ANONYMOUS_LOGIN'],
-      blank_passwords: false,
-      password_spray: datastore['PASSWORD_SPRAY']
+      blank_passwords: false
     )
 
     opts = {
@@ -83,16 +82,18 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     scanner = Metasploit::Framework::LoginScanner::LDAP.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: datastore['LDAP::ConnectTimeout'].to_i,
-      framework: framework,
-      framework_module: self,
-      realm_key: realm_key,
-      opts: opts
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: datastore['LDAP::ConnectTimeout'].to_i,
+        framework: framework,
+        framework_module: self,
+        realm_key: realm_key,
+        opts: opts
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options(
       'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING', 'BLANK_PASSWORDS',
       'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE',
-      'PASSWORD_SPRAY', 'STOP_ON_SUCCESS'
+      'STOP_ON_SUCCESS'
     )
   end
 
@@ -67,11 +67,13 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = prepend_db_passwords(cred_collection)
 
     scanner = Metasploit::Framework::LoginScanner::FreeswitchEventSocket.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      stop_on_success: true, # this will have no effect due to the scanner behaviour when scanning without username
-      connection_timeout: 10
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: true, # this will have no effect due to the scanner behaviour when scanning without username
+        connection_timeout: 10
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/mqtt/connect.rb
+++ b/modules/auxiliary/scanner/mqtt/connect.rb
@@ -36,8 +36,6 @@ class MetasploitModule < Msf::Auxiliary
           'PASS_FILE' => 'data/wordlists/unix_passwords.txt'
         }
     )
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def test_login(username, password)
@@ -76,25 +74,27 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::MQTT.new(
-      host: rhost,
-      port: rport,
-      read_timeout: datastore['READ_TIMEOUT'],
-      client_id: client_id,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: datastore['ConnectTimeout'],
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      ssl: datastore['SSL'],
-      ssl_version: datastore['SSLVersion'],
-      ssl_verify_mode: datastore['SSLVerifyMode'],
-      ssl_cipher: datastore['SSLCipher'],
-      local_port: datastore['CPORT'],
-      local_host: datastore['CHOST']
+      configure_login_scanner(
+        host: rhost,
+        port: rport,
+        read_timeout: datastore['READ_TIMEOUT'],
+        client_id: client_id,
+        proxies: datastore['PROXIES'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: datastore['ConnectTimeout'],
+        max_send_size: datastore['TCP::max_send_size'],
+        send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -40,11 +40,10 @@ class MetasploitModule < Msf::Auxiliary
       OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
     ])
 
-    options_to_deregister = %w[PASSWORD_SPRAY]
     if framework.features.enabled?(Msf::FeatureManager::MSSQL_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCreateSession%clr option within this module can open an interactive session')
     else
-      options_to_deregister << 'CreateSession'
+      options_to_deregister = %w[CreateSession]
     end
     deregister_options(*options_to_deregister)
   end
@@ -92,6 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::MSSQL.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         proxies: datastore['PROXIES'],
@@ -115,6 +115,7 @@ class MetasploitModule < Msf::Auxiliary
         ssl_cipher: datastore['SSLCipher'],
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
+      )
     )
     successful_logins = []
     successful_sessions = []

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -39,11 +39,10 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ])
 
-    options_to_deregister = %w[PASSWORD_SPRAY]
     if framework.features.enabled?(Msf::FeatureManager::MYSQL_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCreateSession%clr option within this module can open an interactive session')
     else
-      options_to_deregister << 'CreateSession'
+      options_to_deregister = %w[CreateSession]
     end
     deregister_options(*options_to_deregister)
   end
@@ -83,9 +82,7 @@ class MetasploitModule < Msf::Auxiliary
         )
 
         scanner = Metasploit::Framework::LoginScanner::MySQL.new(
-            host: ip,
-            port: rport,
-            proxies: datastore['Proxies'],
+          configure_login_scanner(
             cred_details: cred_collection,
             stop_on_success: datastore['STOP_ON_SUCCESS'],
             bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
@@ -101,6 +98,7 @@ class MetasploitModule < Msf::Auxiliary
             ssl_cipher: datastore['SSLCipher'],
             local_port: datastore['CPORT'],
             local_host: datastore['CHOST']
+          )
         )
 
         successful_logins = []

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [ true,  'The path to the Nessus server login API', '/session']),
       ])
 
-    deregister_options('HttpUsername', 'HttpPassword', 'PASSWORD_SPRAY')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
 

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -43,8 +43,6 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt')
         ])
     ])
-
-  deregister_options('PASSWORD_SPRAY')
   end
 
   def target
@@ -58,22 +56,24 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::POP3.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      ssl: datastore['SSL'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      ssl_version: datastore['SSLVersion'],
-      ssl_verify_mode: datastore['SSLVerifyMode'],
-      ssl_cipher: datastore['SSLCipher'],
-      local_port: datastore['CPORT'],
-      local_host: datastore['CHOST']
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        proxies: datastore['PROXIES'],
+        ssl: datastore['SSL'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        max_send_size: datastore['TCP::max_send_size'],
+        send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('CreateSession', [false, 'Create a new session for every successful login', false])
       ])
 
-    options_to_deregister = %w[SQL PASSWORD_SPRAY]
+    options_to_deregister = %w[SQL]
     if framework.features.enabled?(Msf::FeatureManager::POSTGRESQL_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCreateSession%clr option within this module can open an interactive session')
     else
@@ -88,16 +88,18 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::Postgres.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['Proxies'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 30,
-      framework: framework,
-      framework_module: self,
-      use_client_as_proof: create_session?
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        proxies: datastore['Proxies'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 30,
+        framework: framework,
+        framework_module: self,
+        use_client_as_proof: create_session?
+      )
     )
     successful_logins = []
     successful_sessions = []

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
     # redis does not have an username, there's only password
     deregister_options(
       'DB_ALL_CREDS', 'DB_ALL_USERS', 'DB_SKIP_EXISTING',
-      'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'PASSWORD_SPRAY'
+      'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE'
     )
   end
 
@@ -70,12 +70,14 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = prepend_db_passwords(cred_collection)
 
     scanner = Metasploit::Framework::LoginScanner::Redis.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      connection_timeout: 30
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        proxies: datastore['PROXIES'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        connection_timeout: 30
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/sage/x3_adxsrv_login.rb
+++ b/modules/auxiliary/scanner/sage/x3_adxsrv_login.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('PASSWORD_SPRAY', 'BLANK_PASSWORDS')
+    deregister_options('BLANK_PASSWORDS')
   end
 
   def run_host(ip)
@@ -50,17 +50,19 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::X3.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      local_port: datastore['CPORT'],
-      local_host: datastore['CHOST']
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        max_send_size: datastore['TCP::max_send_size'],
+        send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    options_to_deregister = %w[USERNAME PASSWORD PASSWORD_SPRAY CommandShellCleanupCommand AutoVerifySession]
+    options_to_deregister = %w[USERNAME PASSWORD CommandShellCleanupCommand AutoVerifySession]
 
     if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCreateSession%clr option within this module can open an interactive session')
@@ -131,21 +131,23 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     @scanner = Metasploit::Framework::LoginScanner::SMB.new(
-      host: ip,
-      port: rport,
-      local_port: datastore['CPORT'],
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      proxies: datastore['Proxies'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      always_encrypt: datastore['SMB::AlwaysEncrypt'],
-      versions: datastore['SMB::ProtocolVersion'].split(',').map(&:strip).reject(&:blank?).map(&:to_i),
-      kerberos_authenticator_factory: kerberos_authenticator_factory,
-      use_client_as_proof: create_session?
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        local_port: datastore['CPORT'],
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        proxies: datastore['Proxies'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5,
+        max_send_size: datastore['TCP::max_send_size'],
+        send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
+        always_encrypt: datastore['SMB::AlwaysEncrypt'],
+        versions: datastore['SMB::ProtocolVersion'].split(',').map(&:strip).reject(&:blank?).map(&:to_i),
+        kerberos_authenticator_factory: kerberos_authenticator_factory,
+        use_client_as_proof: create_session?
+      )
     )
 
     if datastore['DETECT_ANY_AUTH']

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
     ])
 
-    deregister_options('USERNAME', 'USER_FILE', 'USERPASS_FILE', 'PASSWORD_SPRAY')
+    deregister_options('USERNAME', 'USER_FILE', 'USERPASS_FILE')
   end
 
   # Operate on a single host so that we can take advantage of multithreading
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::SNMP.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         protocol: datastore['PROTOCOL'],
@@ -60,6 +61,7 @@ class MetasploitModule < Msf::Auxiliary
         framework: framework,
         framework_module: self,
         queue_size: 100
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ssh/karaf_login.rb
+++ b/modules/auxiliary/scanner/ssh/karaf_login.rb
@@ -49,8 +49,6 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def rport
@@ -88,14 +86,16 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      proxies: datastore['Proxies'],
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      connection_timeout: datastore['SSH_TIMEOUT'],
-      framework: framework,
-      framework_module: self,
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        proxies: datastore['Proxies'],
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        connection_timeout: datastore['SSH_TIMEOUT'],
+        framework: framework,
+        framework_module: self,
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -48,8 +48,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true])
       ]
     )
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def rport
@@ -100,16 +98,18 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      proxies: datastore['Proxies'],
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: datastore['SSH_TIMEOUT'],
-      framework: framework,
-      framework_module: self,
-      skip_gather_proof: !datastore['GatherProof']
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        proxies: datastore['Proxies'],
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: datastore['SSH_TIMEOUT'],
+        framework: framework,
+        framework_module: self,
+        skip_gather_proof: !datastore['GatherProof']
+      )
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     deregister_options(
-      'PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS','USERPASS_FILE','PASSWORD_SPRAY',
+      'PASSWORD','PASS_FILE','BLANK_PASSWORDS','USER_AS_PASS','USERPASS_FILE',
       'DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_SKIP_EXISTING'
     )
 
@@ -153,16 +153,18 @@ class MetasploitModule < Msf::Auxiliary
 
     print_brute :level => :vstatus, :ip => ip, :msg => "Testing #{key_count} #{'key'.pluralize(key_count)} from #{key_sources.join(' and ')}"
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
-      host: ip,
-      port: rport,
-      cred_details: keys,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      proxies: datastore['Proxies'],
-      connection_timeout: datastore['SSH_TIMEOUT'],
-      framework: framework,
-      framework_module: self,
-      skip_gather_proof: !datastore['GatherProof']
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: keys,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        proxies: datastore['Proxies'],
+        connection_timeout: datastore['SSH_TIMEOUT'],
+        framework: framework,
+        framework_module: self,
+        skip_gather_proof: !datastore['GatherProof']
+      )
     )
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
+++ b/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
@@ -41,8 +41,6 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class
     )
 
-    deregister_options('PASSWORD_SPRAY')
-
     @no_pass_prompt = []
   end
 
@@ -96,6 +94,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       scanner = Metasploit::Framework::LoginScanner::Telnet.new(
+      configure_login_scanner(
           host: ip,
           port: rport,
           proxies: datastore['PROXIES'],
@@ -116,6 +115,7 @@ class MetasploitModule < Msf::Auxiliary
           ssl_cipher: datastore['SSLCipher'],
           local_port: datastore['CPORT'],
           local_host: datastore['CHOST']
+        )
       )
 
       scanner.scan! do |result|

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -38,8 +38,6 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class
     )
 
-    deregister_options('PASSWORD_SPRAY')
-
     @no_pass_prompt = []
   end
 
@@ -53,6 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::Telnet.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         proxies: datastore['PROXIES'],
@@ -72,6 +71,7 @@ class MetasploitModule < Msf::Auxiliary
         ssl_cipher: datastore['SSLCipher'],
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/varnish/varnish_cli_login.rb
+++ b/modules/auxiliary/scanner/varnish/varnish_cli_login.rb
@@ -40,8 +40,6 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, 'wordlists', 'unix_passwords.txt') ])
       ])
 
-    deregister_options('PASSWORD_SPRAY')
-
     # We don't currently support an auth mechanism that uses usernames, so we'll ignore any
     # usernames that are passed in.
     @strip_usernames = true
@@ -70,14 +68,15 @@ class MetasploitModule < Msf::Auxiliary
       username: '<BLANK>'
     )
     scanner = Metasploit::Framework::LoginScanner::VarnishCLI.new(
-      host: ip,
-      port: rport,
-      cred_details: cred_collection,
-      stop_on_success: true,
-      connection_timeout: 10,
-      framework: framework,
-      framework_module: self,
-
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: true,
+        connection_timeout: 10,
+        framework: framework,
+        framework_module: self,
+      )
     )
     scanner.scan! do |result|
       credential_data = result.to_h

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -29,8 +29,6 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([Opt::RPORT(902)])
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run_host(ip)
@@ -62,23 +60,25 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::VMAUTHD.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 30,
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      ssl: datastore['SSL'],
-      ssl_version: datastore['SSLVersion'],
-      ssl_verify_mode: datastore['SSLVerifyMode'],
-      ssl_cipher: datastore['SSLCipher'],
-      local_port: datastore['CPORT'],
-      local_host: datastore['CHOST']
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        proxies: datastore['PROXIES'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 30,
+        max_send_size: datastore['TCP::max_send_size'],
+        send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -46,8 +46,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('USER_AS_PASS', [false, 'Try the username as the password for all users', false])
       ])
 
-    deregister_options('PASSWORD_SPRAY')
-
     register_autofilter_ports((5900..5910).to_a) # Each instance increments the port by one.
 
     # We don't currently support an auth mechanism that uses usernames, so we'll ignore any
@@ -64,6 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::VNC.new(
+      configure_login_scanner(
         host: ip,
         port: rport,
         proxies: datastore['PROXIES'],
@@ -81,6 +80,7 @@ class MetasploitModule < Msf::Auxiliary
         ssl_cipher: datastore['SSLCipher'],
         local_port: datastore['CPORT'],
         local_host: datastore['CHOST']
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -33,8 +33,6 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'License' => MSF_LICENSE
     )
-
-    deregister_options('PASSWORD_SPRAY')
   end
 
   def run
@@ -74,17 +72,19 @@ class MetasploitModule < Msf::Auxiliary
     keep_connection_alive = datastore['CreateSession']
 
     scanner = Metasploit::Framework::LoginScanner::WinRM.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['Proxies'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 10,
-      framework: framework,
-      framework_module: self,
-      kerberos_authenticator_factory: kerberos_authenticator_factory,
-      keep_connection_alive: keep_connection_alive
+      configure_login_scanner(
+        host: ip,
+        port: rport,
+        proxies: datastore['Proxies'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 10,
+        framework: framework,
+        framework_module: self,
+        kerberos_authenticator_factory: kerberos_authenticator_factory,
+        keep_connection_alive: keep_connection_alive
+      )
     )
 
     scanner.scan! do |result|


### PR DESCRIPTION
This PR updates login scanner modules to support `PASSWORD_SPRAY`. We updated the existing modules no longer deregister the `PASSWORD_SPRAY` module option.

I added a base configure scanner method for binding common datastore options to the login scanners, similar to the [HTTP implementations](https://github.com/3V3RYONE/metasploit-framework/blob/fe63d80679f0ae827e3e0e43759bd73f486ec77f/modules/auxiliary/scanner/nessus/nessus_rest_login.rb#L45-L56). 

I updated the existing `configure_http_login_scanner` implementation to call off to the new generic `configure_login_scanner` implementation, so that the `configure_http_login_scanner` method gets any new options that we add in the future for free.

## Verification
- [ ]  Start msfconsole
- [ ] Test various login modules
- [ ] Verify `password_spray` now works as intended
- [ ] Verify code changes are sane