### PR TITLE
Update msftidy logging for older modules

### DIFF
--- a/spec/tools/dev/rubocop_runner_spec.rb
+++ b/spec/tools/dev/rubocop_runner_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe RuboCopRunner do
       expect(@status).to be_zero
     end
 
-    it 'contains no warnings' do
-      expect(@stdout).to be_empty
+    it 'contains a status message' do
+      expect(@stdout).to match /Rubocop not required for older modules skipping/
     end
   end
 end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -55,6 +55,7 @@ class RuboCopRunner
   # @return [Integer] RuboCop::CLI status code
   def run(full_filepath, options = {})
     unless requires_rubocop?(full_filepath)
+      puts "#{full_filepath} - [*] Rubocop not required for older modules skipping. If making a large update - run rubocop #{"rubocop -a #{full_filepath}".yellow} and verify all issues are resolved"
       return RuboCop::CLI::STATUS_SUCCESS
     end
 


### PR DESCRIPTION
Update msftidy logging message to include details about optionally running Rubocop on older modules. The rationale being, generally our older modules just have simple metadata changes made - rather than full rewrites.

## Verification

Run msftidy against older modules and verify the updated log message:

```
$ ruby tools/dev/msftidy.rb modules/exploits/linux/http/empire_skywalker.rb
modules/exploits/linux/http/empire_skywalker.rb - [*] Rubocop not required for older modules skipping. If making a large update - run rubocop rubocop -a modules/exploits/linux/http/empire_skywalker.rb and verify all issues are resolved
``` 