### PR TITLE
Revert "Land #19731, new feature for recognizing broken SMB session a…

### DIFF
--- a/lib/msf/base/sessions/smb.rb
+++ b/lib/msf/base/sessions/smb.rb
@@ -23,7 +23,7 @@ class Msf::Sessions::SMB
   # @option opts [RubySMB::Client] :client
   def initialize(rstream, opts = {})
     @client = opts.fetch(:client)
-    @simple_client = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client, msf_session: self)
+    @simple_client = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
     self.console = Rex::Post::SMB::Ui::Console.new(self)
     super(rstream, opts)
   end
@@ -51,13 +51,6 @@ class Msf::Sessions::SMB
       print_status("Session ID #{sid} (#{tunnel_to_s}) processing #{key} '#{datastore[key]}'")
       execute_script(args.shift, *args)
     end
-  end
-
-  def verify_connectivity
-    @client.dispatcher.tcp_socket.peerinfo
-  rescue Errno::ENOTCONN
-    self.kill
-    raise
   end
 
   def type
@@ -147,4 +140,5 @@ class Msf::Sessions::SMB
     # the EOFError so we can drop this handle like a bad habit.
     raise EOFError if (console.stopped? == true)
   end
+
 end

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -22,45 +22,42 @@ class SimpleClient
   attr_accessor :last_error, :server_max_buffer_size
 
   # Private accessors
-  attr_accessor :socket, :client, :direct, :shares, :last_share, :versions, :msf_session
+  attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
 
   attr_reader :address, :port
 
   # Pass the socket object and a boolean indicating whether the socket is netbios or cifs
-  def initialize(socket, direct = false, versions = DEFAULT_VERSIONS, always_encrypt: true, backend: nil, client: nil, msf_session: nil)
-    self.msf_session = msf_session
-    session_lifetime do
-      self.socket = socket
-      self.direct = direct
-      self.versions = versions
-      self.shares = {}
-      self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
+  def initialize(socket, direct = false, versions = DEFAULT_VERSIONS, always_encrypt: true, backend: nil, client: nil)
+    self.socket = socket
+    self.direct = direct
+    self.versions = versions
+    self.shares = {}
+    self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
 
-      if !client.nil?
-        self.client = client
-      elsif (self.versions == [1] && backend.nil?) || backend == :rex
-        self.client = Rex::Proto::SMB::Client.new(socket)
-      elsif (backend.nil? || backend == :ruby_smb)
-        self.client = RubySMB::Client.new(RubySMB::Dispatcher::Socket.new(self.socket, read_timeout: 60),
-                                          username: '',
-                                          password: '',
-                                          smb1: self.versions.include?(1),
-                                          smb2: self.versions.include?(2),
-                                          smb3: self.versions.include?(3),
-                                          always_encrypt: always_encrypt
-                      )
+    if !client.nil?
+      self.client = client
+    elsif (self.versions == [1] && backend.nil?) || backend == :rex
+      self.client = Rex::Proto::SMB::Client.new(socket)
+    elsif (backend.nil? || backend == :ruby_smb)
+      self.client = RubySMB::Client.new(RubySMB::Dispatcher::Socket.new(self.socket, read_timeout: 60),
+                                        username: '',
+                                        password: '',
+                                        smb1: self.versions.include?(1),
+                                        smb2: self.versions.include?(2),
+                                        smb3: self.versions.include?(3),
+                                        always_encrypt: always_encrypt
+                    )
 
-        self.client.evasion_opts = {
-          # Padding is performed between packet headers and data
-          'pad_data' => EVADE::EVASION_NONE,
-          # File path padding is performed on all open/create calls
-          'pad_file' => EVADE::EVASION_NONE,
-          # Modify the \PIPE\ string in trans_named_pipe calls
-          'obscure_trans_pipe' => EVADE::EVASION_NONE,
-        }
-      end
-      @address, @port = self.socket.peerinfo.split(':')
+      self.client.evasion_opts = {
+        # Padding is performed between packet headers and data
+        'pad_data' => EVADE::EVASION_NONE,
+        # File path padding is performed on all open/create calls
+        'pad_file' => EVADE::EVASION_NONE,
+        # Modify the \PIPE\ string in trans_named_pipe calls
+        'obscure_trans_pipe' => EVADE::EVASION_NONE,
+      }
     end
+    @address, @port = self.socket.peerinfo.split(':')
   end
 
   def login(name = '', user = '', pass = '', domain = '',
@@ -68,212 +65,194 @@ class SimpleClient
       send_lm = true, use_lanman_key = false, send_ntlm = true,
       native_os = 'Windows 2000 2195', native_lm = 'Windows 2000 5.0', spnopt = {})
 
