### PR TITLE
Rework nil guard logic in certain modules

### DIFF
--- a/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
+++ b/modules/exploits/linux/fileformat/unrar_cve_2022_30333.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('FILENAME', [ false, 'The file name.', 'payload.rar']),
         OptString.new('CUSTOM_PAYLOAD', [ false, 'A custom payload to encode' ]),
         OptString.new('TARGET_PATH', [ true, 'The location the payload should extract to (can, and should, contain path traversal characters - "../../" - as well as a filename).']),
-        OptString.new('SYMLINK_FILENAME', [ false, 'The name of the symlink file to use (must be 12 characters or less; default: random)'])
+        OptString.new('SYMLINK_FILENAME', [ true, 'The name of the symlink file to use (must be 12 characters or less; default: random)', Rex::Text.rand_text_alpha_lower(4..12)])
       ]
     )
   end
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     begin
-      rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'] || Rex::Text.rand_text_alpha_lower(4..12), datastore['TARGET_PATH'], payload_data)
+      rar = encode_as_traversal_rar(datastore['SYMLINK_FILENAME'], datastore['TARGET_PATH'], payload_data)
     rescue StandardError => e
       fail_with(Failure::BadConfig, "Failed to encode RAR file: #{e}")
     end

--- a/modules/exploits/multi/fileformat/office_word_macro.rb
+++ b/modules/exploits/multi/fileformat/office_word_macro.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      OptPath.new("CUSTOMTEMPLATE", [false, 'A docx file that will be used as a template to build the exploit']),
+      OptPath.new("CUSTOMTEMPLATE", [true, 'A docx file that will be used as a template to build the exploit', File.join(macro_resource_directory, 'template.docx')]),
       OptString.new('FILENAME', [true, 'The Office document macro file (docm)', 'msf.docm'])
     ])
   end
@@ -256,11 +256,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_template_path
-    if datastore['CUSTOMTEMPLATE']
-      datastore['CUSTOMTEMPLATE']
-    else
-      File.join(macro_resource_directory, 'template.docx')
-    end
+    datastore['CUSTOMTEMPLATE']
   end
 
   def exploit

--- a/modules/exploits/windows/fileformat/winrar_cve_2023_38831.rb
+++ b/modules/exploits/windows/fileformat/winrar_cve_2023_38831.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptString.new('PAYLOAD_NAME', [false, 'The filename for the payload executable.', nil])
+      OptString.new('PAYLOAD_NAME', [true, 'The filename for the payload executable.', Rex::Text.rand_text_alpha(8) + '.exe'])
     ])
   end
 
@@ -59,8 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       input_file = datastore['INPUT_FILE']
       decoy_name = File.basename(input_file)
       decoy_ext = ".#{File.extname(input_file)[1..]}"
-      payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(8) + '.exe'
-
+      payload_name = datastore['PAYLOAD_NAME']
       decoy_dir = File.join(temp_dir, "#{decoy_name}A")
       Dir.mkdir(decoy_dir)
 

--- a/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
+++ b/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptPath.new('CUSTOMTEMPLATE', [false, 'A DOCX file that will be used as a template to build the exploit.']),
+      OptPath.new('CUSTOMTEMPLATE', [true, 'A DOCX file that will be used as a template to build the exploit.', File.join(Msf::Config.data_directory, 'exploits', 'word_msdtjs.docx')]),
       OptEnum.new('OUTPUT_FORMAT', [true, 'File format to use [docx, rtf].', 'docx', %w[docx rtf]]),
       OptBool.new('OBFUSCATE', [true, 'Obfuscate JavaScript content.', true])
     ])
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_template_path
-    datastore['CUSTOMTEMPLATE'] || File.join(Msf::Config.data_directory, 'exploits', 'word_msdtjs.docx')
+    datastore['CUSTOMTEMPLATE']
   end
 
   def generate_html

--- a/modules/exploits/windows/fileformat/word_mshtml_rce.rb
+++ b/modules/exploits/windows/fileformat/word_mshtml_rce.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptBool.new('OBFUSCATE', [true, 'Obfuscate JavaScript content.', true])
     ])
     register_advanced_options([
-      OptPath.new('DocxTemplate', [ false, 'A DOCX file that will be used as a template to build the exploit.' ]),
+      OptPath.new('DocxTemplate', [ true, 'A DOCX file that will be used as a template to build the exploit.', File.join(Msf::Config.data_directory, 'exploits', 'CVE-2021-40444', 'cve-2021-40444.docx') ]),
     ])
   end
 
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_template_path
-    datastore['DocxTemplate'] || File.join(Msf::Config.data_directory, 'exploits', 'CVE-2021-40444', 'cve-2021-40444.docx')
+    datastore['DocxTemplate']
   end
 
   def inject_docx


### PR DESCRIPTION
This PR guards against an issue where in certain contexts empty strings are being sent to framework modules that only check for nils. Some default options were added, as well as a couple nil/empty checks where the default logic couldn't be plugged right into the datastore.

## Verification

List the steps needed to make sure this thing works

- [ ] Ensure standard functionality doesn't change for each module. Make sure defaults for new datastore options are sane, and blank options for modules with new guards provide the expected values.

