### PR TITLE
Revert "Replace Readline with Reline"

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -92,6 +92,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
       driver_options['ModulePath'] = options.modules.path
       driver_options['Plugins'] = options.console.plugins
       driver_options['Readline'] = options.console.readline
+      driver_options['RealReadline'] = options.console.real_readline
       driver_options['Resource'] = options.console.resources
       driver_options['XCommands'] = options.console.commands
 

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -16,6 +16,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         options.console.plugins = []
         options.console.quiet = false
         options.console.readline = true
+        options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
       }
@@ -53,11 +54,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         end
 
         option_parser.on('-L', '--real-readline', 'Use the system Readline library instead of RbReadline') do
-          message = "The RealReadline option has been marked as deprecated, and is currently a noop.\n"
-          message << "Metasploit Framework now uses Reline exclusively as the input handling library.\n"
-          message << "If you require this functionality, please use the following link to tell us:\n"
-          message << '  https://github.com/rapid7/metasploit-framework/issues/19399'
-          warn message
+          options.console.real_readline = true
         end
 
         option_parser.on('-o', '--output FILE', 'Output to the specified file') do |file|

--- a/lib/metasploit/framework/parsed_options/remote_db.rb
+++ b/lib/metasploit/framework/parsed_options/remote_db.rb
@@ -13,6 +13,7 @@ class Metasploit::Framework::ParsedOptions::RemoteDB < Metasploit::Framework::Pa
         options.console.local_output = nil
         options.console.plugins = []
         options.console.quiet = false
+        options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
       }

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -760,7 +760,7 @@ class Core
   end
 
   def cmd_history(*args)
-    length = ::Reline::HISTORY.length
+    length = Readline::HISTORY.length
 
     if length < @history_limit
       limit = length
@@ -780,7 +780,14 @@ class Core
           limit = val.to_i
         end
       when '-c'
-        ::Reline::HISTORY.clear
+        if Readline::HISTORY.respond_to?(:clear)
+          Readline::HISTORY.clear
+        elsif defined?(RbReadline)
+          RbReadline.clear_history
+        else
+          print_error('Could not clear history, skipping file')
+          return false
+        end
 
         # Portable file truncation?
         if File.writable?(Msf::Config.history_file)
@@ -801,7 +808,7 @@ class Core
 
     (start..length-1).each do |pos|
       cmd_num = (pos + 1).to_s
-      print_line "#{cmd_num.ljust(pad_len)}  #{::Reline::HISTORY[pos]}"
+      print_line "#{cmd_num.ljust(pad_len)}  #{Readline::HISTORY[pos]}"
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -131,7 +131,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
       framework.history_manager.with_context(name: :irb) do
         begin
-          reline_autocomplete = Reline.autocompletion
           if active_module
             print_status("You are in #{active_module.fullname}\n")
             Rex::Ui::Text::IrbShell.new(active_module).run
@@ -141,8 +140,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
           end
         rescue
           print_error("Error during IRB: #{$!}\n\n#{$@.join("\n")}")
-        ensure
-          Reline.autocompletion = reline_autocomplete if defined? reline_autocomplete
         end
       end
 
@@ -518,10 +515,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   private
 
   def modified_files
-    # Temporary work-around until Open3 gets fixed on Windows 11:
-    # https://github.com/ruby/open3/issues/9
-    return [] if Rex::Compat.is_cygwin || Rex::Compat.is_windows
-
     # Using an array avoids shelling out, so we avoid escaping/quoting
     changed_files = %w[git diff --name-only]
     begin

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -53,18 +53,18 @@ module Msf
             option_name = str.chop
             option_value = ''
 
-            ::Reline.completion_append_character = ' '
+            ::Readline.completion_append_character = ' '
             return tab_complete_option_values(mod, option_value, words, opt: option_name).map { |value| "#{str}#{value}" }
           elsif str.include?('=')
             str_split = str.split('=')
             option_name = str_split[0].strip
             option_value = str_split[1].strip
 
-            ::Reline.completion_append_character = ' '
+            ::Readline.completion_append_character = ' '
             return tab_complete_option_values(mod, option_value, words, opt: option_name).map { |value| "#{option_name}=#{value}" }
           end
 
-          ::Reline.completion_append_character = ''
+          ::Readline.completion_append_character = ''
           tab_complete_option_names(mod, str, words).map { |name| "#{name}=" }
         end
 

--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -220,13 +220,13 @@ module Msf
       end
 
       def self.history(driver)
-        end_pos = ::Reline::HISTORY.length - 1
+        end_pos = Readline::HISTORY.length - 1
         start_pos = end_pos - COMMAND_HISTORY_TOTAL > driver.hist_last_saved ? end_pos - (COMMAND_HISTORY_TOTAL - 1) : driver.hist_last_saved
 
         commands = ''
         while start_pos <= end_pos
           # Formats command position in history to 6 characters in length
