### PR TITLE
Fix Redis Service Reporting

### DIFF
--- a/lib/metasploit/framework/login_scanner/redis.rb
+++ b/lib/metasploit/framework/login_scanner/redis.rb
@@ -9,21 +9,26 @@ module Metasploit
       # This is the LoginScanner class for dealing with REDIS.
       # It is responsible for taking a single target, and a list of credentials
       # and attempting them. It then saves the results.
-
       class Redis
         include Metasploit::Framework::LoginScanner::Base
         include Metasploit::Framework::LoginScanner::RexSocket
         include Metasploit::Framework::Tcp::Client
 
-        DEFAULT_PORT         = 6379
-        LIKELY_PORTS         = [ DEFAULT_PORT ]
-        LIKELY_SERVICE_NAMES = [ 'redis' ]
-        PRIVATE_TYPES        = [ :password ]
-        REALM_KEY            = nil
+        DEFAULT_PORT          = 6379
+        LIKELY_PORTS          = [ DEFAULT_PORT ]
+        LIKELY_SERVICE_NAMES  = [ 'redis' ]
+        PRIVATE_TYPES         = [ :password ]
+        REALM_KEY             = nil
+        OLD_PASSWORD_NOT_SET  = /but no password is set/i
+        PASSWORD_NOT_SET      = /without any password configured/i
+        WRONG_PASSWORD_SET    = /^-WRONGPASS/i
+        INVALID_PASSWORD_SET  = /^-ERR invalid password/i
+        OK                    = /^\+OK/
 
         # This method can create redis command which can be read by redis server
         def redis_proto(command_parts)
           return if command_parts.blank?
+
           command = "*#{command_parts.length}\r\n"
           command_parts.each do |p|
             command << "$#{p.length}\r\n#{p}\r\n"
@@ -50,40 +55,50 @@ module Metasploit
             connect
             select([sock], nil, nil, 0.4)
 
-            command = redis_proto(['AUTH', "#{credential.private}"])
+            command = redis_proto(['AUTH', credential.private.to_s])
+
             sock.put(command)
+
             result_options[:proof] = sock.get_once
-
-            # No password      - ( -ERR Client sent AUTH, but no password is set\r\n )
-            # Invalid password - ( -ERR invalid password\r\n )
-            # Valid password   - (+OK\r\n)
-
-            if result_options[:proof] && result_options[:proof] =~ /but no password is set/i
-              result_options[:status] = Metasploit::Model::Login::Status::NO_AUTH_REQUIRED
-            elsif result_options[:proof] && result_options[:proof] =~ /^-ERR invalid password/i
-              result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
-            elsif result_options[:proof] && result_options[:proof][/^\+OK/]
-              result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
-            end
-
+            result_options[:status] = validate_login(result_options[:proof])
           rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE => e
             result_options.merge!(
               proof: e,
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             )
           end
+
           disconnect if self.sock
+
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 
         private
 
+        # Validates the login data received from Redis and returns the correct Login status
+        # based upon the contents Redis sent back:
+        #
+        # No password      - ( -ERR Client sent AUTH, but no password is set\r\n )
+        # Invalid password - ( -ERR invalid password\r\n )
+        # Valid password   - (+OK\r\n)
+        def validate_login(data)
+          return if data.nil?
+
+          return Metasploit::Model::Login::Status::NO_AUTH_REQUIRED if data =~ OLD_PASSWORD_NOT_SET
+          return Metasploit::Model::Login::Status::NO_AUTH_REQUIRED if data =~ PASSWORD_NOT_SET
+          return Metasploit::Model::Login::Status::INCORRECT if (data =~ INVALID_PASSWORD_SET) == 0
+          return Metasploit::Model::Login::Status::INCORRECT if (data =~ WRONG_PASSWORD_SET) == 0
+          return Metasploit::Model::Login::Status::SUCCESSFUL if (data =~ OK) == 0
+
+          nil
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
-          self.connection_timeout  ||= 30
-          self.port                ||= DEFAULT_PORT
-          self.max_send_size       ||= 0
-          self.send_delay          ||= 0
+          self.connection_timeout ||= 30
+          self.port               ||= DEFAULT_PORT
+          self.max_send_size      ||= 0
+          self.send_delay         ||= 0
         end
       end
     end

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -84,7 +84,8 @@ module Msf::DBManager::Vuln
   # opts can contain
   # +:info+::   a human readable description of the vuln, free-form text
   # +:refs+::   an array of Ref objects or string names of references
-  # +:details:: a hash with :key pointed to a find criteria hash and the rest containing VulnDetail fields
+  # +:details+:: a hash with :key pointed to a find criteria hash and the rest containing VulnDetail fields
+  # +:sname+:: the name of the service this vulnerability relates to, used to associate it or create it.
   #
   def report_vuln(opts)
     return if not active
@@ -150,6 +151,7 @@ module Msf::DBManager::Vuln
         case opts[:proto].to_s.downcase # Catch incorrect usages, as in report_note
         when 'tcp','udp'
           proto = opts[:proto]
+          sname = opts[:sname]
         when 'dns','snmp','dhcp'
           proto = 'udp'
           sname = opts[:proto]
@@ -158,7 +160,9 @@ module Msf::DBManager::Vuln
           sname = opts[:proto]
         end
 
-        service = host.services.where(port: opts[:port].to_i, proto: proto).first_or_create
+        services = host.services.where(port: opts[:port].to_i, proto: proto)
+        services = services.where(name: sname) if sname.present?
+        service = services.first_or_create
       end
 
       # Try to find an existing vulnerability with the same service & references


### PR DESCRIPTION
Preliminary pull request to resolve an issue with a service not being properly detected for Redis.

* Ensure service name is properly passed down when detecting vulnerabilities
* Ensure Redis properly detects no-auth requirements

## Verification

List the steps needed to make sure this thing works

Run redis in docker without auth:

```
docker run --rm -p 6379:6379 redis
```

If needing to configure redis for auth

```
$ nc 127.0.0.1 6379
config set requirepass p4$$W0rd
+OK
```

- [X] Start `msfconsole`
- [X] `use auxiliary/scanner/redis/redis_login`
- [X] `run RHOSTS=127.0.0.1` if no auth
- [X] `run RHOSTS=127.0.0.1 username=default password=p4$$w0rd` if auth enabled
- [X] Verify output and scanner works as expected; if msfdb is enabled - services should be populated correctly:

```
msf6 auxiliary(scanner/redis/redis_login) > run rhost=127.0.0.1

[+] 127.0.0.1:6379        - 127.0.0.1:6379        - No password is required.
[*] 127.0.0.1:6379        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/redis/redis_login) > services
Services
========

host       port  proto  name   state  info
----       ----  -----  ----   -----  ----
127.0.0.1  6379  tcp    redis

msf6 auxiliary(scanner/redis/redis_login) > 
```

```
msf6 auxiliary(scanner/redis/redis_login) > run RHOSTS=192.168.73.1 rport=6380 anonymous_login=true

[!] 192.168.73.1:6380     - No active DB -- Credential data will not be saved!
[+] 192.168.73.1:6380     - 192.168.73.1:6380     - Login Successful: :foobared (Successful: +OK)
[*] 192.168.73.1:6380     - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

```
msf6 auxiliary(scanner/redis/redis_login) > run RHOSTS=192.168.73.1 rport=6380 username=redis password=foobared

[!] 192.168.73.1:6380     - No active DB -- Credential data will not be saved!
[+] 192.168.73.1:6380     - 192.168.73.1:6380     - Login Successful: :foobared (Successful: +OK)
[*] 192.168.73.1:6380     - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```