### PR TITLE
Remove some useless code in modules/encoders/php/base64.rb

### DIFF
--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -56,10 +56,6 @@ class MetasploitModule < Msf::Encoder
     # raw string, so strip it off.
     b64.gsub!(/[=\n]+/, '')
 
-    # The first character must not be a non-alpha character or PHP chokes.
-    i = 0
-    b64[i] = "chr(#{b64[i]})." while (b64[i].chr =~ %r{[0-9/+]})
-
     # Similarly, when we separate large payloads into chunks to avoid the
     # 998-byte problem mentioned above, we have to make sure that the first
     # character of each chunk is an alpha character.  This simple algorithm


### PR DESCRIPTION
The payload is always quoted since 975de9d4795, so there is no need to care if the first character is alpha or not. This has some chance to make the payload 5 chars smaller, woo!