### PR TITLE
Update windows acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -135,10 +135,10 @@ jobs:
       # pcaprub skipped until new version released: https://github.com/pcaprub/pcaprub/issues/70
       - name: Remove pcaprub dependency
         shell: pwsh
-        if: runner.os == 'Windows':
+        if: runner.os == 'Windows'
         run: |
-          Set-Content -Path "Gemfile.lock" -Value (Get-Content -Path "Gemfile.lock" | Select-String -Pattern 'pcaprub' -NotMatch)
-          Set-Content -Path "metasploit-framework.gemspec" -Value (Get-Content -Path "metasploit-framework.gemspec" | Select-String -Pattern 'pcaprub' -NotMatch)
+          Set-Content -Path "Gemfile.lock" -Value (Get-Content -Path "Gemfile.lock" | Select-String -Pattern 'pcaprub' -NotMatch | Select-String -Pattern 'packetfu' -NotMatch)
+          Set-Content -Path "metasploit-framework.gemspec" -Value (Get-Content -Path "metasploit-framework.gemspec" | Select-String -Pattern 'pcaprub' -NotMatch | Select-String -Pattern 'packetfu' -NotMatch)
 
       - name: Setup Ruby
         env:

--- a/lib/metasploit/framework.rb
+++ b/lib/metasploit/framework.rb
@@ -11,7 +11,6 @@ require 'json'
 require 'msgpack'
 require 'metasploit/credential'
 require 'nokogiri'
-require 'packetfu'
 # railties has not autorequire defined
 # rkelly-remix is a fork of rkelly, so it's autorequire is 'rkelly' and not 'rkelly-remix'
 require 'rkelly'

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -10,8 +10,6 @@ require 'uri'
 # Gems
 #
 
-require 'packetfu'
-
 module Msf::DBManager::Import
   autoload :Acunetix, 'msf/core/db_manager/import/acunetix'
   autoload :Amap, 'msf/core/db_manager/import/amap'

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -50,9 +50,8 @@ module Msf
           ], Msf::Exploit::Capture
         )
 
-        require 'packetfu'
-
         begin
+          require 'packetfu'
           require 'pcaprub'
           @pcaprub_loaded = true
         rescue ::LoadError => e

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -339,6 +339,7 @@ autoload :Faker, 'faker'
 autoload :BinData, 'bindata'
 autoload :RubySMB, 'ruby_smb'
 autoload :MetasploitPayloads, 'metasploit-payloads'
+autoload :PacketFu, 'packetfu'
 
 require 'rexml/document'
 # Load IO#expect moneypatch

--- a/modules/auxiliary/scanner/scada/profinet_siemens.rb
+++ b/modules/auxiliary/scanner/scada/profinet_siemens.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'packetfu'
-
 class MetasploitModule < Msf::Auxiliary
   def initialize
     super(


### PR DESCRIPTION
Update windows acceptance tests to no longer depend on packetfu or pcaprub - a follow up from  https://github.com/rapid7/metasploit-framework/pull/19251

## Verification

Verify CI passes