### PR TITLE
Adds the features configuration to the debug command output

### DIFF
--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -101,6 +101,7 @@ module Msf
         all_information = preamble
         all_information << datastore(framework, driver)
         all_information << database_configuration(framework)
+        all_information << framework_config(framework)
         all_information << history(driver)
         all_information << errors
         all_information << logs
@@ -198,6 +199,23 @@ module Msf
           'Database Configuration',
           ERROR_BLURB,
           section_build_error('Failed to extract Database configuration', e)
+        )
+      end
+
+      def self.framework_config(framework)
+        required_features = framework.features.all.map { |feature| [feature[:name], feature[:enabled].to_s] }
+        markdown_formatted_features = required_features.map { |feature| "| #{feature.join(' | ')} |" }
+        required_fields = %w[name enabled]
+
+        table = "| #{required_fields.join(' | ')} |\n"
+        table += '|' + '-:|' * required_fields.count + "\n"
+        table += markdown_formatted_features.join("\n").to_s
+
+        # The markdown table can't be placed in a code block or it will not render as a table.
+        build_section_no_block(
+          'Framework Configuration',
+          'The features are configured as follows:',
+          table
         )
       end
 


### PR DESCRIPTION
Resolves https://github.com/rapid7/metasploit-framework/issues/18793

Adds the features configuration to the debug commands output, example below:


##  Framework Configuration

The features are configured as follows:
<details>
<summary>Collapse</summary>

| name | enabled |
|-:|-:|
| wrapped_tables | true |
| fully_interactive_shells | false |
| manager_commands | true |
| datastore_fallbacks | true |
| metasploit_payload_warnings | true |
| defer_module_loads | false |
| smb_session_type | true |
| postgresql_session_type | true |
| mysql_session_type | true |
| mssql_session_type | true |
| dns | true |
| hierarchical_search_table | true |

</details>


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use a random module
- [ ] Run `debug`
- [ ] **Verify** the features output match the features configuration output from running the `features` command
- [ ] **Verify** the code changes are sane
- [ ] **Verify** the markdown renders correctly on GitHub (I just used a comment for this)