### PR TITLE
Use existing input object when calling init_tab_complete

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -107,7 +107,7 @@ class Driver < Msf::Ui::Driver
     # Initialize the user interface to use a different input and output
     # handle if one is supplied
     input = opts['LocalInput']
-    input ||= Rex::Ui::Text::Input::Stdio.new
+    input ||= Rex::Ui::Text::Input::Readline.new
 
     if !opts['Readline']
       input.disable_readline

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -66,8 +66,7 @@ module Shell
   def init_tab_complete
     if (self.input and self.input.supports_readline)
       # Unless cont_flag because there's no tab complete for continuation lines
-      self.input = Input::Readline.new(lambda { |str| tab_complete(str) unless cont_flag })
-      self.input.output = self.output
+      self.input.reset_tab_completion(lambda { |str| tab_complete(str) unless cont_flag })
     end
   end
 


### PR DESCRIPTION
This PR changes the input class used by the Driver to be Rex Readline instead of Rex Stdio.
It also changes the `init_tab_complete` method to no longer overwrite the currently existing `self.input` object but to instead reset its tab completion.

The original code originated around 2005, with no reason given as to why `init_tab_complete` would need to overwrite the `Stdio` object with `Readline.new(lambda ...)`. This also fixes the scenario of the `self.input` object being overwritten if passed in as an option to the Driver constructor and then calling the `init_tab_complete` method.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Ensure you can use the console as expected
- [x] Ensure tab completion works as expected
- [x] CI passes
