### PR TITLE
Fix windows platform detection bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.31)
+    rex-core (0.1.32)
     rex-encoder (0.1.7)
       metasm
       rex-arch


### PR DESCRIPTION
Fix windows platform detection bug when running on a UCRT compiled environment

Pulls in the changes from https://github.com/rapid7/rex-core/pull/40

## Verification

- Ensure CI passes