-    session_lifetime do
-      begin
-  
-        if (self.direct != true)
-          self.client.session_request(name)
-        end
-        self.client.native_os = native_os
-        self.client.native_lm = native_lm
-        self.client.verify_signature = verify_signature
-        self.client.use_ntlmv2 = usentlmv2
-        self.client.usentlm2_session = usentlm2_session
-        self.client.send_lm = send_lm
-        self.client.use_lanman_key =  use_lanman_key
-        self.client.send_ntlm = send_ntlm
-  
-        dlog("SMB version(s) to negotiate: #{self.versions}")
-        ok = self.client.negotiate
-        dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
-  
-        if self.client.is_a?(RubySMB::Client)
-          self.server_max_buffer_size = self.client.server_max_buffer_size
-        else
-          self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
-        end
-  
-        # Disable NTLMv2 Session for Windows 2000 (breaks authentication on some systems)
-        # XXX: This in turn breaks SMB auth for Windows 2000 configured to enforce NTLMv2
-        # XXX: Tracked by ticket #4785#4785
-        if self.client.native_lm =~ /Windows 2000 5\.0/ and usentlm2_session
-        #	self.client.usentlm2_session = false
-        end
-  
-        self.client.spnopt = spnopt
-  
-        # In case the user unsets the username or password option, we make sure this is
-        # always a string
-        user ||= ''
-        pass ||= ''
-  
-        res = self.client.session_setup(user, pass, domain)
-      rescue ::Interrupt
-        raise $!
-      rescue ::Exception => e
-        elog(e)
-        n = XCEPT::LoginError.new
-        n.source = e
-        if e.respond_to?('error_code') && e.respond_to?('get_error')
-          n.error_code   = e.error_code
-          n.error_reason = e.get_error(e.error_code)
-        end
-        raise n
+    begin
+
+      if (self.direct != true)
+        self.client.session_request(name)
       end
-  
-      # RubySMB does not raise any exception if the Session Setup fails
-      if self.client.is_a?(RubySMB::Client) && res != WindowsError::NTStatus::STATUS_SUCCESS
-        n = XCEPT::LoginError.new
-        n.source       = res
-        n.error_code   = res.value
-        n.error_reason = res.name
-        raise n
+      self.client.native_os = native_os
+      self.client.native_lm = native_lm
+      self.client.verify_signature = verify_signature
+      self.client.use_ntlmv2 = usentlmv2
+      self.client.usentlm2_session = usentlm2_session
+      self.client.send_lm = send_lm
+      self.client.use_lanman_key =  use_lanman_key
+      self.client.send_ntlm = send_ntlm
+
+      dlog("SMB version(s) to negotiate: #{self.versions}")
+      ok = self.client.negotiate
+      dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
+
+      if self.client.is_a?(RubySMB::Client)
+        self.server_max_buffer_size = self.client.server_max_buffer_size
+      else
+        self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
       end
-  
-      return true
+
+      # Disable NTLMv2 Session for Windows 2000 (breaks authentication on some systems)
+      # XXX: This in turn breaks SMB auth for Windows 2000 configured to enforce NTLMv2
+      # XXX: Tracked by ticket #4785#4785
+      if self.client.native_lm =~ /Windows 2000 5\.0/ and usentlm2_session
+      #	self.client.usentlm2_session = false
+      end
+
+      self.client.spnopt = spnopt
+
+      # In case the user unsets the username or password option, we make sure this is
+      # always a string
+      user ||= ''
+      pass ||= ''
+
+      res = self.client.session_setup(user, pass, domain)
+    rescue ::Interrupt
+      raise $!
+    rescue ::Exception => e
+      elog(e)
+      n = XCEPT::LoginError.new
+      n.source = e
+      if e.respond_to?('error_code') && e.respond_to?('get_error')
+        n.error_code   = e.error_code
+        n.error_reason = e.get_error(e.error_code)
+      end
+      raise n
     end
+
+    # RubySMB does not raise any exception if the Session Setup fails
+    if self.client.is_a?(RubySMB::Client) && res != WindowsError::NTStatus::STATUS_SUCCESS
+      n = XCEPT::LoginError.new
+      n.source       = res
+      n.error_code   = res.value
+      n.error_reason = res.name
+      raise n
+    end
+
+    return true
   end
 
 
   def login_split_start_ntlm1(name = '')
 
-    session_lifetime do
-      begin
+    begin
 
