### PR TITLE
Fix username/password generation in case both PASSWORD_SPRAY and USER_AS_PASS are enabled

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -280,6 +280,16 @@ module Metasploit::Framework
         yield Metasploit::Framework::Credential.new(public: '', private: '', realm: realm, private_type: :password)
       end
 
+      if user_as_pass
+        if user_fd
+          user_fd.each_line do |user_from_file|
+            user_from_file.chomp!
+            yield Metasploit::Framework::Credential.new(public: user_from_file, private: user_from_file, realm: realm, private_type: private_type(password))
+          end
+          user_fd.seek(0)
+        end
+      end
+
       if password.present?
         if nil_passwords
           yield Metasploit::Framework::Credential.new(public: username, private: nil, realm: realm, private_type: :password)
@@ -308,9 +318,6 @@ module Metasploit::Framework
             pass_from_file.chomp!
             if username.present?
               yield Metasploit::Framework::Credential.new(public: username, private: pass_from_file, realm: realm, private_type: :password)
-            end
-            if user_as_pass
-              yield Metasploit::Framework::Credential.new(public: pass_from_file, private: pass_from_file, realm: realm, private_type: :password)
             end
             next unless user_fd
 

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -157,6 +157,24 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
           Metasploit::Framework::Credential.new(public: "user3", private: "password2"),
         )
       end
+
+      context 'when :user_as_pass is true' do
+        let(:user_as_pass) { true }
+
+        specify  do
+          expect { |b| collection.each(&b) }.to yield_successive_args(
+            Metasploit::Framework::Credential.new(public: "user1", private: "user1"),
+            Metasploit::Framework::Credential.new(public: "user2", private: "user2"),
+            Metasploit::Framework::Credential.new(public: "user3", private: "user3"),
+            Metasploit::Framework::Credential.new(public: "user1", private: "password1"),
+            Metasploit::Framework::Credential.new(public: "user2", private: "password1"),
+            Metasploit::Framework::Credential.new(public: "user3", private: "password1"),
+            Metasploit::Framework::Credential.new(public: "user1", private: "password2"),
+            Metasploit::Framework::Credential.new(public: "user2", private: "password2"),
+            Metasploit::Framework::Credential.new(public: "user3", private: "password2"),
+          )
+        end
+      end
     end
 
     context 'when given a username and password' do


### PR DESCRIPTION
Fixes #19525 

I think this is the minimal code for fixing this bug.

But looking at the `each_filtered` method, I think I found a few more bugs along the way.
I didn't want to go into this to make this review easier but I think it would be worth spending a bit more time on this method to:
- add test cases to show the suspected bugs & fix them
- take some time to refactor this code a bit (it looks like the `each_unfiltered_password_first`, introduced for the `PASSWORD_SPRAY` option, is a quick adaptation of the `each_unfiltered_username_first`, maybe with a few mistakes)

This is my first PR for the metasploit project and I've looked at the basecode for the first time today, so sorry in advance if I missed something in the process 😓 
