### PR TITLE
Revert "Use existing input object when calling init_tab_complete"

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -107,7 +107,7 @@ class Driver < Msf::Ui::Driver
     # Initialize the user interface to use a different input and output
     # handle if one is supplied
     input = opts['LocalInput']
-    input ||= Rex::Ui::Text::Input::Readline.new
+    input ||= Rex::Ui::Text::Input::Stdio.new
 
     if !opts['Readline']
       input.disable_readline

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -66,7 +66,8 @@ module Shell
   def init_tab_complete
     if (self.input and self.input.supports_readline)
       # Unless cont_flag because there's no tab complete for continuation lines
-      self.input.reset_tab_completion(lambda { |str| tab_complete(str) unless cont_flag })
+      self.input = Input::Readline.new(lambda { |str| tab_complete(str) unless cont_flag })
+      self.input.output = self.output
     end
   end
 


### PR DESCRIPTION
Reverts rapid7/metasploit-framework#19711

The acceptance tests failed on this line:
```
[write] loadpath test/modules
```
Which then times out.
Using the Rex Readline input object did not work in this case as expected.
The failing acceptance tests only showed something is wrong after landing the PR. The actions on the original PR were all green.
Reverting.