### PR TITLE
SQL sessions have correct history manager support (again)

### DIFF
--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -74,7 +74,8 @@ class Config < Hash
       'PluginDirectory'     => "plugins",
       'DataDirectory'       => "data",
       'LootDirectory'       => "loot",
-      'LocalDirectory'      => "local"
+      'LocalDirectory'      => "local",
+      'HistoriesDirectory'  => "histories"
     }
 
   ##
@@ -95,6 +96,13 @@ class Config < Hash
   # @return [String] the root configuration directory.
   def self.config_directory
     self.new.config_directory
+  end
+
+  # Returns the histories directory default.
+  #
+  # @return [String] the SQL session histories directory.
+  def self.histories_directory
+    self.new.histories_directory
   end
 
   # Return the directory that logo files should be loaded from.
@@ -235,6 +243,13 @@ class Config < Hash
     self.new.postgresql_session_history
   end
 
+  # Returns the full path to the PostgreSQL interactive query history file
+  #
+  # @return [String] path to the interactive query history file.
+  def self.postgresql_session_interactive_history
+    self.new.postgresql_session_interactive_history
+  end
+
   # Returns the full path to the MSSQL session history file.
   #
   # @return [String] path to the history file.
@@ -242,11 +257,25 @@ class Config < Hash
     self.new.mssql_session_history
   end
 
+  # Returns the full path to the MSSQL interactive query history file
+  #
+  # @return [String] path to the interactive query history file.
+  def self.mssql_session_interactive_history
+    self.new.mssql_session_interactive_history
+  end
+
   # Returns the full path to the MySQL session history file.
   #
   # @return [String] path to the history file.
   def self.mysql_session_history
     self.new.mysql_session_history
+  end
+
+  # Returns the full path to the MySQL interactive query history file
+  #
+  # @return [String] path to the interactive query history file.
+  def self.mysql_session_interactive_history
+    self.new.mysql_session_interactive_history
   end
 
   def self.pry_history
@@ -336,6 +365,13 @@ class Config < Hash
     self['ConfigDirectory']
   end
 
+  # Returns the histories directory default.
+  #
+  # @return [String] the SQL session histories directory.
+  def histories_directory
+    config_directory + FileSep + self['HistoriesDirectory']
+  end
+
   # Returns the full path to the configuration file.
   #
   # @return [String] path to the configuration file.
@@ -363,15 +399,27 @@ class Config < Hash
   end
 
   def postgresql_session_history
-    config_directory + FileSep + "postgresql_session_history"
+    histories_directory + FileSep + "postgresql_session_history"
+  end
+
+  def postgresql_session_interactive_history
+    histories_directory + FileSep + "postgresql_session_interactive_history"
   end
 
   def mysql_session_history
-    config_directory + FileSep + "mysql_session_history"
+    histories_directory + FileSep + "mysql_session_history"
+  end
+
+  def mysql_session_interactive_history
+    histories_directory + FileSep + "mysql_session_interactive_history"
   end
 
   def mssql_session_history
-    config_directory + FileSep + "mssql_session_history"
+    histories_directory + FileSep + "mssql_session_history"
+  end
+
+  def mssql_session_interactive_history
+    histories_directory + FileSep + "mssql_session_interactive_history"
   end
 
   def pry_history
@@ -495,6 +543,7 @@ class Config < Hash
     FileUtils.mkdir_p(user_module_directory)
     FileUtils.mkdir_p(user_plugin_directory)
     FileUtils.mkdir_p(user_data_directory)
+    FileUtils.mkdir_p(histories_directory)
   end
 
   # Loads configuration from the supplied file path, or the default one if

--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -236,46 +236,11 @@ class Config < Hash
     self.new.ldap_session_history
   end
 
