### PR TITLE
Reline behind a feature flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,7 +405,7 @@ GEM
       nokogiri
     redcarpet (3.6.0)
     regexp_parser (2.9.2)
-    reline (0.5.10)
+    reline (0.5.11)
       io-console (~> 0.5)
     require_all (3.0.0)
     rex-arch (0.1.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    io-console (0.7.2)
+    io-console (0.8.0)
     irb (1.7.4)
       reline (>= 0.3.6)
     jmespath (1.6.2)
@@ -405,7 +405,7 @@ GEM
       nokogiri
     redcarpet (3.6.0)
     regexp_parser (2.9.2)
-    reline (0.5.11)
+    reline (0.5.12)
       io-console (~> 0.5)
     require_all (3.0.0)
     rex-arch (0.1.16)

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -547,9 +547,11 @@ Shell Banner:
     if expressions.empty?
       print_status('Starting IRB shell...')
       print_status("You are in the \"self\" (session) object\n")
-      framework.history_manager.with_context(name: :irb) do
+      Msf::Ui::Console::MsfReadline.instance.cache_current_config
+      framework.history_manager.with_context(name: :irb, input_library: :reline) do
         Rex::Ui::Text::IrbShell.new(self).run
       end
+      Msf::Ui::Console::MsfReadline.instance.restore_cached_config
     else
       # XXX: No vprint_status here
       if framework.datastore['VERBOSE'].to_s == 'true'
@@ -586,7 +588,7 @@ Shell Banner:
     print_status('Starting Pry shell...')
     print_status("You are in the \"self\" (session) object\n")
     Pry.config.history_load = false
-    framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+    framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry, input_library: Pry.input) do
       self.pry
     end
   end

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -29,6 +29,7 @@ module Msf
     LDAP_SESSION_TYPE = 'ldap_session_type'
     SHOW_SUCCESSFUL_LOGINS = 'show_successful_logins'
     DISPLAY_MODULE_ACTION = 'display_module_action'
+    USE_RELINE = 'use_reline'
 
     DEFAULTS = [
       {
@@ -132,6 +133,13 @@ module Msf
         requires_restart: false,
         default_value: true,
         developer_notes: 'Added as a feature so users can turn it off if they wish to reduce clutter in their terminal'
+      }.freeze,
+      {
+        name: USE_RELINE,
+        description: 'When enabled, the new Reline library will be used instead of the legacy Readline library for input/output.',
+        requires_restart: true,
+        default_value: false,
+        developer_notes: 'To be enabled by default after sufficient testing and Reline fixes the issues raised here: https://github.com/ruby/reline/issues/created_by/sjanusz-r7'
       }.freeze
     ].freeze
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -760,7 +760,8 @@ class Core
   end
 
   def cmd_history(*args)
-    length = Readline::HISTORY.length
+    history = Msf::Ui::Console::MsfReadline.instance.history
+    length = history.length
 
     if length < @history_limit
       limit = length
@@ -780,10 +781,10 @@ class Core
           limit = val.to_i
         end
       when '-c'
-        if Readline::HISTORY.respond_to?(:clear)
-          Readline::HISTORY.clear
-        elsif defined?(RbReadline)
-          RbReadline.clear_history
+        if history.respond_to?(:clear)
+          history.clear
+        elsif history.respond_to?(:pop) && history.respond_to?(:length)
+          history.length.times { |_i| history.pop }
         else
           print_error('Could not clear history, skipping file')
           return false
@@ -808,7 +809,7 @@ class Core
 
     (start..length-1).each do |pos|
       cmd_num = (pos + 1).to_s
-      print_line "#{cmd_num.ljust(pad_len)}  #{Readline::HISTORY[pos]}"
+      print_line "#{cmd_num.ljust(pad_len)}  #{history[pos]}"
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/session.rb
+++ b/lib/msf/ui/console/command_dispatcher/session.rb
@@ -96,9 +96,11 @@ module Msf
             if expressions.empty?
               print_status('Starting IRB shell...')
               print_status("You are in the session object\n")
-              framework.history_manager.with_context(name: :irb) do
+              Msf::Ui::Console::MsfReadline.instance.cache_current_config
+              framework.history_manager.with_context(name: :irb, input_library: :reline) do
                 Rex::Ui::Text::IrbShell.new(session).run
               end
