### PR TITLE
Rename `Acceptance::Meterpreter` module to `Acceptance::Session`

### DIFF
--- a/.github/workflows/meterpreter_acceptance.yml
+++ b/.github/workflows/meterpreter_acceptance.yml
@@ -98,8 +98,8 @@ jobs:
       metasploitPayloadsCommit: ${{ github.event.inputs.metasploitPayloadsCommit || 'master' }}
       mettleCommit: ${{ github.event.inputs.mettleCommit|| 'master' }}
       HOST_RUNNER_IMAGE: ${{ matrix.os }}
-      METERPRETER: ${{ matrix.meterpreter.name }}
-      METERPRETER_RUNTIME_VERSION: ${{ matrix.meterpreter.runtime_version }}
+      SESSION: 'meterpreter/${{ matrix.meterpreter.name }}'
+      SESSION_RUNTIME_VERSION: ${{ matrix.meterpreter.runtime_version }}
       BUNDLE_WITHOUT: "coverage development"
 
     name: ${{ matrix.meterpreter.name }} ${{ matrix.meterpreter.runtime_version }} ${{ matrix.os }}

--- a/spec/acceptance/README.md
+++ b/spec/acceptance/README.md
@@ -10,8 +10,8 @@ There is no remote host support currently.
 ### Meterpreter
 
 Useful environment variables:
-- `METERPRETER` - Filter the test suite for specific Meterpreter instances, example: `METERPRETER=java`
-- `METERPRETER_MODULE_TEST` - Filter the post modules to run, example: `METERPRETER_MODULE_TEST=test/meterpreter`
+- `SESSION` - Filter the test suite for specific Meterpreter instances, example: `SESSION=meterpreter/java`
+- `SESSION_MODULE_TEST` - Filter the post modules to run, example: `SESSION_MODULE_TEST=test/meterpreter`
 - `SPEC_HELPER_LOAD_METASPLOIT` - Skip RSpec from loading Metasploit framework and requiring a connected msfdb instance, example: `SPEC_HELPER_LOAD_METASPLOIT=false`
 
 Running Meterpreter test suite:
@@ -30,13 +30,17 @@ Run a specific Meterpreter/module test Unix / Windows:
 
 Bash command:
 ```
-SPEC_OPTS='--tag acceptance' METERPRETER=php METERPRETER_MODULE_TEST=post/test/unix bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+SPEC_OPTS='--tag acceptance' SESSION=meterpreter/php SESSION_MODULE_TEST=post/test/unix bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
 ```
 
 Powershell command:
 ```
-$env:SPEC_OPTS='--tag acceptance'; $env:SPEC_HELPER_LOAD_METASPLOIT=$false; $env:METERPRETER = 'php'; bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
+$env:SPEC_OPTS='--tag acceptance'; $env:SPEC_HELPER_LOAD_METASPLOIT=$false; $env:SESSION = 'meterpreter/php'; bundle exec rspec './spec/acceptance/meterpreter_spec.rb'
 ```
+
+Session types can be specified via the `SESSION` argument. Meterpreter and command shell are support and use the following notation:
+- SESSION=meterpreter/php
+- SESSION=command_shell/php
 
 ### Postgres
 

--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'LDAP modules' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Meterpreter.current_platform }
+  let_it_be(:current_platform) { Acceptance::Session.current_platform }
 
   # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
   let_it_be(:driver) do
@@ -196,7 +196,7 @@ RSpec.describe 'LDAP modules' do
         end
 
         validated_lines.each do |test_line|
-          test_line = Acceptance::Meterpreter.uncolorize(test_line)
+          test_line = Acceptance::Session.uncolorize(test_line)
           expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
         end
 
@@ -286,12 +286,12 @@ RSpec.describe 'LDAP modules' do
   tests.each do |runtime_name, test_config|
     runtime_name = "#{runtime_name}#{ENV.fetch('RUNTIME_VERSION', '')}"
 
-    describe "#{Acceptance::Meterpreter.current_platform}/#{runtime_name}", focus: test_config[:focus] do
+    describe "#{Acceptance::Session.current_platform}/#{runtime_name}", focus: test_config[:focus] do
       test_config[:module_tests].each do |module_test|
         describe(
           module_test[:name],
           if:
-            Acceptance::Meterpreter.supported_platform?(module_test)
+            Acceptance::Session.supported_platform?(module_test)
         ) do
           let(:target) { Acceptance::Target.new(test_config[:target]) }
 
