### PR TITLE
Fix icpr_cert to error when ESC15 is patched

### DIFF
--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -198,7 +198,7 @@ module Exploit::Remote::MsIcpr
 
     policy_oids = get_cert_policy_oids(response[:certificate])
     if application_policies.present? && !(application_policies - policy_oids.map(&:value)).empty?
-      print_error('Certificate application policy OIDs were submitted, but some are missing in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019).')
+      print_error('Certificate application policy OIDs were submitted, but some are missing in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019) or the template is not vulnerable.')
       return
     end
 

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -6,6 +6,7 @@
 # -*- coding: binary -*-
 
 require 'windows_error'
+require 'windows_error/h_result'
 require 'rex/proto/x509/request'
 
 module Msf
@@ -195,6 +196,18 @@ module Exploit::Remote::MsIcpr
 
     return unless response[:certificate]
 
+    if (policy_oids = get_cert_policy_oids(response[:certificate])).empty?
+      if application_policies.present?
+        print_error('Certificate application policy OIDs were submitted, but none were found in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019)')
+        return
+      end
+    else
+      print_status('Certificate Policies:')
+      policy_oids.each do |oid|
+        print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))
+      end
+    end
+
     unless (dns = get_cert_san_dns(response[:certificate])).empty?
       print_status("Certificate DNS: #{dns.join(', ')}")
     end
@@ -209,13 +222,6 @@ module Exploit::Remote::MsIcpr
 
     unless (upn = get_cert_msext_upn(response[:certificate])).empty?
       print_status("Certificate UPN: #{upn.join(', ')}")
-    end
-
-    unless (policy_oids = get_cert_policy_oids(response[:certificate])).empty?
-      print_status("Certificate Policies:")
-      policy_oids.each do |oid|
-        print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))
-      end
     end
 
     pkcs12 = OpenSSL::PKCS12.create('', '', private_key, response[:certificate])

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -196,12 +196,13 @@ module Exploit::Remote::MsIcpr
 
     return unless response[:certificate]
 
-    if (policy_oids = get_cert_policy_oids(response[:certificate])).empty?
-      if application_policies.present?
-        print_error('Certificate application policy OIDs were submitted, but none were found in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019)')
-        return
-      end
-    else
+    policy_oids = get_cert_policy_oids(response[:certificate])
+    if application_policies.present? && !(application_policies - policy_oids.map(&:value)).empty?
+      print_error('Certificate application policy OIDs were submitted, but some are missing in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019).')
+      return
+    end
+
+    if policy_oids
       print_status('Certificate Policies:')
       policy_oids.each do |oid|
         print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))


### PR DESCRIPTION
Prior to this fix, when using this module against a server patched for ESC15, with the `ADD_CERT_APP_POLICY` datastore option set, the module would appear to run successfully. However, no certificate application policy OIDs would be found in the response. This indicates that the target has received the patch for ESC15 (CVE-2024-49019). In this scenario, the module now raises an error and informs the user that the target is likely patched.

