### PR TITLE
Deprecate real-readline option

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -92,7 +92,6 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
       driver_options['ModulePath'] = options.modules.path
       driver_options['Plugins'] = options.console.plugins
       driver_options['Readline'] = options.console.readline
-      driver_options['RealReadline'] = options.console.real_readline
       driver_options['Resource'] = options.console.resources
       driver_options['XCommands'] = options.console.commands
 

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -16,7 +16,6 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         options.console.plugins = []
         options.console.quiet = false
         options.console.readline = true
-        options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
       }
@@ -54,7 +53,10 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         end
 
         option_parser.on('-L', '--real-readline', 'Use the system Readline library instead of RbReadline') do
-          options.console.real_readline = true
+          message = "The RealReadline option has been marked as deprecated, and is currently a noop.\n"
+          message << "If you require this functionality, please use the following link to tell us:\n"
+          message << '  https://github.com/rapid7/metasploit-framework/issues/19399'
+          warn message
         end
 
         option_parser.on('-o', '--output FILE', 'Output to the specified file') do |file|

--- a/lib/metasploit/framework/parsed_options/remote_db.rb
+++ b/lib/metasploit/framework/parsed_options/remote_db.rb
@@ -13,7 +13,6 @@ class Metasploit::Framework::ParsedOptions::RemoteDB < Metasploit::Framework::Pa
         options.console.local_output = nil
         options.console.plugins = []
         options.console.quiet = false
-        options.console.real_readline = false
         options.console.resources = []
         options.console.subcommand = :run
       }


### PR DESCRIPTION
This PR is based on this PR: https://github.com/rapid7/metasploit-framework/pull/19559
The purpose of this PR is to split out some of the review and testing effort into a separate PR.
This PR marks the real-readline option as deprecated as we are planning on moving to Reline, which is pure-Ruby.
This option is also broken on Windows hosts, e.g. Windows 10 running Git for Windows in Windows Terminal or other terminal emulators.

## Verification

- [ ] Start `msfconsole`
- [ ] Ensure you can use the console as expected as this functionality is not changed
- [ ] Run `msfconsole -L` or `msfconsole --real-readline`
- [ ] Ensure that you get a warning message
- [ ] Ensure you can use the console as expected