### PR TITLE
Give likely Windows versions for SMB v2-3

### DIFF
--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -10,41 +10,46 @@ module Msf
     VER_NT_DOMAIN_CONTROLLER = 2
     VER_NT_SERVER = 3
 
-    Win2000 = Rex::Version.new('5.0.2195')
-    XP_SP0 = Rex::Version.new('5.1.2600.0')
-    XP_SP1 = Rex::Version.new('5.1.2600.1')
-    XP_SP2 = Rex::Version.new('5.1.2600.2')
-    XP_SP3 = Rex::Version.new('5.1.2600.3')
-    Server2003_SP0 = Rex::Version.new('5.2.3790.0')
-    Server2003_SP1 = Rex::Version.new('5.2.3790.1')
-    Server2003_SP2 = Rex::Version.new('5.2.3790.2')
-    Vista_SP0 = Server2008_SP0 = Rex::Version.new('6.0.6000.0')
-    Vista_SP1 = Server2008_SP1 = Rex::Version.new('6.0.6001.1')
-    Vista_SP2 = Server2008_SP2 = Rex::Version.new('6.0.6002.2')
-    Server2008_SP2_Update = Rex::Version.new('6.0.6003.2') # https://support.microsoft.com/en-us/topic/build-number-changing-to-6003-in-windows-server-2008-1335e4d4-c155-52eb-4a45-b85bd1909ca8
-    Win7_SP0 = Server2008_R2_SP0 = Rex::Version.new('6.1.7600.0')
-    Win7_SP1 = Server2008_R2_SP1 = Rex::Version.new('6.1.7601.1')
-    Win8 = Server2012 = Rex::Version.new('6.2.9200.0')
-    Win81 = Server2012_R2 = Rex::Version.new('6.3.9600.0')
-    Win10_1507 = Win10_InitialRelease = Rex::Version.new('10.0.10240.0')
-    Win10_1511 = Rex::Version.new('10.0.10586.0')
-    Win10_1607 = Server2016 = Rex::Version.new('10.0.14393.0')
-    Win10_1703 = Rex::Version.new('10.0.15063.0')
-    Win10_1709 = Rex::Version.new('10.0.16299.0')
-    Win10_1803 = Rex::Version.new('10.0.17134.0')
-    Win10_1809 = Server2019 = Rex::Version.new('10.0.17763.0')
-    Win10_1903 = Rex::Version.new('10.0.18362.0')
-    Win10_1909 = Rex::Version.new('10.0.18363.0')
-    Win10_2004 = Rex::Version.new('10.0.19041.0')
-    Win10_20H2 = Rex::Version.new('10.0.19042.0')
-    Win10_21H1 = Rex::Version.new('10.0.19043.0')
-    Win10_21H2 = Rex::Version.new('10.0.19044.0')
-    Win10_22H2 = Rex::Version.new('10.0.19045.0')
-    Server2022 = Rex::Version.new('10.0.20348.0')
-    Win11_21H2 = Rex::Version.new('10.0.22000.0')
-    Win11_22H2 = Rex::Version.new('10.0.22621.0')
-    Win11_23H2 = Rex::Version.new('10.0.22631.0')
-    Server2022_23H2 = Rex::Version.new('10.0.25398.0')
+    module SpecificVersions
+      Win2000 = Rex::Version.new('5.0.2195')
+      XP_SP0 = Rex::Version.new('5.1.2600.0')
+      XP_SP1 = Rex::Version.new('5.1.2600.1')
+      XP_SP2 = Rex::Version.new('5.1.2600.2')
+      XP_SP3 = Rex::Version.new('5.1.2600.3')
+      Server2003_SP0 = Rex::Version.new('5.2.3790.0')
+      Server2003_SP1 = Rex::Version.new('5.2.3790.1')
+      Server2003_SP2 = Rex::Version.new('5.2.3790.2')
+      Vista_SP0 = Server2008_SP0 = Rex::Version.new('6.0.6000.0')
+      Vista_SP1 = Server2008_SP1 = Rex::Version.new('6.0.6001.1')
+      Vista_SP2 = Server2008_SP2 = Rex::Version.new('6.0.6002.2')
+      Server2008_SP2_Update = Rex::Version.new('6.0.6003.2') # https://support.microsoft.com/en-us/topic/build-number-changing-to-6003-in-windows-server-2008-1335e4d4-c155-52eb-4a45-b85bd1909ca8
+      Win7_SP0 = Server2008_R2_SP0 = Rex::Version.new('6.1.7600.0')
+      Win7_SP1 = Server2008_R2_SP1 = Rex::Version.new('6.1.7601.1')
+      Win8 = Server2012 = Rex::Version.new('6.2.9200.0')
+      Win81 = Server2012_R2 = Rex::Version.new('6.3.9600.0')
+      Win10_1507 = Win10_InitialRelease = Rex::Version.new('10.0.10240.0')
+      Win10_1511 = Rex::Version.new('10.0.10586.0')
+      Win10_1607 = Server2016 = Rex::Version.new('10.0.14393.0')
+      Win10_1703 = Rex::Version.new('10.0.15063.0')
+      Win10_1709 = Rex::Version.new('10.0.16299.0')
+      Win10_1803 = Rex::Version.new('10.0.17134.0')
+      Win10_1809 = Server2019 = Rex::Version.new('10.0.17763.0')
+      Win10_1903 = Rex::Version.new('10.0.18362.0')
+      Win10_1909 = Rex::Version.new('10.0.18363.0')
+      Win10_2004 = Rex::Version.new('10.0.19041.0')
+      Win10_20H2 = Rex::Version.new('10.0.19042.0')
+      Win10_21H1 = Rex::Version.new('10.0.19043.0')
+      Win10_21H2 = Rex::Version.new('10.0.19044.0')
+      Win10_22H2 = Rex::Version.new('10.0.19045.0')
+      Server2022 = Rex::Version.new('10.0.20348.0')
+      Win11_21H2 = Rex::Version.new('10.0.22000.0')
+      Win11_22H2 = Rex::Version.new('10.0.22621.0')
+      Win11_23H2 = Rex::Version.new('10.0.22631.0')
+      Win11_24H2 = Rex::Version.new('10.0.26100.0')
+      Server2022_23H2 = Rex::Version.new('10.0.25398.0')
+    end
+
+    include SpecificVersions
 
     module MajorRelease
       NT351 = 'Windows NT 3.51'.freeze
