### PR TITLE
Don't require Username and Password for every RHost auth: allows Scha…

### DIFF
--- a/lib/msf/core/optional_session/ldap.rb
+++ b/lib/msf/core/optional_session/ldap.rb
@@ -6,7 +6,7 @@ module Msf
       include Msf::OptionalSession
 
       RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT DOMAIN USERNAME PASSWORD THREADS]
-      REQUIRED_OPTIONS = %w[RHOSTS RPORT USERNAME PASSWORD THREADS]
+      REQUIRED_OPTIONS = %w[RHOSTS RPORT THREADS]
 
       def initialize(info = {})
         super(


### PR DESCRIPTION
This fixes a datastore options bug for LDAP modules. With the new optional session functionality enabled, if using `RHOST`, the system forced the use of Username and Password. However several valid configurations exist that do not require these settings (e.g. Schannel, or cached Kerberos creds).

```
msf6 auxiliary(gather/ldap_query) > run rhost=4.200.16.98 ssl=true ldap::certfile=/home/smash/.msf4/loot/20241008165417_default_4.200.16.98_windows.ad.cs_371440.pfx ldap::auth=schannel

[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option PASSWORD: PASSWORD must be specified
[-] Invalid option USERNAME: USERNAME must be specified

msf6 auxiliary(gather/ldap_query) > run rhost=4.200.16.98 ldap::auth=kerberos ldap::RHostname=dc22 domain=msf.local domaincontrollerrhost=4.200.16.98 username=AzureAdmin

[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option PASSWORD: PASSWORD must be specified
```

This PR resolves the issue by only initially requiring RHOST runs to have the bare minimum settings (host and port), and then let each auth provider do its own checks (schannel for certfile, kerberos for... all of its various possible settings).

## Verification

List the steps needed to make sure this thing works

- [x] Procure a domain controller
- [x] Start `msfconsole`
- [x] `features set ldap_session_type true`
- [x] Obtain a valid pfx file (e.g. using an ADCS module)
- [x] Auth to the system using Kerberos (e.g. by using `ldap_query` with `ldap::auth` set to `kerberos`
- [x] Validate you have the cached cred by running `klist`
- [ ] `use use auxiliary/gather/ldap_query`
- [ ] Auth to the system using `ldap::auth=schannel` and the `certfile` set
- [ ] Verify that it runs the query successfully
- [x] Auth to the system using `ldap::auth=kerberos`, with a username (so that it picks the correct cached cred), but no passward
- [ ] Verify that it runs the query successfully

## Test runs


After fix:

```
msf6 auxiliary(gather/ldap_query) > run rhost=4.200.16.98 ssl=true ldap::certfile=/home/smash/.msf4/loot/20241008165417_default_4.200.16.98_windows.ad.cs_371440.pfx ldap::auth=schannel
[*] Running module against 4.200.16.98
[*] 4.200.16.98:389 Discovered base DN: DC=msf,DC=local
CN=Administrators,CN=Builtin,DC=msf,DC=local
============================================
...


msf6 auxiliary(gather/ldap_query) > run rhost=4.200.16.98 ldap::auth=kerberos ldap::RHostname=dc22 domain=msf.local domaincontrollerrhost=4.200.16.98 username=AzureAdmin
[*] Running module against 4.200.16.98
[*] Using cached credential for ldap/dc22@MSF.LOCAL AzureAdmin@MSF.LOCAL
[+] 4.200.16.98:88 - Received AP-REQ. Extracting session key...
[*] 4.200.16.98:389 Discovered base DN: DC=msf,DC=local
CN=Administrators,CN=Builtin,DC=msf,DC=local
============================================
...
```