### PR TITLE
Update build cache to run xargs in parallel

### DIFF
--- a/tools/automation/cache/build_new_cache.sh
+++ b/tools/automation/cache/build_new_cache.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 bundle install
 rm db/modules_metadata_base.json
-git ls-files modules/ -z | xargs -0 -n1 -I{} -- git log -1 --format="%ai {}" {} | while read -r udate utime utz ufile ; do
+git ls-files modules/ -z | xargs -0 -n1 -P `nproc` -I{} -- git log -1 --format="%ai {}" {} | while read -r udate utime utz ufile ; do
   touch -d "$udate $utime" $ufile
 done
 ./msfconsole -qr tools/automation/cache/wait_for_cache.rc

--- a/tools/automation/cache/update_module_cache.sh
+++ b/tools/automation/cache/update_module_cache.sh
@@ -17,4 +17,4 @@ IMG='metasploitframework/metasploit-framework:latest'
 docker run --rm=true --tty \
   --volume=`pwd`:/r7-source \
   --workdir=/r7-source ${IMG} \
-  /bin/sh -c ./tools/automation/cache/build_new_cache.sh
+  /bin/sh -c 'time ./tools/automation/cache/build_new_cache.sh'


### PR DESCRIPTION
Update build cache to run xargs in parallel so that it takes less time to update the cache

## Verification

Ensure CI passes