### PR TITLE
Recognise broken SMB sessions and close them

### DIFF
--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -22,42 +22,45 @@ class SimpleClient
   attr_accessor :last_error, :server_max_buffer_size
 
   # Private accessors
-  attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
+  attr_accessor :socket, :client, :direct, :shares, :last_share, :versions, :msf_session
 
   attr_reader :address, :port
 
   # Pass the socket object and a boolean indicating whether the socket is netbios or cifs
-  def initialize(socket, direct = false, versions = DEFAULT_VERSIONS, always_encrypt: true, backend: nil, client: nil)
-    self.socket = socket
-    self.direct = direct
-    self.versions = versions
-    self.shares = {}
-    self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
+  def initialize(socket, direct = false, versions = DEFAULT_VERSIONS, always_encrypt: true, backend: nil, client: nil, msf_session: nil)
+    self.msf_session = msf_session
+    session_lifetime do
+      self.socket = socket
+      self.direct = direct
+      self.versions = versions
+      self.shares = {}
+      self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
 
-    if !client.nil?
-      self.client = client
-    elsif (self.versions == [1] && backend.nil?) || backend == :rex
-      self.client = Rex::Proto::SMB::Client.new(socket)
-    elsif (backend.nil? || backend == :ruby_smb)
-      self.client = RubySMB::Client.new(RubySMB::Dispatcher::Socket.new(self.socket, read_timeout: 60),
-                                        username: '',
-                                        password: '',
-                                        smb1: self.versions.include?(1),
-                                        smb2: self.versions.include?(2),
-                                        smb3: self.versions.include?(3),
-                                        always_encrypt: always_encrypt
-                    )
+      if !client.nil?
+        self.client = client
+      elsif (self.versions == [1] && backend.nil?) || backend == :rex
+        self.client = Rex::Proto::SMB::Client.new(socket)
+      elsif (backend.nil? || backend == :ruby_smb)
+        self.client = RubySMB::Client.new(RubySMB::Dispatcher::Socket.new(self.socket, read_timeout: 60),
+                                          username: '',
+                                          password: '',
+                                          smb1: self.versions.include?(1),
+                                          smb2: self.versions.include?(2),
+                                          smb3: self.versions.include?(3),
+                                          always_encrypt: always_encrypt
+                      )
 
-      self.client.evasion_opts = {
-        # Padding is performed between packet headers and data
-        'pad_data' => EVADE::EVASION_NONE,
-        # File path padding is performed on all open/create calls
-        'pad_file' => EVADE::EVASION_NONE,
-        # Modify the \PIPE\ string in trans_named_pipe calls
-        'obscure_trans_pipe' => EVADE::EVASION_NONE,
-      }
+        self.client.evasion_opts = {
+          # Padding is performed between packet headers and data
+          'pad_data' => EVADE::EVASION_NONE,
+          # File path padding is performed on all open/create calls
+          'pad_file' => EVADE::EVASION_NONE,
+          # Modify the \PIPE\ string in trans_named_pipe calls
+          'obscure_trans_pipe' => EVADE::EVASION_NONE,
+        }
+      end
+      @address, @port = self.socket.peerinfo.split(':')
     end
-    @address, @port = self.socket.peerinfo.split(':')
   end
 
   def login(name = '', user = '', pass = '', domain = '',
@@ -65,194 +68,212 @@ class SimpleClient
       send_lm = true, use_lanman_key = false, send_ntlm = true,
       native_os = 'Windows 2000 2195', native_lm = 'Windows 2000 5.0', spnopt = {})
 
-    begin
-
-      if (self.direct != true)
-        self.client.session_request(name)
+    session_lifetime do
+      begin
+  
+        if (self.direct != true)
+          self.client.session_request(name)
+        end
+        self.client.native_os = native_os
+        self.client.native_lm = native_lm
+        self.client.verify_signature = verify_signature
+        self.client.use_ntlmv2 = usentlmv2
+        self.client.usentlm2_session = usentlm2_session
+        self.client.send_lm = send_lm
+        self.client.use_lanman_key =  use_lanman_key
+        self.client.send_ntlm = send_ntlm
+  
+        dlog("SMB version(s) to negotiate: #{self.versions}")
+        ok = self.client.negotiate
+        dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
+  
+        if self.client.is_a?(RubySMB::Client)
+          self.server_max_buffer_size = self.client.server_max_buffer_size
+        else
+          self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
+        end
+  
+        # Disable NTLMv2 Session for Windows 2000 (breaks authentication on some systems)
+        # XXX: This in turn breaks SMB auth for Windows 2000 configured to enforce NTLMv2
+        # XXX: Tracked by ticket #4785#4785
+        if self.client.native_lm =~ /Windows 2000 5\.0/ and usentlm2_session
+        #	self.client.usentlm2_session = false
+        end
+  
+        self.client.spnopt = spnopt
+  
+        # In case the user unsets the username or password option, we make sure this is
+        # always a string
+        user ||= ''
+        pass ||= ''
+  
+        res = self.client.session_setup(user, pass, domain)
+      rescue ::Interrupt
+        raise $!
+      rescue ::Exception => e
+        elog(e)
+        n = XCEPT::LoginError.new
+        n.source = e
+        if e.respond_to?('error_code') && e.respond_to?('get_error')
+          n.error_code   = e.error_code
+          n.error_reason = e.get_error(e.error_code)
+        end
+        raise n
       end
