### PR TITLE
Don't show regular option groups when viewing advanced options

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -569,15 +569,15 @@ class ReadableText
   # @param missing [Boolean] dump only empty required options.
   # @return [String] the string form of the information.
   def self.dump_options(mod, indent = '', missing = false, advanced: false, evasion: false)
-    filtered_options = mod.options.values.select { |opt| opt.advanced? == advanced && opt.evasion? == evasion }
+    filtered_options = mod.options.select { |_name, opt| opt.advanced? == advanced && opt.evasion? == evasion }
 
-    option_groups = mod.options.groups.map { |_name, group| group }.sort_by(&:name)
+    option_groups = mod.options.groups.values.select { |group| group.option_names.any? { |name| filtered_options.keys.include?(name) } }
     options_by_group = option_groups.map do |group|
-      [group, group.option_names.map { |name| mod.options[name] }.compact]
+      [group, group.option_names.map { |name| filtered_options[name] }.compact]
     end.to_h
     grouped_option_names = option_groups.flat_map(&:option_names)
-    remaining_options = filtered_options.reject { |option| grouped_option_names.include?(option.name) }
-    options_grouped_by_conditions = remaining_options.group_by(&:conditions)
+    remaining_options = filtered_options.reject { |_name, option| grouped_option_names.include?(option.name) }
+    options_grouped_by_conditions = remaining_options.values.group_by(&:conditions)
 
     option_tables = []
 

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Msf::Serializer::ReadableText do
     context 'when some options are grouped' do
       let(:group_name) { 'group_name' }
       let(:group_description) { 'Used for example reasons' }
-      let(:option_names) { %w[RHOSTS SMBUser SMBDomain] }
+      let(:option_names) { %w[DigestAlgorithm RHOSTS SMBUser SMBDomain] }
       let(:group) { Msf::OptionGroup.new(name: group_name, description: group_description, option_names: option_names) }
       let(:aux_mod_with_grouped_options) do
         mod = aux_mod_with_set_options.replicant
@@ -294,6 +294,35 @@ RSpec.describe Msf::Serializer::ReadableText do
           Winrm::Krb5Ccname                                                                   no        The ccache file to use for kerberos authentication
           Winrm::KrbOfferedEncryptionTypes  AES256,AES128,RC4-HMAC,DES-CBC-MD5,DES3-CBC-SHA1  yes       Kerberos encryption types to offer
           Winrm::Rhostname                                                                    no        The rhostname which is required for kerberos - the SPN
+        TABLE
+      end
+    end
+
+    context 'when some options are grouped' do
+      let(:group_name) { 'group_name' }
+      let(:group_description) { 'Used for example reasons' }
+      let(:option_names) { %w[DigestAlgorithm RHOSTS SMBUser SMBDomain] }
+      let(:group) { Msf::OptionGroup.new(name: group_name, description: group_description, option_names: option_names) }
+      let(:aux_mod_with_grouped_options) do
+        mod = aux_mod_with_set_options.replicant
+        mod.options.add_group(group)
+        mod
+      end
+
+      it 'should return the grouped options separate to the rest of the options' do
+        expect(described_class.dump_advanced_options(aux_mod_with_grouped_options, indent_string)).to match_table <<~TABLE
+          Name       Current Setting  Required  Description
+          ----       ---------------  --------  -----------
+          VERBOSE    false            no        Enable detailed status messages
+          WORKSPACE                   no        Specify the workspace for this module
+
+
+          #{group_description}:
+
+          Name             Current Setting  Required  Description
+          ----             ---------------  --------  -----------
+          DigestAlgorithm  SHA256           yes       The digest algorithm to use (Accepted: SHA1, SHA256)
+
         TABLE
       end
     end


### PR DESCRIPTION
Fixes the display of option groups so that the option group only displays the relevant options (regular/advanced/evasion) if any are present in the group, and only displays the group at all if it has an option to display

Also updated the tests to have an option group with mixed regular and advanced options

# Verification Steps
- [ ] use a module with grouped options e.g. `use ldap_query`
- [ ] verify that the option groups appear when running `options`
- [ ] verify the option groups are no longer displayed when running `advanced`
