### PR TITLE
Fixes reusable pipeline allure report generation

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -310,8 +310,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rapid7/metasploit-framework
-          path: metasploit-framework
-          ref: ${{ env.metasploitFrameworkCommit }}
+          ref: ${{ inputs.metasploit_framework_commit }}
 
       - name: Install system dependencies (Linux)
         if: always()
@@ -326,7 +325,6 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
           cache-version: 5
-          working-directory: metasploit-framework
 
       - uses: actions/download-artifact@v4
         id: raw_report_data
@@ -348,7 +346,6 @@ jobs:
 
           find ${{steps.raw_report_data.outputs.download-path}}
           bundle exec ruby tools/dev/report_generation/support_matrix/generate.rb --allure-data ${{steps.raw_report_data.outputs.download-path}} > ./allure-report/support_matrix.html
-        working-directory: metasploit-framework
 
       - name: archive results
         if: always()

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -308,7 +308,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        if: always()
+        with:
+          repository: rapid7/metasploit-framework
+          path: metasploit-framework
+          ref: ${{ env.metasploitFrameworkCommit }}
 
       - name: Install system dependencies (Linux)
         if: always()
@@ -323,6 +326,7 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
           cache-version: 5
+          working-directory: metasploit-framework
 
       - uses: actions/download-artifact@v4
         id: raw_report_data
@@ -344,6 +348,7 @@ jobs:
 
           find ${{steps.raw_report_data.outputs.download-path}}
           bundle exec ruby tools/dev/report_generation/support_matrix/generate.rb --allure-data ${{steps.raw_report_data.outputs.download-path}} > ./allure-report/support_matrix.html
+        working-directory: metasploit-framework
 
       - name: archive results
         if: always()

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -308,6 +308,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        if: always()
         with:
           repository: rapid7/metasploit-framework
           ref: ${{ inputs.metasploit_framework_commit }}


### PR DESCRIPTION
Fixes an issue where the previous allure report generation did not need to have metasploit-framework as it's working directory whereas it now does when part of the reusable pipeline

Tested against metasploit-payloads: https://github.com/rapid7/metasploit-payloads/actions/runs/11407147245/job/31742597653?pr=729

## Verification

- [ ] Code changes are sane