### PR TITLE
remove duplicated rescue

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -400,8 +400,7 @@ protected
             resp.body = blob
 
           rescue NoMethodError => e
-          rescue NoMethodError => e
-            print_error('Staging failed. This can occur when stageless listeners are used with staged payloads.''')
+            print_error('Staging failed. This can occur when stageless listeners are used with staged payloads.')
             elog('Staging failed. This can occur when stageless listeners are used with staged payloads.', error: e)
             return
           end


### PR DESCRIPTION
Removes some duplicated code from `reverse_http` added in https://github.com/rapid7/metasploit-framework/commit/07aa024b219b21f5ac2d9d270976d7e7f0e5dd0c#diff-e6fedbbb694bdda6fa431f397da600bca22b13fe5570d0bb5e23a2d4eb386261

Testing:
- make sure this doesn't break anything re: error handling