+              Msf::Ui::Console::MsfReadline.instance.restore_cached_config
             else
               # XXX: No vprint_status here
               if framework.datastore['VERBOSE'].to_s == 'true'
@@ -136,7 +138,7 @@ module Msf
             print_status("You are in the session object\n")
 
             Pry.config.history_load = false
-            session.framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry) do
+            session.framework.history_manager.with_context(history_file: Msf::Config.pry_history, name: :pry, input_library: Pry.input) do
               session.pry
             end
           end

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -313,12 +313,9 @@ class Driver < Msf::Ui::Driver
   # Saves the recent history to the specified file
   #
   def save_recent_history(path)
-    num = Readline::HISTORY.length - hist_last_saved - 1
-
-    tmprc = ""
-    num.times { |x|
-      tmprc << Readline::HISTORY[hist_last_saved + x] + "\n"
-    }
+    history = Msf::Ui::Console::MsfReadline.instance.history
+    num = history.length - hist_last_saved - 1
+    tmprc = history.entries[hist_last_saved..].join("\n")
 
     if tmprc.length > 0
       print_status("Saving last #{num} commands to #{path} ...")
@@ -329,7 +326,7 @@ class Driver < Msf::Ui::Driver
 
     # Always update this, even if we didn't save anything. We do this
     # so that we don't end up saving the "makerc" command itself.
-    self.hist_last_saved = Readline::HISTORY.length
+    self.hist_last_saved = history.length
   end
 
   #

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -53,18 +53,18 @@ module Msf
             option_name = str.chop
             option_value = ''
 
-            ::Readline.completion_append_character = ' '
+            Msf::Ui::Console::MsfReadline.instance.completion_append_character = ' '
             return tab_complete_option_values(mod, option_value, words, opt: option_name).map { |value| "#{str}#{value}" }
           elsif str.include?('=')
             str_split = str.split('=')
             option_name = str_split[0].strip
             option_value = str_split[1].strip
 
-            ::Readline.completion_append_character = ' '
+            Msf::Ui::Console::MsfReadline.instance.completion_append_character = ' '
             return tab_complete_option_values(mod, option_value, words, opt: option_name).map { |value| "#{option_name}=#{value}" }
           end
 
-          ::Readline.completion_append_character = ''
+          Msf::Ui::Console::MsfReadline.instance.completion_append_character = ''
           tab_complete_option_names(mod, str, words).map { |name| "#{name}=" }
         end
 

--- a/lib/msf/ui/console/msf_readline.rb
+++ b/lib/msf/ui/console/msf_readline.rb
@@ -15,6 +15,7 @@ class Msf::Ui::Console::MsfReadline
   def initialize
     @backend = using_reline? ? ::Reline : ::Readline
     @history = @backend::HISTORY
+    @current_config = {}
   end
 
   def method_missing(sym, *args, &block)
@@ -30,14 +31,17 @@ class Msf::Ui::Console::MsfReadline
   # IRB changes propagate out of the context of IRB. We store the current state and restore it on exit.
   # TODO: Once IRB fixes this behaviour, we should be able to remove this patch.
   def cache_current_config
-    @current_config = {}
+    return unless using_reline?
+
     @current_config[:autocompletion] = self.autocompletion
-    @current_config[:core] = @backend.core.dup if using_reline?
+    @current_config[:core] = @backend.core.dup
   end
 
   def restore_cached_config
+    return unless using_reline?
+
     self.autocompletion = @current_config[:autocompletion]
-    @backend.instance_variable_set(:@core, @current_config[:core]) if using_reline?
+    @backend.instance_variable_set(:@core, @current_config[:core])
   end
 
   # Read a line from the user, and return it.

