### PR TITLE
data/wordlists: Add default passwords for common single-board computers

### DIFF
--- a/data/wordlists/common_roots.txt
+++ b/data/wordlists/common_roots.txt
@@ -1454,6 +1454,7 @@ bewan
 beyonce
 bhaby
 bhebhe
+bianbu
 bianca
 bier
 bigboy
@@ -3061,6 +3062,7 @@ lucas
 lucenttech1
 lucenttech2
 lucero
+luckfox
 lucky
 lucky1
 lucky7
@@ -3248,6 +3250,7 @@ mikel
 mikey
 milagros
 milkshake
+milkv
 miller
 millie
 mine
@@ -3477,6 +3480,7 @@ operator
 oqksad
 oracle
 orange
+orangepi
 orlando
 orpheus
 oscar
@@ -4192,6 +4196,7 @@ stacey
 stanley
 star
 starfish
+starfive
 stargate
 stark123
 starl

--- a/data/wordlists/password.lst
+++ b/data/wordlists/password.lst
@@ -7290,6 +7290,7 @@ bi
 bi-level
 bia
 bialystok
+bianbu
 bianca
 bianco
 bianka
@@ -44356,6 +44357,7 @@ limy
 lin
 lina
 linage
+linaro
 linc
 linchpin
 lincoln
@@ -45397,6 +45399,7 @@ lucita
 lucite
 lucius
 luck
+luckfox
 luckhoff
 luckier
 luckily
@@ -49040,6 +49043,7 @@ milkshark
 milksop
 milkweed
 milkwoodpark
+milkv
 milky
 mill
 millaa
@@ -55429,6 +55433,7 @@ orang-utan
 orang-utans
 orange
 orangeade
+orangepi
 orangery
 oranges
 orangey
@@ -63171,6 +63176,7 @@ radium
 radius
 radix
 radon
+radxa
 rae
 raeann
 raedene
@@ -74326,6 +74332,7 @@ stardust
 stare
 starer
 starfish
+starfive
 starfruit
 stargate
 stargaze
@@ -77837,6 +77844,7 @@ temporizer
 temporizing
 temporizingly
 temporizings
+temppwd
 tempt
 temptation
 tempted

--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1007,3 +1007,15 @@ arcsight
 MargaretThatcheris110%SEXY
 karaf
 vagrant
+1234
+milkv
+luckfox
+orangepi
+temppwd
+bianbu
+debian
+starfive
+linaro
+rock
+radxa
+ubuntu

--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -28,6 +28,7 @@ cups-pk-helper
 daemon
 dbadmin
 dbus
+debian
 Debian-exim
 Debian-snmp
 demo
@@ -65,6 +66,7 @@ landscape
 libstoragemgmt
 libuuid
 lightdm
+linaro
 list
 listen
 lp
@@ -95,6 +97,7 @@ operator
 oracle
 OutOfBox
 pi
+pico
 polkitd
 pollinate
 popr
@@ -104,9 +107,12 @@ postmaster
 printer
 proxy
 pulse
+radxa
 redsocks
 rfindd
+riscv
 rje
+rock
 root
 ROOT
 rooty
@@ -143,6 +149,7 @@ systemd-timesync
 tcpdump
 trouble
 tss
+ubuntu
 udadmin
 ultra
 umountfs


### PR DESCRIPTION
Add default vendor passwords for common single-board computers (SBCs) to wordlists.


# Luckfox Pico

https://wiki.luckfox.com/Luckfox-Pico/SSH-Telnet-Login/

* root:luckfox
* pico:luckfox


# Milk-V Vega / Duo

https://milkv.io/docs/duo/getting-started/setup
https://milkv.io/docs/vega/getting-started/setup

* root:milkv


# Milk-V Mars

https://milkv.io/docs/mars/getting-started/images

* user:milkv


# Milk-V Jupiter

https://milkv.io/docs/jupiter/build-os/buildroot

* root:bianbu


# Milk-V Meles RevyOS

https://milkv.io/docs/meles/os-usage/revyos

* debian:debian


# OrangePi

https://www.router-reset.com/default-password-ip-list/Orange-Pi

* root:orangepi


# BeagleBoard / BeagleBone

https://www.router-reset.com/default-password-ip-list/BeagleBoardorg

* debian:temppwd

https://elinux.org/BeagleBoardUbuntu

* ubuntu:temppwd


# StarFive VisionFive2

https://rvspace.org/en/project/VisionFive2_Debian_User_Guide
https://jamesachambers.com/starfive-visionfive-2-firmware-update-guide/
https://doc-en.rvspace.org/VisionFive2/Quick_Start_Guide/VisionFive2_QSG/logging_into_the_os.html

* user:starfive
* root:starfive


# StarFive VisionFive
	
https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive
https://starfivetech.com/uploads/VisionFive%20Single%20Board%20Computer%20Quick%20Start%20Guide.pdf
https://doc-en.rvspace.org/VisionFive/Software_Technical_Reference_Manual/VisionFive_SWTRM/method_2_using_ethernet_cable.html?hl=password

* ubuntu:ubuntu
* riscv:starfive
* root:starfive



# Armbian

https://docs.armbian.com/User-Guide_Getting-Started/

* root:1234



# Radxa

https://wiki.radxa.com/Rock4/Debian
https://wiki.radxa.com/Rock/FAQ

* linaro:linaro
* rock:rock
* radxa:radxa


# Asus Tinker Board

https://www.abelectronics.co.uk/kb/article/1064/asus-tinker-board-introduction

* linaro:linaro


