### PR TITLE
Set readline output to non-prompting on method exit

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -100,6 +100,7 @@ begin
         ::Readline::HISTORY.pop if (line and line.empty?)
       ensure
         Thread.current.priority = orig || 0
+        output.prompting(false)
       end
 
       line


### PR DESCRIPTION
This PR sets the output to be non-prompting after the `pgets` method exits. This follows other examples in the codebase and seems like a sane thing to do.

## Verification

- [x] Start `msfconsole`
- [x] Get a session
- [x] Ensure calling `sessions -i -1` works as expected
- [x] Ensure you can background the session
- [x] Ensure user input to the console in the session and Console contexts works as expected
- [x] Ensure CI passes