### PR TITLE
Add Reline autocomplete prompt behind feature flag

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -29,6 +29,7 @@ module Msf
     LDAP_SESSION_TYPE = 'ldap_session_type'
     SHOW_SUCCESSFUL_LOGINS = 'show_successful_logins'
     DISPLAY_MODULE_ACTION = 'display_module_action'
+    SHOW_AUTOCOMPLETION_PROMPT = 'show_autocompletion_prompt'
 
     DEFAULTS = [
       {
@@ -132,6 +133,13 @@ module Msf
         requires_restart: false,
         default_value: true,
         developer_notes: 'Added as a feature so users can turn it off if they wish to reduce clutter in their terminal'
+      }.freeze,
+      {
+        name: SHOW_AUTOCOMPLETION_PROMPT,
+        description: 'When enabled, an autocompletion prompt will be shown when typing in commands',
+        requires_restart: true,
+        default_value: false,
+        developer_notes: 'To be enabled once the Readline to Reline upgrade has been confirmed to not cause issues'
       }.freeze
     ].freeze
 

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -130,6 +130,10 @@ module Shell
       # Pry is a development dependency, if not available suppressing history_load can be safely ignored.
     end
 
+    if framework.features.enabled?(Msf::FeatureManager::SHOW_AUTOCOMPLETION_PROMPT)
+      Reline.autocompletion = true
+    end
+
     with_history_manager_context do
       begin
         while true


### PR DESCRIPTION
This PR builds on the Readline to Reline refactor here: https://github.com/rapid7/metasploit-framework/pull/19397

This PR adds a new feature flag, that when enabled, will result in valid options that can be tab-completed to be shown below the currently typed text, same as IRB.

This PR should have no technical impact as it only changes how the UI is presented. It does not change valid tab complete options.

Currently putting this up as a draft but will convert to a normal PR without the initial Readline -> Reline commit once it is merged.

## Before
- Tab completion works, but is different from the nice approach of e.g. IRB:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/5a051e3b-1820-4e31-b096-c6c5de83fb11">

## After
- We see valid auto-complete options that can be chosen/toggled between by pressing tab:
<img width="648" alt="image" src="https://github.com/user-attachments/assets/a2f5fac0-425b-485e-9ca2-8a46aef019df">

- We can have nested auto-completions:
<img width="987" alt="image" src="https://github.com/user-attachments/assets/f9fa18c0-e7d0-4cb4-993e-72149d77f007">

- We can also auto-complete the valid values for options:
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/2d8eaff4-8474-4708-84d3-be53877080ef">

- For example, the path option can auto-complete files from disk, the bool option can default to `true/false` etc.
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/77e4d73b-d638-4212-a4ad-2e79cc7a650d">

## Verification

- [ ] Boot up msfconsole
- [ ] Ensure tab-completion continues to work