### PR TITLE
Post::Linux::Kernel.kernel_arch: Add support for RISC-V and LoongArch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,7 @@ GEM
     reline (0.5.8)
       io-console (~> 0.5)
     require_all (3.0.0)
-    rex-arch (0.1.15)
+    rex-arch (0.1.16)
       rex-text
     rex-bin_tools (0.1.9)
       metasm

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -71,6 +71,9 @@ module Kernel
     return ARCH_MIPS if arch == 'mips'
     return ARCH_MIPS64 if arch == 'mips64'
     return ARCH_SPARC if arch == 'sparc'
+    return ARCH_RISCV32LE if arch == 'riscv32'
+    return ARCH_RISCV64LE if arch == 'riscv64'
+    return ARCH_LOONGARCH64 if arch == 'loongarch64'
     arch
   end
 


### PR DESCRIPTION
~~Requires: https://github.com/rapid7/rex-arch/pull/9~~