@@ -352,7 +352,7 @@ RSpec.describe 'LDAP modules' do
 
           context 'when targeting a session', if: module_test[:targets].include?(:session) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 # Ensure we have a valid session id; We intentionally omit this from a `before(:each)` to ensure the allure attachments are generated if the session dies
@@ -379,7 +379,7 @@ RSpec.describe 'LDAP modules' do
 
           context 'when targeting an rhost', if: module_test[:targets].include?(:rhost) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"

--- a/spec/acceptance/meterpreter_spec.rb
+++ b/spec/acceptance/meterpreter_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe 'Meterpreter' do
   include_context 'wait_for_expect'
 
   # Tests to ensure that Meterpreter is consistent across all implementations/operation systems
-  METERPRETER_PAYLOADS = Acceptance::Meterpreter.with_meterpreter_name_merged(
+  METERPRETER_PAYLOADS = Acceptance::Session.with_session_name_merged(
     {
-      python: Acceptance::Meterpreter::PYTHON_METERPRETER,
-      php: Acceptance::Meterpreter::PHP_METERPRETER,
-      java: Acceptance::Meterpreter::JAVA_METERPRETER,
-      mettle: Acceptance::Meterpreter::METTLE_METERPRETER,
-      windows_meterpreter: Acceptance::Meterpreter::WINDOWS_METERPRETER
+      python: Acceptance::Session::PYTHON_METERPRETER,
+      php: Acceptance::Session::PHP_METERPRETER,
+      java: Acceptance::Session::JAVA_METERPRETER,
+      mettle: Acceptance::Session::METTLE_METERPRETER,
+      windows_meterpreter: Acceptance::Session::WINDOWS_METERPRETER
     }
   )
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Meterpreter::current_platform }
+  let_it_be(:current_platform) { Acceptance::Session::current_platform }
 
   # @!attribute [r] port_allocator
   #   @return [Acceptance::PortAllocator]
@@ -55,10 +55,10 @@ RSpec.describe 'Meterpreter' do
     describe meterpreter_runtime_name, focus: meterpreter_config[:focus] do
       meterpreter_config[:payloads].each.with_index do |payload_config, payload_config_index|
         describe(
-          Acceptance::Meterpreter.human_name_for_payload(payload_config).to_s,
+          Acceptance::Session.human_name_for_payload(payload_config).to_s,
           if: (
-            Acceptance::Meterpreter.run_meterpreter?(meterpreter_config) &&
-              Acceptance::Meterpreter.supported_platform?(payload_config)
+            Acceptance::Session.run_meterpreter?(meterpreter_config) &&
+              Acceptance::Session.supported_platform?(payload_config)
           )
         ) do
           let(:payload) { Acceptance::Payload.new(payload_config) }
@@ -183,18 +183,18 @@ RSpec.describe 'Meterpreter' do
             console.reset
           end
 
-          context "#{Acceptance::Meterpreter.current_platform}" do
-            describe "#{Acceptance::Meterpreter.current_platform}/#{meterpreter_runtime_name} Meterpreter successfully opens a session for the #{payload_config[:name].inspect} payload" do
+          context "#{Acceptance::Session.current_platform}" do
+            describe "#{Acceptance::Session.current_platform}/#{meterpreter_runtime_name} Meterpreter successfully opens a session for the #{payload_config[:name].inspect} payload" do
               it(
                 "exposes available metasploit commands",
                 if: (
                   # Assume that regardless of payload, staged/unstaged/etc, the Meterpreter will have the same commands available
                   # So only run this test when config_index == 0
-                  payload_config_index == 0 && Acceptance::Meterpreter.supported_platform?(payload_config)
-                  # Run if ENV['METERPRETER'] = 'java php' etc
-                  Acceptance::Meterpreter.run_meterpreter?(meterpreter_config) &&
+                  payload_config_index == 0 && Acceptance::Session.supported_platform?(payload_config)
+                  # Run if ENV['SESSION'] = 'java php' etc
+                  Acceptance::Session.run_meterpreter?(meterpreter_config) &&
                     # Only run payloads / tests, if the host machine can run them
-                    Acceptance::Meterpreter.supported_platform?(payload_config)
+                    Acceptance::Session.supported_platform?(payload_config)
                 )
               ) do
                 begin
