### PR TITLE
Fixes an issue were a regex match could return `nil`

### DIFF
--- a/lib/postgres/postgres-pr/connection.rb
+++ b/lib/postgres/postgres-pr/connection.rb
@@ -213,14 +213,18 @@ class Connection
   def detect_platform_and_arch
     result = {}
 
-    query_result = query('select version()').rows.join.match(/on (?<architecture>\w+)-\w+-(?<platform>\w+)/)
-    server_vars = {
-      'version_compile_machine' => query_result[:architecture],
-      'version_compile_os' => query_result[:platform]
-    }
+    query_result = query('select version()').rows[0][0]
+    match_platform_and_arch = query_result.match(/on (?<architecture>\w+)-\w+-(?<platform>\w+)/)
 
-    result[:arch] = map_compile_arch_to_architecture(server_vars['version_compile_machine'])
-    result[:platform] = map_compile_os_to_platform(server_vars['version_compile_os'])
+    if match_platform_and_arch.nil?
+      arch = platform = query_result
+    else
+      arch = match_platform_and_arch[:architecture]
+      platform = match_platform_and_arch[:platform]
+    end
+
+    result[:arch] = map_compile_arch_to_architecture(arch)
+    result[:platform] = map_compile_os_to_platform(platform)
 
     result
   end

--- a/spec/lib/rex/proto/postgresql/client_spec.rb
+++ b/spec/lib/rex/proto/postgresql/client_spec.rb
@@ -68,7 +68,14 @@ RSpec.describe Msf::Db::PostgresPR::Connection do
     [
       { version: 'PostgreSQL 9.4.26 on x86_64-pc-linux-gnu (Debian 9.4.26-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit', expected: { arch: 'x86_64', platform: 'Linux' } },
       { version: 'PostgreSQL 14.11 (Debian 14.11-1.pgdg120+2) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit', expected: { arch: 'x86_64', platform: 'Linux' } },
-      { version: 'PostgreSQL 14.11 (Homebrew) on x86_64-apple-darwin22.6.0, compiled by Apple clang version 15.0.0 (clang-1500.1.0.2.5), 64-bit', expected: { arch: 'x86_64', platform: 'OSX' } }
+      { version: 'PostgreSQL 14.11 (Homebrew) on x86_64-apple-darwin22.6.0, compiled by Apple clang version 15.0.0 (clang-1500.1.0.2.5), 64-bit', expected: { arch: 'x86_64', platform: 'OSX' } },
+      {
+        version: 'PostgreSQL 14.11 (Homebrew) <arch>-<platform>, compiled by <platform> clang version 15.0.0 (clang-1500.1.0.2.5), <arch>',
+        expected: {
+          arch: 'postgresql 14.11 (homebrew) <arch>-<platform>, compiled by <platform> clang version 15.0.0 (clang-1500.1.0.2.5), <arch>',
+          platform: 'postgresql 14.11 (homebrew) <arch>-<platform>, compiled by <platform> clang version 15.0.0 (clang-1500.1.0.2.5), <arch>'
+        }
+      }
     ].each do |test|
       context "when the database is version #{test[:version]}" do
         it "returns #{test[:expected]}" do


### PR DESCRIPTION
Fixes an issue were `nil` could have been returned when matching a regex for the PostgreSQL version query result. 

## Verification

- [ ] Ci passes (New test passes)
- [ ] Code changes are sane