### PR TITLE
Add additional library dependencies for Ruby 3.4 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ PATH
       base64
       bcrypt
       bcrypt_pbkdf
+      benchmark
       bigdecimal
       bootsnap
       bson
@@ -31,6 +32,7 @@ PATH
       faraday-retry
       faye-websocket
       ffi (< 1.17.0)
+      fiddle
       filesize
       getoptlong
       hrr_rb_ssh-ed25519
@@ -60,6 +62,7 @@ PATH
       octokit (~> 4.0)
       openssl-ccm
       openvas-omp
+      ostruct
       packetfu
       patch_finder
       pcaprub
@@ -186,6 +189,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
     bindata (2.4.15)
     bootsnap (1.18.4)
@@ -242,6 +246,7 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.16.3)
+    fiddle (1.1.6)
     filesize (0.2.0)
     fivemat (1.3.7)
     getoptlong (0.2.1)
@@ -351,6 +356,7 @@ GEM
     openssl-ccm (1.2.3)
     openssl-cmac (2.0.2)
     openvas-omp (0.0.4)
+    ostruct (0.6.1)
     packetfu (2.0.0)
       pcaprub (~> 0.13.1)
     parallel (1.26.3)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -258,11 +258,14 @@ Gem::Specification.new do |spec|
   %w[
     abbrev
     base64
+    benchmark
     bigdecimal
     csv
     drb
+    fiddle
     getoptlong
     mutex_m
+    ostruct
   ].each do |library|
     spec.add_runtime_dependency library
   end


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/19767

Add additional library dependencies for Ruby 3.4 support

Fixes the following warnings:

```
$ ./msfconsole -q                                                                                                                                                        ‹ruby-3.4.0@metasploit-framework›
/Users/dwelch/dev/metasploit-framework/config/application.rb:1: warning: /Users/dwelch/.rvm/rubies/ruby-3.4.0/lib/ruby/3.4.0+1/fiddle.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to silence this warning.
/Users/dwelch/.rvm/gems/ruby-3.4.0@metasploit-framework/gems/activesupport-7.0.8.6/lib/active_support/core_ext/benchmark.rb:3: warning: /Users/dwelch/.rvm/rubies/ruby-3.4.0/lib/ruby/3.4.0+1/benchmark.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
/Users/dwelch/.rvm/gems/ruby-3.4.0@metasploit-framework/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: /Users/dwelch/.rvm/rubies/ruby-3.4.0/lib/ruby/3.4.0+1/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of pry-0.14.2 to request adding ostruct into its gemspec.
```

## Verification

- Ensure CI passes
- Ensure there are no warnings when opening msfconsole with Ruby 3.4:
```
$ bundle exec ./msfconsole -q                                              
msf6 auxiliary(scanner/http/title) > 
```