### PR TITLE
add check for prometheus pprof endpoints

### DIFF
--- a/modules/auxiliary/gather/prometheus_api_gather.rb
+++ b/modules/auxiliary/gather/prometheus_api_gather.rb
@@ -153,9 +153,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET'
     )
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response from server (response code #{res.code})") unless res.code == 200
-
-    print_good("#{peer}#{target_uri.path}debug/pprof/ found, potential DoS and information disclosure. Should be manually reviewed.") if res.body.include?('Profile Descriptions')
+    print_good("#{peer}#{target_uri.path}debug/pprof/ found, potential DoS and information disclosure. Should be manually reviewed.") if res.code == 200 && res.body.include?('Profile Descriptions')
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/auxiliary/gather/prometheus_api_gather.rb
+++ b/modules/auxiliary/gather/prometheus_api_gather.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Auxiliary
           'h00die'
         ],
         'References' => [
-          ['URL', 'https://jfrog.com/blog/dont-let-prometheus-steal-your-fire/']
+          ['URL', 'https://jfrog.com/blog/dont-let-prometheus-steal-your-fire/'],
+          ['URL', 'https://www.aquasec.com/blog/300000-prometheus-servers-and-exporters-exposed-to-dos-attacks/']
         ],
 
         'Targets' => [
@@ -145,6 +146,16 @@ class MetasploitModule < Msf::Auxiliary
     json = res.get_json_document
     fail_with(Failure::UnexpectedReply, "#{peer} - Unable to parse JSON document") unless json
     print_good("Config file: #{json.dig('data', 'config.file')}") if json.dig('data', 'config.file')
+
+    # check for pprof
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'debug', 'pprof/'), # include trailing /
+      'method' => 'GET'
+    )
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response from server (response code #{res.code})") unless res.code == 200
+
+    print_good("#{peer}#{target_uri.path}debug/pprof/ found, potential DoS and information disclosure. Should be manually reviewed.") if res.body.include?('Profile Descriptions')
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/auxiliary/gather/prometheus_node_exporter_gather.rb
+++ b/modules/auxiliary/gather/prometheus_node_exporter_gather.rb
@@ -316,9 +316,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET'
     )
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response from server (response code #{res.code})") unless res.code == 200
-
-    print_good("#{peer}#{target_uri.path}debug/pprof/ found, potential DoS and information disclosure. Should be manually reviewed.") if res.body.include?('Profile Descriptions')
+    print_good("#{peer}#{target_uri.path}debug/pprof/ found, potential DoS and information disclosure. Should be manually reviewed.") if res.code == 200 && res.body.include?('Profile Descriptions')
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/auxiliary/gather/prometheus_node_exporter_gather.rb
+++ b/modules/auxiliary/gather/prometheus_node_exporter_gather.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://github.com/prometheus/node_exporter'],
-          ['URL', 'https://sysdig.com/blog/exposed-prometheus-exploit-kubernetes-kubeconeu/']
+          ['URL', 'https://sysdig.com/blog/exposed-prometheus-exploit-kubernetes-kubeconeu/'],
+          ['URL', 'https://www.aquasec.com/blog/300000-prometheus-servers-and-exporters-exposed-to-dos-attacks/']
         ],
 
         'Targets' => [
@@ -308,6 +309,16 @@ class MetasploitModule < Msf::Auxiliary
     ].each do |table|
       print_good(table.to_s) if !table.rows.empty?
     end
+
+    # check for pprof
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'debug', 'pprof/'), # include trailing /
+      'method' => 'GET'
+    )
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response from server (response code #{res.code})") unless res.code == 200
+
+    print_good("#{peer}#{target_uri.path}debug/pprof/ found, potential DoS and information disclosure. Should be manually reviewed.") if res.body.include?('Profile Descriptions')
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end


### PR DESCRIPTION
Fix #19728

Adds a check for the two prometheus modules to check for the newly documented `/debug/pprof/` endpoint that can have an information disclosure and DoS.

## Verification


- [ ] Use docker images as is noted in the previous documents, `:lastest` still works for both.
- [ ] `use modules/auxiliary/gather/prometheus_node_exporter_gather`
- [ ] `run`
- [ ] **Verify** the last line mentions finding the endpoint
- [ ] `use modules/auxiliary/gather/prometheus_api_gather`
- [ ] `run`
- [ ] **Verify** the last line mentions finding the endpoint