@@ -332,17 +332,17 @@ RSpec.describe 'Meterpreter' do
             meterpreter_config[:module_tests].each do |module_test|
               describe module_test[:name].to_s, focus: module_test[:focus] do
                 it(
-                  "#{Acceptance::Meterpreter.current_platform}/#{meterpreter_runtime_name} meterpreter successfully opens a session for the #{payload_config[:name].inspect} payload and passes the #{module_test[:name].inspect} tests",
+                  "#{Acceptance::Session.current_platform}/#{meterpreter_runtime_name} meterpreter successfully opens a session for the #{payload_config[:name].inspect} payload and passes the #{module_test[:name].inspect} tests",
                   if: (
-                    # Run if ENV['METERPRETER'] = 'java php' etc
-                    Acceptance::Meterpreter.run_meterpreter?(meterpreter_config) &&
-                      # Run if ENV['METERPRETER_MODULE_TEST'] = 'test/cmd_exec' etc
-                      Acceptance::Meterpreter.run_meterpreter_module_test?(module_test[:name]) &&
+                    # Run if ENV['SESSION'] = 'java php' etc
+                    Acceptance::Session.run_meterpreter?(meterpreter_config) &&
+                      # Run if ENV['SESSION_MODULE_TEST'] = 'test/cmd_exec' etc
+                      Acceptance::Session.run_meterpreter_module_test?(module_test[:name]) &&
                       # Only run payloads / tests, if the host machine can run them
-                      Acceptance::Meterpreter.supported_platform?(payload_config) &&
-                      Acceptance::Meterpreter.supported_platform?(module_test) &&
+                      Acceptance::Session.supported_platform?(payload_config) &&
+                      Acceptance::Session.supported_platform?(module_test) &&
                       # Skip tests that are explicitly skipped, or won't pass in the current environment
-                      !Acceptance::Meterpreter.skipped_module_test?(module_test, allure_test_environment)
+                      !Acceptance::Session.skipped_module_test?(module_test, allure_test_environment)
                   ),
                   # test metadata - will appear in allure report
                   module_test: module_test[:name]
@@ -406,7 +406,7 @@ RSpec.describe 'Meterpreter' do
                       end
 
                       validated_lines.each do |test_line|
-                        test_line = Acceptance::Meterpreter.uncolorize(test_line)
+                        test_line = Acceptance::Session.uncolorize(test_line)
                         expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
                       end
 

--- a/spec/acceptance/mssql_spec.rb
+++ b/spec/acceptance/mssql_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Meterpreter::current_platform }
+  let_it_be(:current_platform) { Acceptance::Session::current_platform }
 
   # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
   let_it_be(:driver) do
@@ -183,7 +183,7 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
         end
 
         validated_lines.each do |test_line|
-          test_line = Acceptance::Meterpreter.uncolorize(test_line)
+          test_line = Acceptance::Session.uncolorize(test_line)
           expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
         end
 
@@ -272,12 +272,12 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
   tests.each do |runtime_name, test_config|
     runtime_name = "#{runtime_name}#{ENV.fetch('RUNTIME_VERSION', '')}"
 
-    describe "#{Acceptance::Meterpreter.current_platform}/#{runtime_name}", focus: test_config[:focus] do
+    describe "#{Acceptance::Session.current_platform}/#{runtime_name}", focus: test_config[:focus] do
       test_config[:module_tests].each do |module_test|
         describe(
           module_test[:name],
           if: (
-            Acceptance::Meterpreter.supported_platform?(module_test)
+            Acceptance::Session.supported_platform?(module_test)
           )
         ) do
           let(:target) { Acceptance::Target.new(test_config[:target]) }
@@ -340,7 +340,7 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
 
           context "when targeting a session", if: module_test[:targets].include?(:session) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 # Ensure we have a valid session id; We intentionally omit this from a `before(:each)` to ensure the allure attachments are generated if the session dies
@@ -365,7 +365,7 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
 
           context "when targeting an rhost", if: module_test[:targets].include?(:rhost) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Meterpreter::current_platform }
+  let_it_be(:current_platform) { Acceptance::Session::current_platform }
 
   # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
   let_it_be(:driver) do
@@ -161,7 +161,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
         end
 
         validated_lines.each do |test_line|
-          test_line = Acceptance::Meterpreter.uncolorize(test_line)
+          test_line = Acceptance::Session.uncolorize(test_line)
           expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
         end
 
@@ -250,12 +250,12 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
   tests.each do |runtime_name, test_config|
     runtime_name = "#{runtime_name}#{ENV.fetch('RUNTIME_VERSION', '')}"
 
