### PR TITLE
Added LDAP query searching for likely Pre-Windows-2000 computers

### DIFF
--- a/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
+++ b/data/auxiliary/gather/ldap_query/ldap_queries_default.yaml
@@ -373,3 +373,17 @@ queries:
       - https://malicious.link/post/2022/ldapsearch-reference/
       - https://burmat.gitbook.io/security/hacking/domain-exploitation
       - https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
+  - action: ENUM_PRE_WINDOWS_2000_COMPUTERS
+    description: 'Dump info about all computer objects likely created as a "pre-Windows 2000 computer", for which the password might be predictable.'
+    filter: '(&(userAccountControl=4128))'
+    attributes:
+      - cn
+      - displayName
+      - description
+      - sAMAccountName
+      - userPrincipalName
+      - logonCount
+      - userAccountControl
+    references:
+      - https://www.thehacker.recipes/ad/movement/builtins/pre-windows-2000-computers
+      - https://trustedsec.com/blog/diving-into-pre-created-computer-accounts

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
@@ -75,7 +75,7 @@ This module has a selection of inbuilt queries which can be configured via the `
 - `ENUM_COMPUTERS` - Dump all objects containing an objectCategory or objectClass of Computer.
 - `ENUM_CONSTRAINED_DELEGATION` - Dump info about all known objects that allow constrained delegation.
 - `ENUM_DNS_RECORDS` - Dump info about DNS records the server knows about using the dnsNode object class.
-- `ENUM_DNS_ZONES` - Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This isneeded - as without this BASEDN prefix we often miss certain entries.
+- `ENUM_DNS_ZONES` - Dump info about DNS zones the server knows about using the dnsZone object class under the DC DomainDnsZones. This is needed - as without this BASEDN prefix we often miss certain entries.
 - `ENUM_DOMAIN` - Dump info about the Active Directory domain.
 - `ENUM_DOMAIN_CONTROLLERS` - Dump all known domain controllers.
 - `ENUM_EXCHANGE_RECIPIENTS` - Dump info about all known Exchange recipients.
@@ -96,6 +96,7 @@ This module has a selection of inbuilt queries which can be configured via the `
 - `ENUM_USER_PASSWORD_NEVER_EXPIRES` - Dump info about all users whose password never expires.
 - `ENUM_USER_PASSWORD_NOT_REQUIRED` - Dump info about all users whose password never expires and whose account is still enabled.
 - `ENUM_USER_SPNS_KERBEROAST` - Dump info about all user objects with Service Principal Names (SPNs) for kerberoasting.
+- `ENUM_PRE_WINDOWS_2000_COMPUTERS` - Dump info about all computer objects likely created as a "pre-Windows 2000 computer", for which the password might be predictable.
 
 ### Kerberos Authentication
 


### PR DESCRIPTION
This PR implements a search for computer accounts created with the "Assign this computer account as a pre-Windows 2000 computer" checkbox marked. These accounts are initially created with their own computer name (sans dollar-sign, all lowercase) as the password. We also return the logon count attribute; if it's zero, it's highly likely that the password hasn't been changed.

## Verification

- [x] In an AD domain, create a new computer, ticking the "Pre-Windows 2000" checkbox
- [x] Start `msfconsole`
- [x] `use ldap_query`
- [x] `set action ENUM_PRE_WINDOWS_2000_COMPUTERS`
- [x] `run`
- [x] Verify that this account is returned, with the `logonCount` attribute included.

## Demo

```
msf6 auxiliary(gather/ldap_query) > set action ENUM_PRE_WINDOWS_2000_COMPUTERS
action => ENUM_PRE_WINDOWS_2000_COMPUTERS
msf6 auxiliary(gather/ldap_query) > run rhost=4.237.57.48 username=admin password=Password123 domain=msf.local
[*] Running module against 4.237.57.48

[*] 4.237.57.48:389 Discovered base DN: DC=msf,DC=local
CN=pre2k,CN=Computers,DC=msf,DC=local
=====================================

 Name                Attributes
 ----                ----------
 cn                  pre2k
 logoncount          1
 samaccountname      PRE2K$
 useraccountcontrol  4128

[*] Query returned 1 result.
[*] Auxiliary module execution completed
```