### PR TITLE
Update gemspec to use require relative

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -4,16 +4,16 @@
 # we must manually define the project root
 if ENV['MSF_ROOT']
   lib = File.realpath(File.expand_path('lib', ENV['MSF_ROOT']))
+  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+  require 'metasploit/framework/version'
+  require 'metasploit/framework/rails_version_constraint'
+  require 'msf/util/helper'
 else
-  # have to use realpath as metasploit-framework is often loaded through a symlink and tools like Coverage and debuggers
-  # require realpaths.
-  lib = File.realpath(File.expand_path('../lib', __FILE__))
+  # XXX: Use explicit calls to require_relative to ensure that static analysis tools such as dependabot work
+  require_relative 'lib/metasploit/framework/version'
+  require_relative 'lib/metasploit/framework/rails_version_constraint'
+  require_relative 'lib/msf/util/helper'
 end
-
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'metasploit/framework/version'
-require 'metasploit/framework/rails_version_constraint'
-require 'msf/util/helper'
 
 Gem::Specification.new do |spec|
   spec.name          = 'metasploit-framework'


### PR DESCRIPTION
Update gemspec to use require relative, so that it can be used with external static analysis tools

I believe this will fix the following dependabot update issue of not being able to auto-generate update PRs:

![image](https://github.com/rapid7/metasploit-framework/assets/60357436/1e42d8af-75cd-4470-8dc0-559dff2680d5)

As under the hood, only the first level of require_relative expressions are fetched and loaded by dependabot according to this comment: https://github.com/dependabot/feedback/issues/393#issuecomment-470727196 and implementation: https://github.com/dependabot/dependabot-core/blob/13bf8117e4d1731a64a3d2bf8d1f56a000b4bfb0/bundler/lib/dependabot/bundler/file_fetcher.rb#L143-L154


## Verification

- Ensure CI passes