-    describe "#{Acceptance::Meterpreter.current_platform}/#{runtime_name}", focus: test_config[:focus] do
+    describe "#{Acceptance::Session.current_platform}/#{runtime_name}", focus: test_config[:focus] do
       test_config[:module_tests].each do |module_test|
         describe(
           module_test[:name],
           if: (
-            Acceptance::Meterpreter.supported_platform?(module_test)
+            Acceptance::Session.supported_platform?(module_test)
           )
         ) do
           let(:target) { Acceptance::Target.new(test_config[:target]) }
@@ -318,7 +318,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
 
           context "when targeting a session", if: module_test[:targets].include?(:session) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 # Ensure we have a valid session id; We intentionally omit this from a `before(:each)` to ensure the allure attachments are generated if the session dies
@@ -343,7 +343,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
 
           context "when targeting an rhost", if: module_test[:targets].include?(:rhost) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"

--- a/spec/acceptance/postgres_spec.rb
+++ b/spec/acceptance/postgres_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Postgres sessions and postgres modules' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Meterpreter::current_platform }
+  let_it_be(:current_platform) { Acceptance::Session::current_platform }
 
   # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
   let_it_be(:driver) do
@@ -167,7 +167,7 @@ RSpec.describe 'Postgres sessions and postgres modules' do
         end
 
         validated_lines.each do |test_line|
-          test_line = Acceptance::Meterpreter.uncolorize(test_line)
+          test_line = Acceptance::Session.uncolorize(test_line)
           expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
         end
 
@@ -256,12 +256,12 @@ RSpec.describe 'Postgres sessions and postgres modules' do
   tests.each do |runtime_name, test_config|
     runtime_name = "#{runtime_name}#{ENV.fetch('RUNTIME_VERSION', '')}"
 
-    describe "#{Acceptance::Meterpreter.current_platform}/#{runtime_name}", focus: test_config[:focus] do
+    describe "#{Acceptance::Session.current_platform}/#{runtime_name}", focus: test_config[:focus] do
       test_config[:module_tests].each do |module_test|
         describe(
           module_test[:name],
           if: (
-            Acceptance::Meterpreter.supported_platform?(module_test)
+            Acceptance::Session.supported_platform?(module_test)
           )
         ) do
           let(:target) { Acceptance::Target.new(test_config[:target]) }
@@ -324,7 +324,7 @@ RSpec.describe 'Postgres sessions and postgres modules' do
 
           context "when targeting a session", if: module_test[:targets].include?(:session) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 # Ensure we have a valid session id; We intentionally omit this from a `before(:each)` to ensure the allure attachments are generated if the session dies
@@ -349,7 +349,7 @@ RSpec.describe 'Postgres sessions and postgres modules' do
 
           context "when targeting an rhost", if: module_test[:targets].include?(:rhost) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"

--- a/spec/acceptance/smb_spec.rb
+++ b/spec/acceptance/smb_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Meterpreter::current_platform }
+  let_it_be(:current_platform) { Acceptance::Session::current_platform }
 
   # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
   let_it_be(:driver) do
@@ -169,7 +169,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
         end
 
         validated_lines.each do |test_line|
-          test_line = Acceptance::Meterpreter.uncolorize(test_line)
+          test_line = Acceptance::Session.uncolorize(test_line)
           expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
         end
 
@@ -262,12 +262,12 @@ RSpec.describe 'SMB sessions and SMB modules' do
   tests.each do |runtime_name, test_config|
     runtime_name = "#{runtime_name}#{ENV.fetch('RUNTIME_VERSION', '')}"
 
-    describe "#{Acceptance::Meterpreter.current_platform}/#{runtime_name}", focus: test_config[:focus] do
+    describe "#{Acceptance::Session.current_platform}/#{runtime_name}", focus: test_config[:focus] do
       test_config[:module_tests].each do |module_test|
         describe(
           module_test[:name],
           if: (
-            Acceptance::Meterpreter.supported_platform?(module_test)
+            Acceptance::Session.supported_platform?(module_test)
           )
         ) do
           let(:target) { Acceptance::Target.new(test_config[:target]) }
@@ -330,7 +330,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
 
           context "when targeting a session", if: module_test[:targets].include?(:session) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 # Ensure we have a valid session id; We intentionally omit this from a `before(:each)` to ensure the allure attachments are generated if the session dies