@@ -60,7 +65,7 @@ module Msf
       Server2008 = 'Windows Server 2008'.freeze
 
       Win7 = 'Windows 7'.freeze
-      Server2008R2 = 'Windows 2008 R2'.freeze
+      Server2008R2 = 'Windows Server 2008 R2'.freeze
 
       Win8 = 'Windows 8'.freeze
       Server2012 = 'Windows Server 2012'.freeze
@@ -140,6 +145,24 @@ module Msf
       build_number.between?(XP_SP0, Server2003_SP2)
     end
 
+    def self.from_ntlm_os_version(major, minor, build)
+      SpecificVersions.constants.each do |version_sym|
+        version = const_get(version_sym)
+        segments = version.segments
+        if segments[0..2] == [major, minor, build]
+          workstation = WindowsVersion.new(segments[0], segments[1], segments[2], segments[3], 0, VER_NT_WORKSTATION).product_name
+          server = WindowsVersion.new(segments[0], segments[1], segments[2], segments[3], 0, VER_NT_SERVER).product_name
+          if workstation == server
+            return workstation
+          else
+            return "#{workstation}/#{server}"
+          end
+        end
+      end
+
+      nil
+    end
+
     private
 
     attr_accessor :_major, :_minor, :_build, :_service_pack, :_revision, :product_type
@@ -154,7 +177,7 @@ module Msf
         elsif _minor == 2
           return MajorRelease::Server2003 if windows_server?
 
-          return MajorRelease::XP
+          return MajorRelease::XP # x64 Build
         end
       elsif _major == 6
         if _minor == 0

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -222,12 +222,13 @@ module Msf
 
     # Get the string representation of the OS, given a major, minor and build number
     # (as reported by an NTLM handshake).
-    # The NTLM structure makes no guarantee that it is actually Windows, so if we
-    # don't find a precise match, return nil
+    # The NTLM structure makes no guarantee that the underlying OS of the server is
+    # actually Windows, so if we don't find a precise match, return nil
+    #
     # @param major [Integer] The major build number reported in the NTLM handshake
     # @param minor [Integer] The minor build number reported in the NTLM handshake
     # @param build [Integer] The build build number reported in the NTLM handshake
