### PR TITLE
Report CA, ADCS Template and Password along with Pkcs12 in the database

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -132,6 +132,7 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Setup Ruby
+        run: git config --system core.longpaths true
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -196,6 +196,7 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Setup Ruby
+        run: git config --system core.longpaths true
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
           # Required for macos13 pg gem compilation

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
-gem 'metasploit-credential', git: 'git@github.com:cdelafuente-r7/metasploit-credential.git', branch: 'enh/MS-9710/add_pkcs12_metadata'
+gem 'metasploit-credential', git: 'https://github.com/cdelafuente-r7/metasploit-credential', branch: 'enh/MS-9710/add_pkcs12_metadata'
 
 # separate from test as simplecov is not run on travis-ci
 group :coverage do

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
-gem 'metasploit-credential', git: 'https://github.com/cdelafuente-r7/metasploit-credential', branch: 'enh/MS-9710/add_pkcs12_metadata'
-gem 'metasploit_data_models',  git: 'https://github.com/cdelafuente-r7/metasploit_data_models', branch: 'enh/visitor/jsonb'
-
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
+gem 'metasploit-credential', git: 'git@github.com:cdelafuente-r7/metasploit-credential.git', branch: 'enh/MS-9710/add_pkcs12_metadata'
+
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec name: 'metasploit-framework'
 
 gem 'metasploit-credential', git: 'https://github.com/cdelafuente-r7/metasploit-credential', branch: 'enh/MS-9710/add_pkcs12_metadata'
-gem 'metasploit-model', git: 'https://github.com/cdelafuente-r7/metasploit-model', branch: 'feat/model/search/operation/jsonb'
 gem 'metasploit_data_models',  git: 'https://github.com/cdelafuente-r7/metasploit_data_models', branch: 'enh/visitor/jsonb'
 
 # separate from test as simplecov is not run on travis-ci

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gemspec name: 'metasploit-framework'
 
 gem 'metasploit-credential', git: 'https://github.com/cdelafuente-r7/metasploit-credential', branch: 'enh/MS-9710/add_pkcs12_metadata'
+gem 'metasploit-model', git: 'https://github.com/cdelafuente-r7/metasploit-model', branch: 'feat/model/search/operation/jsonb'
+gem 'metasploit_data_models',  git: 'https://github.com/cdelafuente-r7/metasploit_data_models', branch: 'enh/visitor/jsonb'
 
 # separate from test as simplecov is not run on travis-ci
 group :coverage do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,16 +15,6 @@ GIT
       rubyzip
 
 GIT
-  remote: https://github.com/cdelafuente-r7/metasploit-model
-  revision: 925a11f61f02123f29e32bb196b374390d36beb6
-  branch: feat/model/search/operation/jsonb
-  specs:
-    metasploit-model (5.0.3)
-      activemodel (~> 7.0)
-      activesupport (~> 7.0)
-      railties (~> 7.0)
-
-GIT
   remote: https://github.com/cdelafuente-r7/metasploit_data_models
   revision: 34fc27d3059c919eac98cf2a8061c31146189a26
   branch: enh/visitor/jsonb
@@ -335,6 +325,10 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
+    metasploit-model (5.0.3)
+      activemodel (~> 7.0)
+      activesupport (~> 7.0)
+      railties (~> 7.0)
     metasploit-payloads (2.0.189)
     metasploit_payloads-mettle (1.0.35)
     method_source (1.1.0)
@@ -608,7 +602,6 @@ DEPENDENCIES
   memory_profiler
   metasploit-credential!
   metasploit-framework!
-  metasploit-model!
   metasploit_data_models!
   octokit
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,19 @@
+GIT
+  remote: git@github.com:cdelafuente-r7/metasploit-credential.git
+  revision: acc5a012f4bc7e7774af059e778b947cd994da1e
+  branch: enh/MS-9710/add_pkcs12_metadata
+  specs:
+    metasploit-credential (6.0.12)
+      metasploit-concern
+      metasploit-model
+      metasploit_data_models (>= 5.0.0)
+      net-ssh
+      pg
+      railties
+      rex-socket
+      rubyntlm
+      rubyzip
+
 PATH
   remote: .
   specs:
