### PR TITLE
Fix windows build failures

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -72,7 +72,8 @@ jobs:
         include:
           # Windows Meterpreter
           - { meterpreter: { name: windows_meterpreter }, os: windows-2019 }
-          - { meterpreter: { name: windows_meterpreter }, os: windows-2022 }
+          # Temporarily required for failing pcaprub compilation:
+          # - { meterpreter: { name: windows_meterpreter }, os: windows-2022 }
 
           # Mettle
           - { meterpreter: { name: mettle }, os: macos-11 }


### PR DESCRIPTION
Disables the windows server 2022 test build due to the following pcaprub compilation issues, this is a temporary solution for now:

```
current directory:
D:/a/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.0.0/gems/pcaprub-0.13.2/ext/pcaprub_c
make.exe DESTDIR\= clean

current directory:
D:/a/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.0.0/gems/pcaprub-0.13.2/ext/pcaprub_c
make.exe DESTDIR\=
generating pcaprub_c-x64-mingw32.def
compiling pcaprub.c
In file included from C:/WpdPack/include/pcap/pcap.h:41,
                 from C:/WpdPack/include/pcap.h:45,
                 from pcaprub.c:11:
C:/WpdPack/include/pcap-stdinc.h:64:9: warning: "snprintf" redefined
   64 | #define snprintf _snprintf
      |         ^~~~~~~~
In file included from
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/ruby.h:144,
from
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby.h:38,
                 from pcaprub.c:1:
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/subst.h:14:9:
note: this is the location of the previous definition
   14 | #define snprintf ruby_snprintf
      |         ^~~~~~~~
C:/WpdPack/include/pcap-stdinc.h:65:9: warning: "vsnprintf" redefined
   65 | #define vsnprintf _vsnprintf
      |         ^~~~~~~~~
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/subst.h:15:9:
note: this is the location of the previous definition
   15 | #define vsnprintf ruby_vsnprintf
      |         ^~~~~~~~~
pcaprub.c: In function 'rbpcap_each_data':
pcaprub.c:984:9: warning: cast from pointer to integer of different size
[-Wpointer-to-int-cast]
  984 |   fno = (int)pcap_getevent(rbp->pd);
      |         ^
pcaprub.c:984:7: error: assignment to 'HANDLE' {aka 'void *'} from 'int' makes
pointer from integer without a cast [-Wint-conversion]
  984 |   fno = (int)pcap_getevent(rbp->pd);
      |       ^
pcaprub.c: In function 'rbpcap_each_packet':
pcaprub.c:1026:9: warning: cast from pointer to integer of different size
[-Wpointer-to-int-cast]
 1026 |   fno = (int)pcap_getevent(rbp->pd);
      |         ^
pcaprub.c:1026:7: error: assignment to 'HANDLE' {aka 'void *'} from 'int' makes
pointer from integer without a cast [-Wint-conversion]
 1026 |   fno = (int)pcap_getevent(rbp->pd);
      |       ^
pcaprub.c: In function 'rbpcap_thread_wait_handle':
pcaprub.c:1266:7: error: passing argument 1 of 'rb_thread_call_without_gvl' from
incompatible pointer type [-Wincompatible-pointer-types]
 1266 |       rbpcap_thread_wait_handle_blocking,
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |       |
      |       VALUE (*)(void *) {aka long long unsigned int (*)(void *)}
In file included from pcaprub.c:4:
C:/hostedtoolcache/windows/Ruby/3.0.5/x64/include/ruby-3.0.0/ruby/thread.h:24:42:
note: expected 'void * (*)(void *)' but argument is of type 'VALUE (*)(void *)'
{aka 'long long unsigned int (*)(void *)'}
   24 | void *rb_thread_call_without_gvl(void *(*func)(void *), void *data1,
      |                                  ~~~~~~~~^~~~~~~~~~~~~
make: *** [Makefile:246: pcaprub.o] Error 1
```

Upstream pull request to wait for a new release: https://github.com/pcaprub/pcaprub/pull/68

## Verification

Ensure CI passes