### PR TITLE
Remove uri unescape usage

### DIFF
--- a/modules/auxiliary/gather/ie_sandbox_findfiles.rb
+++ b/modules/auxiliary/gather/ie_sandbox_findfiles.rb
@@ -129,12 +129,12 @@ class MetasploitModule < Msf::Auxiliary
 
       case request.uri
       when /^\/found\/\?f=/
-        f = URI.unescape(request.uri.gsub('/found/?f=', ''))
+        f = URI.decode_www_form(request.uri.split("/found/?").last).assoc('f').last
         report_note(host: cli.peerhost, type: 'ie.filenames', data: f)
         print_good("Found file " + f)
         send_response(cli, '')
       when /^\/notfound\/\?f=/
-        f = URI.unescape(request.uri.gsub('/notfound/?f=', ''))
+        f = URI.decode_www_form(request.uri.split("/notfound/?").last).assoc('f').last
         print_error("The file " + f + " does not exist")
         send_response(cli, '')
       when "/"

--- a/modules/auxiliary/scanner/http/rails_mass_assignment.rb
+++ b/modules/auxiliary/scanner/http/rails_mass_assignment.rb
@@ -44,9 +44,9 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     case datastore['METHOD']
     when 'POST'
-      parsed_data = queryparse(URI.unescape(datastore['DATA']))
+      parsed_data = queryparse(URI.decode_www_form_component(datastore['DATA']))
     when 'GET'
-      parsed_data = queryparse(URI.unescape(datastore['QUERY']))
+      parsed_data = queryparse(URI.decode_www_form_component(datastore['QUERY']))
     end
     data_base_params = get_base_params(parsed_data)
 

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
           url_enc = line.sub(/^PREFIX=/, '')
           # Remove CASE and VHOST
           url_enc = url_enc.sub(/&CASE=.*/, '')
-          url_dec = URI.unescape(url_enc).sub(/;/, '')
+          url_dec = CGI.unescape(url_enc).sub(/;/, '')
           urls << url_dec.strip
         end
       end

--- a/modules/exploits/multi/http/dexter_casinoloader_exec.rb
+++ b/modules/exploits/multi/http/dexter_casinoloader_exec.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     if res and !res.get_cookies.empty? and res.get_cookies.start_with?('response=')
-      return Rex::Text.decode_base64(URI.unescape(res.get_cookies['response='.length..-1]))[1..-3]
+      return Rex::Text.decode_base64(URI.decode_uri_component(res.get_cookies['response='.length..-1]))[1..-3]
     end
     return false
   end
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and !res.get_cookies.empty? and res.get_cookies.start_with?('response=') and
-      Rex::Text.decode_base64(URI.unescape(res.get_cookies['response='.length..-1])) == '$' + testvalue + ';#' and database_get_field('users', 'name', 0) != false
+      Rex::Text.decode_base64(URI.decode_uri_component(res.get_cookies['response='.length..-1])) == '$' + testvalue + ';#' and database_get_field('users', 'name', 0) != false
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -330,12 +330,12 @@ class MetasploitModule < Msf::Post
           unless ieffcreds.blank?
             ieffcreds.each do |creds|
               if creds[1].blank? # No master password found
-                account_map[account][browser]['lp_creds'][URI.unescape(creds[0])] = { 'lp_password' => nil }
+                account_map[account][browser]['lp_creds'][URI.decode_uri_component(creds[0])] = { 'lp_password' => nil }
               else
-                sha256_hex_email = OpenSSL::Digest::SHA256.hexdigest(URI.unescape(creds[0]))
+                sha256_hex_email = OpenSSL::Digest::SHA256.hexdigest(URI.decode_uri_component(creds[0]))
                 sha256_binary_email = [sha256_hex_email].pack 'H*' # Do hex2bin
-                creds[1] = decrypt_data(sha256_binary_email, URI.unescape(creds[1]))
-                account_map[account][browser]['lp_creds'][URI.unescape(creds[0])] = { 'lp_password' => creds[1] }
+                creds[1] = decrypt_data(sha256_binary_email, URI.decode_uri_component(creds[1]))
+                account_map[account][browser]['lp_creds'][URI.decode_uri_component(creds[0])] = { 'lp_password' => creds[1] }
               end
             end
           end
@@ -551,7 +551,7 @@ class MetasploitModule < Msf::Post
       # Use the cookie to obtain the encryption key to decrypt the vault key
       uri = URI('https://lastpass.com/login_check.php')
       request = Net::HTTP::Post.new(uri)
-      request.set_form_data('wxsessid' => URI.unescape(session_cookie_value), 'uuid' => browser_map['lp_2fa'])
+      request.set_form_data('wxsessid' => URI.decode_uri_component(session_cookie_value), 'uuid' => browser_map['lp_2fa'])
       request.content_type = 'application/x-www-form-urlencoded; charset=UTF-8'
       response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
 


### PR DESCRIPTION
Addresses https://github.com/rapid7/metasploit-framework/issues/19201

Removes usage of outdated `URI.unescape` method, replacing with `CGI.unescape` or other relevant `URI` methods. Relevant rubocop rule has been verified working

Affected modules:
```
modules/auxiliary/gather/ie_sandbox_findfiles.rb
modules/auxiliary/scanner/http/rails_mass_assignment.rb
modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
modules/exploits/multi/http/dexter_casinoloader_exec.rb
modules/post/multi/gather/lastpass_creds.rb
```

Testing:

- Ensure `[-] Auxiliary failed: NoMethodError undefined method 'unescape' for URI:Module` does not pop up on module run
- Verify touched modules work the same as expected