@@ -293,16 +309,6 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.12)
-      metasploit-concern
-      metasploit-model
-      metasploit_data_models (>= 5.0.0)
-      net-ssh
-      pg
-      railties
-      rex-socket
-      rubyntlm
-      rubyzip
     metasploit-model (5.0.2)
       activemodel (~> 7.0)
       activesupport (~> 7.0)
@@ -588,6 +594,7 @@ DEPENDENCIES
   factory_bot_rails
   fivemat
   memory_profiler
+  metasploit-credential!
   metasploit-framework!
   octokit
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:cdelafuente-r7/metasploit-credential.git
+  remote: https://github.com/cdelafuente-r7/metasploit-credential
   revision: acc5a012f4bc7e7774af059e778b947cd994da1e
   branch: enh/MS-9710/add_pkcs12_metadata
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cdelafuente-r7/metasploit-credential
-  revision: acc5a012f4bc7e7774af059e778b947cd994da1e
+  revision: 6c8554df2feab43489ca86eada790970e9749fb3
   branch: enh/MS-9710/add_pkcs12_metadata
   specs:
     metasploit-credential (6.0.12)
@@ -13,6 +13,32 @@ GIT
       rex-socket
       rubyntlm
       rubyzip
+
+GIT
+  remote: https://github.com/cdelafuente-r7/metasploit-model
+  revision: 925a11f61f02123f29e32bb196b374390d36beb6
+  branch: feat/model/search/operation/jsonb
+  specs:
+    metasploit-model (5.0.3)
+      activemodel (~> 7.0)
+      activesupport (~> 7.0)
+      railties (~> 7.0)
+
+GIT
+  remote: https://github.com/cdelafuente-r7/metasploit_data_models
+  revision: 34fc27d3059c919eac98cf2a8061c31146189a26
+  branch: enh/visitor/jsonb
+  specs:
+    metasploit_data_models (6.0.6)
+      activerecord (~> 7.0)
+      activesupport (~> 7.0)
+      arel-helpers
+      metasploit-concern
+      metasploit-model (>= 3.1)
+      pg
+      railties (~> 7.0)
+      recog
+      webrick
 
 PATH
   remote: .
@@ -309,21 +335,7 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
-    metasploit-model (5.0.2)
-      activemodel (~> 7.0)
-      activesupport (~> 7.0)
-      railties (~> 7.0)
     metasploit-payloads (2.0.189)
-    metasploit_data_models (6.0.6)
-      activerecord (~> 7.0)
-      activesupport (~> 7.0)
-      arel-helpers
-      metasploit-concern
-      metasploit-model (>= 3.1)
-      pg
-      railties (~> 7.0)
-      recog
-      webrick
     metasploit_payloads-mettle (1.0.35)
     method_source (1.1.0)
     mime-types (3.6.0)
@@ -596,6 +608,8 @@ DEPENDENCIES
   memory_profiler
   metasploit-credential!
   metasploit-framework!
+  metasploit-model!
+  metasploit_data_models!
   octokit
   pry-byebug
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,3 @@
-GIT
-  remote: https://github.com/cdelafuente-r7/metasploit-credential
-  revision: 6c8554df2feab43489ca86eada790970e9749fb3
-  branch: enh/MS-9710/add_pkcs12_metadata
-  specs:
-    metasploit-credential (6.0.12)
-      metasploit-concern
-      metasploit-model
-      metasploit_data_models (>= 5.0.0)
-      net-ssh
-      pg
-      railties
-      rex-socket
-      rubyntlm
-      rubyzip
-
-GIT
-  remote: https://github.com/cdelafuente-r7/metasploit_data_models
-  revision: 34fc27d3059c919eac98cf2a8061c31146189a26
-  branch: enh/visitor/jsonb
-  specs:
-    metasploit_data_models (6.0.6)
-      activerecord (~> 7.0)
-      activesupport (~> 7.0)
-      arel-helpers
-      metasploit-concern
-      metasploit-model (>= 3.1)
-      pg
-      railties (~> 7.0)
-      recog
-      webrick
-
 PATH
   remote: .
   specs:
