### PR TITLE
Update rpc compatible modules to handle unknown sessions

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -506,14 +506,18 @@ class RPC_Session < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('session.compatible_modules', 3)
   def rpc_compatible_modules(sid)
-    session_type = self.framework.sessions[sid].type
-    search_params = { 'session_type' => [[session_type], []] }
-    cached_modules = Msf::Modules::Metadata::Cache.instance.find(search_params)
-
+    session = self.framework.sessions[sid]
     compatible_modules = []
-    cached_modules.each do |cached_module|
-      m = _find_module(cached_module.type, cached_module.fullname)
-      compatible_modules << m.fullname if m.session_compatible?(sid)
+
+    if session
+      session_type = session.type
+      search_params = { 'session_type' => [[session_type], []] }
+      cached_modules = Msf::Modules::Metadata::Cache.instance.find(search_params)
+
+      cached_modules.each do |cached_module|
+        m = _find_module(cached_module.type, cached_module.fullname)
+        compatible_modules << m.fullname if m.session_compatible?(sid)
+      end
     end
 
     { "modules" => compatible_modules }


### PR DESCRIPTION
Updates `rpc_compatible_modules` to gracefully handle unknown session ids

Stack:

```
NoMethodError undefined method `type' for nil:NilClass session_type = self.framework.sessions[sid].type ^^^^^ (
[
  "lib/msf/core/rpc/v10/rpc_session.rb:509:in `rpc_compatible_modules'",
  "lib/msf/core/rpc/v10/service.rb:143:in `block in process'",
  "lib/ruby/3.1.0/timeout.rb:107:in `block in timeout'",
  "lib/ruby/3.1.0/timeout.rb:36:in `block in catch'",
  "lib/ruby/3.1.0/timeout.rb:36:in `catch'",
  "lib/ruby/3.1.0/timeout.rb:36:in `catch'",
  "lib/ruby/3.1.0/timeout.rb:123:in `timeout'",
  "lib/msf/core/rpc/v10/service.rb:143:in `process'",
  "lib/msf/core/rpc/v10/service.rb:81:in `on_request_uri'",
  "lib/msf/core/rpc/v10/service.rb:62:in `block in start'",
  "lib/rex/proto/http/handler/proc.rb:38:in `on_request'",
  "lib/rex/proto/http/server.rb:316:in `dispatch_request'",
  "lib/rex/proto/http/server.rb:250:in `on_client_data'",
  "lib/rex/proto/http/server.rb:109:in `block in start'",
  "lib/rex/io/stream_server.rb:42:in `on_client_data'",
  "lib/rex/io/stream_server.rb:185:in `block in monitor_clients'",
  "lib/rex/io/stream_server.rb:184:in `each'",
  "lib/rex/io/stream_server.rb:184:in `monitor_clients'",
  "lib/rex/io/stream_server.rb:64:in `block in start'",
  "lib/rex/thread_factory.rb:22:in `block in spawn'",
  "lib/msf/core/thread_manager.rb:105:in `block in spawn'",
  "lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'"
)
```


## Verification

Verify CI passes