### PR TITLE
Keep LDAP sessions alive

### DIFF
--- a/lib/msf/base/sessions/ldap.rb
+++ b/lib/msf/base/sessions/ldap.rb
@@ -15,6 +15,9 @@ class Msf::Sessions::LDAP
   attr_accessor :client
 
   attr_accessor :keep_alive_thread
+  
+  # @return [Integer] Seconds between keepalive requests
+  attr_accessor :keepalive_seconds
 
   attr_accessor :platform, :arch
   attr_reader :framework
@@ -22,8 +25,10 @@ class Msf::Sessions::LDAP
   # @param[Rex::IO::Stream] rstream
   # @param [Hash] opts
   # @option opts [Rex::Proto::LDAP::Client] :client
+  # @option opts [Integer] :keepalive
   def initialize(rstream, opts = {})
     @client = opts.fetch(:client)
+    @keepalive_seconds = opts.fetch(:keepalive_seconds)
     self.console = Rex::Post::LDAP::Ui::Console.new(self)
     super(rstream, opts)
   end
@@ -152,20 +157,19 @@ class Msf::Sessions::LDAP
 
   # Start a background thread for regularly sending a no-op command to keep the connection alive
   def start_keep_alive_loop
-    self.keep_alive_thread = framework.threads.spawn('LDAP-shell-keepalive', false) do
-      keep_alive_timeout = 10 * 60 # 10 minutes
+    self.keep_alive_thread = framework.threads.spawn("LDAP-shell-keepalive-#{sid}", false) do
       loop do
         if client.last_interaction.nil?
-          remaining_sleep = keep_alive_timeout
+          remaining_sleep = @keepalive_seconds
         else
-          remaining_sleep = keep_alive_timeout - (Time.now - client.last_interaction)
+          remaining_sleep = @keepalive_seconds - (Process.clock_gettime(Process::CLOCK_MONOTONIC) - client.last_interaction)
         end
         sleep(remaining_sleep)
-        if (Time.now - client.last_interaction) > keep_alive_timeout
+        if (Process.clock_gettime(Process::CLOCK_MONOTONIC) - client.last_interaction) > @keepalive_seconds
           client.search_root_dse
         end
         # This should have moved last_interaction forwards
-        fail if (Time.now - client.last_interaction) > keep_alive_timeout
+        fail if (Process.clock_gettime(Process::CLOCK_MONOTONIC) - client.last_interaction) > @keepalive_seconds
       end
     end
   end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -168,6 +168,7 @@ module Msf
     #   the target LDAP server.
     def ldap_new(opts = {})
       ldap = Rex::Proto::LDAP::Client.new(resolve_connect_opts(get_connect_opts.merge(opts)))
+      mutex = Mutex.new
 
       # NASTY, but required
       # monkey patch ldap object in order to ignore bind errors
@@ -177,13 +178,17 @@ module Msf
       # "Note that disabling the anonymous bind mechanism does not prevent anonymous
       # access to the directory."
       # Bug created for Net:LDAP at https://github.com/ruby-ldap/ruby-net-ldap/issues/375
+      # Also used to support multi-threading (used for keep-alive)
       #
       # @yieldparam conn [Rex::Proto::LDAP::Client] The LDAP connection handle to use for connecting to
       #   the target LDAP server.
       # @param args [Hash] A hash containing options for the ldap connection
       def ldap.use_connection(args)
         if @open_connection
-          yield @open_connection
+          mutex.synchronize do
+            yield @open_connection
+          end
+          register_interaction
         else
           begin
             conn = new_connection

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -168,7 +168,6 @@ module Msf
     #   the target LDAP server.
     def ldap_new(opts = {})
       ldap = Rex::Proto::LDAP::Client.new(resolve_connect_opts(get_connect_opts.merge(opts)))
-      mutex = Mutex.new
 
       # NASTY, but required
       # monkey patch ldap object in order to ignore bind errors
@@ -185,9 +184,7 @@ module Msf
       # @param args [Hash] A hash containing options for the ldap connection
       def ldap.use_connection(args)
         if @open_connection
-          mutex.synchronize do
-            yield @open_connection
-          end
+          yield @open_connection
           register_interaction
         else
           begin

--- a/lib/rex/proto/ldap/client.rb
+++ b/lib/rex/proto/ldap/client.rb
@@ -11,9 +11,21 @@ module Rex
         # @return [Rex::Socket]
         attr_reader :socket
 
+        # [Time] The last time an interaction occurred on the connection (for keep-alive purposes)
+        attr_reader :last_interaction
+
+        # [Mutex] Control access to the connection. One at a time.
+        attr_reader :connection_use_mutex
+
         def initialize(args)
           @base_dn = args[:base]
+          @last_interaction = nil
+          @connection_use_mutex = Mutex.new
           super
+        end
+
+        def register_interaction
+          @last_interaction = Time.now
         end
 
         # @return [Array<String>] LDAP servers naming contexts
@@ -46,6 +58,14 @@ module Rex
           "#{peerhost}:#{peerport}"
         end
 
+        def use_connection(args)
+          @connection_use_mutex.synchronize do
+            return super(args)
+          ensure
+            register_interaction
+          end
+        end
+
         # https://github.com/ruby-ldap/ruby-net-ldap/issues/11
         # We want to keep the ldap connection open to use later
         # but there's no built in way within the `Net::LDAP` library to do that
