### PR TITLE
Mettle now copying gem correctly and running acceptance tests

### DIFF
--- a/.github/workflows/meterpreter_acceptance.yml
+++ b/.github/workflows/meterpreter_acceptance.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Move mettle gem into framework
         if: ${{ matrix.meterpreter.name == 'mettle' && (contains(github.event.issue.labels.*.name, 'mettle-testing-branch')) }}
         run: |
-          cp ./mettle/pkg/metasploit_payloads-mettle-${{ env.METTLE_VERSION }}.pre.dev.gem ./metasploit-framework
+          cp ../mettle/pkg/metasploit_payloads-mettle-${{ env.METTLE_VERSION }}.pre.dev.gem .
         working-directory: metasploit-framework
 
       - name: Install mettle gem
@@ -218,7 +218,7 @@ jobs:
         run: |
           set -x
           bundle exec gem install metasploit_payloads-mettle-${{ env.METTLE_VERSION }}.pre.dev.gem
-          ruby -pi.bak -e "gsub(/'metasploit_payloads-mettle', '${{ env.METTLE_VERSION }}'/, '\'metasploit_payloads-mettle\', \'${{ env.METTLE_VERSION }}.pre.dev\'')" metasploit-framework.gemspec
+          ruby -pi.bak -e "gsub(/'metasploit_payloads-mettle', '.*'/, '\'metasploit_payloads-mettle\', \'${{ env.METTLE_VERSION }}.pre.dev\'')" metasploit-framework.gemspec
           bundle config unset deployment
           bundle update metasploit_payloads-mettle
           bundle install


### PR DESCRIPTION
Fixes and issue that was introduced as part of #19413. This PR updates the `cp` to now copy with the correct paths as well as an additional fix to pull out the current metasploit-framework Mettle version so it can be replaced within `metasploit-framework.gemspec`.

## Verification

List the steps needed to make sure this thing works

- [ ] Code changes are sane. 
- [ ] See this test [branch](https://github.com/cgranleese-r7/metasploit-framework/actions/runs/11032997435) of mine and ensure the mettle tests now pass, and it is using the correct mettle version (1.0.32)