@@ -355,7 +355,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
 
           context "when targeting an rhost", if: module_test[:targets].include?(:rhost) do
             it(
-              "#{Acceptance::Meterpreter.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
+              "#{Acceptance::Session.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"

--- a/spec/allure_config.rb
+++ b/spec/allure_config.rb
@@ -13,12 +13,12 @@ AllureRspec.configure do |config|
     ruby_version: RUBY_VERSION,
     host_runner_image: ENV['HOST_RUNNER_IMAGE'],
   }.compact
-  meterpreter_name = ENV['METERPRETER']
-  meterpreter_runtime_version = ENV['METERPRETER_RUNTIME_VERSION']
-  if meterpreter_name.present?
-    environment_properties[:meterpreter_name] = meterpreter_name
-    if meterpreter_runtime_version.present?
-      environment_properties[:meterpreter_runtime_version] = "#{meterpreter_name}#{meterpreter_runtime_version}"
+  session_name = ENV['SESSION']
+  session_runtime_version = ENV['SESSION_RUNTIME_VERSION']
+  if session_name.present?
+    environment_properties[:session_name] = session_name
+    if session_runtime_version.present?
+      environment_properties[:session_runtime_version] = "#{session_name}#{session_runtime_version}"
     end
   end
   environment_properties[:runtime_version] = ENV['RUNTIME_VERSION']

--- a/spec/support/acceptance/line_validation.rb
+++ b/spec/support/acceptance/line_validation.rb
@@ -47,9 +47,9 @@ module Acceptance
 
     private
 
-    # (see Acceptance::Meterpreter#eval_predicate)
+    # (see Acceptance::Session#eval_predicate)
     def evaluate_predicate(value, environment)
-      Acceptance::Meterpreter.eval_predicate(value, environment)
+      Acceptance::Session.eval_predicate(value, environment)
     end
   end
 end

--- a/spec/support/acceptance/session.rb
+++ b/spec/support/acceptance/session.rb
@@ -1,4 +1,4 @@
-module Acceptance::Meterpreter
+module Acceptance::Session
   # @return [Symbol] The current platform
   def self.current_platform
     host_os = RbConfig::CONFIG['host_os']
@@ -17,18 +17,35 @@ module Acceptance::Meterpreter
   # Allows restricting the tests of a specific Meterpreter's test suite with the METERPRETER environment variable
   # @return [TrueClass, FalseClass] True if the given Meterpreter should be run, false otherwise.
   def self.run_meterpreter?(meterpreter_config)
-    return true if ENV['METERPRETER'].blank?
+    return true if ENV['SESSION'].blank?
 
     name = meterpreter_config[:name].to_s
-    ENV['METERPRETER'].include?(name)
+    ENV['SESSION'].include?(name)
   end
 
   # Allows restricting the tests of a specific Meterpreter's test suite with the METERPRETER environment variable
   # @return [TrueClass, FalseClass] True if the given Meterpreter should be run, false otherwise.
   def self.run_meterpreter_module_test?(module_test)
-    return true if ENV['METERPRETER_MODULE_TEST'].blank?
+    return true if ENV['SESSION_MODULE_TEST'].blank?
 
-    ENV['METERPRETER_MODULE_TEST'].include?(module_test)
+    ENV['SESSION_MODULE_TEST'].include?(module_test)
+  end
+
+  # Allows restricting the tests of a specific session's test suite with the SESSION environment variable
+  # @return [TrueClass, FalseClass] True if the given session should be run, false otherwise.
+  def self.run_session?(session_config)
+    return true if ENV['SESSION'].blank?
+
+    name = session_config[:name].to_s
+    ENV['SESSION'].include?("command_shell/#{name}")
+  end
+
+  # Allows restricting the tests of a specific session's test suite with the SESSION environment variable
+  # @return [TrueClass, FalseClass] True if the given session should be run, false otherwise.
+  def self.run_session_module_test?(module_test)
+    return true if ENV['SESSION_MODULE_TEST'].blank?
+
+    ENV['SESSION_MODULE_TEST'].include?(module_test)
   end
 
   # @param [String] string A console string with ANSI escape codes present
@@ -54,8 +71,8 @@ module Acceptance::Meterpreter
   # @param [Hash] payload_config
   # @return [String] The human readable name for the given payload configuration
   def self.human_name_for_payload(payload_config)
-    is_stageless = payload_config[:name].include?('meterpreter_reverse_tcp')
-    is_staged = payload_config[:name].include?('meterpreter/reverse_tcp')
+    is_stageless = payload_config[:name].include?('_reverse_tcp')
+    is_staged = payload_config[:name].include?('/reverse_tcp')
 
     details = []
     details << 'stageless' if is_stageless