-        if (self.direct != true)
-          self.client.session_request(name)
-        end
-
-        # Disable extended security
-        self.client.negotiate(false)
-      rescue ::Interrupt
-        raise $!
-      rescue ::Exception => e
-        n = XCEPT::LoginError.new
-        n.source = e
-        if(e.respond_to?('error_code'))
-          n.error_code   = e.error_code
-          n.error_reason = e.get_error(e.error_code)
-        end
-        raise n
+      if (self.direct != true)
+        self.client.session_request(name)
       end
 
-      return true
+      # Disable extended security
+      self.client.negotiate(false)
+    rescue ::Interrupt
+      raise $!
+    rescue ::Exception => e
+      n = XCEPT::LoginError.new
+      n.source = e
+      if(e.respond_to?('error_code'))
+        n.error_code   = e.error_code
+        n.error_reason = e.get_error(e.error_code)
+      end
+      raise n
     end
+
+    return true
   end
 
 
   def login_split_next_ntlm1(user, domain, hash_lm, hash_nt)
-    session_lifetime do
-      begin
-        ok = self.client.session_setup_no_ntlmssp_prehash(user, domain, hash_lm, hash_nt)
-      rescue ::Interrupt
-        raise $!
-      rescue ::Exception => e
-        n = XCEPT::LoginError.new
-        n.source = e
-        if(e.respond_to?('error_code'))
-          n.error_code   = e.error_code
-          n.error_reason = e.get_error(e.error_code)
-        end
-        raise n
+    begin
+      ok = self.client.session_setup_no_ntlmssp_prehash(user, domain, hash_lm, hash_nt)
+    rescue ::Interrupt
+      raise $!
+    rescue ::Exception => e
+      n = XCEPT::LoginError.new
+      n.source = e
+      if(e.respond_to?('error_code'))
+        n.error_code   = e.error_code
+        n.error_reason = e.get_error(e.error_code)
       end
-
-      return true
+      raise n
     end
+
+    return true
   end
 
   def connect(share)
-    session_lifetime do
-      ok = self.client.tree_connect(share)
+    ok = self.client.tree_connect(share)
 
-      if self.client.is_a?(RubySMB::Client)
-        tree_id = ok.id
-      else
-        tree_id = ok['Payload']['SMB'].v['TreeID']
-      end
-
-      self.shares[share] = tree_id
-      self.last_share = share
+    if self.client.is_a?(RubySMB::Client)
+      tree_id = ok.id
+    else
+      tree_id = ok['Payload']['SMB'].v['TreeID']
     end
+
+    self.shares[share] = tree_id
+    self.last_share = share
   end
 
   def disconnect(share)
-    session_lifetime do
-      if self.shares[share]
-        ok = self.client.tree_disconnect(self.shares[share])
-        self.shares.delete(share)
-        return ok
-      end
-      false
+    if self.shares[share]
+      ok = self.client.tree_disconnect(self.shares[share])
+      self.shares.delete(share)
+      return ok
     end
+    false
   end
 
   def open(path, perm, chunk_size = 48000, read: true, write: false)
-    session_lifetime do
-      if self.client.is_a?(RubySMB::Client)
-        mode = 0
-        if perm.include?('c')
-          if perm.include?('o')
-            mode = RubySMB::Dispositions::FILE_OPEN_IF
-          elsif perm.include?('t')
-            mode = RubySMB::Dispositions::FILE_OVERWRITE_IF
-          else
-            mode = RubySMB::Dispositions::FILE_CREATE
-          end
+    if self.client.is_a?(RubySMB::Client)
+      mode = 0
+      if perm.include?('c')
+        if perm.include?('o')
+          mode = RubySMB::Dispositions::FILE_OPEN_IF
+        elsif perm.include?('t')
+          mode = RubySMB::Dispositions::FILE_OVERWRITE_IF
         else
-          if perm.include?('o')
-            mode = RubySMB::Dispositions::FILE_OPEN
-          elsif perm.include?('t')
-            mode = RubySMB::Dispositions::FILE_OVERWRITE
-          end
+          mode = RubySMB::Dispositions::FILE_CREATE
         end
-
-        file_id = self.client.open(path, mode, read: true, write: write || perm.include?('w'))
-
       else
-        mode = UTILS.open_mode_to_mode(perm)
-        access = UTILS.open_mode_to_access(perm)
-
-        ok = self.client.open(path, mode, access)
-        file_id = ok['Payload'].v['FileID']
+        if perm.include?('o')
+          mode = RubySMB::Dispositions::FILE_OPEN
+        elsif perm.include?('t')
+          mode = RubySMB::Dispositions::FILE_OVERWRITE
+        end
       end
 
