### PR TITLE
Carry on if the record can't be cached

### DIFF
--- a/lib/rex/proto/dns/cached_resolver.rb
+++ b/lib/rex/proto/dns/cached_resolver.rb
@@ -62,7 +62,11 @@ module DNS
         resolved = super(resolve, type)
         req.instance_variable_set(:@answer, (req.answer + resolved.answer).uniq)
         resolved.answer.each do |ans|
-          self.cache.cache_record(ans) rescue nil
+          begin
+            self.cache.cache_record(ans)
+          rescue StandardError => e
+            elog('Failed to cache the DNS answer', error: e)
+          end
         end
       end
       # Finalize answers in response

--- a/lib/rex/proto/dns/cached_resolver.rb
+++ b/lib/rex/proto/dns/cached_resolver.rb
@@ -62,7 +62,7 @@ module DNS
         resolved = super(resolve, type)
         req.instance_variable_set(:@answer, (req.answer + resolved.answer).uniq)
         resolved.answer.each do |ans|
-          self.cache.cache_record(ans)
+          self.cache.cache_record(ans) rescue nil
         end
       end
       # Finalize answers in response


### PR DESCRIPTION
This fixes an exception when a custom DNS resolver is used that was preventing SRV records from resolving correctly. Only some records can be cached by DNS, and if a record that isn't compatible is added to the cache, an exception is raised. The caller should ignore the exception if they have the answer they require and just continue with it.

https://github.com/rapid7/metasploit-framework/blob/8344c2c624791406d79b0d42a4f87badbb15aa4b/lib/rex/proto/dns/cache.rb#L48

This came up while using the functionality added in #18446 that uses DNS to lookup SRV records. SRV records can't be cached and the exception was preventing the data from being returned at all.

## Testing Steps
- [ ] Setup a custom DNS server, this should be the default with Metasploit now but double check with `dns`
- [ ] Run through the steps outlined in #18446 and see that the KDC can be automatically found with DNS instead of failing to resolve even though the DNS queries are made just fine as can be confirmed by wireshark