-    # @return [String] The possible matching OS versions, or nil if no identical match can be found
+    # @return [String] The possible matching OS versions, or nil if no corresponding match can be found
     def self.from_ntlm_os_version(major, minor, build)
       workstation_string = self.version_string(major, minor, build, WorkstationSpecificVersions, WorkstationNameMapping)
       server_string = self.version_string(major, minor, build, ServerSpecificVersions, ServerNameMapping)
@@ -287,7 +288,7 @@ module Msf
       return nil
     end
 
-    # Get a Windows OS string from a version, given a set of version constants
+    # Get a Windows OS version string representation for a given major, minor and build number
     def self.version_string(major, minor, build, version_module, mapping)
       version_module.constants.each do |version_sym|
         version = version_module.const_get(version_sym)

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -10,30 +10,44 @@ module Msf
     VER_NT_DOMAIN_CONTROLLER = 2
     VER_NT_SERVER = 3
 
-    module SpecificVersions
+    module ServerSpecificVersions
+      Server2003_SP0 = Rex::Version.new('5.2.3790.0')
+      Server2003_SP1 = Rex::Version.new('5.2.3790.1')
+      Server2003_SP2 = Rex::Version.new('5.2.3790.2')
+      Server2008_SP0 = Rex::Version.new('6.0.6000.0')
+      Server2008_SP1 = Rex::Version.new('6.0.6001.1')
+      Server2008_SP2 = Rex::Version.new('6.0.6002.2')
+      Server2008_SP2_Update = Rex::Version.new('6.0.6003.2') # https://support.microsoft.com/en-us/topic/build-number-changing-to-6003-in-windows-server-2008-1335e4d4-c155-52eb-4a45-b85bd1909ca8
+      Server2008_R2_SP0 = Rex::Version.new('6.1.7600.0')
+      Server2008_R2_SP1 = Rex::Version.new('6.1.7601.1')
+      Server2012 = Rex::Version.new('6.2.9200.0')
+      Server2012_R2 = Rex::Version.new('6.3.9600.0')
+      Server2016 = Rex::Version.new('10.0.14393.0')
+      Server2019 = Rex::Version.new('10.0.17763.0')
+      Server2022 = Rex::Version.new('10.0.20348.0')
+      Server2022_23H2 = Rex::Version.new('10.0.25398.0')
+    end
+
+    module WorkstationSpecificVersions
       Win2000 = Rex::Version.new('5.0.2195')
       XP_SP0 = Rex::Version.new('5.1.2600.0')
       XP_SP1 = Rex::Version.new('5.1.2600.1')
       XP_SP2 = Rex::Version.new('5.1.2600.2')
       XP_SP3 = Rex::Version.new('5.1.2600.3')
-      Server2003_SP0 = Rex::Version.new('5.2.3790.0')
-      Server2003_SP1 = Rex::Version.new('5.2.3790.1')
-      Server2003_SP2 = Rex::Version.new('5.2.3790.2')
-      Vista_SP0 = Server2008_SP0 = Rex::Version.new('6.0.6000.0')
-      Vista_SP1 = Server2008_SP1 = Rex::Version.new('6.0.6001.1')
-      Vista_SP2 = Server2008_SP2 = Rex::Version.new('6.0.6002.2')
-      Server2008_SP2_Update = Rex::Version.new('6.0.6003.2') # https://support.microsoft.com/en-us/topic/build-number-changing-to-6003-in-windows-server-2008-1335e4d4-c155-52eb-4a45-b85bd1909ca8
-      Win7_SP0 = Server2008_R2_SP0 = Rex::Version.new('6.1.7600.0')
-      Win7_SP1 = Server2008_R2_SP1 = Rex::Version.new('6.1.7601.1')
-      Win8 = Server2012 = Rex::Version.new('6.2.9200.0')
-      Win81 = Server2012_R2 = Rex::Version.new('6.3.9600.0')
-      Win10_1507 = Win10_InitialRelease = Rex::Version.new('10.0.10240.0')
+      Vista_SP0 = Rex::Version.new('6.0.6000.0')
+      Vista_SP1 = Rex::Version.new('6.0.6001.1')
+      Vista_SP2 = Rex::Version.new('6.0.6002.2')
+      Win7_SP0 = Rex::Version.new('6.1.7600.0')
+      Win7_SP1 = Rex::Version.new('6.1.7601.1')
+      Win8 = Rex::Version.new('6.2.9200.0')
+      Win81 = Rex::Version.new('6.3.9600.0')
+      Win10_1507 = Rex::Version.new('10.0.10240.0')
       Win10_1511 = Rex::Version.new('10.0.10586.0')