When testing with a user that did not have enrolment rights to the template specified a stack trace was being thrown due to an uninitialized constant `WindowsError::HResult`. To fix this `'windows_error/h_result'` was added.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use admin/dcerpc/icpr_cert`
- [ ] Set `ADD_CERT_APP_POLICY`, `ALT_SID`, `ALT_UPN`, `CA`, `RHOSTS`, `SMBDomain`, `SMBPass`, `SMBUser` 
- [ ] Run the module against a patched server and verify the module prints the error: `Certificate application policy OIDs were submitted, but none were found in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019)`
- [ ] Run the module against an unpatched server and verify the module receives a response containing the OIDs specified.

# Before
User with enrolment rights running against patched Server (no OIDs in response):
```
run ALT_SID=S-1-5-21-3907774564-2315225553-1676620424-500 ALT_UPN=Administrator@demo.lab CA=demo-DC1-CA RHOSTS=172.16.199.100 SMBDomain=demo.lab SMBPass=N0tpassword! SMBUser=Administrator
[*] Running module against 172.16.199.100
[*] 172.16.199.100:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 172.16.199.100:445 - Binding to \cert...
[+] 172.16.199.100:445 - Bound to \cert
[*] 172.16.199.100:445 - Requesting a certificate for user Administrator - alternate UPN: Administrator@demo.lab - digest algorithm: SHA256 - template: WebServer
[+] 172.16.199.100:445 - The requested certificate was issued.
[*] 172.16.199.100:445 - Certificate UPN: Administrator@demo.lab
[!] 172.16.199.100:445 - No active DB -- Credential data will not be saved!
[*] 172.16.199.100:445 - Certificate stored at: /Users/jheysel/.msf4/loot/20250113153626_default_172.16.199.100_windows.ad.cs_064466.pfx
[*] Auxiliary module execution completed
```

Low privilege user (user with no enrolment rights):
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run ALT_SID=S-1-5-21-2324486357-3075865580-3606784161-500 ALT_UPN=Administrator@kerberos.issue CA=kerberos-DC2-CA RHOSTS=172.16.199.200 SMBDomain=kerberos.issue SMBPass=N0tpassword! SMBUser=msfuser
[*] Running module against 172.16.199.200
[*] 172.16.199.200:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 172.16.199.200:445 - Binding to \cert...
[+] 172.16.199.200:445 - Bound to \cert
[*] 172.16.199.200:445 - Requesting a certificate for user msfuser - alternate UPN: Administrator@kerberos.issue - digest algorithm: SHA256 - template: WebServer
[-] 172.16.199.200:445 - There was an error while requesting the certificate.
[-] 172.16.199.200:445 - Denied by Policy Module
[-] 172.16.199.200:445 - Auxiliary failed: NameError uninitialized constant WindowsError::HResult
[-] 172.16.199.200:445 - Call stack:
[-] 172.16.199.200:445 -   /Users/jheysel/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:187:in `do_request_cert'
[-] 172.16.199.200:445 -   /Users/jheysel/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ms_icpr.rb:100:in `request_certificate'
[-] 172.16.199.200:445 -   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:68:in `block in action_request_cert'
[-] 172.16.199.200:445 -   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:82:in `with_ipc_tree'
[-] 172.16.199.200:445 -   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:67:in `action_request_cert'
[-] 172.16.199.200:445 -   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/admin/dcerpc/icpr_cert.rb:53:in `run'
```



# After 
User with enrolment rights running against patched Server (we now error):
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run ALT_SID=S-1-5-21-3907774564-2315225553-1676620424-500 ALT_UPN=Administrator@demo.lab CA=demo-DC1-CA RHOSTS=172.16.199.100 SMBDomain=demo.lab SMBPass=N0tpassword! SMBUser=Administrator
[*] Running module against 172.16.199.100
[*] 172.16.199.100:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 172.16.199.100:445 - Binding to \cert...
[+] 172.16.199.100:445 - Bound to \cert
[*] 172.16.199.100:445 - Requesting a certificate for user Administrator - alternate UPN: Administrator@demo.lab - digest algorithm: SHA256 - template: WebServer
[+] 172.16.199.100:445 - The requested certificate was issued.
[-] 172.16.199.100:445 - Certificate application policy OIDs were submitted, but none were found in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019)
[*] Auxiliary module execution completed
```

Low privilege user (user with no enrolment rights):
```
msf6 auxiliary(admin/dcerpc/icpr_cert) > run ALT_SID=S-1-5-21-2324486357-3075865580-3606784161-500 ALT_UPN=Administrator@kerberos.issue CA=kerberos-DC2-CA RHOSTS=172.16.199.200 SMBDomain=kerberos.issue SMBPass=Derpderp69! SMBUser=msfuser
[*] Running module against 172.16.199.200
[*] 172.16.199.200:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 172.16.199.200:445 - Binding to \cert...
[+] 172.16.199.200:445 - Bound to \cert
[*] 172.16.199.200:445 - Requesting a certificate for user msfuser - alternate UPN: Administrator@kerberos.issue - digest algorithm: SHA256 - template: WebServer
[-] 172.16.199.200:445 - There was an error while requesting the certificate.
[-] 172.16.199.200:445 - Denied by Policy Module
[-] 172.16.199.200:445 - Error details:
[-] 172.16.199.200:445 -   Source:  (0x0009) FACILITY_SECURITY: The source of the error code is the Security API layer.
[-] 172.16.199.200:445 -   HRESULT: (0x80094012) CERTSRV_E_TEMPLATE_DENIED: The permissions on the certificate template do not allow the current user to enroll for this type of certificate.