### PR TITLE
Add check_setup to Jenkins login scanner

### DIFF
--- a/lib/msf/core/exploit/remote/http/jenkins.rb
+++ b/lib/msf/core/exploit/remote/http/jenkins.rb
@@ -6,6 +6,8 @@ module Msf
       module HTTP
         # This module provides a way of logging into Jenkins
         module Jenkins
+
+          LOGIN_PATH_REGEX = /action="(j_([a-z0-9_]+))"/
           # Returns the Jenkins version.
           #
           # @return [String] Jenkins version.
@@ -15,7 +17,7 @@ module Msf
             res = send_request_cgi({ 'uri' => uri })
 
             unless res
-              return nil 
+              return nil
             end
 
             # shortcut for new versions such as 2.426.2 and 2.440
@@ -36,7 +38,7 @@ module Msf
             # if keep_cookies is true we get the first cookie that's needed by newer Jenkins versions
             res = send_request_cgi({ 'uri' => normalize_uri(target_uri, 'login'), 'keep_cookies' => keep_cookies })
             fail_with(Msf::Module::Failure::UnexpectedReply, 'Unexpected reply from server') unless res&.code == 200
-            if res.body =~ /action="(j_([a-z0-9_]+))"/
+            if res.body =~ LOGIN_PATH_REGEX
               uri = Regexp.last_match(1)
             else
               fail_with(Msf::Module::Failure::UnexpectedReply, 'Failed to identify the login resource.')

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
       configure_http_login_scanner(
-        uri: '/',
+        uri: datastore['TARGETURI'],
         ssl: datastore['SSL'],
         method: datastore['HTTP_METHOD'],
         cred_details: cred_collection,

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -38,10 +38,10 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['PASSWORD']
     )
 
-    login_uri = jenkins_uri_check(target_uri)
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
       configure_http_login_scanner(
-        uri: normalize_uri(login_uri),
+        uri: '/',
+        ssl: datastore['SSL'],
         method: datastore['HTTP_METHOD'],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
@@ -51,6 +51,12 @@ class MetasploitModule < Msf::Auxiliary
         http_password: datastore['HttpPassword']
       )
     )
+
+    msg = scanner.check_setup
+    if msg
+      print_brute level: :error, ip: ip, msg: msg
+      return
+    end
 
     scanner.scan! do |result|
       credential_data = result.to_h


### PR DESCRIPTION
HTTP login scanners are supposed to call off to `check_setup` but the Jenkins login scanner wasn't doing that so I added that in and fixed up any issues I ran into to get it working

# Setup
- `docker run -p 8080:8080 -p 50000:50000 --restart=on-failure jenkins/jenkins:latest`
- finish the setup at `127.0.0.1:8080` 
- set your username and password to be used in the verification steps

# Verification steps:
- [ ] `use auxiliary/scanner/http/jenkins_login`
- [ ] `run http://127.0.0.1:8080 username=<username> password=<password>`
- [ ] The login scanner should show success for valid user/pass and fail for incorrect user/pass