### PR TITLE
Load Readline without a conditional

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -62,7 +62,7 @@ class Driver < Msf::Ui::Driver
   # @option opts [Boolean] 'SkipDatabaseInit' (false) Whether to skip
   #   connecting to the database and running migrations
   def initialize(prompt = DefaultPrompt, prompt_char = DefaultPromptChar, opts = {})
-    setup_readline if opts['Readline']
+    setup_readline
 
     histfile = opts['HistFile'] || Msf::Config.history_file
 


### PR DESCRIPTION
This PR fixes an issue I've introduced with the `--no-readline` option.

This PR allows for loading of Readline, but other code dictates if it is used or not.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole --no-readline`
- [ ] Ensure the console is usable, but tab completion is disabled and arrow keys are entered as escape codes.
- [ ] `exit`
- [ ] Start `msfconsole` or `msfconsole --readline`
- [ ] Verify tab completion is enabled and you can move left and right using the arrow keys.