### PR TITLE
Remove connection pool patch

### DIFF
--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -111,16 +111,6 @@ class ThreadManager < Array
               error: e
           )
           raise e
-        ensure
-          if framework.db && framework.db.active && framework.db.is_local?
-            # NOTE: despite the Deprecation Warning's advice, this should *NOT*
-            # be ApplicationRecord.connection.close which causes unrelated
-            # threads to raise ActiveRecord::StatementInvalid exceptions at
-            # some point in the future, presumably due to the pool manager
-            # believing that the connection is still usable and handing it out
-            # to another thread.
-            ::ApplicationRecord.connection_pool.release_connection
-          end
         end
       end
     else


### PR DESCRIPTION
Remove connection pool patch

These lines of code are causing issues with the Rails 7.1 upgrade, where the connection pool is closed during the test suite run.

A git blame indicates that this was a patch/workaround:

> Close any open connections if the thread happens to have one when it finishes.
Partial bandaid for new AR pool mgmt methods
> https://github.com/rapid7/metasploit-framework/commit/12102b9adc9921949658ff0a2a09617a032ade1e

## Verification

Ensure CI passes