@@ -325,11 +293,31 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
+    metasploit-credential (6.0.14)
+      metasploit-concern
+      metasploit-model
+      metasploit_data_models (>= 5.0.0)
+      net-ssh
+      pg
+      railties
+      rex-socket
+      rubyntlm
+      rubyzip
     metasploit-model (5.0.3)
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
     metasploit-payloads (2.0.189)
+    metasploit_data_models (6.0.9)
+      activerecord (~> 7.0)
+      activesupport (~> 7.0)
+      arel-helpers
+      metasploit-concern
+      metasploit-model (>= 3.1)
+      pg
+      railties (~> 7.0)
+      recog
+      webrick
     metasploit_payloads-mettle (1.0.35)
     method_source (1.1.0)
     mime-types (3.6.0)
@@ -600,9 +588,7 @@ DEPENDENCIES
   factory_bot_rails
   fivemat
   memory_profiler
-  metasploit-credential!
   metasploit-framework!
-  metasploit_data_models!
   octokit
   pry-byebug
   rake

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_09_005658) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_04_172657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -314,6 +314,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_09_005658) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "jtr_format"
+    t.jsonb "metadata", default: {}, null: false
     t.index "type, decode(md5(data), 'hex'::text)", name: "index_metasploit_credential_privates_on_type_and_data_pkcs12", unique: true, where: "((type)::text = 'Metasploit::Credential::Pkcs12'::text)"
     t.index "type, decode(md5(data), 'hex'::text)", name: "index_metasploit_credential_privates_on_type_and_data_sshkey", unique: true, where: "((type)::text = 'Metasploit::Credential::SSHKey'::text)"
     t.index ["type", "data"], name: "index_metasploit_credential_privates_on_type_and_data", unique: true, where: "(NOT (((type)::text = 'Metasploit::Credential::SSHKey'::text) OR ((type)::text = 'Metasploit::Credential::Pkcs12'::text)))"

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -251,8 +251,12 @@ module Exploit::Remote::MsIcpr
       workspace_id: myworkspace_id,
       username: upn || datastore['SMBUser'],
       private_type: :pkcs12,
-      # pkcs12 is a binary format, but for persisting we Base64 encode it
-      private_data: Base64.strict_encode64(pkcs12.to_der),
+      private_data: Metasploit::Credential::Pkcs12.build_data(
+        # pkcs12 is a binary format, but for persisting we Base64 encode it
+        pkcs12: Base64.strict_encode64(pkcs12.to_der),
+        ca: datastore['CA'],
+        adcs_template: cert_template
+      ),
       origin_type: :service,
       module_fullname: fullname
     }

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -251,12 +251,8 @@ module Exploit::Remote::MsIcpr
       workspace_id: myworkspace_id,
       username: upn || datastore['SMBUser'],
       private_type: :pkcs12,