-      self.client.native_os = native_os
-      self.client.native_lm = native_lm
-      self.client.verify_signature = verify_signature
-      self.client.use_ntlmv2 = usentlmv2
-      self.client.usentlm2_session = usentlm2_session
-      self.client.send_lm = send_lm
-      self.client.use_lanman_key =  use_lanman_key
-      self.client.send_ntlm = send_ntlm
-
-      dlog("SMB version(s) to negotiate: #{self.versions}")
-      ok = self.client.negotiate
-      dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
-
-      if self.client.is_a?(RubySMB::Client)
-        self.server_max_buffer_size = self.client.server_max_buffer_size
-      else
-        self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
+  
+      # RubySMB does not raise any exception if the Session Setup fails
+      if self.client.is_a?(RubySMB::Client) && res != WindowsError::NTStatus::STATUS_SUCCESS
+        n = XCEPT::LoginError.new
+        n.source       = res
+        n.error_code   = res.value
+        n.error_reason = res.name
+        raise n
       end
-
-      # Disable NTLMv2 Session for Windows 2000 (breaks authentication on some systems)
-      # XXX: This in turn breaks SMB auth for Windows 2000 configured to enforce NTLMv2
-      # XXX: Tracked by ticket #4785#4785
-      if self.client.native_lm =~ /Windows 2000 5\.0/ and usentlm2_session
-      #	self.client.usentlm2_session = false
-      end
-
-      self.client.spnopt = spnopt
-
-      # In case the user unsets the username or password option, we make sure this is
-      # always a string
-      user ||= ''
-      pass ||= ''
-
-      res = self.client.session_setup(user, pass, domain)
-    rescue ::Interrupt
-      raise $!
-    rescue ::Exception => e
-      elog(e)
-      n = XCEPT::LoginError.new
-      n.source = e
-      if e.respond_to?('error_code') && e.respond_to?('get_error')
-        n.error_code   = e.error_code
-        n.error_reason = e.get_error(e.error_code)
-      end
-      raise n
+  
+      return true
     end
-
-    # RubySMB does not raise any exception if the Session Setup fails
-    if self.client.is_a?(RubySMB::Client) && res != WindowsError::NTStatus::STATUS_SUCCESS
-      n = XCEPT::LoginError.new
-      n.source       = res
-      n.error_code   = res.value
-      n.error_reason = res.name
-      raise n
-    end
-
-    return true
   end
 
 
   def login_split_start_ntlm1(name = '')
 
-    begin
+    session_lifetime do
+      begin
 
-      if (self.direct != true)
-        self.client.session_request(name)
+        if (self.direct != true)
+          self.client.session_request(name)
+        end
+
+        # Disable extended security
+        self.client.negotiate(false)
+      rescue ::Interrupt
+        raise $!
+      rescue ::Exception => e
+        n = XCEPT::LoginError.new
+        n.source = e
+        if(e.respond_to?('error_code'))
+          n.error_code   = e.error_code
+          n.error_reason = e.get_error(e.error_code)
+        end
+        raise n
       end
 
-      # Disable extended security
-      self.client.negotiate(false)
-    rescue ::Interrupt
-      raise $!
-    rescue ::Exception => e
-      n = XCEPT::LoginError.new
-      n.source = e
-      if(e.respond_to?('error_code'))
-        n.error_code   = e.error_code
-        n.error_reason = e.get_error(e.error_code)
-      end
-      raise n
+      return true
     end
-
-    return true
   end
 
 
   def login_split_next_ntlm1(user, domain, hash_lm, hash_nt)
-    begin
-      ok = self.client.session_setup_no_ntlmssp_prehash(user, domain, hash_lm, hash_nt)
-    rescue ::Interrupt
-      raise $!
-    rescue ::Exception => e
-      n = XCEPT::LoginError.new
-      n.source = e
-      if(e.respond_to?('error_code'))
-        n.error_code   = e.error_code
-        n.error_reason = e.get_error(e.error_code)
+    session_lifetime do
+      begin
+        ok = self.client.session_setup_no_ntlmssp_prehash(user, domain, hash_lm, hash_nt)
+      rescue ::Interrupt
+        raise $!
+      rescue ::Exception => e
+        n = XCEPT::LoginError.new
+        n.source = e
+        if(e.respond_to?('error_code'))
+          n.error_code   = e.error_code
+          n.error_reason = e.get_error(e.error_code)
+        end
+        raise n
       end
