### PR TITLE
Display current action on module load

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -28,6 +28,7 @@ module Msf
     MSSQL_SESSION_TYPE = 'mssql_session_type'
     LDAP_SESSION_TYPE = 'ldap_session_type'
     SHOW_SUCCESSFUL_LOGINS = 'show_successful_logins'
+    DISPLAY_MODULE_ACTION = 'display_module_action'
 
     DEFAULTS = [
       {
@@ -124,6 +125,13 @@ module Msf
         requires_restart: false,
         default_value: true,
         developer_notes: 'Enabled in Metasploit 6.4.x'
+      }.freeze,
+      {
+        name: DISPLAY_MODULE_ACTION,
+        description: 'When enabled after using a module the current action and number of actions will be displayed',
+        requires_restart: false,
+        default_value: true,
+        developer_notes: 'Added as a feature so users can turn it off if they wish to reduce clutter in their terminal'
       }.freeze
     ].freeze
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -905,6 +905,12 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
+            if mod.actions.size > 1
+              print_status "This module has #{mod.actions.size} actions to select from"
+              print_status 'Display them all with the %grnshow actions%clr command'
+              print_status "The current action is set to %grn#{mod.action.name}%clr"
+            end
+
             mod.init_ui(driver.input, driver.output)
           end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -906,9 +906,7 @@ module Msf
             end
 
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.actions.size > 1
-              print_status "This module has #{mod.actions.size} actions to select from"
-              print_status 'Display them all with the %grnshow actions%clr command'
-              print_status "The current action is set to %grn#{mod.action.name}%clr"
+              print_status "Using action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end
 
             mod.init_ui(driver.input, driver.output)

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -905,7 +905,7 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
-            if mod.actions.size > 1
+            if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.actions.size > 1
               print_status "This module has #{mod.actions.size} actions to select from"
               print_status 'Display them all with the %grnshow actions%clr command'
               print_status "The current action is set to %grn#{mod.action.name}%clr"


### PR DESCRIPTION
Displays info about the modules current action and number of available actions to the user when they `use <module_name`

Example of how it looks for `ldap_query`
![image](https://github.com/rapid7/metasploit-framework/assets/19910435/a0a2e29c-edea-470d-bad0-6e1b9eb65c6b)

This is intended to help users learn that a module has actions and what the current action is proactively
I placed it behind a feature flag but defaulted it to be on so people can switch it off if they don't like the extra clutter in their terminal

# Verification steps
- [x] use a module e.g. `use auxiliary/gather/ldap_query` and verify the output is correct (number of actions + selected action are accurate)
- [x] Turn the feature off and use the module again _without_ rebooting and verify the output is gone
- [x] check that the output doesn't change for any modules without any actions