-          commands += "#{'%-6.6s' % start_pos.to_s} #{::Reline::HISTORY[start_pos]}\n"
+          commands += "#{'%-6.6s' % start_pos.to_s} #{Readline::HISTORY[start_pos]}\n"
           start_pos += 1
         end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -902,7 +902,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   def tab_complete_path(str, words, dir_only)
     if client.platform == 'windows'
-      ::Reline.completion_case_fold = true
+        ::Readline.completion_case_fold = true
     end
     if client.commands.include?(COMMAND_ID_STDAPI_FS_LS)
       expanded = str
@@ -915,7 +915,7 @@ class Console::CommandDispatcher::Stdapi::Fs
         # This is annoying if we're recursively tab-traversing our way through subdirectories -
         # we may want to continue traversing, but MSF will add a space, requiring us to back up to continue
         # tab-completing our way through successive subdirectories.
-        ::Reline.completion_append_character = nil
+        ::Readline.completion_append_character = nil
       end
       results
     else
@@ -939,6 +939,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       result
     end
   end
+
 end
 
 end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -2,7 +2,6 @@
 require 'pp'
 require 'rex/text/table'
 require 'erb'
-require 'readline'
 
 module Rex
 module Ui
@@ -312,7 +311,7 @@ module DispatcherShell
         # This is annoying if we're recursively tab-traversing our way through subdirectories -
         # we may want to continue traversing, but MSF will add a space, requiring us to back up to continue
         # tab-completing our way through successive subdirectories.
-        ::Reline.completion_append_character = nil
+        ::Readline.completion_append_character = nil
       end
 
       if dirs.length == 0 && File.directory?(str)
@@ -407,16 +406,11 @@ module DispatcherShell
   # routine, stores all completed words, and passes the partial
   # word to the real tab completion function. This works around
   # a design problem in the Readline module and depends on the
-  # Reline.basic_word_break_characters variable being set to \x00
+  # Readline.basic_word_break_characters variable being set to \x00
   #
-  def tab_complete(str, opts: {})
-    # Compatibility with how Readline worked before Reline
-    if opts[:preposing]
-      str = "#{opts[:preposing]}#{str}"
-    end
-
-    ::Reline.completion_append_character = ' '
-    ::Reline.completion_case_fold = false
+  def tab_complete(str)
+    ::Readline.completion_append_character = ' '
+    ::Readline.completion_case_fold = false
 
     # Check trailing whitespace so we can tell 'x' from 'x '
     str_match = str.match(/[^\\]([\\]{2})*\s+$/)
@@ -430,7 +424,11 @@ module DispatcherShell
 
     # Pop the last word and pass it to the real method
     result = tab_complete_stub(str, split_str)
-    result&.uniq
+    if result
+      result.uniq
+    else
+      result
+    end
   end
 
   # Performs tab completion of a command, if supported

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -8,7 +8,7 @@ begin
 
   ###
   #
-  # This class implements standard input using Reline against
+  # This class implements standard input using readline against
   # standard input.  It supports tab completion.
   #
   ###
@@ -18,12 +18,16 @@ begin
     # Initializes the readline-aware Input instance for text.
     #
     def initialize(tab_complete_proc = nil)
-      self.extend(::Reline)
+      if(not Object.const_defined?('Readline'))
+        require 'readline'
+      end
+
+      self.extend(::Readline)
 
       if tab_complete_proc
-        ::Reline.basic_word_break_characters = ""
+        ::Readline.basic_word_break_characters = ""
         @rl_saved_proc = with_error_handling(tab_complete_proc)
-        ::Reline.completion_proc = @rl_saved_proc
+        ::Readline.completion_proc = @rl_saved_proc
       end
     end
 
@@ -31,8 +35,8 @@ begin
     # Reattach the original completion proc
     #
     def reset_tab_completion(tab_complete_proc = nil)
-      ::Reline.basic_word_break_characters = "\x00"
-      ::Reline.completion_proc = tab_complete_proc ? with_error_handling(tab_complete_proc) : @rl_saved_proc
+      ::Readline.basic_word_break_characters = "\x00"
+      ::Readline.completion_proc = tab_complete_proc ? with_error_handling(tab_complete_proc) : @rl_saved_proc
     end
 
 
@@ -40,7 +44,11 @@ begin
     # Retrieve the line buffer
     #
     def line_buffer
-      ::Reline.line_buffer
+      if defined? RbReadline
+        RbReadline.rl_line_buffer
+      else
+        ::Readline.line_buffer
+      end
     end
 
     attr_accessor :prompt
@@ -89,7 +97,7 @@ begin
 
         output.prompting
         line = readline_with_output(prompt, true)
