### PR TITLE
Fix service 'updated at' time not being updated correctly

### DIFF
--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -211,7 +211,7 @@ module Msf::DBManager::Cred
 
     # Update the timestamp
     if cred.changed?
-      msf_import_timestamps(opts,cred)
+      msf_assign_timestamps(opts, cred)
       cred.save!
     end
 

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -274,7 +274,7 @@ module Msf::DBManager::Host
       host_state_changed(host, ostate) if host.state != ostate
 
       if host.changed?
-        msf_import_timestamps(opts, host)
+        msf_assign_timestamps(opts, host)
         host.save!
       end
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -480,23 +480,84 @@ module Msf::DBManager::Import
     raise Msf::DBImportError.new("Could not automatically determine file type")
   end
 
-  # Handles timestamps from Metasploit Express/Pro imports.
-  def msf_import_timestamps(opts,obj)
+  def msf_import_service(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_service(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_vuln(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_vuln(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_note(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_note(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_host(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_host(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_task(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_task(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_user(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_user(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_loot(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_loot(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_web_site(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_web_site(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_web_page(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_web_page(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_web_vuln(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_web_vuln(normalised_import_timestamp_opts)
+  end
+
+  def msf_import_artifact(opts)
+    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    report_artifact(normalised_import_timestamp_opts)
+  end
+
+  # Assigns created_at and updated_at time stamps to an object.
+  def msf_assign_timestamps(opts,obj)
     obj.created_at = opts["created_at"] if opts["created_at"]
     obj.created_at = opts[:created_at] if opts[:created_at]
-    obj.updated_at = opts["updated_at"] ? opts["updated_at"] : obj.created_at
-    obj.updated_at = opts[:updated_at] ? opts[:updated_at] : obj.created_at
-    return obj
+    obj.updated_at = opts["updated_at"] if opts["updated_at"]
+    obj.updated_at = opts[:updated_at] if opts[:updated_at]
+  end
+
+  # Handles timestamps from Metasploit Express/Pro imports.
+  def normalise_import_timestamps(opts)
+    opts[:created_at] ||= (opts["created_at"] || ::Time.now.utc)
+    opts[:updated_at] ||= (opts["updated_at"] || opts[:created_at])
+    opts
   end
 
   def report_import_note(wspace,addr)
     if @import_filedata.kind_of?(Hash) && @import_filedata[:filename] && @import_filedata[:filename] !~ /msfe-nmap[0-9]{8}/
-    report_note(
-      :workspace => wspace,
-      :host => addr,
-      :type => 'host.imported',
-      :data => @import_filedata.merge(:time=> Time.now.utc)
-    )
+      msf_import_note(
+        :workspace => wspace,
+        :host => addr,
+        :type => 'host.imported',
+        :data => @import_filedata.merge(:time=> Time.now.utc)
+      )
     end
   end
 

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -481,57 +481,57 @@ module Msf::DBManager::Import
   end
 
   def msf_import_service(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_service(normalised_import_timestamp_opts)
   end
 
   def msf_import_vuln(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_vuln(normalised_import_timestamp_opts)
   end
 
   def msf_import_note(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_note(normalised_import_timestamp_opts)
   end
 
   def msf_import_host(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_host(normalised_import_timestamp_opts)
   end
 
   def msf_import_task(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_task(normalised_import_timestamp_opts)
   end
 
   def msf_import_user(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_user(normalised_import_timestamp_opts)
   end
 
   def msf_import_loot(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_loot(normalised_import_timestamp_opts)
   end
 
   def msf_import_web_site(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_web_site(normalised_import_timestamp_opts)
   end
 
   def msf_import_web_page(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_web_page(normalised_import_timestamp_opts)
   end
 
   def msf_import_web_vuln(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_web_vuln(normalised_import_timestamp_opts)
   end
 
   def msf_import_artifact(opts)
-    normalised_import_timestamp_opts = normalise_import_timestamps(opts)
+    normalised_import_timestamp_opts = msf_normalise_import_timestamps(opts)
     report_artifact(normalised_import_timestamp_opts)
   end
 
@@ -544,7 +544,7 @@ module Msf::DBManager::Import
   end
 
   # Handles timestamps from Metasploit Express/Pro imports.
-  def normalise_import_timestamps(opts)
+  def msf_normalise_import_timestamps(opts)
     opts[:created_at] ||= (opts["created_at"] || ::Time.now.utc)
     opts[:updated_at] ||= (opts["updated_at"] || opts[:created_at])
     opts

--- a/lib/msf/core/db_manager/import/gpp.rb
+++ b/lib/msf/core/db_manager/import/gpp.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::GPP
     end
 
     # Store entire file as loot, including metadata
-    report_loot(
+    msf_import_loot(
       workspace: wspace,
       path:      args[:filename],
       name:      File.basename(args[:filename]),

--- a/lib/msf/core/db_manager/import/ip360/v3.rb
+++ b/lib/msf/core/db_manager/import/ip360/v3.rb
@@ -83,11 +83,11 @@ module Msf::DBManager::Import::IP360::V3
       host_hash[:name] = hname.to_s.strip if hname
       host_hash[:mac]  = mac.to_s.strip.upcase if mac
 
-      hobj = report_host(host_hash)
+      hobj = msf_import_host(host_hash)
 
       yield(:os, os) if block
       if os
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => hobj,
@@ -131,7 +131,7 @@ module Msf::DBManager::Import::IP360::V3
   # IP360 v3 svc
   def handle_ip360_v3_svc(wspace,hobj,port,proto,hname,task=nil)
     addr = hobj.address
-    report_host(:workspace => wspace, :host => hobj, :state => Msf::HostState::Alive, :task => task)
+    msf_import_host(:workspace => wspace, :host => hobj, :state => Msf::HostState::Alive, :task => task)
 
     info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto, :task => task }
     if hname != "unknown" and hname[-1,1] != "?"
@@ -139,7 +139,7 @@ module Msf::DBManager::Import::IP360::V3
     end
 
     if port.to_i != 0
-      report_service(info)
+      msf_import_service(info)
     end
   end
 
@@ -153,7 +153,7 @@ module Msf::DBManager::Import::IP360::V3
     end
 
     if port.to_i != 0
-      report_service(info)
+      msf_import_service(info)
     end
 
     refs = []
@@ -181,6 +181,6 @@ module Msf::DBManager::Import::IP360::V3
       vuln[:proto] = proto
     end
 
-    report_vuln(vuln)
+    msf_import_vuln(vuln)
   end
 end

--- a/lib/msf/core/db_manager/import/libpcap.rb
+++ b/lib/msf/core/db_manager/import/libpcap.rb
@@ -35,7 +35,7 @@ module Msf::DBManager::Import::Libpcap
       unless( bl.include?(saddr) || rfc3330_reserved(saddr))
         yield(:address,saddr) if block and !seen_hosts.keys.include?(saddr)
         unless seen_hosts[saddr]
-          report_host(
+          msf_import_host(
               :workspace => wspace,
               :host      => saddr,
               :state     => Msf::HostState::Alive,
@@ -48,7 +48,7 @@ module Msf::DBManager::Import::Libpcap
       unless( bl.include?(daddr) || rfc3330_reserved(daddr))
         yield(:address,daddr) if block and !seen_hosts.keys.include?(daddr)
         unless seen_hosts[daddr]
-          report_host(
+          msf_import_host(
               :workspace => wspace,
               :host      => daddr,
               :state     => Msf::HostState::Alive,
@@ -63,7 +63,7 @@ module Msf::DBManager::Import::Libpcap
           pkt.tcp_src < 1024 # If it's a low port, assume it's a proper service.
           if seen_hosts[saddr]
             unless seen_hosts[saddr].include? [pkt.tcp_src,"tcp"]
-              report_service(
+              msf_import_service(
                   :workspace => wspace, :host => saddr,
                   :proto     => "tcp", :port => pkt.tcp_src,
                   :state     => Msf::ServiceState::Open,
@@ -79,7 +79,7 @@ module Msf::DBManager::Import::Libpcap
           [saddr,daddr].each do |xaddr|
             if seen_hosts[xaddr]
               unless seen_hosts[xaddr].include? [pkt.udp_src,"udp"]
-                report_service(
+                msf_import_service(
                     :workspace => wspace, :host => xaddr,
                     :proto     => "udp", :port => pkt.udp_src,
                     :state     => Msf::ServiceState::Open,
@@ -93,7 +93,7 @@ module Msf::DBManager::Import::Libpcap
         elsif pkt.udp_src < 1024 # Probably a service
           if seen_hosts[saddr]
             unless seen_hosts[saddr].include? [pkt.udp_src,"udp"]
-              report_service(
+              msf_import_service(
                   :workspace => wspace, :host => saddr,
                   :proto     => "udp", :port => pkt.udp_src,
                   :state     => Msf::ServiceState::Open,
@@ -142,7 +142,7 @@ module Msf::DBManager::Import::Libpcap
       if pkt.payload =~ /^HTTP\x2f1\x2e[01]/n
         http_server_match = pkt.payload.match(/\nServer:\s+([^\r\n]+)[\r\n]/n)
         if http_server_match.kind_of?(MatchData) and http_server_match[1]
-          report_service(
+          msf_import_service(
               :workspace => wspace,
               :host      => pkt.ip_saddr,
               :port      => pkt.tcp_src,
@@ -172,7 +172,7 @@ module Msf::DBManager::Import::Libpcap
         # this point, we'll just believe everything the packet says -- validation ought
         # to come later.
         user,pass = b64_cred.unpack("m*").first.split(/:/,2)
-        report_service(
+        msf_import_service(
             :workspace => wspace,
             :host      => pkt.ip_daddr,
             :port      => pkt.tcp_dst,

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -85,7 +85,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
         note_data[datum.gsub("-","_")] = nils_for_nulls(note.at(datum).text.to_s.strip)
       end
     }
-    report_note(note_data)
+    msf_import_note(note_data)
   end
 
   # Imports web_form element using Msf::DBManager#report_web_form.
@@ -294,7 +294,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
       end
     }
 
-    report_web_site(info)
+    msf_import_web_site(info)
     yield(:web_site, "#{info[:host]}:#{info[:port]} (#{info[:vhost]})") if block
   end
 
@@ -331,7 +331,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
       end
     }
     host_address = host_data[:host].dup # Preserve after report_host() deletes
-    hobj = report_host(host_data)
+    hobj = msf_import_host(host_data)
 
     host.xpath("host_details/host_detail").each do |hdet|
       hdet_data = {}
@@ -371,7 +371,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
           end
         end
       }
-      report_service(service_data)
+      msf_import_service(service_data)
     end
 
     host.xpath('notes/note').each do |note|
@@ -417,7 +417,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
         end
       end
 
-      vobj = report_vuln(vuln_data)
+      vobj = msf_import_vuln(vuln_data)
 
       vuln.xpath("notes/note").each do |note|
         note_data = {}

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -144,7 +144,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
       if ::File.exist?(new_task)
         ::File.unlink new_task # Delete it, and don't report it.
       else
-        report_task(task_info) # It's new, so report it.
+        msf_import_task(task_info) # It's new, so report it.
       end
       ::FileUtils.copy(task_info[:orig_path], new_task)
       yield(:msf_task, new_task) if block

--- a/lib/msf/core/db_manager/import/nessus.rb
+++ b/lib/msf/core/db_manager/import/nessus.rb
@@ -30,7 +30,7 @@ module Msf::DBManager::Import::Nessus
     if name and name != "unknown" and name[-1,1] != "?"
       info[:name] = name
     end
-    report_service(info)
+    msf_import_service(info)
 
     if nasl.nil? || nasl.empty? || nasl == 0 || nasl == "0"
       return
@@ -78,6 +78,6 @@ module Msf::DBManager::Import::Nessus
       :refs => refs,
       :task => task,
     }
-    report_vuln(vuln_info)
+    msf_import_vuln(vuln_info)
   end
 end

--- a/lib/msf/core/db_manager/import/nessus/nbe.rb
+++ b/lib/msf/core/db_manager/import/nessus/nbe.rb
@@ -45,7 +45,7 @@ module Msf::DBManager::Import::Nessus::NBE
         yield(:address,addr) if block
       end
 
-      hobj_map[ addr ] ||= report_host(:host => addr, :workspace => wspace, :task => args[:task])
+      hobj_map[ addr ] ||= msf_import_host(:host => addr, :workspace => wspace, :task => args[:task])
 
       # Match the NBE types with the XML severity ratings
       case type
@@ -61,7 +61,7 @@ module Msf::DBManager::Import::Nessus::NBE
       end
       if nasl == "11936"
         os = data.match(/The remote host is running (.*)\\n/)[1]
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => hobj_map[ addr ],

--- a/lib/msf/core/db_manager/import/nessus/xml/v1.rb
+++ b/lib/msf/core/db_manager/import/nessus/xml/v1.rb
@@ -34,13 +34,13 @@ module Msf::DBManager::Import::Nessus::XML::V1
 
       # Record the hostname
       hinfo.merge!(:name => hname.to_s.strip) if hname
-      hobj = report_host(hinfo)
+      hobj = msf_import_host(hinfo)
       report_import_note(wspace,hobj)
 
       # Record the OS
       os ||= host.elements["os_name"]
       if os
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => hobj,

--- a/lib/msf/core/db_manager/import/nessus/xml/v2.rb
+++ b/lib/msf/core/db_manager/import/nessus/xml/v2.rb
@@ -50,13 +50,13 @@ module Msf::DBManager::Import::Nessus::XML::V2
       # We can't use them anyway, so take just the first.
       host_info[:mac]  = mac.to_s.strip.upcase.split(/\s+/).first if mac
 
-      hobj = report_host(host_info)
+      hobj = msf_import_host(host_info)
       report_import_note(wspace,hobj)
 
       os = host['os']
       yield(:os,os) if block
       if os
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => hobj,
@@ -110,7 +110,7 @@ module Msf::DBManager::Import::Nessus::XML::V2
     end
 
     if port.to_i != 0
-      report_service(info)
+      msf_import_service(info)
     end
 
     if nasl.nil? || nasl.empty? || nasl == 0 || nasl == "0"
@@ -159,6 +159,6 @@ module Msf::DBManager::Import::Nessus::XML::V2
       vuln[:proto] = proto
     end
 
-    report_vuln(vuln)
+    msf_import_vuln(vuln)
   end
 end

--- a/lib/msf/core/db_manager/import/netsparker.rb
+++ b/lib/msf/core/db_manager/import/netsparker.rb
@@ -92,7 +92,7 @@ module Msf::DBManager::Import::Netsparker
           end
 
           # Report the web page to the database
-          report_web_page(info)
+          msf_import_web_page(info)
 
           yield(:web_page, url) if block
         end
@@ -145,7 +145,7 @@ module Msf::DBManager::Import::Netsparker
 
       next if vuln['type'].to_s.empty?
 
-      report_web_vuln(info)
+      msf_import_web_vuln(info)
       yield(:web_vuln, url) if block
     end
 

--- a/lib/msf/core/db_manager/import/nexpose/raw.rb
+++ b/lib/msf/core/db_manager/import/nexpose/raw.rb
@@ -106,7 +106,7 @@ module Msf::DBManager::Import::Nexpose::Raw
     end
 
     if (data[:state] != Msf::HostState::Dead)
-      hobj = report_host(data)
+      hobj = msf_import_host(data)
       report_import_note(wspace, hobj)
     end
 
@@ -124,7 +124,7 @@ module Msf::DBManager::Import::Nexpose::Raw
         next if note[:data][v].include? k
         note[:data][v] << k
       end
-      report_note(note)
+      msf_import_note(note)
     end
 
     if h["os_family"]
@@ -143,7 +143,7 @@ module Msf::DBManager::Import::Nexpose::Raw
       note[:data][:version] = h["os_version"] if h["os_version"]
       note[:data][:arch]    = h["arch"]       if h["arch"]
 
-      report_note(note)
+      msf_import_note(note)
     end
 
     h["endpoints"].each { |p|
@@ -168,7 +168,7 @@ module Msf::DBManager::Import::Nexpose::Raw
       if p["name"] != "<unknown>"
         data[:name] = p["name"]
       end
-      report_service(data)
+      msf_import_service(data)
     }
 
     h["vulns"].each_pair { |k,v|
@@ -185,7 +185,7 @@ module Msf::DBManager::Import::Nexpose::Raw
       data[:info]      = vstruct.title
       data[:refs]      = vstruct.refs
       data[:task]      = task
-      report_vuln(data)
+      msf_import_vuln(data)
     }
   end
 

--- a/lib/msf/core/db_manager/import/nexpose/simple.rb
+++ b/lib/msf/core/db_manager/import/nexpose/simple.rb
@@ -65,10 +65,10 @@ module Msf::DBManager::Import::Nexpose::Simple
         :task      => args[:task]
       }
 
-      host = report_host(conf)
+      host = msf_import_host(conf)
       report_import_note(wspace, host)
 
-      report_note(
+      msf_import_note(
         :workspace => wspace,
         :host      => host,
         :type      => 'host.os.nexpose_fingerprint',
@@ -106,7 +106,7 @@ module Msf::DBManager::Import::Nexpose::Simple
         end
 
         if(sname.downcase != '<unknown>')
-          report_service(
+          msf_import_service(
               :workspace => wspace,
               :host      => host,
               :proto     => sprot,
@@ -116,7 +116,7 @@ module Msf::DBManager::Import::Nexpose::Simple
               :task      => args[:task]
           )
         else
-          report_service(
+          msf_import_service(
               :workspace => wspace,
               :host      => host,
               :proto     => sprot,
@@ -131,7 +131,7 @@ module Msf::DBManager::Import::Nexpose::Simple
           vid  = vuln.attributes['id'].to_s.downcase
           refs = process_nexpose_data_sxml_refs(vuln)
           next if not refs
-          report_vuln(
+          msf_import_vuln(
               :workspace => wspace,
               :host      => host,
               :port      => sport,

--- a/lib/msf/core/db_manager/import/nikto.rb
+++ b/lib/msf/core/db_manager/import/nikto.rb
@@ -39,7 +39,7 @@ module Msf::DBManager::Import::Nikto
                 :task      => args[:task]
             }
             # Always report it as a note.
-            report_note(desc_data)
+            msf_import_note(desc_data)
             # Sometimes report it as a vuln, too.
             # XXX: There's a Vuln.info field but nothing reads from it? See Bug #5837
             if item.attributes['osvdbid'].to_i != 0
@@ -48,7 +48,7 @@ module Msf::DBManager::Import::Nikto
               desc_data.delete(:data)
               desc_data.delete(:type)
               desc_data.delete(:update)
-              report_vuln(desc_data)
+              msf_import_vuln(desc_data)
             end
           end
         end

--- a/lib/msf/core/db_manager/import/nmap.rb
+++ b/lib/msf/core/db_manager/import/nmap.rb
@@ -74,7 +74,7 @@ module Msf::DBManager::Import::Nmap
             next if port_states.compact.empty?
           end
           yield(:address,data[:host]) if block
-          hobj = report_host(data)
+          hobj = msf_import_host(data)
           report_import_note(wspace,hobj)
         end
       end
@@ -97,11 +97,11 @@ module Msf::DBManager::Import::Nmap
           note[:data][:os_match] = h['os_match']
         end
 
-        report_note(note)
+        msf_import_note(note)
       end
 
       if (h["last_boot"])
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :host => hobj || addr,
           :type => 'host.last_boot',
@@ -122,7 +122,7 @@ module Msf::DBManager::Import::Nmap
             "name"    => hop["host"].to_s
           }
         end
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :host => hobj || addr,
           :type => 'host.nmap.traceroute',
@@ -164,7 +164,7 @@ module Msf::DBManager::Import::Nmap
         data[:info]  = extra if not extra.empty?
         data[:task]  = args[:task]
         data[:name]  = p['tunnel'] ? "#{p['tunnel']}/#{p['name'] || 'unknown'}" : p['name']
-        report_service(data)
+        msf_import_service(data)
       }
       #Parse the scripts output
       if h["scripts"]
@@ -186,7 +186,7 @@ module Msf::DBManager::Import::Nmap
                   'MSF-Microsoft Server Service Relative Path Stack Corruption',
                   'NSS-34476']
               }
-              report_vuln(vuln_info)
+              msf_import_vuln(vuln_info)
             end
             if val =~ /MS06-025: VULNERABLE/
               vuln_info = {
@@ -206,7 +206,7 @@ module Msf::DBManager::Import::Nmap
                   'MSF-Microsoft RRAS Service RASMAN Registry Overflow',
                   'NSS-21689']
               }
-              report_vuln(vuln_info)
+              msf_import_vuln(vuln_info)
             end
             # This one has NOT been  Tested , remove this comment if confirmed working
             if val =~ /MS07-029: VULNERABLE/
@@ -223,7 +223,7 @@ module Msf::DBManager::Import::Nmap
                   'MSF-Microsoft DNS RPC Service extractQuotedChar()',
                   'NSS-25168']
               }
-              report_vuln(vuln_info)
+              msf_import_vuln(vuln_info)
             end
           end
         end

--- a/lib/msf/core/db_manager/import/nuclei.rb
+++ b/lib/msf/core/db_manager/import/nuclei.rb
@@ -45,7 +45,7 @@ module Msf::DBManager::Import::Nuclei
         task: args[:task]
       }
 
-      report_note(note)
+      msf_import_note(note)
 
       next unless %w[low medium high critical].include?(severity)
 
@@ -68,7 +68,7 @@ module Msf::DBManager::Import::Nuclei
         task: args[:task]
       }
 
-      report_vuln(vuln)
+      msf_import_vuln(vuln)
     end
   end
 
@@ -122,7 +122,7 @@ module Msf::DBManager::Import::Nuclei
         task: args[:task]
       }
 
-      report_note(note)
+      msf_import_note(note)
 
       next unless %w[low medium high critical].include?(severity)
 
@@ -145,7 +145,7 @@ module Msf::DBManager::Import::Nuclei
         task: args[:task]
       }
 
-      report_vuln(vuln)
+      msf_import_vuln(vuln)
     end
   end
 end

--- a/lib/msf/core/db_manager/import/qualys.rb
+++ b/lib/msf/core/db_manager/import/qualys.rb
@@ -21,7 +21,7 @@ module Msf::DBManager::Import::Qualys
     end
 
     if info[:host] && info[:port] && info[:proto]
-      report_service(info)
+      msf_import_service(info)
     end
 
     fixed_refs = []
@@ -39,7 +39,7 @@ module Msf::DBManager::Import::Qualys
     return if qid == 0
     title = 'QUALYS-' + qid if title.nil? or title.empty?
     if addr
-      report_vuln(
+      msf_import_vuln(
         :workspace => wspace,
         :task => task,
         :host => hobj,

--- a/lib/msf/core/db_manager/import/qualys/asset.rb
+++ b/lib/msf/core/db_manager/import/qualys/asset.rb
@@ -77,13 +77,13 @@ module Msf::DBManager::Import::Qualys::Asset
         (netbios_el.text if netbios_el) ||
          (dns_el.text if dns_el) ||
          "" )
-      hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
+      hobj = msf_import_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
       report_import_note(wspace,hobj)
 
       os_el = host.xpath("OPERATING_SYSTEM").first
       if os_el
         hos = os_el.text
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => hobj,

--- a/lib/msf/core/db_manager/import/qualys/scan.rb
+++ b/lib/msf/core/db_manager/import/qualys/scan.rb
@@ -16,13 +16,13 @@ module Msf::DBManager::Import::Qualys::Scan
       end
       hname = host.attr('name') || ''
 
-      hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
+      hobj = msf_import_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
       report_import_note(wspace,hobj)
 
       os_el = host.xpath("OS").first
       if os_el
         hos = os_el.text
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => hobj,

--- a/lib/msf/core/db_manager/import/report.rb
+++ b/lib/msf/core/db_manager/import/report.rb
@@ -42,7 +42,7 @@ module Msf::DBManager::Import::Report
       # Update to full path
       artifact_opts[:file_path].gsub!(/^\./, tmp)
 
-      report_artifact(artifact_opts)
+      msf_import_artifact(artifact_opts)
     end
   end
 end

--- a/lib/msf/core/db_manager/import/retina.rb
+++ b/lib/msf/core/db_manager/import/retina.rb
@@ -38,7 +38,7 @@ module Msf::DBManager::Import::Retina
       yield(:address, data[:host]) if block
 
       # Import Host
-      hobj = report_host(data)
+      hobj = msf_import_host(data)
       report_import_note(wspace, hobj)
 
       # Import OS fingerprint
@@ -52,7 +52,7 @@ module Msf::DBManager::Import::Retina
             :os => host["os"]
           }
         }
-        report_note(note)
+        msf_import_note(note)
       end
 
       # Import vulnerabilities
@@ -76,7 +76,7 @@ module Msf::DBManager::Import::Retina
           )
         end
 
-        report_vuln(vuln_info)
+        msf_import_vuln(vuln_info)
       end
     end
 

--- a/lib/msf/core/db_manager/import/spiceworks.rb
+++ b/lib/msf/core/db_manager/import/spiceworks.rb
@@ -28,7 +28,7 @@ module Msf::DBManager::Import::Spiceworks
 
 
       if os
-        report_note(
+        msf_import_note(
           :workspace => wspace,
           :task => args[:task],
           :host => ip,
@@ -44,7 +44,7 @@ module Msf::DBManager::Import::Spiceworks
       info << "Location: #{location}" unless location.blank?
       conf[:info] = info.join(", ") unless info.empty?
 
-      host = report_host(conf)
+      host = msf_import_host(conf)
       report_import_note(wspace, host)
     end
   end

--- a/lib/msf/core/db_manager/loot.rb
+++ b/lib/msf/core/db_manager/loot.rb
@@ -89,7 +89,7 @@ module Msf::DBManager::Loot
     loot.name         = name if name
     loot.info         = info if info
     loot.workspace    = wspace
-    msf_import_timestamps(opts,loot)
+    msf_assign_timestamps(opts, loot)
     loot.save!
 
     ret[:loot] = loot

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -191,7 +191,7 @@ module Msf::DBManager::Note
     if opts[:vuln_id]
       note.vuln_id = opts[:vuln_id]
     end
-    msf_import_timestamps(opts,note)
+    msf_assign_timestamps(opts, note)
     note.save!
     ret[:note] = note
   }

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -82,14 +82,6 @@ module Msf::DBManager::Service
     end
 
     ret  = {}
-=begin
-    host = get_host(:workspace => wspace, :address => addr)
-    if host
-      host.updated_at = host.created_at
-      host.state      = HostState::Alive
-      host.save!
-    end
-=end
 
     proto = opts[:proto] || Msf::DBManager::DEFAULT_SERVICE_PROTO
 
@@ -120,7 +112,6 @@ module Msf::DBManager::Service
     end
 
     if (service and service.changed?)
-      msf_import_timestamps(opts,service)
       service.save!
     end
 

--- a/lib/msf/core/db_manager/task.rb
+++ b/lib/msf/core/db_manager/task.rb
@@ -36,7 +36,7 @@ module Msf::DBManager::Task
     task.path = path
     task.progress = prog
     task.result = result if result
-    msf_import_timestamps(opts,task)
+    msf_assign_timestamps(opts, task)
     # Having blank completed_ats, while accurate, will cause unstoppable tasks.
     if completed_at.nil? || completed_at.empty?
       task.completed_at = opts[:updated_at]

--- a/lib/msf/core/db_manager/user.rb
+++ b/lib/msf/core/db_manager/user.rb
@@ -60,7 +60,7 @@ module Msf::DBManager::User
 
       # Finalize
       if user.changed?
-        msf_import_timestamps(opts, user)
+        msf_assign_timestamps(opts, user)
         user.save!
       end
 

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -226,7 +226,7 @@ module Msf::DBManager::Vuln
 
     # Finalize
     if vuln.changed?
-      msf_import_timestamps(opts,vuln)
+      msf_assign_timestamps(opts, vuln)
       vuln.save!
     end
 

--- a/lib/msf/core/db_manager/web.rb
+++ b/lib/msf/core/db_manager/web.rb
@@ -71,7 +71,7 @@ module Msf::DBManager::Web
       form.query       = quer
     end
 
-    msf_import_timestamps(opts, form)
+    msf_assign_timestamps(opts, form)
     form.save!
     ret[:web_form] = form
   }
@@ -154,7 +154,7 @@ module Msf::DBManager::Web
 
     page.location = opts[:location] if opts[:location]
 
-    msf_import_timestamps(opts, page)
+    msf_assign_timestamps(opts, page)
     page.save!
 
     ret[:web_page] = page
@@ -258,7 +258,7 @@ module Msf::DBManager::Web
     site.options = opts[:options] if opts[:options]
 
     # XXX:
-    msf_import_timestamps(opts, site)
+    msf_assign_timestamps(opts, site)
     site.save!
 
     ret[:web_site] = site
@@ -366,7 +366,7 @@ module Msf::DBManager::Web
     vuln.payload = payload
     vuln.owner   = owner
 
-    msf_import_timestamps(opts, vuln)
+    msf_assign_timestamps(opts, vuln)
     vuln.save!
 
     ret[:web_vuln] = vuln

--- a/spec/support/shared/examples/msf/db_manager/import.rb
+++ b/spec/support/shared/examples/msf/db_manager/import.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples_for 'Msf::DBManager::Import' do
   it { is_expected.to respond_to :import_file }
   it { is_expected.to respond_to :import_filetype_detect }
   it { is_expected.to respond_to :msf_assign_timestamps }
-  it { is_expected.to respond_to :normalise_import_timestamps }
+  it { is_expected.to respond_to :msf_normalise_import_timestamps }
   it { is_expected.to respond_to :report_import_note }
   it { is_expected.to respond_to :rexmlify }
   it { is_expected.to respond_to :validate_import_file }

--- a/spec/support/shared/examples/msf/db_manager/import.rb
+++ b/spec/support/shared/examples/msf/db_manager/import.rb
@@ -9,7 +9,8 @@ RSpec.shared_examples_for 'Msf::DBManager::Import' do
   it { is_expected.to respond_to :import }
   it { is_expected.to respond_to :import_file }
   it { is_expected.to respond_to :import_filetype_detect }
-  it { is_expected.to respond_to :msf_import_timestamps }
+  it { is_expected.to respond_to :msf_assign_timestamps }
+  it { is_expected.to respond_to :normalise_import_timestamps }
   it { is_expected.to respond_to :report_import_note }
   it { is_expected.to respond_to :rexmlify }
   it { is_expected.to respond_to :validate_import_file }


### PR DESCRIPTION
This PR fixes an issue where the service updated_at and created_at would not be updated due to different expected data.

## Before
In Pro, running a scan vs. a host, then closing a port, re-running the scan, opening the port and re-running the scan results in incorrect `updated_at` timestamp for the service.

## After
In Pro, re-running the scan vs. a host after closing and re-opening a port results in the correct `updated_at` timestamp.

## Verification

- [ ] Start Metasploit Pro
- [ ] Run a scan vs a host
- [ ] Confirm you get some open services with correct dates
- [ ] Use the Windows Firewall to block one of the ports
- [ ] Run the scan again
- [ ] Confirm the closed service reports the correct updated_at time
- [ ] Delete the firewall rule so that the port is open again
- [ ] Run the scan again
- [ ] Confirm the open service reports the correct updated_at time