-      Win10_1607 = Server2016 = Rex::Version.new('10.0.14393.0')
+      Win10_1607 = Rex::Version.new('10.0.14393.0')
       Win10_1703 = Rex::Version.new('10.0.15063.0')
       Win10_1709 = Rex::Version.new('10.0.16299.0')
       Win10_1803 = Rex::Version.new('10.0.17134.0')
-      Win10_1809 = Server2019 = Rex::Version.new('10.0.17763.0')
+      Win10_1809 = Rex::Version.new('10.0.17763.0')
       Win10_1903 = Rex::Version.new('10.0.18362.0')
       Win10_1909 = Rex::Version.new('10.0.18363.0')
       Win10_2004 = Rex::Version.new('10.0.19041.0')
@@ -41,15 +55,67 @@ module Msf
       Win10_21H1 = Rex::Version.new('10.0.19043.0')
       Win10_21H2 = Rex::Version.new('10.0.19044.0')
       Win10_22H2 = Rex::Version.new('10.0.19045.0')
-      Server2022 = Rex::Version.new('10.0.20348.0')
       Win11_21H2 = Rex::Version.new('10.0.22000.0')
       Win11_22H2 = Rex::Version.new('10.0.22621.0')
       Win11_23H2 = Rex::Version.new('10.0.22631.0')
       Win11_24H2 = Rex::Version.new('10.0.26100.0')
-      Server2022_23H2 = Rex::Version.new('10.0.25398.0')
     end
 
-    include SpecificVersions
+    include WorkstationSpecificVersions
+    include ServerSpecificVersions
+
+    ServerNameMapping = {
+      :Server2003_SP0 => "Windows Server 2003",
+      :Server2003_SP1 => "Windows Server 2003 Service Pack 1",
+      :Server2003_SP2 => "Windows Server 2003 Service Pack 2",
+      :Server2008_SP0 => "Windows Server 2008",
+      :Server2008_SP1 => "Windows Server 2008 Service Pack 1",
+      :Server2008_SP2 => "Windows Server 2008 Service Pack 2",
+      :Server2008_SP2_Update => "Windows Server 2008 Service Pack 2 Update",
+      :Server2008_R2_SP0 => "Windows Server 2008 R2",
+      :Server2008_R2_SP1 => "Windows Server 2008 R2 Service Pack 1",
+      :Server2012 => "Windows Server 2012 R2",
+      :Server2012_R2 => "Windows Server 2012 R2",
+      :Server2016 => "Windows Server 2016",
+      :Server2019 => "Windows Server 2019",
+      :Server2022 => "Windows Server 2022",
+      :Server2022_23H2 => "Windows Server 2022 version 23H2"
+    }
+
+    WorkstationNameMapping = {
+      :Win2000 => "Windows 2000",
+      :XP_SP0 => "Windows XP",
+      :XP_SP1 => "Windows XP Service Pack 1",
+      :XP_SP2 => "Windows XP Service Pack 2",
+      :XP_SP3 => "Windows XP Service Pack 3",
+      :Vista_SP0 => "Windows Vista",
+      :Vista_SP1 => "Windows Vista Service Pack 1",
+      :Vista_SP2 => "Windows Vista Service Pack 2",
+      :Win7_SP0 => "Windows 7",
+      :Win7_SP1 => "Windows 7 Service Pack 1",
+      :Win8 => "Windows 8",
+      :Win81 => "Windows 8.1",
+      :Win10_1507 => "Windows 10 version 1507",
+      :Win10_1511 => "Windows 10 version 1511",
+      :Win10_1607 => "Windows 10 version 1607",
+      :Win10_1703 => "Windows 10 version 1703",
+      :Win10_1709 => "Windows 10 version 1709",
+      :Win10_1803 => "Windows 10 version 1803",
+      :Win10_1809 => "Windows 10 version 1809",
+      :Win10_1903 => "Windows 10 version 1903",
+      :Win10_1909 => "Windows 10 version 1909",
+      :Win10_2004 => "Windows 10 version 2004",
+      :Win10_20H2 => "Windows 10 version 20H2",
+      :Win10_21H1 => "Windows 10 version 21H1",
+      :Win10_21H2 => "Windows 10 version 21H2",
+      :Win10_22H2 => "Windows 10 version 22H2",
+      :Win11_21H2 => "Windows 11 version 21H2",
+      :Win11_22H2 => "Windows 11 version 22H2",
+      :Win11_23H2 => "Windows 11 version 23H2",
+      :Win11_24H2 => "Windows 11 version 24H2"
+    }
+
+    Win10_InitialRelease = Win10_1507
 
     module MajorRelease
       NT351 = 'Windows NT 3.51'.freeze