-      private_data: Metasploit::Credential::Pkcs12.build_data(
-        # pkcs12 is a binary format, but for persisting we Base64 encode it
-        pkcs12: Base64.strict_encode64(pkcs12.to_der),
-        ca: datastore['CA'],
-        adcs_template: cert_template
-      ),
+      private_data: Base64.strict_encode64(pkcs12.to_der),
+      private_metadata: { adcs_ca: datastore['CA'], adcs_template: cert_template },
       origin_type: :service,
       module_fullname: fullname
     }

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -100,16 +100,18 @@ class Creds
     print_line "Usage - Adding credentials:"
     print_line "  creds add uses the following named parameters."
     {
-      user:         'Public, usually a username',
-      password:     'Private, private_type Password.',
-      ntlm:         'Private, private_type NTLM Hash.',
-      postgres:     'Private, private_type postgres MD5',
-      pkcs12:       'Private, private_type pkcs12 archive file, must be a file path.',
-      'ssh-key' =>  'Private, private_type SSH key, must be a file path.',
-      hash:         'Private, private_type Nonreplayable hash',
-      jtr:          'Private, private_type John the Ripper hash type.',
-      realm:        'Realm, ',
-      'realm-type'=>"Realm, realm_type (#{Metasploit::Model::Realm::Key::SHORT_NAMES.keys.join(' ')}), defaults to domain."
+      user:              'Public, usually a username',
+      password:          'Private, private_type Password.',
+      ntlm:              'Private, private_type NTLM Hash.',
+      postgres:          'Private, private_type postgres MD5',
+      pkcs12:            'Private, private_type pkcs12 archive file, must be a file path.',
+      'ssh-key'       => 'Private, private_type SSH key, must be a file path.',
+      hash:              'Private, private_type Nonreplayable hash',
+      jtr:               'Private, private_type John the Ripper hash type.',
+      realm:             'Realm, ',
+      'realm-type'    => "Realm, realm_type (#{Metasploit::Model::Realm::Key::SHORT_NAMES.keys.join(' ')}), defaults to domain.",
+      ca:                'CA, Certificate Authority that issued the pkcs12 certificate',
+      'adcs-template' => 'ADCS Template, template used to issue the pkcs12 certificate'
     }.each_pair do |keyword, description|
       print_line "    #{keyword.to_s.ljust 10}:  #{description}"
     end
@@ -206,7 +208,7 @@ class Creds
     end
 
     begin
-      params.assert_valid_keys('user','password','realm','realm-type','ntlm','ssh-key','hash','address','port','protocol', 'service-name', 'jtr', 'pkcs12', 'postgres')
+      params.assert_valid_keys('user','password','realm','realm-type','ntlm','ssh-key','hash','address','port','protocol', 'service-name', 'jtr', 'pkcs12', 'postgres', 'ca', 'adcs-template')
     rescue ArgumentError => e
       print_error(e.message)
     end
@@ -275,7 +277,11 @@ class Creds
         print_error("Failed to add pkcs12 archive: #{e}")
       end
       data[:private_type] = :pkcs12
-      data[:private_data] = pkcs12_data
+      data[:private_data] = Metasploit::Credential::Pkcs12.build_data(
+        pkcs12: pkcs12_data,
+        ca: params['ca'],
+        adcs_template: params['adcs-template']
+      )
     end
 
     if params.key? 'hash'
@@ -414,11 +420,13 @@ class Creds
              when 'password'
                Metasploit::Credential::Password
              when 'hash'
-               Metasploit::Credential::PasswordHash
+               Metasploit::Credential::NonreplayableHash
              when 'ntlm'
                Metasploit::Credential::NTLMHash
              when 'KrbEncKey'.downcase
                Metasploit::Credential::KrbEncKey
+             when 'pkcs12'
+               Metasploit::Credential::Pkcs12
              when *Metasploit::Credential::NonreplayableHash::VALID_JTR_FORMATS
                opts[:jtr_format] = ptype
                Metasploit::Credential::NonreplayableHash

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -212,32 +212,48 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                                realm: nil,
                                workspace: framework.db.workspace)
           end
