### PR TITLE
Replace Readline with Reline

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -92,7 +92,6 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
       driver_options['ModulePath'] = options.modules.path
       driver_options['Plugins'] = options.console.plugins
       driver_options['Readline'] = options.console.readline
-      driver_options['RealReadline'] = options.console.real_readline
       driver_options['Resource'] = options.console.resources
       driver_options['XCommands'] = options.console.commands
 

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -16,7 +16,6 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         options.console.plugins = []
         options.console.quiet = false
         options.console.readline = true
-        options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
       }
@@ -54,7 +53,11 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         end
 
         option_parser.on('-L', '--real-readline', 'Use the system Readline library instead of RbReadline') do
-          options.console.real_readline = true
+          message = "The RealReadline option has been marked as deprecated, and is currently a noop.\n"
+          message << "Metasploit Framework now uses Reline exclusively as the input handling library.\n"
+          message << "If you require this functionality, please use the following link to tell us:\n"
+          message << '  https://github.com/rapid7/metasploit-framework/issues/19399'
+          warn message
         end
 
         option_parser.on('-o', '--output FILE', 'Output to the specified file') do |file|

--- a/lib/metasploit/framework/parsed_options/remote_db.rb
+++ b/lib/metasploit/framework/parsed_options/remote_db.rb
@@ -13,7 +13,6 @@ class Metasploit::Framework::ParsedOptions::RemoteDB < Metasploit::Framework::Pa
         options.console.local_output = nil
         options.console.plugins = []
         options.console.quiet = false
-        options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
       }

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -760,7 +760,7 @@ class Core
   end
 
   def cmd_history(*args)
-    length = Readline::HISTORY.length
+    length = ::Reline::HISTORY.length
 
     if length < @history_limit
       limit = length
@@ -780,14 +780,7 @@ class Core
           limit = val.to_i
         end
       when '-c'
-        if Readline::HISTORY.respond_to?(:clear)
-          Readline::HISTORY.clear
-        elsif defined?(RbReadline)
-          RbReadline.clear_history
-        else
-          print_error('Could not clear history, skipping file')
-          return false
-        end
+        ::Reline::HISTORY.clear
 
         # Portable file truncation?
         if File.writable?(Msf::Config.history_file)
@@ -808,7 +801,7 @@ class Core
 
     (start..length-1).each do |pos|
       cmd_num = (pos + 1).to_s
-      print_line "#{cmd_num.ljust(pad_len)}  #{Readline::HISTORY[pos]}"
+      print_line "#{cmd_num.ljust(pad_len)}  #{::Reline::HISTORY[pos]}"
     end
   end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -53,8 +53,6 @@ class Driver < Msf::Ui::Driver
   # @option opts [Boolean] 'AllowCommandPassthru' (true) Whether to allow
   #   unrecognized commands to be executed by the system shell
   # @option opts [Boolean] 'Readline' (true) Whether to use the readline or not
-  # @option opts [Boolean] 'RealReadline' (false) Whether to use the system's
-  #   readline library instead of RBReadline
   # @option opts [String] 'HistFile' (Msf::Config.history_file) Path to a file
   #   where we can store command history
   # @option opts [Array<String>] 'Resources' ([]) A list of resource files to
@@ -64,8 +62,6 @@ class Driver < Msf::Ui::Driver
   # @option opts [Boolean] 'SkipDatabaseInit' (false) Whether to skip
   #   connecting to the database and running migrations
   def initialize(prompt = DefaultPrompt, prompt_char = DefaultPromptChar, opts = {})
-    choose_readline(opts)
-
     histfile = opts['HistFile'] || Msf::Config.history_file
 
     begin
@@ -131,14 +127,6 @@ class Driver < Msf::Ui::Driver
     # Add the core command dispatcher as the root of the dispatcher
     # stack
     enstack_dispatcher(CommandDispatcher::Core)
