### PR TITLE
Updates report summary mixin with an additional fallback when finding creds

### DIFF
--- a/lib/msf/core/auxiliary/report_summary.rb
+++ b/lib/msf/core/auxiliary/report_summary.rb
@@ -39,6 +39,31 @@ module Msf
         result
       end
 
+      # Take credentials hash and check data for username and password and then returns a hash for those values
+      #
+      # @param [Hash] credential_data
+      # @return [Hash]
+      def login_credentials(credential_data)
+        # If the database is active and core is populated then grab the creds from there, otherwise
+        # fallback and check in credentials data's top layer
+        if framework.db&.active && credential_data[:core]
+          {
+            public: credential_data[:core].public,
+            private_data: credential_data[:core].private
+          }
+        elsif credential_data[:username] && credential_data[:private_data]
+          {
+            public: credential_data[:username],
+            private_data: credential_data[:private_data]
+          }
+        else
+          {
+            public: 'credentials could not be reported',
+            private_data: 'credentials could not be reported'
+          }
+        end
+      end
+
       # Creates a credential and adds to to the DB if one is present
       #
       # @param [Hash] credential_data
@@ -46,12 +71,8 @@ module Msf
       def create_credential_login(credential_data)
         return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins'] && @report
 
-        credential = {
-          public: credential_data[:username],
-          private_data: credential_data[:private_data]
-        }
         @report[rhost] = { successful_logins: [] }
-        @report[rhost][:successful_logins] << credential
+        @report[rhost][:successful_logins] << login_credentials(credential_data)
         super
       end
 
@@ -69,12 +90,8 @@ module Msf
       def create_credential_and_login(credential_data)
         return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins'] && @report
 
-        credential = {
-          public: credential_data[:username],
-          private_data: credential_data[:private_data]
-        }
         @report[rhost] = { successful_logins: [] }
-        @report[rhost][:successful_logins] << credential
+        @report[rhost][:successful_logins] << login_credentials(credential_data)
         super
       end
 


### PR DESCRIPTION
Fixes an issue where if `credential_data[:username]` and `credential_data[:private_data]` where not populated the report summary would be blank even with a successful login.

## Before 
```
msf6 auxiliary(scanner/smb/smb_login) > run

[*] <IP>:445   - <IP>:445 - Starting SMB login bruteforce
[+] <IP>:445   - <IP>:445 - Success: '.\Administrator:Password1' Administrator
[*] <IP>:445   - Scanned 1 of 1 hosts (100% complete)
[*] <IP>:445   - Scan completed, 1 credential was successful.

Successful logins
=================

    Host             Public         Private
    ----             ------         -------
    <IP>            


[*] <IP>:445   - Bruteforce completed, 1 credential was successful.
[*] <IP>:445   - You can open an SMB session with these credentials and CreateSession set to true
[*] Auxiliary module execution completed
```

## After 
```
msf6 auxiliary(scanner/smb/smb_login) > run

[*] <IP>:445   - <IP>:445 - Starting SMB login bruteforce
[+] <IP>:445   - <IP>:445 - Success: '.\Administrator:Password1' Administrator
[*] <IP>:445   - Scanned 1 of 1 hosts (100% complete)
[*] <IP>:445   - Scan completed, 1 credential was successful.

Successful logins
=================

    Host             Public         Private
    ----             ------         -------
    <IP>             Administrator  Password1


[*] <IP>:445   - Bruteforce completed, 1 credential was successful.
[*] <IP>:445   - You can open an SMB session with these credentials and CreateSession set to true
[*] Auxiliary module execution completed
```

## Verification

- [ ] Start `msfconsole`
- [ ] Run `use scanner/smb/smb_login`
- [ ] **Verify** the module now returns credentials
- [ ] **Verify** other modules that rely on the mixin still report as expected e.g. `scanner/ldap/ldap_login`
