### PR TITLE
Fix redis_login scanner when auth is enabled

### DIFF
--- a/documentation/modules/auxiliary/scanner/redis/redis_login.md
+++ b/documentation/modules/auxiliary/scanner/redis/redis_login.md
@@ -8,6 +8,36 @@ Note that Redis does not require a username to log in; login is done purely via 
 
 A complete installation guide for Redis can be found [here](https://redis.io/topics/quickstart)
 
+## Setup
+
+Run redis in docker without auth:
+
+```
+docker run --rm -p 6379:6379 redis
+```
+
+Optionally setting the default password for the implicit `default` username account, connect to the running Redis instance and set a password:
+
+```
+$ nc 127.0.0.1 6379
+config set requirepass mypass
++OK
+```
+
+Optionally creating an enabled `test_user` user account with password `mypass` - if ACL is supported (Redis >= 6.0.0):
+
+```
+$ nc 127.0.0.1 6379
+ACL SETUSER test_user allkeys on +@string +@set -SADD >mypass
+```
+
+Optionally creating a disabled `test_user_disabled` user account with password `mypass` - if ACL is supported (Redis >= 6.0.0):
+
+```
+$ nc 127.0.0.1 6379
+ACL SETUSER test_user_disabled allkeys off +@string +@set -SADD >mypass
+```
+
 ## Verification Steps
 1. Do: `use auxiliary/scanner/redis/redis_login`
 2. Do: `set RHOSTS [ips]`

--- a/spec/lib/metasploit/framework/private_credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/private_credential_collection_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+require 'metasploit/framework/credential_collection'
+
+RSpec.describe Metasploit::Framework::PrivateCredentialCollection do
+
+  subject(:collection) do
+    described_class.new(
+      nil_passwords: nil_passwords,
+      blank_passwords: blank_passwords,
+      pass_file: pass_file,
+      password: password,
+      prepended_creds: prepended_creds,
+      additional_privates: additional_privates
+    )
+  end
+
+  before(:each) do
+    # The test suite overrides File.open(...) calls; fall back to the normal behavior for any File.open calls that aren't explicitly mocked
+    allow(File).to receive(:open).with(anything).and_call_original
+    allow(File).to receive(:open).with(anything, anything).and_call_original
+    allow(File).to receive(:open).with(anything, anything, anything).and_call_original
+  end
+
+  let(:nil_passwords) { nil }
+  let(:blank_passwords) { nil }
+  let(:password) { "pass" }
+  let(:pass_file) { nil }
+  # PrivateCredentialCollection yields `nil` as the username; unlike CredentialCollection
+  let(:username) { nil }
+  let(:prepended_creds) { [] }
+  let(:additional_privates) { [] }
+
+  describe "#each" do
+    specify do
+      expect { |b| collection.each(&b) }.to yield_with_args(Metasploit::Framework::Credential)
+    end
+
+    context "when given a pass_file" do
+      let(:password) { nil }
+      let(:pass_file) do
+        filename = "foo"
+        stub_file = StringIO.new("asdf\njkl\n")
+        allow(File).to receive(:open).with(filename,/^r/).and_return stub_file
+
+        filename
+      end
+
+      specify  do
+        expect { |b| collection.each(&b) }.to yield_successive_args(
+          Metasploit::Framework::Credential.new(public: username, private: "asdf"),
+          Metasploit::Framework::Credential.new(public: username, private: "jkl"),
+        )
+      end
+    end
+
+    context "when :nil_passwords is true" do
+      let(:nil_passwords) { true }
+      specify  do
+        expect { |b| collection.each(&b) }.to yield_successive_args(
+          Metasploit::Framework::Credential.new(public: username, private: password),
+          Metasploit::Framework::Credential.new(public: username, private: nil),
+        )
+      end
+    end
+
+    context "when :blank_passwords is true" do
+      let(:blank_passwords) { true }
+      specify  do
+        expect { |b| collection.each(&b) }.to yield_successive_args(
+          Metasploit::Framework::Credential.new(public: username, private: password),
+          Metasploit::Framework::Credential.new(public: username, private: ""),
+        )
+      end
+    end
+
+  end
+
+  describe "#empty?" do
+    context "when :password is not set" do
+      let(:username) { nil }
+      let(:password) { nil }
+      specify do
+        expect(collection.empty?).to eq true
+      end
+
+      context "and :prepended_creds is not empty" do
+        let(:prepended_creds) { [ "test" ] }
+        specify do
+          expect(collection.empty?).to eq false
+        end
+      end
+
+      context "and :additional_privates is not empty" do
+        let(:additional_privates) { [ "test_private" ] }
+        specify do
+          expect(collection.empty?).to eq false
+        end
+      end
+
+      context "and :additional_publics is not empty" do
+        let(:additional_publics) { [ "test_public" ] }
+        specify do
+          expect(collection.empty?).to eq true
+        end
+      end
+    end
+
+    context "when :password is set" do
+      let(:password) { 'pass' }
+      specify do
+        expect(collection.empty?).to eq false
+      end
+    end
+  end
+
+  describe "#prepend_cred" do
+    specify do
+      prep = Metasploit::Framework::Credential.new(public: "foo", private: "bar")
+      collection.prepend_cred(prep)
+      expect { |b| collection.each(&b) }.to yield_successive_args(
+        prep,
+        Metasploit::Framework::Credential.new(public: username, private: password),
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes the `auxiliary/scanner/redis/redis_login.rb` module to no longer crash when the remote target has authentication enabled

## Verification

Follow the test steps from `documentation/modules/auxiliary/scanner/redis/redis_login.md` to enable an authed redis instance


### Before

```
msf6 auxiliary(scanner/redis/redis_login) > run rhost=127.0.0.1 password=p4$$w0rd

[-] 127.0.0.1:6379        - Auxiliary failed: NameError undefined local variable or method `password_spray' for #<Metasploit::Framework::PrivateCredentialCollection:0x0000000116ba5718 @blank_passwords=false, @pass_file="/Users/adfoster/Documents/code/metasploit-framework/data/wordlists/unix_passwords.txt", @password="p4$$w0rd", @prepended_creds=[], @additional_privates=[], @filter=nil>
Did you mean?  password
[-] 127.0.0.1:6379        - Call stack:
[-] 127.0.0.1:6379        -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/credential_collection.rb:91:in `each_filtered'
[-] 127.0.0.1:6379        -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:141:in `each_credential'
[-] 127.0.0.1:6379        -   /Users/user/Documents/code/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:205:in `scan!'
[-] 127.0.0.1:6379        -   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/redis/redis_login.rb:83:in `run_host'
[-] 127.0.0.1:6379        -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:128:in `block (2 levels) in run'
[-] 127.0.0.1:6379        -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/redis/redis_login) >
```

### After

```
msf6 auxiliary(scanner/redis/redis_login) > run rhost=127.0.0.1 password=p4$$w0rd

[+] 127.0.0.1:6379        - 127.0.0.1:6379        - Login Successful: :p4$$w0rd (Successful: +OK)
[*] 127.0.0.1:6379        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```