-  # Returns the full path to the PostgreSQL session history file.
-  #
-  # @return [String] path to the history file.
-  def self.postgresql_session_history
-    self.new.postgresql_session_history
-  end
-
-  # Returns the full path to the PostgreSQL interactive query history file
-  #
-  # @return [String] path to the interactive query history file.
-  def self.postgresql_session_interactive_history
-    self.new.postgresql_session_interactive_history
-  end
-
-  # Returns the full path to the MSSQL session history file.
-  #
-  # @return [String] path to the history file.
-  def self.mssql_session_history
-    self.new.mssql_session_history
-  end
-
-  # Returns the full path to the MSSQL interactive query history file
-  #
-  # @return [String] path to the interactive query history file.
-  def self.mssql_session_interactive_history
-    self.new.mssql_session_interactive_history
-  end
-
-  # Returns the full path to the MySQL session history file.
-  #
-  # @return [String] path to the history file.
-  def self.mysql_session_history
-    self.new.mysql_session_history
-  end
-
   # Returns the full path to the MySQL interactive query history file
   #
   # @return [String] path to the interactive query history file.
-  def self.mysql_session_interactive_history
-    self.new.mysql_session_interactive_history
+  def self.history_file_for_session_type(opts)
+    self.new.history_file_for_session_type(opts)
   end
 
   def self.pry_history
@@ -398,28 +363,24 @@ class Config < Hash
     config_directory + FileSep + "ldap_session_history"
   end
 
-  def postgresql_session_history
-    histories_directory + FileSep + "postgresql_session_history"
+  def history_options_valid?(opts)
+    return false if (opts[:session_type].nil? || opts[:interactive].nil?)
+
+    true
   end
 
-  def postgresql_session_interactive_history
-    histories_directory + FileSep + "postgresql_session_interactive_history"
+  def interactive_to_string_map(interactive)
+    # Check for true explicitly rather than just a value that is truthy.
+    interactive == true ? '_interactive' : ''
   end
 
-  def mysql_session_history
-    histories_directory + FileSep + "mysql_session_history"
-  end
+  def history_file_for_session_type(opts)
+    return nil unless history_options_valid?(opts)
 
-  def mysql_session_interactive_history
-    histories_directory + FileSep + "mysql_session_interactive_history"
-  end
+    session_type_name = opts[:session_type]
+    interactive = interactive_to_string_map(opts[:interactive])
 
-  def mssql_session_history
-    histories_directory + FileSep + "mssql_session_history"
-  end
-
-  def mssql_session_interactive_history
-    histories_directory + FileSep + "mssql_session_interactive_history"
+    histories_directory + FileSep + "#{session_type_name}_session#{interactive}_history"
   end
 
   def pry_history

--- a/lib/rex/post/mssql/ui/console.rb
+++ b/lib/rex/post/mssql/ui/console.rb
@@ -30,8 +30,8 @@ module Rex
             self.client = session.client
             envchange = ::Rex::Proto::MSSQL::ClientMixin::ENVCHANGE
             prompt = "%undMSSQL @ #{client.peerinfo} (#{client.initial_info_for_envchange(envchange: envchange::DATABASE)[:new]})%clr"
-            history_manager = Msf::Config.mssql_session_history
-            super(prompt, '>', history_manager, nil, :mssql)
+            history_file = Msf::Config.history_file_for_session_type(session_type: session.type, interactive: false)
+            super(prompt, '>', history_file, nil, :mssql)
 
             # Queued commands array
             self.commands = []

--- a/lib/rex/post/mysql/ui/console.rb
+++ b/lib/rex/post/mysql/ui/console.rb
@@ -25,8 +25,8 @@ module Rex
             self.session = session
             self.client = session.client
             prompt = "%undMySQL @ #{client.peerinfo} (#{current_database})%clr"
-            history_manager = Msf::Config.mysql_session_history
-            super(prompt, '>', history_manager, nil, :mysql)
+            history_file = Msf::Config.history_file_for_session_type(session_type: session.type, interactive: false)
+            super(prompt, '>', history_file, nil, :mysql)
 
             # Queued commands array
             self.commands = []

--- a/lib/rex/post/postgresql/ui/console.rb
+++ b/lib/rex/post/postgresql/ui/console.rb
@@ -29,8 +29,8 @@ module Rex
             self.session = session
             self.client = session.client
             prompt = "%undPostgreSQL @ #{client.peerinfo} (#{current_database})%clr"
