### PR TITLE
Support checks in relay modules

### DIFF
--- a/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
+++ b/docs/metasploit-framework.wiki/ad-certificates/Attacking-AD-CS-ESC-Vulnerabilities.md
@@ -892,7 +892,7 @@ In the following example the AUTO mode is used to issue a certificate for the MS
 authenticated.
 
 ```msf
-msf6 auxiliary(server/relay/esc8) > set RELAY_TARGETS 172.30.239.85
+msf6 auxiliary(server/relay/esc8) > set RHOSTS 172.30.239.85
 msf6 auxiliary(server/relay/esc8) > run
 [*] Auxiliary module running as background job 1.
 msf6 auxiliary(server/relay/esc8) > 

--- a/lib/msf/core/auxiliary/multiple_target_hosts.rb
+++ b/lib/msf/core/auxiliary/multiple_target_hosts.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+module Msf
+
+###
+#
+# This module provides methods for modules which intend to handle multiple hosts
+# themselves through some means, e.g. scanners. This circumvents the typical
+# RHOSTS -> RHOST logic offered by the framework.
+#
+###
+
+module Auxiliary::MultipleTargetHosts
+
+  def has_check?
+    respond_to?(:check_host)
+  end
+
+  def check
+    nmod = replicant
+    begin
+      nmod.check_host(datastore['RHOST'])
+    rescue NoMethodError
+      Exploit::CheckCode::Unsupported
+    end
+  end
+
+end
+end

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -10,6 +10,8 @@ module Msf
 
 module Auxiliary::Scanner
 
+include Msf::Auxiliary::MultipleTargetHosts
+
 class AttemptFailed < Msf::Auxiliary::Failed
 end
 
@@ -30,20 +32,6 @@ def initialize(info = {})
   ], Auxiliary::Scanner)
 
 end
-
-def has_check?
-  respond_to?(:check_host)
-end
-
-def check
-  nmod = replicant
-  begin
-    nmod.check_host(datastore['RHOST'])
-  rescue NoMethodError
-    Exploit::CheckCode::Unsupported
-  end
-end
-
 
 def peer
   # IPv4 addr can be 16 chars + 1 for : and + 5 for port

--- a/lib/msf/core/exploit/remote/smb/relay_server.rb
+++ b/lib/msf/core/exploit/remote/smb/relay_server.rb
@@ -4,6 +4,7 @@ module Msf
   module Exploit::Remote::SMB
     # This mixin provides a minimal SMB server
     module RelayServer
+      include ::Msf::Auxiliary::MultipleTargetHosts
       include ::Msf::Exploit::Remote::SocketServer
       include ::Msf::Exploit::Remote::SMB::Server::HashCapture
 
@@ -15,7 +16,7 @@ module Msf
             OptPort.new('SRVPORT', [true, 'The local port to listen on.', 445]),
             OptString.new('SMBDomain', [true, 'The domain name used during SMB exchange.', 'WORKGROUP'], aliases: ['DOMAIN_NAME']),
             OptInt.new('SRV_TIMEOUT', [true, 'Seconds that the server socket will wait for a response after the client has initiated communication.', 25]),
-            OptAddressRange.new('RELAY_TARGETS', [true, 'Target address range or CIDR identifier to relay to'], aliases: ['SMBHOST']),
+            OptAddressRange.new('RHOSTS', [true, 'Target address range or CIDR identifier to relay to'], aliases: ['SMBHOST', 'RELAY_TARGETS']),
             OptInt.new('RELAY_TIMEOUT', [true, 'Seconds that the relay socket will wait for a response after the client has initiated communication.', 25])
           ], self.class)
       end

--- a/lib/msf/core/exploit/remote/tcp.rb
+++ b/lib/msf/core/exploit/remote/tcp.rb
@@ -209,11 +209,22 @@ module Exploit::Remote::Tcp
     # Otherwise we are logging in the global context where rhost can be any
     # size (being an alias for rhosts), which is not very useful to insert into
     # a single log line.
-    if rhost && rhost.split(' ').length == 1
-      super + peer + ' - '
-    else
-      super
+    unless instance_variable_defined?(:@print_prefix)
+      if rhost.present? && Rex::Socket::RangeWalker.new(rhost).length == 1
+        @print_prefix = peer + ' - '
+      else
+        @print_prefix = ''
+      end
     end
+
+    super + @print_prefix
+  end
+
+  def replicant
+    obj = super
+    # invalidate the cached print_prefix in case the target changes
+    obj.remove_instance_variable(:@print_prefix) if instance_variable_defined?(:@print_prefix)
+    obj
   end
 
   ##
@@ -259,7 +270,7 @@ module Exploit::Remote::Tcp
 
   # Returns the rhost:rport
   def peer
-    "#{rhost}:#{rport}"
+    Rex::Socket.to_authority(rhost, rport)
   end
 
   #

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -187,9 +187,17 @@ module Session
   # exploit instance. Store references from and to the exploit module.
   #
   def set_from_exploit(m)
+    target_host = nil
+    unless m.target_host.blank?
+      # only propagate the target_host value if it's exactly 1 host
+      if (rw = Rex::Socket::RangeWalker.new(m.target_host)).length == 1
+        target_host = rw.next_ip
+      end
+    end
+
     self.via = { 'Exploit' => m.fullname }
     self.via['Payload'] = ('payload/' + m.datastore['PAYLOAD'].to_s) if m.datastore['PAYLOAD']
-    self.target_host = Rex::Socket.getaddress(m.target_host) if (m.target_host.to_s.strip.length > 0)
+    self.target_host = target_host
     self.target_port = m.target_port if (m.target_port.to_i != 0)
     self.workspace   = m.workspace
     self.username    = m.owner

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -62,7 +62,7 @@ class Auxiliary
 
     begin
       # Check if this is a scanner module or doesn't target remote hosts
-      if rhosts.blank? || mod.class.included_modules.include?(Msf::Auxiliary::Scanner)
+      if rhosts.blank? || mod.class.included_modules.include?(Msf::Auxiliary::MultipleTargetHosts)
         mod_with_opts.run_simple(
           'Action'         => args[:action],
           'LocalInput'     => driver.input,

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -138,7 +138,7 @@ class Exploit
 
     driver.run_single('reload_lib -a') if args[:reload_libs]
 
-    if rhosts && has_rhosts_option
+    if rhosts && has_rhosts_option && !mod.class.included_modules.include?(Msf::Auxiliary::MultipleTargetHosts)
       rhosts_walker = Msf::RhostsWalker.new(rhosts, mod_with_opts.datastore)
       rhosts_walker_count = rhosts_walker.count
       rhosts_walker = rhosts_walker.to_enum

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -288,7 +288,15 @@ class SimpleClient
   end
 
   def peerinfo
-    "#{peerhost}:#{peerport}"
+    Rex::Socket.to_authority(peerhost, peerport)
+  end
+
+  def signing_required
+    if client.is_a?(Rex::Proto::SMB::Client)
+      client.peer_require_signing
+    else
+      client.signing_required
+    end
   end
 
   private

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -70,15 +70,13 @@ class MetasploitModule < Msf::Auxiliary
     res&.code == 401
   end
 
-  def check_options
-    if datastore['RHOSTS'].present?
-      print_warning('Warning: RHOSTS datastore value has been set which is not supported by this module. Please verify RELAY_TARGETS is set correctly.')
-    end
+  def validate
+    super
 
     case datastore['MODE']
     when 'SPECIFIC_TEMPLATE'
-      if datastore['CERT_TEMPLATE'].nil? || datastore['CERT_TEMPLATE'].blank?
-        fail_with(Failure::BadConfig, 'CERT_TEMPLATE must be set in AUTO and SPECIFIC_TEMPLATE mode')
+      if datastore['CERT_TEMPLATE'].blank?
+        raise Msf::OptionValidateError.new({ 'CERT_TEMPLATE' => 'CERT_TEMPLATE must be set when MODE is SPECIFIC_TEMPLATE' })
       end
     when 'ALL', 'AUTO', 'QUERY_ONLY'
       unless datastore['CERT_TEMPLATE'].nil? || datastore['CERT_TEMPLATE'].blank?
@@ -88,7 +86,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    check_options
     @issued_certs = {}
     relay_targets.each do |target|
       vprint_status("Checking endpoint on #{target}")

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     deregister_options(
-      'RPORT', 'RHOSTS', 'SMBPass', 'SMBUser', 'CommandShellCleanupCommand', 'AutoVerifySession'
+      'RPORT', 'SMBPass', 'SMBUser', 'CommandShellCleanupCommand', 'AutoVerifySession'
     )
     if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCREATE_SMB_SESSION%clr action within this module can open an interactive session')
@@ -163,11 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def exploit
-    if datastore['RHOSTS'].present?
-      print_warning('Warning: RHOSTS datastore value has been set which is not supported by this module. Please verify RELAY_TARGETS is set correctly.')
-    end
-
+  def validate
     case action.name
     when 'PSEXEC'
       validate_service_stub_encoder!
@@ -218,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
     Msf::Exploit::Remote::SMB::Relay::TargetList.new(
       :smb,
       445,
-      datastore['RELAY_TARGETS'],
+      datastore['RHOSTS'],
       randomize_targets: datastore['RANDOMIZE_TARGETS']
     )
   end

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
     framework.threads.spawn(thread_name, false, new_mod_instance) do |mod_instance|
       mod_instance.exploit_smb_target
     rescue StandardError => e
-      print_error("Failed running psexec against target #{datastore['RHOST']} - #{e.class} #{e.message}")
+      print_error("Failed running psexec against target #{relay_connection.target.ip} - #{e.class} #{e.message}")
       elog(e)
       # ensure
       #   # Note: Don't cleanup explicitly, as the shared replicant state leads to payload handlers etc getting closed.
@@ -213,10 +213,29 @@ class MetasploitModule < Msf::Exploit::Remote
   def relay_targets
     Msf::Exploit::Remote::SMB::Relay::TargetList.new(
       :smb,
-      445,
+      rport,
       datastore['RHOSTS'],
       randomize_targets: datastore['RANDOMIZE_TARGETS']
     )
+  end
+
+  def check_host(target_ip)
+    generic_message = 'Failed to connect and negotiate an SMB connection.'
+    begin
+      simple = connect(false, direct: true)
+      protocol = simple.client.negotiate
+    rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError, Errno::ECONNRESET
+      return Exploit::CheckCode::Unknown(generic_message)
+    rescue ::Exception => e # rubocop:disable Lint/RescueException
+      elog(generic_message, error: e)
+      return Exploit::CheckCode::Unknown(generic_message)
+    end
+
+    if simple.signing_required
+      return Exploit::CheckCode::Safe('Signing is required by the target server.')
+    end
+
+    Exploit::CheckCode::Vulnerable('Signing is not required by the target server.')
   end
 
   # Called after a successful connection to a relayed host is opened
@@ -283,4 +302,7 @@ class MetasploitModule < Msf::Exploit::Remote
     s
   end
 
+  def rport
+    445
+  end
 end


### PR DESCRIPTION
We now have two relay modules with more on the horizon. This PR adds the ability for our users to check targets for viability in the context of the modules. In the case of SMB, this checks the target has SMB signing disabled. In the case of ESC8, it checks that the target URI responds with a 401 and offers NTLM as an authentication mechanism.

Adding the check method required changes to how the modules operate. They had originally used the `RELAY_TARGETS` datastore option to avoid the framework splitting RHOSTS into individual RHOST options as it does for other modules types (except those that are scanners or do not register the RHOSTS option). In order for the `check` command to work, the RHOSTS needed to be registered, so the target to check is available to the module. For the actual exploitation though, the RHOSTS value needed to be kept as it is (e.g. a list of IP addresses, CIDR range, etc.). To support this, I added a new `MultipleTargetHosts` mixin that is checked for in the `run` command dispatcher when an Auxiliary or Exploit module is run. This check is included where the previous `Scanner` mixin check was included and where the datastore is checked for containing `RHOSTS`. With this in place, the relay modules can now uses the RHOSTS datastore option and iterate over the targets itself, while also having a `check_host` method that can return a check code for individual hosts. This ensures the option works consistently when the `RHOSTS` datastore option is set or a range is specified as an argument to the `check` command.

Because of where the RHOSTS string is split into individual target hosts, **the `MultipleTargetHosts` mixin is incompatible with the `AutoCheck` mixin.** The issue here is that the `run` method has the RHOSTS string without having been split and the `AutoCheck` mixin is incapable of splitting it and checking each host individually for exploitability. This would also introduce an ambiguity for how a case where a group of N hosts are defined and N-1 are vulnerable. Presumably, the module should fail, but it's not well equipped to report the vulnerability status of each individual host as the `check` command is. This seems like a reasonable limitation at this time and something that can be left alone for the time being.

## Testing

- [x] Use the `auxiliary/server/relay/esc8` module
    - [x] Set the RHOSTS option to multiple targets
    - [x] Run the `check` command with no arguments, see it pulled the hosts to test from the `RHOSTS` datastore option
    - [x] Run the `check` command with a target host argument (e.g. `check 192.168.159.10-11`) and see that it pulled the hosts to test from the argument
    - [ ] See that the module still works as intended
- [x] Use the `exploit/windows/smb/smb_relay` module
    - [x] Set the RHOSTS option to multiple targets
    - [x] Run the `check` command with no arguments, see it pulled the hosts to test from the `RHOSTS` datastore option
    - [x] Run the `check` command with a target host argument (e.g. `check 192.168.159.10-11`) and see that it pulled the hosts to test from the argument
    - [ ] See that the module still works as intended

## Example
ESC8 checking:
```
metasploit-framework.pr (S:0 J:0) auxiliary(server/relay/esc8) > check 192.168.159.10-11
[*] 192.168.159.10:80 - The target appears to be vulnerable. Server replied that authentication is required and NTLM is supported.

[-] The host (192.168.159.11:80) was unreachable.
[*] 192.168.159.11:80 - Cannot reliably check exploitability.
metasploit-framework.pr (S:0 J:0) auxiliary(server/relay/esc8) >
```

SMB relay checking:
```
metasploit-framework.pr (S:0 J:0) exploit(windows/smb/smb_relay) > check 192.168.159.10-11
[+] 192.168.159.10 - The target is vulnerable. Signing is not required by the target server.
[*] 192.168.159.11 - Cannot reliably check exploitability. Failed to connect and negotiate an SMB connection.
metasploit-framework.pr (S:0 J:0) exploit(windows/smb/smb_relay) >
```