### PR TITLE
Add additional paths for triggering meterpreter acceptance

### DIFF
--- a/.github/workflows/meterpreter_acceptance.yml
+++ b/.github/workflows/meterpreter_acceptance.yml
@@ -46,6 +46,7 @@ on:
       - 'modules/payloads/**'
       - 'lib/msf/core/payload/**'
       - 'lib/msf/core/**'
+      - 'test/modules/**'
       - 'tools/dev/**'
       - 'spec/acceptance/**'
       - 'spec/support/acceptance/**'


### PR DESCRIPTION
Spotted as part of https://github.com/rapid7/metasploit-framework/pull/19554

Add additional paths for triggering meterpreter acceptance

## Verification

Ensure CI passes