### PR TITLE
Capitalize TeamCity correctly

### DIFF
--- a/lib/metasploit/framework/login_scanner/teamcity.rb
+++ b/lib/metasploit/framework/login_scanner/teamcity.rb
@@ -7,7 +7,7 @@ module Metasploit
       # This is the LoginScanner class for dealing with JetBrains TeamCity instances.
       # It is responsible for taking a single target, and a list of credentials
       # and attempting them. It then saves the results.
-      class Teamcity < HTTP
+      class TeamCity < HTTP
 
         module Crypto
           # https://github.com/openssl/openssl/blob/a08a145d4a7e663dd1e973f06a56e983a5e916f7/crypto/rsa/rsa_pk1.c#L125

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -297,7 +297,8 @@ class MsfAutoload
       'appapi' => 'AppApi',
       'uds_errors' => 'UDSErrors',
       'smb_hash_capture' => 'SMBHashCapture',
-      'rex_ntlm' => 'RexNTLM'
+      'rex_ntlm' => 'RexNTLM',
+      'teamcity' => 'TeamCity'
     }
   end
 

--- a/modules/auxiliary/scanner/teamcity/teamcity_login.rb
+++ b/modules/auxiliary/scanner/teamcity/teamcity_login.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
       ssl: datastore['SSL']
     )
 
-    scanner = Metasploit::Framework::LoginScanner::Teamcity.new(scanner_opts)
+    scanner = Metasploit::Framework::LoginScanner::TeamCity.new(scanner_opts)
     run_scanner(scanner)
   end
 end

--- a/spec/modules/auxiliary/scanner/teamcity/teamcity_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/teamcity/teamcity_login_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'metasploit/framework/login_scanner/teamcity'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Teamcity do
+RSpec.describe Metasploit::Framework::LoginScanner::TeamCity do
 
   let(:subject) { described_class.new }
 


### PR DESCRIPTION
This PR correctly capitalizes TeamCity correctly, instead of the previous `Teamcity` definition.
This PR will also change these values in Pro's UI.

## Working module
```
➜  metasploit-framework git:(TeamCity-is-capitalized) bundle exec ./msfconsole -q
msf6 auxiliary(scanner/teamcity/teamcity_login) > run
[+] 127.0.0.1:8111 - Login Successful: admin:admin
[!] No active DB -- Credential data will not be saved!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Tests
```
bundle exec rspec spec/modules/auxiliary/scanner/teamcity/teamcity_login_spec.rb
...
Finished in 0.10561 seconds (files took 8 seconds to load)
26 examples, 0 failures
```

## Verification

- [ ] Start `msfconsole`
- [ ] `use teamcity_login scanner`
- [ ] Confirm you can run the module and it works as expected
- [ ] You can also run this in `irb` to confirm the class is capitalized correctly: `scanner = Metasploit::Framework::LoginScanner::TeamCity.new`
- [ ] Passing CI & RSpec tests