### PR TITLE
Excluding test folders from snyk scan (test data)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+version: v1.25.0
+ignore: {}
+patch: {}
+exclude:
+  global:
+    # includes our unit tests which include hard coded passwords and encrypting keys for testing purposes.
+    - spec/
+    # includes the source code to local exploits and utilities which have to be written in a particular way to exploit the vulnerabilities that we're targeting.
+    - external/source/

--- a/.snyk
+++ b/.snyk
@@ -3,7 +3,7 @@ ignore: {}
 patch: {}
 exclude:
   global:
-    # includes our unit tests which include hard coded passwords and encrypting keys for testing purposes.
+    # exclude unit tests which contain hard coded passwords and encrypting keys for testing purposes.
     - spec/
-    # includes the source code to local exploits and utilities which have to be written in a particular way to exploit the vulnerabilities that we're targeting.
+    # exclude the source code to local exploits and utilities which have to be written in a particular way to exploit the vulnerabilities that we're targeting.
     - external/source/


### PR DESCRIPTION
Excluding test folders for Snyk scans. 
Makes zero changes to actual application.

## Verification

List the steps needed to make sure this thing works

- [N/A] Start `msfconsole`
- [N/A] `use exploit/windows/smb/ms08_067_netapi`.
- [X] **Verify** the thing does what it should
- [X] **Verify** the thing does not do what it should not
- [N/A] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

## Testing:

```bash
snyk code test

pre:
  469 Code issues found
  35 [High]   298 [Medium]   136 [Low] 
post:
  160 Code issues found
  28 [High]   71 [Medium]   61 [Low] 
```


