### PR TITLE
Dcsync individual

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,11 +499,11 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.10)
+    ruby_smb (3.3.11)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac
-      rubyntlm
+      rubyntlm (>= 0.6.5)
       windows_error (>= 0.1.4)
     rubyntlm (0.6.5)
       base64

--- a/documentation/modules/auxiliary/gather/windows_secrets_dump.md
+++ b/documentation/modules/auxiliary/gather/windows_secrets_dump.md
@@ -27,7 +27,7 @@ Solino.
 ### Setup
 A privileged user is required to run this module, typically a local or domain
 Administrator. It has been tested against multiple Windows versions, from
-Windows XP/Server 2003 to Windows 10/Server version 2004.
+Windows XP/Server 2003 to Windows 10/Server version 2022.
 
 ## Verification Steps
 1. Start msfconsole
@@ -52,6 +52,18 @@ Windows XP/Server 2003 to Windows 10/Server version 2004.
 ### INLINE
 Use inline technique to read protected keys from the registry remotely without
 saving the hives to disk (default: true).
+
+### KRB_USERS
+Restrict retrieving domain information to the users or groups specified. This
+is a comma-separated list of Active Directory groups and users. This parameter
+is only utilised for domain replication (`action` set to `DOMAIN` or `ALL`).
+`set KRB_USERS "user1,user2,Domain Admins"
+
+### KRB_TYPES
+Restrict retrieving domain information to a specific type of account; either
+`USERS_ONLY` or `COMPUTERS_ONLY`, or `ALL` to retrieve all accounts. This
+parameter is only utilised for domain replication (`action` set to `DOMAIN` or
+`ALL`). It is ignored if `KRB_USERS` is also set.
 
 ## Actions
 

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -891,7 +891,7 @@ class MetasploitModule < Msf::Auxiliary
       )
       return
     end
-    specific_users = datastore['KRB_USERS'].strip.split(',').map { |s| s.strip }
+    specific_users = datastore['KRB_USERS'].strip.split(',').map(&:strip)
 
     if specific_users.empty?
       users = get_domain_users
@@ -903,7 +903,7 @@ class MetasploitModule < Msf::Auxiliary
       users = get_domain_users_by_name(specific_users)
     end
 
-    sids = Set.new(users.map {|sid_and_user| sid_and_user[0]})
+    sids = Set.new(users.map { |sid_and_user| sid_and_user[0] })
 
     dcerpc_client = connect_drs
     unless dcerpc_client

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
           conditions: ['ACTION', 'in', %w[ALL SAM CACHE LSA]]
         ),
         OptEnum.new('KRB_TYPES', [true, 'Which type of accounts to retrieve kerberos details for', 'ALL', ['ALL', 'USERS_ONLY', 'COMPUTERS_ONLY']], conditions: ['ACTION', 'in', %w[ALL DOMAIN]]),
-        OptString.new('KRB_USERS', [false, 'Which specific user accounts or groups to retrieve kerberos details for', ''], conditions: ['ACTION', 'in', %w[ALL DOMAIN]])
+        OptString.new('KRB_USERS', [false, 'Comma-separated list of user accounts or groups to retrieve kerberos details for', ''], conditions: ['ACTION', 'in', %w[ALL DOMAIN]])
       ]
     )
 


### PR DESCRIPTION
This PR adds some features to the `windows_secrets_dump` module, and fixes a bug.

- Add the ability to perform a DCSync for an individual user or group.
- Add the ability to only request Users (rather than also computers) or vice versa
- Incidentally fixed a bug wherein the DC was queried multiple times for the same information, if there are other DCs present in the environment.

Requires https://github.com/rapid7/ruby_smb/pull/278

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use windows_secrets_dump`
- [x] Test the settings for `KRB_TYPES` (request users only, or computers only, or both)
- [x] Test the settings for `KRB_USERS` (request an individual group, or user, or a comma-separated list of either)
- [x] Verify the fix for the multi-DCSync query (multiple DCs should only result in a single query per user)
