### PR TITLE
bypassuac_comhijack: Specify x86/x64 as supported payload architectures

### DIFF
--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
           'OJ Reeves'       # MSF module
         ],
         'Platform' => ['win'],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => ['meterpreter'],
         'Targets' => [
           ['Automatic', {}]


### PR DESCRIPTION
Prior to this change, users could not `set` Windows x64 payloads for the `exploit/windows/local/bypassuac_comhijack` module within `msfconsole`:

```
msf6 exploit(windows/local/bypassuac_comhijack) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/local/bypassuac_comhijack) > set session 1
session => 1
msf6 exploit(windows/local/bypassuac_comhijack) > run

[-] Exploit failed: windows/x64/meterpreter/reverse_tcp is not a compatible payload.
[*] Exploit completed, but no session was created.
```

After this change, users can now select x64 Windows payloads.

Apparently this used to work, but broke, indicating that framework behavior for modules missing `arch` may have changed at some point.

Context https://github.com/rapid7/metasploit-framework/issues/7926#issuecomment-2329113807
