### PR TITLE
Add docs for Stance and Passive metadata

### DIFF
--- a/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
+++ b/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
@@ -112,6 +112,11 @@ end
     * **Reliability** - The Reliability field describes how reliable the session is that gets returned by the exploit, ex: `REPEATABLE_SESSION`, `UNRELIABLE_SESSION`
     * **SideEffects** - The SideEffects field describes the side effects cause by the exploit that the user should be aware of, ex: `ARTIFACTS_ON_DISK`, `IOC_IN_LOGS`, `ACCOUNT_LOCKOUTS`.
 
+### Non-required fields
+
+* **Stance** - The types of stances an exploit can take, such as passive or aggressive. Stances indicate whether or not the exploit triggers the exploit without waiting for one or more conditions to be met (aggressive) or whether it must wait for certain conditions to be satisfied before the exploit can be initiated (passive). Passive exploits usually would wait for interaction from a client or other entity for being able to trigger the vulnerability.
+
+* **Passive** - Either `true` or `false` indicates whether or not the exploit should be run as a background job. If for example you know the vulnerability takes an hour to trigger, setting `Passive` to `true` would be beneficial as it allows the user to continue using msfconsole while waiting for a response from the exploit.
 
 Your exploit should also have a `check` method to support the check command, but this is optional in case it's not possible.
 

--- a/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
+++ b/docs/metasploit-framework.wiki/Get-Started-Writing-an-Exploit.md
@@ -114,7 +114,7 @@ end
 
 ### Non-required fields
 
-* **Stance** - The types of stances an exploit can take, such as passive or aggressive. Stances indicate whether or not the exploit triggers the exploit without waiting for one or more conditions to be met (aggressive) or whether it must wait for certain conditions to be satisfied before the exploit can be initiated (passive). Passive exploits usually would wait for interaction from a client or other entity for being able to trigger the vulnerability.
+* **Stance** - The types of stances an exploit can take, such as passive or aggressive. Stances indicate whether or not the module triggers the exploit without waiting for one or more conditions to be met (aggressive) or whether it must wait for certain conditions to be satisfied before the exploit can be initiated (passive). Passive exploits usually would wait for interaction from a client or other entity for being able to trigger the vulnerability.
 
 * **Passive** - Either `true` or `false` indicates whether or not the exploit should be run as a background job. If for example you know the vulnerability takes an hour to trigger, setting `Passive` to `true` would be beneficial as it allows the user to continue using msfconsole while waiting for a response from the exploit.
 


### PR DESCRIPTION
This outlines the `Stance` and `Passive` metadata fields. 

## Verification
- [x] Ensure documentation is sane and english is good
- [x] Build documentation locally and ensure everything renders as expected ([docs](https://github.com/rapid7/metasploit-framework/blob/852bb8bfe29ddced7432e58557982d9fb83898d2/docs/README.md) to build docs site locally)