### PR TITLE
Missing PayloadType = cmd in Fetch Payloads

### DIFF
--- a/modules/payloads/adapters/cmd/linux/http/x64.rb
+++ b/modules/payloads/adapters/cmd/linux/http/x64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/http/x86.rb
+++ b/modules/payloads/adapters/cmd/linux/http/x86.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X86,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/https/mips64.rb
+++ b/modules/payloads/adapters/cmd/linux/https/mips64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_MIPS64,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/https/x64.rb
+++ b/modules/payloads/adapters/cmd/linux/https/x64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/https/x86.rb
+++ b/modules/payloads/adapters/cmd/linux/https/x86.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X86,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/tftp/mips64.rb
+++ b/modules/payloads/adapters/cmd/linux/tftp/mips64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_MIPS64,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/tftp/x64.rb
+++ b/modules/payloads/adapters/cmd/linux/tftp/x64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/linux/tftp/x86.rb
+++ b/modules/payloads/adapters/cmd/linux/tftp/x86.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X86,
-        'AdaptedPlatform' => 'linux'
+        'AdaptedPlatform' => 'linux',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/unix/python.rb
+++ b/modules/payloads/adapters/cmd/unix/python.rb
@@ -17,7 +17,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_PYTHON,
-        'AdaptedPlatform' => 'python'
+        'AdaptedPlatform' => 'python',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/windows/http/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x64.rb
@@ -19,7 +19,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'win'
+        'AdaptedPlatform' => 'win',
+        'PayloadType' => 'cmd'
       )
     )
     deregister_options('FETCH_COMMAND')

--- a/modules/payloads/adapters/cmd/windows/https/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/https/x64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'win'
+        'AdaptedPlatform' => 'win',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/windows/powershell.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell.rb
@@ -19,7 +19,8 @@ module MetasploitModule
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X86,
         'AdaptedPlatform' => 'win',
-        'RequiredCmd' => 'powershell'
+        'RequiredCmd' => 'powershell',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/windows/powershell/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/powershell/x64.rb
@@ -19,7 +19,8 @@ module MetasploitModule
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
         'AdaptedPlatform' => 'win',
-        'RequiredCmd' => 'powershell'
+        'RequiredCmd' => 'powershell',
+        'PayloadType' => 'cmd'
       )
     )
   end

--- a/modules/payloads/adapters/cmd/windows/python.rb
+++ b/modules/payloads/adapters/cmd/windows/python.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_PYTHON,
         'AdaptedPlatform' => 'python',
-        'RequiredCmd' => 'python'
+        'RequiredCmd' => 'python',
+        'PayloadType' => 'cmd'
       )
     )
     register_advanced_options(

--- a/modules/payloads/adapters/cmd/windows/smb/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/smb/x64.rb
@@ -17,7 +17,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'win'
+        'AdaptedPlatform' => 'win',
+        'PayloadType' => 'cmd'
       )
     )
     deregister_options('FETCH_DELETE', 'FETCH_SRVPORT', 'FETCH_WRITABLE_DIR')

--- a/modules/payloads/adapters/cmd/windows/tftp/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/tftp/x64.rb
@@ -18,7 +18,8 @@ module MetasploitModule
         'Arch' => ARCH_CMD,
         'License' => MSF_LICENSE,
         'AdaptedArch' => ARCH_X64,
-        'AdaptedPlatform' => 'win'
+        'AdaptedPlatform' => 'win',
+        'PayloadType' => 'cmd'
       )
     )
   end


### PR DESCRIPTION
While testing #19454 I noticed the `Fetch Payloads` were not compatible with the module even if they are `ARCH_CMD`.
Commenting the line `'PayloadType' => 'cmd'` inside the module, was possible to select all the payload so I deducted the `PayloadType = 'cmd'` was missing inside the `Fetch Payload` adapters.

This PR add the missing information in the `Fetch Payloads`.




