### PR TITLE
Update metasploit dns docs syntax highlight

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-Configure-DNS.md
+++ b/docs/metasploit-framework.wiki/How-to-Configure-DNS.md
@@ -18,7 +18,7 @@ Metasploit's DNS configuration is controlled by the `dns` command which has mult
 
 The current configuration can be printed by running `dns print`:
 
-```msf6
+```msf
 msf6 > dns print
 Default search domain: N/A
 Default search list:   lab.lan


### PR DESCRIPTION
Update metasploit dns docs syntax highlighting

Before:

![image](https://github.com/user-attachments/assets/32335c5b-d502-4206-b184-24a8e02c7873)

## Verification

- Ensure CI passes