### PR TITLE
Update the ldap_esc_vulnerable_cert_finder module

### DIFF
--- a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
+++ b/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
@@ -190,17 +190,19 @@ msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > show options
 
 Module options (auxiliary/gather/ldap_esc_vulnerable_cert_finder):
 
-   Name                  Current Setting  Required  Description
-   ----                  ---------------  --------  -----------
-   BASE_DN                                no        LDAP base DN if you already have it
-   DOMAIN                                 no        The domain to authenticate to
-   PASSWORD                               no        The password to authenticate with
-   REPORT_NONENROLLABLE  false            yes       Report nonenrollable certificate templates
-   RHOSTS                                 yes       The target host(s), see https://github.com/rapid7/metasploit
-                                                    -framework/wiki/Using-Metasploit
-   RPORT                 389              yes       The target port
-   SSL                   false            no        Enable SSL on the LDAP connection
-   USERNAME                               no        The username to authenticate with
+   Name                   Current Setting  Required  Description
+   ----                   ---------------  --------  -----------
+   BASE_DN                                 no        LDAP base DN if you already have it
+   DOMAIN                                  no        The domain to authenticate to
+   PASSWORD                                no        The password to authenticate with
+   REPORT_NONENROLLABLE   false            yes       Report nonenrollable certificate templates
+   REPORT_PRIVENROLLABLE  false            yes       Report certificate templates restricted to domain
+                                                      and enterprise admin
+   RHOSTS                                  yes       The target host(s), see https://github.com/rapid7/metasploit
+                                                     -framework/wiki/Using-Metasploit
+   RPORT                  389              yes       The target port
+   SSL                    false            no        Enable SSL on the LDAP connection
+   USERNAME                                no        The username to authenticate with
 
 
 View the full module info with the info, or info -d command.
@@ -218,114 +220,81 @@ msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
 
 [*] Discovering base DN automatically
 [+] 172.30.239.85:389 Discovered base DN: DC=daforest,DC=com
