### PR TITLE
add passive flag to obsidian plugin module

### DIFF
--- a/modules/exploits/multi/local/obsidian_plugin_persistence.rb
+++ b/modules/exploits/multi/local/obsidian_plugin_persistence.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
           'BadChars' => '"'
         },
         'Stance' => Msf::Exploit::Stance::Passive,
+        'Passive' => true,
         'Targets' => [
           ['Auto', {} ],
           ['Linux', { 'Platform' => 'unix' } ],


### PR DESCRIPTION
Add passive flag to the recent obsidian plugin module since its used for persistence, thus it should be in the background.

https://github.com/rapid7/metasploit-framework/pull/19676#discussion_r1907594308