### PR TITLE
Improve setg SessionLogging support

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -654,6 +654,7 @@ Shell Banner:
   def shell_read(length=-1, timeout=1)
     begin
       rv = rstream.get_once(length, timeout)
+      rlog(rv, self.log_source) if rv && self.log_source
       framework.events.on_session_output(self, rv) if rv
       return rv
     rescue ::Rex::SocketError, ::EOFError, ::IOError, ::Errno::EPIPE => e
@@ -672,6 +673,7 @@ Shell Banner:
     return unless buf
 
     begin
+      rlog(buf, self.log_source) if self.log_source
       framework.events.on_session_command(self, buf.strip)
       rstream.write(buf)
     rescue ::Rex::SocketError, ::EOFError, ::IOError, ::Errno::EPIPE => e

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -569,10 +569,16 @@ protected
   def handle_session_logging(val)
     if (val =~ /^(y|t|1)/i)
       Msf::Logging.enable_session_logging(true)
-      print_line("Session logging will be enabled for future sessions.")
+      framework.sessions.values.each do |session|
+        Msf::Logging.start_session_log(session)
+      end
+      print_line("Session logging enabled.")
     else
       Msf::Logging.enable_session_logging(false)
-      print_line("Session logging will be disabled for future sessions.")
+      framework.sessions.values.each do |session|
+        Msf::Logging.stop_session_log(session)
+      end
+      print_line("Session logging disabled.")
     end
   end
 


### PR DESCRIPTION
Improve setg SessionLogging support to work with command shells, as well as allowing logging to be turned on/off at anypoint - not just for newly created sessions

## Verification

Enable session logging:

```
setg SessionLogging true
```

- Verify that logging works for command shells (python reverse tcp, powershell, netcat, etc) at `~/.msf4/logs/sessions/*`
- Verify that logging works for Meterpreter/SQL/SMB shells at `~/.msf4/logs/sessions/*` 
- Verify that you can add/remove logging at any point in time without needing to close and reopen sessions to enable logging