### PR TITLE
Escape LDAP query string filters

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -309,5 +309,14 @@ module Msf
         end
       end
     end
+
+    # Return a string suitable for placement in an LDAP filter
+    # e.g. (certificateTemplates=#{ldap_escape_string(name)})
+    #
+    # @param string String The string to escape.
+    # @return The escaped string.
+    def ldap_escape_filter(string)
+      Net::LDAP::Filter.escape(string)
+    end
   end
 end

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
   def convert_sids_to_human_readable_name(sids_array)
     output = []
     for sid in sids_array
-      raw_filter = "(objectSID=#{sid})"
+      raw_filter = "(objectSID=#{ldap_escape_filter(sid.to_s)})"
       attributes = ['sAMAccountName', 'name']
       base_prefix = 'CN=Configuration'
       sid_entry = query_ldap_server(raw_filter, attributes, base_prefix: base_prefix) # First try with prefix to find entries that may be group specific.
@@ -344,7 +344,7 @@ class MetasploitModule < Msf::Auxiliary
     # have permissions to enroll in certificates on each server.
 
     @vuln_certificate_details.each_key do |certificate_template|
-      certificate_enrollment_raw_filter = "(&(objectClass=pKIEnrollmentService)(certificateTemplates=#{certificate_template}))"
+      certificate_enrollment_raw_filter = "(&(objectClass=pKIEnrollmentService)(certificateTemplates=#{ldap_escape_filter(certificate_template.to_s)}))"
       attributes = ['cn', 'dnsHostname', 'ntsecuritydescriptor']
       base_prefix = 'CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration'
       enrollment_ca_data = query_ldap_server(certificate_enrollment_raw_filter, attributes, base_prefix: base_prefix)
@@ -418,7 +418,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if pki_object.nil?
       pki_object = query_ldap_server(
-        "(&(objectClass=msPKI-Enterprise-Oid)(msPKI-Cert-Template-OID=#{oid}))",
+        "(&(objectClass=msPKI-Enterprise-Oid)(msPKI-Cert-Template-OID=#{ldap_escape_filter(oid.to_s)}))",
         nil,
         base_prefix: 'CN=OID,CN=Public Key Services,CN=Services,CN=Configuration'
       )&.first

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
     end
   end
 
+  describe '#ldap_escape_filter' do
+    let(:string) do
+      'John Doe (Developer) *'
+    end
+
+    it do
+      expect(subject.ldap_escape_filter(string)).to eq("John Doe \\28Developer\\29 \\2A")
+    end
+  end
+
   describe '#resolve_connect_opts' do
     let(:cred) do
       'I am a cred'


### PR DESCRIPTION
This fixes an issue that was privately reported to me whereby if an AD CS server had a certificate template which contained parenthesis, the `ldap_esc_vulnerable_cert_finder` module would crash with an error saying the filter could not be compiled. This is due to the string being placed within the LDAP query to obtain more information. When that string is placed in the query, it needs to have key characters escaped in order to compile.

## Verification

- [ ] Create a template vulnerable to one of the ESC techniques that contains parenthesis, e.g. `ESC(Test-1)`
    * See steps from here: https://github.com/RayRRT/Active-Directory-Certificate-Services-abuse
- [ ] Run the `auxiliary/gather/ldap_esc_vulnerable_cert_finder` module, see that it does not fail


## Example

Old and broke with VERBOSE=true

```
[!] Couldn't find any vulnerable ESC13 templates!
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=CA)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=SubCA)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=OfflineRouter)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=ESC1-Test)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=ESC2-Test)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=EnrollmentAgent)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=EnrollmentAgentOffline)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=MachineEnrollmentAgent)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=CEPEncryption)).
[*] Successfully queried (&(objectClass=pKIEnrollmentService)(certificateTemplates=ESC3-Test)).
[-] Auxiliary aborted due to failure: bad-config: Could not compile the filter! Error was Invalid filter syntax.
[*] Auxiliary module execution completed
metasploit-framework.pr (S:0 J:0) auxiliary(gather/ldap_esc_vulnerable_cert_finder) 
```