+          let!(:pkcs12_subject) { '/C=FR/O=MyOrg/OU=MyUnit/CN=SubjectTestName' }
+          let!(:pkcs12_issuer) { '/C=US/O=MyIssuer/OU=MyIssuerUnit/CN=IssuerTestName' }
+          let!(:pkcs12_ca) { 'testCA' }
+          let!(:pkcs12_adcs_template) { 'TestTemplate' }
+          let!(:pkcs12_core) do
+            priv = FactoryBot.create(:metasploit_credential_pkcs12_with_ca_and_adcs_template,
+                                     subject: pkcs12_subject,
+                                     issuer: pkcs12_issuer,
+                                     ca: pkcs12_ca,
+                                     adcs_template: pkcs12_adcs_template)
+            FactoryBot.create(:metasploit_credential_core,
+                               origin: FactoryBot.create(:metasploit_credential_origin_import),
+                               private: priv,
+                               public: nil,
+                               realm: nil,
+                               workspace: framework.db.workspace)
+          end
 
-          #         # Somehow this is hitting a unique constraint on Cores with the same
-          #         # Public, even though it has a different Private. Skip for now
-          #         let!(:ntlm_core) do
-          #           priv = FactoryBot.create(:metasploit_credential_ntlm_hash, data: ntlm_hash)
-          #           FactoryBot.create(:metasploit_credential_core,
-          #                              origin: FactoryBot.create(:metasploit_credential_origin_import),
-          #                              private: priv,
-          #                              public: pub,
-          #                              realm: nil,
-          #                              workspace: framework.db.workspace)
-          #         end
-          #         let!(:nonreplayable_core) do
-          #           priv = FactoryBot.create(:metasploit_credential_nonreplayable_hash, data: 'asdf')
-          #           FactoryBot.create(:metasploit_credential_core,
-          #                              origin: FactoryBot.create(:metasploit_credential_origin_import),
-          #                              private: priv,
-          #                              public: pub,
-          #                              realm: nil,
-          #                              workspace: framework.db.workspace)
-          #         end
+          let!(:ntlm_core) do
+            priv = FactoryBot.create(:metasploit_credential_ntlm_hash, data: ntlm_hash)
+            FactoryBot.create(:metasploit_credential_core,
+                               origin: FactoryBot.create(:metasploit_credential_origin_import),
+                               private: priv,
+                               public: pub,
+                               realm: nil,
+                               workspace: framework.db.workspace)
+          end
+          let!(:nonreplayable_core) do
+            priv = FactoryBot.create(:metasploit_credential_nonreplayable_hash, data: 'asdf')
+            FactoryBot.create(:metasploit_credential_core,
+                               origin: FactoryBot.create(:metasploit_credential_origin_import),
+                               private: priv,
+                               public: pub,
+                               realm: nil,
+                               workspace: framework.db.workspace)
+          end
 
           after(:example) do
-            # ntlm_core.destroy
+            ntlm_core.destroy
             password_core.destroy
-            # nonreplayable_core.destroy
+            nonreplayable_core.destroy
+            pkcs12_core.destroy
           end
 
           context 'password' do
@@ -283,16 +299,48 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
 
           context 'ntlm' do
             it 'should show just the ntlm' do
-              skip 'Weird uniqueness constraint on Core (workspace_id, public_id)'
 
               creds.cmd_creds('-t', 'ntlm')
               expect(@output.join("\n")).to match_table <<~TABLE
                 Credentials
                 ===========
 
