### PR TITLE
Fix out of scope variable with original behaviour

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
@@ -19,7 +19,7 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
           end
         end
       else
-        return ticket.ccache.credentials.first
+        return available_tickets.first.ccache.credentials.first
       end
 
       nil


### PR DESCRIPTION
This fixes a regression introduced while implementing etype-respecting klist retrieval in #19553. If no offeredetypes are provided, it would crash with an invalid variable name:

```
Error: Msf::Exploit::Remote::SMB::Client::Ipc::SmbIpcAuthenticationError Unable to authenticate ([Rex::Proto::SMB::Exceptions::LoginError] Login Failed: undefined local variable or method `ticket' for #<Msf::Exploit::Remote::Kerberos::Ticket::Storage::ReadWrite:0x00007fecbfdaa8a0
```

## Verification

To test this one, I wasn't sure of any modules that allowed null etypes; so I modified the code passing the options in to overwrite it with a null entry for `SMB::KrbOfferedEncryptionTypes`. Without this fix, the above error was encountered. After the fix, based on WireShark logs, I found that this would always use the earliest ticket.

If there's a module that allows this testing without modifying the code, that would be preferable.