-        ::Reline::HISTORY.pop if (line and line.empty?)
+        ::Readline::HISTORY.pop if (line and line.empty?)
       ensure
         Thread.current.priority = orig || 0
       end
@@ -124,8 +132,13 @@ begin
     private
 
     def readline_with_output(prompt, add_history=false)
-      # Output needs to be set so that colorization works for the prompt on Windows.
-
+      # rb-readlines's Readline.readline hardcodes the input and output to
+      # $stdin and $stdout, which means setting `Readline.input` or
+      # `Readline.ouput` has no effect when running `Readline.readline` with
+      # rb-readline, so need to reimplement
+      # []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
+      # for rb-readline to support setting input and output.  Output needs to
+      # be set so that colorization works for the prompt on Windows.
       self.prompt = prompt
 
       # TODO: there are unhandled quirks in async output buffering that
@@ -140,17 +153,38 @@ begin
 =end
       reset_sequence = ""
 
-      ::Reline.input = fd
-      ::Reline.output = output
+      if defined? RbReadline
+        RbReadline.rl_instream = fd
+        RbReadline.rl_outstream = output
 
-      line = ::Reline.readline(reset_sequence + prompt, add_history)
+        begin
+          line = RbReadline.readline(reset_sequence + prompt)
+        rescue ::Exception => exception
+          RbReadline.rl_cleanup_after_signal()
+          RbReadline.rl_deprep_terminal()
 
-      # Don't add duplicate lines to history
-      if ::Reline::HISTORY.length > 1 && line == ::Reline::HISTORY[-2]
-        ::Reline::HISTORY.pop
+          raise exception
+        end
+
+        if add_history && line && !line.start_with?(' ')
+          # Don't add duplicate lines to history
+          if ::Readline::HISTORY.empty? || line.strip != ::Readline::HISTORY[-1]
+            RbReadline.add_history(line.strip)
+          end
+        end
+
+        line.try(:dup)
+      else
+        # The line that's read is immediately added to history
+        line = ::Readline.readline(reset_sequence + prompt, true)
+
+        # Don't add duplicate lines to history
+        if ::Readline::HISTORY.length > 1 && line == ::Readline::HISTORY[-2]
+          ::Readline::HISTORY.pop
+        end
+
+        line
       end
-
-      line
     end
 
     private

--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -39,18 +39,21 @@ class IrbShell
     # commands will work.
     IRB.conf[:MAIN_CONTEXT] = irb.context
 
-    begin
-      old_sigint = trap("SIGINT") do
+    # Trap interrupt
+    old_sigint = trap("SIGINT") do
+      begin
         irb.signal_handle
-      end
-
-      # Keep processing input until the cows come home...
-      catch(:IRB_EXIT) do
+      rescue RubyLex::TerminateLineInput
         irb.eval_input
       end
-    ensure
-      trap("SIGINT", old_sigint) if old_sigint
     end
+
+    # Keep processing input until the cows come home...
+    catch(:IRB_EXIT) do
+      irb.eval_input
+    end
+
+    trap("SIGINT", old_sigint)
   end
 
 end

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -94,7 +94,6 @@ class Output::Stdio < Rex::Ui::Text::Output
     msg
   end
   alias_method :write, :print_raw
-  alias_method :<<, :write
 
   def supports_color?
     case config[:color]

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -66,10 +66,7 @@ module Shell
   def init_tab_complete
     if (self.input and self.input.supports_readline)
       # Unless cont_flag because there's no tab complete for continuation lines
-      tab_complete_lambda = proc do |str, preposing = nil, postposing = nil|
-        next tab_complete(str, opts: { preposing: preposing, postposing: postposing }).map { |result| result[preposing.to_s.length..] } unless cont_flag
-      end
-      self.input = Input::Readline.new(tab_complete_lambda)
+      self.input = Input::Readline.new(lambda { |str| tab_complete(str) unless cont_flag })
       self.input.output = self.output
     end
   end
@@ -117,8 +114,8 @@ module Shell
   #
   # Performs tab completion on the supplied string.
   #
-  def tab_complete(str, opts: {})
-    tab_complete_proc(str, opts: opts) if tab_complete_proc
+  def tab_complete(str)
+    return tab_complete_proc(str) if (tab_complete_proc)
   end
 
   #
@@ -307,13 +304,13 @@ module Shell
 
     begin
       history_manager.with_context(history_file: histfile, name: name) do
-        self.hist_last_saved = ::Reline::HISTORY.length
+        self.hist_last_saved = Readline::HISTORY.length
 
         yield
       end
     ensure
       history_manager.flush
-      self.hist_last_saved = ::Reline::HISTORY.length
+      self.hist_last_saved = Readline::HISTORY.length
     end
   end
 
@@ -513,6 +510,7 @@ module Shell
   attr_reader   :cont_flag # :nodoc:
   attr_accessor :name
 private
