### PR TITLE
Fix flaky windows version detection

### DIFF
--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -292,8 +292,10 @@ module Msf
 
     # Get a Windows OS version string representation for a given major, minor and build number
     def self.version_string(major, minor, build, version_module, mapping)
-      version_module.constants.each do |version_sym|
-        version = version_module.const_get(version_sym)
+      sorted_versions = version_module.constants
+                                      .map { |version_sym| [version_sym, version_module.const_get(version_sym)] }
+                                      .sort_by { |_version_sym, version| version.segments }
+      sorted_versions.each do |version_sym, version|
         segments = version.segments
         if segments[0..2] == [major, minor, build]
           return mapping[version_sym]


### PR DESCRIPTION
Alternative to https://github.com/rapid7/metasploit-framework/pull/19761

Fix non-deterministic windows version detection

### Before

Tests fail due to non-deterministic ordering of constants

Spotted test failure on CI:

```
  1) Msf::WindowsVersion Reports correct SMB version for single match
     Failure/Error: expect(version_string).to eq('Windows XP')

       expected: #<Encoding:UTF-8> "Windows XP"
            got: #<Encoding:ASCII-8BIT> "Windows XP Service Pack 2"

       (compared using ==)
     # ./spec/lib/msf/core/windows_version_spec.rb:51:in `block (2 levels) in <top (required)>'
```

### After

Tests pass

### Debugging

Adding extra logging to log out the enumerated version constants:

```diff
diff --git a/lib/msf/core/windows_version.rb b/lib/msf/core/windows_version.rb
index eb52faee0c..ae387cc360 100644
--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -292,6 +292,7 @@ module Msf
 
     # Get a Windows OS version string representation for a given major, minor and build number
     def self.version_string(major, minor, build, version_module, mapping)
+      puts version_module.constants.inspect
       sorted_versions = version_module.constants
                                       .map { |version_sym| [version_sym, version_module.const_get(version_sym)] }
                                       .sort_by { |_version_sym, version| version.segments }

```

Local logging:

```
[:Win10_1507, :Win10_1511, :Win10_1607, :Win10_1703, :Win10_1709, :Win10_1803, :Win10_1809, :Win10_1903, :Win10_1909, :Win10_2004, :Win10_20H2, :Win10_21H1, :Win10_21H2, :Win10_22H2, :Win11_21H2, :Win11_22H2, :Win11_23H2, :Win11_24H2, :Win2000, :XP_SP0, :XP_SP1, :XP_SP2, :XP_SP3, :Vista_SP0, :Vista_SP1, :Vista_SP2, :Win7_SP0, :Win7_SP1, :Win8, :Win81]
```

Ruby 3.1's test failure related to different ordering of constants:

```
[:Win10_1809, :XP_SP2, :Win10_1903, :Win10_1909, :Win10_2004, :Win10_20H2, :Win2000, :Win10_21H2, :Win10_21H1, :Win10_22H2, :Win11_21H2, :Vista_SP0, :Win11_23H2, :Win11_24H2, :Win11_22H2, :XP_SP0, :XP_SP1, :XP_SP3, :Vista_SP1, :Vista_SP2, :Win7_SP0, :Win7_SP1, :Win8, :Win81, :Win10_1507, :Win10_1511, :Win10_1607, :Win10_1703, :Win10_1709, :Win10_1803]
```

Solution: Sort the versions by their segments

## Verification

Ensure CI passes