@@ -117,6 +183,15 @@ module Msf
 
     # The name of the OS, as it is most commonly rendered. Includes Service Pack if present, or build number if Win10 or higher.
     def product_name
+      # First check if there's a specific, known version we have a string for
+      if windows_server?
+        known_version = self.class.version_string(_major, _minor, _build, ServerSpecificVersions, ServerNameMapping)
+      else
+        known_version = self.class.version_string(_major, _minor, _build, WorkstationSpecificVersions, WorkstationNameMapping)
+      end
+      return known_version unless known_version.nil?
+
+      # Otherwise, build it up from version numbers, to the best of our ability
       result = "Unknown Windows version: #{_major}.#{_minor}.#{_build}"
       name = major_release_name
       result = name unless name.nil?
@@ -145,22 +220,27 @@ module Msf
       build_number.between?(XP_SP0, Server2003_SP2)
     end
 
+    # Get the string representation of the OS, given a major, minor and build number
+    # (as reported by an NTLM handshake).
+    # The NTLM structure makes no guarantee that it is actually Windows, so if we
+    # don't find a precise match, return nil
+    # @param major [Integer] The major build number reported in the NTLM handshake
+    # @param minor [Integer] The minor build number reported in the NTLM handshake
+    # @param build [Integer] The build build number reported in the NTLM handshake
+    # @return [String] The possible matching OS versions, or nil if no identical match can be found
     def self.from_ntlm_os_version(major, minor, build)
-      SpecificVersions.constants.each do |version_sym|
-        version = const_get(version_sym)
-        segments = version.segments
-        if segments[0..2] == [major, minor, build]
-          workstation = WindowsVersion.new(segments[0], segments[1], segments[2], segments[3], 0, VER_NT_WORKSTATION).product_name
-          server = WindowsVersion.new(segments[0], segments[1], segments[2], segments[3], 0, VER_NT_SERVER).product_name
-          if workstation == server
-            return workstation
-          else
-            return "#{workstation}/#{server}"
-          end
-        end
-      end
+      workstation_string = self.version_string(major, minor, build, WorkstationSpecificVersions, WorkstationNameMapping)
+      server_string = self.version_string(major, minor, build, ServerSpecificVersions, ServerNameMapping)
 
-      nil
+      version_strings = []
+      version_strings.append(workstation_string) unless workstation_string.nil?
+      version_strings.append(server_string) unless server_string.nil?
+
+      if version_strings.length > 0
+        version_strings.join('/')
+      else
+        nil
+      end
     end
 
     private
@@ -205,6 +285,19 @@ module Msf
         end
       end
       return nil
+    end
+
+    # Get a Windows OS string from a version, given a set of version constants
+    def self.version_string(major, minor, build, version_module, mapping)
+      version_module.constants.each do |version_sym|
+        version = version_module.const_get(version_sym)
+        segments = version.segments
+        if segments[0..2] == [major, minor, build]
+          return mapping[version_sym]
+        end
+      end
+
+      nil
     end
   end
 end

