### PR TITLE
Allow settings the RPORT option for pipe_dcerpc_auditor

### DIFF
--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -24,11 +24,18 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
     )
 
-    deregister_options('RPORT')
     register_options(
       [
         OptString.new('SMBPIPE', [ true,  "The pipe name to use (BROWSER)", 'BROWSER']),
       ])
+  end
+
+  def connect(*args, **kwargs)
+    super(*args, **kwargs, direct: @smb_direct)
+  end
+
+  def rport
+    @rport
   end
 
   @@target_uuids = [
@@ -253,59 +260,69 @@ class MetasploitModule < Msf::Auxiliary
 
   # Fingerprint a single host
   def run_host(ip)
-    ports = [139, 445]
-
     if session
       print_status("Using existing session #{session.sid}")
       client = session.client
+      @rport = datastore['RPORT'] = session.port
       self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
-      ports = [simple.port]
       self.simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
+      check_uuids(ip)
+    else
+      if datastore['RPORT'].blank? || datastore['RPORT'] == 0
+        smb_services = [
+          { port: 445, direct: true },
+          { port: 139, direct: false }
+        ]
+      else
+        smb_services = [
+          { port: datastore['RPORT'], direct: datastore['SMBDirect'] }
+        ]
+      end
+
+      smb_services.each do |smb_service|
+        @rport = smb_service[:port]
+        @smb_direct = smb_service[:direct]
+  
+        begin
+          connect
+          smb_login
+          check_uuids(ip)
+          disconnect
+        rescue ::Exception
+          print_line($!.to_s)
+        end
+
+      end
     end
 
-    ports.each do |port|
-      datastore['RPORT'] = port
+  end
+
+  def check_uuids(ip)
+    @@target_uuids.each do |uuid|
+  
+      handle = dcerpc_handle_target(
+        uuid[0], uuid[1],
+        'ncacn_np', ["\\#{datastore['SMBPIPE']}"], self.simple.address
+      )
 
       begin
-        unless session
-          connect()
-          smb_login()
-        end
-
-        @@target_uuids.each do |uuid|
-
-          handle = dcerpc_handle_target(
-            uuid[0], uuid[1],
-            'ncacn_np', ["\\#{datastore['SMBPIPE']}"], self.simple.address
-          )
-
-          begin
-            dcerpc_bind(handle)
-            print_line("UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}")
-            # Add Report
-            report_note(
-              :host	=> ip,
-              :proto => 'tcp',
-              :sname	=> 'smb',
-              :port	=> rport,
-              :type	=> "UUID #{uuid[0]} #{uuid[1]}",
-              :data	=> "UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}"
-            )
-          rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-            print_line("UUID #{uuid[0]} #{uuid[1]} ERROR 0x%.8x" % e.error_code)
-          rescue StandardError => e
-            print_line("UUID #{uuid[0]} #{uuid[1]} ERROR #{$!}")
-          end
-        end
-
-        disconnect()
-
-        return
-      rescue ::Exception
-        print_line($!.to_s)
+        dcerpc_bind(handle)
+        print_line("UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}")
+        # Add Report
+        report_note(
+          :host	=> ip,
+          :proto => 'tcp',
+          :sname	=> 'smb',
+          :port	=> rport,
+          :type	=> "UUID #{uuid[0]} #{uuid[1]}",
+          :data	=> "UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}"
+        )
+      rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
+        print_line("UUID #{uuid[0]} #{uuid[1]} ERROR 0x%.8x" % e.error_code)
+      rescue StandardError => e
+        print_line("UUID #{uuid[0]} #{uuid[1]} ERROR #{$!}")
       end
     end
   end
-
 
 end


### PR DESCRIPTION
This PR adds the same pattern in #19163 to `pipe_dcerpc_auditor`.