### PR TITLE
Allow setting the RPORT option for smb_version

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Auxiliary
 
     if datastore['RPORT'].blank? || datastore['RPORT'] == 0
       smb_services = [
-        { port: 139, direct: false },
-        { port: 445, direct: true }
+        { port: 445, direct: true },
+        { port: 139, direct: false }
       ]
     else
       smb_services = [

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -195,8 +195,8 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     if datastore['RPORT'].blank? || datastore['RPORT'] == 0
       smb_services = [
-        { port: 139, direct: false },
-        { port: 445, direct: true }
+        { port: 445, direct: true },
+        { port: 139, direct: false }
       ]
     else
       smb_services = [

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -40,6 +40,10 @@ class MetasploitModule < Msf::Auxiliary
       'License' => MSF_LICENSE
     )
 
+    register_options([
+      Msf::Opt::RPORT(nil, false)
+    ])
+
     register_advanced_options(
       [
         *kerberos_storage_options(protocol: 'SMB'),
@@ -47,15 +51,15 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    deregister_options('RPORT', 'SMBDIRECT', 'SMB::ProtocolVersion')
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def rport
-    @smb_port
+    @rport
   end
 
-  def smb_direct
-    (@smb_port == 445)
+  def connect(*args, **kwargs)
+    super(*args, **kwargs, direct: @smb_direct)
   end
 
   def seconds_to_timespan(seconds)
@@ -189,10 +193,21 @@ class MetasploitModule < Msf::Auxiliary
   # Fingerprint a single host
   #
   def run_host(ip)
-    smb_ports = [445, 139]
+    if datastore['RPORT'].blank? || datastore['RPORT'] == 0
+      smb_services = [
+        { port: 139, direct: false },
+        { port: 445, direct: true }
+      ]
+    else
+      smb_services = [
+        { port: datastore['RPORT'], direct: datastore['SMBDirect'] }
+      ]
+    end
+
     lines = [] # defer status output to the very end to group lines together by host
-    smb_ports.each do |pnum|
-      @smb_port = pnum
+    smb_services.each do |smb_service|
+      @rport = smb_service[:port]
+      @smb_direct = smb_service[:direct]
       self.simple = nil
 
       begin


### PR DESCRIPTION
This fixes #19072 by allowing RPORT to be optionally set. When RPORT is not set, the original behavior of trying 139/tcp with SMBDirect=false, and 445/tcp with SMBDirect=true is retained. However when `RPORT` is set, that is the only port that is targeted and the `SMBDirect` datastore option is used to control it's setting.

This supersedes:

* #19076
* #19073 

The following `auxiliary/scanner/smb` modules should be updated with this same pattern as well. They too are hard coded to try 139/tcp with SMBDirect=false, and 445/tcp with SMBDirect=true without an option for the user to change them.
* pipe_auditor
* pipe_dcerpc_auditor
* smb_enumshares
* smb_enumusers_domain
* smb_lookupsid
* smb_uninit_cred

## Verification

- [ ] Use socat to target an SMB server and forward a non-default port to it (e.g. `socat TCP-LISTEN:1445,fork TCP:192.168.250.5:445`)
- [ ] Use the smb_version module and target the non-default port (`set RPORT 1445` in the previous example)
- [ ] Run the module and see that it works
- [ ] Unset the `RPORT` option and target the host directly, see that it still works
