### PR TITLE
Update metasploit-payloads gem to 2.0.176

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.175)
+      metasploit-payloads (= 2.0.176)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.31)
       mqtt
@@ -295,7 +295,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.175)
+    metasploit-payloads (2.0.176)
     metasploit_data_models (6.0.3)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -88,7 +88,7 @@ metasploit-concern, 5.0.2, "New BSD"
 metasploit-credential, 6.0.9, "New BSD"
 metasploit-framework, 6.4.31, "New BSD"
 metasploit-model, 5.0.2, "New BSD"
-metasploit-payloads, 2.0.175, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.176, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.3, "New BSD"
 metasploit_payloads-mettle, 1.0.31, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.175'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.176'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.31'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Includes changes from:
* rapid7/metasploit-payloads#716