-[*] Template: SubCA
-[*]    Distinguished Name: CN=SubCA,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1, ESC2, ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC1-Template
-[*]    Distinguished Name: CN=ESC1-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC2-Template
-[*]    Distinguished Name: CN=ESC2-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC3-Template1
-[*]    Distinguished Name: CN=ESC3-Template1,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: User
-[*]    Distinguished Name: CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: Administrator
-[*]    Distinguished Name: CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: Machine
-[*]    Distinguished Name: CN=Machine,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-515 (Domain Computers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: DomainController
-[*]    Distinguished Name: CN=DomainController,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-498 (Enterprise Read-only Domain Controllers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-516 (Domain Controllers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]       * S-1-5-9 (Enterprise Domain Controllers)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC3-Template2
-[*]    Distinguished Name: CN=ESC3-Template2,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
+[+] Template: ESC1-Template
+[*]   Distinguished Name: CN=ESC1-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC1
+[*]   Notes: ESC1: Request can specify a subjectAltName (msPKI-Certificate-Name-Flag)
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
+[+]   Issuing CA: daforest-WIN-BR0CCBA815B-CA (WIN-BR0CCBA815B.daforest.com)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[+] Template: ESC2-Template
+[*]   Distinguished Name: CN=ESC2-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC2
+[*]   Notes: ESC2: Template defines the Any Purpose OID or no EKUs (PkiExtendedKeyUsage)
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
+[+]   Issuing CA: daforest-WIN-BR0CCBA815B-CA (WIN-BR0CCBA815B.daforest.com)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[+] Template: ESC3-Template1
+[*]   Distinguished Name: CN=ESC3-Template1,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC3_TEMPLATE_1
+[*]   Notes: ESC3: Template defines the Certificate Request Agent OID (PkiExtendedKeyUsage)
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
+[+]   Issuing CA: daforest-WIN-BR0CCBA815B-CA (WIN-BR0CCBA815B.daforest.com)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[+] Template: User
+[*]   Distinguished Name: CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC3_TEMPLATE_2
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
+[+]   Issuing CA: daforest-WIN-BR0CCBA815B-CA (WIN-BR0CCBA815B.daforest.com)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[+] Template: Machine
+[*]   Distinguished Name: CN=Machine,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC3_TEMPLATE_2
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-515 (Domain Computers)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
+[+]   Issuing CA: daforest-WIN-BR0CCBA815B-CA (WIN-BR0CCBA815B.daforest.com)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[+] Template: ESC3-Template2
+[*]   Distinguished Name: CN=ESC3-Template2,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC3_TEMPLATE_2
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
+[*]     * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
+[+]   Issuing CA: daforest-WIN-BR0CCBA815B-CA (WIN-BR0CCBA815B.daforest.com)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
 [*] Auxiliary module execution completed
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) >
 ```
@@ -893,21 +862,21 @@ ESC13-Test template is vulenerable to ESC13 and will yield a ticket including th
 ```
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
 ...
-[*] Template: ESC13-Test
-[*]    Distinguished Name: CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=collalabs1,DC=local
-[*]    Vulnerable to: ESC13
-[*]    Notes: ESC13 groups: ESC13-Group
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3474343397-3755413101-2031708755-512 (Domain Admins)
-[*]       * S-1-5-21-3474343397-3755413101-2031708755-513 (Domain Users)
+[+] Template: ESC13-Test
+[*]   Distinguished Name: CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=collalabs1,DC=local
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC13
+[*]   Notes: ESC13 groups: ESC13-Group
+[*]   Certificate Template Enrollment SIDs:
+[*]     * S-1-5-21-3474343397-3755413101-2031708755-512 (Domain Admins)
+[*]     * S-1-5-21-3474343397-3755413101-2031708755-513 (Domain Users)
+[*]     * S-1-5-21-3474343397-3755413101-2031708755-519 (Enterprise Admins)
+[+]   Issuing CA: collalabs1-SRV-ADDS01-CA (SRV-ADDS01.collalabs1.local)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
 [*]       * S-1-5-21-3474343397-3755413101-2031708755-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * collalabs1-SRV-ADDS01-CA
-[*]          Server: SRV-ADDS01.collalabs1.local
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*]             * S-1-5-21-3474343397-3755413101-2031708755-519 (Enterprise Admins)
-[*]             * S-1-5-21-3474343397-3755413101-2031708755-512 (Domain Admins)
+[*]       * S-1-5-21-3474343397-3755413101-2031708755-512 (Domain Admins)
 ```
 
 In this case, the ticket can be issued with the `icpr_cert` module. No additional options are required to issue the

--- a/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
+++ b/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
@@ -95,358 +95,49 @@ If set to `True` then report any certificate templates that are vulnerable but w
 If set to `False` then skip over these certificate templates and only report on certificate templates
 that are both vulnerable and enrollable.
 
+### REPORT_PRIVENROLLABLE
+If set to `True` then report certificate templates that are only enrollable by the Domain and Enterprise Admins groups.
+If set to `False` then skip over these certificate templates and only report on certificate templates that are
+enrollable by at least one additional user or group.
+
 ## Scenarios
 
 ### Windows Server 2022 with AD CS
 ```msf
-msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set RHOST 172.26.104.157
-RHOST => 172.26.104.157
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set BIND_DN DAFOREST\\Administrator
-BIND_DN => DAFOREST\Administrator
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set BIND_PW theAdmin123
-BIND_PW => theAdmin123
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > show options
-
-Module options (auxiliary/gather/ldap_esc_vulnerable_cert_finder):
-
-   Name                  Current Setting         Required  Description
-   ----                  ---------------         --------  -----------
-   BASE_DN                                       no        LDAP base DN if you already have it
-   BIND_DN               DAFOREST\Administrator  no        The username to authenticate to LDAP server
-   BIND_PW               theAdmin123             no        Password for the BIND_DN
-   REPORT_NONENROLLABLE  false                   yes       Report nonenrollable certificate templates
-   RHOSTS                172.26.104.157          yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT                 389                     yes       The target port
-   SSL                   false                   no        Enable SSL on the LDAP connection
-
 msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
