### PR TITLE
Fix ntp_nak_to_the_future

### DIFF
--- a/documentation/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.md
+++ b/documentation/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.md
@@ -1,0 +1,96 @@
+## Vulnerable Application
+
+## Verification Steps
+
+1. Use the supplied Dockerfile to start a vulnerable instance of the application
+   1. Build it with: `docker build -t ntpd:4.2.8p3 .`
+   1. Run it with: `docker run --rm -it --name ntp-server -p 123:123/udp ntpd:4.2.8p3`
+1. Start `msfconsole` and use the module
+1. Set the `RHOSTS` value as necessary
+1. Run the module and see that the target is vulnerable
+
+### Dockerfile
+Use this as `ntp.conf`:
+
+```
+# Basic NTP configuration
+server 0.pool.ntp.org iburst
+server 1.pool.ntp.org iburst
+server 2.pool.ntp.org iburst
+server 3.pool.ntp.org iburst
+
+driftfile /var/lib/ntp/ntp.drift
+
+# Enable authentication for secure associations
+enable auth
+
+# Define trusted keys
+trustedkey 1
+
+# Open restrictions for all clients on the local network (example: 192.168.0.0/16)
+restrict default kod nomodify notrap
+restrict 127.0.0.1
+restrict ::1
+restrict 192.168.0.0 mask 255.255.0.0 autokey
+
+# Uncomment to allow all clients (use cautiously)
+# restrict default kod nomodify notrap
+```
+
+Use this as `Dockerfile`:
+
+```
+ARG version=4.2.8p3
+FROM ubuntu:16.04
+ARG version
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    build-essential \
+    libcap-dev \
+    libssl-dev && \
+    apt-get clean
+
+# Download and build NTPD
+WORKDIR /tmp
+RUN wget https://web.archive.org/web/20240608062853/https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-$version.tar.gz && \
+    tar -xzf ntp-$version.tar.gz && \
+    cd ntp-$version && \
+    ./configure --prefix=/usr/local --enable-linuxcaps && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf ntp-$version*
+
+# Add configuration file
+COPY ntp.conf /etc/ntp.conf
+
+# Expose NTP port (123)
+EXPOSE 123/udp
+
+# Run ntpd
+ENTRYPOINT ["/usr/local/bin/ntpd"]
+CMD ["-g", "-d", "-d"]
+```
+
+## Options
+
+## Scenarios
+
+### Ubuntu 16.04 NTPd 4.2.8p3
+
+```
+metasploit-framework (S:0 J:0) auxiliary(scanner/ntp/ntp_nak_to_the_future) > set RHOSTS 192.168.159.128, 192.168.159.10
+RHOSTS => 192.168.159.128, 192.168.159.10
+metasploit-framework (S:0 J:0) auxiliary(scanner/ntp/ntp_nak_to_the_future) > run
+[+] 192.168.159.128:123 - NTP - VULNERABLE: Accepted a NTP symmetric active association
+[*] Scanned 1 of 2 hosts (50% complete)
+[*] Scanned 1 of 2 hosts (50% complete)
+[*] Scanned 1 of 2 hosts (50% complete)
+[*] Scanned 1 of 2 hosts (50% complete)
+[*] Scanned 1 of 2 hosts (50% complete)
+[*] Scanned 2 of 2 hosts (100% complete)
+[*] Auxiliary module execution completed
+metasploit-framework (S:0 J:0) auxiliary(scanner/ntp/ntp_nak_to_the_future) >
+```

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -98,25 +98,6 @@ module NTP::Modes
     end
   end
 
-  class NTPSymmetric < BinData::Record
-    alias size num_bytes
-    endian :big
-    bit2   :li
-    bit3   :version, initial_value: 3
-    bit3   :mode
-    uint8  :stratum
-    uint8  :poll
-    uint8  :precision
-    uint32 :root_delay
-    uint32 :root_dispersion
-    uint32 :reference_id
-    uint64 :reference_timestamp
-    uint64 :origin_timestamp
-    uint64 :receive_timestamp
-    uint64 :transmit_timestamp
-    rest   :payload
-  end
-
   def ntp_control(version, operation, payload = nil)
     n = NTPControl.new
     n.version = version


### PR DESCRIPTION
This fixes the `auxiliary/scanner/ntp/ntp_nak_to_the_future` module which was broken in commit 5f88971ca9a9bb62845f765f555a3ab12fd16ad0 (landed in #8185). The issue was that when the `BinData::Record` instance is sent with the socket, the string representation of it was used instead of the packed binary. It should be calling `#to_binar_s`. This PR fixes the issue and documents how the module can be tested.

This was the only module that used the `NTPSymmetric` definition and it's been converted to instead use the new `NTPHeader` definition which adds more natural handing for `NTPTimestamp` and `NTPShort` fields. The `NTPHeader` definition was originally written for #19748 and these two PRs share common commits in their history for the new definition.

Other NTP modules could be broken and have not been tested. NTPSymmetric had the most overlap with the definition needed for timeroast, so that was the only one that was thoroughly reviewed.

## Verification

- [x] Use the Dockerfile included in the module docs to start a vulnerable instance of the application
   - [x] Build it with: `docker build -t ntpd:4.2.8p3 .`
   - [x] Run it with: `docker run --rm -it --name ntp-server -p 123:123/udp ntpd:4.2.8p3`
- [x] Start `msfconsole` and use the module
- [x] Set the `RHOSTS` value as necessary
- [x] Run the module and see that the target is vulnerable

## Demo
```
metasploit-framework (S:0 J:0) auxiliary(scanner/ntp/ntp_nak_to_the_future) > run
[+] 192.168.159.128:123 - NTP - VULNERABLE: Accepted a NTP symmetric active association
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 1 of 2 hosts (50% complete)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(scanner/ntp/ntp_nak_to_the_future) >
```
