### PR TITLE
Disable mssql tests for now

### DIFF
--- a/.github/workflows/mssql_acceptance.yml
+++ b/.github/workflows/mssql_acceptance.yml
@@ -66,9 +66,9 @@ jobs:
           - '3.2'
         os:
           - ubuntu-latest
-        docker_image:
-          - mcr.microsoft.com/mssql/server:2022-latest
-          - mcr.microsoft.com/mssql/server:2019-latest
+        docker_image: []
+#          - mcr.microsoft.com/mssql/server:2022-latest
+#          - mcr.microsoft.com/mssql/server:2019-latest
 
     env:
       RAILS_ENV: test


### PR DESCRIPTION
The mssql tests are currently failing due to the location of the health check binary being different/removed. Removing for now

## Verification

Ensure CI passes