-[*] Running module against 172.26.104.157
+[*] Running module against 192.168.159.10
 
 [*] Discovering base DN automatically
-[+] 172.26.104.157:389 Discovered base DN: DC=daforest,DC=com
-[*] Template: SubCA
-[*]    Distinguished Name: CN=SubCA,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1, ESC2, ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC1-Template
-[*]    Distinguished Name: CN=ESC1-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC2-Template
-[*]    Distinguished Name: CN=ESC2-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC3-Template1
-[*]    Distinguished Name: CN=ESC3-Template1,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: User
-[*]    Distinguished Name: CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: Administrator
-[*]    Distinguished Name: CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: Machine
-[*]    Distinguished Name: CN=Machine,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-515 (Domain Computers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: DomainController
-[*]    Distinguished Name: CN=DomainController,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-498 (Enterprise Read-only Domain Controllers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-516 (Domain Controllers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]       * S-1-5-9 (Enterprise Domain Controllers)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC3-Template2
-[*]    Distinguished Name: CN=ESC3-Template2,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
+[!] Couldn't find any vulnerable ESC13 templates!
+[+] Template: ESC1-Test
+[*]   Distinguished Name: CN=ESC1-Test,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=msflab,DC=local
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC1
+[*]   Notes: ESC1: Request can specify a subjectAltName (msPKI-Certificate-Name-Flag)
+[*]     Certificate Template Enrollment SIDs:
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-512 (Domain Admins)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-513 (Domain Users)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-519 (Enterprise Admins)
+[+]   Issuing CA: msflab-DC-CA (DC.msflab.local)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-519 (Enterprise Admins)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-512 (Domain Admins)
+[+] Template: ESC2-Test
+[*]   Distinguished Name: CN=ESC2-Test,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=msflab,DC=local
+[*]   Manager Approval: Disabled
+[*]   Required Signatures: 0
+[+]   Vulnerable to: ESC2
+[*]   Notes: ESC2: Template defines the Any Purpose OID or no EKUs (PkiExtendedKeyUsage)
+[*]     Certificate Template Enrollment SIDs:
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-512 (Domain Admins)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-513 (Domain Users)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-519 (Enterprise Admins)
+[+]   Issuing CA: msflab-DC-CA (DC.msflab.local)
+[*]     Enrollment SIDs:
+[*]       * S-1-5-11 (Authenticated Users)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-519 (Enterprise Admins)
+[*]       * S-1-5-21-3978004297-3499718965-4169012971-512 (Domain Admins)
 [*] Auxiliary module execution completed
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) >
-```
-
-### Windows Server 2022 with AD CS and REPORT_NONENROLLABLE Set To TRUE
-```msf
-msf6 > use auxiliary/gather/ldap_esc_vulnerable_cert_finder
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set RHOST 172.26.104.157
-RHOST => 172.26.104.157
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set BIND_DN DAFOREST\\Administrator
-BIND_DN => DAFOREST\Administrator
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set BIND_PW theAdmin123
-BIND_PW => theAdmin123
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > set REPORT_NONENROLLABLE true
-REPORT_NONENROLLABLE => true
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > show options
-
-Module options (auxiliary/gather/ldap_esc_vulnerable_cert_finder):
-
-   Name                  Current Setting         Required  Description
-   ----                  ---------------         --------  -----------
-   BASE_DN                                       no        LDAP base DN if you already have it
-   BIND_DN               DAFOREST\Administrator  no        The username to authenticate to LDAP server
-   BIND_PW               theAdmin123             no        Password for the BIND_DN
-   REPORT_NONENROLLABLE  true                    yes       Report nonenrollable certificate templates
-   RHOSTS                172.26.104.157          yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT                 389                     yes       The target port
-   SSL                   false                   no        Enable SSL on the LDAP connection
-
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
-[*] Running module against 172.26.104.157
-
-[*] Discovering base DN automatically
-[+] 172.26.104.157:389 Discovered base DN: DC=daforest,DC=com
-[*] Template: CA
-[*]    Distinguished Name: CN=CA,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1, ESC2, ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    CA not published as an enrollable certificate!
-[*] Template: SubCA
-[*]    Distinguished Name: CN=SubCA,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1, ESC2, ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: OfflineRouter
-[*]    Distinguished Name: CN=OfflineRouter,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1, ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    OfflineRouter not published as an enrollable certificate!
-[*] Template: ESC1-Template
-[*]    Distinguished Name: CN=ESC1-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC2-Template
-[*]    Distinguished Name: CN=ESC2-Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: EnrollmentAgent
-[*]    Distinguished Name: CN=EnrollmentAgent,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    EnrollmentAgent not published as an enrollable certificate!
-[*] Template: EnrollmentAgentOffline
-[*]    Distinguished Name: CN=EnrollmentAgentOffline,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    EnrollmentAgentOffline not published as an enrollable certificate!
-[*] Template: MachineEnrollmentAgent
-[*]    Distinguished Name: CN=MachineEnrollmentAgent,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    MachineEnrollmentAgent not published as an enrollable certificate!
-[*] Template: CEPEncryption
-[*]    Distinguished Name: CN=CEPEncryption,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    CEPEncryption not published as an enrollable certificate!
-[*] Template: ESC3-Template1
-[*]    Distinguished Name: CN=ESC3-Template1,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_1
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: User
-[*]    Distinguished Name: CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: UserSignature
-[*]    Distinguished Name: CN=UserSignature,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    UserSignature not published as an enrollable certificate!
-[*] Template: SmartcardUser
-[*]    Distinguished Name: CN=SmartcardUser,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    SmartcardUser not published as an enrollable certificate!
-[*] Template: ClientAuth
-[*]    Distinguished Name: CN=ClientAuth,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    ClientAuth not published as an enrollable certificate!
-[*] Template: SmartcardLogon
-[*]    Distinguished Name: CN=SmartcardLogon,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[!]    SmartcardLogon not published as an enrollable certificate!
-[*] Template: Administrator
-[*]    Distinguished Name: CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: Machine
-[*]    Distinguished Name: CN=Machine,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-515 (Domain Computers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: DomainController
-[*]    Distinguished Name: CN=DomainController,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-498 (Enterprise Read-only Domain Controllers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-516 (Domain Controllers)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]       * S-1-5-9 (Enterprise Domain Controllers)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Template: ESC3-Template2
-[*]    Distinguished Name: CN=ESC3-Template2,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=daforest,DC=com
-[*]    Vulnerable to: ESC3_TEMPLATE_2
-[*]    Certificate Template Enrollment SIDs:
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-512 (Domain Admins)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-513 (Domain Users)
-[*]       * S-1-5-21-3290009963-1772292745-3260174523-519 (Enterprise Admins)
-[*]    Issuing CAs:
-[*]       * daforest-WIN-BR0CCBA815B-CA
-[*]          Server: WIN-BR0CCBA815B.daforest.com
-[*]          Enrollment SIDs:
-[*]             * S-1-5-11 (Authenticated Users)
-[*] Auxiliary module execution completed
-msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) >
 ```

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -2,12 +2,23 @@ class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::LDAP
   include Msf::OptionalSession::LDAP
+  include Rex::Proto::Secauthz
 
   ADS_GROUP_TYPE_BUILTIN_LOCAL_GROUP = 0x00000001
   ADS_GROUP_TYPE_GLOBAL_GROUP = 0x00000002
   ADS_GROUP_TYPE_DOMAIN_LOCAL_GROUP = 0x00000004
   ADS_GROUP_TYPE_SECURITY_ENABLED = 0x80000000
   ADS_GROUP_TYPE_UNIVERSAL_GROUP = 0x00000008
+
+  SID = Struct.new(:value, :name) do
+    def to_s
+      name.present? ? "#{value} (#{name})" : value
+    end
+
+    def rid
+      value.split('-').last.to_i
+    end
+  end
 
   def initialize(info = {})
     super(
@@ -53,7 +64,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
-      OptBool.new('REPORT_NONENROLLABLE', [true, 'Report nonenrollable certificate templates', false])
+      OptBool.new('REPORT_NONENROLLABLE', [true, 'Report nonenrollable certificate templates', false]),
+      OptBool.new('REPORT_PRIVENROLLABLE', [true, 'Report certificate templates restricted to domain and enterprise admins', false]),
     ])
   end
 
@@ -144,8 +156,8 @@ class MetasploitModule < Msf::Auxiliary
     returned_entries
   end
 
-  def query_ldap_server_certificates(esc_raw_filter, esc_name)
-    attributes = ['cn', 'description', 'ntSecurityDescriptor']
+  def query_ldap_server_certificates(esc_raw_filter, esc_name, notes: [])
+    attributes = ['cn', 'description', 'ntSecurityDescriptor', 'msPKI-Enrollment-Flag', 'msPKI-RA-Signature', 'PkiExtendedKeyUsage']
     base_prefix = 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration'
     esc_entries = query_ldap_server(esc_raw_filter, attributes, base_prefix: base_prefix)
 
@@ -165,12 +177,22 @@ class MetasploitModule < Msf::Auxiliary
 
       allowed_sids = parse_acl(security_descriptor.dacl) if security_descriptor.dacl
       next if allowed_sids.empty?
+      next if allowed_sids.empty?
 
       certificate_symbol = entry[:cn][0].to_sym
       if @vuln_certificate_details.key?(certificate_symbol)
         @vuln_certificate_details[certificate_symbol][:vulns] << esc_name
+        @vuln_certificate_details[certificate_symbol][:notes] += notes
       else
-        @vuln_certificate_details[certificate_symbol] = { vulns: [esc_name], dn: entry[:dn][0], certificate_enrollment_sids: convert_sids_to_human_readable_name(allowed_sids), ca_servers_n_enrollment_sids: {}, notes: [] }
+        @vuln_certificate_details[certificate_symbol] = {
+          vulns: [esc_name],
+          dn: entry[:dn][0],
+          certificate_enrollment_sids: convert_sids_to_human_readable_name(allowed_sids),
+          ca_servers_n_enrollment_sids: {},
+          manager_approval: ([entry[%s(mspki-enrollment-flag)].first.to_i].pack('l').unpack1('L') & Rex::Proto::MsCrtd::CT_FLAG_PEND_ALL_REQUESTS) != 0,
+          required_signatures: [entry[%s(mspki-ra-signature)].first.to_i].pack('l').unpack1('L'),
+          notes: notes
+        }
       end
     end
   end
@@ -193,16 +215,12 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    result = []
+    results = []
     output.each do |sid_string, sid_name, sam_account_name|
-      if sam_account_name
-        result << "#{sid_string} (#{sam_account_name})"
-      else
-        result << "#{sid_string} (#{sid_name})"
-      end
+      results << SID.new(sid_string, sam_account_name || sid_name)
     end
 
-    result.join(' | ')
+    results
   end
 
   def find_esc1_vuln_cert_templates
@@ -219,7 +237,10 @@ class MetasploitModule < Msf::Auxiliary
       ')'\
       '(mspki-certificate-name-flag:1.2.840.113556.1.4.804:=1)'\
     ')'
-    query_ldap_server_certificates(esc1_raw_filter, 'ESC1')
+    notes = [
+      'ESC1: Request can specify a subjectAltName (msPKI-Certificate-Name-Flag)'
+    ]
+    query_ldap_server_certificates(esc1_raw_filter, 'ESC1', notes: notes)
   end
 
   def find_esc2_vuln_cert_templates
@@ -232,8 +253,10 @@ class MetasploitModule < Msf::Auxiliary
         '(!(pkiextendedkeyusage=*))'\
       ')'\
     ')'
-
-    query_ldap_server_certificates(esc2_raw_filter, 'ESC2')
+    notes = [
+      'ESC2: Template defines the Any Purpose OID or no EKUs (PkiExtendedKeyUsage)'
+    ]
+    query_ldap_server_certificates(esc2_raw_filter, 'ESC2', notes: notes)
   end
 
   def find_esc3_vuln_cert_templates
@@ -249,7 +272,10 @@ class MetasploitModule < Msf::Auxiliary
       ')'\
       '(pkiextendedkeyusage=1.3.6.1.4.1.311.20.2.1)'\
     ')'
-    query_ldap_server_certificates(esc3_template_1_raw_filter, 'ESC3_TEMPLATE_1')
+    notes = [
+      'ESC3: Template defines the Certificate Request Agent OID (PkiExtendedKeyUsage)'
+    ]
+    query_ldap_server_certificates(esc3_template_1_raw_filter, 'ESC3_TEMPLATE_1', notes: notes)
 
     # Find the second vulnerable types of ESC3 templates, those that
     # have the right template schema version and, for those with a template
@@ -369,48 +395,79 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def print_vulnerable_cert_info
-    @vuln_certificate_details.each do |key, hash|
-      enrollable = true
-      if hash[:ca_servers_n_enrollment_sids].blank?
-        next unless datastore['REPORT_NONENROLLABLE']
-
-        enrollable = false
+    vuln_certificate_details = @vuln_certificate_details.select do |_key, hash|
+      select = true
+      select = false unless datastore['REPORT_PRIVENROLLABLE'] || hash[:certificate_enrollment_sids].any? do |sid|
+        # compare based on RIDs to avoid issues language specific issues
+        !(sid.value.starts_with?("#{WellKnownSids::SECURITY_NT_NON_UNIQUE}-") && [
+          # RID checks
+          WellKnownSids::DOMAIN_GROUP_RID_ADMINS,
+          WellKnownSids::DOMAIN_GROUP_RID_ENTERPRISE_ADMINS,
+          WellKnownSids::DOMAIN_GROUP_RID_ENTERPRISE_READONLY_DOMAIN_CONTROLLERS,
+          WellKnownSids::DOMAIN_GROUP_RID_CONTROLLERS,
+          WellKnownSids::DOMAIN_GROUP_RID_SCHEMA_ADMINS
+        ].include?(sid.rid)) && ![
+          # SID checks
+          WellKnownSids::SECURITY_ENTERPRISE_CONTROLLERS_SID
+        ].include?(sid.value)
       end
 
-      print_status("Template: #{key}")
-      unless enrollable
-        print_warning("   #{key} not published as an enrollable certificate!")
-      end
+      select = false unless datastore['REPORT_NONENROLLABLE'] || hash[:ca_servers_n_enrollment_sids].any?
+      select
+    end
 
-      print_status("   Distinguished Name: #{hash[:dn]}")
-      print_status("   Vulnerable to: #{hash[:vulns].join(', ')}")
+    any_esc3t1 = vuln_certificate_details.values.any? do |hash|
+      hash[:vulns].include?('ESC3_TEMPLATE_1') && (datastore['REPORT_NONENROLLABLE'] || hash[:ca_servers_n_enrollment_sids].any?)
+    end
+
+    vuln_certificate_details.each do |key, hash|
+      vulns = hash[:vulns]
+      vulns.delete('ESC3_TEMPLATE_2') unless any_esc3t1 # don't report ESC3_TEMPLATE_2 if there are no instances of ESC3_TEMPLATE_1
+      next if vulns.empty?
+
+      print_good("Template: #{key}")
+
+      print_status("  Distinguished Name: #{hash[:dn]}")
+      print_status("  Manager Approval: #{hash[:manager_approval] ? '%redRequired' : '%grnDisabled'}%clr")
+      print_status("  Required Signatures: #{hash[:required_signatures] == 0 ? '%grn0' : '%red' + hash[:required_signatures].to_s}%clr")
+      print_good("  Vulnerable to: #{vulns.join(', ')}")
       if hash[:notes].present? && hash[:notes].length == 1
-        print_status("   Notes: #{hash[:notes].first}")
+        print_status("  Notes: #{hash[:notes].first}")
       elsif hash[:notes].present? && hash[:notes].length > 1
-        print_status('   Notes:')
+        print_status('  Notes:')
         hash[:notes].each do |note|
-          print_status("     * #{note}")
+          print_status("    * #{note}")
         end
       end
 
-      print_status('   Certificate Template Enrollment SIDs:')
-      for sid in hash[:certificate_enrollment_sids].split(' | ')
-        print_status("      * #{sid}")
+      print_status('  Certificate Template Enrollment SIDs:')
+      hash[:certificate_enrollment_sids].each do |sid|
+        print_status("    * #{highlight_sid(sid)}")
       end
 
-      next unless enrollable
-
-      for ca_hostname, ca_hash in hash[:ca_servers_n_enrollment_sids]
-        print_status('   Issuing CAs:')
-        print_status("      * #{ca_hash[:cn]}")
-        print_status("         Server: #{ca_hostname}")
-        print_status('         Enrollment SIDs:')
-        sid_list_string = convert_sids_to_human_readable_name(ca_hash[:ca_enrollment_sids])
-        for sid_info in sid_list_string.split(' | ')
-          print_status("            * #{sid_info}")
+      if hash[:ca_servers_n_enrollment_sids].any?
+        hash[:ca_servers_n_enrollment_sids].each do |ca_hostname, ca_hash|
+          print_good("  Issuing CA: #{ca_hash[:cn]} (#{ca_hostname})")
+          print_status('    Enrollment SIDs:')
+          convert_sids_to_human_readable_name(ca_hash[:ca_enrollment_sids]).each do |sid|
+            print_status("      * #{highlight_sid(sid)}")
+          end
         end
+      else
+        print_warning('   Issuing CAs: none (not published as an enrollable certificate)')
       end
     end
+  end
+
+  def highlight_sid(sid)
+    color = ''
+    color = '%grn' if sid.value == WellKnownSids::SECURITY_AUTHENTICATED_USER_SID
+    if sid.value.starts_with?("#{WellKnownSids::SECURITY_NT_NON_UNIQUE}-")
+      color = '%grn' if sid.rid == WellKnownSids::DOMAIN_GROUP_RID_USERS
+      color = '%grn' if sid.rid == WellKnownSids::DOMAIN_GROUP_RID_GUESTS
+      color = '%grn' if sid.rid == WellKnownSids::DOMAIN_GROUP_RID_COMPUTERS
+    end
+    "#{color}#{sid.value} (#{sid.name})%clr"
   end
 
   def get_pki_object_by_oid(oid)


### PR DESCRIPTION
This makes a few changes to the output of the `auxiliary/gather/ldap_esc_vulnerable_cert_finder` module to make things easier for reporting These are the main changes:

* Templates vulnerable to `ESC3_Template_2` are ignored unless there is at least 1 template identified as being vulnerable to `ESC3_Template_1` or the template is also vulnerable to another misconfiguration.
* Templates that are *only* enrollable by highly privileged accounts (domain admins, enterprise admins, etc) are filtered out by default. This can be changed by setting `REPORT_PRIVENROLLABLE` to true. If there is at least one group other than what is filtered out, then the template and all of its groups will be displayed.
* More information is displayed regarding *why* the template is vulnerable. This is two fields included for all templates, `Manager Approval` and `Required Signatures` which will almost always be disabled and 0 respectively because they're filtered out at the LDAP query level before additional processing takes place. Noting these values though is helpful for reporting purposes to remind why the template is usable. Additional notes are populated for ESC specific flaws as well, e.g. "ESC1: Request can specify a subjectAltName (msPKI-Certificate-Name-Flag)"
* Output was tweaked so some results show up prefixed with `[+] ` using Metasploit's `#print_good` which allows for easier grepping from logs to get the very high level info to identify attack paths.
* Output was tweaked so some SIDs that are low-privileged are highlighted in green (users, guests and computers), all other SIDs show up normally with no colorization

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_esc_vulnerable_cert_finder`
- [x] Run the module and see the new output


![image](https://github.com/user-attachments/assets/5c507e7a-62c8-4801-a843-27d4d6b607d4)
