### PR TITLE
Multiple RHOSTS handling improvement

### DIFF
--- a/modules/auxiliary/scanner/mssql/mssql_version.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_version.rb
@@ -11,75 +11,114 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name' => 'MSSQL Version Utility',
-      'Description' => 'Executes a TDS7 pre-login request against the MSSQL instance to query for version information.',
+      'Description' => 'Executes a TDS7 pre-login request against the MSSQL instance to query for version information, with enhanced RHOSTS handling.',
       'Author' => 'Zach Goldman',
       'License' => MSF_LICENSE
     )
 
     register_options([
+      OptString.new('RHOSTS', [true, 'Target IP address(es) (CIDR, range, space/comma-separated)', nil]),
       Opt::RPORT(1433)
     ])
   end
 
-    def run_host(ip)
-    datastore['RHOSTS'] = ip  # Set the current target IP in the datastore
-    begin
-      if session
-        set_mssql_session(session.client)
-        data = mssql_client.initial_connection_info[:prelogin_data]
-      else
-        create_mssql_client  # No arguments needed here
-        data = mssql_prelogin
+  def run
+    # Parse RHOSTS to handle CIDR, ranges, spaces, and commas
+    targets = parse_rhosts(datastore['RHOSTS'])
+    if targets.empty?
+      print_error('No valid targets found in RHOSTS')
+      return
+    end
+
+    targets.each do |ip|
+      begin
+        print_status("Scanning #{ip}...")
+        run_host(ip)
+      rescue ::Rex::ConnectionError
+        print_error("Failed to connect to #{ip}:#{datastore['RPORT']}")
+      ensure
+        disconnect
       end
-  
-      if data.blank?
-        print_error("Unable to retrieve version information for #{ip}")
-        return
-      end
-  
-      print_status("SQL Server for #{ip}:")
-      if data[:version]
-        print_good("Version: #{data[:version]}")
-      else
-        print_error('Unknown Version')
-      end
-      if data[:encryption]
-        case data[:encryption]
-        when ENCRYPT_OFF
-          data[:encryption] = 'off'
-        when ENCRYPT_ON
-          data[:encryption] = 'on'
-        when ENCRYPT_NOT_SUP
-          data[:encryption] = 'unsupported'
-        when ENCRYPT_REQ
-          data[:encryption] = 'required'
-        else
-          data[:encryption] = 'unknown'
-        end
-        print_good("Encryption: #{data[:encryption]}")
-      else
-        print_error('Unknown encryption status')
-      end
-  
-      report_mssql_service(ip, data)
-    rescue ::Rex::ConnectionError
-      print_error("Failed to connect to #{ip}:#{datastore['RPORT']}")
-    ensure
-      disconnect
     end
   end
 
+  def run_host(ip)
+    datastore['RHOSTS'] = ip  # Set the current target in the datastore for each iteration
+
+    if session
+      set_mssql_session(session.client)
+      data = mssql_client.initial_connection_info[:prelogin_data]
+    else
+      create_mssql_client  # Uses the current datastore['RHOSTS'] and datastore['RPORT']
+      data = mssql_prelogin
+    end
+
+    if data.blank?
+      print_error("Unable to retrieve version information for #{ip}")
+      return
+    end
+
+    print_status("SQL Server for #{ip}:")
+    if data[:version]
+      print_good("Version: #{data[:version]}")
+    else
+      print_error('Unknown Version')
+    end
+    if data[:encryption]
+      case data[:encryption]
+      when ENCRYPT_OFF
+        data[:encryption] = 'off'
+      when ENCRYPT_ON
+        data[:encryption] = 'on'
+      when ENCRYPT_NOT_SUP
+        data[:encryption] = 'unsupported'
+      when ENCRYPT_REQ
+        data[:encryption] = 'required'
+      else
+        data[:encryption] = 'unknown'
+      end
+      print_good("Encryption: #{data[:encryption]}")
+    else
+      print_error('Unknown encryption status')
+    end
+
+    report_mssql_service(ip, data)
+  end
+
+  def parse_rhosts(input)
+    # Parse RHOSTS to handle CIDR, spaces, commas, and ranges
+    ips = []
+    input.to_s.split(/[\s,]+/).each do |entry|
+      begin
+        if entry.include?('/')
+          # Handle CIDR notation
+          Rex::Socket::RangeWalker.new(entry).each { |ip| ips << ip }
+        elsif entry.include?('-')
+          # Handle IP ranges (e.g., 192.168.1.1-192.168.1.10)
+          Rex::Socket::RangeWalker.new(entry).each { |ip| ips << ip }
+        else
+          # Handle single IPs
+          ips << entry
+        end
+      rescue ArgumentError
+        print_error("Invalid entry in RHOSTS: #{entry}")
+      end
+    end
+    ips.uniq
+  end
+  
+
   def report_mssql_service(ip, data)