-                host  origin  service  public         private                                                            realm  private_type  JtR Format  cracked_password
-                ----  ------  -------  ------         -------                                                            -----  ------------  ----------  ----------------
-                                       thisuser       1443d06412d8c0e6e72c57ef50f76a05:27c433245e4763d074d30a05aae0af2c         NTLM hash
+                host  origin  service  public    private                                                            realm  private_type  JtR Format  cracked_password
+                ----  ------  -------  ------    -------                                                            -----  ------------  ----------  ----------------
+                                       thisuser  1443d06412d8c0e6e72c57ef50f76a05:27c433245e4763d074d30a05aae0af2c         NTLM hash
+
+              TABLE
+            end
+          end
+
+          context 'nonreplayable' do
+            it 'should show just the ntlm' do
+
+              creds.cmd_creds('-t', 'hash')
+              expect(@output.join("\n")).to match_table <<~TABLE
+                Credentials
+                ===========
+
+                host  origin  service  public    private  realm  private_type        JtR Format  cracked_password
+                ----  ------  -------  ------    -------  -----  ------------        ----------  ----------------
+                                       thisuser  asdf            Nonreplayable hash
+
+              TABLE
+            end
+          end
+
+          context 'pkcs12' do
+            it 'should show just the pkcs12' do
+              private_str = "subject:#{pkcs12_subject},issuer:#{pkcs12_issuer},CA:#{pkcs12_ca},ADCS_template:#{pkcs12_adcs_template}"
+              private_str = "#{private_str[0,76]} (TRUNCATED)"
+              creds.cmd_creds('-t', 'pkcs12')
+              expect(@output.join("\n")).to match_table <<~TABLE
+                Credentials
+                ===========
+
+                host  origin  service  public  private                                                                                   realm  private_type  JtR Format  cracked_password
+                ----  ------  -------  ------  -------                                                                                   -----  ------------  ----------  ----------------
+                                               #{private_str}         Pkcs12 (pfx)
 
               TABLE
             end
@@ -476,6 +524,30 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 workspace: framework.db.workspace)
               expect {
                 creds.cmd_creds('add', "user:#{username}", "ssh-key:#{@file.path}")
+              }.to_not change { Metasploit::Credential::Core.count }
+            end
+          end
+          context 'pkcs12' do
+            let(:priv) { FactoryBot.create(:metasploit_credential_pkcs12) }
+            before(:each) do
+              @file = Tempfile.new('mypkcs12.pfx')
+              @file.write(Base64.strict_decode64(priv.pkcs12))
+              @file.close
+            end
+            it 'creates a core if one does not exist' do
+              expect {
+                creds.cmd_creds('add', "pkcs12:#{@file.path}")
+              }.to change { Metasploit::Credential::Core.count }.by 1
+            end
+            it 'does not create a core if it already exists' do
+              FactoryBot.create(:metasploit_credential_core,
+                origin: FactoryBot.create(:metasploit_credential_origin_import),
+                private: priv,
+                public: nil,
+                realm: nil,
+                workspace: framework.db.workspace)
+              expect {
+                creds.cmd_creds('add', "pkcs12:#{@file.path}")
               }.to_not change { Metasploit::Credential::Core.count }
             end
           end


### PR DESCRIPTION
This adds support to the new Pkcs12 data format added in https://github.com/rapid7/metasploit-credential/pull/183. Now, the CA and ADCS template can be added to the Pkcs12 as metadata in the database.

Also, it is now possible to store a Pkcs12 password as a metadata in the database. If the Pkcs12 is encrypted, the password can (and must) be added to the metadata field. It will be used to decrypt the Pkcs12. The `creds` command has been updated to accept a new option `pkcs12-password`. The validation will fail if the Pkcs12 we want to add with `creds` is encrypted and the password is wrong or empty.

This PR needs the `metasploit-credentials` counterpart be landed first. I have updated the Gemfile to point to the feature branch to be able to test it. This will need to be reverted before landing.


## Verification