@@ -65,6 +85,7 @@ module Rex
             @socket = @open_connection.socket
             payload[:connection] = @open_connection
             payload[:bind] = @result = @open_connection.bind(@auth)
+            register_interaction
             return self
           end
         end

--- a/lib/rex/proto/ldap/client.rb
+++ b/lib/rex/proto/ldap/client.rb
@@ -25,7 +25,7 @@ module Rex
         end
 
         def register_interaction
-          @last_interaction = Time.now
+          @last_interaction = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
 
         # @return [Array<String>] LDAP servers naming contexts

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -36,7 +36,8 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new(
           'APPEND_DOMAIN', [true, 'Appends `@<DOMAIN> to the username for authentication`', false],
           conditions: ['LDAP::Auth', 'in', [Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::PLAINTEXT]]
-        )
+        ),
+        OptInt.new('SessionKeepalive', [true, 'Time (in seconds) for sending protocol-level keepalive messages', 10 * 60])
       ]
     )
 
@@ -48,6 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     else
       # Don't give the option to create a session unless ldap sessions are enabled
       options_to_deregister << 'CreateSession'
+      options_to_deregister << 'SessionKeepalive'
     end
 
     deregister_options(*options_to_deregister)
@@ -175,7 +177,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless result.connection && result.proof
 
     # Create a new session
-    my_session = Msf::Sessions::LDAP.new(result.connection, { client: result.proof })
+    my_session = Msf::Sessions::LDAP.new(result.connection, { client: result.proof, keepalive_seconds: datastore['SessionKeepalive'] })
 
     merge_me = {
       'USERPASS_FILE' => nil,

--- a/spec/lib/msf/base/sessions/ldap_spec.rb
+++ b/spec/lib/msf/base/sessions/ldap_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Msf::Sessions::LDAP do
   let(:client) { instance_double(Rex::Proto::LDAP::Client) }
-  let(:opts) { { client: client } }
+  let(:opts) { { client: client, keepalive_seconds: 600 } }
   let(:console_class) { Rex::Post::LDAP::Ui::Console }
   let(:user_input) { instance_double(Rex::Ui::Text::Input::Readline) }
   let(:user_output) { instance_double(Rex::Ui::Text::Output::Stdio) }


### PR DESCRIPTION
Domain Controllers by default time out after 15 minutes, forcibly terminating an LDAP connection if there has been no activity on the connection in that time. This adds functionality to keep the new LDAP sessions alive beyond a server's idle timeout. By sending a benign request (in our case after 10 minutes), the server happily keeps it alive.

To verify:

- [ ] Enable LDAP sessions (`features set ldap_session_type true`)
- [ ] Create an LDAP session against Active Directory (`ldap_login` module)
- [ ] Do nothing for >15 minutes
- [ ] Run some LDAPpy goodness (e.g. `ldap_query` or `shadow_credentials`)
- [ ] Test against other LDAP servers (I've tested against slapd on Ubuntu 20.04.6, so feel free to pick a different one to get extra coverage)

I've tested against Server 2008, Server 2012, Server 2022 and slapd.


```
msf6 auxiliary(scanner/ldap/ldap_login) > run rhost=192.168.20.2 username=Administrator domain=pod8 password=password

[+] 192.168.20.2:389 - Success: 'Administrator:password'
[*] LDAP session 2 opened (192.168.20.206:33839 -> 192.168.20.2:389) at 2024-10-09 11:42:24 +1100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Bruteforce completed, 1 credential was successful.
[*] 1 LDAP session was opened successfully.
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ldap/ldap_login) > use auxiliary/gather/ldap_query
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf6 auxiliary(gather/ldap_query) > date
[*] exec: date

Wed 09 Oct 2024 11:43:04 AEDT
msf6 auxiliary(scanner/ldap/ldap_login) > use auxiliary/gather/ldap_query
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf6 auxiliary(gather/ldap_query) > date
[*] exec: date

Wed 09 Oct 2024 11:58:24 AEDT
msf6 auxiliary(gather/ldap_query) > run session=2

[*] 192.168.20.2:389 Discovered base DN: DC=pod8,DC=lan
CN=Administrator,CN=Users,DC=pod8,DC=lan
========================================

 Name                Attributes
 ----                ----------
 badpwdcount         0
 description         Built-in account for administering the computer/domain
 lastlogoff          1601-01-01 00:00:00 UTC
 lastlogon           2024-10-03 13:48:59 UTC
 logoncount          509
 memberof            CN=Group Policy Creator Owners,CN=Users,DC=pod8,DC=lan
   \_                CN=Domain Admins,CN=Users,DC=pod8,DC=lan
   \_                CN=Enterprise Admins,CN=Users,DC=pod8,DC=lan
   \_                CN=Schema Admins,CN=Users,DC=pod8,DC=lan
   \_                CN=Administrators,CN=Builtin,DC=pod8,DC=lan
 name                Administrator
 objectsid           S-1-5-21-417865548-2826249791-3824062093-500
 pwdlastset
 samaccountname      Administrator
 useraccountcontrol  66048
 ...
```