### PR TITLE
MS-9517 Jenkins Login Scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -5,13 +5,13 @@ module Metasploit
     module LoginScanner
       # Jenkins login scanner
       class Jenkins < HTTP
-
         include Msf::Exploit::Remote::HTTP::Jenkins
 
         # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
-        CAN_GET_SESSION = true
-        DEFAULT_PORT    = 8080
-        PRIVATE_TYPES   = [ :password ]
+        CAN_GET_SESSION             = true
+        DEFAULT_AUTHORIZATION_CODES = [403]
+        DEFAULT_PORT                = 8080
+        PRIVATE_TYPES               = [:password]
 
         # (see Base#set_sane_defaults)
         def set_sane_defaults
@@ -49,6 +49,18 @@ module Metasploit
           result_opts.merge!(status: status, proof: proof)
 
           Result.new(result_opts)
+        end
+
+        protected
+
+        # Returns a boolean value indicating whether the request requires authentication or not.
+        #
+        # @param [Rex::Proto::Http::Response] response The response received from the HTTP endpoint
+        # @return [Boolean] True if the request required authentication; otherwise false.
+        def no_authentication_required?(response)
+          return true unless response
+
+          !self.class::DEFAULT_AUTHORIZATION_CODES.include?(response.code)
         end
       end
     end


### PR DESCRIPTION
Jenkins responds with a 403 Forbidden on requests when Authentication is required.

The original code checks for a 401 response only.
Overwriting the behavior for Jenkins allows us to handle this use-case properly and report the correct behavior.
## Verification

List the steps needed to make sure this thing works

Testing the Framework Console
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/jenkins_login`
- [ ] `run rhost=127.0.0.1 rport=8080 username=admin password=password`
- [ ] should successfully auth against a running Jenkins instance with authentication.

Testing the Pro Console
- [ ] Start `msfpro`
- [ ] `use auxiliary/pro/bruteforce/simple_guess`
- [ ] `run -r bruteforce_quickmode_creds="username password" bruteforce_services="http" verbose=true REALLY_VERBOSE=true`
- [ ] should successfully auth against a running Jenkins instance with authentication.
