### PR TITLE
Update ffi pin version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       faraday (= 2.7.11)
       faraday-retry
       faye-websocket
-      ffi (= 1.16.3)
+      ffi (< 1.17.0)
       filesize
       getoptlong
       hrr_rb_ssh-ed25519

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -154,7 +154,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'net-sftp'
   spec.add_runtime_dependency 'winrm'
-  spec.add_runtime_dependency 'ffi', '1.16.3'
+  spec.add_runtime_dependency 'ffi', '< 1.17.0'
 
   #
   # REX Libraries


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/19319

But using a more lenient pin of any version less than 1.17.0

## Verification

Ensure CI passes