### PR TITLE
Bugfix for DNS resolver on Windows throwing NoMethodError

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1081,7 +1081,7 @@ module Net # :nodoc:
         if RUBY_PLATFORM =~ /mswin32|cygwin|mingw|bccwin/
           require 'win32/resolv'
           arr = Win32::Resolv.get_resolv_info
-          self.domain = arr[0]&.first
+          self.searchlist = arr[0]
           self.nameservers = arr[1]
         else
           begin

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1081,7 +1081,7 @@ module Net # :nodoc:
         if RUBY_PLATFORM =~ /mswin32|cygwin|mingw|bccwin/
           require 'win32/resolv'
           arr = Win32::Resolv.get_resolv_info
-          self.domain = arr[0]
+          self.domain = arr[0]&.first
           self.nameservers = arr[1]
         else
           begin


### PR DESCRIPTION
I came across the issue #19464 while testing the Framework on Windows today, using the latest Windows installer.

Trying to run the framework results in this exception:

```
C:\metasploit-framework>bin\msfconsole.bat
C:/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-core-0.1.32/lib/rex/compat.rb:381: warning: Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead
Metasploit tip: View advanced module options with advanced
C:/metasploit-framework/embedded/framework/lib/net/dns/resolver.rb:1274:in `valid?': undefined method `=~' for ["fritz.box"]:Array (NoMethodError)
        from C:/metasploit-framework/embedded/framework/lib/net/dns/resolver.rb:359:in `domain='
        from C:/metasploit-framework/embedded/framework/lib/net/dns/resolver.rb:1084:in `parse_config_file'
        from C:/metasploit-framework/embedded/framework/lib/rex/proto/dns/resolver.rb:66:in `initialize'
        from C:/metasploit-framework/embedded/framework/lib/rex/proto/dns/cached_resolver.rb:25:in `initialize'
        from C:/metasploit-framework/embedded/framework/lib/msf/ui/console/driver.rb:86:in `new'
        from C:/metasploit-framework/embedded/framework/lib/msf/ui/console/driver.rb:86:in `initialize'
        from C:/metasploit-framework/embedded/framework/lib/metasploit/framework/command/console.rb:66:in `new'
        from C:/metasploit-framework/embedded/framework/lib/metasploit/framework/command/console.rb:66:in `driver'
        from C:/metasploit-framework/embedded/framework/lib/metasploit/framework/command/console.rb:54:in `start'
        from C:/metasploit-framework/embedded/framework/lib/metasploit/framework/command/base.rb:82:in `start'
        from C:/metasploit-framework/bin/../embedded/framework/msfconsole:23:in `<main>'
```

The issue is a call to `Win32::Resolv.get_resolv_info` returns an array with two items, `[ search, nameserver ]`  ([see here](https://github.com/ruby/ruby/blob/master/ext/win32/lib/win32/resolv.rb#L20) for original source on how these are generated). For example on my system a call to `Win32::Resolv.get_resolv_info` returns `[["fritz.box"], ["192.168.86.1"]]`

The first item (search) is itself an array of unique domain names, or nil. However `parse_config_file` assumes it is a string, so when  `self.domain = arr[0]` is called, an array is passed to `domain=` and ends up in an Regex comparison during a call to `valid?`, however a string is expected and an exception is thrown.

The solution that works for me is to pick the first item in the search array, or nil if there are no items.