### PR TITLE
wip: Fix Reline ASCII-8BIT <-> UTF-8 issues

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -105,7 +105,7 @@ class Driver < Msf::Ui::Driver
     # Initialize the user interface to use a different input and output
     # handle if one is supplied
     input = opts['LocalInput']
-    input ||= Rex::Ui::Text::Input::Stdio.new
+    input ||= Rex::Ui::Text::Input::Utf8Stdio.new
 
     if !opts['Readline']
       input.disable_readline
@@ -118,7 +118,7 @@ class Driver < Msf::Ui::Driver
         output = opts['LocalOutput']
       end
     else
-      output = Rex::Ui::Text::Output::Stdio.new
+      output = Rex::Ui::Text::Output::Utf8Stdio.new
     end
 
     init_ui(input, output)

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -459,6 +459,8 @@ module DispatcherShell
         res = tab_complete_helper(dispatcher, current_word, tab_words)
       end
 
+      res.map! { |item| item.dup.force_encoding(::Encoding::UTF_8) } if self.input.respond_to?(:utf8?) && self.input.utf8?
+
       if res.nil?
         # A nil response indicates no optional arguments
         return [''] if items.empty?
@@ -466,6 +468,8 @@ module DispatcherShell
         if res.second == :override_completions
           return res.first
         else
+          next if res.empty?
+
           # Otherwise we add the completion items to the list
           items.concat(res)
         end

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -92,6 +92,7 @@ begin
         ::Reline::HISTORY.pop if (line and line.empty?)
       ensure
         Thread.current.priority = orig || 0
+        output.prompting(false)
       end
 
       line

--- a/lib/rex/ui/text/input/utf8_buffer.rb
+++ b/lib/rex/ui/text/input/utf8_buffer.rb
@@ -1,0 +1,38 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/input/utf8_common'
+
+module Rex
+module Ui
+module Text
+
+require 'rex/io/stream_abstraction'
+
+###
+#
+# This class implements input against a socket and forces UTF-8 encoding.
+#
+###
+class Input::Utf8Buffer < Rex::Ui::Text::Input::Buffer
+
+  # Array of methods that will be used to override methods from the base class to wrap them with forced UTF-8 encoding.
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING = %i[sysread gets put].freeze
+
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING.each do |method|
+    class_eval %{
+      def #{method} (*args, &block)
+        Rex::Ui::Text::Input::Utf8Common.with_utf8_encoding do
+          super
+        end
+      end
+    }
+  end
+
+  def utf8?
+    true
+  end
+end
+
+end
+end
+end

--- a/lib/rex/ui/text/input/utf8_common.rb
+++ b/lib/rex/ui/text/input/utf8_common.rb
@@ -1,0 +1,26 @@
+# -*- coding: binary -*-
+
+module Rex
+module Ui
+module Text
+class Input::Utf8Common
+  def self.with_utf8_encoding(&block)
+    external_encoding_on_entry = ::Encoding.default_external
+    ::Encoding.default_external = ::Encoding::UTF_8
+
+    internal_encoding_on_entry = ::Encoding.default_internal
+    ::Encoding.default_internal = ::Encoding::UTF_8
+
+    begin
+      return block.call
+    rescue StandardError => e
+      elog("Failed to call block with UTF8 encoding. Backtrace: #{e.backtrace}", error: e)
+    ensure
+      ::Encoding.default_external = external_encoding_on_entry
+      ::Encoding.default_internal = internal_encoding_on_entry
+    end
+  end
+end
+end
+end
+end

--- a/lib/rex/ui/text/input/utf8_readline.rb
+++ b/lib/rex/ui/text/input/utf8_readline.rb
@@ -1,0 +1,37 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/input/utf8_common'
+
+module Rex
+module Ui
+module Text
+
+###
+#
+# This class implements standard input using Reline against
+# standard input, and forces UTF-8 encoding. It supports tab completion.
+#
+###
+class Input::Utf8Readline < Input::Readline
+
+  # Array of methods that will be used to override methods from the base class to wrap them with forced UTF-8 encoding.
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING = %i[pgets gets sysread readline_with_output update_prompt].freeze
+
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING.each do |method|
+    class_eval %{
+      def #{method} (*args, &block)
+        Rex::Ui::Text::Input::Utf8Common.with_utf8_encoding do
+          super
+        end
+      end
+    }
+  end
+
+  def utf8?
+    true
+  end
+end
+end
+
+end
+end

--- a/lib/rex/ui/text/input/utf8_socket.rb
+++ b/lib/rex/ui/text/input/utf8_socket.rb
@@ -1,0 +1,36 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/input/utf8_common'
+
+module Rex
+module Ui
+module Text
+
+###
+#
+# This class implements input against a socket and forces UTF-8 encoding.
+#
+###
+class Input::Utf8Socket < Rex::Ui::Text::Input::Socket
+
+  # Array of methods that will be used to override methods from the base class to wrap them with forced UTF-8 encoding.
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING = %i[sysread gets].freeze
+
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING.each do |method|
+    class_eval %{
+      def #{method} (*args, &block)
+        Rex::Ui::Text::Input::Utf8Common.with_utf8_encoding do
+          super
+        end
+      end
+    }
+  end
+
+  def utf8?
+    true
+  end
+end
+
+end
+end
+end