-      raise n
-    end
 
-    return true
+      return true
+    end
   end
 
   def connect(share)
-    ok = self.client.tree_connect(share)
+    session_lifetime do
+      ok = self.client.tree_connect(share)
 
-    if self.client.is_a?(RubySMB::Client)
-      tree_id = ok.id
-    else
-      tree_id = ok['Payload']['SMB'].v['TreeID']
+      if self.client.is_a?(RubySMB::Client)
+        tree_id = ok.id
+      else
+        tree_id = ok['Payload']['SMB'].v['TreeID']
+      end
+
+      self.shares[share] = tree_id
+      self.last_share = share
     end
-
-    self.shares[share] = tree_id
-    self.last_share = share
   end
 
   def disconnect(share)
-    if self.shares[share]
-      ok = self.client.tree_disconnect(self.shares[share])
-      self.shares.delete(share)
-      return ok
+    session_lifetime do
+      if self.shares[share]
+        ok = self.client.tree_disconnect(self.shares[share])
+        self.shares.delete(share)
+        return ok
+      end
+      false
     end
-    false
   end
 
   def open(path, perm, chunk_size = 48000, read: true, write: false)
-    if self.client.is_a?(RubySMB::Client)
-      mode = 0
-      if perm.include?('c')
-        if perm.include?('o')
-          mode = RubySMB::Dispositions::FILE_OPEN_IF
-        elsif perm.include?('t')
-          mode = RubySMB::Dispositions::FILE_OVERWRITE_IF
+    session_lifetime do
+      if self.client.is_a?(RubySMB::Client)
+        mode = 0
+        if perm.include?('c')
+          if perm.include?('o')
+            mode = RubySMB::Dispositions::FILE_OPEN_IF
+          elsif perm.include?('t')
+            mode = RubySMB::Dispositions::FILE_OVERWRITE_IF
+          else
+            mode = RubySMB::Dispositions::FILE_CREATE
+          end
         else
-          mode = RubySMB::Dispositions::FILE_CREATE
+          if perm.include?('o')
+            mode = RubySMB::Dispositions::FILE_OPEN
+          elsif perm.include?('t')
+            mode = RubySMB::Dispositions::FILE_OVERWRITE
+          end
         end
+
+        file_id = self.client.open(path, mode, read: true, write: write || perm.include?('w'))
+
       else
-        if perm.include?('o')
-          mode = RubySMB::Dispositions::FILE_OPEN
-        elsif perm.include?('t')
-          mode = RubySMB::Dispositions::FILE_OVERWRITE
-        end
+        mode = UTILS.open_mode_to_mode(perm)
+        access = UTILS.open_mode_to_access(perm)
+
+        ok = self.client.open(path, mode, access)
+        file_id = ok['Payload'].v['FileID']
       end
 
-      file_id = self.client.open(path, mode, read: true, write: write || perm.include?('w'))
-
-    else
-      mode = UTILS.open_mode_to_mode(perm)
-      access = UTILS.open_mode_to_access(perm)
-
-      ok = self.client.open(path, mode, access)
-      file_id = ok['Payload'].v['FileID']
+      fh = OpenFile.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
+      fh.chunk_size = chunk_size
+      fh
     end
-
-    fh = OpenFile.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
-    fh.chunk_size = chunk_size
-    fh
   end
 
   def delete(*args)
-    if self.client.is_a?(RubySMB::Client)
-      self.client.delete(args[0])
-    else
-      self.client.delete(*args)
+    session_lifetime do
+      if self.client.is_a?(RubySMB::Client)
+        self.client.delete(args[0])
+      else
+        self.client.delete(*args)
+      end
     end
   end
 
   def create_pipe(path, perm = 'o')
-    disposition = UTILS.create_mode_to_disposition(perm)
-    ok = self.client.create_pipe(path, disposition)
+    session_lifetime do
+      disposition = UTILS.create_mode_to_disposition(perm)
+      ok = self.client.create_pipe(path, disposition)
 
-    if self.client.is_a?(RubySMB::Client)
-      file_id = ok
-    else
-      file_id = ok['Payload'].v['FileID']
+      if self.client.is_a?(RubySMB::Client)
+        file_id = ok
+      else
+        file_id = ok['Payload'].v['FileID']
+      end
+
+      fh = OpenPipe.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
     end