--- a/spec/lib/msf/core/windows_version_spec.rb
+++ b/spec/lib/msf/core/windows_version_spec.rb
@@ -26,4 +26,36 @@ RSpec.describe Msf::WindowsVersion do
     subject = described_class.new(1,2,3000,0, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Unknown Windows version: 1.2.3000')
   end
+
+  it 'Reports correct SMB version for single match' do
+    major = 5
+    minor = 1
+    build = 2600
+    version_string = described_class.from_ntlm_os_version(major, minor, build)
+    expect(version_string).to eq('Windows XP')
+  end
+
+  it 'Reports correct SMB version for multiple matches' do
+    major = 6
+    minor = 1
+    build = 7601
+    version_string = described_class.from_ntlm_os_version(major, minor, build)
+    expect(version_string).to eq('Windows 7 Service Pack 1/Windows Server 2008 R2 Service Pack 1')
+  end
+
+  it 'Reports unknown SMB version for no identical old OS' do
+    major = 6
+    minor = 1
+    build = 7604
+    version_string = described_class.from_ntlm_os_version(major, minor, build)
+    expect(version_string).to eq(nil)
+  end
+
+  it 'Reports unknown SMB version for no identical Win10+' do
+    major = 10
+    minor = 0
+    build = 15064
+    version_string = described_class.from_ntlm_os_version(major, minor, build)
+    expect(version_string).to eq(nil)
+  end
 end

--- a/spec/lib/msf/core/windows_version_spec.rb
+++ b/spec/lib/msf/core/windows_version_spec.rb
@@ -13,18 +13,32 @@ RSpec.describe Msf::WindowsVersion do
   end
 
   it 'Adds build suffix to Windows 10' do
+    subject = described_class.new(10,0,18360,0, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    expect(subject.to_s).to eq('Windows 10+ Build 18360')
+  end
+
+  it 'Uses known Windows 10 version' do
     subject = described_class.new(10,0,18362,0, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
-    expect(subject.to_s).to eq('Windows 10+ Build 18362')
+    expect(subject.to_s).to eq('Windows 10 version 1903')
   end
 
   it 'Adds service pack suffix' do
-    subject = described_class.new(5,1,2600,2, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
+    subject = described_class.new(5,1,2602,2, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Windows XP Service Pack 2')
   end
 
   it 'Outputs unknown version' do
     subject = described_class.new(1,2,3000,0, 0,Msf::WindowsVersion::VER_NT_WORKSTATION)
     expect(subject.to_s).to eq('Unknown Windows version: 1.2.3000')
+  end
+
+  it 'Has string name for each named version' do
+    described_class::ServerSpecificVersions.constants.each do |version_sym|
+      expect(described_class::ServerNameMapping).to include(version_sym)
+    end
+    described_class::WorkstationSpecificVersions.constants.each do |version_sym|
+      expect(described_class::WorkstationNameMapping).to include(version_sym)
+    end
   end
 
   it 'Reports correct SMB version for single match' do


### PR DESCRIPTION
This addresses  #17402 - listing OS information when the target doesn't support SMBv1.

There is information in the NTLM negotiation (`os_version`) that can be used to fingerprint this. On Windows this works well; on Samba servers, it's not entirely clear to me what it's supposed to be presenting (e.g. my Samba 4.6.2 on Ubuntu 20.04 reported a version of 6.1.0).

The approach I took was to look at our list of known Windows versions, and if we get an exact match, report it as Windows, with a meaningful name. If we can't match it as a Windows version, rather than saying that it's Windows, just report the version listed.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

## Demo

Server 2022:

```
msf6 auxiliary(scanner/smb/smb_version) > run rhost=4.237.57.48
[*] 4.237.57.48:445       - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1, Pattern_V1) (encryption capabilities:AES-256-GCM) (signatures:required) (guid:{0a6d1a52-f418-408e-a82d-ee5b034b4c0a}) (authentication domain:MSF)
[+] 4.237.57.48:445       -   Host is running Version 10.0.20348 (likely Windows Server 2022)
[*] 4.237.57.48:          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Samba:
```
msf6 auxiliary(scanner/smb/smb_version) > run rhost=127.0.0.1

[*] 127.0.0.1:445         - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:) (encryption capabilities:AES-128-GCM) (signatures:optional) (guid:{6466736d-7665-6275-756e-747500000000}) (authentication domain:MSFDEVUBUNTU)
[+] 127.0.0.1:445         -   Host is running Version 6.1.0 (unknown OS)
[*] 127.0.0.1:            - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Win 2008 SP2:

```
msf6 auxiliary(scanner/smb/smb_version) > run rhost=192.168.20.99
[*] 192.168.20.99:445     - SMB Detected (versions:1, 2) (preferred dialect:SMB 2.0.2) (signatures:required) (uptime:3d 7h 0m 9s) (guid:{c8a8499c-1874-4b6d-8e74-47d71c95eb2f}) (authentication domain:POD7)
[+] 192.168.20.99:445     -   Host is running Windows 2008  Standard  SP2  (build:6002)
[*] 192.168.20.99:        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Windows 10:
```
msf6 auxiliary(scanner/smb/smb_version) > run rhost=192.168.20.214

[*] 192.168.20.214:445    - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-GCM) (signatures:optional) (guid:{74e94c29-e27d-48bb-8346-9953cfb83999}) (authentication domain:WIN10BASE)
[+] 192.168.20.214:445    -   Host is running Version 10.0.19041 (likely Windows 10 version 2004)
[*] 192.168.20.214:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```