### PR TITLE
Update docs dependencies

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -6,6 +6,7 @@ gem 'just-the-docs', github: 'rapid7/just-the-docs', branch: 'r7_ver_custom'
 #gem 'just-the-docs', path: '../../just-the-docs'
 gem 'webrick'
 gem 'rexml'
+gem 'jekyll-sass-converter', '~> 2.2.0'
 
 group :jekyll_plugins do
   gem 'jekyll-sitemap'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -12,22 +12,22 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     byebug (11.1.3)
     coderay (1.1.3)
     colorator (1.1.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.4)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
+    ffi (1.17.0)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
-    i18n (1.12.0)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.1)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -53,46 +53,45 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
-    listen (3.7.1)
+    liquid (4.0.4)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    method_source (1.0.0)
+    method_source (1.1.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pry (0.14.1)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (5.0.1)
-    rake (13.0.6)
+    public_suffix (6.0.1)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.6)
-      strscan
-    rouge (4.0.0)
+    rexml (3.3.9)
+    rouge (4.5.1)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.3.0)
-    webrick (1.7.0)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jekyll (~> 4.3.0)
+  jekyll-sass-converter (~> 2.2.0)
   jekyll-sitemap
   just-the-docs!
   pry-byebug
@@ -103,4 +102,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.22
+   2.5.10


### PR DESCRIPTION
Update docs dependencies

## Verification

- Ensure CI passes
- Ensure the docs site works locally: https://github.com/rapid7/metasploit-framework/blob/2355ab546d02bfee99183083b12c6953836c12a1/docs/README.md#developer-build