### PR TITLE
CVE-2022-0995 - Fix an exception when the target is not Ubuntu

### DIFF
--- a/modules/exploits/linux/local/cve_2022_0995_watch_queue.rb
+++ b/modules/exploits/linux/local/cve_2022_0995_watch_queue.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::BadConfig, 'DEBUG_PRINT is only supported when COMPILE is set to True')
     end
     unless kernel_version =~ /[uU]buntu/
-      fail_with(Failure::NoTarget, "Unsupported Distro: '#{version}'")
+      fail_with(Failure::NoTarget, "Unsupported Distro: '#{kernel_version}'")
     end
     arch = kernel_hardware
     unless arch.include?('x86_64')


### PR DESCRIPTION
While testing #19410 I ran a bunch of LPE modules on a Fedora target to ensure they would compile their source code with clang. This one through an exception instead of failing gracefully due to a typo when the kernel is not Ubuntu.

## Testing

- [ ] Run the module on a target other than Ubuntu to trigger the failure condition and the exception

## Old and broken
```
msf6 exploit(linux/local/cve_2022_0995_watch_queue) > run

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Failed to parse the kernel version data: 6.10.7-200.fc40.x86_64
[!] Cannot reliably check exploitability. Failed to obtain kernel version ForceExploit is enabled, proceeding with exploitation.
[-] Exploit failed: NameError undefined local variable or method `version' for #<Module:exploit/linux/local/cve_2022_0995_watch_queue datastore=[#<Msf::ModuleDataStoreWithFallbacks:0x00007fe796617c88 @options={"WORKSPACE"=>#<Msf::OptString:0x00007fe7962d70c8 @name="WORKSPACE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Specify the workspace for this module", @default=nil, @enums=[], @owner=Msf::Module>, "VERBOSE"=>#<Msf::OptBool:0x00007fe7962d6768 @name="VERBOSE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Enable detailed status messages", @default=false, @enums=[], @owner=Msf::Module>, "WfsDelay"=>#<Msf::OptInt:0x00007fe796ef0918 @name="WfsDelay", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Additional delay in seconds to wait for a session", @default=2, @enums=[], @owner=Msf::Exploit>, "EnableContextEncoding"=>#<Msf::OptBool:0x00007fe796f06e70 @name="EnableContextEncoding", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use transient context when encoding payloads", @default=false, @enums=[], @owner=Msf::Exploit>, "ContextInformationFile"=>#<Msf::OptPath:0x00007fe796f060d8 @name="ContextInformationFile", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The information file that contains context information", @default=nil, @enums=[], @owner=Msf::Exploit>, "DisablePayloadHandler"=>#<Msf::OptBool:0x00007fe796f05228 @name="DisablePayloadHandler", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Disable the handler code for the selected payload", @default=false, @enums=[], @owner=Msf::Exploit>, "SESSION"=>#<Msf::OptInt:0x00007fe796e597e8 @name="SESSION", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="The session to run this module on", @default=nil, @enums=[], @owner=Msf::Post>, "COMPILE"=>#<Msf::OptEnum:0x00007fe796e663a8 @name="COMPILE", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc_string="Compile on target", @default="Auto", @enums=["Auto", "True", "False"], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "COMPILER"=>#<Msf::OptEnum:0x00007fe796e65980 @name="COMPILER", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc_string="Compiler to use on target", @default="gcc", @enums=["gcc", "clang"], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::EICAR"=>#<Msf::OptBool:0x00007fe796e71b68 @name="EXE::EICAR", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Generate an EICAR file instead of regular payload exe", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Custom"=>#<Msf::OptPath:0x00007fe796e715a0 @name="EXE::Custom", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use custom exe instead of automatically generating a payload exe", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Path"=>#<Msf::OptPath:0x00007fe796e71168 @name="EXE::Path", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The directory in which to look for the executable template", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Template"=>#<Msf::OptPath:0x00007fe796e70d80 @name="EXE::Template", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The executable template file name.", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Inject"=>#<Msf::OptBool:0x00007fe796e70b78 @name="EXE::Inject", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Set to preserve the original EXE function", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::OldMethod"=>#<Msf::OptBool:0x00007fe796e70768 @name="EXE::OldMethod", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Set to use the substitution EXE generation method.", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::FallBack"=>#<Msf::OptBool:0x00007fe796e70470 @name="EXE::FallBack", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use the default template in case the specified one is missing", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::EICAR"=>#<Msf::OptBool:0x00007fe796e70100 @name="MSI::EICAR", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Generate an EICAR file instead of regular payload msi", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::Custom"=>#<Msf::OptPath:0x00007fe796e77db0 @name="MSI::Custom", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use custom msi instead of automatically generating a payload msi", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::Path"=>#<Msf::OptPath:0x00007fe796e771f8 @name="MSI::Path", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The directory in which to look for the msi template", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::Template"=>#<Msf::OptPath:0x00007fe796e76c08 @name="MSI::Template", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The msi template file name", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::UAC"=>#<Msf::OptBool:0x00007fe796e765f0 @name="MSI::UAC", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "FileDropperDelay"=>#<Msf::OptInt:0x00007fe796dee3a8 @name="FileDropperDelay", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Delay in seconds before attempting cleanup", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "AllowNoCleanup"=>#<Msf::OptBool:0x00007fe796dee088 @name="AllowNoCleanup", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Allow exploitation without the possibility of cleaning up files", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "DEBUG_SOURCE"=>#<Msf::OptBool:0x00007fe796e0a008 @name="DEBUG_SOURCE", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use source code with debug prints to help troubleshoot", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "WritableDir"=>#<Msf::OptString:0x00007fe796e36338 @name="WritableDir", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="A directory where we can write files", @default="/tmp", @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "AutoCheck"=>#<Msf::OptBool:0x00007fe796d9d840 @name="AutoCheck", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Run check before exploit", @default=true, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "ForceExploit"=>#<Msf::OptBool:0x00007fe796d9cb20 @name="ForceExploit", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Override check result", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "LHOST"=>#<Msf::OptAddressLocal:0x00007fe796fb5a10 @name="LHOST", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="The listen address (an interface may be specified)", @default=nil, @enums=[], @owner=Msf::Handler::Reverse>, "LPORT"=>#<Msf::OptPort:0x00007fe7962d4fd0 @name="LPORT", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="The listen port", @default=4444, @enums=[], @owner=Msf::Handler::Reverse>, "ReverseListenerBindPort"=>#<Msf::OptPort:0x00007fe7962dba38 @name="ReverseListenerBindPort", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The port to bind to on the local system if different from LPORT", @default=nil, @enums=[], @owner=Msf::Handler::Reverse>, "ReverseAllowProxy"=>#<Msf::OptBool:0x00007fe7962da408 @name="ReverseAllowProxy", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST", @default=false, @enums=[], @owner=Msf::Handler::Reverse>, "ReverseListenerComm"=>#<Msf::OptString:0x00007fe7962d81f8 @name="ReverseListenerComm", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The specific communication channel to use for this listener", @default=nil, @enums=[], @owner=Msf::Handler::Reverse::Comm>, "ReverseListenerBindAddress"=>#<Msf::OptAddress:0x00007fe7962dea08 @name="ReverseListenerBindAddress", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The specific IP address to bind to on the local system", @default=nil, @enums=[], @owner=Msf::Handler::ReverseTcp>, "ReverseListenerThreaded"=>#<Msf::OptBool:0x00007fe7962ddc98 @name="ReverseListenerThreaded", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Handle every connection in a new thread (experimental)", @default=false, @enums=[], @owner=Msf::Handler::ReverseTcp>, "StagerRetryCount"=>#<Msf::OptInt:0x00007fe7962dd388 @name="StagerRetryCount", @advanced=true, @evasion=false, @aliases=["ReverseConnectRetries"], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The number of times the stager should retry if the first connect fails", @default=10, @enums=[], @owner=Msf::Handler::ReverseTcp>, "StagerRetryWait"=>#<Msf::OptInt:0x00007fe7962dcb18 @name="StagerRetryWait", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Number of seconds to wait for the stager between reconnect attempts", @default=5, @enums=[], @owner=Msf::Handler::ReverseTcp>, "AutoLoadStdapi"=>#<Msf::OptBool:0x00007fe7962e1c58 @name="AutoLoadStdapi", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically load the Stdapi extension", @default=true, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoVerifySessionTimeout"=>#<Msf::OptInt:0x00007fe7962e0d58 @name="AutoVerifySessionTimeout", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Timeout period to wait for session validation to occur, in seconds", @default=30, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "InitialAutoRunScript"=>#<Msf::OptString:0x00007fe7962e7f68 @name="InitialAutoRunScript", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="An initial script to run on session creation (before AutoRunScript)", @default="", @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoRunScript"=>#<Msf::OptString:0x00007fe7962e7950 @name="AutoRunScript", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A script to run automatically on session creation.", @default="", @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoSystemInfo"=>#<Msf::OptBool:0x00007fe7962e74a0 @name="AutoSystemInfo", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically capture system information on initialization.", @default=true, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "EnableUnicodeEncoding"=>#<Msf::OptBool:0x00007fe7962e7018 @name="EnableUnicodeEncoding", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically encode UTF-8 strings as hexadecimal", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "HandlerSSLCert"=>#<Msf::OptPath:0x00007fe7962e6730 @name="HandlerSSLCert", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Path to a SSL certificate in unified PEM format, ignored for HTTP transports", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionRetryTotal"=>#<Msf::OptInt:0x00007fe7962e5ce0 @name="SessionRetryTotal", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Number of seconds try reconnecting for on network failure", @default=3600, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionRetryWait"=>#<Msf::OptInt:0x00007fe7962e5600 @name="SessionRetryWait", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Number of seconds to wait between reconnect attempts", @default=10, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionExpirationTimeout"=>#<Msf::OptInt:0x00007fe7962e4430 @name="SessionExpirationTimeout", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The number of seconds before this session should be forcibly shut down", @default=604800, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionCommunicationTimeout"=>#<Msf::OptInt:0x00007fe7962ebe60 @name="SessionCommunicationTimeout", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The number of seconds of no activity before this session should be killed", @default=300, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadProcessCommandLine"=>#<Msf::OptString:0x00007fe7962eb5a0 @name="PayloadProcessCommandLine", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The displayed command line that will be used by the payload", @default="", @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoUnhookProcess"=>#<Msf::OptBool:0x00007fe7962ea678 @name="AutoUnhookProcess", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically load the unhook extension and unhook the process", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "MeterpreterDebugBuild"=>#<Msf::OptBool:0x00007fe7962ea0d8 @name="MeterpreterDebugBuild", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use a debug version of Meterpreter", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "MeterpreterDebugLogging"=>#<Msf::OptMeterpreterDebugLogging:0x00007fe7962e92f0 @name="MeterpreterDebugLogging", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The Meterpreter debug logging configuration, see https://docs.metasploit.com/docs/using-metasploit/advanced/meterpreter/meterpreter-debugging-meterpreter-sessions.html", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PingbackRetries"=>#<Msf::OptInt:0x00007fe796273ac8 @name="PingbackRetries", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="How many additional successful pingbacks", @default=0, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PingbackSleep"=>#<Msf::OptInt:0x00007fe796273550 @name="PingbackSleep", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Time (in seconds) to sleep between pingbacks", @default=30, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDSeed"=>#<Msf::OptString:0x00007fe796276c78 @name="PayloadUUIDSeed", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A string to use when generating the payload UUID (deterministic)", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDRaw"=>#<Msf::OptString:0x00007fe796276610 @name="PayloadUUIDRaw", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A hex string representing the raw 8-byte PUID value for the UUID", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDName"=>#<Msf::OptString:0x00007fe796275c88 @name="PayloadUUIDName", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A human-friendly name to reference this unique payload (requires tracking)", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDTracking"=>#<Msf::OptBool:0x00007fe796275648 @name="PayloadUUIDTracking", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Whether or not to automatically register generated UUIDs", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "EnableStageEncoding"=>#<Msf::OptBool:0x00007fe796278cf8 @name="EnableStageEncoding", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Encode the second stage payload", @default=false, @enums=[], @owner=Msf::Payload::Stager>, "StageEncoder"=>#<Msf::OptString:0x00007fe796278668 @name="StageEncoder", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Encoder to use if EnableStageEncoding is set", @default=nil, @enums=[], @owner=Msf::Payload::Stager>, "StageEncoderSaveRegisters"=>#<Msf::OptString:0x00007fe796278140 @name="StageEncoderSaveRegisters", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Additional registers to preserve in the staged payload if EnableStageEncoding is set", @default="", @enums=[], @owner=Msf::Payload::Stager>, "StageEncodingFallback"=>#<Msf::OptBool:0x00007fe79627fcb0 @name="StageEncodingFallback", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Fallback to no encoding if the selected StageEncoder is not compatible", @default=true, @enums=[], @owner=Msf::Payload::Stager>, "PrependFork"=>#<Msf::OptBool:0x00007fe7962802c8 @name="PrependFork", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that starts the payload in its own process via fork", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetresuid"=>#<Msf::OptBool:0x00007fe796287618 @name="PrependSetresuid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setresuid(0, 0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetreuid"=>#<Msf::OptBool:0x00007fe796286bf0 @name="PrependSetreuid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setreuid(0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetuid"=>#<Msf::OptBool:0x00007fe796286470 @name="PrependSetuid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setuid(0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetresgid"=>#<Msf::OptBool:0x00007fe796284d78 @name="PrependSetresgid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setresgid(0, 0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetregid"=>#<Msf::OptBool:0x00007fe796284210 @name="PrependSetregid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setregid(0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetgid"=>#<Msf::OptBool:0x00007fe79628b470 @name="PrependSetgid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setgid(0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependChrootBreak"=>#<Msf::OptBool:0x00007fe79628acf0 @name="PrependChrootBreak", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that will break out of a chroot (includes setreuid to root)", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "AppendExit"=>#<Msf::OptBool:0x00007fe79628a660 @name="AppendExit", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Append a stub that executes the exit(0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "MeterpreterTryToFork"=>#<Msf::OptBool:0x00007fe796296e10 @name="MeterpreterTryToFork", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Fork a new process if the functionality is available", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>}, @aliases={"reverseconnectretries"=>"stagerretrycount"}, @defaults={"PAYLOAD"=>"linux/x64/meterpreter/reverse_tcp", "LHOST"=>"192.168.250.134"}, @user_defined={"SESSION"=>-1, "ForceExploit"=>true, "VERBOSE"=>false, "WfsDelay"=>2, "EnableContextEncoding"=>false, "DisablePayloadHandler"=>false, "COMPILE"=>"Auto", "COMPILER"=>"gcc", "EXE::EICAR"=>false, "EXE::Inject"=>false, "EXE::OldMethod"=>false, "EXE::FallBack"=>false, "MSI::EICAR"=>false, "MSI::UAC"=>false, "AllowNoCleanup"=>false, "DEBUG_SOURCE"=>false, "WritableDir"=>"/tmp", "AutoCheck"=>true, "LHOST"=>"192.168.250.134", "LPORT"=>4444, "ReverseAllowProxy"=>false, "ReverseListenerThreaded"=>false, "StagerRetryCount"=>10, "StagerRetryWait"=>5, "AutoLoadStdapi"=>true, "AutoVerifySessionTimeout"=>30, "InitialAutoRunScript"=>"", "AutoRunScript"=>"", "AutoSystemInfo"=>true, "EnableUnicodeEncoding"=>false, "SessionRetryTotal"=>3600, "SessionRetryWait"=>10, "SessionExpirationTimeout"=>604800, "SessionCommunicationTimeout"=>300, "PayloadProcessCommandLine"=>"", "AutoUnhookProcess"=>false, "MeterpreterDebugBuild"=>false, "PingbackRetries"=>0, "PingbackSleep"=>30, "PayloadUUIDTracking"=>false, "EnableStageEncoding"=>false, "StageEncoderSaveRegisters"=>"", "StageEncodingFallback"=>true, "PrependFork"=>false, "PrependSetresuid"=>false, "PrependSetreuid"=>false, "PrependSetuid"=>false, "PrependSetresgid"=>false, "PrependSetregid"=>false, "PrependSetgid"=>false, "PrependChrootBreak"=>false, "AppendExit"=>false, "MeterpreterTryToFork"=>false, "TARGET"=>0}, @_module=#<Module:exploit/linux/local/cve_2022_0995_watch_queue datastore=[#<Msf::ModuleDataStoreWithFallbacks:0x00007fe79720b580 @options={"WORKSPACE"=>#<Msf::OptString:0x00007fe796194760 @name="WORKSPACE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Specify the workspace for this module", @default=nil, @enums=[], @owner=Msf::Module>, "VERBOSE"=>#<Msf::OptBool:0x00007fe79619b6c8 @name="VERBOSE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Enable detailed status messages", @default=false, @enums=[], @owner=Msf::Module>, "WfsDelay"=>#<Msf::OptInt:0x00007fe796ef0918 @name="WfsDelay", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Additional delay in seconds to wait for a session", @default=2, @enums=[], @owner=Msf::Exploit>, "EnableContextEncoding"=>#<Msf::OptBool:0x00007fe796f06e70 @name="EnableContextEncoding", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use transient context when encoding payloads", @default=false, @enums=[], @owner=Msf::Exploit>, "ContextInformationFile"=>#<Msf::OptPath:0x00007fe796f060d8 @name="ContextInformationFile", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The information file that contains context information", @default=nil, @enums=[], @owner=Msf::Exploit>, "DisablePayloadHandler"=>#<Msf::OptBool:0x00007fe796f05228 @name="DisablePayloadHandler", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Disable the handler code for the selected payload", @default=false, @enums=[], @owner=Msf::Exploit>, "SESSION"=>#<Msf::OptInt:0x00007fe796e597e8 @name="SESSION", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="The session to run this module on", @default=nil, @enums=[], @owner=Msf::Post>, "COMPILE"=>#<Msf::OptEnum:0x00007fe796e663a8 @name="COMPILE", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc_string="Compile on target", @default="Auto", @enums=["Auto", "True", "False"], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "COMPILER"=>#<Msf::OptEnum:0x00007fe796e65980 @name="COMPILER", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc_string="Compiler to use on target", @default="gcc", @enums=["gcc", "clang"], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::EICAR"=>#<Msf::OptBool:0x00007fe796e71b68 @name="EXE::EICAR", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Generate an EICAR file instead of regular payload exe", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Custom"=>#<Msf::OptPath:0x00007fe796e715a0 @name="EXE::Custom", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use custom exe instead of automatically generating a payload exe", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Path"=>#<Msf::OptPath:0x00007fe796e71168 @name="EXE::Path", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The directory in which to look for the executable template", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Template"=>#<Msf::OptPath:0x00007fe796e70d80 @name="EXE::Template", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The executable template file name.", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::Inject"=>#<Msf::OptBool:0x00007fe796e70b78 @name="EXE::Inject", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Set to preserve the original EXE function", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::OldMethod"=>#<Msf::OptBool:0x00007fe796e70768 @name="EXE::OldMethod", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Set to use the substitution EXE generation method.", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "EXE::FallBack"=>#<Msf::OptBool:0x00007fe796e70470 @name="EXE::FallBack", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use the default template in case the specified one is missing", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::EICAR"=>#<Msf::OptBool:0x00007fe796e70100 @name="MSI::EICAR", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Generate an EICAR file instead of regular payload msi", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::Custom"=>#<Msf::OptPath:0x00007fe796e77db0 @name="MSI::Custom", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use custom msi instead of automatically generating a payload msi", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::Path"=>#<Msf::OptPath:0x00007fe796e771f8 @name="MSI::Path", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The directory in which to look for the msi template", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::Template"=>#<Msf::OptPath:0x00007fe796e76c08 @name="MSI::Template", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The msi template file name", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "MSI::UAC"=>#<Msf::OptBool:0x00007fe796e765f0 @name="MSI::UAC", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "FileDropperDelay"=>#<Msf::OptInt:0x00007fe796dee3a8 @name="FileDropperDelay", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Delay in seconds before attempting cleanup", @default=nil, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "AllowNoCleanup"=>#<Msf::OptBool:0x00007fe796dee088 @name="AllowNoCleanup", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Allow exploitation without the possibility of cleaning up files", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "DEBUG_SOURCE"=>#<Msf::OptBool:0x00007fe796e0a008 @name="DEBUG_SOURCE", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use source code with debug prints to help troubleshoot", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "WritableDir"=>#<Msf::OptString:0x00007fe796e36338 @name="WritableDir", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="A directory where we can write files", @default="/tmp", @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "AutoCheck"=>#<Msf::OptBool:0x00007fe796d9d840 @name="AutoCheck", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Run check before exploit", @default=true, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "ForceExploit"=>#<Msf::OptBool:0x00007fe796d9cb20 @name="ForceExploit", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Override check result", @default=false, @enums=[], @owner=Msf::Modules::Exploit__Linux__Local__Cve_2022_0995_watch_queue::MetasploitModule>, "LHOST"=>#<Msf::OptAddressLocal:0x00007fe796fb5a10 @name="LHOST", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="The listen address (an interface may be specified)", @default=nil, @enums=[], @owner=Msf::Handler::Reverse>, "LPORT"=>#<Msf::OptPort:0x00007fe796198a90 @name="LPORT", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="The listen port", @default=4444, @enums=[], @owner=Msf::Handler::Reverse>, "ReverseListenerBindPort"=>#<Msf::OptPort:0x00007fe79619f070 @name="ReverseListenerBindPort", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The port to bind to on the local system if different from LPORT", @default=nil, @enums=[], @owner=Msf::Handler::Reverse>, "ReverseAllowProxy"=>#<Msf::OptBool:0x00007fe79619e8f0 @name="ReverseAllowProxy", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST", @default=false, @enums=[], @owner=Msf::Handler::Reverse>, "ReverseListenerComm"=>#<Msf::OptString:0x00007fe79619cc08 @name="ReverseListenerComm", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The specific communication channel to use for this listener", @default=nil, @enums=[], @owner=Msf::Handler::Reverse::Comm>, "ReverseListenerBindAddress"=>#<Msf::OptAddress:0x00007fe7961a2a18 @name="ReverseListenerBindAddress", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The specific IP address to bind to on the local system", @default=nil, @enums=[], @owner=Msf::Handler::ReverseTcp>, "ReverseListenerThreaded"=>#<Msf::OptBool:0x00007fe7961a1ff0 @name="ReverseListenerThreaded", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Handle every connection in a new thread (experimental)", @default=false, @enums=[], @owner=Msf::Handler::ReverseTcp>, "StagerRetryCount"=>#<Msf::OptInt:0x00007fe7961a0a10 @name="StagerRetryCount", @advanced=true, @evasion=false, @aliases=["ReverseConnectRetries"], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The number of times the stager should retry if the first connect fails", @default=10, @enums=[], @owner=Msf::Handler::ReverseTcp>, "StagerRetryWait"=>#<Msf::OptInt:0x00007fe7961a01c8 @name="StagerRetryWait", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Number of seconds to wait for the stager between reconnect attempts", @default=5, @enums=[], @owner=Msf::Handler::ReverseTcp>, "AutoLoadStdapi"=>#<Msf::OptBool:0x00007fe7961a8788 @name="AutoLoadStdapi", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically load the Stdapi extension", @default=true, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoVerifySessionTimeout"=>#<Msf::OptInt:0x00007fe7961afe48 @name="AutoVerifySessionTimeout", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Timeout period to wait for session validation to occur, in seconds", @default=30, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "InitialAutoRunScript"=>#<Msf::OptString:0x00007fe7961aec00 @name="InitialAutoRunScript", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="An initial script to run on session creation (before AutoRunScript)", @default="", @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoRunScript"=>#<Msf::OptString:0x00007fe7961add28 @name="AutoRunScript", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A script to run automatically on session creation.", @default="", @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoSystemInfo"=>#<Msf::OptBool:0x00007fe7961acec8 @name="AutoSystemInfo", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically capture system information on initialization.", @default=true, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "EnableUnicodeEncoding"=>#<Msf::OptBool:0x00007fe7961b3660 @name="EnableUnicodeEncoding", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically encode UTF-8 strings as hexadecimal", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "HandlerSSLCert"=>#<Msf::OptPath:0x00007fe7961b28a0 @name="HandlerSSLCert", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Path to a SSL certificate in unified PEM format, ignored for HTTP transports", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionRetryTotal"=>#<Msf::OptInt:0x00007fe7961b1b80 @name="SessionRetryTotal", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Number of seconds try reconnecting for on network failure", @default=3600, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionRetryWait"=>#<Msf::OptInt:0x00007fe7961b0e60 @name="SessionRetryWait", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Number of seconds to wait between reconnect attempts", @default=10, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionExpirationTimeout"=>#<Msf::OptInt:0x00007fe7961b7760 @name="SessionExpirationTimeout", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The number of seconds before this session should be forcibly shut down", @default=604800, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "SessionCommunicationTimeout"=>#<Msf::OptInt:0x00007fe7961b64c8 @name="SessionCommunicationTimeout", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The number of seconds of no activity before this session should be killed", @default=300, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadProcessCommandLine"=>#<Msf::OptString:0x00007fe7961b54d8 @name="PayloadProcessCommandLine", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The displayed command line that will be used by the payload", @default="", @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "AutoUnhookProcess"=>#<Msf::OptBool:0x00007fe7961b44c0 @name="AutoUnhookProcess", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Automatically load the unhook extension and unhook the process", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "MeterpreterDebugBuild"=>#<Msf::OptBool:0x00007fe7961bb900 @name="MeterpreterDebugBuild", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Use a debug version of Meterpreter", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "MeterpreterDebugLogging"=>#<Msf::OptMeterpreterDebugLogging:0x00007fe7961bb388 @name="MeterpreterDebugLogging", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="The Meterpreter debug logging configuration, see https://docs.metasploit.com/docs/using-metasploit/advanced/meterpreter/meterpreter-debugging-meterpreter-sessions.html", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PingbackRetries"=>#<Msf::OptInt:0x00007fe7960c7008 @name="PingbackRetries", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="How many additional successful pingbacks", @default=0, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PingbackSleep"=>#<Msf::OptInt:0x00007fe7960c6450 @name="PingbackSleep", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Time (in seconds) to sleep between pingbacks", @default=30, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDSeed"=>#<Msf::OptString:0x00007fe7960cacd0 @name="PayloadUUIDSeed", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A string to use when generating the payload UUID (deterministic)", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDRaw"=>#<Msf::OptString:0x00007fe7960ca898 @name="PayloadUUIDRaw", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A hex string representing the raw 8-byte PUID value for the UUID", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDName"=>#<Msf::OptString:0x00007fe7960ca1b8 @name="PayloadUUIDName", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="A human-friendly name to reference this unique payload (requires tracking)", @default=nil, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "PayloadUUIDTracking"=>#<Msf::OptBool:0x00007fe7960c98a8 @name="PayloadUUIDTracking", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Whether or not to automatically register generated UUIDs", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>, "EnableStageEncoding"=>#<Msf::OptBool:0x00007fe7960d4f00 @name="EnableStageEncoding", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Encode the second stage payload", @default=false, @enums=[], @owner=Msf::Payload::Stager>, "StageEncoder"=>#<Msf::OptString:0x00007fe7960d4460 @name="StageEncoder", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Encoder to use if EnableStageEncoding is set", @default=nil, @enums=[], @owner=Msf::Payload::Stager>, "StageEncoderSaveRegisters"=>#<Msf::OptString:0x00007fe7960db7b0 @name="StageEncoderSaveRegisters", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Additional registers to preserve in the staged payload if EnableStageEncoding is set", @default="", @enums=[], @owner=Msf::Payload::Stager>, "StageEncodingFallback"=>#<Msf::OptBool:0x00007fe7960daa40 @name="StageEncodingFallback", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Fallback to no encoding if the selected StageEncoder is not compatible", @default=true, @enums=[], @owner=Msf::Payload::Stager>, "PrependFork"=>#<Msf::OptBool:0x00007fe7960e1d90 @name="PrependFork", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that starts the payload in its own process via fork", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetresuid"=>#<Msf::OptBool:0x00007fe7960e1728 @name="PrependSetresuid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setresuid(0, 0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetreuid"=>#<Msf::OptBool:0x00007fe7960e0eb8 @name="PrependSetreuid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setreuid(0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetuid"=>#<Msf::OptBool:0x00007fe7960e08c8 @name="PrependSetuid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setuid(0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetresgid"=>#<Msf::OptBool:0x00007fe7960e0260 @name="PrependSetresgid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setresgid(0, 0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetregid"=>#<Msf::OptBool:0x00007fe7960e7880 @name="PrependSetregid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setregid(0, 0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependSetgid"=>#<Msf::OptBool:0x00007fe7960e7650 @name="PrependSetgid", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that executes the setgid(0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "PrependChrootBreak"=>#<Msf::OptBool:0x00007fe7960e6d18 @name="PrependChrootBreak", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Prepend a stub that will break out of a chroot (includes setreuid to root)", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "AppendExit"=>#<Msf::OptBool:0x00007fe7960e6ae8 @name="AppendExit", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Append a stub that executes the exit(0) system call", @default="false", @enums=[], @owner=Msf::Payload::Linux>, "MeterpreterTryToFork"=>#<Msf::OptBool:0x00007fe7960f3950 @name="MeterpreterTryToFork", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Fork a new process if the functionality is available", @default=false, @enums=[], @owner=#<Class:0x00007fe79616d5e8>>}, @aliases={"reverseconnectretries"=>"stagerretrycount"}, @defaults={"PAYLOAD"=>"linux/x64/meterpreter/reverse_tcp", "LHOST"=>"192.168.250.134"}, @user_defined={"SESSION"=>-1, "ForceExploit"=>true}, @_module=#<Module:exploit/linux/local/cve_2022_0995_watch_queue datastore=[#<Msf::ModuleDataStoreWithFallbacks:0x00007fe79720b580 ...>]>>]>>]>
Did you mean?  version_info
[*] Exploit completed, but no session was created.
msf6 exploit(linux/local/cve_2022_0995_watch_queue) >
```

## New and fixed
```
msf6 exploit(linux/local/cve_2022_0995_watch_queue) > rerun
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Failed to parse the kernel version data: 6.10.7-200.fc40.x86_64
[!] Cannot reliably check exploitability. Failed to obtain kernel version ForceExploit is enabled, proceeding with exploitation.
[-] Exploit aborted due to failure: no-target: Unsupported Distro: '#1 SMP PREEMPT_DYNAMIC Fri Aug 30 00:08:59 UTC 2024'
[*] Exploit completed, but no session was created.
msf6 exploit(linux/local/cve_2022_0995_watch_queue) >
```