### PR TITLE
Close ssh session on error

### DIFF
--- a/lib/msf/base/sessions/aws_instance_connect_command_shell_bind.rb
+++ b/lib/msf/base/sessions/aws_instance_connect_command_shell_bind.rb
@@ -76,7 +76,7 @@ module Msf::Sessions
     end
 
     def bootstrap(datastore = {}, handler = nil)
-      @ssh_command_stream = Net::SSH::CommandStream.new(ssh_connection)
+      @ssh_command_stream = Net::SSH::CommandStream.new(ssh_connection, session: self)
 
       @ssh_command_stream.verify_channel
       # set remote_window_size to 32 which seems to help stability

--- a/lib/msf/base/sessions/aws_instance_connect_command_shell_bind.rb
+++ b/lib/msf/base/sessions/aws_instance_connect_command_shell_bind.rb
@@ -76,7 +76,7 @@ module Msf::Sessions
     end
 
     def bootstrap(datastore = {}, handler = nil)
-      @ssh_command_stream = Net::SSH::CommandStream.new(ssh_connection, session: self)
+      @ssh_command_stream = Net::SSH::CommandStream.new(ssh_connection, session: self, logger: self)
 
       @ssh_command_stream.verify_channel
       # set remote_window_size to 32 which seems to help stability

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -243,7 +243,7 @@ module Msf::Sessions
       # shells accessed through SSH may respond to the echo command issued for verification as expected
       datastore['AutoVerifySession'] &= @platform.blank?
 
-      @rstream = Net::SSH::CommandStream.new(ssh_connection, session: self).lsock
+      @rstream = Net::SSH::CommandStream.new(ssh_connection, session: self, logger: self).lsock
       super
 
       @info = "SSH #{username} @ #{@peer_info}"

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -243,7 +243,7 @@ module Msf::Sessions
       # shells accessed through SSH may respond to the echo command issued for verification as expected
       datastore['AutoVerifySession'] &= @platform.blank?
 
-      @rstream = Net::SSH::CommandStream.new(ssh_connection).lsock
+      @rstream = Net::SSH::CommandStream.new(ssh_connection, session: self).lsock
       super
 
       @info = "SSH #{username} @ #{@peer_info}"

--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -96,7 +96,7 @@ class Net::SSH::CommandStream
         rssh.close
       end
     end
-  rescue ::Exception => e
+  rescue ::StandardError => e
     # XXX: This won't be set UNTIL there's a failure from a thread
     self.error = e
   ensure
@@ -111,6 +111,11 @@ class Net::SSH::CommandStream
       raise EOFError if ! self.thread.alive?
       ::IO.select(nil, nil, nil, 0.10)
     end
+  end
+
+  def handle_error(error: nil)
+    self.error = error if error
+    cleanup
   end
 
   def cleanup

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
       info: version
     )
 
-    shell = Net::SSH::CommandStream.new(ssh)
+    shell = Net::SSH::CommandStream.new(ssh, logger: self)
 
     # XXX: Wait for CommandStream to log a channel request failure
     sleep 0.1

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       info: version
     )
 
-    shell = Net::SSH::CommandStream.new(ssh)
+    shell = Net::SSH::CommandStream.new(ssh, logger: self)
 
     # XXX: Wait for CommandStream to log a channel request failure
     sleep 0.1

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       info: version
     )
 
-    shell = Net::SSH::CommandStream.new(ssh, datastore['CMD'], pty: datastore['SPAWN_PTY'])
+    shell = Net::SSH::CommandStream.new(ssh, datastore['CMD'], pty: datastore['SPAWN_PTY'], logger: self)
 
     # XXX: Wait for CommandStream to log a channel request failure
     sleep 0.1

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh)
+      conn = Net::SSH::CommandStream.new(ssh, logger: self)
       ssh = nil
       return conn
     end

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -349,7 +349,7 @@ $user->set_var('junos-version',$imageName);
     end
 
     if ssh
-      Net::SSH::CommandStream.new(ssh)
+      Net::SSH::CommandStream.new(ssh, logger: self)
     end
   end
 

--- a/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
         private: private_key,
         private_type: :ssh_key
       )
-      return Net::SSH::CommandStream.new(ssh)
+      return Net::SSH::CommandStream.new(ssh, logger: self)
     end
 
     nil

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket)
+      conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
+++ b/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh)
+      conn = Net::SSH::CommandStream.new(ssh, logger: self)
       ssh = nil
       return conn
     end

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket)
+      conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return false unless ssh_socket
 
     # Create a new session from the socket, then dump it.
