### PR TITLE
Bump the ruby_smb and rex-socket gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,8 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.57)
+    rex-socket (0.1.58)
+      dnsruby
       rex-core
     rex-sslscan (0.1.10)
       rex-core


### PR DESCRIPTION
This bumps the ruby_smb and rex-socket gems to pull in fixes for two bugs.

## ~~RubySMB~~ Already merged

* https://github.com/rapid7/ruby_smb/pull/280

This pulls in a fix that adjusts two fields to be optional. This fixes the parsing error in `windows_secrets_dump` that was originally identified in #19665. The original steps to reproduce the bug can be used to confirm the fix.

> This fixes an issue in the windows_secrets_dump module, wherein it fails after certain password change APIs.
> 
> To reproduce this issue (and verify the fix):
>
> Force a password reset with impacket to force Kerberos keys to be removed:
changepasswd.py -reset -newpass Pass123123$ domain/user@192.168.1.1 -altuser administrator -altpass Password1!
> 
> Run the windows_secrets_dump module with appropriate credentials:

## Rex-Socket

* https://github.com/rapid7/rex-socket/pull/67

This fixed where `.rex_getaddrinfo` was handing IP addresses inconsistently when a custom DNS resolver was in use. To reproduce the original issue:

1. Enable the DNS feature in Metasploit
2. Obtain a Meterpreter session somehow
3. From msfconsole, run the route command using the following syntax to route all traffic through the new session: `route add 0 0 -1`. 
4. See that the command did not fail because `0` was converted to `0.0.0.0`