### PR TITLE
add explicit error handling to base login scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -251,8 +251,11 @@ module Metasploit
                   break if total_error_count >= 10
                 end
               end
-            rescue Rex::ConnectionRefused, Rex::SocketError, Rex::HostCommunicationError, Rex::ConnectionError, Rex::TimeoutError, OpenSSL::Cipher::CipherError, Rex::ConnectionProxyError, Errno::ECONNRESET, Errno::EINTR, Errno::EPIPE, ::SystemCallError, ::EOFError, Errno::ENOTCONN, ::Timeout::Error, Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported, ::JSON::ParserError, Errno::ECONNRESET, OpenSSL::SSL::SSLError, Rex::StreamClosedError, ::Rex::Proto::Kerberos::Model::Error::KerberosError, Errno::ETIMEDOUT => e
-              framework_module.print_error("Error, scan may not produce results: #{e.message}")
+            rescue => e
+              if framework_module
+                prefix = framework_module.respond_to?(:peer) ? "#{framework_module.peer} - LOGIN FAILED:" : "LOGIN FAILED:"
+                framework_module.print_warning("#{prefix} #{credential.to_h} - Unhandled error - scan may not produce correct results: #{e.message} - #{e.backtrace}")
+              end
               elog("Scan Error: #{e.message}", error: e)
               consecutive_error_count += 1
               total_error_count += 1

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -251,8 +251,13 @@ module Metasploit
                   break if total_error_count >= 10
                 end
               end
-            rescue => e
-              elog('Attempt may not yield a result', error: e)
+            rescue Rex::ConnectionRefused, Rex::SocketError, Rex::HostCommunicationError, Rex::ConnectionError, Rex::TimeoutError, OpenSSL::Cipher::CipherError, Rex::ConnectionProxyError, Errno::ECONNRESET, Errno::EINTR, Errno::EPIPE, ::SystemCallError, ::EOFError, Errno::ENOTCONN, ::Timeout::Error, Rex::Proto::Kerberos::Model::Error::KerberosEncryptionNotSupported, ::JSON::ParserError, Errno::ECONNRESET, OpenSSL::SSL::SSLError, Rex::StreamClosedError, ::Rex::Proto::Kerberos::Model::Error::KerberosError, Errno::ETIMEDOUT => e
+              framework_module.print_error("Error, scan may not produce results: #{e.message}")
+              elog("Scan Error: #{e.message}", error: e)
+              consecutive_error_count += 1
+              total_error_count += 1
+              break if consecutive_error_count >= 3
+              break if total_error_count >= 10
             end
             nil
           end


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/17959

This PR addresses a silent catch-all rescue in our base login scanner. Previously, exceptions not caught by whatever login scanner implementation was being used would silently fail:
<img width="974" alt="Screenshot 2024-06-11 at 10 54 23 AM" src="https://github.com/rapid7/metasploit-framework/assets/106169455/342c66a1-48d3-4701-99fd-9738f7064313">
This adds explicit error catching for known errors. 
<img width="989" alt="Screenshot 2024-06-11 at 10 54 38 AM" src="https://github.com/rapid7/metasploit-framework/assets/106169455/c292599c-2409-4ef1-83be-d16c56d8c8e1">
This exception list is pulled from the exceptions potentially raised by each of the modules, excluding exceptions specific to one module that are already caught.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use a module that leverages `login_scanner` such as `mssql_login`
- [ ] trigger an error context that the module does not rescue that is in the exception list (shortcut: hardcode a `raise` in the module)
- [ ] verify the behavior is what we'd want and expect
- [ ] double check the exception list
