### PR TITLE
Corrected a mistaken CVE-ID in exploit references.

### DIFF
--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [ 'Silas Cutler (p1nk)' ],
         'References' => [
           [ 'URL', 'https://seclists.org/fulldisclosure/2017/Dec/42' ],
-          [ 'CVE', '2017-171069' ]
+          [ 'CVE', '2017-17105' ]
         ],
         'Platform' => 'unix',
         'Targets' => [


### PR DESCRIPTION
This entry for exploit/unix/http/zivif_ipcheck_exec contained a mistaken reference to a CVE that does not exist.  The referenced CVE-ID is "CVE-2017-171069".  The corrected CVE is "CVE-2017-17105".

## Verification
- Note that the listed CVE does not exist: [https://nvd.nist.gov/vuln/detail/CVE-2017-171069](https://nvd.nist.gov/vuln/detail/CVE-2017-171069)
- Note that the corrected CVE does exist, and describes the vuln used by this exploit: [https://nvd.nist.gov/vuln/detail/CVE-2017-17105](https://nvd.nist.gov/vuln/detail/CVE-2017-17105)
- Observe that the correct CVE is mentioned in the exploit's description: "This module exploits a remote command execution vulnerability in Zivif webcams.  This is known to impact versions prior to and including v2.3.4.2103. Exploit was reported in CVE-2017-17105."