### PR TITLE
Fix SSH scanner tests when report summary enabled

### DIFF
--- a/lib/msf/core/auxiliary/report_summary.rb
+++ b/lib/msf/core/auxiliary/report_summary.rb
@@ -44,7 +44,7 @@ module Msf
       # @param [Hash] credential_data
       # @return [Metasploit::Credential::Login]
       def create_credential_login(credential_data)
-        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins']
+        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins'] && @report
 
         credential = {
           public: credential_data[:username],
@@ -65,7 +65,7 @@ module Msf
       # @param [Msf::Sessions::<SESSION_CLASS>] sess
       # @return [Msf::Sessions::<SESSION_CLASS>]
       def start_session(obj, info, ds_merge, crlf = false, sock = nil, sess = nil)
-        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins']
+        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins'] && @report
 
         result = super
         @report[rhost].merge!({ successful_sessions: [] })


### PR DESCRIPTION
Fix SSH scanner test when report summary enabled, and the `run` function hasn't been called first.

## Verification

Verify hat the following tests pass with the report summary feature enabled:

`bundle exec rspec ./spec/modules/auxiliary/scanner/ssh/ssh_login_spec.rb`