### PR TITLE
MS-9454 Redis Scanner: Support newer versions

### DIFF
--- a/documentation/modules/auxiliary/scanner/redis/redis_login.md
+++ b/documentation/modules/auxiliary/scanner/redis/redis_login.md
@@ -4,9 +4,18 @@ database with optional durability. Redis supports different kinds of abstract da
 such as strings, lists, maps, sets, sorted sets, HyperLogLogs, bitmaps, streams, and spatial indexes.
 
 This module is login utility to find the password of the Redis server by bruteforcing the login portal.
-Note that Redis does not require a username to log in; login is done purely via supplying a valid password.
 
 A complete installation guide for Redis can be found [here](https://redis.io/topics/quickstart)
+
+### Redis Authentication
+
+Redis has several ways to support secure connections to the in-memory database:
+
+* Prior to Redis 6, the `requirepass` directive could be set, setting a master password for all connections.
+  This requires the usage of the `AUTH <password>` command before executing any commands on the cluster.
+* After Redis 6, the `requirepass` directive sets a password for the default user `default`
+  * The `AUTH` command now takes two arguments instead of one: `AUTH <username> <password>`
+  * The `AUTH` command still accepts a single arguments, but defaults to the user `default`
 
 ## Setup
 

--- a/lib/rex/proto/redis.rb
+++ b/lib/rex/proto/redis.rb
@@ -1,0 +1,13 @@
+require 'rex/proto/redis/base'
+require 'rex/proto/redis/version6'
+
+module Rex
+  module Proto
+    # Protocol module inside the Rex namespace to support Redis.
+    # Because the behavior of Redis changes between certain versions,
+    # dedicated submodules exist for each version
+    module Redis
+
+    end
+  end
+end

--- a/lib/rex/proto/redis/base.rb
+++ b/lib/rex/proto/redis/base.rb
@@ -1,0 +1,17 @@
+module Rex
+  module Proto
+    module Redis
+      # Module containing the constants and functionality for any Redis version.
+      # When a behavior changes, check whether a more recent version module exits
+      # and include the constants from there, or use the functionality defined there.
+      module Base
+        module Constants
+          AUTHENTICATION_REQUIRED = /(?<auth_response>NOAUTH Authentication required)/i
+          NO_PASSWORD_SET         = /(?<auth_response>ERR Client sent AUTH, but no password is set)/i
+          WRONG_PASSWORD          = /(?<auth_response>ERR invalid password)/i
+          OKAY                    = /\+OK/i
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/redis/version6.rb
+++ b/lib/rex/proto/redis/version6.rb
@@ -1,0 +1,15 @@
+module Rex
+  module Proto
+    module Redis
+      # Module containing the required constants and functionality
+      # specifically for Redis 6 and newer.
+      module Version6
+        module Constants
+          AUTHENTICATION_REQUIRED = /(?<auth_response>NOAUTH Authentication required)/i
+          NO_PASSWORD_SET         = /(?<auth_response>ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?)/i
+          WRONG_PASSWORD          = /(?<auth_response>WRONGPASS invalid username-password pair or user is disabled)/i
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -6,6 +6,11 @@
 require 'metasploit/framework/login_scanner/redis'
 require 'metasploit/framework/credential_collection'
 
+# Metasploit Module - Redis Login Scanner
+#
+# @example
+#   use auxiliary/scanner/redis/login
+#
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
@@ -45,7 +50,12 @@ class MetasploitModule < Msf::Auxiliary
   def requires_password?(_ip)
     connect
     command_response = send_redis_command('INFO')
-    !(command_response && REDIS_UNAUTHORIZED_RESPONSE !~ command_response)
+
+    ## Check against the old and new password required response to support all Redis versions
+    !(
+      (command_response && Rex::Proto::Redis::Base::Constants::AUTHENTICATION_REQUIRED !~ command_response) ||
+        (command_response && Rex::Proto::Redis::Version6::Constants::AUTHENTICATION_REQUIRED !~ command_response)
+    )
   end
 
   def run_host(ip)


### PR DESCRIPTION
Updating the Redis Login Scanner to properly support all versions of Redis and their implementations to handle the `AUTH` command.

## Verification

### Redis 5 and older without AUTH

- [X] `docker pull redis:5`
- [X] `docker run -p 6379:6379 -d redis:5`
- [X] `./msfconsole`
- [X] `use auxiliary/scanner/redis/redis_login`
- [X] `run rhosts=127.0.0.1`

```
[+] 127.0.0.1:6379        - 127.0.0.1:6379        - No password is required.
[*] 127.0.0.1:6379        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### Redis 5 and older with AUTH

- [X] `docker pull redis:5`
- [X] `docker run -p 6379:6379 -d redis:5`
- [X] `redis-cli`
- [X] `CONFIG SET requirepass "foobared"`
- [X] `exit`
- [X] `./msfconsole`
- [X] `use auxiliary/scanner/redis/redis_login`
- [X] `run rhosts=127.0.0.1`

```
[+] 127.0.0.1:6379        - 127.0.0.1:6379        - Login Successful: :foobared (Successful: +OK)
[*] 127.0.0.1:6379        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### Redis 6 and newer without AUTH

- [X] `docker pull redis`
- [X] `docker run -p 6379:6379 -d redis`
- [X] `./msfconsole`
- [X] `use auxiliary/scanner/redis/redis_login`
- [X] `run rhosts=127.0.0.1`

```
[+] 127.0.0.1:6379        - 127.0.0.1:6379        - No password is required.
[*] 127.0.0.1:6379        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### Redis 6 and newer with AUTH

- [X] `docker pull redis`
- [X] `docker run -p 6379:6379 -d redis`
- [X] `redis-cli`
- [X] `CONFIG SET requirepass "foobared"`
- [X] `exit`
- [X] `./msfconsole`
- [X] `use auxiliary/scanner/redis/redis_login`
- [X] `run rhosts=127.0.0.1`

```
[+] 127.0.0.1:6379        - 127.0.0.1:6379        - Login Successful: :foobared (Successful: +OK)
[*] 127.0.0.1:6379        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```