-
-    # Report readline error if there was one..
-    if !@rl_err.nil?
-      print_error("***")
-      print_error("* Unable to load readline: #{@rl_err}")
-      print_error("* Falling back to RbReadLine")
-      print_error("***")
-    end
 
     # Load the other "core" command dispatchers
     CommandDispatchers.each do |dispatcher_class|
@@ -323,11 +311,11 @@ class Driver < Msf::Ui::Driver
   # Saves the recent history to the specified file
   #
   def save_recent_history(path)
-    num = Readline::HISTORY.length - hist_last_saved - 1
+    num = ::Reline::HISTORY.length - hist_last_saved - 1
 
     tmprc = ""
     num.times { |x|
-      tmprc << Readline::HISTORY[hist_last_saved + x] + "\n"
+      tmprc << ::Reline::HISTORY[hist_last_saved + x] + "\n"
     }
 
     if tmprc.length > 0
@@ -339,7 +327,7 @@ class Driver < Msf::Ui::Driver
 
     # Always update this, even if we didn't save anything. We do this
     # so that we don't end up saving the "makerc" command itself.
-    self.hist_last_saved = Readline::HISTORY.length
+    self.hist_last_saved = ::Reline::HISTORY.length
   end
 
   #
@@ -701,44 +689,6 @@ protected
     end
 
     false
-  end
-
-  # Require the appropriate readline library based on the user's preference.
-  #
-  # @return [void]
-  def choose_readline(opts)
-    # Choose a readline library before calling the parent
-    @rl_err = nil
-    if opts['RealReadline']
-      # Remove the gem version from load path to be sure we're getting the
-      # stdlib readline.
-      gem_dir = Gem::Specification.find_all_by_name('rb-readline').first.gem_dir
-      rb_readline_path = File.join(gem_dir, "lib")
-      index = $LOAD_PATH.index(rb_readline_path)
-      # Bundler guarantees that the gem will be there, so it should be safe to
-      # assume we found it in the load path, but check to be on the safe side.
-      if index
-        $LOAD_PATH.delete_at(index)
-      end
-    end
-
-    begin
-      require 'readline'
-    rescue ::LoadError => e
-      if @rl_err.nil? && index
-        # Then this is the first time the require failed and we have an index
-        # for the gem version as a fallback.
-        @rl_err = e
-        # Put the gem back and see if that works
-        $LOAD_PATH.insert(index, rb_readline_path)
-        index = rb_readline_path = nil
-        retry
-      else
-        # Either we didn't have the gem to fall back on, or we failed twice.
-        # Nothing more we can do here.
-        raise e
-      end
-    end
   end
 end
 

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -53,18 +53,18 @@ module Msf
             option_name = str.chop
             option_value = ''
 
-            ::Readline.completion_append_character = ' '
+            ::Reline.completion_append_character = ' '
             return tab_complete_option_values(mod, option_value, words, opt: option_name).map { |value| "#{str}#{value}" }
           elsif str.include?('=')
             str_split = str.split('=')
             option_name = str_split[0].strip
             option_value = str_split[1].strip
 
-            ::Readline.completion_append_character = ' '
+            ::Reline.completion_append_character = ' '
             return tab_complete_option_values(mod, option_value, words, opt: option_name).map { |value| "#{option_name}=#{value}" }
           end
 
-          ::Readline.completion_append_character = ''
+          ::Reline.completion_append_character = ''
           tab_complete_option_names(mod, str, words).map { |name| "#{name}=" }
         end
 

--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -220,13 +220,13 @@ module Msf
       end
 
       def self.history(driver)
-        end_pos = Readline::HISTORY.length - 1
+        end_pos = ::Reline::HISTORY.length - 1
         start_pos = end_pos - COMMAND_HISTORY_TOTAL > driver.hist_last_saved ? end_pos - (COMMAND_HISTORY_TOTAL - 1) : driver.hist_last_saved
 
         commands = ''
         while start_pos <= end_pos
           # Formats command position in history to 6 characters in length
