### PR TITLE
Add LDAP to the set of interactive session types

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -531,6 +531,7 @@ class RPC_Session < RPC_Base
     postgresql
     mysql
     smb
+    ldap
   ].freeze
 
   def _find_module(_mtype, mname)
@@ -545,7 +546,7 @@ class RPC_Session < RPC_Base
     error(500, "Unknown Session ID #{sid}") if session.nil?
 
     unless INTERACTIVE_SESSION_TYPES.include?(session.type)
-      error(500, "Use `interactive_read` and `interactive_write` for sessions of #{session.type} type")
+      error(500, "`interactive_read` and `interactive_write` not available for #{session.type} sessions")
     end
 
     session

--- a/lib/rex/post/ldap/ui/console/command_dispatcher/client.rb
+++ b/lib/rex/post/ldap/ui/console/command_dispatcher/client.rb
@@ -104,7 +104,12 @@ module Rex
           end
 
           def cmd_getuid
-            username = client.ldapwhoami
+            begin
+              username = client.ldapwhoami
+            rescue Net::LDAP::Error => e
+              print_error(e.message)
+              return
+            end
             username.delete_prefix!('u:')
             print_status("Server username: #{username}")
           end

--- a/lib/rex/proto/ldap/client.rb
+++ b/lib/rex/proto/ldap/client.rb
@@ -121,12 +121,16 @@ module Rex
         end
 
         # Monkeypatch upstream library to support the extended Whoami request. Delete
-        # this after https://github.com/ruby-ldap/ruby-net-ldap/pull/425 is landed.
+        # this after https://github.com/ruby-ldap/ruby-net-ldap/pull/425 is released.
         # This is not the only occurrence of a patch for this functionality.
         def ldapwhoami(args = {})
           instrument "ldapwhoami.net_ldap", args do |payload|
             @result = use_connection(args, &:ldapwhoami)
-            @result.success? ? @result.extended_response : nil
+            if @result.success?
+              @result.extended_response
+            else
+              raise Net::LDAP::Error, "#{peerinfo} LDAP Error: #{@result.error_message}"
+            end
           end
         end
       end


### PR DESCRIPTION
Adds LDAP to the set of interactive session types, it was already interactive just not marked as such

Also fixes an issue with `getuid` command when interacting with the LDAP session when the `whoami` command is not available

# Testing
- [ ] Get an LDAP session on a system without `whoami` capabilites (you can use the docker container https://github.com/rapid7/metasploit-framework/tree/master/test/ldap in with 
```
docker compose build
docker compose up --wait -d
```
- [ ] Interact with the session
- [ ] Run `getuid`