-
-    fh = OpenPipe.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
   end
 
   def trans_pipe(fid, data, no_response = nil)
-    client.trans_named_pipe(fid, data, no_response)
+    session_lifetime do
+      client.trans_named_pipe(fid, data, no_response)
+  end
   end
 
   def negotiated_smb_version
@@ -273,6 +294,15 @@ class SimpleClient
   private
 
   attr_writer :address, :port
+
+  def session_lifetime
+    yield
+  rescue RubySMB::Error::CommunicationError, ::Rex::ConnectionError, Errno::ENOTCONN, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+    if msf_session
+      msf_session.kill
+    end
+    raise
+  end
 end
 end
 end

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -75,8 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     opts = {}
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       opts[:tree] = simple.client.tree_connect("\\\\#{client.dispatcher.tcp_socket.peerhost}\\IPC$")
     end
 

--- a/modules/auxiliary/admin/dcerpc/samr_account.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_account.rb
@@ -109,9 +109,8 @@ class MetasploitModule < Msf::Auxiliary
     opts = {}
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
-      opts[:tree] = simple.client.tree_connect("\\\\#{client.dispatcher.tcp_socket.peerhost}\\IPC$")
+      self.simple = session.simple_client
+      opts[:tree] = simple.client.tree_connect("\\\\#{session.client.dispatcher.tcp_socket.peerhost}\\IPC$")
     end
 
     yield opts

--- a/modules/auxiliary/admin/registry_security_descriptor.rb
+++ b/modules/auxiliary/admin/registry_security_descriptor.rb
@@ -71,8 +71,7 @@ class MetasploitModule < Msf::Auxiliary
   def do_connect
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       simple.connect("\\\\#{simple.address}\\IPC$")
     else
       connect

--- a/modules/auxiliary/admin/smb/change_password.rb
+++ b/modules/auxiliary/admin/smb/change_password.rb
@@ -93,8 +93,7 @@ class MetasploitModule < Msf::Auxiliary
   def authenticate(anonymous_on_expired: false)
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
     else
       connect

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -42,8 +42,7 @@ class MetasploitModule < Msf::Auxiliary
   def smb_delete_files
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
     else
       vprint_status("Connecting to the server...")
       connect()

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -38,8 +38,7 @@ class MetasploitModule < Msf::Auxiliary
     if session
 
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
     else
       connect
       smb_login()

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -57,8 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     # Try and connect
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       @ip = simple.address
     else
       return unless connect

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -44,9 +44,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       if session
         print_status("Using existing session #{session.sid}")
-        client = session.client
-        self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
-
+        self.simple = session.simple_client
       else
         vprint_status("Connecting to the server...")
         connect

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -1113,8 +1113,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
     else
       connect

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -40,9 +40,8 @@ class MetasploitModule < Msf::Auxiliary
 
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
       @rport = datastore['RPORT'] = session.port
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       self.simple.connect("\\\\#{session.address}\\IPC$")
       report_pipes(ip, check_pipes)
     else

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -260,9 +260,8 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
       @rport = datastore['RPORT'] = session.port
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      self.simple = session.simple_client
       simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
       check_uuids(ip)
     else

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -167,8 +167,8 @@ class MetasploitModule < Msf::Auxiliary
     begin
       if session
         print_status("Using existing session #{session.sid}")
-        client = session.client
-        self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+        self.simple = session.simple_client
+        session.verify_connectivity
       else
         connect
         smb_login

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -289,8 +289,8 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      session.verify_connectivity
+      self.simple = session.simple_client
       enum_shares(session.address)
     else
       [{ port: SMB1_PORT }, { port: SMB2_3_PORT } ].each do |info|

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -198,9 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_simple_smb_client!
     if session
       print_status("Using existing session #{session.sid}")
-      client = session.client
-      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
-
+      self.simple = session.simple_client
     else
       print_status('Connecting to the server...')
       connect


### PR DESCRIPTION
If an SMB session is forcibly closed or inoperative, the session remained in the list of open sessions (until forcibly closed). This recognises certain errors and shuts the SMB sessions down.

## Verification

- [ ] Start `msfconsole`
- [ ] Create several sessions with the `smb_login` module onto the one host
- [ ] Shut down the server (this won't cause the sessions to terminate yet)
- [ ] Run a module with an SMB session (any of the ones that use SMB optional sessions)
- [ ] Verify that it is terminated, and removed from the list of active sessions

## Demo

```
msf6 auxiliary(scanner/smb/pipe_auditor) > run session=3
[*] Using existing session 3
[*] 192.168.20.99 - SMB session 3 closed.
[*] Error: 192.168.20.99: RubySMB::Error::CommunicationError An error occurred writing to the Socket: Connection reset by peer
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```