### PR TITLE
feat: Allow explicit SSL configuration in start_service method

### DIFF
--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -125,7 +125,7 @@ module Exploit::Remote::HttpServer
     self.service = Rex::ServiceManager.start(
       Rex::Proto::Http::Server,
       (opts['ServerPort'] || bindport).to_i,
-      opts['ServerHost']  || bindhost,
+      opts['ServerHost'] || bindhost,
       opts['ssl'],
       {
         'Msf'        => framework,

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -154,8 +154,6 @@ module Exploit::Remote::HttpServer
 
     proto = (opts['ssl'] ? "https" : "http")
 
-    puts proto
-
     # SSLCompression may or may not actually be available. For example, on
     # Ubuntu, it's disabled by default, unless the correct environment
     # variable is set. See https://github.com/rapid7/metasploit-framework/pull/2666

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -116,14 +116,17 @@ module Exploit::Remote::HttpServer
   # completely on the datastore. (See dlink_upnp_exec_noauth)
   def start_service(opts = {})
 
+    # Keep compatibility with modules that don't pass the ssl option to the start server but rely on the datastore instead.
+    opts['ssl'] = opts['ssl'].nil? ? datastore['SSL'] : opts['ssl']
+
     check_dependencies
 
     # Start a new HTTP server service.
     self.service = Rex::ServiceManager.start(
       Rex::Proto::Http::Server,
       (opts['ServerPort'] || bindport).to_i,
-      opts['ServerHost'] || bindhost,
-      datastore['SSL'], # XXX: Should be in opts, need to test this
+      opts['ServerHost']  || bindhost,
+      opts['ssl'],
       {
         'Msf'        => framework,
         'MsfExploit' => self,
@@ -149,7 +152,9 @@ module Exploit::Remote::HttpServer
       'Path' => opts['Path'] || resource_uri
     }.update(opts['Uri'] || {})
 
-    proto = (datastore["SSL"] ? "https" : "http")
+    proto = (opts['ssl'] ? "https" : "http")
+
+    puts proto
 
     # SSLCompression may or may not actually be available. For example, on
     # Ubuntu, it's disabled by default, unless the correct environment

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -154,19 +154,16 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
     end
 
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
           on_request_uri(cli, req)
         end,
         'Path' => '/'
-      }
+      },
+      'ssl' => false
     })
-    datastore['SSL'] = true if ssl_restore
+
     xxe_request
   rescue Timeout::Error => e
     fail_with(Failure::TimeoutExpired, e.message)

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -122,11 +122,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
@@ -144,9 +139,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -155,11 +155,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
         srv_host = Rex::Socket.source_address(rhost)
@@ -174,9 +169,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+      })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -253,12 +253,6 @@ class MetasploitModule < Msf::Exploit::Remote
       @elf_sent = false
       resource_uri = '/' + downfile
 
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
-
       if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
         srv_host = Rex::Socket.source_address(rhost)
       else
@@ -272,7 +266,9 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+      })
 
       datastore['SSL'] = true if ssl_restore
       print_status("#{peer} - Asking the device to download and execute #{service_url}")

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -270,7 +270,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'ssl' => false # do not use SSL
       })
 
-      datastore['SSL'] = true if ssl_restore
       print_status("#{peer} - Asking the device to download and execute #{service_url}")
 
       filename = rand_text_alpha_lower(rand(8) + 2)

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -151,11 +151,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
@@ -172,9 +167,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -304,11 +304,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
@@ -325,9 +320,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -155,11 +155,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
@@ -176,9 +171,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -270,11 +270,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
@@ -291,9 +286,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -252,28 +252,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_server
-    #
-    # HttpClient and HttpServer use same SSL variable :(
-    # We don't need SSL for payload delivery so we
-    # will disable it temporarily.
-    #
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
+    
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
           on_request_uri(cli, req)
         end,
         'Path' => resource_uri
-      }
+      },
+      'ssl' => false # do not use SSL
     })
     print_status("Second payload download URI is #{get_uri}")
     # We need to use instance variables since get_uri keeps using
     # the SSL setting from the datastore.
     # Once the URI is retrieved, we will restore the SSL settings within the datastore.
     @second_stage_url = get_uri
-    datastore['SSL'] = true if ssl_restore
+
   end
 end

--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -252,7 +252,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_server
-    
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
@@ -267,6 +266,5 @@ class MetasploitModule < Msf::Exploit::Remote
     # the SSL setting from the datastore.
     # Once the URI is retrieved, we will restore the SSL settings within the datastore.
     @second_stage_url = get_uri
-
   end
 end

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -112,12 +112,6 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::Unknown, 'The Web Server needs to live on SRVPORT=80')
       end
 
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
-
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
       if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
@@ -134,9 +128,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
 

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -141,12 +141,6 @@ class MetasploitModule < Msf::Exploit::Remote
       srv_host = datastore['SRVHOST']
     end
 
-    # do not use SSL for the attacking web server
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
-
     @service_url = "http:\\x2f\\x2f#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"
     service_url_payload = srv_host + resource_uri
     print_status("#{rhost}:#{rport} - Starting up our web service on #{@service_url} ...")
@@ -155,8 +149,10 @@ class MetasploitModule < Msf::Exploit::Remote
         on_request_uri(cli, req)
       },
       'Path' => resource_uri
