### PR TITLE
Improves UX for scanner/login modules

### DIFF
--- a/lib/msf/core/auxiliary/report_summary.rb
+++ b/lib/msf/core/auxiliary/report_summary.rb
@@ -1,0 +1,147 @@
+# -*- coding: binary -*-
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# https://metasploit.com/framework/
+##
+
+module Msf
+  class Auxiliary
+    ###
+    #
+    # This module provides a means to report module summaries
+    #
+    ###
+    module ReportSummary
+      def initialize(info = {})
+        super(info)
+
+        if framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS)
+          register_options(
+            [
+              OptBool.new('ShowSuccessfulLogins', [false, 'Outputs a table of successful logins', true]),
+            ]
+          )
+        end
+      end
+
+      def run
+        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins']
+
+        @report = {}
+        @report.extend(::Rex::Ref)
+        rhost_walker = Msf::RhostsWalker.new(datastore['RHOSTS'], datastore).to_enum
+        conditional_verbose_output(rhost_walker.count)
+        result = super
+        print_report_summary
+        result
+      end
+
+      # Creates a credential and adds to to the DB if one is present
+      #
+      # @param [Hash] credential_data
+      # @return [Metasploit::Credential::Login]
+      def create_credential_login(credential_data)
+        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins']
+
+        credential = {
+          public: credential_data[:username],
+          private_data: credential_data[:private_data]
+        }
+        @report[rhost] = { successful_logins: [] }
+        @report[rhost][:successful_logins] << credential
+        super
+      end
+
+      # Framework is notified that we have a new session opened
+      #
+      # @param [MetasploitModule] obj
+      # @param [Object] info
+      # @param [Hash] ds_merge
+      # @param [FalseClass] crlf
+      # @param [Socket] sock
+      # @param [Msf::Sessions::<SESSION_CLASS>] sess
+      # @return [Msf::Sessions::<SESSION_CLASS>]
+      def start_session(obj, info, ds_merge, crlf = false, sock = nil, sess = nil)
+        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins']
+
+        result = super
+        @report[rhost].merge!({ successful_sessions: [] })
+        @report[rhost][:successful_sessions] << result
+        result
+      end
+
+      private
+
+      # Prints a summary of successful logins
+      # Returns a ::Rex::Text::Table with the following data: host, public and private credentials for each
+      # successful login per host
+      #
+      # @return [Hash] Rhost keys mapped to successful logins and sessions for each host
+      def print_report_summary
+        report = @report
+
+        logins = report.flat_map { |_k, v| v[:successful_logins] }.compact
+        sessions = report.flat_map { |_k, v| v[:successful_sessions] }.compact
+
+        print_status("Scan completed, #{logins.size} #{logins.size == 1 ? 'credential was' : 'credentials were'} successful.")
+        print_successful_logins(report)
+
+        if datastore['CreateSession']
+          print_status("#{sessions.size} #{sessions.size == 1 ? 'session was' : 'sessions were'} opened successfully.")
+        end
+
+        report
+      end
+
+      # Logic to detect if the ShowSuccessLogins datastore option has been set
+      #
+      # @param [Hash] report Host mapped to successful logins and sessions
+      # @return [String] Rex::Text::Table containing successful logins
+      def print_successful_logins(report)
+        if datastore['ShowSuccessfulLogins'] == true && !report.empty?
+          table = successful_logins_to_table(report)
+          print_line("\n" + table.to_s + "\n")
+        end
+      end
+
+      # The idea here is to add a hybrid approach for scanner modules
+      # If only one host is scanned a more verbose output is useful to the user
+      # If scanning multiple hosts we would want more lightweight information
+      #
+      # @param [Object] host_count The number of hosts
+      def conditional_verbose_output(host_count)
+        if host_count == 1
+          datastore['Verbose'] = true
+        end
+      end
+
+      # Takes the login/session results and converts them into a Rex::Text::Table format
+      #
+      # @param report [Hash{String => [Metasploit::Framework::LoginScanner::Result, Msf::Sessions]}]
+      # @return [Rex::Text::WrappedTable] Rex::Text::Table containing successful logins
+      def successful_logins_to_table(report)
+        field_headers = %w[Host Public Private]
+
+        markdown_fields = report.flat_map do |host, result|
+          if result[:successful_logins].nil?
+            next
+          end
+
+          result[:successful_logins].map do |credential|
+            [host, credential[:public], credential[:private_data]]
+          end
+        end
+
+        ::Rex::Text::Table.new(
+          'Header' => 'Successful logins',
+          'Indent' => 4,
+          'Columns' => field_headers,
+          'Rows' => markdown_fields.compact
+        )
+      end
+    end
+  end
+end

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -27,6 +27,7 @@ module Msf
     MYSQL_SESSION_TYPE = 'mysql_session_type'
     MSSQL_SESSION_TYPE = 'mssql_session_type'
     LDAP_SESSION_TYPE = 'ldap_session_type'
+    SHOW_SUCCESSFUL_LOGINS = 'show_successful_logins'
 
     DEFAULTS = [
       {
@@ -102,6 +103,13 @@ module Msf
         requires_restart: true,
         default_value: false,
         developer_notes: 'To be enabled by default after appropriate testing'
+      }.freeze,
+      {
+        name: SHOW_SUCCESSFUL_LOGINS,
+        description: 'When enabled scanners/login modules will return a table off successful logins once the module completes',
+        requires_restart: false,
+        default_value: false,
+        developer_notes: 'To be enabled after appropriate testing'
       }.freeze,
       {
         name: DNS,

--- a/modules/auxiliary/cloud/aws/enum_ssm.rb
+++ b/modules/auxiliary/cloud/aws/enum_ssm.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::LDAP
   include Msf::Sessions::CreateSessionOptions
   include Msf::Auxiliary::CommandShell
+  include Msf::Auxiliary::ReportSummary
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -15,6 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Sessions::CreateSessionOptions
   include Msf::Auxiliary::CommandShell
+  include Msf::Auxiliary::ReportSummary
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -14,6 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   # Creates an instance of this module.
   def initialize(info = {})

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Login
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   Aliases = [
     'auxiliary/scanner/smb/login'

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Report
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
   include Msf::Auxiliary::Report
+  include Msf::Auxiliary::ReportSummary
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Report
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -15,6 +15,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::SSH::Options
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::SSH::Options
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   attr_accessor :ssh_socket, :good_key
 

--- a/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
+++ b/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::CommandShell
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
 
   def initialize
     super(


### PR DESCRIPTION
This PR adds support for a summarised output to the end of login/scanner modules within Framework. The idea was that some scanners are either way to quite or way too noisy. So this implementation aims to add a module option that will be enabled by default but is configurable by the user, which will dictate if the table will be output or not.

### Example output
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/3d777167-2086-4c85-bbcb-e31b1532ee3c)

When targeting a single host, the scanner is too quiet. Logic was added to check for when a single user is passed and change to verbose mode.

## Verification

- [ ] Start `msfconsole`
- [ ] Use a login module
- [ ] Test against a single host
- [ ] Test against multiple hosts
- [ ] **Verify** the table is output by default
- [ ] **Verify** the table is not output when `ShowSuccessLogins` is set to `false`
- [ ] **Verify** the module outputs the verbose output when ran against a single host