--- a/lib/msf/ui/console/msf_readline.rb
+++ b/lib/msf/ui/console/msf_readline.rb
@@ -1,0 +1,127 @@
+#
+# This class is responsible for handling Readline/Reline-agnostic user input.
+#
+class Msf::Ui::Console::MsfReadline
+  require 'singleton'
+  # Required to check the Reline flag.
+  require 'msf/core/feature_manager'
+  require 'readline'
+  require 'reline'
+
+  include Singleton
+
+  attr_reader :history
+
+  def initialize
+    @backend = using_reline? ? ::Reline : ::Readline
+    @history = @backend::HISTORY
+  end
+
+  def method_missing(sym, *args, &block)
+    if @backend.respond_to?(sym)
+      @backend.send(sym, *args, &block)
+    else
+      msg = "Method '#{sym}' not found in #{@backend.class}"
+      elog(msg)
+      raise NoMethodError, msg
+    end
+  end
+
+  # IRB changes propagate out of the context of IRB. We store the current state and restore it on exit.
+  # TODO: Once IRB fixes this behaviour, we should be able to remove this patch.
+  def cache_current_config
+    @current_config = {}
+    @current_config[:autocompletion] = self.autocompletion
+    @current_config[:core] = @backend.core.dup if using_reline?
+  end
+
+  def restore_cached_config
+    self.autocompletion = @current_config[:autocompletion]
+    @backend.instance_variable_set(:@core, @current_config[:core]) if using_reline?
+  end
+
+  # Read a line from the user, and return it.
+  # @param prompt [String] The prompt to show to the user.
+  # @param add_history [Boolean] True if the user's input should be saved to the history.
+  # @param opts [Hash] Options
+  # @return String The line that the user has entered.
+  def readline(prompt, add_history = false, opts: {})
+    input(prompt, add_history, opts: opts)
+  end
+
+  def using_reline?
+    return @using_reline unless @using_reline.nil?
+
+    @using_reline = Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::USE_RELINE)
+  end
+
+  private
+
+  attr_accessor :using_reline, :backend, :current_config
+
+  def input(*args, opts: {})
+    using_reline? ? input_reline(*args, opts: opts) : input_rbreadline(*args, opts: opts)
+  end
+
+  def input_rbreadline(prompt, add_history = false, opts: {})
+    # rb-readlines's Readline.readline hardcodes the input and output to
+    # $stdin and $stdout, which means setting `Readline.input` or
+    # `Readline.output` has no effect when running `Readline.readline` with
+    # rb-readline, so need to reimplement
+    # []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
+    # for rb-readline to support setting input and output.  Output needs to
+    # be set so that colorization works for the prompt on Windows.
+
+    input_on_entry = RbReadline.rl_instream
+    output_on_entry = RbReadline.rl_outstream
+
+    begin
+      RbReadline.rl_instream = opts[:fd]
+      RbReadline.rl_outstream = opts[:output]
+      line = RbReadline.readline(prompt.to_s)
+    rescue ::StandardError => e
+      RbReadline.rl_instream = input_on_entry
+      RbReadline.rl_outstream = output_on_entry
+      RbReadline.rl_cleanup_after_signal
+      RbReadline.rl_deprep_terminal
+
+      raise e
+    end
+
+    if add_history && line && !line.start_with?(' ')
+      # Don't add duplicate lines to history
+      if ::Readline::HISTORY.empty? || line.strip != ::Readline::HISTORY[-1]
+        RbReadline.add_history(line.strip)
+      end
+    end
+
+    line.dup
+  end
+
+  def input_reline(prompt, add_history = false, opts: {})
+    input_on_entry = Reline::IOGate.instance_variable_get(:@input)
+    output_on_entry = Reline::IOGate.instance_variable_get(:@output)
+
+    begin
+      # TODO: Currently we can't pase in non-ASCII chars. The code below fixes that but breaks out rab completion due
+      # to encoding issues.
+      # input_external_encoding = opts[:fd].external_encoding
+      # input_internal_encoding = opts[:fd].internal_encoding
+      # opts[:fd].set_encoding(::Encoding::UTF_8)
+      Reline.input = opts[:fd]
+      Reline.output = opts[:output]
+      line = Reline.readline(prompt.to_s, add_history)
+    ensure
+      # opts[:fd].set_encoding(input_external_encoding, input_internal_encoding)
+      Reline.input = input_on_entry
+      Reline.output = output_on_entry
+    end
+
+    # Don't add duplicate lines to history
+    if Reline::HISTORY.length > 1 && line == Reline::HISTORY[-2]
+      Reline::HISTORY.pop
+    end
+
+    line.dup
+  end
+end

--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -220,13 +220,14 @@ module Msf
       end
 
       def self.history(driver)
-        end_pos = Readline::HISTORY.length - 1
+        history = Msf::Ui::Console::MsfReadline.instance.history
+        end_pos = history.length - 1
         start_pos = end_pos - COMMAND_HISTORY_TOTAL > driver.hist_last_saved ? end_pos - (COMMAND_HISTORY_TOTAL - 1) : driver.hist_last_saved
 
         commands = ''
         while start_pos <= end_pos
           # Formats command position in history to 6 characters in length
