### PR TITLE
Fix overlap of shell built-in commands with host's

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -621,8 +621,13 @@ Shell Banner:
     end
 
     # Built-in command
-    if commands.key?(method)
-      return run_builtin_cmd(method, arguments)
+    if commands.key?(method) or ( not method.nil? and method[0] == '.' and commands.key?(method[1..-1]))
+      # Handle overlapping built-ins with actual shell commands by prepending '.'
+      if method[0] == '.' and commands.key?(method[1..-1])
+        return shell_write(cmd[1..-1] + command_termination)
+      else
+        return run_builtin_cmd(method, arguments)
+      end
     end
 
     # User input is not a built-in command, write to socket directly

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -202,6 +202,8 @@ Shell Banner:
       tbl << [key, value]
     end
 
+    tbl << ['.<command>', "Prefix any built-in command on this list with a '.' to execute in the underlying shell (ex: .help)"]
+
     print(tbl.to_s)
   end
 


### PR DESCRIPTION
When a shell session is established against a system which offers limited shells, its very common to run into something like "help" being a native command in the target. MSF now intercepts those as built-ins and presents the MSF shell help instead of letting the user see the relevant output from the target.

Implement a fix by allowing the user to prepend built-ins with '.' to pass-through execution of the intended command (such as '.help' being executed as 'help') to the target.

Testing:
  Local testing with racadm SSH shell - works as intended