-    }})
-    datastore['SSL'] = true if ssl_restore
+    },
+    'ssl' => false # do not use SSL
+    })
+
     connect
   end
 

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -113,11 +113,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def start_web_service
     print_status("Setting up the Web Service...")
 
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
-
     resource_uri = '/' + @elfname + '.elf'
     service_url = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_uri}"
 
@@ -127,8 +122,9 @@ class MetasploitModule < Msf::Exploit::Remote
         on_request_uri(cli, req)
       },
       'Path' => resource_uri
-    }})
-    datastore['SSL'] = true if ssl_restore
+    },
+    'ssl' => false # do not use SSL
+    })
 
     return service_url
   end

--- a/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
+++ b/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
@@ -162,12 +162,6 @@ class MetasploitModule < Msf::Exploit::Remote
       srv_host = datastore['SRVHOST']
     end
 
-    # do not use SSL for the attacking web server
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
-
     @service_url = "http://#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"
     service_url_payload = srv_host + resource_uri
     print_status("#{rhost}:#{rport} - Starting up our web service on #{@service_url} ...")
@@ -176,8 +170,10 @@ class MetasploitModule < Msf::Exploit::Remote
         on_request_uri(cli, req)
       },
       'Path' => resource_uri
-    }})
-    datastore['SSL'] = true if ssl_restore
+    },
+    'ssl' => false # do not use SSL
+    })
+
     connect
   end
 

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -115,14 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_service
-    # do not use SSL for this part
-    # XXX: See https://github.com/rapid7/metasploit-framework/issues/3853
-    # It must be possible to do this without directly editing the
-    # datastore.
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
 
     if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
       srv_host = Rex::Socket.source_address(rhost)
@@ -138,14 +130,9 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => '/'
-      }
+      },
+      'ssl' => false # do not use SSL
     })
-
-    # Restore SSL preference
-    # XXX: See https://github.com/rapid7/metasploit-framework/issues/3853
-    # It must be possible to do this without directly editing the
-    # datastore.
-    datastore['SSL'] = true if ssl_restore
 
     return service_url
   end

--- a/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
+++ b/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
@@ -151,12 +151,6 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = rand_text_alpha(8+rand(8))
     resource_uri = '/' + downfile
 
-    # do not use SSL for the attacking web server
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
-
     if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
@@ -172,9 +166,10 @@ class MetasploitModule < Msf::Exploit::Remote
         on_request_uri(cli, req)
       },
       'Path' => resource_uri
-    }})
+    },
+    'ssl' => false # do not use SSL
+    })
 
-    datastore['SSL'] = true if ssl_restore
     connect
   end
 

--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -528,12 +528,6 @@ class MetasploitModule < Msf::Exploit::Remote
       @pl = generate_payload_exe
     end
 
-    # do not use SSL for the CAM server!
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
-
     print_status('Starting up the fake CAM server...')
     start_service(
       {
@@ -542,10 +536,11 @@ class MetasploitModule < Msf::Exploit::Remote
             on_request_uri(cli, req)
           end,
           'Path' => '/'
-        }
+        },
+        'ssl' => false # do not use SSL
       }
     )
-    datastore['SSL'] = true if ssl_restore
+
 
     # Step 4: send the server config update packet, and ignore what it sends back
     print_status('Changing authentication method to 4 (CAM auth)')

--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -541,7 +541,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-
     # Step 4: send the server config update packet, and ignore what it sends back
     print_status('Changing authentication method to 4 (CAM auth)')
     upd_cent = update_auth(4)

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -215,11 +215,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-      #do not use SSL
-      if datastore['SSL']
-        ssl_restore = true
-        datastore['SSL'] = false
-      end
 
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
@@ -236,9 +231,10 @@ class MetasploitModule < Msf::Exploit::Remote
           on_request_uri(cli, req)
         },
         'Path' => resource_uri
-      }})
+      },
+      'ssl' => false # do not use SSL
+    })
 
-      datastore['SSL'] = true if ssl_restore
     end
 
     #

--- a/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
+++ b/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def srv_host
-    if ((datastore['SRVHOST'] == '0.0.0.0') || (datastore['SRVHOST'] == '::'))
+    if (datastore['SRVHOST'] == '0.0.0.0') || (datastore['SRVHOST'] == '::')
       return datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     end
 
@@ -417,7 +417,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def serve_http_file(path, respond_with = '')
-
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, _req|
@@ -427,7 +426,6 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'ssl' => false # do not use SSL
     })
-
   end
 
   def create_json_request(xml_payload)

--- a/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
+++ b/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
@@ -417,11 +417,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def serve_http_file(path, respond_with = '')
-    # do not use SSL for the attacking web server
-    if datastore['SSL']
-      ssl_restore = true
-      datastore['SSL'] = false
-    end
 
     start_service({
       'Uri' => {
@@ -429,10 +424,10 @@ class MetasploitModule < Msf::Exploit::Remote
           send_response(cli, respond_with)
         end,
         'Path' => path
-      }
+      },
+      'ssl' => false # do not use SSL
     })
 
-    datastore['SSL'] = true if ssl_restore
   end
 
   def create_json_request(xml_payload)


### PR DESCRIPTION
The `start_service` method now allows users to specify their SSL preferences directly through the opts parameter. If the ssl option is not provided in opts, it will default to the value in datastore['SSL'].

This change enhances the flexibility and usability of the start_service method, preventing unintended behavior when users need to control the SSL setting explicitly.

Closes #19329

