### PR TITLE
Fix Kerberos cache storage exception

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb
@@ -9,6 +9,8 @@ module Msf::Exploit::Remote::Kerberos::Ticket::Storage
       available_tickets = tickets(options).select do |ticket|
         !ticket.expired?(now)
       end
+      return unless available_tickets.any?
+
       if options[:offered_etypes].present?
         # Prefer etypes mentioned first
         options[:offered_etypes].each do |etype|


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/19619

Fixes the following exception

![image](https://github.com/user-attachments/assets/2e9c1e21-78e7-4143-9340-a190ddf59cc5)

To handle the scenario of there being no tickets available

## Verification

### Before

```
msf6 auxiliary(admin/kerberos/get_ticket) > klist -d
Kerberos Cache
==============
No tickets


msf6 auxiliary(admin/kerberos/get_ticket) > run rhost=10.140.10.10 domain=ad.pro.local username=RBCD01$ password=RBCD01$P4$$W0RD SPN=cifs/mspro-dc.ad.pro.local action=GET_TGS
[*] Running module against 10.140.10.10

[-] Auxiliary failed: NoMethodError undefined method `ccache' for nil:NilClass
[-] Call stack:
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/ticket/storage/read_mixin.rb:25:in `load_credential'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb:1035:in `get_cached_credential'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb:353:in `request_tgt_only'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/admin/kerberos/get_ticket.rb:207:in `action_get_tgs'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/admin/kerberos/get_ticket.rb:145:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > 
```

### After


```
msf6 auxiliary(admin/kerberos/get_ticket) > klist -d
Kerberos Cache
==============
No tickets

msf6 auxiliary(admin/kerberos/get_ticket) > run rhost=10.140.10.10 domain=ad.pro.local username=RBCD01$ password=RBCD01$P4$$W0RD SPN=cifs/mspro-dc.ad.pro.local action=GET_TGS
[*] Running module against 10.140.10.10

[+] 10.140.10.10:88 - Received a valid TGT-Response
[*] 10.140.10.10:88 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20241108112846_default_10.140.10.10_mit.kerberos.cca_576363.bin
[*] 10.140.10.10:88 - Getting TGS for RBCD01$@ad.pro.local (SPN: cifs/mspro-dc.ad.pro.local)
[+] 10.140.10.10:88 - Received a valid TGS-Response
[*] 10.140.10.10:88 - TGS MIT Credential Cache ticket saved to /Users/adfoster/.msf4/loot/20241108112847_default_10.140.10.10_mit.kerberos.cca_530412.bin
[+] 10.140.10.10:88 - Received a valid delegation TGS-Response
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > 
```