### PR TITLE
MS-9517 Jenkins Login Scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -1,4 +1,3 @@
-
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
 
@@ -12,14 +11,16 @@ module Metasploit
         include Metasploit::Framework::LoginScanner::Base
         include Metasploit::Framework::LoginScanner::RexSocket
 
-        DEFAULT_REALM        = nil
-        DEFAULT_PORT         = 80
-        DEFAULT_SSL_PORT     = 443
-        DEFAULT_HTTP_SUCCESS_CODES = [ 200, 201 ].append(*(300..309))
-        LIKELY_PORTS         = [ 80, 443, 8000, 8080 ]
-        LIKELY_SERVICE_NAMES = [ 'http', 'https' ]
-        PRIVATE_TYPES        = [ :password ]
-        REALM_KEY            = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
+        AUTHORIZATION_HEADER = 'WWW-Authenticate'.freeze
+        DEFAULT_REALM = nil
+        DEFAULT_PORT = 80
+        DEFAULT_SSL_PORT = 443
+        DEFAULT_HTTP_SUCCESS_CODES = [200, 201].append(*(300..309))
+        DEFAULT_HTTP_NOT_AUTHED_CODES = [401]
+        LIKELY_PORTS = [80, 443, 8000, 8080]
+        LIKELY_SERVICE_NAMES = %w[http https]
+        PRIVATE_TYPES = [:password]
+        REALM_KEY = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
 
         # @!attribute uri
         #   @return [String] The path and query string on the server to
@@ -213,16 +214,14 @@ module Metasploit
             # authentication
             response = http_client._send_recv(request)
           rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
-            return "Unable to connect to target"
+            return 'Unable to connect to target'
           end
 
-          if !(response && response.code == 401 && response.headers['WWW-Authenticate'])
-            error_message = "No authentication required"
-          else
-            error_message = false
+          if authentication_required?(response)
+            return false
           end
 
-          error_message
+          'No authentication required'
         end
 
         # Sends a HTTP request with Rex
@@ -252,7 +251,7 @@ module Metasploit
                   else
                     cli._send_recv(req)
                   end
-          rescue ::EOFError, Errno::ETIMEDOUT ,Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
+          rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             raise Rex::ConnectionError, e.message
           ensure
             # If we didn't create the client, don't close it
@@ -315,18 +314,31 @@ module Metasploit
           Result.new(result_opts)
         end
 
+        protected
+
+        # Returns a boolean value indicating whether the request requires authentication or not.
+        #
+        # @param [Rex::Proto::Http::Response] response The response received from the HTTP endpoint
+        # @return [Boolean] True if the request required authentication; otherwise false.
+        def authentication_required?(response)
+          return false unless response
+
+          self.class::DEFAULT_HTTP_NOT_AUTHED_CODES.include?(response.code) &&
+            response.headers[self.class::AUTHORIZATION_HEADER]
+        end
+
         private
 
         def create_client(opts)
-          rhost           = opts['host'] || host
-          rport           = opts['rport'] || port
-          cli_ssl         = opts['ssl'] || ssl
+          rhost = opts['host'] || host
+          rport = opts['rport'] || port
+          cli_ssl = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
-          cli_proxies     = opts['proxies'] || proxies
-          username        = opts['credential'] ? opts['credential'].public : http_username
-          password        = opts['credential'] ? opts['credential'].private : http_password
-          realm           = opts['credential'] ? opts['credential'].realm : nil
-          context         = opts['context'] || { 'Msf' => framework, 'MsfExploit' => framework_module}
+          cli_proxies = opts['proxies'] || proxies
+          username = opts['credential'] ? opts['credential'].public : http_username
+          password = opts['credential'] ? opts['credential'].private : http_password
+          realm = opts['credential'] ? opts['credential'].realm : nil
+          context = opts['context'] || { 'Msf' => framework, 'MsfExploit' => framework_module}
 
           kerberos_authenticator = nil
           if kerberos_authenticator_factory
@@ -441,10 +453,22 @@ module Metasploit
 
         # Combine the base URI with the target URI in a sane fashion
         #
-        # @param [String] target_uri the target URL
+        # @param [Array<String>] target_uri the target URL
         # @return [String] the final URL mapped against the base
-        def normalize_uri(target_uri)
-          (self.uri.to_s + "/" + target_uri.to_s).gsub(/\/+/, '/')
+        def normalize_uri(*target_uri)
+          if target_uri.count == 1
+            (uri.to_s + '/' + target_uri.first.to_s).gsub(%r{/+}, '/')
+          else
+            new_str = target_uri * '/'
+            new_str = new_str.gsub!('//', '/') while new_str.index('//')
+
+            # Makes sure there's a starting slash
+            unless new_str[0,1] == '/'
+              new_str = '/' + new_str
+            end
+
+            new_str
+          end
         end
 
         private

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -5,21 +5,32 @@ module Metasploit
     module LoginScanner
       # Jenkins login scanner
       class Jenkins < HTTP
-
-        include Msf::Exploit::Remote::HTTP::Jenkins
-
         # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
         CAN_GET_SESSION = true
-        DEFAULT_PORT    = 8080
-        PRIVATE_TYPES   = [ :password ]
+        DEFAULT_HTTP_NOT_AUTHED_CODES = [403]
+        DEFAULT_PORT = 8080
+        PRIVATE_TYPES = [:password].freeze
+        LOGIN_PATH_REGEX = /action="(j_([a-z0-9_]+))"/
+
+        # Checks the setup for the Jenkins Login scanner.
+        #
+        # @return [String, false] Always returns false.
+        def check_setup
+          login_uri = jenkins_login_url
+
+          return 'Unable to locate the Jenkins login path' if login_uri.nil?
+
+          self.uri = normalize_uri(login_uri)
+
+          false
+        end
 
         # (see Base#set_sane_defaults)
         def set_sane_defaults