-          commands += "#{'%-6.6s' % start_pos.to_s} #{Readline::HISTORY[start_pos]}\n"
+          commands += "#{'%-6.6s' % start_pos.to_s} #{::Reline::HISTORY[start_pos]}\n"
           start_pos += 1
         end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -902,7 +902,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   def tab_complete_path(str, words, dir_only)
     if client.platform == 'windows'
-        ::Readline.completion_case_fold = true
+      ::Reline.completion_case_fold = true
     end
     if client.commands.include?(COMMAND_ID_STDAPI_FS_LS)
       expanded = str
@@ -915,7 +915,7 @@ class Console::CommandDispatcher::Stdapi::Fs
         # This is annoying if we're recursively tab-traversing our way through subdirectories -
         # we may want to continue traversing, but MSF will add a space, requiring us to back up to continue
         # tab-completing our way through successive subdirectories.
-        ::Readline.completion_append_character = nil
+        ::Reline.completion_append_character = nil
       end
       results
     else
@@ -939,7 +939,6 @@ class Console::CommandDispatcher::Stdapi::Fs
       result
     end
   end
-
 end
 
 end

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -20,7 +20,7 @@ module InteractiveSqlClient
   #
   def _interact
     while self.interacting
-      sql_input = _multiline_with_fallback
+      sql_input = reline_multiline
       self.interacting = (sql_input[:status] != :exit)
 
       if sql_input[:status] == :help
@@ -65,35 +65,21 @@ module InteractiveSqlClient
     # noop
   end
 
-  # Try getting multi-line input support provided by Reline, fall back to Readline.
-  def _multiline_with_fallback
+  # Get multi-line input support provided by Reline.
+  def reline_multiline
     name = session.type
     query = {}
     history_file = Msf::Config.history_file_for_session_type(session_type: name, interactive: true)
     return { status: :fail, errors: ["Unable to get history file for session type: #{name}"] } if history_file.nil?
 
-    # Multiline (Reline) and fallback (Readline) have separate history contexts as they are two different libraries.
-    framework.history_manager.with_context(history_file: history_file , name: name, input_library: :reline) do
+    framework.history_manager.with_context(history_file: history_file , name: name) do
       query = _multiline
-    end
-
-    if query[:status] == :fail
-      framework.history_manager.with_context(history_file: history_file, name: name, input_library: :readline) do
-        query = _fallback
-      end
     end
 
     query
   end
 
   def _multiline
-    begin
-      require 'reline' unless defined?(::Reline)
-    rescue ::LoadError => e
-      elog('Failed to load Reline', e)
-      return { status: :fail, errors: [e] }
-    end
-
     stop_words = %w[stop s exit e end quit q].freeze
     help_words = %w[help h].freeze
 
@@ -150,28 +136,6 @@ module InteractiveSqlClient
     end
 
     { status: :success, result: raw_query }
-  end
-
-  def _fallback
-    stop_words = %w[stop s exit e end quit q].freeze
-    line_buffer = []
-    while (line = ::Readline.readline(prompt = line_buffer.empty? ? 'SQL >> ' : 'SQL *> ', add_history = true))
-      return { status: :exit, result: nil } unless self.interacting
-
-      if stop_words.include? line.chomp.downcase
-        self.interacting = false
-        print_status 'Exiting Interactive mode.'
-        return { status: :exit, result: nil }
-      end
-
-      next if line.empty?
-
-      line_buffer.append line
-
-      break if line.end_with? ';'
-    end
-
-    { status: :success, result: line_buffer.join(' ') }
   end
 
   attr_accessor :on_log_proc, :client_dispatcher

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -2,6 +2,7 @@
 require 'pp'
 require 'rex/text/table'
 require 'erb'
+require 'readline'
 
 module Rex
 module Ui
