### PR TITLE
Removes bundler version from MSSQL acceptance testing

### DIFF
--- a/.github/workflows/mssql_acceptance.yml
+++ b/.github/workflows/mssql_acceptance.yml
@@ -147,9 +147,6 @@ jobs:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
           cache-version: 4
-          # Github actions with Ruby requires Bundler 2.2.18+
-          # https://github.com/ruby/setup-ruby/tree/d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c#windows
-          bundler: 2.2.33
 
       - uses: actions/download-artifact@v4
         id: download


### PR DESCRIPTION
This PR removes the bundler version from MSSQL acceptance testing.

## Verification

- [ ] CI goes green
