### PR TITLE
Fix `auxiliary/admin/kerberos/get_ticket` issue on Windows

### DIFF
--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def validate_options
     if datastore['CERT_FILE'].present?
-      certificate = File.open(datastore['CERT_FILE'], 'rb', &:read)
+      certificate = File.binread(datastore['CERT_FILE'])
       begin
         @pfx = OpenSSL::PKCS12.new(certificate, datastore['CERT_PASSWORD'] || '')
       rescue OpenSSL::PKCS12::PKCS12Error => e

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def validate_options
     if datastore['CERT_FILE'].present?
-      certificate = File.read(datastore['CERT_FILE'])
+      certificate = File.open(datastore['CERT_FILE'], 'rb', &:read)
       begin
         @pfx = OpenSSL::PKCS12.new(certificate, datastore['CERT_PASSWORD'] || '')
       rescue OpenSSL::PKCS12::PKCS12Error => e


### PR DESCRIPTION
This fix an issue when the module reads a certificate file locally. On Windows, using `File.read` without specifying the binary mode when reading binary files causes `OpenSSL::PKCS12` to ail parsing it. This PR fixes it.

## Verification
- [ ] Install Metasploit on Windows (https://windows.metasploit.com/metasploitframework-latest.msi)
- [ ] Start `msfconsole`
- [ ] Get a valid certificate (using `admin/dcerpc/icpr_cert` for example
- [ ] `use admin/kerberos/get_ticket`
- [ ] `set rhosts <remote host>`
- [ ] `set cert_file  <certificate file path>`
- [ ] `set verbose true`
- [ ] `run`
- [ ] **Verify** it doesn't break
- [ ] **Verify** the TGT has been obtained

## Without this fix
```

msf6 auxiliary(admin/kerberos/get_ticket) > run
[*] Running module against 10.120.33.147

[-] Auxiliary aborted due to failure: bad-config: Unable to parse certificate file (PKCS12_parse: mac verify failure)
[*] Auxiliary module execution completed
```

## With this fix:
```
msf6 auxiliary(admin/kerberos/get_ticket) > run
[*] Running module against 10.120.33.147

[*] 10.120.33.147:88 - Getting TGT for administrator@ad.pro.local
[+] 10.120.33.147:88 - Received a valid TGT-Response
[*] 10.120.33.147:88 - TGT MIT Credential Cache ticket saved to C:/Users/n00tmeg/.msf4/loot/20241118053732_default_10.120.33.147_mit.kerberos.cca_385496.bin
[*] Auxiliary module execution completed
```