-      fh = OpenFile.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
-      fh.chunk_size = chunk_size
-      fh
+      file_id = self.client.open(path, mode, read: true, write: write || perm.include?('w'))
+
+    else
+      mode = UTILS.open_mode_to_mode(perm)
+      access = UTILS.open_mode_to_access(perm)
+
+      ok = self.client.open(path, mode, access)
+      file_id = ok['Payload'].v['FileID']
     end
+
+    fh = OpenFile.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
+    fh.chunk_size = chunk_size
+    fh
   end
 
   def delete(*args)
-    session_lifetime do
-      if self.client.is_a?(RubySMB::Client)
-        self.client.delete(args[0])
-      else
-        self.client.delete(*args)
-      end
+    if self.client.is_a?(RubySMB::Client)
+      self.client.delete(args[0])
+    else
+      self.client.delete(*args)
     end
   end
 
   def create_pipe(path, perm = 'o')
-    session_lifetime do
-      disposition = UTILS.create_mode_to_disposition(perm)
-      ok = self.client.create_pipe(path, disposition)
+    disposition = UTILS.create_mode_to_disposition(perm)
+    ok = self.client.create_pipe(path, disposition)
 
-      if self.client.is_a?(RubySMB::Client)
-        file_id = ok
-      else
-        file_id = ok['Payload'].v['FileID']
-      end
-
-      fh = OpenPipe.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
+    if self.client.is_a?(RubySMB::Client)
+      file_id = ok
+    else
+      file_id = ok['Payload'].v['FileID']
     end
+
+    fh = OpenPipe.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
   end
 
   def trans_pipe(fid, data, no_response = nil)
-    session_lifetime do
-      client.trans_named_pipe(fid, data, no_response)
-  end
+    client.trans_named_pipe(fid, data, no_response)
   end
 
   def negotiated_smb_version
@@ -294,15 +273,6 @@ class SimpleClient
   private
 
   attr_writer :address, :port
-
-  def session_lifetime
-    yield
-  rescue RubySMB::Error::CommunicationError, ::Rex::ConnectionError, Errno::ENOTCONN, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-    if msf_session
-      msf_session.kill
-    end
-    raise
-  end
 end
 end
 end

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -75,7 +75,8 @@ class MetasploitModule < Msf::Auxiliary
     opts = {}
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       opts[:tree] = simple.client.tree_connect("\\\\#{client.dispatcher.tcp_socket.peerhost}\\IPC$")
     end
 

--- a/modules/auxiliary/admin/dcerpc/samr_account.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_account.rb
@@ -109,8 +109,9 @@ class MetasploitModule < Msf::Auxiliary
     opts = {}
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
-      opts[:tree] = simple.client.tree_connect("\\\\#{session.client.dispatcher.tcp_socket.peerhost}\\IPC$")
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+      opts[:tree] = simple.client.tree_connect("\\\\#{client.dispatcher.tcp_socket.peerhost}\\IPC$")
     end
 
     yield opts

--- a/modules/auxiliary/admin/registry_security_descriptor.rb
+++ b/modules/auxiliary/admin/registry_security_descriptor.rb
@@ -71,7 +71,8 @@ class MetasploitModule < Msf::Auxiliary
   def do_connect
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       simple.connect("\\\\#{simple.address}\\IPC$")
     else
       connect

--- a/modules/auxiliary/admin/smb/change_password.rb
+++ b/modules/auxiliary/admin/smb/change_password.rb
@@ -93,7 +93,8 @@ class MetasploitModule < Msf::Auxiliary
   def authenticate(anonymous_on_expired: false)
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
     else
       connect

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -42,7 +42,8 @@ class MetasploitModule < Msf::Auxiliary
   def smb_delete_files
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
     else
       vprint_status("Connecting to the server...")
       connect()

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -38,7 +38,8 @@ class MetasploitModule < Msf::Auxiliary
     if session
 
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
     else
       connect
       smb_login()

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -57,7 +57,8 @@ class MetasploitModule < Msf::Auxiliary
     # Try and connect
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       @ip = simple.address
     else
       return unless connect

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -44,7 +44,9 @@ class MetasploitModule < Msf::Auxiliary
     begin
       if session
         print_status("Using existing session #{session.sid}")
-        self.simple = session.simple_client
+        client = session.client
+        self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+
       else
         vprint_status("Connecting to the server...")
         connect

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -1113,7 +1113,8 @@ class MetasploitModule < Msf::Auxiliary
 
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
     else
       connect

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -40,8 +40,9 @@ class MetasploitModule < Msf::Auxiliary
 
     if session
       print_status("Using existing session #{session.sid}")
