### PR TITLE
Fix table width bug when running from docker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.4)
-    rex-text (0.2.58)
+    rex-text (0.2.59)
     rex-zip (0.1.5)
       rex-text
     rexml (3.3.6)


### PR DESCRIPTION
Updates to https://github.com/rapid7/rex-text/pull/71

Fixes a bug that caused tables to render incorrectly when running under docker


## Verification

Ensure CI passes