### PR TITLE
Add an encoder to minify php payloads

### DIFF
--- a/modules/encoders/php/minify.rb
+++ b/modules/encoders/php/minify.rb
@@ -1,0 +1,42 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder
+  Rank = GreatRanking
+
+  def initialize
+    super(
+      'Name' => 'PHP Minify Encoder',
+      'Description' => %q{
+        This encoder minifies a PHP payload by removing leasing spaces, trailing
+        new lines, comments, …
+      },
+      'Author' => 'Julien Voisin',
+      'License' => BSD_LICENSE,
+      'Arch' => ARCH_PHP)
+  end
+
+  def encode_block(_, buf)
+    # Remove comments
+    buf.gsub!(/^\s*#.*$/, '')
+
+    # Remove spaces after keywords
+    buf.gsub!(/^\s*(if|else|elsif|while|for|foreach)\s*\(/, '\1(')
+
+    # Remove spaces before block opening
+    buf.gsub!(/\s*{$/, '{')
+
+    # Remove empty lines
+    buf.squeeze!("\n")
+
+    # Remove leading/trailing spaces
+    buf.gsub!(/^[ \t]+/, '')
+
+    # Remove new lines
+    buf.gsub!(/([;{}])\n/, '\1')
+
+    return buf
+  end
+end


### PR DESCRIPTION
```console
$ ./msfvenom --platform php -a php -p php/reverse_php | ./msfvenom -e php/base64 --platform php -a php | php -l
Attempting to read payload from STDIN...
No encoder specified, outputting raw payload
Payload size: 3010 bytes
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of php/base64
php/base64 succeeded with size 4052 (iteration=0)
php/base64 chosen with final size 4052
Payload size: 4052 bytes

No syntax errors detected in Standard input code
$ ./msfvenom --platform php -a php -p php/reverse_php -e php/minify | ./msfvenom -e php/base64 --platform php -a php | php -l
Attempting to read payload from STDIN...
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of php/minify
php/minify succeeded with size 2109 (iteration=0)
php/minify chosen with final size 2109
Payload size: 2109 bytes

Found 1 compatible encoders
Attempting to encode payload with 1 iterations of php/base64
php/base64 succeeded with size 2839 (iteration=0)
php/base64 chosen with final size 2839
Payload size: 2839 bytes

No syntax errors detected in Standard input code
$
```