-            history_manager = Msf::Config.postgresql_session_history
-            super(prompt, '>', history_manager, nil, :postgresql)
+            history_file = Msf::Config.history_file_for_session_type(session_type: session.type, interactive: false)
+            super(prompt, '>', history_file, nil, :postgresql)
 
             # Queued commands array
             self.commands = []

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -69,7 +69,8 @@ module InteractiveSqlClient
   def _multiline_with_fallback
     name = session.type
     query = {}
-    history_file = Msf::Config.send("#{name}_session_interactive_history")
+    history_file = Msf::Config.history_file_for_session_type(session_type: name, interactive: true)
+    return { status: :fail, errors: ["Unable to get history file for session type: #{name}"] } if history_file.nil?
 
     # Multiline (Reline) and fallback (Readline) have separate history contexts as they are two different libraries.
     framework.history_manager.with_context(history_file: history_file , name: name, input_library: :reline) do

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -67,8 +67,20 @@ module InteractiveSqlClient
 
   # Try getting multi-line input support provided by Reline, fall back to Readline.
   def _multiline_with_fallback
-    query = _multiline
-    query = _fallback if query[:status] == :fail
+    name = session.type
+    query = {}
+    history_file = Msf::Config.send("#{name}_session_interactive_history")
+
+    # Multiline (Reline) and fallback (Readline) have separate history contexts as they are two different libraries.
+    framework.history_manager.with_context(history_file: history_file , name: name, input_library: :reline) do
+      query = _multiline
+    end
+
+    if query[:status] == :fail
+      framework.history_manager.with_context(history_file: history_file, name: name, input_library: :readline) do
+        query = _fallback
+      end
+    end
 
     query
   end
@@ -158,10 +170,20 @@ module InteractiveSqlClient
       break if line.end_with? ';'
     end
 
-    { status: :success, result: line_buffer.join }
+    { status: :success, result: line_buffer.join(' ') }
   end
 
   attr_accessor :on_log_proc, :client_dispatcher
+
+  private
+
+  def framework
+    client_dispatcher.shell.framework
+  end
+
+  def session
+    client_dispatcher.shell.session
+  end
 
 end
 end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -200,8 +200,9 @@ class HistoryManager
   def write_history_file(history_file, cmds)
     write_queue_ref = @write_queue
     remaining_work_ref = @remaining_work
+
     @write_thread ||= Rex::ThreadFactory.spawn("HistoryManagerWriter", false) do
-      while (event = write_queue_ref.pop)
+      while (write_queue_ref.size > 0 && event = write_queue_ref.pop)
         begin
           history_file = event[:history_file]
           cmds = event[:cmds]

--- a/spec/lib/rex/ui/text/shell/history_manager_spec.rb
+++ b/spec/lib/rex/ui/text/shell/history_manager_spec.rb
@@ -1,8 +1,6 @@
 # -*- coding:binary -*-
 require 'spec_helper'
 require 'rex/ui/text/shell/history_manager'
-require 'readline'
-require 'reline'
 require 'tempfile'
 
 RSpec.describe Rex::Ui::Text::Shell::HistoryManager do

--- a/spec/lib/rex/ui/text/shell/history_manager_spec.rb
+++ b/spec/lib/rex/ui/text/shell/history_manager_spec.rb
@@ -1,13 +1,18 @@
 # -*- coding:binary -*-
 require 'spec_helper'
 require 'rex/ui/text/shell/history_manager'
+require 'readline'
+require 'reline'
+require 'tempfile'
 
 RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
   subject { described_class.send(:new) }
   let(:readline_available) { false }
+  let(:reline_available) { false }
 
   before(:each) do
     allow(subject).to receive(:readline_available?).and_return(readline_available)
+    allow(subject).to receive(:reline_available?).and_return(reline_available)
   end
 
   describe '#with_context' do
