### PR TITLE
Fix crash in `Kerberos::Client::Pkinit#extract_user_and_realm` with specific SAN extension

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb
@@ -67,12 +67,13 @@ module Msf
               certificate.extensions.select { |ext| ext.oid == 'subjectAltName' }.each do |san_extension|
                 begin
                   asn_san = OpenSSL::ASN1.decode(san_extension)
-                  asn_san_value = asn_san.value[1]&.value
+                  asn_san_value = asn_san.value.find {|value| value.is_a? OpenSSL::ASN1::OctetString }
+
                   if asn_san_value.nil?
                     raise ArgumentError, 'Invalid certificate provided: unable to decode SAN'
                   end
 
-                  asn_san_seq = OpenSSL::ASN1.decode(asn_san_value)
+                  asn_san_seq = OpenSSL::ASN1.decode(asn_san_value.value)
                 rescue OpenSSL::ASN1::ASN1Error
                   raise ArgumentError, 'Invalid certificate provided: unable to decode SAN'
                 end


### PR DESCRIPTION
This fix a crash that occurs when `subjectAltName` (`SAN`) extension contains a boolean flag in the ASN1 nested sequence.

For exemple:
```
[1] pry(#<Msf::Modules::Auxiliary__Admin__Kerberos__Get_ticket::MetasploitModule>)> asn_san
=> #<OpenSSL::ASN1::Sequence:0x000071f7dc12cf28
 @indefinite_length=false,
 @tag=16,
 @tag_class=:UNIVERSAL,
 @tagging=nil,
 @value=
  [#<OpenSSL::ASN1::ObjectId:0x000071f7dc12e760 @indefinite_length=false, @tag=6, @tag_class=:UNIVERSAL, @tagging=nil, @value="subjectAltName">,
   #<OpenSSL::ASN1::Boolean:0x000071f7dc12df68 @indefinite_length=false, @tag=1, @tag_class=:UNIVERSAL, @tagging=nil, @value=true>,
   #<OpenSSL::ASN1::OctetString:0x000071f7dc12d748 @indefinite_length=false, @tag=4, @tag_class=:UNIVERSAL, @tagging=nil, @value="0$\xA0\"\x06\n+\x06\x01\x04\x01\x827\x14\x02\x03\xA0\x14\f\x12msfus@ad.foo.local">]>
```
First value in the sequence is an `ASN1::ObjectId`, second value is a `ASN1::Boolean` (I suppose it is the `critical extension` [flag](https://datatracker.ietf.org/doc/html/rfc3280#section-4.1)) and finally the last value is the nested ASN1 sequence we are looking for.

The original code responsible for parsing the `SAN` extension assumes the nested ASN1 sequence is always the second value. If the extension is marked as critical, the second field is a boolean and it will fail when calling `OpenSSL::ASN1.decode`.

## Setup the test environment
- Setup an AD CS server following the Metasploit [documentation](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/overview.html#setting-up-a-vulnerable-ad-cs-server).
- Open up `cmd` as Domain Administrator and run `certtmpl.msc`.
- Look for the `User` certificate template, click left and select `Duplicate Template`.
- In the `General` tab, set the display name and the name to `TestCrash`.
- In the `Subject Name` tab, make sure `Build from the Active Directory information` is selected and select `None` in the `Subject name format`. Also, uncheck `E-mail name` if it is checked. Click `OK`.
![Screenshot 2024-09-24 at 14 52 39](https://github.com/user-attachments/assets/2e2565df-56a2-4cf6-bebe-3f3c8a48a104)
- Go back to the `cmd` prompt and run `certsrv.msc`.
- Under the CA name, right click the `Certificate Template` folder, then click `New` followed by `Certificate Template to Issue`. Finally, select the `TestCrash` certificate template and click `OK`.

## Verification
- [ ] Start `msfconsole`
- [ ] `use admin/dcerpc/icpr_cert`
- [ ] `run verbose=true CA=<name of the CA> RHOSTS=<remote host IP> username=<username of a normal domain user> password=<password> CERT_TEMPLATE=TestCrash`
- [ ] `use modules/auxiliary/admin/kerberos/get_ticket.rb`
- [ ] `run verbose=true RHOSTS=<remote host IP> cert_file=<local path of the certificate saved by the previous module>`

###  Before the fix
```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true RHOSTS=192.168.22.198 cert_file=/home/msfuser/.msf4/loot/20240924145839_default_192.168.22.198_windows.ad.cs_271153.pfx
[*] Running module against 192.168.22.198

[-] Auxiliary failed: TypeError no implicit conversion of true into String
[-] Call stack:
[-]   /home/msfuser/dev/metasploit-framework/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb:75:in `decode'
[-]   /home/msfuser/dev/metasploit-framework/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb:75:in `block in extract_user_and_realm'
[-]   /home/msfuser/dev/metasploit-framework/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb:67:in `each'
[-]   /home/msfuser/dev/metasploit-framework/lib/msf/core/exploit/remote/kerberos/client/pkinit.rb:67:in `extract_user_and_realm'
[-]   /home/msfuser/dev/metasploit-framework/modules/auxiliary/admin/kerberos/get_ticket.rb:108:in `validate_options'
[-]   /home/msfuser/dev/metasploit-framework/modules/auxiliary/admin/kerberos/get_ticket.rb:143:in `run'
[*] Auxiliary module execution completed
```

### With the fix
```
msf6 auxiliary(admin/kerberos/get_ticket) > run verbose=true RHOSTS=192.168.22.198 cert_file=/home/msfuser/.msf4/loot/20240924150544_default_192.168.22.198_windows.ad.cs_776004.pfx
[*] Running module against 192.168.22.198

[*] 10.140.10.69:88 - Getting TGT for msfuser@ad.foo.local
[+] 10.140.10.69:88 - Received a valid TGT-Response
[*] 10.140.10.69:88 - TGT MIT Credential Cache ticket saved to /home/msfuser/.msf4/loot/20240924150620_default_192.168.22.198_mit.kerberos.cca_429485.bin
[*] Auxiliary module execution completed
```