### PR TITLE
Added Server 2025 to Windows version constants

### DIFF
--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -26,6 +26,7 @@ module Msf
       Server2019 = Rex::Version.new('10.0.17763.0')
       Server2022 = Rex::Version.new('10.0.20348.0')
       Server2022_23H2 = Rex::Version.new('10.0.25398.0')
+      Server2025 = Rex::Version.new('10.0.26100.0')
     end
 
     module WorkstationSpecificVersions
@@ -79,7 +80,8 @@ module Msf
       :Server2016 => "Windows Server 2016",
       :Server2019 => "Windows Server 2019",
       :Server2022 => "Windows Server 2022",
-      :Server2022_23H2 => "Windows Server 2022 version 23H2"
+      :Server2022_23H2 => "Windows Server 2022 version 23H2",
+      :Server2025 => "Windows Server 2025"
     }
 
     WorkstationNameMapping = {


### PR DESCRIPTION
This adds the version constants for Windows Server 2025.

## Verification

- [x] Spin up a Server 2025 instance (I tested on AWS)
- [x] Start `msfconsole`
- [x] Obtain a meterpreter session on it
- [x] Use a module with the `WindowsVersion` mixin; e.g.:
- [x] `use windows/local/cve_2020_0787_bits_arbitrary_file_move`
- [x] `set session 1`
- [x] `irb`
- [x] `version = get_version_info_impl`
- [x] `version.product_name`
- [x] Verify that it says `Windows Server 2025`