@@ -67,7 +84,7 @@ module Acceptance::Meterpreter
 
   # @param [Object] hash A hash of key => hash
   # @return [Object] Returns a new hash with the 'key' merged into hash value and all payloads
-  def self.with_meterpreter_name_merged(hash)
+  def self.with_session_name_merged(hash)
     hash.each_with_object({}) do |(name, config), acc|
       acc[name] = config.merge({ name: name })
     end
@@ -81,7 +98,7 @@ module Acceptance::Meterpreter
     case value
     when Array
       left_operand, operator, right_operand = value
-      # Map values such as `:meterpreter_name` to the runtime value
+      # Map values such as `:session_name` to the runtime value
       left_operand = environment[left_operand] if environment.key?(left_operand)
       right_operand = environment[right_operand] if environment.key?(right_operand)
 

--- a/spec/support/acceptance/session/java.rb
+++ b/spec/support/acceptance/session/java.rb
@@ -1,4 +1,4 @@
-module Acceptance::Meterpreter
+module Acceptance::Session
   JAVA_METERPRETER = {
     payloads: [
       {

--- a/spec/support/acceptance/session/mettle.rb
+++ b/spec/support/acceptance/session/mettle.rb
@@ -1,19 +1,37 @@
-module Acceptance::Meterpreter
-  PYTHON_METERPRETER = {
+module Acceptance::Session
+  METTLE_METERPRETER = {
     payloads: [
       {
-        name: "python/meterpreter_reverse_tcp",
-        extension: ".py",
-        platforms: [:osx, :linux, :windows],
-        execute_cmd: ["python", "${payload_path}"],
+        name: "linux/x64/meterpreter/reverse_tcp",
+        extension: "",
+        platforms: [:linux],
+        executable: true,
+        execute_cmd: ["${payload_path}"],
         generate_options: {
-          '-f': "raw"
+          '-f': "elf"
         },
         datastore: {
           global: {},
           module: {
             MeterpreterTryToFork: false,
-            PythonMeterpreterDebug: true
+            MeterpreterDebugBuild: true
+          }
+        }
+      },
+      {
+        name: "osx/x64/meterpreter_reverse_tcp",
+        extension: "",
+        platforms: [:osx],
+        executable: true,
+        execute_cmd: ["${payload_path}"],
+        generate_options: {
+          '-f': "macho"
+        },
+        datastore: {
+          global: {},
+          module: {
+            MeterpreterTryToFork: false,
+            MeterpreterDebugBuild: true
           }
         }
       }
@@ -47,34 +65,23 @@ module Acceptance::Meterpreter
             known_failures: []
           },
           windows: {
-            known_failures: [
-              "[-] [should start W32Time] FAILED: should start W32Time",
-              "[-] [should start W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
-              "[-] [should stop W32Time] FAILED: should stop W32Time",
-              "[-] [should stop W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
-              "[-] [should list services] FAILED: should list services",
-              "[-] [should list services] Exception: NoMethodError: undefined method `service' for nil:NilClass",
-              "[-] [should return info on a given service winmgmt] FAILED: should return info on a given service winmgmt",
-              "[-] [should return info on a given service winmgmt] Exception: NoMethodError: undefined method `service' for nil:NilClass",
-              "[-] FAILED: should create a service testes",
-              "[-] [should return info on the newly-created service testes] FAILED: should return info on the newly-created service testes",
-              "[-] [should return info on the newly-created service testes] Exception: NoMethodError: undefined method `service' for nil:NilClass",
-              "[-] [should delete the new service testes] FAILED: should delete the new service testes",
-              "[-] [should delete the new service testes] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
-              "[-] [should return status on a given service winmgmt] FAILED: should return status on a given service winmgmt",
-              "[-] [should return status on a given service winmgmt] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
-              "[-] [should modify config on a given service] FAILED: should modify config on a given service",
-              "[-] [should modify config on a given service] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
-              "[-] FAILED: should start a disabled service",
-              "[-] [should restart a started service W32Time] FAILED: should restart a started service W32Time",
-              "[-] [should restart a started service W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6."
-            ]
+            known_failures: []
           }
         }
       },
       {
         name: "post/test/cmd_exec",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
@@ -90,7 +97,17 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/extapi",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
@@ -100,18 +117,23 @@ module Acceptance::Meterpreter
             known_failures: []
           },
           windows: {
-            known_failures: [
-              "[-] [should return clipboard jpg dimensions] FAILED: should return clipboard jpg dimensions",
-              "[-] [should return clipboard jpg dimensions] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass",
-              "[-] [should download clipboard jpg data] FAILED: should download clipboard jpg data",
-              "[-] [should download clipboard jpg data] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass"
-            ]
+            known_failures: []
           }
         }
       },
       {
         name: "post/test/file",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
@@ -127,7 +149,17 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/get_env",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
@@ -143,25 +175,46 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/meterpreter",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
             known_failures: []
           },
           osx: {
-            known_failures: []
+            known_failures: [
+              "[-] FAILED: should return network interfaces",
+              "[-] FAILED: should have an interface that matches session_host"
+            ]
           },
           windows: {
-            known_failures: [
-              "[-] FAILED: should return the proper directory separator"
-            ]
+            known_failures: []
           }
         }
       },
       {
         name: "post/test/railgun",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
@@ -177,7 +230,17 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/railgun_reverse_lookups",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {
@@ -225,7 +288,23 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/search",
-        platforms: [:linux, :osx, :windows],
+        platforms: [
+          :linux,
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "skipped - test/search hangs in osx and CPU spikes to >300%"
+            }
+          ],
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
         skipped: false,
         lines: {
           linux: {

--- a/spec/support/acceptance/session/php.rb
+++ b/spec/support/acceptance/session/php.rb
@@ -1,4 +1,4 @@
-module Acceptance::Meterpreter
+module Acceptance::Session
   PHP_METERPRETER = {
     payloads: [
       {

--- a/spec/support/acceptance/session/python.rb
+++ b/spec/support/acceptance/session/python.rb
@@ -1,21 +1,19 @@
-module Acceptance::Meterpreter
-  WINDOWS_METERPRETER = {
+module Acceptance::Session
+  PYTHON_METERPRETER = {
     payloads: [
       {
-        name: "windows/meterpreter/reverse_tcp",
-        extension: ".exe",
-        platforms: [:windows],
-        execute_cmd: ["${payload_path}"],
-        executable: true,
+        name: "python/meterpreter_reverse_tcp",
+        extension: ".py",
+        platforms: [:osx, :linux, :windows],
+        execute_cmd: ["python", "${payload_path}"],
         generate_options: {
-          '-f': "exe"
+          '-f': "raw"
         },
         datastore: {
           global: {},
           module: {
-            # Not supported by Windows Meterpreter
-            # MeterpreterTryToFork: false,
-            MeterpreterDebugBuild: true
+            MeterpreterTryToFork: false,
+            PythonMeterpreterDebug: true
           }
         }
       }
@@ -49,29 +47,34 @@ module Acceptance::Meterpreter
             known_failures: []
           },
           windows: {
-            known_failures: []
+            known_failures: [
+              "[-] [should start W32Time] FAILED: should start W32Time",
+              "[-] [should start W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
+              "[-] [should stop W32Time] FAILED: should stop W32Time",
+              "[-] [should stop W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
+              "[-] [should list services] FAILED: should list services",
+              "[-] [should list services] Exception: NoMethodError: undefined method `service' for nil:NilClass",
+              "[-] [should return info on a given service winmgmt] FAILED: should return info on a given service winmgmt",
+              "[-] [should return info on a given service winmgmt] Exception: NoMethodError: undefined method `service' for nil:NilClass",
+              "[-] FAILED: should create a service testes",
+              "[-] [should return info on the newly-created service testes] FAILED: should return info on the newly-created service testes",
+              "[-] [should return info on the newly-created service testes] Exception: NoMethodError: undefined method `service' for nil:NilClass",
+              "[-] [should delete the new service testes] FAILED: should delete the new service testes",
+              "[-] [should delete the new service testes] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
+              "[-] [should return status on a given service winmgmt] FAILED: should return status on a given service winmgmt",
+              "[-] [should return status on a given service winmgmt] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
+              "[-] [should modify config on a given service] FAILED: should modify config on a given service",
+              "[-] [should modify config on a given service] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
+              "[-] FAILED: should start a disabled service",
+              "[-] [should restart a started service W32Time] FAILED: should restart a started service W32Time",
+              "[-] [should restart a started service W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6."
+            ]
           }
         }
       },
       {
         name: "post/test/cmd_exec",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -87,23 +90,7 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/extapi",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -113,29 +100,18 @@ module Acceptance::Meterpreter
             known_failures: []
           },
           windows: {
-            known_failures: []
+            known_failures: [
+              "[-] [should return clipboard jpg dimensions] FAILED: should return clipboard jpg dimensions",
+              "[-] [should return clipboard jpg dimensions] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass",
+              "[-] [should download clipboard jpg data] FAILED: should download clipboard jpg data",
+              "[-] [should download clipboard jpg data] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass"
+            ]
           }
         }
       },
       {
         name: "post/test/file",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -151,23 +127,7 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/get_env",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -183,23 +143,7 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/meterpreter",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -209,29 +153,15 @@ module Acceptance::Meterpreter
             known_failures: []
           },
           windows: {
-            known_failures: []
+            known_failures: [
+              "[-] FAILED: should return the proper directory separator"
+            ]
           }
         }
       },
       {
         name: "post/test/railgun",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -247,23 +177,7 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/railgun_reverse_lookups",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {
@@ -311,23 +225,7 @@ module Acceptance::Meterpreter
       },
       {
         name: "post/test/search",
-        platforms: [
-          [
-            :linux,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          [
-            :osx,
-            {
-              skip: true,
-              reason: "Payload not compiled for platform"
-            }
-          ],
-          :windows
-        ],
+        platforms: [:linux, :osx, :windows],
         skipped: false,
         lines: {
           linux: {

--- a/spec/support/acceptance/session/windows_meterpreter.rb
+++ b/spec/support/acceptance/session/windows_meterpreter.rb
@@ -1,36 +1,20 @@
-module Acceptance::Meterpreter
-  METTLE_METERPRETER = {
+module Acceptance::Session
+  WINDOWS_METERPRETER = {
     payloads: [
       {
-        name: "linux/x64/meterpreter/reverse_tcp",
-        extension: "",
-        platforms: [:linux],
-        executable: true,
+        name: "windows/meterpreter/reverse_tcp",
+        extension: ".exe",
+        platforms: [:windows],
         execute_cmd: ["${payload_path}"],
+        executable: true,
         generate_options: {
-          '-f': "elf"
+          '-f': "exe"
         },
         datastore: {
           global: {},
           module: {
-            MeterpreterTryToFork: false,
-            MeterpreterDebugBuild: true
-          }
-        }
-      },
-      {
-        name: "osx/x64/meterpreter_reverse_tcp",
-        extension: "",
-        platforms: [:osx],
-        executable: true,
-        execute_cmd: ["${payload_path}"],
-        generate_options: {
-          '-f': "macho"
-        },
-        datastore: {
-          global: {},
-          module: {
-            MeterpreterTryToFork: false,
+            # Not supported by Windows Meterpreter
+            # MeterpreterTryToFork: false,
             MeterpreterDebugBuild: true
           }
         }
@@ -72,15 +56,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/cmd_exec",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -98,15 +88,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/extapi",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -124,15 +120,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/file",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -150,15 +152,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/get_env",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -176,15 +184,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/meterpreter",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -192,10 +206,7 @@ module Acceptance::Meterpreter
             known_failures: []
           },
           osx: {
-            known_failures: [
-              "[-] FAILED: should return network interfaces",
-              "[-] FAILED: should have an interface that matches session_host"
-            ]
+            known_failures: []
           },
           windows: {
             known_failures: []
@@ -205,15 +216,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/railgun",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -231,15 +248,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/railgun_reverse_lookups",
         platforms: [
-          :linux,
-          :osx,
           [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {
@@ -289,21 +312,21 @@ module Acceptance::Meterpreter
       {
         name: "post/test/search",
         platforms: [
-          :linux,
           [
-            :osx,
-            {
-              skip: true,
-              reason: "skipped - test/search hangs in osx and CPU spikes to >300%"
-            }
-          ],
-          [
-            :windows,
+            :linux,
             {
               skip: true,
               reason: "Payload not compiled for platform"
             }
-          ]
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
         ],
         skipped: false,
         lines: {


### PR DESCRIPTION
This PR renames `Acceptance::Meterpreter` module to `Acceptance::Session`. This has been done as more tests have now been added to our acceptance testing. In this [PR](https://github.com/rapid7/metasploit-framework/pull/19413) we will be adding command shell acceptance testing ontop of our existing Meterpreter testing. So this PR is in preparation to adding those new tests.

## Verification
 - [ ] Code changes are sane
 - [ ] Acceptance tests pass (use [ReadMe](https://github.com/rapid7/metasploit-framework/pull/19428/files#diff-9ecacac14ce6f04291584bb29781580dca674a4efbe8c8daa6cf384d55985a53) to test this locally as well)