@@ -311,7 +312,7 @@ module DispatcherShell
         # This is annoying if we're recursively tab-traversing our way through subdirectories -
         # we may want to continue traversing, but MSF will add a space, requiring us to back up to continue
         # tab-completing our way through successive subdirectories.
-        ::Readline.completion_append_character = nil
+        ::Reline.completion_append_character = nil
       end
 
       if dirs.length == 0 && File.directory?(str)
@@ -406,11 +407,16 @@ module DispatcherShell
   # routine, stores all completed words, and passes the partial
   # word to the real tab completion function. This works around
   # a design problem in the Readline module and depends on the
-  # Readline.basic_word_break_characters variable being set to \x00
+  # Reline.basic_word_break_characters variable being set to \x00
   #
-  def tab_complete(str)
-    ::Readline.completion_append_character = ' '
-    ::Readline.completion_case_fold = false
+  def tab_complete(str, opts: {})
+    # Compatibility with how Readline worked before Reline
+    if opts[:preposing]
+      str = "#{opts[:preposing]}#{str}"
+    end
+
+    ::Reline.completion_append_character = ' '
+    ::Reline.completion_case_fold = false
 
     # Check trailing whitespace so we can tell 'x' from 'x '
     str_match = str.match(/[^\\]([\\]{2})*\s+$/)
@@ -424,11 +430,7 @@ module DispatcherShell
 
     # Pop the last word and pass it to the real method
     result = tab_complete_stub(str, split_str)
-    if result
-      result.uniq
-    else
-      result
-    end
+    result&.uniq
   end
 
   # Performs tab completion of a command, if supported

--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -39,21 +39,18 @@ class IrbShell
     # commands will work.
     IRB.conf[:MAIN_CONTEXT] = irb.context
 
-    # Trap interrupt
-    old_sigint = trap("SIGINT") do
-      begin
+    begin
+      old_sigint = trap("SIGINT") do
         irb.signal_handle
-      rescue RubyLex::TerminateLineInput
+      end
+
+      # Keep processing input until the cows come home...
+      catch(:IRB_EXIT) do
         irb.eval_input
       end
+    ensure
+      trap("SIGINT", old_sigint) if old_sigint
     end
-
-    # Keep processing input until the cows come home...
-    catch(:IRB_EXIT) do
-      irb.eval_input
-    end
-
-    trap("SIGINT", old_sigint)
   end
 
 end

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -94,6 +94,7 @@ class Output::Stdio < Rex::Ui::Text::Output
     msg
   end
   alias_method :write, :print_raw
+  alias_method :<<, :write
 
   def supports_color?
     case config[:color]

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'singleton'
+require 'reline'
 
 module Rex
 module Ui
@@ -24,12 +25,11 @@ class HistoryManager
   #
   # @param [String,nil] history_file The file to load and persist commands to
   # @param [String] name Human readable history context name
-  # @param [Symbol] input_library The input library to provide context for. :reline, :readline
   # @param [Proc] block
   # @return [nil]
-  def with_context(history_file: nil, name: nil, input_library: nil, &block)
+  def with_context(history_file: nil, name: nil, &block)
     # Default to Readline for backwards compatibility.
-    push_context(history_file: history_file, name: name, input_library: input_library || :readline)
+    push_context(history_file: history_file, name: name)
 
     begin
       block.call
@@ -73,33 +73,9 @@ class HistoryManager
     @debug
   end
 
-  # A wrapper around mapping the input library to its history; this way we can mock the return value of this method.
-  def map_library_to_history(input_library)
-    case input_library
-    when :readline
-      ::Readline::HISTORY
-    when :reline
-      ::Reline::HISTORY
-    else
-      $stderr.puts("Unknown input library: #{input_library}") if debug?
-      []
-    end
-  end
-
-  def clear_library(input_library)
-    case input_library
-    when :readline
-      clear_readline
-    when :reline
-      clear_reline
-    else
-      $stderr.puts("Unknown input library: #{input_library}") if debug?
-    end
-  end
-
-  def push_context(history_file: nil, name: nil, input_library: nil)
+  def push_context(history_file: nil, name: nil)
     $stderr.puts("Push context before\n#{JSON.pretty_generate(_contexts)}") if debug?
