### PR TITLE
Update bundler version

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -135,9 +135,6 @@ jobs:
           bundler-cache: true
           working-directory: metasploit-framework
           cache-version: 5
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - name: Acceptance
         env:
@@ -187,9 +184,6 @@ jobs:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           cache-version: 4
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/ldap_acceptance.yml
+++ b/.github/workflows/ldap_acceptance.yml
@@ -130,9 +130,6 @@ jobs:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           cache-version: 4
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/mysql_acceptance.yml
+++ b/.github/workflows/mysql_acceptance.yml
@@ -146,9 +146,6 @@ jobs:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           cache-version: 4
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/postgres_acceptance.yml
+++ b/.github/workflows/postgres_acceptance.yml
@@ -148,9 +148,6 @@ jobs:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           cache-version: 4
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/smb_acceptance.yml
+++ b/.github/workflows/smb_acceptance.yml
@@ -132,9 +132,6 @@ jobs:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           cache-version: 4
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - uses: actions/download-artifact@v4
         id: download

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,4 +592,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.5.10


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/19316
Closes https://github.com/rapid7/metasploit-framework/issues/19492

Update bundler version

## Verification

- Ensure CI passes
- Test the branch on your local dev environment, i.e. for my Kali machine:
```
┌──(vagrant㉿Kali)-[~/metasploit-framework]
└─$ bundle                                                                                                                                                                                
Bundler 2.3.27 is running, but your lockfile was generated with 2.5.10. Installing Bundler 2.5.10 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.10
...

┌──(vagrant㉿Kali)-[~/metasploit-framework]
└─$ bundle exec ruby ./msfconsole -v                                                                                                                                                    
Framework Version: 6.4.28-dev-9ff47b0eb3
```