### PR TITLE
Fix a crash in lib/msf/core/payload/php.rb

### DIFF
--- a/lib/msf/core/payload/php.rb
+++ b/lib/msf/core/payload/php.rb
@@ -135,7 +135,7 @@ module Msf::Payload::Php
     "
 
     exec_methods = [passthru, shell_exec, system, exec, proc_open, popen];
-    shuffle(exec_methods);
+    exec_methods = exec_methods.shuffle
     buf = setup + exec_methods.join("") + fail_block
 
     return buf


### PR DESCRIPTION
As it seems that shuffle is a method
(https://ruby-doc.org/core-2.7.0/Array.html#method-i-shuffle) and not a function.

As spotted by @Chocapikk in
https://github.com/rapid7/metasploit-framework/pull/19445#pullrequestreview-2320780104