-    new_context = { history_file: history_file, name: name, input_library: input_library || :readline }
+    new_context = { history_file: history_file, name: name }
 
     switch_context(new_context, @contexts.last)
     @contexts.push(new_context)
@@ -119,40 +95,18 @@ class HistoryManager
     nil
   end
 
-  def readline_available?
-    defined?(::Readline)
-  end
-
-  def reline_available?
-    begin
-      require 'reline'
-      defined?(::Reline)
-    rescue ::LoadError => _e
-      false
-    end
-  end
-
-  def clear_readline
-    return unless readline_available?
-
-    ::Readline::HISTORY.length.times { ::Readline::HISTORY.pop }
-  end
-
-  def clear_reline
-    return unless reline_available?
-
-    ::Reline::HISTORY.length.times { ::Reline::HISTORY.pop }
+  def clear_history
+    history.clear
   end
 
   def load_history_file(context)
     history_file = context[:history_file]
-    history = map_library_to_history(context[:input_library])
 
     begin
       File.open(history_file, 'rb') do |f|
-        clear_library(context[:input_library])
+        clear_history
         f.each_line(chomp: true) do |line|
-          if context[:input_library] == :reline && history.last&.end_with?("\\")
+          if history.last&.end_with?("\\")
             history.last.delete_suffix!("\\")
             history.last << "\n" << line
           else
@@ -167,8 +121,6 @@ class HistoryManager
 
   def store_history_file(context)
     history_file = context[:history_file]
-    history = map_library_to_history(context[:input_library])
-
     history_diff = history.length < MAX_HISTORY ? history.length : MAX_HISTORY
 
     cmds = []
@@ -188,12 +140,10 @@ class HistoryManager
     if new_context && new_context[:history_file]
       load_history_file(new_context)
     else
-      clear_readline
-      clear_reline
+      clear_history
     end
   rescue SignalException => _e
-    clear_readline
-    clear_reline
+    clear_history
   end
 
   def write_history_file(history_file, cmds)
@@ -223,6 +173,10 @@ class HistoryManager
     event = { type: :write, history_file: history_file, cmds: cmds }
     @write_queue << event
     @remaining_work << event
+  end
+
+  def history
+    ::Reline::HISTORY
   end
 end
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -197,6 +197,8 @@ Gem::Specification.new do |spec|
   # Library for exploit development helpers
   spec.add_runtime_dependency 'rex-exploitation'
   # Command line editing, history, and tab completion in msfconsole
+  spec.add_runtime_dependency 'reline'
+  # Legacy support for FILENAME_COMPLETION_PROC, not present in Reline
   spec.add_runtime_dependency 'rb-readline'
   # Needed by some modules
   spec.add_runtime_dependency 'rubyzip'
@@ -247,9 +249,6 @@ Gem::Specification.new do |spec|
   # Do not use this to process untrusted PNG files! This is only to be used
   # to generate PNG files, not to parse untrusted PNG files.
   spec.add_runtime_dependency 'chunky_png'
