### PR TITLE
remove duplicate word in wiki docs

### DIFF
--- a/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
+++ b/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
@@ -253,7 +253,7 @@ To run tests defined in file(s):
 bundle exec rspec ./spec/path/to/your/tests_1.rb ./spec/path/to/your/tests_2.rb
 ```
 
-To run run the tests defined at a line number - for instance line 23:
+To run the tests defined at a line number - for instance line 23:
 
 ```
 bundle exec rspec ./spec/path/to/your/tests_1.rb:23


### PR DESCRIPTION
Removes duplicate word `run` from wiki page