### PR TITLE
MS-9457 Support `NO_AUTH_REQUIRED`

### DIFF
--- a/lib/rex/proto/redis/base.rb
+++ b/lib/rex/proto/redis/base.rb
@@ -6,10 +6,11 @@ module Rex
       # and include the constants from there, or use the functionality defined there.
       module Base
         module Constants
-          AUTHENTICATION_REQUIRED = /(?<auth_response>NOAUTH Authentication required)/i
-          NO_PASSWORD_SET         = /(?<auth_response>ERR Client sent AUTH, but no password is set)/i
-          WRONG_PASSWORD          = /(?<auth_response>ERR invalid password)/i
-          OKAY                    = /\+OK/i
+          AUTHENTICATION_REQUIRED   = /(?<auth_response>NOAUTH Authentication required)/i
+          NO_PASSWORD_SET           = /(?<auth_response>ERR Client sent AUTH, but no password is set)/i
+          WRONG_PASSWORD            = /(?<auth_response>ERR invalid password)/i
+          WRONG_ARGUMENTS_FOR_AUTH  = /(?<auth_response>ERR wrong number of arguments for 'auth' command)/i
+          OKAY                      = /\+OK/i
         end
       end
     end


### PR DESCRIPTION
Support the `NO_AUTH_REQUIRED` condition and terminate the scan to avoid further unneeded attempts.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/redis/redis/redis_login`
- [ ] `run rhosts=127.0.0.1`
- [ ] **Runs a single credentials scan when no authentication is required**
- [ ] Verify specs pass, `lib` code is only used by Pro directly.

## Testing
Tested this locally using an instance of Metasploit Pro, and running the scanner as local gem.
Worked as expected and didn't throw any errors.