--- a/lib/rex/ui/text/input/utf8_stdio.rb
+++ b/lib/rex/ui/text/input/utf8_stdio.rb
@@ -1,0 +1,36 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/input/utf8_common'
+
+module Rex
+module Ui
+module Text
+
+###
+#
+# This class implements input against standard in and forces UTF-8 encoding.
+#
+###
+class Input::Utf8Stdio < Rex::Ui::Text::Input::Stdio
+
+  # Array of methods that will be used to override methods from the base class to wrap them with forced UTF-8 encoding.
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING = %i[sysread gets].freeze
+
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING.each do |method|
+    class_eval %{
+      def #{method} (*args, &block)
+        Rex::Ui::Text::Input::Utf8Common.with_utf8_encoding do
+          super
+        end
+      end
+    }
+  end
+
+  def utf8?
+    true
+  end
+end
+
+end
+end
+end

--- a/lib/rex/ui/text/output/utf8_common.rb
+++ b/lib/rex/ui/text/output/utf8_common.rb
@@ -1,0 +1,28 @@
+# -*- coding: binary -*-
+
+module Rex
+module Ui
+module Text
+class Output::Utf8Common
+  def self.with_utf8_encoding(&block)
+    external_encoding_on_entry = ::Encoding.default_external
+    ::Encoding.default_external = ::Encoding::UTF_8
+
+    internal_encoding_on_entry = ::Encoding.default_internal
+    ::Encoding.default_internal = ::Encoding::UTF_8
+
+    begin
+      return block.call
+    rescue ::StandardError => e
+      puts 'Output'
+      puts caller
+      elog('Failed to call block with UTF8 encoding', error: e)
+    ensure
+      ::Encoding.default_external = external_encoding_on_entry
+      ::Encoding.default_internal = internal_encoding_on_entry
+    end
+  end
+end
+end
+end
+end

--- a/lib/rex/ui/text/output/utf8_stdio.rb
+++ b/lib/rex/ui/text/output/utf8_stdio.rb
@@ -1,0 +1,37 @@
+# -*- coding: binary -*-
+
+require 'rex/ui/text/output/utf8_common'
+
+module Rex
+module Ui
+module Text
+
+###
+#
+# This class implements output against standard out and forces UTF-8 encoding.
+#
+###
+class Output::Utf8Stdio < Rex::Ui::Text::Output::Stdio
+
+  # Array of methods that will be used to override methods from the base class to wrap them with forced UTF-8 encoding.
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING = %i[print_line print_raw].freeze
+
+  METHODS_TO_WRAP_WITH_UTF8_ENCODING.each do |method|
+    class_eval %{
+      def #{method} (*args, &block)
+        Rex::Ui::Text::Input::Utf8Common.with_utf8_encoding do
+          super
+        end
+      end
+    }
+  end
+
+  def utf8?
+    true
+  end
+end
+
+end
+end
+end
+


### PR DESCRIPTION
This PR is trying to fix some of the Reline issues I have introduced as part of: https://github.com/rapid7/metasploit-framework/pull/19397

This PR changes the main msfconsole prompt to provide input and output as UTF-8-encoded strings by providing UTF-8 wrappers around some of our commonly used IO classes. 

It seems like these changes could have a wide impact than I initially anticipated as it begins to introduce ASCII-8BIT <-> UTF-8 encoding issues both ways. I will keep testing and addressing any edge cases I come across.

Affected issues:
- https://github.com/rapid7/metasploit-framework/issues/19513
- https://github.com/rapid7/metasploit-framework/issues/19519 (Will be fixed in a separate PR)

~~I am currently fixing the tests.~~ Tests should now pass.

## Verification

- [ ] Create an example file on disk with non-English characters, e.g. `touch メタスプロイトが大好きです`
- [ ] Write some output to the file, e.g. `echo 'hello world!' > メタスプロイトが大好きです`
- [ ] Start `msfconsole`
- [ ] ~~Verify you can call off to the local filesystem with autocompletion: `cat メタスプ<TAB>`~~ This did not work previously with Readline as we do not have a Filesystem dispatcher in the stack which implements `def_cat_tabs` when trying to auto-complete local filenames.
- [ ] Get a meterpreter shell vs e.g. Windows
- [ ] Create the non-English file on the Windows box
- [ ] Enter the Meterpreter shell
- [ ] **Verify** you can auto-complete the filename: `cat メタスプ<TAB>` which should result in `cat メタスプロイトが大好きです`
- [ ] **Verify** pressing Enter results in the file contents being read and output.