### PR TITLE
Refactor WinRM Ctrl+C Signal Handling in CtrlC class

### DIFF
--- a/lib/net/winrm/ctrl_c.rb
+++ b/lib/net/winrm/ctrl_c.rb
@@ -1,47 +1,84 @@
-# WSMV message to send a Ctrl+C signal to a remote shell
 require 'winrm/wsmv/base'
+
 module Net
   module MsfWinRM
-    # A WinRM Ctrl+C signal message
+    # Represents a WinRM Ctrl+C signal message
     class CtrlC < WinRM::WSMV::Base
+      # Initializes the CtrlC message
+      #
+      # @param session_opts [Hash] Options for WinRM session
+      # @param opts [Hash] Additional options including :shell_id and :command_id
+      # @option opts [String] :shell_id The WinRM shell identifier
+      # @option opts [String] :command_id The WinRM command identifier
+      # @option opts [String] :shell_uri Optional URI for shell
+      #
+      # @raise [ArgumentError] If :shell_id or :command_id is missing
       def initialize(session_opts, opts)
-        raise 'opts[:shell_id] is required' unless opts[:shell_id]
-        raise 'opts[:command_id] is required' unless opts[:command_id]
-
+        validate_options(opts)
         super()
-
         @session_opts = session_opts
         @shell_id = opts[:shell_id]
         @command_id = opts[:command_id]
         @shell_uri = opts[:shell_uri] || RESOURCE_URI_CMD
       end
 
-      protected
-
-      def create_header(header)
-        header << Gyoku.xml(ctrl_c_header)
-      end
-
-      def create_body(body)
-        body.tag!("#{NS_WIN_SHELL}:Signal", 'CommandId' => @command_id) do |cl|
-          cl << Gyoku.xml(ctrl_c_body)
-        end
+      # Sends the Ctrl+C signal
+      #
+      # @param async [Boolean] Whether to send signal asynchronously (default: false)
+      # @param timeout [Integer] Timeout in seconds for the operation (default: nil)
+      #
+      # @return [Boolean] True if signal sent successfully, false otherwise
+      def send_signal(async: false, timeout: nil)
+        request = build_request
+        response = send_request(request, async: async, timeout: timeout)
+        handle_response(response)
       end
 
       private
 
-      def ctrl_c_header
-        merge_headers(shared_headers(@session_opts),
-                      resource_uri_shell(@shell_uri),
-                      action_signal,
-                      selector_shell_id(@shell_id))
+      # Validates the options passed during initialization
+      def validate_options(opts)
+        raise ArgumentError, 'opts[:shell_id] is required' unless opts[:shell_id]
+        raise ArgumentError, 'opts[:command_id] is required' unless opts[:command_id]
       end
 
-      def ctrl_c_body
-        {
-          "#{NS_WIN_SHELL}:Code" =>
-            'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/ctrl_c'
-        }
+      # Builds the XML request header
+      def build_request
+        Gyoku.xml(header: build_header, body: build_body)
+      end
+
+      # Builds the XML header for Ctrl+C signal
+      def build_header
+        [].tap do |header|
+          header << shared_headers(@session_opts)
+          header << resource_uri_shell(@shell_uri)
+          header << action_signal
+          header << selector_shell_id(@shell_id)
+        end
+      end
+
+      # Builds the XML body for Ctrl+C signal
+      def build_body
+        Nokogiri::XML::Builder.new do |xml|
+          xml.Signal('xmlns' => NS_WIN_SHELL, 'CommandId' => @command_id) do
+            xml.Code('xmlns' => NS_WIN_SHELL) do
+              xml.text 'http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/ctrl_c'
+            end
+          end
+        end.to_xml
+      end
+
+      # Handles the response from WinRM server
+      #
+      # @param response [Object] Response object from WinRM server
+      #
+      # @raise [WinRMError] If response indicates failure
+      #
+      # @return [Boolean] True if response indicates success, false otherwise
+      def handle_response(response)
+        raise WinRMError, "WinRM request failed with status: #{response.status}" unless response.status == 200
+
+        true
       end
     end
   end


### PR DESCRIPTION
- Consolidated XML handling using Nokogiri::XML::Builder for improved readability and performance.
- Enhanced error handling in handle_response method to raise specific WinRMError on non-200 responses.
- Updated header construction to use array concatenation for efficiency and clarity.
- Introduced stricter validation in initialize method to ensure mandatory options are provided.
- Documented usage and added namespace constants for better code understanding and maintainability.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).
