### PR TITLE
Fix IRB deadlock recursive locking on Ctrl+C

### DIFF
--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -40,20 +40,18 @@ class IrbShell
     IRB.conf[:MAIN_CONTEXT] = irb.context
 
     # Trap interrupt
-    old_sigint = trap("SIGINT") do
-      begin
+    begin
+      old_sigint = trap("SIGINT") do
         irb.signal_handle
-      rescue RubyLex::TerminateLineInput
+      end
+
+      # Keep processing input until the cows come home...
+      catch(:IRB_EXIT) do
         irb.eval_input
       end
+    ensure
+      trap("SIGINT", old_sigint) if old_sigint
     end
-
-    # Keep processing input until the cows come home...
-    catch(:IRB_EXIT) do
-      irb.eval_input
-    end
-
-    trap("SIGINT", old_sigint)
   end
 
 end


### PR DESCRIPTION
This PR fixes an issue with how we handle IRB; when in an `irb` shell and Ctrl+C is pressed, we currently get `[-] Error during IRB: deadlock; recursive locking`.
With this PR, we replicate what the standalone `irb` executable does and we no longer crash.
This is also extracted from the current Reline PR.

## Verification

- [ ] Start `msfconsole`
- [ ] `irb`
- [ ] Press Ctrl+C
- [ ] **Verify** that you don't crash
- [ ] Verify that you can cancel a blocking command

## Before

```ruby
➜  metasploit-framework git:(acc9940cdb) ✗ bundle exec ruby ./msfconsole -q
msf6 auxiliary(scanner/ssh/ssh_login) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/scanner/ssh/ssh_login

>> 
^C
[-] Error during IRB: deadlock; recursive locking

/Users/sjanusz/.rvm/gems/ruby-3.2.5@metasploit-framework/gems/reline-0.5.10/lib/reline.rb:252:in `synchronize'
/Users/sjanusz/.rvm/gems/ruby-3.2.5@metasploit-framework/gems/reline-0.5.10/lib/reline.rb:252:in `readmultiline'
/Users/sjanusz/.rvm/rubies/ruby-3.2.5/lib/ruby/3.2.0/forwardable.rb:240:in `readmultiline'
...
```

## After

```ruby
➜  metasploit-framework git:(acc9940cdb) ✗ bundle exec ruby ./msfconsole -q
msf6 auxiliary(scanner/ssh/ssh_login) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/scanner/ssh/ssh_login

>> 
^C
>> 
^C
>> 
^C
```

## Standalone irb

```ruby
➜  metasploit-framework git:(fix-irb-deadlock-error) ✗ irb                             
3.2.5 :001 > 
^C
3.2.5 :001 > 
^C
3.2.5 :001 > 
^C
3.2.5 :001 >
```