### PR TITLE
Allow setting the RPORT option for pipe_auditor

### DIFF
--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
     pipes
   end
 
-  def report_pipes(pipes)
+  def report_pipes(ip, pipes)
     if(pipes.length > 0)
       print_good("Pipes: #{pipes.join(", ")}")
       # Add Report

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
       @rport = datastore['RPORT'] = session.port
       self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       self.simple.connect("\\\\#{session.address}\\IPC$")
-      pipes += check_pipes
+      report_pipes(ip, check_pipes)
     else
       if datastore['RPORT'].blank? || datastore['RPORT'] == 0
         smb_services = [

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
           smb_login
           pipes += check_pipes
           disconnect
-          report_pipes(pipes)
+          report_pipes(ip, pipes)
         rescue Rex::Proto::SMB::Exceptions::SimpleClientError, Rex::ConnectionError => e
           vprint_error("SMB client Error with RPORT=#{@rport} SMBDirect=#{@smb_direct}: #{e.to_s}")
         end

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -27,6 +27,10 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
+  def rport
+    @rport
+  end
+
   def domain
     @smb_domain || super
   end


### PR DESCRIPTION
This PR adds the same pattern in #19163 to `pipe_auditor` and also fixes a bug in `smb_enumusers`, which causes invalid operation in case **Empty/Zero RPORT**.