### PR TITLE
Kerberos asrep roasting improvements

### DIFF
--- a/documentation/modules/auxiliary/gather/asrep.md
+++ b/documentation/modules/auxiliary/gather/asrep.md
@@ -44,7 +44,7 @@ usually preferable, but may be less stealthy.
 An example of brute forcing usernames, in the hope of finding one with pre-auth not required:
 
 ```msf
-msf6 auxiliary(gather/asrep) > run action=BRUTE_FORCE user_file=/tmp/users.txt rhost=192.168.1.1 domain=msf.local rhostname=dc22
+msf6 auxiliary(gather/asrep) > run action=BRUTE_FORCE user_file=/tmp/users.txt rhost=192.168.1.1 domain=msf.local
 [*] Running module against 192.168.1.1
 
 $krb5asrep$23$user@MSF.LOCAL:9fb9954fa32193185ab32e2de2ab9f13$bf14e834c661246cad302073c228e6ff7894cd3023665f0f84338432c3929922ae998c4a23bb9d163dda536a230d0503b2cf575389317b52bde782264940e80206a29e9613e47328228441cf013fb1f6672359f6799be97b962de9429e8859f437e53549be6b11ca07af6f09eae6cd78279af6d7f6dcdfd011eccb74b4aa753b2f9e6561c59c9408ee4bec983777908f3a7eef5fba977710e47e4e8ac0af10608a7dd23db506202b27d7892bc28426d2080c343edfe243bf1cae554cf6204733082332be2455e4674e1c3e84614818a6c15b54221dcaa832

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -292,11 +292,12 @@ module Msf
             # If we receive an AS_REP response immediately, no-preauthentication was required and we can return immediately
             if initial_as_res.msg_type == Rex::Proto::Kerberos::Model::AS_REP
               pa_data = initial_as_res.pa_data
-              etype_entries = pa_data.find {|entry| entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2}
               if password.nil? && key.nil?
                 decrypted_part = nil
                 krb_enc_key = nil
               else
+                etype_entries = pa_data.find {|entry| entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2}
+
                 # Let's try to check the password
                 server_ciphers = etype_entries.decoded_value
                 # Should only have one etype


### PR DESCRIPTION
Makes improvements to the asrep roasting module

Bug fix:

```
[+] [2024.07.22-23:57:58] Workspace:test Beginning step 1/1 Scanning 192.168.123.133-192.168.123.133 - Progress: 0%
[*] [2024.07.22-23:57:58] Using domain: DEMO.LOCAL - 192.168.123.133:88   ...
[*] [2024.07.22-23:57:58] 192.168.123.133 - User: "user1" user not found
[+] [2024.07.22-23:57:58] 192.168.123.133 - User: "vagrant" is present
[!] [2024.07.22-23:57:58] 192.168.123.133:88    - LOGIN FAILED: {:private_data=>nil, :private_type=>:password, :username=>"test_user", :realm_key=>"Active Directory Domain", :realm_value=>"DEMO.LOCAL"} - Unhandled error - scan may not produce correct results: undefined method `find' for nil:NilClass

              etype_entries = pa_data.find {|entry| entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_ETYPE_INFO2}
                                     ^^^^^ - 
[+] [2024.07.22-23:57:58] 192.168.123.133 - User: "administrator" is present
[*] [2024.07.22-23:57:58] Complete (0 sessions opened) auxiliary/gather/kerberos_enumusers
[+] [2024.07.22-23:57:58] Workspace:test Task Completed - Progress: 100%
```

## Verification

- Create an ASREP roastable account in your AD environment

![image](https://github.com/user-attachments/assets/5dcd69fd-5024-4e0f-a905-0c92930074e5)

- Verify `gather/asrep` and `gather/kerberos_enumusers` can detect this user account