### PR TITLE
Renames LDAP datastore options

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -30,9 +30,9 @@ module Msf
         Opt::RHOST,
         Opt::RPORT(389),
         OptBool.new('SSL', [false, 'Enable SSL on the LDAP connection', false]),
-        Msf::OptString.new('DOMAIN', [false, 'The domain to authenticate to']),
-        Msf::OptString.new('USERNAME', [false, 'The username to authenticate with'], aliases: ['BIND_DN']),
-        Msf::OptString.new('PASSWORD', [false, 'The password to authenticate with'], aliases: ['BIND_PW'])
+        Msf::OptString.new('LDAPDomain', [false, 'The domain to authenticate to'], fallbacks: ['DOMAIN']),
+        Msf::OptString.new('LDAPUsername', [false, 'The username to authenticate with'], fallbacks: %w[USERNAME BIND_DN]),
+        Msf::OptString.new('LDAPPassword', [false, 'The password to authenticate with'], fallbacks: %w[PASSWORD BIND_PW])
       ])
 
       register_advanced_options(
@@ -76,9 +76,9 @@ module Msf
     #    LDAP server.
     def get_connect_opts
       opts = {
-        username: datastore['USERNAME'],
-        password: datastore['PASSWORD'],
-        domain: datastore['DOMAIN'],
+        username: datastore['LDAPUsername'],
+        password: datastore['LDAPPassword'],
+        domain: datastore['LDAPDomain'],
         base: datastore['BASE_DN'],
         domain_controller_rhost: datastore['DomainControllerRhost'],
         ldap_auth: datastore['LDAP::Auth'],

--- a/lib/msf/core/optional_session/ldap.rb
+++ b/lib/msf/core/optional_session/ldap.rb
@@ -5,7 +5,7 @@ module Msf
     module LDAP
       include Msf::OptionalSession
 
-      RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT DOMAIN USERNAME PASSWORD THREADS]
+      RHOST_GROUP_OPTIONS = %w[RHOSTS RPORT LDAPDomain LDAPUsername LDAPPassword THREADS]
       REQUIRED_OPTIONS = %w[RHOSTS RPORT THREADS]
 
       def initialize(info = {})

--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -37,12 +37,16 @@ class MetasploitModule < Msf::Auxiliary
           'APPEND_DOMAIN', [true, 'Appends `@<DOMAIN> to the username for authentication`', false],
           conditions: ['LDAP::Auth', 'in', [Msf::Exploit::Remote::AuthOption::AUTO, Msf::Exploit::Remote::AuthOption::PLAINTEXT]]
         ),
+        Msf::OptString.new('LDAPDomain', [false, 'The domain to authenticate to']),
+        Msf::OptString.new('LDAPUsername', [false, 'The username to authenticate with'], aliases: ['BIND_DN']),
+        Msf::OptString.new('LDAPPassword', [false, 'The password to authenticate with'], aliases: ['BIND_PW']),
         OptInt.new('SessionKeepalive', [true, 'Time (in seconds) for sending protocol-level keepalive messages', 10 * 60])
       ]
     )
 
     # A password must be supplied unless doing anonymous login
-    options_to_deregister = %w[BLANK_PASSWORDS]
+    # De-registering USERNAME and PASSWORD as they are pulled in via the Msf::Auxiliary::AuthBrute mixin
+    options_to_deregister = %w[USERNAME PASSWORD BLANK_PASSWORDS]
 
     if framework.features.enabled?(Msf::FeatureManager::LDAP_SESSION_TYPE)
       add_info('The %grnCreateSession%clr option within this module can open an interactive session')
@@ -92,12 +96,12 @@ class MetasploitModule < Msf::Auxiliary
     ignore_public = datastore['LDAP::Auth'] == Msf::Exploit::Remote::AuthOption::SCHANNEL
     ignore_private =
       datastore['LDAP::Auth'] == Msf::Exploit::Remote::AuthOption::SCHANNEL ||
-      (Msf::Exploit::Remote::AuthOption::KERBEROS && !datastore['ANONYMOUS_LOGIN'] && !datastore['PASSWORD'])
+      (Msf::Exploit::Remote::AuthOption::KERBEROS && !datastore['ANONYMOUS_LOGIN'] && !datastore['LDAPPassword'])
 
     cred_collection = build_credential_collection(
-      username: datastore['USERNAME'],
-      password: datastore['PASSWORD'],
-      realm: datastore['DOMAIN'],
+      username: datastore['LDAPUsername'],
+      password: datastore['LDAPPassword'],
+      realm: datastore['LDAPDomain'],
       anonymous_login: datastore['ANONYMOUS_LOGIN'],
       blank_passwords: false,
       ignore_public: ignore_public,
@@ -105,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     opts = {
-      domain: datastore['DOMAIN'],
+      ldap_domain: datastore['LDAPDomain'],
       append_domain: datastore['APPEND_DOMAIN'],
       ssl: datastore['SSL'],
       proxies: datastore['PROXIES'],
@@ -120,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
     realm_key = nil
     if opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::KERBEROS
       realm_key = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
-      if !datastore['ANONYMOUS_LOGIN'] && !datastore['PASSWORD']
+      if !datastore['ANONYMOUS_LOGIN'] && !datastore['LDAPPassword']
         # In case no password has been provided, we assume the user wants to use Kerberos tickets stored in cache
         # Write mode is still enable in case new TGS tickets are retrieved.
         opts[:kerberos_ticket_storage] = kerberos_ticket_storage({ read: true, write: true })

--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'LDAP modules' do
         datastore: {
           global: {},
           module: {
-            username: ENV.fetch('LDAP_USERNAME', "'DEV-AD\\Administrator'"),
-            password: ENV.fetch('LDAP_PASSWORD', 'admin123!'),
+            ldapusername: ENV.fetch('LDAP_LDAPUsername', "'DEV-AD\\Administrator'"),
+            ldappassword: ENV.fetch('LDAP_LDAPPassword', 'admin123!'),
             rhost: ENV.fetch('LDAP_RHOST', '127.0.0.1'),
             rport: ENV.fetch('LDAP_RPORT', '389'),
             ssl: ENV.fetch('LDAP_SSL', 'false')


### PR DESCRIPTION
> [!NOTE]
This PR is required for another PR with Pro - https://github.com/rapid7/pro/pull/3808

This PR renames the LDAP datastore options to facilitate some changes being made in Pro as part of the following [PR](https://github.com/rapid7/pro/pull/3808). 

The reason this was required was due to adding the previous LDAP datastore values into the configuration hash within Pro in the following file - `ui/app/models/scan_task.rb`, this would result in duplicate hash keys as previous LDAP used:
- USERNAME
- PASSWORD
- DOMAIN

So I decided to align with how SMB was handling its datastore by updating them to be:
- LDAPUsername
- LDAPPassword
- LDAPDomain

## Verification
- [ ] Run `auxiliary/scanner/ldap/ldap_login` against an ldap server to get a session (an example of running an ldap container can be found in the ldap acceptance tests here https://github.com/rapid7/metasploit-framework/blob/33ffc14e6b58de95fa90f28add871cbbb2bc7fd4/.github/workflows/ldap_acceptance.yml#L67-L71 
- [ ] Run `SPEC_OPTS='--tag acceptance' SPEC_HELPER_LOAD_METASPLOIT=false bundle exec rspec ./spec/acceptance/ldap_spec.rb` and ensure those pass locally.
- [ ] Start `msfconsole`
- [ ] Test `ldap_login` module
- [ ] Code changes are sane