@@ -25,7 +30,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'a') do
             expected_contexts = [
-              { history_file: nil, name: 'a' },
+              { history_file: nil, input_library: :readline, name: 'a' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -36,7 +41,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
 
     context 'when there is an existing stack' do
       before(:each) do
-        subject.send(:push_context, history_file: nil, name: 'a')
+        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
       end
 
       it 'continues to have the previous existing stack' do
@@ -44,7 +49,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           # noop
         }
         expected_contexts = [
-          { history_file: nil, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -53,8 +58,8 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'b') do
             expected_contexts = [
-              { history_file: nil, name: 'a' },
-              { history_file: nil, name: 'b' },
+              { history_file: nil, input_library: :readline, name: 'a' },
+              { history_file: nil, input_library: :readline, name: 'b' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -69,7 +74,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           }
         end.to raise_exception ArgumentError, 'Mock error'
         expected_contexts = [
-          { history_file: nil, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -79,9 +84,9 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
   describe '#push_context' do
     context 'when the stack is empty' do
       it 'stores the history contexts' do
-        subject.send(:push_context, history_file: nil, name: 'a')
+        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
         expected_contexts = [
-          { history_file: nil, name: 'a' }
+          { history_file: nil, input_library: :readline, name: 'a' }
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -90,12 +95,12 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     context 'when multiple values are pushed' do
       it 'stores the history contexts' do
         subject.send(:push_context, history_file: nil, name: 'a')
-        subject.send(:push_context, history_file: nil, name: 'b')
-        subject.send(:push_context, history_file: nil, name: 'c')
+        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'b')
+        subject.send(:push_context, history_file: nil, input_library: :reline, name: 'c')
         expected_contexts = [
-          { history_file: nil, name: 'a' },
-          { history_file: nil, name: 'b' },
-          { history_file: nil, name: 'c' },
+          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'b' },
+          { history_file: nil, input_library: :reline, name: 'c' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -113,14 +118,118 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     end
 
     context 'when the stack is not empty' do
-      it 'continues to have an empty stack' do
+      it 'continues to have a non-empty stack' do
         subject.send(:push_context, history_file: nil, name: 'a')
         subject.send(:push_context, history_file: nil, name: 'b')
         subject.send(:pop_context)
         expected_contexts = [
-          { history_file: nil, name: 'a' },
+          { history_file: nil, input_library: :readline, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
+      end
+    end
+  end
+
+  describe '#store_history_file' do
+    context 'when storing above max history lines' do
+      def clear_readline
+        ::Readline::HISTORY.pop until ::Readline::HISTORY.empty?
+      end
+
+      def clear_reline
+        ::Reline::HISTORY.pop until ::Reline::HISTORY.empty?
+      end
+
+      before(:each) do
+        @history_file = ::Tempfile.new('history')
+
+        # Store the current history & clear Readline && Reline
+        @readline_history_before = ::Readline::HISTORY.to_a
+        @reline_history_before = ::Reline::HISTORY.to_a
+
+        clear_readline
+        clear_reline
+      end
+
+      after(:each) do
+        clear_readline
+        @readline_history_before.each { |line| ::Readline::HISTORY << line }
+
+        clear_reline
+        @reline_history_before.each { |line| ::Reline::HISTORY << line }
+      end
+
+      it 'truncates to max allowed history' do
+        allow(subject).to receive(:_remaining_work).and_call_original
+        allow(subject).to receive(:store_history_file).and_call_original
+
+        history_choices = %w[sessions run query help]
+        max_history = subject.class::MAX_HISTORY
+        # Populate example history we want to store
+        total_times = max_history + 10
+        total_times.times do
+          ::Readline::HISTORY << history_choices[rand(history_choices.count)]
+        end
+
+        context = { input_library: :readline, history_file: @history_file.path, name: 'history'}
+
+        subject.send(:store_history_file, context)
+
+        sleep(0.1) until subject._remaining_work.empty?
+
+        expect(@history_file.read.split("\n").count).to eq(max_history)
+      end
+    end
+  end
+
+  describe '#load_history_file' do
+    def clear_readline
+      ::Readline::HISTORY.pop until ::Readline::HISTORY.empty?
+    end
+
+    def clear_reline
+      ::Reline::HISTORY.pop until ::Reline::HISTORY.empty?
+    end
+
+    before(:each) do
+      @history_file = ::Tempfile.new('history')
+
+      # Store the current history & clear Readline && Reline
+      @readline_history_before = ::Readline::HISTORY.to_a
+      @reline_history_before = ::Reline::HISTORY.to_a
+
+      clear_readline
+      clear_reline
+    end
+
+    after(:each) do
+      clear_readline
+      @readline_history_before.each { |line| ::Readline::HISTORY << line }
+
+      clear_reline
+      @reline_history_before.each { |line| ::Reline::HISTORY << line }
+    end
+
+    context 'when history file is not accessible' do
+      it 'the library history remains unchanged' do
+        history_file = ::File.join('does/not/exist/history')
+        context = { input_library: :readline, history_file: history_file, name: 'history' }
+
+        subject.send(:load_history_file, context)
+        expect(::Readline::HISTORY.to_a).to eq(@readline_history_before)
+      end
+    end
+
+    context 'when history file is accessible' do
+      it 'correctly loads the history' do
+        history_file = ::File.join(Msf::Config.history_file)
+        history_lines = ::File.read(history_file).split("\n")
+
+        context = { input_library: :readline, history_file: history_file, name: 'history' }
+
+        subject.send(:load_history_file, context)
+
+        expect(::Readline::HISTORY.to_a).to eq(history_lines)
       end
     end
   end


### PR DESCRIPTION
This PR is based on the previous attempt from: https://github.com/rapid7/metasploit-framework/pull/18933 however, I have fixed the history file truncation & restored a `clear_readline` method call that caused the exponential history file growth in the first place.
I added in tests to ensure that the maximum history is respected in the future.

I also put the SQL session history files in a separate folder as requested on the original PR.

This PR also fixed a previous bug in the Readline SQL fallback, `{ status: :success, result: line_buffer.join }` where previously multi-line queries would be returned as `SHOWDATABASES;`, rather than `SHOW DATABASES;`. This can be tested by using the following code diff:
```diff
diff --git a/lib/rex/post/sql/ui/console/interactive_sql_client.rb b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
index 55a098a525..0101a625e7 100644
--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -71,15 +71,8 @@ module InteractiveSqlClient
     query = {}
     history_file = Msf::Config.send("#{name}_session_interactive_history")
 
-    # Multiline (Reline) and fallback (Readline) have separate history contexts as they are two different libraries.
-    framework.history_manager.with_context(history_file: history_file , name: name, input_library: :reline) do
-      query = _multiline
-    end
-
-    if query[:status] == :fail
-      framework.history_manager.with_context(history_file: history_file, name: name, input_library: :readline) do
-        query = _fallback
-      end
+    framework.history_manager.with_context(history_file: history_file, name: name, input_library: :readline) do
+      query = _fallback
     end
 
     query
```

I removed a check for `if File.exist?(history_file)` as before, it could result in a time-of-check time-of-use error where the file gets deleted & we raise after the `if` check. Now we try to open the file and handle the raised exceptions.

To ensure that the user's current Readline/Reline history is not impacted by the tests, I am mocking the history object instead (it acts like an Array, so that is what I mock it as).

## Verification

- [ ] Start `msfconsole`
- [ ] `use` a SQL login module
- [ ] Get multiple sessions - we will be switching between them
- [ ] `sessions -i -1`
- [ ] Verify you can run some commands like `query`, `help`.
- [ ] Go into interactive query mode: `query -i`
- [ ] Verify you can input single & multi-line queries, such as `SHOW*enter*DATABASES;`
- [ ] Verify that you can `exit` out of the interactive query mode
- [ ] Verify that when going into the interactive query mode again, your previous history is present by pressing the up arrow.
- [ ] Verify that you can switch between sessions by using `session -i id` when in the context of a session already
- [ ] Verify you can enter query commands
- [ ] Exit framework
- [ ] Check the line count of the history files by calling `wc -l ~/.msf4/history ~/.msf4/histories/*`
- [ ] Verify that doing the above steps twice results in a reasonable line count increase and that it does not double every time.
