### PR TITLE
Fix missing attributes on LDAP SSL sockets

### DIFF
--- a/lib/rex/proto/ldap.rb
+++ b/lib/rex/proto/ldap.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require 'net/ldap'
 require 'rex/socket'
 
@@ -205,6 +206,8 @@ class Net::LDAP::Connection # :nodoc:
 
     if server[:encryption]
       setup_encryption server[:encryption]
+      @conn.extend Forwardable
+      @conn.def_delegators :@io, :localinfo, :peerinfo
     end
 
     yield self if block_given?


### PR DESCRIPTION
Metasploit's LDAP sockets use the SSL wrapping logic provided by the Net::LDAP module. This means the socket gets swapped to an OpenSSL socket when SSL is enabled and the socket doesn't have some attributes that Metasploit expects. When that socket is treated as one used for a session, this missing information gets propagated up and is shown to the user. This is the issue described in #19744. 

This change fixes it by extending the SSL socket after it's setup with the `Forwardable` module and defines delegators for the `#localinfo` and `#peerinfo` to come from the underlying socket (`@io`). This allows the local and peer socket address to be passed up and displayed to the user. Previously, the missing attribute would cause an exception to be raised which would result in an [address of 127.0.0.1](https://github.com/rapid7/metasploit-framework/blob/227143efa1802b1ddc730ba032279ece91626670/lib/msf/core/session/interactive.rb#L46-L67) being shown to the user for a session.

## Verification

- [x] Start msfconsole
- [x] Use the `ldap/ldap_login` module
- [x] Set `CreateSession` and `SSL` to `true`, enable the SSL session feature if necessary
- [x] Set the rest of the options to valid values so a session can be opened
- [x] Run the module and get a session
- [x] See the correct address information shown in the output instead of 127.0.0.1


## Demo (Old and Broken)
```
metasploit-framework (S:3 J:0) auxiliary(scanner/ldap/ldap_login) > run LDAP::Auth=ntlm
[+] 192.168.159.10:636 - Success: 'smcintyre:Password1!'
[*] LDAP session 4 opened (127.0.0.1 -> 127.0.0.1) at 2024-12-19 13:58:46 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Bruteforce completed, 1 credential was successful.
[*] 1 LDAP session was opened successfully.
[*] Auxiliary module execution completed
metasploit-framework (S:4 J:0) auxiliary(scanner/ldap/ldap_login) >
```

## Demo (New and Fixed)
```
metasploit-framework (S:1 J:0) auxiliary(scanner/ldap/ldap_login) > run
[+] 192.168.159.10:636 - Success: 'smcintyre:Password1!'
[*] LDAP session 2 opened (192.168.159.128:36377 -> 192.168.159.10:636) at 2024-12-19 15:00:57 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Bruteforce completed, 1 credential was successful.
[*] 1 LDAP session was opened successfully.
[*] Auxiliary module execution completed
metasploit-framework (S:2 J:0) auxiliary(scanner/ldap/ldap_login) >
```