-    mssql_info = 'Version: %<version>s, Encryption: %<encryption>s' % [
+    mssql_info = 'Version: %<version>s, Encryption: %<encryption>s' % {
       version: data[:version] || 'unknown',
       encryption: data[:encryption] || 'unknown'
-    ]
+    }
     report_service(
       host: ip,
-      port: mssql_client.peerport,
+      port: datastore['RPORT'],
       name: 'mssql',
       info: mssql_info,
-      state: (data['Status'].nil? ? 'closed' : data['Status'])
+      state: data[:status] || 'closed'
     )
   end
 end


### PR DESCRIPTION
## What This Change Does

This PR enhances the `auxiliary/scanner/mssql/mssql_version` module by adding improved support for the `RHOSTS` parameter. It now supports CIDR notation (e.g., `192.168.1.0/24`), IP ranges (e.g., `192.168.1.1-192.168.1.10`), space-separated IPs, and comma-separated IPs. This change retains all original functionality while expanding the usability of the module for scenarios involving multiple target definitions.

### Key Changes:
1. **CIDR Support**: Expands CIDR notation into individual IPs for scanning.
2. **Range Support**: Handles IP ranges (e.g., `192.168.1.1-192.168.1.10`) correctly.
3. **Space/Comma Handling**: Supports space-separated and comma-separated lists of IPs.
4. **Improved Parsing Logic**: Refactored `RHOSTS` parsing to ensure consistent handling of various input formats without breaking existing functionality.
5. **Error Handling**: Adds logging for invalid `RHOSTS` entries while continuing to process valid ones.

I looked but didn't see any specific issues for this module and this functionality. I noticed this bug and fixed it.
---

## Verification
To verify the functionality of this update:

1. Start `msfconsole`:
   ```bash
   msfconsole
   ```

2. Use the module:
   ```bash
   use auxiliary/scanner/mssql/mssql_version
   ```

3. Set the `RHOSTS` parameter with various input formats:
   - CIDR:
     ```bash
     set RHOSTS 192.168.1.0/24
     ```
   - IP Range:
     ```bash
     set RHOSTS 192.168.1.1-192.168.1.10
     ```
   - Space-separated:
     ```bash
     set RHOSTS 192.168.1.1 192.168.1.2
     ```
   - Comma-separated:
     ```bash
     set RHOSTS 192.168.1.1,192.168.1.2
     ```

4. Run the module:
   ```bash
   run
   ```

5. **Verify** that:
   - The module correctly expands all IPs from CIDR and ranges.
   - The module handles space-separated and comma-separated IPs without errors.
   - Invalid `RHOSTS` entries are logged without interrupting valid target processing.

6. **Verify** that:
   - Version and encryption details are printed for each valid target.
   - The module reports appropriate errors for unreachable targets.

7. Document the functionality of the module:
   - Update the module documentation to describe the enhanced `RHOSTS` handling.
   - Include examples for all supported input formats.

---

## Notes
This change ensures backward compatibility with the original implementation while providing expanded support for modern use cases involving dynamic IP ranges and CIDR notation.

Let me know if further refinements are needed!


Fix for error below:
```
[-] Auxiliary failed: SocketError getaddrinfo: Name or service not known
[-] Call stack:
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:996:in `rex_resolve_hostname'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:942:in `rex_getaddrinfo'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:235:in `getaddresses'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:216:in `getaddress'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:325:in `resolv_nbo'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:342:in `resolv_nbo_i'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket/switch_board.rb:233:in `best_comm'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket/switch_board.rb:127:in `best_comm'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket/parameters.rb:359:in `comm'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket.rb:51:in `create_param'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket/tcp.rb:37:in `create_param'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/3.2.0/gems/rex-socket-0.1.57/lib/rex/socket/tcp.rb:28:in `create'
[-]   /opt/metasploit-framework/embedded/framework/lib/metasploit/framework/tcp/client.rb:83:in `connect'
[-]   /opt/metasploit-framework/embedded/framework/lib/rex/proto/mssql/client.rb:482:in `mssql_prelogin'
[-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/exploit/remote/mssql.rb:195:in `mssql_prelogin'
[-]   /opt/metasploit-framework/embedded/framework/modules/auxiliary/scanner/mssql/mssql_version.rb:30:in `run'
[*] Auxiliary module execution completed
```