### PR TITLE
Remove a test that should be working now

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -36,15 +36,16 @@ jobs:
   java_meterpreter_compilation:
     name: Compile Java Meterpreter
     runs-on: ubuntu-latest
-    if: ${{ inputs.build_metasploit_payloads }}
+    # temporarily force compiling the java meterpreter by removing this conditional
+    #if: ${{ inputs.build_metasploit_payloads }}
 
     steps:
       - name: Checkout metasploit-payloads
         uses: actions/checkout@v4
         with:
-          repository: rapid7/metasploit-payloads
+          repository: zeroSteiner/metasploit-payloads
           path: metasploit-payloads
-          ref: ${{ inputs.metasploit_payloads_commit }}
+          ref: fix/met/java/symlinks
 
       - name: Build Java and Android payloads
         run: |
@@ -185,9 +186,9 @@ jobs:
       - name: Checkout metasploit-framework commit
         uses: actions/checkout@v4
         with:
-          repository: rapid7/metasploit-framework
+          repository: zeroSteiner/metasploit-framework
           path: metasploit-framework
-          ref: ${{ inputs.metasploit_framework_commit }}
+          ref: fix/met/java-win-symlink-tests
 
       - name: Setup Ruby
         env:
@@ -246,9 +247,9 @@ jobs:
         if: ${{ inputs.build_metasploit_payloads && matrix.meterpreter.name != 'mettle' }}
         uses: actions/checkout@v4
         with:
-          repository: rapid7/metasploit-payloads
+          repository: zeroSteiner/metasploit-payloads
           path: metasploit-payloads
-          ref: ${{ inputs.metasploit_payloads_commit }}
+          ref: fix/met/java/symlinks
 
       - name: Get metasploit-payloads version
         if: ${{ inputs.build_metasploit_payloads && matrix.meterpreter.name != 'mettle' }}

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -36,16 +36,15 @@ jobs:
   java_meterpreter_compilation:
     name: Compile Java Meterpreter
     runs-on: ubuntu-latest
-    # temporarily force compiling the java meterpreter by removing this conditional
-    #if: ${{ inputs.build_metasploit_payloads }}
+    if: ${{ inputs.build_metasploit_payloads }}
 
     steps:
       - name: Checkout metasploit-payloads
         uses: actions/checkout@v4
         with:
-          repository: zeroSteiner/metasploit-payloads
+          repository: rapid7/metasploit-payloads
           path: metasploit-payloads
-          ref: fix/met/java/symlinks
+          ref: ${{ inputs.metasploit_payloads_commit }}
 
       - name: Build Java and Android payloads
         run: |
@@ -186,9 +185,9 @@ jobs:
       - name: Checkout metasploit-framework commit
         uses: actions/checkout@v4
         with:
-          repository: zeroSteiner/metasploit-framework
+          repository: rapid7/metasploit-framework
           path: metasploit-framework
-          ref: fix/met/java-win-symlink-tests
+          ref: ${{ inputs.metasploit_framework_commit }}
 
       - name: Setup Ruby
         env:
@@ -247,9 +246,9 @@ jobs:
         if: ${{ inputs.build_metasploit_payloads && matrix.meterpreter.name != 'mettle' }}
         uses: actions/checkout@v4
         with:
-          repository: zeroSteiner/metasploit-payloads
+          repository: rapid7/metasploit-payloads
           path: metasploit-payloads
-          ref: fix/met/java/symlinks
+          ref: ${{ inputs.metasploit_payloads_commit }}
 
       - name: Get metasploit-payloads version
         if: ${{ inputs.build_metasploit_payloads && matrix.meterpreter.name != 'mettle' }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.187)
+      metasploit-payloads (= 2.0.189)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.35)
       mqtt
@@ -300,7 +300,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.187)
+    metasploit-payloads (2.0.189)
     metasploit_data_models (6.0.5)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -90,7 +90,7 @@ metasploit-concern, 5.0.3, "New BSD"
 metasploit-credential, 6.0.11, "New BSD"
 metasploit-framework, 6.4.40, "New BSD"
 metasploit-model, 5.0.2, "New BSD"
-metasploit-payloads, 2.0.187, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.189, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.5, "New BSD"
 metasploit_payloads-mettle, 1.0.35, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.187'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.189'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.35'
   # Needed by msfgui and other rpc components

--- a/spec/support/acceptance/session/java.rb
+++ b/spec/support/acceptance/session/java.rb
@@ -117,9 +117,7 @@ module Acceptance::Session
             known_failures: []
           },
           windows: {
-            known_failures: [
-              "[-] [should delete a symbolic link target] failed to create the symbolic link"
-            ]
+            known_failures: []
           }
         }
       },


### PR DESCRIPTION
This removes a test that should be fixed once this is landed:

* rapid7/metasploit-payloads#731

Don't merge until then.