### PR TITLE
Fix query param in reconfig_redirect_opts!

### DIFF
--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -499,7 +499,7 @@ module Exploit::Remote::HttpClient
     end
 
     # Don't forget any GET parameters
-    opts['query'] ||= location.query if location.query
+    opts['query'] = location.query if location.query
   end
 
   #

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -499,7 +499,11 @@ module Exploit::Remote::HttpClient
     end
 
     # Don't forget any GET parameters
-    opts['query'] = location.query if location.query
+    if location.query
+      opts['query'] = location.query
+    else
+      opts['query'] = ''
+    end
   end
 
   #


### PR DESCRIPTION
The `reconfig_redirect_opts!` method in `http_client.rb` seems to be incorrectly setting the `opts['query']` parameter when using `send_request_cgi!` to follow redirects. 

If your original request is: 
```
GET /oauth2/authorize?sessionDataKey=4458b43e-2893-4040-97c5-86ea755d3e02
```

and the response to that request has a location header of: 
```
Location: https://localhost:9443/publisher/services/auth/callback/login?code=e99ba285-3080-3e04-bf65-361f65ed19ae&session_state=014cce7455854c32ab50bc4c570e6f00f99c1bf267c930f0529fc646e5c69e22.l6peBE-xSHT2Un6O6fgi5Q
```

The URI of the next request should be the location header mentioned above however because `opts['query']` (the GET request parameter(s) from the original request) is already set, it doesn't get reset, so the next request ends up being:

```
GET /publisher/services/auth/callback/login?sessionDataKey=4458b43e-2893-4040-97c5-86ea755d3e02 
```
 Which seems to be an incorrect combination of the original requests's parameters with the location header's path.

I noticed this when I was attempting to rewrite the manual handling of redirection here:
https://github.com/rapid7/metasploit-framework/pull/19647/files#diff-0c05ed862598aef0fcdd978f22c5676c187ea3d7d41da4de51627170fed6f455R195-R211

Below are some HTTP trace logs from the failed attempt of trying to replace the manual redirection with `send_request_cgi!`. 
<details> 
<summary>HTTP trace of current incorrect behaviour</summary>

<p>

```
####################
# Request:
####################
POST /commonauth HTTP/1.1
Host: 127.0.0.1:9443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15
Cookie: CLIENT_ID=Cs3HoNXfgrrQxQFz1zCh48GplTwa; sessionNonceCookie-e6b37efb-7fe2-45f6-9490-d1adbff1dfc8=e719c76d-b805-464f-bb27-e1fb02c57f34
Connection: keep-alive
Content-Type: application/x-www-form-urlencoded
Content-Length: 105

usernameUserInput=admin&username=admin&password=admin&sessionDataKey=e6b37efb-7fe2-45f6-9490-d1adbff1dfc8
####################
# Response:
####################
HTTP/1.1 302
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Set-Cookie: pastr-e6b37efb-7fe2-45f6-9490-d1adbff1dfc8=5aa579e8-37e3-480f-b790-2535d1441270; Path=/; Secure; HttpOnly, pastr-e6b37efb-7fe2-45f6-9490-d1adbff1dfc8=5aa579e8-37e3-480f-b790-2535d1441270; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly, sessionNonceCookie-e6b37efb-7fe2-45f6-9490-d1adbff1dfc8=e719c76d-b805-464f-bb27-e1fb02c57f34; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly, commonAuthId=be1036f1-4a32-4820-b85d-8b2de905c20b; Path=/; Secure; HttpOnly
Location: https://127.0.0.1:9443/oauth2/authorize?sessionDataKey=4458b43e-2893-4040-97c5-86ea755d3e02
Content-Length: 0
Date: Fri, 06 Dec 2024 01:29:52 GMT
Keep-Alive: timeout=60
Connection: keep-alive
Server: WSO2 Carbon Server


####################
# Request:
####################
GET /oauth2/authorize?sessionDataKey=4458b43e-2893-4040-97c5-86ea755d3e02 HTTP/1.1
Host: 127.0.0.1:9443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15
Cookie: CLIENT_ID=Cs3HoNXfgrrQxQFz1zCh48GplTwa; commonAuthId=be1036f1-4a32-4820-b85d-8b2de905c20b
Connection: keep-alive


####################
# Response:
####################
HTTP/1.1 302
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Set-Cookie: opbs=d07376fb-babd-4020-bc8e-771c0ec31ae7; Path=/; Secure
Location: https://localhost:9443/publisher/services/auth/callback/login?code=e99ba285-3080-3e04-bf65-361f65ed19ae&session_state=014cce7455854c32ab50bc4c570e6f00f99c1bf267c930f0529fc646e5c69e22.l6peBE-xSHT2Un6O6fgi5Q
Date: Fri, 06 Dec 2024 01:29:52 GMT
Content-Length: 0
Keep-Alive: timeout=60
Connection: keep-alive
Server: WSO2 Carbon Server


####################
# Request:
####################
GET /publisher/services/auth/callback/login?sessionDataKey=4458b43e-2893-4040-97c5-86ea755d3e02 HTTP/1.1
Host: localhost:9443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15
Cookie: CLIENT_ID=Cs3HoNXfgrrQxQFz1zCh48GplTwa; commonAuthId=be1036f1-4a32-4820-b85d-8b2de905c20b; opbs=d07376fb-babd-4020-bc8e-771c0ec31ae7
Connection: keep-alive


####################
# Response:
####################
HTTP/1.1 200
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-store, no-cache, must-revalidate, private
Content-Type: text/html
Content-Length: 0
Date: Fri, 06 Dec 2024 01:29:52 GMT
Keep-Alive: timeout=60
Connection: keep-alive
Server: WSO2 Carbon Server
```

</p>

</details>

After implementing this change the module works correctly when using `send_request_cgi!` instead of manually handing the redirection.