+      client = session.client
       @rport = datastore['RPORT'] = session.port
-      self.simple = session.simple_client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       self.simple.connect("\\\\#{session.address}\\IPC$")
       report_pipes(ip, check_pipes)
     else

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -260,8 +260,9 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     if session
       print_status("Using existing session #{session.sid}")
+      client = session.client
       @rport = datastore['RPORT'] = session.port
-      self.simple = session.simple_client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       simple.connect("\\\\#{simple.address}\\IPC$") # smb_login connects to this share for some reason and it doesn't work unless we do too
       check_uuids(ip)
     else

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -167,8 +167,8 @@ class MetasploitModule < Msf::Auxiliary
     begin
       if session
         print_status("Using existing session #{session.sid}")
-        self.simple = session.simple_client
-        session.verify_connectivity
+        client = session.client
+        self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       else
         connect
         smb_login

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -289,8 +289,8 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     if session
       print_status("Using existing session #{session.sid}")
-      session.verify_connectivity
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
       enum_shares(session.address)
     else
       [{ port: SMB1_PORT }, { port: SMB2_3_PORT } ].each do |info|

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -198,7 +198,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_simple_smb_client!
     if session
       print_status("Using existing session #{session.sid}")
-      self.simple = session.simple_client
+      client = session.client
+      self.simple = ::Rex::Proto::SMB::SimpleClient.new(client.dispatcher.tcp_socket, client: client)
+
     else
       print_status('Connecting to the server...')
       connect


### PR DESCRIPTION
Reverting as new commit causes tests to fail: 
```
Randomized with seed 41512
2024-12-23 11:42:56 +0000 Thin web server (v1.8.2 codename Ruby Razor)
2024-12-23 11:42:56 +0000 Maximum connections set to 1024
2024-12-23 11:42:56 +0000 Listening on 0.0.0.0:8080, CTRL+C to stop
[2024-12-23 11:47:54 +0000] Failed, 1 failure
/opt/hostedtoolcache/Ruby/3.1.6/x64/bin/ruby -I/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib:/home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-support-3.13.1/lib /home/runner/work/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/exe/rspec --pattern deliberately-left-blank ./spec/lib/msf/core/windows_version_spec.rb:44 --require rspec-rerun/formatter --format RSpec::Rerun::Formatter --color --format Fivemat --require spec_helper
Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
Run options:
  include {:locations=>{"./spec/lib/msf/core/windows_version_spec.rb"=>[44]}}
  exclude {:acceptance=>true, :content=>true}

Randomized with seed 40561
Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
[!] SSL Disabled
Started process with pid 5540
Msf::WindowsVersion F

  1) Msf::WindowsVersion Reports correct SMB version for single match
     Failure/Error: expect(version_string).to eq('Windows XP')

       expected: #<Encoding:UTF-8> "Windows XP"
            got: #<Encoding:ASCII-8BIT> "Windows XP Service Pack 3"

       (compared using ==)
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-support-3.13.1/lib/rspec/support.rb:110:in `block in <module:Support>'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-support-3.13.1/lib/rspec/support.rb:119:in `notify_failure'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/fail_with.rb:35:in `fail_with'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:37:in `handle_failure'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:55:in `block in handle_matcher'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:26:in `with_matcher'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/handler.rb:47:in `handle_matcher'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/expectation_target.rb:65:in `to'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-expectations-3.13.3/lib/rspec/expectations/expectation_target.rb:101:in `to'
     # ./spec/lib/msf/core/windows_version_spec.rb:49:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:263:in `instance_exec'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:263:in `block in run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:486:in `block in run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:352:in `call'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-rails-7.0.1/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:457:in `instance_exec'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:457:in `instance_exec'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:390:in `execute_with'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:352:in `call'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/hooks.rb:486:in `run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example.rb:259:in `run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:646:in `block in run_examples'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:642:in `map'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:642:in `run_examples'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/example_group.rb:607:in `run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:121:in `map'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/reporter.rb:74:in `report'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:115:in `run_specs'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:89:in `run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:71:in `run'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/lib/rspec/core/runner.rb:45:in `invoke'
     # ./vendor/bundle/ruby/3.1.0/gems/rspec-core-3.13.2/exe/rspec:4:in `<main>'

Top 1 slowest examples (0.01183 seconds, 0.4% of total time):
  Msf::WindowsVersion Reports correct SMB version for single match
    0.01183 seconds ./spec/lib/msf/core/windows_version_spec.rb:44

Finished in 3.06 seconds (files took 4.12 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/msf/core/windows_version_spec.rb:44 # Msf::WindowsVersion Reports correct SMB version for single match
```