### PR TITLE
Add CVE info to projectsend module

### DIFF
--- a/modules/exploits/linux/http/projectsend_unauth_rce.rb
+++ b/modules/exploits/linux/http/projectsend_unauth_rce.rb
@@ -24,6 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'ostrichgolf' # Metasploit module
         ],
         'References' => [
+          ['CVE', '2024-11680'],
           ['URL', 'https://github.com/projectsend/projectsend/commit/193367d937b1a59ed5b68dd4e60bd53317473744'],
           ['URL', 'https://www.synacktiv.com/sites/default/files/2024-07/synacktiv-projectsend-multiple-vulnerabilities.pdf'],
         ],


### PR DESCRIPTION
This is super easy and adds the CVE info for the Projectsend exploit PR.  I started to work on the same CVE (https://github.com/rapid7/metasploit-framework/pull/19699) because a quick search showed CVE-2024-11680 was not in Framework.  This just adds the CVE info so it is easy to locate in the future.