### PR TITLE
Clean up CVEs: Remove two mistaken references to CVE IDs that do not exist.

### DIFF
--- a/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
+++ b/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
@@ -27,7 +27,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          ['CVE', '2014-5470'],
           ['EDB', '34450'],
           ['OSVDB', '110601']
         ],

--- a/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
@@ -33,8 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             ['OSVDB', '80984'],
             ['EDB', '18718'],
-            ['URL', 'http://www.spentera.com/advisories/2012/SPN-01-2012.pdf'],
-            ['CVE', '2012-6664']
+            ['URL', 'http://www.spentera.com/advisories/2012/SPN-01-2012.pdf']
           ],
         'Payload' =>
           {


### PR DESCRIPTION
Two module files contain mistaken references to CVE-IDs that do not exist.

- ActualAnalyzer: The referenced CVE-ID (CVE-2012-6664) does not exist.
    - The only ActualAnalyzer CVEs I can find are CVE-2006-1959, CVE-2008-2076, and CVE-2008-2527, none of which appear to match this exploit.
    - This vuln does not appear to have a CVE.
- Distinct TFTP Traversal:  This CVE (CVE-2012-6664) also does not exist.
    - This vuln does not appear to have a CVE, either.

While it is possible that these vulns were submitted, and may even have received tentative CVE numbers, at best they were never completed, or never left "reserved" status.  I have already reached out to MITRE requesting updates on these CVEs.  Given that both are over 10 years old, it is extremely unlikely that either vuln will ever complete the CVE process.

Some references on the web to these CVE numbers appear to be based on the fact that they are listed by Metasploit modules, which was also the case with the mistaken entry CVE corrected in commit f49b9ea6cfb25f6c976dcefc0ab9ba465a26c55c

## Verification

- Note that the CVE referenced for ActualAnalyzer does not exist: [https://nvd.nist.gov/vuln/detail/CVE-2014-5470](https://nvd.nist.gov/vuln/detail/CVE-2014-5470)
- Note that the CVE referenced for Distinct FTP does not exist: [https://nvd.nist.gov/vuln/detail/CVE-2012-6664](https://nvd.nist.gov/vuln/detail/CVE-2012-6664)