+
   def try_exec(command)
     begin
       %x{ #{ command } }

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -197,8 +197,6 @@ Gem::Specification.new do |spec|
   # Library for exploit development helpers
   spec.add_runtime_dependency 'rex-exploitation'
   # Command line editing, history, and tab completion in msfconsole
-  spec.add_runtime_dependency 'reline'
-  # Legacy support for FILENAME_COMPLETION_PROC, not present in Reline
   spec.add_runtime_dependency 'rb-readline'
   # Needed by some modules
   spec.add_runtime_dependency 'rubyzip'
@@ -249,6 +247,9 @@ Gem::Specification.new do |spec|
   # Do not use this to process untrusted PNG files! This is only to be used
   # to generate PNG files, not to parse untrusted PNG files.
   spec.add_runtime_dependency 'chunky_png'
+
+  # Needed for multiline REPL support for interactive SQL sessions
+  spec.add_runtime_dependency 'reline'
 
   # Standard libraries: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
   %w[

--- a/modules/post/linux/manage/pseudo_shell.rb
+++ b/modules/post/linux/manage/pseudo_shell.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'reline'
+require 'readline'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
@@ -104,9 +104,9 @@ class MetasploitModule < Msf::Post
   def prompt_show
     promptshell = "#{@vusername}@#{@vhostname}:#{pwd.strip}#{@vpromptchar} "
     comp = proc { |s| LIST.grep(/^#{Regexp.escape(s)}/) }
-    Reline.completion_append_character = ' '
-    Reline.completion_proc = comp
-    input = Reline.readline(promptshell, true)
+    Readline.completion_append_character = ' '
+    Readline.completion_proc = comp
+    input = Readline.readline(promptshell, true)
     return nil if input.nil?
 
     input

--- a/msfconsole
+++ b/msfconsole
@@ -6,8 +6,6 @@
 #
 
 require 'pathname'
-require 'reline'
-
 begin
 
   # Silences warnings as they only serve to confuse end users

--- a/spec/lib/msf/debug_spec.rb
+++ b/spec/lib/msf/debug_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Msf::Ui::Debug do
   end
 
   it 'correctly retrieves and parses a command history shorter than the command total' do
-    stub_const('Reline::HISTORY', Array.new(4) { |i| "Command #{i + 1}" })
+    stub_const('Readline::HISTORY', Array.new(4) { |i| "Command #{i + 1}" })
 
     driver = instance_double(
       Msf::Ui::Console::Driver,
@@ -251,7 +251,7 @@ RSpec.describe Msf::Ui::Debug do
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
 
-    stub_const('Reline::HISTORY', Array.new(10) { |i| "Command #{i + 1}" })
+    stub_const('Readline::HISTORY', Array.new(10) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr
@@ -288,7 +288,7 @@ RSpec.describe Msf::Ui::Debug do
     )
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
-    stub_const('Reline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
+    stub_const('Readline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr
@@ -325,7 +325,7 @@ RSpec.describe Msf::Ui::Debug do
     )
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
-    stub_const('Reline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
+    stub_const('Readline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
-require 'reline'
+
+require 'readline'
 
 RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
   include_context 'Msf::DBManager'

--- a/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
+++ b/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'reline'
+require 'readline'
 
 RSpec.describe Rex::Ui::Text::DispatcherShell do
   let(:prompt) { '%undmsf6%clr' }

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -31,7 +31,7 @@ require 'msfenv'
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'rex'
-require 'reline'
+require 'readline'
 require 'metasm'
 
 #PowerPC, seems broken for now in metasm

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -21,7 +21,7 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'msfenv'
 require 'rex'
-require 'reline'
+require 'readline'
 
 # Check to make sure nasm is installed and reachable through the user's PATH.
 begin


### PR DESCRIPTION
Reverts rapid7/metasploit-framework#19397

## Testing
- [ ] Ensure the tests pass
- [ ] Ensure the `spool` command works as expected
- [ ] Ensure that you have no crashes when scrolling through your history using up/down arrow keys
- [ ] Ensure you can paste, delete, input non-English characters, e.g. `メタスプロイトが大好きです`
- [ ] Ensure that in a Meterpreter session, you can `cat` a non-English file and that the contents are what you would expect
- [ ] Ensure tab-completion when pressing `use exploit/<TAB>` does not insert wild spaces at the end of the suggestion
- [ ] Ensure that tab-completing module options using `set` works and adds a space at the end
- [ ] Ensure that tab-completing run options using `run lho<TAB>` (or other option e.g. `rhosts`) autocompletes to `run lhost=` as expected
- [ ] Ensure that tab-completing run options using `run lhost=<TAB>` (or other option e.g. `rhosts`) suggests valid values
- [ ] Ensure that multi-line input in SQL shells works as expected