### PR TITLE
Improve database module cache performance

### DIFF
--- a/spec/support/shared/examples/msf/db_manager/module_cache.rb
+++ b/spec/support/shared/examples/msf/db_manager/module_cache.rb
@@ -812,7 +812,8 @@ RSpec.shared_examples_for 'Msf::DBManager::ModuleCache' do
           allow(db_manager).to receive(
               :module_to_details_hash
           ).with(
-              module_instance
+              module_instance,
+              with_mixins: false
           ).and_return(
               module_to_details_hash
           )

--- a/spec/support/shared/examples/msf/db_manager/update_all_module_details_refresh.rb
+++ b/spec/support/shared/examples/msf/db_manager/update_all_module_details_refresh.rb
@@ -29,19 +29,20 @@ RSpec.shared_examples_for 'Msf::DBManager#update_all_module_details refresh' do
       update_all_module_details
     end
 
-    it 'should call update_module_details to create a new Mdm::Module::Detail from the module instance returned by create' do
-      expect(db_manager).to receive(:update_module_details) do |module_instance|
-        expect(module_instance).to be_a Msf::Module
-        expect(module_instance.type).to eq module_detail.mtype
-        expect(module_instance.refname).to eq module_detail.refname
-      end
-
+    it 'should create a new Mdm::Module::Detail entry' do
       update_all_module_details
+
+      aggregate_failures do
+        expect(Mdm::Module::Detail.count).to eq 1
+        db_module_detail = Mdm::Module::Detail.first
+        expect(db_module_detail.mtype).to eq(module_detail.mtype)
+        expect(db_module_detail.refname).to eq(module_detail.refname)
+      end
     end
 
-    context 'with exception raised by #update_module_details' do
+    context 'with exception raised by #insert_all' do
       before(:example) do
-        expect(db_manager).to receive(:update_module_details).and_raise(Exception)
+        expect(db_manager).to receive(:module_to_details_hash).and_raise(Exception)
       end
 
       it 'should log error' do


### PR DESCRIPTION
Improves the database module cache performance from ~3 minutes to ~1 by performing bulk inserts of module metadata instead of multiple smaller inserts for every module/reference/author/etc.

## Verification

- Open msfconsole
- Open IRB when inside of msfconsole
- Run the migration
- Verify the cache is correctly populated into the database

### Before

The multiple DB inserts for each record takes 100 or so seconds

```
>> framework.db.purge_all_module_details; puts 'updating'; _, elapsed_time = Rex::Stopwatch.elapsed_time { framework.db.update_all_module_details }; puts elapsed_time
190.257881
```

### After

The DB inserts take a 1-2 seconds

```
>> framework.db.purge_all_module_details; puts 'updating'; _, elapsed_time = Rex::Stopwatch.elapsed_time { framework.db.update_all_module_details }; puts elapsed_time
76.59721399999944
```