### PR TITLE
Fix crash when importing Metasploit xml file

### DIFF
--- a/lib/msf/core/db_manager/import/metasploit_framework.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework.rb
@@ -8,6 +8,7 @@ module Msf::DBManager::Import::MetasploitFramework
   include Msf::DBManager::Import::MetasploitFramework::Zip
 
   # Convert the string "NULL" to actual nil
+  # @param [String] str
   def nils_for_nulls(str)
     str == "NULL" ? nil : str
   end

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -307,7 +307,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
 
     # A regression resulted in the address field being serialized in some cases.
     # Lets handle both instances to keep things happy. See #5837 & #5985
-    addr = nils_for_nulls(host.at('address'))
+    addr = nils_for_nulls(host.at('address')&.text&.to_s&.strip)
     return 0 unless addr
 
     # No period or colon means this must be in base64-encoded serialized form

--- a/spec/file_fixtures/import/basic_host_data_set.xml
+++ b/spec/file_fixtures/import/basic_host_data_set.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MetasploitV4>
+  <generated time="2012-05-30 17:20:08 UTC" user="test" project="export" />
+  <hosts>
+    <host>
+      <id>75</id>
+      <created-at>2012-05-30 17:12:44 UTC</created-at>
+      <address>10.6.200.2</address>
+      <mac>00:0C:29:63:B3:95</mac>
+      <comm></comm>
+      <name/>
+      <state>alive</state>
+      <os-name>Linux</os-name>
+      <os-flavor>2.6.X</os-flavor>
+      <os-sp/>
+      <os-lang/>
+      <arch/>
+      <workspace-id>4</workspace-id>
+      <updated-at>2012-05-30 17:14:37 UTC</updated-at>
+      <purpose>device</purpose>
+      <info/>
+      <comments/>
+      <scope/>
+      <virtual-host>VMWare</virtual-host>
+      <services>
+        <service>
+          <id>641</id>
+          <host-id>75</host-id>
+          <created-at>2012-05-30 17:12:44 UTC</created-at>
+          <port>514</port>
+          <proto>tcp</proto>
+          <state>open</state>
+          <name>shell</name>
+          <updated-at>2012-05-30 17:12:44 UTC</updated-at>
+          <info></info>
+        </service>
+      </services>
+      <notes>
+        <note>
+          <id>349</id>
+          <created-at>2012-05-30 17:14:17 UTC</created-at>
+          <ntype>smb.shares</ntype>
+          <workspace-id>4</workspace-id>
+          <service-id>640</service-id>
+          <host-id>75</host-id>
+          <updated-at>2012-05-30 17:14:17 UTC</updated-at>
+          <critical/>
+          <seen/>
+          <data>BAh7BjoLc2hhcmVzWwlbCCILcHJpbnQkIglESVNLIhRQcmludGVyIERyaXZlcnNbCCILcHVibGljIglESVNLIhFTaGFyZWQgRmlsZXNbCCIMc2NyYXRjaCIJRElTSyIUVGVtcG9yYXJ5IEZpbGVzWwgiCUlQQyQiCElQQyIeSVBDIFNlcnZpY2UgKEZpbGUgU2VydmVyKQ==</data>
+        </note>
+      </notes>
+      <tags>
+      </tags>
+      <vulns>
+      </vulns>
+      <creds>
+      </creds>
+      <sessions>
+      </sessions>
+    </host>
+  </hosts>
+</MetasploitV4>

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
@@ -1035,6 +1035,22 @@ RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
       import_msf_xml
     end
 
+    context 'with host elements present' do
+      let(:data) do
+        File.binread(File.join(FILE_FIXTURES_PATH, 'import', 'basic_host_data_set.xml'))
+      end
+
+      it 'import the host' do
+        expect {
+          import_msf_xml
+        }.to(
+          change(Mdm::Host, :count).by(1)
+           .and change(Mdm::Service, :count).by(1)
+           .and change(Mdm::Note, :count).by(1)
+        )
+      end
+    end
+
     context 'with web_forms/web_form elements' do
       let(:data) do
         xml.tag!('MetasploitV4') do


### PR DESCRIPTION
Fix crash when importing Metasploit xml file

Before:

```
Msf::DBManager F

  1) Msf::DBManager it should behave like Msf::DBManager::Import it should behave like Msf::DBManager::Import::MetasploitFramework it should behave like Msf::DBManager::Import::MetasploitFramework::XML #import_msf_xml with host elements present import the host
     Failure/Error: if addr !~ /[\.\:]/
     
     NoMethodError:
       undefined method `=~' for #<Nokogiri::XML::Element:0x56a4 name="address" children=[#<Nokogiri::XML::Text:0x5690 "10.6.200.2">]>
 
```


Ruby 3.1:

```
3.1.5 :015 > Nokogiri::VERSION
 => "1.16.7" 
3.1.5 :016 > RUBY_DESCRIPTION
 => "ruby 3.1.5p252 (2024-04-23 revision 1945f8dc0e) [x86_64-darwin23]" 
3.1.5 :019 > Nokogiri::XML('<address>123</address>').methods.grep /~/
 => [:=~, :!~] 
3.1.5 :017 > Nokogiri::XML('<address>123</address>') !~ /123/
 => true 
```

Ruby 3.2:

```
3.2.5 :004 > Nokogiri::VERSION
 => "1.16.7" 
3.2.5 :005 > RUBY_DESCRIPTION
 => "ruby 3.2.5 (2024-07-26 revision 31d0f1a2e7) [x86_64-darwin23]" 
3.2.5 :010 > Nokogiri::XML('<address>123</address>').methods.grep /~/
 => [:!~] 
3.2.5 :006 > Nokogiri::XML('<address>123</address>') !~ /123/
(irb):6:in `!~': undefined method `=~' for #<Nokogiri::XML::Document:0xa5a0 name="document" children=[#<Nokogiri::XML::Element:0xa58c name="address" children=[#<Nokogiri::XML::Text:0xa578 "123">]>]> (NoMethodError)
```


## Verification

- Ensure CI passes