### PR TITLE
Fix loadmaster privesc check method and refs

### DIFF
--- a/modules/exploits/linux/local/progress_kemp_loadmaster_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_kemp_loadmaster_sudo_privesc_2024.rb
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Local
         'License' => MSF_LICENSE,
         'References' => [
           ['URL', 'https://rhinosecuritylabs.com/research/cve-2024-1212unauthenticated-command-injection-in-progress-kemp-loadmaster/'],
-          ['URL', 'https://kemptechnologies.com/kemp-load-balancers']
+          ['URL', 'https://kemptechnologies.com/kemp-load-balancers'],
+          ['CVE', '2024-1212']
         ],
         'DisclosureDate' => '2024-03-19',
         'Notes' => {

--- a/modules/exploits/linux/local/progress_kemp_loadmaster_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_kemp_loadmaster_sudo_privesc_2024.rb
@@ -84,13 +84,12 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     score = 0
-    score += 1 if read_file('/usr/wui/index.js').include?('KEMP')
-    score += 1 if read_file('/etc/motd').include?('Kemp LoadMaster')
-    score += 1 if exists?('/usr/wui/eula.kemp.html')
-    vprint_status("Found #{score} indicators this is a KEMP product")
-    return CheckCode::Detected if score > 0
+    score += 1 if file?('/usr/wui/index.js') && read_file('/usr/wui/index.js').include?('KEMP')
+    score += 1 if file?('/etc/motd') && read_file('/etc/motd').include?('Kemp LoadMaster')
+    score += 1 if file?('/usr/wui/eula.kemp.html')
+    return CheckCode::Detected("Found #{score} indicators this is a KEMP product") if score > 0
 
-    return CheckCode::Safe
+    CheckCode::Safe("Found #{score} indicators this is a KEMP product")
   end
 
   def verify_copy(src, dest, elevate)


### PR DESCRIPTION
`linux/local/progress_kemp_loadmaster_sudo_privesc_2024` has 2 issues when running on a non-loadmaster device:

1. CVE in URL isn't listed as CVE in references
2. check method crashes if the files don't exist.
3. While in there, also moved the prints into the returned check code

## Pre

```
[msf](Jobs:2 Agents:1) exploit(linux/local/progress_kemp_loadmaster_sudo_privesc_2024) > recheck
[*] Reloading module...
[-] Failed to open file: /usr/wui/index.js: core_channel_open: Operation failed: 1
[-] Exploit failed: NoMethodError undefined method `include?' for nil:NilClass
[-] Check failed: The state could not be determined.
```

## Post

```
[msf](Jobs:2 Agents:1) exploit(linux/local/progress_kemp_loadmaster_sudo_privesc_2024) > recheck
[*] Reloading module...
[*] The target is not exploitable. Found 0 indicators this is a KEMP product
```