-          commands += "#{'%-6.6s' % start_pos.to_s} #{Readline::HISTORY[start_pos]}\n"
+          commands += "#{'%-6.6s' % start_pos.to_s} #{history[start_pos]}\n"
           start_pos += 1
         end
 

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -347,3 +347,17 @@ require 'expect'
 
 # XXX: Should be removed once the `lib/metasploit` folder is loaded by Zeitwerk
 require 'metasploit/framework/hashes'
+
+# TODO: Remove this monkey-patch once the following issue is addressed over on Reline's repository here:
+# https://github.com/ruby/reline/issues/756
+require 'reline'
+class ::Reline::Core
+  alias old_completion_append_character= completion_append_character=
+  alias old_completion_append_character completion_append_character
+
+  def completion_append_character=(v)
+    self.old_completion_append_character = v
+    # Additionally keep the line_editor in sync
+    line_editor.completion_append_character = self.old_completion_append_character
+  end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -902,7 +902,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   def tab_complete_path(str, words, dir_only)
     if client.platform == 'windows'
-        ::Readline.completion_case_fold = true
+      Msf::Ui::Console::MsfReadline.instance.completion_case_fold = true
     end
     if client.commands.include?(COMMAND_ID_STDAPI_FS_LS)
       expanded = str
@@ -915,7 +915,7 @@ class Console::CommandDispatcher::Stdapi::Fs
         # This is annoying if we're recursively tab-traversing our way through subdirectories -
         # we may want to continue traversing, but MSF will add a space, requiring us to back up to continue
         # tab-completing our way through successive subdirectories.
-        ::Readline.completion_append_character = nil
+        Msf::Ui::Console::MsfReadline.instance.completion_append_character = nil
       end
       results
     else

--- a/lib/rex/post/sql/ui/console/interactive_sql_client.rb
+++ b/lib/rex/post/sql/ui/console/interactive_sql_client.rb
@@ -73,7 +73,7 @@ module InteractiveSqlClient
     return { status: :fail, errors: ["Unable to get history file for session type: #{name}"] } if history_file.nil?
 
     # Multiline (Reline) and fallback (Readline) have separate history contexts as they are two different libraries.
-    framework.history_manager.with_context(history_file: history_file , name: name, input_library: :reline) do
+    framework.history_manager.with_context(history_file: history_file, name: name, input_library: :reline) do
       query = _multiline
     end
 

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -4,30 +4,32 @@ module Rex
 module Ui
 module Text
 
-begin
-
-  ###
   #
   # This class implements standard input using readline against
   # standard input.  It supports tab completion.
   #
-  ###
   class Input::Readline < Rex::Ui::Text::Input
+
+    #
+    # The prompt that is to be displayed.
+    #
+    attr_accessor :prompt
+
+    #
+    # The output handle to use when displaying the prompt.
+    #
+    attr_accessor :output
 
     #
     # Initializes the readline-aware Input instance for text.
     #
     def initialize(tab_complete_proc = nil)
-      if(not Object.const_defined?('Readline'))
-        require 'readline'
-      end
-
-      self.extend(::Readline)
-
+      super()
       if tab_complete_proc
-        ::Readline.basic_word_break_characters = ""
-        @rl_saved_proc = with_error_handling(tab_complete_proc)
-        ::Readline.completion_proc = @rl_saved_proc
+        Msf::Ui::Console::MsfReadline.instance.basic_word_break_characters = ''
+        # Cache the value so that we can use it when resetting the proc.
+        @completion_proc = tab_complete_proc
+        Msf::Ui::Console::MsfReadline.instance.completion_proc = with_error_handling(@completion_proc)
       end
     end
 
@@ -35,23 +37,10 @@ begin
     # Reattach the original completion proc
     #
     def reset_tab_completion(tab_complete_proc = nil)
-      ::Readline.basic_word_break_characters = "\x00"
-      ::Readline.completion_proc = tab_complete_proc ? with_error_handling(tab_complete_proc) : @rl_saved_proc
+      Msf::Ui::Console::MsfReadline.instance.basic_word_break_characters = "\x00"
+      @completion_proc = with_error_handling(tab_complete_proc) if tab_complete_proc
+      Msf::Ui::Console::MsfReadline.instance.completion_proc = @completion_proc
     end