-
-  # Needed for multiline REPL support for interactive SQL sessions
-  spec.add_runtime_dependency 'reline'
 
   # Standard libraries: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
   %w[

--- a/modules/post/linux/manage/pseudo_shell.rb
+++ b/modules/post/linux/manage/pseudo_shell.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'readline'
+require 'reline'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
@@ -104,9 +104,9 @@ class MetasploitModule < Msf::Post
   def prompt_show
     promptshell = "#{@vusername}@#{@vhostname}:#{pwd.strip}#{@vpromptchar} "
     comp = proc { |s| LIST.grep(/^#{Regexp.escape(s)}/) }
-    Readline.completion_append_character = ' '
-    Readline.completion_proc = comp
-    input = Readline.readline(promptshell, true)
+    Reline.completion_append_character = ' '
+    Reline.completion_proc = comp
+    input = Reline.readline(promptshell, true)
     return nil if input.nil?
 
     input

--- a/msfconsole
+++ b/msfconsole
@@ -6,6 +6,8 @@
 #
 
 require 'pathname'
+require 'reline'
+
 begin
 
   # Silences warnings as they only serve to confuse end users

--- a/spec/lib/msf/debug_spec.rb
+++ b/spec/lib/msf/debug_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Msf::Ui::Debug do
   end
 
   it 'correctly retrieves and parses a command history shorter than the command total' do
-    stub_const('Readline::HISTORY', Array.new(4) { |i| "Command #{i + 1}" })
+    stub_const('Reline::HISTORY', Array.new(4) { |i| "Command #{i + 1}" })
 
     driver = instance_double(
       Msf::Ui::Console::Driver,
@@ -251,7 +251,7 @@ RSpec.describe Msf::Ui::Debug do
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
 
-    stub_const('Readline::HISTORY', Array.new(10) { |i| "Command #{i + 1}" })
+    stub_const('Reline::HISTORY', Array.new(10) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr
@@ -288,7 +288,7 @@ RSpec.describe Msf::Ui::Debug do
     )
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
-    stub_const('Readline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
+    stub_const('Reline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr
@@ -325,7 +325,7 @@ RSpec.describe Msf::Ui::Debug do
     )
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
-    stub_const('Readline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
+    stub_const('Reline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
-
-require 'readline'
+require 'reline'
 
 RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
   include_context 'Msf::DBManager'

--- a/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
+++ b/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'readline'
+require 'reline'
 
 RSpec.describe Rex::Ui::Text::DispatcherShell do
   let(:prompt) { '%undmsf6%clr' }

--- a/spec/lib/rex/ui/text/shell/history_manager_spec.rb
+++ b/spec/lib/rex/ui/text/shell/history_manager_spec.rb
@@ -7,13 +7,6 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
   include_context 'wait_for_expect'
 
   subject { described_class.send(:new) }
-  let(:readline_available) { false }
-  let(:reline_available) { false }
-
-  before(:each) do
-    allow(subject).to receive(:readline_available?).and_return(readline_available)
-    allow(subject).to receive(:reline_available?).and_return(reline_available)
-  end
 
   describe '#with_context' do
     context 'when there is not an existing stack' do
@@ -30,7 +23,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'a') do
             expected_contexts = [
-              { history_file: nil, input_library: :readline, name: 'a' },
+              { history_file: nil, name: 'a' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -41,7 +34,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
 
     context 'when there is an existing stack' do
       before(:each) do
-        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
+        subject.send(:push_context, history_file: nil, name: 'a')
       end
 
       it 'continues to have the previous existing stack' do
@@ -49,7 +42,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           # noop
         }
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -58,8 +51,8 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         (expect do |block|
           subject.with_context(name: 'b') do
             expected_contexts = [
-              { history_file: nil, input_library: :readline, name: 'a' },
-              { history_file: nil, input_library: :readline, name: 'b' },
+              { history_file: nil, name: 'a' },
+              { history_file: nil, name: 'b' },
             ]
             expect(subject._contexts).to eq(expected_contexts)
             block.to_proc.call
@@ -74,7 +67,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
           }
         end.to raise_exception ArgumentError, 'Mock error'
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -84,9 +77,9 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
   describe '#push_context' do
     context 'when the stack is empty' do
       it 'stores the history contexts' do
-        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'a')
+        subject.send(:push_context, history_file: nil, name: 'a')
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' }
+          { history_file: nil, name: 'a' }
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -95,12 +88,12 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     context 'when multiple values are pushed' do
       it 'stores the history contexts' do
         subject.send(:push_context, history_file: nil, name: 'a')
-        subject.send(:push_context, history_file: nil, input_library: :readline, name: 'b')
-        subject.send(:push_context, history_file: nil, input_library: :reline, name: 'c')
+        subject.send(:push_context, history_file: nil, name: 'b')
+        subject.send(:push_context, history_file: nil, name: 'c')
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
-          { history_file: nil, input_library: :readline, name: 'b' },
-          { history_file: nil, input_library: :reline, name: 'c' },
+          { history_file: nil, name: 'a' },
+          { history_file: nil, name: 'b' },
+          { history_file: nil, name: 'c' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -123,7 +116,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         subject.send(:push_context, history_file: nil, name: 'b')
         subject.send(:pop_context)
         expected_contexts = [
-          { history_file: nil, input_library: :readline, name: 'a' },
+          { history_file: nil, name: 'a' },
         ]
         expect(subject._contexts).to eq(expected_contexts)
       end
@@ -150,14 +143,14 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
       context "when storing #{test[:history_size]} lines" do
         it "correctly stores #{test[:expected_size]} lines" do
           allow(subject).to receive(:store_history_file).and_call_original
-          allow(subject).to receive(:map_library_to_history).and_return(history_mock)
+          allow(subject).to receive(:history).and_return(history_mock)
 
           test[:history_size].times do
             # This imitates the user typing in a command and pressing the 'enter' key.
             history_mock << history_choices.sample
           end
 
-          context = { input_library: :readline, history_file: history_file.path, name: 'history'}
+          context = { history_file: history_file.path, name: 'history' }
 
           subject.send(:store_history_file, context)
 
@@ -176,15 +169,16 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
     let(:history_file) { ::Tempfile.new('history') }
 
     after(:each) do
+      history_file.close
       history_file.unlink
       subject._close
     end
 
     context 'when history file is not accessible' do
       it 'the library history remains unchanged' do
-        allow(subject).to receive(:map_library_to_history).and_return(history_mock)
+        allow(subject).to receive(:history).and_return(history_mock)
         history_file = ::File.join('does', 'not', 'exist', 'history')
-        context = { input_library: :readline, history_file: history_file, name: 'history' }
+        context = { history_file: history_file, name: 'history' }
 
         subject.send(:load_history_file, context)
         expect(history_mock).to eq(initial_history)
@@ -193,7 +187,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
 
     context 'when history file is accessible' do
       it 'correctly loads the history' do
-        allow(subject).to receive(:map_library_to_history).and_return(history_mock)
+        allow(subject).to receive(:history).and_return(history_mock)
 
         # Populate our own history file with random entries.
         # Using this allows us to not have to worry about history files present/not present on disk.
@@ -204,7 +198,7 @@ RSpec.describe Rex::Ui::Text::Shell::HistoryManager do
         history_file.puts new_history
         history_file.rewind
 
-        context = { input_library: :readline, history_file: history_file.path, name: 'history' }
+        context = { history_file: history_file.path, name: 'history' }
 
         subject.send(:load_history_file, context)
 

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -31,7 +31,7 @@ require 'msfenv'
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'rex'
-require 'readline'
+require 'reline'
 require 'metasm'
 
 #PowerPC, seems broken for now in metasm

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -21,7 +21,7 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'msfenv'
 require 'rex'
-require 'readline'
+require 'reline'
 
 # Check to make sure nasm is installed and reachable through the user's PATH.
 begin


### PR DESCRIPTION
This PR:
- replaces the Readline library with Reline.
- fixes https://github.com/rapid7/metasploit-framework/issues/19294 by working around an `Open3` bug reported on the gem's GitHub issue page for Windows 11 (this compliments Reline, as we need Reline as well as the work-around to fix this)
- still uses the Readline gem, due to needing the `Readline::FILENAME_COMPLETION_PROC`, which is stubbed as `nil` in Reline. We use this to not have to write our own custom `FILENAME_COMPLETION_PROC`.
- fixes an issue present on `master`, where pressing `Ctrl+C` in `irb` prompt would result in a deadlock exception.
- marks the `real-readline` option as deprecated, due to the planned removal of the `Readline` gem in the future
- removes the `Readline` single-line input fallback mode from SQL sessions, as Reline will be used exclusively
- removes the history_manager input_library option, as Reline is the only library being supported moving forward, as we are planning to drop Readline

## Windows 11 - Before
Can't delete characters in the prompt, and getting a bug where the input gets re-entered multiple times.
```
PS C:\Users\x\Desktop\metasploit-framework> bundle exec 'ruby ./msfconsole -q'
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
C:/Users/x/.local/share/gem/ruby/3.1.0/gems/rex-core-0.1.32/lib/rex/compat.rb:381: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
msf6 auxiliary(scanner/oracle/oracle_login) > use postggrgregresgres_gres_lgres_logres_loggres_logigres_login
```

## Windows 11 - After
No duplicate input in prompt, prompt can be cleared using backspace and navigated using left and right arrow keys.
```
PS C:\Users\x\Desktop\metasploit-framework> bundle exec 'ruby ./msfconsole -q'
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
C:/Users/x/.local/share/gem/ruby/3.1.0/gems/rex-core-0.1.32/lib/rex/compat.rb:381: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
msf6 auxiliary(scanner/oracle/oracle_login) > use postgres_login (no duplicated input)

Matching Modules
================

   #  Name                                       Disclosure Date  Rank    Check  Description
   -  ----                                       ---------------  ----    -----  -----------
   0  auxiliary/scanner/postgres/postgres_login  .                normal  No     PostgreSQL Login Utility


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/postgres/postgres_login

[*] Using auxiliary/scanner/postgres/postgres_login
[*] New in Metasploit 6.4 - The CreateSession option within this module can open an interactive session
msf6 auxiliary(scanner/postgres/postgres_login) > use postgres_login (press backspace multiple times)
msf6 auxiliary(scanner/postgres/postgres_login) > (prompt cleared)
```

## IRB - Before
```
msf6 auxiliary(scanner/postgres/postgres_login) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/scanner/postgres/postgres_login

>> 
^C
[-] Error during IRB: deadlock; recursive locking

/Users/x/.rvm/gems/ruby-3.1.5/gems/reline-0.5.8/lib/reline.rb:261:in `synchronize'
/Users/x/.rvm/gems/ruby-3.1.5/gems/reline-0.5.8/lib/reline.rb:261:in `readmultiline'
/Users/x/.rvm/rubies/ruby-3.1.5/lib/ruby/3.1.0/forwardable.rb:238:in `readmultiline'
./msfconsole:23:in `<main>'
msf6 auxiliary(scanner/postgres/postgres_login) > 
```

## IRB - After
```
msf6 auxiliary(scanner/postgres/postgres_login) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/scanner/postgres/postgres_login

>> 
^C
>> 
^C
>> 
```

## Verification

- [x] Start `msfconsole`
- [x] Ensure you can run some commands as expected
- [x] Get a SQL session using e.g. `postgres_login`
- [x] Ensure that the `query` and `query_interactive` commands work when provided single and multi-line input
- [x] Ensure that the `irb` command works
- [x] Ensure that pressing `Ctrl+C` in `irb` prompt does not result in a deadlock exception
- [x] Ensure that after exiting `irb`, the autocompletion suggestions do not leak from `irb`, and prompt remains normal
- [ ] Ensure that `msfconsole` works on Windows 11 and does not freeze (linked issue)
- [x] Ensure tab-completion works in msfconsole's prompt for settings, `set` command etc.
- [x] Ensure that scrolling through the prompt's history using up and down arrow keys works as expected
- [x] Ensure that switching history_manager contexts does not result in history leakage (go into a SQL session, type a command, exit the SQL session, ensure the command you just entered does not show up in msfconsole's prompt)
- [x] Ensure tests pass
