### PR TITLE
Make enum options case normalizing

### DIFF
--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -20,13 +20,22 @@ module Msf
     def valid?(value = self.value, check_empty: true)
       return false if check_empty && empty_required_value?(value)
       return true if value.nil? && !required?
+      return false if value.nil?
 
-      !value.nil? && enums.include?(value.to_s)
+      if case_sensitive?
+        enums.include?(value.to_s)
+      else
+        enums.map(&:downcase).include?(value.to_s.downcase)
+      end
     end
 
     def normalize(value = self.value)
       if valid?(value) && !value.nil?
-        value.to_s
+        if case_sensitive?
+          value.to_s
+        else
+          enums.find { |e| e.casecmp? value }
+        end
       else
         nil
       end
@@ -43,6 +52,10 @@ module Msf
     end
 
     protected
+
+    def case_sensitive?
+      enums.map(&:downcase).uniq.length != enums.uniq.length
+    end
 
     attr_accessor :desc_string # :nodoc:
   end

--- a/spec/lib/msf/core/opt_enum_spec.rb
+++ b/spec/lib/msf/core/opt_enum_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Msf::OptEnum do
       expect(required_optenum.valid?('Bar')).to eq true
     end
 
+    it 'should return true for a value in the list with alternative casing' do
+      expect(required_optenum.valid?('bar')).to eq true
+    end
+
     it 'should return false for a nil value' do
       expect(required_optenum.valid?(nil)).to eq false
     end
@@ -29,6 +33,10 @@ RSpec.describe Msf::OptEnum do
 
     it 'should return true for a value in the list' do
       expect(not_required_optenum.valid?('Bar')).to eq true
+    end
+
+    it 'should return true for a value in the list with alternative casing' do
+      expect(not_required_optenum.valid?('bar')).to eq true
     end
 
     it 'should return false for a value not in the list' do
@@ -45,6 +53,10 @@ RSpec.describe Msf::OptEnum do
       expect(required_optenum.normalize('Bar')).to eq 'Bar'
     end
 
+    it 'should return the value string for a value with alternative casing' do
+      expect(required_optenum.normalize('bar')).to eq 'Bar'
+    end
+
     it 'should return nil for a value not in the list' do
       expect(required_optenum.normalize('Snap')).to eq nil
     end
@@ -57,6 +69,10 @@ RSpec.describe Msf::OptEnum do
 
     it 'should return the value string for a value in the list' do
       expect(not_required_optenum.normalize('Bar')).to eq 'Bar'
+    end
+
+    it 'should return the value string for a value with alternative casing' do
+      expect(not_required_optenum.normalize('bar')).to eq 'Bar'
     end
 
     it 'should return nil for a value not in the list' do


### PR DESCRIPTION
This closes #19450 by introducing changes to the `#valid?` and `#normalize` methods of the `OptEnum` class to make it case-insensitive. This should make it slightly easier for users to set opinions by not having to remember the exact casing of opinion values. As a good example, the `ldap_query` module has an OUTPUT_FORMAT with options of csv and json. Since those words are acronyms and common file extensions, either csv or CSV would make sense in the context. Now users don't need to remember that exact detail. The casing of the option is normalized to what the module author specified though, so the value can still be matched exactly in the module code.

## Testing

- [x] Use the `ldap_query` module
- [x] Set the OUTPUT_FORMAT option to `CSV` and see it get normalized to `csv`
- [x] See the module still works, showing the normalized value was used

## Demo

Old:
```
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_query) > set OUTPUT_FORMAT CSV
[-] The following options failed to validate: Value 'CSV' is not valid for option 'OUTPUT_FORMAT'.
OUTPUT_FORMAT => table
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_query) >
```

New:
```
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_query) > set OUTPUT_FORMAT CSV
OUTPUT_FORMAT => csv
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_query) >
```