-
-
-    #
-    # Retrieve the line buffer
-    #
-    def line_buffer
-      if defined? RbReadline
-        RbReadline.rl_line_buffer
-      else
-        ::Readline.line_buffer
-      end
-    end
-
-    attr_accessor :prompt
 
     #
     # Whether or not the input medium supports readline.
@@ -95,11 +84,11 @@ begin
       begin
         Thread.current.priority = -20
 
-        output.prompting
-        line = readline_with_output(prompt, true)
-        ::Readline::HISTORY.pop if (line and line.empty?)
+        output.prompting(true)
+        line = Msf::Ui::Console::MsfReadline.instance.readline(prompt, true, opts: { fd: fd, output: output })
       ensure
         Thread.current.priority = orig || 0
+        output.prompting(false)
       end
 
       line
@@ -120,88 +109,21 @@ begin
       true
     end
 
-    #
-    # The prompt that is to be displayed.
-    #
-    attr_accessor :prompt
-    #
-    # The output handle to use when displaying the prompt.
-    #
-    attr_accessor :output
-
     private
 
-    def readline_with_output(prompt, add_history=false)
-      # rb-readlines's Readline.readline hardcodes the input and output to
-      # $stdin and $stdout, which means setting `Readline.input` or
-      # `Readline.ouput` has no effect when running `Readline.readline` with
-      # rb-readline, so need to reimplement
-      # []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
-      # for rb-readline to support setting input and output.  Output needs to
-      # be set so that colorization works for the prompt on Windows.
-      self.prompt = prompt
-
-      # TODO: there are unhandled quirks in async output buffering that
-      # we have not solved yet, for instance when loading meterpreter
-      # extensions, supporting Windows, printing output from commands, etc.
-      # Remove this guard when issues are resolved.
-=begin
-      reset_sequence = "\n\001\r\033[K\002"
-      if (/mingw/ =~ RUBY_PLATFORM)
-        reset_sequence = ""
-      end
-=end
-      reset_sequence = ""
-
-      if defined? RbReadline
-        RbReadline.rl_instream = fd
-        RbReadline.rl_outstream = output
-
-        begin
-          line = RbReadline.readline(reset_sequence + prompt)
-        rescue ::Exception => exception
-          RbReadline.rl_cleanup_after_signal()
-          RbReadline.rl_deprep_terminal()
-
-          raise exception
-        end
-
-        if add_history && line && !line.start_with?(' ')
-          # Don't add duplicate lines to history
-          if ::Readline::HISTORY.empty? || line.strip != ::Readline::HISTORY[-1]
-            RbReadline.add_history(line.strip)
-          end
-        end
-
-        line.try(:dup)
-      else
-        # The line that's read is immediately added to history
-        line = ::Readline.readline(reset_sequence + prompt, true)
-
-        # Don't add duplicate lines to history
-        if ::Readline::HISTORY.length > 1 && line == ::Readline::HISTORY[-2]
-          ::Readline::HISTORY.pop
-        end
-
-        line
-      end
-    end
-
-    private
+    attr_accessor :completion_proc
 
     def with_error_handling(proc)
       proc do |*args|
         proc.call(*args)
-      rescue StandardError => e
+      rescue ::StandardError => e
         elog("tab_complete_proc has failed with args #{args}", error: e)
         []
       end
     end
 
   end
-rescue LoadError
 end
 
-end
 end
 end

--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -28,6 +28,7 @@ class IrbShell
 
       IRB.setup(nil)
       IRB.conf[:PROMPT_MODE]  = :SIMPLE
+      IRB.conf[:USE_MULTILINE] = true
 
       @@IrbInitialized = true
     end

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -86,6 +86,11 @@ class Output < Rex::Ui::Output
 
     nil
   end
+
+  # For Reline interop
+  def tty?
+    true
+  end
 end
 
 end

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -94,6 +94,7 @@ class Output::Stdio < Rex::Ui::Text::Output
     msg
   end
   alias_method :write, :print_raw
+  alias_method :<<, :write
 
   def supports_color?
     case config[:color]

--- a/lib/rex/ui/text/output/tee.rb
+++ b/lib/rex/ui/text/output/tee.rb
@@ -44,6 +44,7 @@ class Output::Tee < Rex::Ui::Text::Output
   end
 
   alias :write :print_raw
