### PR TITLE
Update the CachedSize for `reverse_http` and `reverse_http` payloads

### DIFF
--- a/modules/payloads/stagers/windows/x64/reverse_http.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 528
+  CachedSize = 610
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 562
+  CachedSize = 644
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows


### PR DESCRIPTION
This was required after the changes in https://github.com/rapid7/metasploit-framework/pull/19726
