### PR TITLE
Add missing constants for the Kerberos login scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -12,6 +12,10 @@ module Metasploit
         DEFAULT_PORT = 88
         REALM_KEY = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
         DEFAULT_REALM = nil
+        LIKELY_PORTS = [ DEFAULT_PORT ].freeze
+        LIKELY_SERVICE_NAMES = [ 'kerberos', 'kerberos5', 'krb5', 'kerberos-sec' ].freeze
+        PRIVATE_TYPES = %i[ password ].freeze
+        CAN_GET_SESSION = true
 
         def attempt_login(credential)
           result_options = {
@@ -117,6 +121,7 @@ module Metasploit
         private
 
         def set_sane_defaults
+          self.connection_timeout = 10 if self.connection_timeout.nil?
           self.port = DEFAULT_PORT unless self.port
         end
 

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -179,7 +179,7 @@ module Msf
             pfx = options[:pfx]
             request_pac = options.fetch(:request_pac, true)
             realm = options[:realm]
-            server_name = options.fetch(:server_name, "krbtgt/#{realm}")
+            server_name = options[:server_name] || "krbtgt/#{realm}"
             client_name = options[:client_name]
             client_name = client_name.dup.force_encoding('utf-8') if client_name
             ticket_options = options.fetch(:options) { 0x50800000 } # Forwardable, Proxiable, Renewable

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -245,7 +245,7 @@ module Msf
           # @raise [Rex::Proto::Kerberos::Model::Error::KerberosError] if the provided credentials are invalid
           def send_request_tgt(options = {})
             realm = options[:realm]
-            server_name = options[:server_name]
+            server_name = options[:server_name] || "krbtgt/#{realm}"
             client_name = options[:client_name]
             client_name = client_name.dup.force_encoding('utf-8') if client_name
             password = options[:password]


### PR DESCRIPTION
This adds some missing constants for the Kerberos `LoginScanner` as defined in the [documentation](https://docs.metasploit.com/docs/development/developing-modules/guides/scanners/creating-metasploit-framework-loginscanners.html#constants). This also defines the default `connection_timeout` value in `#set_sane_defaults` as defined [here](https://docs.metasploit.com/docs/development/developing-modules/guides/scanners/creating-metasploit-framework-loginscanners.html#set_sane_defaults).

Finally, this also adds a minor improvement to the Kerberos client by setting a default value for the `server_name` option in `#send_request_tgt` when the option is not defined.