### PR TITLE
Patches File to use .exist? when .exists? is called

### DIFF
--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -110,3 +110,10 @@ Kernel.class_eval(<<-EOF, __FILE__, __LINE__ + 1)
     Rex::ThreadSafe.select(rfd, wfd, efd, to)
   end
 EOF
+
+# Add the deprecated File.exists? method to call non-deprecated File.exist?
+File.class_eval(<<-EOF, __FILE__, __LINE__ + 1)
+  def File.exists?(fname)
+    File.exist?(fname)
+  end
+EOF


### PR DESCRIPTION
Adds a patch to address https://github.com/rapid7/metasploit-framework/issues/19160 
`File.exists?` has been deprecated in favor of `File.exist?` in Ruby 3.2+, but not all gems have eliminated its usage. This adds a patch to convert File.exists? to the newer File.exist? when called
Previously, tab completing a path option would cause metasploit to crash when using ruby 3.2+:
```
/home/zgoldman/.rvm/gems/ruby-3.2.3@metasploit-framework/gems/rb-readline-0.5.5/lib/rbreadline.rb:8490:in `append_to_match': undefined method `exists?' for File:Class (NoMethodError)
Did you mean?  exist?
```

To test:

- [ ] In ruby 3.2+, try and set a path option for a module, and tab complete it. Ensure it doesn't crash.