### PR TITLE
Keep track of RPC token per-thread

### DIFF
--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -140,11 +140,16 @@ class Service
         end
       end
 
-      ::Timeout.timeout(self.dispatcher_timeout) { self.handlers[group].send(mname, *msg) }
+      ::Timeout.timeout(self.dispatcher_timeout) do
+        Thread.current[:rpc_token] = token
+        self.handlers[group].send(mname, *msg)
+      end
 
     rescue ::Exception => e
       elog('RPC Exception', error: e)
       process_exception(e)
+    ensure
+      Thread.current[:rpc_token] = nil
     end
   end
 


### PR DESCRIPTION
This PR keeps track of the current RPC token so that it can be referenced in Pro.

## Verification

- [x] Ensure RPC handlers have access to the current RPC token