### PR TITLE
Improve local exploit suggester handling of nil target

### DIFF
--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -50,11 +50,19 @@ class MetasploitModule < Msf::Post
 
   def session_arch
     # Prefer calling native arch when available, as most LPEs will require this (e.g. x86, x64) as opposed to Java/Python Meterpreter's values (e.g. Java, Python)
-    session.respond_to?(:native_arch) ? session.native_arch : session.arch
+    @session_arch ||= session.respond_to?(:native_arch) ? session.native_arch : session.arch
+  end
+
+  def session_platform
+    @session_platform ||= Msf::Module::Platform.find_platform(session.platform)
+  end
+
+  def session_type
+    @session_type ||= session.session_type
   end
 
   def is_module_arch?(mod)
-    mod_arch = mod.target.arch || mod.arch
+    mod_arch = mod.target&.arch || mod.arch
     mod_arch.include?(session_arch)
   end
 
@@ -70,11 +78,10 @@ class MetasploitModule < Msf::Post
   end
 
   def is_module_platform?(mod)
-    platform_obj = Msf::Module::Platform.find_platform session.platform
     return false if mod.target.nil?
 
     module_platforms = mod.target.platform ? mod.target.platform.platforms : mod.platform.platforms
-    module_platforms.include? platform_obj
+    module_platforms.include? session_platform
   rescue ArgumentError => e
     # When not found, find_platform raises an ArgumentError
     elog('Could not find a platform', error: e)
@@ -119,13 +126,15 @@ class MetasploitModule < Msf::Post
   end
 
   def set_module_target(mod)
-    session_platform = Msf::Module::Platform.find_platform(session.platform)
     target_index = mod.targets.find_index do |target|
       # If the target doesn't define its own compatible platforms or architectures, default to the parent (module) values.
       target_platforms = target.platform&.platforms || mod.platform.platforms
       target_architectures = target.arch || mod.arch
 
-      target_platforms.include?(session_platform) && target_architectures.include?(session_arch)
+      correct_platform = @validate_platform ? target_platforms.include?(session_platform) : true
+      correct_arch = @validate_arch ? target_architectures.include?(session_arch) : true
+
+      correct_platform && correct_arch
     end
     mod.datastore['Target'] = target_index if target_index
   end
@@ -133,7 +142,7 @@ class MetasploitModule < Msf::Post
   def setup
     return unless session
 
-    print_status "Collecting local exploits for #{session.session_type}..."
+    print_status "Collecting local exploits for #{session_type}..."
 
     setup_validation_options
     setup_color_options
@@ -144,7 +153,7 @@ class MetasploitModule < Msf::Post
     exploit_refnames.each_with_index do |name, index|
       print "%bld%blu[*]%clr Collecting exploit #{index + 1} / #{exploit_refnames.count}\r"
       mod = framework.exploits.create name
-      next unless mod
+      next unless mod && mod.is_a?(Msf::Exploit::Local)
 
       set_module_options mod
       set_module_target mod
@@ -155,7 +164,7 @@ class MetasploitModule < Msf::Post
   end
 
   def verify_mod(mod)
-    return { has_check: false } unless mod.is_a?(Msf::Exploit::Local) && mod.has_check?
+    return { has_check: false } unless mod.has_check?
 
     result = {
       has_check: true,
@@ -308,9 +317,9 @@ class MetasploitModule < Msf::Post
     session_type_styler = ::Msf::Ui::Console::TablePrint::CustomColorStyler.new
 
     rows = unwanted_modules.map.with_index do |mod, index|
-      platforms = mod[:module].target.platform&.platforms&.any? ? mod[:module].target.platform.platforms : mod[:module].platform.platforms
+      platforms = mod[:module].target&.platform&.platforms&.any? ? mod[:module].target.platform.platforms : mod[:module].platform.platforms
       platforms ||= []
-      arch = mod[:module].target.arch&.any? ? mod[:module].target.arch : mod[:module].arch
+      arch = mod[:module].target&.arch&.any? ? mod[:module].target.arch : mod[:module].arch
       arch ||= []
 
       arch.each do |a|
@@ -328,7 +337,7 @@ class MetasploitModule < Msf::Post
       end
 
       platforms.each do |module_platform|
-        if module_platform != ::Msf::Module::Platform.find_platform(session.platform)
+        if module_platform != session_platform
           if @validate_platform
             color = @invalid_color
           else
@@ -380,7 +389,7 @@ class MetasploitModule < Msf::Post
     vprint_status 'Current Session Info:'
     vprint_status "Session Type: #{session.type}"
     vprint_status "Architecture: #{session_arch}"
-    vprint_status "Platform: #{session.platform}"
+    vprint_status "Platform: #{session_platform}"
   end
 
   def is_check_interesting?(checkcode)


### PR DESCRIPTION
This PR improves how local exploit suggester handles some nil values.

## Docker
```
docker run -it -p 80:80 vulhub/thinkphp:5.0.23 
```

## Verification

- [ ] Start `msfconsole`
- [ ] `use thinkphp_rce`
- [ ] run the module vs a thinkphp container
- [ ] run the local exploit suggester vs. your session
- [ ] **Verify** no crashes (as before - the issue occurs in Pro)
- [ ] Test the local exploit suggester in Pro by pointing Pro to this branch and verify it doesn't crash