### PR TITLE
Ensure module details are marked as ready

### DIFF
--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -408,12 +408,15 @@ module Msf::DBManager::ModuleCache
       end
     end
 
-    # 3) Insert all of the associations
+    # 3) Insert the child associations
     associations.each do |association_clazz, entries|
       next if entries.empty?
 
       association_clazz.insert_all!(entries)
     end
+
+    # 4) Mark the parent models as ready - to avoid repopulating the cache again
+    Mdm::Module::Detail.where(id: module_detail_ids).update_all(ready: true)
 
     nil
   end


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/19546

Ensure module details are marked as ready, so that module details aren't repopulated on each boot

Conditional check for cache invalidation:

https://github.com/rapid7/metasploit-framework/blob/22c16975b6a2eb19801ce5a8a5ef92cc71d5e3f2/lib/msf/core/db_manager/module_cache.rb#L273-L277

Old update logic that was lost in https://github.com/rapid7/metasploit-framework/pull/19546

https://github.com/rapid7/metasploit-framework/blob/22c16975b6a2eb19801ce5a8a5ef92cc71d5e3f2/lib/msf/core/db_manager/module_cache.rb#L358-L359

## Verification
- Verify CI passes