### PR TITLE
Update apache_nifi_credentials algo regex

### DIFF
--- a/modules/post/linux/gather/apache_nifi_credentials.rb
+++ b/modules/post/linux/gather/apache_nifi_credentials.rb
@@ -266,7 +266,10 @@ class MetasploitModule < Msf::Post
     key = properties.scan(/^nifi.sensitive.props.key=(.+)$/).flatten.first.strip
     fail_with(Failure::NotFound, 'Unable to find nifi.properties and/or flow.json.gz files') if key.nil?
     print_good("Key: #{key}")
-    algorithm = properties.scan(/^nifi.sensitive.props.algorithm=(\w+)$/).flatten.first.strip
+    # https://rubular.com/r/N0w0WHTjjdKXHZ
+    # https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#property-encryption-algorithms
+    # https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#java-cryptography-extension-jce-limited-strength-jurisdiction-policies
+    algorithm = properties.scan(/^nifi.sensitive.props.algorithm=([\w-]+)$/).flatten.first.strip
     fail_with(Failure::NotFound, 'Unable to find nifi.properties and/or flow.json.gz files') if algorithm.nil?
 
     columns = ['Name', 'Username', 'Password', 'Other Information']


### PR DESCRIPTION
NiFi encryption algorithms, as shown in the documentation, can also contain `-`. This PR updates the regex to capture the edge cases

## Verification

- [ ] Check the rubular link showing the new regex works, OR
- [ ] Start `msfconsole`
- [ ] get a shell on a linux box
- [ ] drop the files on the box that's contained in the documentation for this module. update `nifi.sensitive.props.algorithm`'s value to be `BEWITHMD5AND256BITAES-CBC-OPENSS`
- [ ] **Verify** module no longer crashes
