### PR TITLE
Fixes an issue where zip paths were not being created correctly for Java payloads

### DIFF
--- a/lib/msf/core/payload/java.rb
+++ b/lib/msf/core/payload/java.rb
@@ -110,12 +110,12 @@ module Msf::Payload::Java
     zip.add_file('WEB-INF/', '')
     zip.add_file('WEB-INF/web.xml', web_xml)
     zip.add_file("WEB-INF/classes/", "")
-    zip.add_file('metasploit/', '') # Create the metasploit dir
+    zip.add_file('WEB-INF/classes/metasploit/', '') # Create the metasploit dir
 
     paths.each do |path_parts|
       path = ['java', path_parts].flatten.join('/')
       contents = ::MetasploitPayloads.read(path)
-      zip.add_file(path_parts.join('/'), contents)
+      zip.add_file("WEB-INF/classes/" + path_parts.join('/'), contents)
     end
 
     zip.add_file("WEB-INF/classes/metasploit.dat", stager_config(opts))


### PR DESCRIPTION
Fixes #19174

This PR fixes an issue where Java payloads zip paths were not being created properly. Originally added as part of this [PR](https://github.com/rapid7/metasploit-framework/pull/18441/files#diff-7793140769d7594865ba54ebeca22d6cf83d001411d09d4fa1dc5b8350a71a0fL106). The zip paths were missing `WEB-INF/classes/` being appeneded when building the paths.

## Before 
```
[1] pry(#<#<Class:0x00007f92471f6810>>)> zipip
=> #<Rex::Zip::Jar entries = [WEB-INF/,WEB-INF/web.xml,WEB-INF/classes/,metasploit/,metasploit/Payload.class,metasploit/PayloadServlet.class,WEB-INF/classes/metasploit.dat]>
```

## After 
```
[2] pry(#<#<Class:0x00007f982b0e6ad0>>)> zip
#<Rex::Zip::Jar entries = [WEB-INF/,WEB-INF/web.xml,WEB-INF/classes/,WEB-INF/classes/metasploit/,WEB-INF/classes/metasploit/Payload.class,WEB-INF/classes/metasploit/PayloadServlet.class,WEB-INF/classes/metasploit.dat]>
```

## Verification

- [ ] Follow testing steps outlined in the linked issue
- [ ] Verify the issue is no longer present