### PR TITLE
Check for nil res when setting echo shell

### DIFF
--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -119,7 +119,7 @@ module SingleCommandShell
     cmd = "echo #{numeric_token}"
     shell_write(cmd + "#{command_separator}echo #{token}#{command_termination}")
     res = shell_read_until_token(token, 0, timeout)
-    @is_echo_shell = res.include?(cmd)
+    @is_echo_shell = res ? res.include?(cmd) : false
   end
 
   def shell_command_token_win32(cmd, timeout=10)


### PR DESCRIPTION
This PR fixes https://github.com/rapid7/metasploit-framework/issues/19615

From the code, `shell_read_until_token` can return `nil`. Now the code that broke in the linked issue explicitly checks for a `nil`.

I wasn't able to reproduce the issue locally using `ssh_login` against a Kali & Ubuntu VM, and I don't have any vCenter environments to test against.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] `sessions -i -1`
- [ ] Verify you can get a `shell` using the `shell` command
- [ ] Verify it doesn't crash

## Example

```ruby
[*] SSH session 1 opened (...:56421 -> ...:22) at 2024-11-05 13:37:01 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Scan completed, 1 credential was successful.

Successful logins
=================

    Host             Public  Private
    ----             ------  -------
    ...                 kali    kali


[*] 1 session was opened successfully.
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) > sessions -i -1
[*] Starting interaction with 1...

shell

[*] Trying to find binary 'python' on the target machine
[*] Found python at /usr/bin/python
[*] Using `python` to pop up an interactive shell
[*] Trying to find binary 'bash' on the target machine
[*] Found bash at /usr/bin/bash

kali@kali:~$ whoami
whoami
kali
```