### PR TITLE
add necessary metadata for bruteforce

### DIFF
--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -11,10 +11,22 @@ module Metasploit
         include Metasploit::Framework::LDAP::Client
         include Msf::Exploit::Remote::LDAP
 
+        # TODO: Verify if we need this additional metadata: https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/http.rb#L15-L23
+        LIKELY_PORTS         = [ 389, 636 ]
+        LIKELY_SERVICE_NAMES = [ 'ldap', 'ldaps', 'ldapssl' ]
+
         attr_accessor :opts, :realm_key
         # @!attribute use_client_as_proof
         #   @return [Boolean] If a login is successful and this attribute is true - an LDAP::Client instance is used as proof
         attr_accessor :use_client_as_proof
+
+        # This method sets the sane defaults for things
+        # like timeouts and TCP evasion options
+        def set_sane_defaults
+          self.opts ||= {}
+          self.connection_timeout = 30 if self.connection_timeout.nil?
+          nil
+        end
 
         def attempt_login(credential)
           result_opts = {
@@ -23,7 +35,8 @@ module Metasploit
             proof: nil,
             host: host,
             port: port,
-            protocol: 'ldap'
+            protocol: 'tcp',
+            service_name: 'ldap'
           }
 
           result_opts.merge!(do_login(credential))
@@ -34,7 +47,8 @@ module Metasploit
           opts = {
             username: credential.public,
             password: credential.private,
-            framework_module: framework_module
+            framework_module: framework_module,
+            ldap_auth: 'auto'
           }.merge(@opts)
 
           connect_opts = ldap_connect_opts(host, port, connection_timeout, ssl: opts[:ssl], opts: opts)

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -11,7 +11,6 @@ module Metasploit
         include Metasploit::Framework::LDAP::Client
         include Msf::Exploit::Remote::LDAP
 
-        # TODO: Verify if we need this additional metadata: https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/http.rb#L15-L23
         LIKELY_PORTS         = [ 389, 636 ]
         LIKELY_SERVICE_NAMES = [ 'ldap', 'ldaps', 'ldapssl' ]
 


### PR DESCRIPTION
This PR adjusts the metadata for the ldap login scanner, adding defaults and adjusting the service and protocol values.

To test:

- spin up docker or windows instance with LDAP running (usable docker env details in `test/ldap`)
- use `ldap_login` module against target and ensure functionality still works