-    conn = Net::SSH::CommandStream.new(ssh_socket)
+    conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
     ssh_socket = nil
     conn
   end

--- a/modules/exploits/linux/ssh/ibm_drm_a3user.rb
+++ b/modules/exploits/linux/ssh/ibm_drm_a3user.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{peer} SSH Error: #{e.class} : #{e.message}")
     end
 
-    return Net::SSH::CommandStream.new(ssh) if ssh
+    return Net::SSH::CommandStream.new(ssh, logger: self) if ssh
 
     nil
   end

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket)
+      conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
+++ b/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh)
+      conn = Net::SSH::CommandStream.new(ssh, logger: self)
       ssh = nil
       return conn
     end

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket)
+      conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh, 'shell-escape')
+      conn = Net::SSH::CommandStream.new(ssh, 'shell-escape', logger: self)
       return conn
     end
 

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh)
+      conn = Net::SSH::CommandStream.new(ssh, logger: self)
       ssh = nil
       return conn
     end

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if ssh_socket
 
       # Create a new session from the socket, then dump it.
-      conn = Net::SSH::CommandStream.new(ssh_socket)
+      conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
       sockets.delete(ssh_socket.transport.socket)
 
       return conn

--- a/modules/exploits/linux/ssh/vmware_vrni_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vrni_known_privkey.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if ssh_socket
       # Create a new session from the socket, then close it.
-      conn = Net::SSH::CommandStream.new(ssh_socket)
+      conn = Net::SSH::CommandStream.new(ssh_socket, logger: self)
       ssh_socket = nil
 
       return conn

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error "#{rhost}:22 SSH Error: #{e.class} : #{e.message}"
     end
     if ssh
-      conn = Net::SSH::CommandStream.new(ssh)
+      conn = Net::SSH::CommandStream.new(ssh, logger: self)
       return conn
     end
   end

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -181,6 +181,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Make the SSH connection and execute our commands + payload
     print_status("#{rhost}:#{rport} - Sending and executing payload to gain root privileges!")
-    Net::SSH::CommandStream.new(ssh, build_command)
+    Net::SSH::CommandStream.new(ssh, build_command, logger: self)
   end
 end

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
       message = transport.next_message.type
 
       if message.to_i == 6 #SSH2_MSG_SERVICE_ACCEPT
-        shell = Net::SSH::CommandStream.new(connection)
+        shell = Net::SSH::CommandStream.new(connection, logger: self)
         connection = nil
         return shell
       end


### PR DESCRIPTION
This PR ensures that an SSH session dies when it encounters errors. For example, the `shell` request can fail asynchronously, leading to an SSH session that cannot be interacted with, as was the case with a Windows VM that has installed OpenSSH version 8.1.0.0 with `choco install openssh --version 8.1.0-beta1`.
As this `shell` request happens asynchronously, we end up with a session that has been reported as open and that the credential works, but the session then dies afterwards.

This PR also allows for the passing of an error_callback method, allowing us to log out the errors to the user:
```ruby
➜  metasploit-framework git:(close-ssh-session-on-error) bundle exec ruby ./msfconsole -qx 'run'
[*] 192.168.112.222:22 - Starting bruteforce
[+] 192.168.112.222:22 - Success: 'win10:win10' 'Microsoft Windows 10 Pro 10.0.19045 N/A Build 19045'
[-] SSH Command Stream encountered an error: Shell/exec channel request failed (Server Version: SSH-2.0-OpenSSH_for_Windows_8.1)
[*] SSH session 1 opened (x:49198 -> x:22) at 2024-11-18 17:26:48 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Scan completed, 1 credential was successful.

Successful logins
=================

    Host             Public  Private
    ----             ------  -------
    x                  win10   win10


[*] 1 session was opened successfully.
[*] Auxiliary module execution completed
[*] x - SSH session 1 closed.  Reason: Died
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Ensure that running the ssh_login module vs. a Windows VM with an OpenSSH version newer than 8.1.0.0 works as expected
- [x] Ensure that running the ssh_login module vs. an Ubuntu VM works as expected
- [x] Ensure that running the ssh_login module vs. a Windows VM with an OpenSSH version of 8.1.0.0 makes the session die.

## Before
An SSH session is broken but has not been killed. When interacting with it, no data is sent through the `shell` channel as it has died silently.

## After
Session is killed, and an error is logged with the server version if the error_callback is provided as the command stream has no access to `print_error` itself, so it is passed in.