### Testing `auxiliary/admin/dcerpc/icpr_cert`
Follow the instructions [here](https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/overview.html) to set up an AD CS server for testing purposes.

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/dcerpc/icpr_cert`
- [x] `run verbose=true CA=<CA name> RHOSTS=<remote host> username=<username> password=<user password> CERT_TEMPLATE=User`
- [x] Verify `creds` returns the generated Pkcs12
- [x] Check with `irb` in `msfconsole` if the Pkcs12 model contains the metadata filed with the expected values.
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run verbose=true CA=myca-CA RHOSTS=10.100.54.12 username=muser password=vagrant CERT_TEMPLATE=User
[*] Running module against 10.100.54.12
[*] 10.100.54.12:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 10.100.54.12:445 - Binding to \cert...
[+] 10.100.54.12:445 - Bound to \cert
[*] 10.100.54.12:445 - Requesting a certificate for user muser - digest algorithm: SHA256 - template: User
[+] 10.100.54.12:445 - The requested certificate was issued.
[*] 10.100.54.12:445 - Certificate UPN: muser@ad.pro.local
[*] 10.100.54.12:445 - Certificate stored at: /home/n00tmeg/.msf4/loot/20241216151952_default_10.100.54.12_windows.ad.cs_020208.pfx
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/icpr_cert) > creds
Credentials
===========

host          origin        service        public              private                                                                                   realm  private_type  JtR Format  cracked_password
----          ------        -------        ------              -------                                                                                   -----  ------------  ----------  ----------------
10.100.54.12  10.100.54.12  445/tcp (smb)  muser@ad.pro.local  subject:/DC=local/DC=pro/DC=ad/OU=UK/OU=Support/CN=muser,issuer:/DC=local/DC (TRUNCATED)         Pkcs12 (pfx)

msf6 auxiliary(admin/dcerpc/icpr_cert) > irb
[*] Starting IRB shell...
[*] You are in auxiliary/admin/dcerpc/icpr_cert

>> Metasploit::Credential::Pkcs12.all
=>
[#<Metasploit::Credential::Pkcs12:0x00007f3f4d255dd0
  id: 1,
  type: "Metasploit::Credential::Pkcs12",
  data: "<REDACTED>",
  created_at: 2025-02-06 13:25:11.731165 UTC,
  updated_at: 2025-02-06 13:25:11.731165 UTC,
  jtr_format: nil,
  metadata: {"ca"=>"myca-CA", "adcs_template"=>"User"}>]
```

### Testing `creds` command
- [x] Start `msfconsole`
- [x] Add a certificate manually with `creds add user:testuser pkcs12:<pkcs12 filepath> ca:myca adcs-template:OtherTemplate`
- [x] Verify `creds` returns the generated Pkcs12
- [x] Check with `irb` in `msfconsole` if the Pkcs12 model contains the metadata filed with the expected values.

### Testing `creds` command with an encrypted Pkcs12 and a password
First we need to get an password protected Pkcs12. We can use `openssl` command with an already retrieved pkcs12, with the `auxiliary/admin/dcerpc/icpr_cert` module for example, and set a password. Check the certificate files with the `loot` command to get the filepath.
1. Extract client certificate:
```
openssl pkcs12 -in /home/n00tmeg/.msf4/loot/20250206142511_default_10.232.45.111_windows.ad.cs_641319.pfx -out existingpkcs12_clcert.pem -nokeys -clcerts
```
Hit Enter when asked for the Import Password (there is no password).
2. Extract client certificate's private key:
```
openssl pkcs12 -in /home/n00tmeg/.msf4/loot/20250206142511_default_10.232.45.111_windows.ad.cs_641319.pfx -out existingpkcs12_key.pem -nocerts -des3
```
Hit Enter when asked for the Import Password (there is no password).
Enter a password for the private key export (e.g. `password`)
3. Re-create the PKCS#12
```
openssl pkcs12 -export -in existingpkcs12_clcert.pem -inkey existingpkcs12_key.pem -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -out newpkcs12.p12
```
Enter the previous password set when asked for the pass phrase for existingpkcs12_key.pem (e.g. `password`)
Enter Export Password: `123456`

- [x] Start `msfconsole`
- [x] Add a certificate manually with `creds add user:testuser pkcs12:newpkcs12.p12 ca:myca adcs-template:OtherTemplate pkcs12-password:123456`
- [x] Verify `creds` returns the generated Pkcs12
- [x] Check with `irb` in `msfconsole` if the Pkcs12 model contains the metadata filed with the expected values.
- [x] Try to add it again with a wrong password: `creds add user:testuser pkcs12:newpkcs12.p12 ca:myca adcs-template:OtherTemplate pkcs12-password:wrongpasswd`
- [x] Verify you get a PKCS12 `Data ArgumentError`