### PR TITLE
Fix crash when using modules

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -905,7 +905,7 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
-            if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.actions.size > 1
+            if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
               print_status "Using action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end
 


### PR DESCRIPTION
Fix crash when using modules that don't have any actions available

## Verification


### Before

evasion modules and payloads crash when using them:

```
msf6 auxiliary(scanner/ssh/ssh_login) > use 0

[-] Error while running command use: undefined method `actions' for #<Module:evasion/windows/applocker_evasion_install_util datastore=[#<Msf::ModuleDataStoreWithFallbacks:0x0000000111335330 @options={"WORKSPACE"=>#<Msf::OptString:0x0000000110d50280 @name="WORKSPACE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Specify the workspace for this module", @default=nil, @enums=[], @owner=Msf::Module>, "VERBOSE"=>#<Msf::OptBool:0x0000000110d501e0 @name="VERBOSE", @advanced=true, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=false, @desc="Enable detailed status messages", @default=false, @enums=[], @owner=Msf::Module>, "FILENAME"=>#<Msf::OptString:0x0000000110cf3df0 @name="FILENAME", @advanced=false, @evasion=false, @aliases=[], @max_length=nil, @conditions=[], @fallbacks=[], @required=true, @desc="Filename for the evasive file (default: install_util.txt)", @default="install_util.txt", @enums=[], @owner=Msf::Modules::Evasion__Windows__Applocker_evasion_install_util::MetasploitModule>}, @aliases={}, @defaults={}, @user_defined={}, @_module=#<Module:evasion/windows/applocker_evasion_install_util datastore=[#<Msf::ModuleDataStoreWithFallbacks:0x0000000111335330 ...>]>>]>
```



### After

No crash

```
msf6 auxiliary(scanner/ssh/ssh_login) > use 0
msf6 evasion(windows/applocker_evasion_install_util) > 
```