### PR TITLE
Add CVE to ProjectSend module

### DIFF
--- a/modules/exploits/linux/http/projectsend_unauth_rce.rb
+++ b/modules/exploits/linux/http/projectsend_unauth_rce.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['URL', 'https://github.com/projectsend/projectsend/commit/193367d937b1a59ed5b68dd4e60bd53317473744'],
           ['URL', 'https://www.synacktiv.com/sites/default/files/2024-07/synacktiv-projectsend-multiple-vulnerabilities.pdf'],
+          ['CVE', '2024-11680']
         ],
         'DisclosureDate' => '2024-07-19',
         'DefaultTarget' => 0,


### PR DESCRIPTION
This PR adds the CVE entry for the recently merged ProjectSend vulnerability exploit module.