-          self.uri = "/j_acegi_security_check" if self.uri.nil?
-          self.method = "POST" if self.method.nil?
+          self.uri ||= '/'
 
-          if self.uri[0] != '/'
-            self.uri = "/#{self.uri}"
+          unless uri.to_s.start_with?('/')
+            self.uri = "/#{uri}"
           end
 
           super
@@ -27,28 +38,93 @@ module Metasploit
 
         def attempt_login(credential)
           result_opts = {
-              credential: credential,
-              host: host,
-              port: port,
-              protocol: 'tcp'
+            credential: credential,
+            host: host,
+            port: port,
+            protocol: 'tcp'
           }
+
           if ssl
             result_opts[:service_name] = 'https'
           else
             result_opts[:service_name] = 'http'
           end
 
-          status, proof = jenkins_login(credential.public, credential.private) do |request|
-            send_request({
-              'method' => method,
-              'uri' => uri,
-              'vars_post' => request['vars_post']
-            })
-          end
+          status, proof = jenkins_login(credential.public, credential.private)
 
           result_opts.merge!(status: status, proof: proof)
 
           Result.new(result_opts)
+        end
+
+        protected
+
+        # Returns a boolean value indicating whether the request requires authentication or not.
+        #
+        # @param [Rex::Proto::Http::Response] response The response received from the HTTP endpoint
+        # @return [Boolean] True if the request required authentication; otherwise false.
+        def authentication_required?(response)
+          return false unless response
+
+          self.class::DEFAULT_HTTP_NOT_AUTHED_CODES.include?(response.code)
+        end
+
+        private
+
+        # This method takes a username and password and a target URI
+        # then attempts to login to Jenkins and will either fail with appropriate errors
+        #
+        # @param [String] username The username for login credentials
+        # @param [String] password The password for login credentials
+        # @return [Array] [status, proof] The result of the login attempt
+        def jenkins_login(username, password)
+          begin
+            res = send_request(
+              'method' => 'POST',
+              'uri' => self.uri,
+              'vars_post' => {
+                'j_username' => username,
+                'j_password' => password,
+                'Submit' => 'log in'
+              }
+            )
+
+            if res && res.headers['Location'] && !res.headers['Location'].include?('loginError')
+              status = Metasploit::Model::Login::Status::SUCCESSFUL
+              proof = res.headers
+            else
+              status = Metasploit::Model::Login::Status::INCORRECT
+              proof = res
+            end
+          rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
+            status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            proof = e
+          end
+
+          [status, proof]
+        end
+
+        # This method uses the provided URI to determine whether login is possible for Jenkins.
+        # Based on the contents of the provided URI, the method looks for the login form and
+        # extracts the endpoint used to authenticate against.
+        #
+        # @return [String, nil] URI for successful login
+        def jenkins_login_url
+          response = send_request({ 'uri' => normalize_uri('login') })
+
+          if response&.code == 200 && response&.body =~ LOGIN_PATH_REGEX
+            return Regexp.last_match(1)
+          end
+
+          nil
+        end
+
+        # Determines whether the provided response is considered valid or not.
+        #
+        # @param [Rex::Proto::Http::Response, nil] response The response received from the HTTP request.
+        # @return [Boolean] True if the response if valid; otherwise false.
+        def valid_response?(response)
+          http_success_codes.include?(response&.code)
         end
       end
     end

--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -15,7 +15,7 @@ module Msf
             res = send_request_cgi({ 'uri' => uri })
 
             unless res
-              return nil 
+              return nil
             end
 
             # shortcut for new versions such as 2.426.2 and 2.440


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/19354

Jenkins does not implement Authentication challenges.

By default, Jenkins responds with a HTTP 403 FORBIDDEN response, and does not include the `WWW-Authenticate` header. This causes problems with the underlying http client, as this one expects the challenge to come forward and resend the request with the auth header.

By changing the code to look for the HTTP 403 response, and setting the default URL to the correct login validation endpoint Pro will have an easier time to investigate whether Jenkins can be bruteforced or not.

The original code checks for a 401 response only.
Overwriting the behaviour for Jenkins allows us to handle this use-case properly and report the correct behavior.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/jenkins_login`
- [ ] `run rhost=127.0.0.1 rport=8080 username=correct_username password=correct_password`
- [ ] **Verify** the output matches below

```bash
[!] No active DB -- Credential data will not be saved!
[+] 127.0.0.1:8080 - Login Successful: correct_username:correct_password
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/jenkins_login`
- [ ] `run rhost=127.0.0.1 rport=8080 username=wrong_username password=wrong_password`
- [ ] **Verify** the output matches below

```bash
[!] No active DB -- Credential data will not be saved!
[-] 127.0.0.1:8080 - LOGIN FAILED: wrong_username:wrong_password (Incorrect)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Testing Results

| Jenkins Version | Result |
|:---:|:---:|
| Jenkins 1.5 | 🟢 |
| Jenkins 2.103 | 🟢 |
| Jenkins 2.346 | 🟢 |
| Jenkins 2.401 | 🟢 |
| Jenkins 2.409 | 🟢 |
| Jenkins 2.410 | 🟢 |
| Jenkins 2.411 | 🟢 |
| Jenkins 2.452.3 | 🟢 |