### PR TITLE
Add ignorelist to local exploit suggester datastore options

### DIFF
--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -110,8 +110,9 @@ class MetasploitModule < Msf::Post
   end
 
   def set_module_options(mod)
+    ignore_list = ['ACTION', 'TARGET'].freeze
     datastore.each_pair do |k, v|
-      mod.datastore[k] = v
+      mod.datastore[k] = v unless ignore_list.include?(k.upcase)
     end
     if !mod.datastore['SESSION'] && session.present?
       mod.datastore['SESSION'] = session.sid


### PR DESCRIPTION
This PR prevents copying of some datastore options known to cause potential issues in the local exploit suggester.
This fixes a Pro-specific crash.

## Verification

- [ ] Start `msfconsole`
- [ ] get a session, e.g. using thinkphp_rce
- [ ] run `local_exploit_suggester` against the session
- [ ] **Verify** it runs as expected
- [ ] **Verify** that following this workflow in Pro works as expected and does not crash anymore
