### PR TITLE
Fix RPC: check result is not nil before getting length

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -539,7 +539,7 @@ class RPC_Module < RPC_Base
       if r[:error]
         {"status" => "errored", "error" => r[:error]}
       else
-        if r[:result].length == 1
+        if r[:result] && r[:result].length == 1
           # A hash of one IP => result
           # TODO: make hashes of IP => result the normal case
           {"status" => "completed", "result" => r[:result].values.first}


### PR DESCRIPTION
This fix a bug in the rpc module in metasploit, by following [this](https://docs.metasploit.com/docs/using-metasploit/advanced/RPC/how-to-use-metasploit-messagepack-rpc.html#auxiliary-module-example) guide, when we execute an auxiliary module and we query the `module.results` we expect an output like this:

```
>> rpc.call('module.results', 'yJWES2Y6d4MRyfFLWjqhqvon')
=> {"status"=>"completed", "result"=>nil}
```

However, the check of `r[:result].length == 1`  without ensuring first `r[:result]` to not be nil will cause an error.

## Verification

- Use the guide linked in the PR
- I used the module: `auxiliary/gather/ray_lfi_cve_2023_6020`

### Before
```
{'error': True, 'error_class': 'NoMethodError', 'error_string': "undefined method `length' for nil:NilClass", 'error_backtrace': ["lib/msf/core/rpc/v10/rpc_module.rb:542:in `rpc_results'", "lib/msf/core/rpc/v10/service.rb:143:in `block in process'", "lib/timeout.rb:186:in `block in timeout'", "lib/timeout.rb:41:in `handle_timeout'", "lib/timeout.rb:195:in `timeout'", "lib/msf/core/rpc/v10/service.rb:143:in `process'", "lib/msf/core/rpc/v10/service.rb:81:in `on_request_uri'", "lib/msf/core/rpc/v10/service.rb:62:in `block in start'", "lib/rex/proto/http/handler/proc.rb:38:in `on_request'", "lib/rex/proto/http/server.rb:316:in `dispatch_request'", "lib/rex/proto/http/server.rb:250:in `on_client_data'", "lib/rex/proto/http/server.rb:109:in `block in start'", "lib/rex/io/stream_server.rb:42:in `on_client_data'", "lib/rex/io/stream_server.rb:185:in `block in monitor_clients'", "lib/rex/io/stream_server.rb:184:in `each'", "lib/rex/io/stream_server.rb:184:in `monitor_clients'", "lib/rex/io/stream_server.rb:64:in `block in start'", "lib/rex/thread_factory.rb:22:in `block in spawn'", "lib/msf/core/thread_manager.rb:105:in `block in spawn'"], 'error_message': "undefined method `length' for nil:NilClass"}
module.results ['rc3asKmGZ6tAnUx96DUPzAHE'] {'error': True, 'error_class': 'NoMethodError', 'error_string': "undefined method `length' for nil:NilClass", 'error_backtrace': ["lib/msf/core/rpc/v10/rpc_module.rb:542:in `rpc_results'", "lib/msf/core/rpc/v10/service.rb:143:in `block in process'", "lib/timeout.rb:186:in `block in timeout'", "lib/timeout.rb:41:in `handle_timeout'", "lib/timeout.rb:195:in `timeout'", "lib/msf/core/rpc/v10/service.rb:143:in `process'", "lib/msf/core/rpc/v10/service.rb:81:in `on_request_uri'", "lib/msf/core/rpc/v10/service.rb:62:in `block in start'", "lib/rex/proto/http/handler/proc.rb:38:in `on_request'", "lib/rex/proto/http/server.rb:316:in `dispatch_request'", "lib/rex/proto/http/server.rb:250:in `on_client_data'", "lib/rex/proto/http/server.rb:109:in `block in start'", "lib/rex/io/stream_server.rb:42:in `on_client_data'", "lib/rex/io/stream_server.rb:185:in `block in monitor_clients'", "lib/rex/io/stream_server.rb:184:in `each'", "lib/rex/io/stream_server.rb:184:in `monitor_clients'", "lib/rex/io/stream_server.rb:64:in `block in start'", "lib/rex/thread_factory.rb:22:in `block in spawn'", "lib/msf/core/thread_manager.rb:105:in `block in spawn'"], 'error_message': "undefined method `length' for nil:NilClass"}
```

### After
```
{'status': 'completed', 'result': None}
```