### PR TITLE
Pin FFI version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ PATH
       faraday (= 2.7.11)
       faraday-retry
       faye-websocket
+      ffi (= 1.16.3)
       filesize
       getoptlong
       hrr_rb_ssh-ed25519
@@ -236,7 +237,7 @@ GEM
     faye-websocket (0.11.3)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.17.0)
+    ffi (1.16.3)
     filesize (0.2.0)
     fivemat (1.3.7)
     getoptlong (0.2.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -154,6 +154,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'net-sftp'
   spec.add_runtime_dependency 'winrm'
+  spec.add_runtime_dependency 'ffi', '1.16.3'
 
   #
   # REX Libraries


### PR DESCRIPTION
We are hitting this issue for the omnibus windows installer:
https://github.com/rapid7/metasploit-omnibus/actions/runs/9874569440/job/27269252292?pr=205

```
Error:
    Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
...
libtool: link: ar cr .libs/libffi.a  src/prep_cif.o src/types.o src/raw_api.o
src/java_raw_api.o src/closures.o src/tramp.o src/x86/ffiw64.o src/x86/win64.o
C:\metasploit-framework\embedded\msys64\ucrt64\bin\ar.exe: could not create
temporary file whilst writing archive: no more archived files
make[3]: *** [Makefile:1114: libffi.la] Error 1
make[3]: *** Waiting for unfinished jobs....
libtool: link: ranlib .libs/libffi_convenience.a
libtool: link: ( cd ".libs" && rm -f "libffi_convenience.la" && cp -pR
...
An error occurred while installing ffi (1.17.0), and Bundler cannot continue.
 In Gemfile:
  metasploit-framework was resolved to 6.4.17, which depends on
    winrm was resolved to 2.3.6, which depends on
      gssapi was resolved to 1.3.1, which depends on
        ffi
```

I don't think this issue is specifically related to this upstream issue https://github.com/ffi/ffi/issues/1105 - however we've seen a theme of issue with repositories that are updated to ffi 1.17.0

## Verification

Verify CI passes