+  alias_method :<<, :write
 
   def close
     self.fd.close if self.fd

--- a/modules/post/linux/manage/pseudo_shell.rb
+++ b/modules/post/linux/manage/pseudo_shell.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'readline'
+require 'reline'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
@@ -104,9 +105,9 @@ class MetasploitModule < Msf::Post
   def prompt_show
     promptshell = "#{@vusername}@#{@vhostname}:#{pwd.strip}#{@vpromptchar} "
     comp = proc { |s| LIST.grep(/^#{Regexp.escape(s)}/) }
-    Readline.completion_append_character = ' '
-    Readline.completion_proc = comp
-    input = Readline.readline(promptshell, true)
+    Msf::Ui::Console::MsfReadline.instance.completion_append_character = ' '
+    Msf::Ui::Console::MsfReadline.instance.completion_proc = comp
+    input = Msf::Ui::Console::MsfReadline.instance.readline(promptshell, true)
     return nil if input.nil?
 
     input

--- a/spec/lib/msf/debug_spec.rb
+++ b/spec/lib/msf/debug_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Msf::Ui::Debug do
   end
 
   it 'correctly retrieves and parses a command history shorter than the command total' do
-    stub_const('Readline::HISTORY', Array.new(4) { |i| "Command #{i + 1}" })
+    allow(Msf::Ui::Console::MsfReadline.instance).to receive(:history).and_return(Array.new(4) { |i| "Command #{i + 1}" })
 
     driver = instance_double(
       Msf::Ui::Console::Driver,
@@ -251,7 +251,7 @@ RSpec.describe Msf::Ui::Debug do
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
 
-    stub_const('Readline::HISTORY', Array.new(10) { |i| "Command #{i + 1}" })
+    allow(Msf::Ui::Console::MsfReadline.instance).to receive(:history).and_return(Array.new(10) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr
@@ -288,7 +288,7 @@ RSpec.describe Msf::Ui::Debug do
     )
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
-    stub_const('Readline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
+    allow(Msf::Ui::Console::MsfReadline.instance).to receive(:history).and_return(Array.new(15) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr
@@ -325,7 +325,7 @@ RSpec.describe Msf::Ui::Debug do
     )
 
     stub_const('Msf::Ui::Debug::COMMAND_HISTORY_TOTAL', 10)
-    stub_const('Readline::HISTORY', Array.new(15) { |i| "Command #{i + 1}" })
+    allow(Msf::Ui::Console::MsfReadline.instance).to receive(:history).and_return(Array.new(15) { |i| "Command #{i + 1}" })
 
     history_output = <<~E_LOG
       ##  %grnHistory%clr

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 require 'readline'
+require 'reline'
 
 RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
   include_context 'Msf::DBManager'

--- a/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
+++ b/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'readline'
+require 'reline'
 
 RSpec.describe Rex::Ui::Text::DispatcherShell do
   let(:prompt) { '%undmsf6%clr' }

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -31,7 +31,6 @@ require 'msfenv'
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'rex'
-require 'readline'
 require 'metasm'
 
 #PowerPC, seems broken for now in metasm

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -21,7 +21,6 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'msfenv'
 require 'rex'
-require 'readline'
 
 # Check to make sure nasm is installed and reachable through the user's PATH.
 begin


### PR DESCRIPTION
This PR is a continuation of https://github.com/rapid7/metasploit-framework/pull/19397

This PR adds in the usage of the Reline library behind a feature flag.

Reline currently has some bugs/issues/inconsistencies compared to Readline. These are tracked as issue reports on Reline's GitHub.
These include:
- Using IO's object encoding to not have to set the encoding globally
- Tab completion append character only being appended when no more completions exist
- Being able to change the completion append character in the completion proc (monkeypatched)
- being able to perform multiple tab completions in a row with different values

We are moving away from Readline in favor if a pure Ruby implementation.
We are having to remove Readline on newer Windows 11 hosts due to an issue that Reline also encountered (and fixed since), where the console output handle would sometimes be incorrect, likely after calling popen, thus calls to console APIs such as `SetConsoleCursorPosition` would fail. A workaround is to periodically refresh the handle variable by calling `handle = GetStdHandle.call(-11) // for STDOUT`.

## Verification

- WIP