### PR TITLE
Added additional validation for IP range format check

### DIFF
--- a/app/concerns/mdm/workspace/boundary_range.rb
+++ b/app/concerns/mdm/workspace/boundary_range.rb
@@ -54,6 +54,16 @@ module Mdm::Workspace::BoundaryRange
           unless valid_ip_or_range?(range)
             errors.add(:boundary, "must be a valid IP range")
           end
+
+          if range.include?('-') && range.match?(/\A(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*-\s*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\z/)
+            start_ip, end_ip = range.split('-').map(&:strip)
+            if start_ip.split('.')[0..2] == end_ip.split('.')[0..2]
+              last_octet_end = end_ip.split('.').last
+              errors.add(:boundary, "'#{range}' should be in the format '#{start_ip}-#{last_octet_end}'")
+            else
+              errors.add(:boundary, "'#{range}' start and end IPs must be in the same subnet")
+            end
+          end
         end
       end
     end

--- a/app/concerns/mdm/workspace/boundary_range.rb
+++ b/app/concerns/mdm/workspace/boundary_range.rb
@@ -55,7 +55,7 @@ module Mdm::Workspace::BoundaryRange
             errors.add(:boundary, "must be a valid IP range")
           end
 
-          if range.include?('-') && range.match?(/\A(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*-\s*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\z/)
+          if range.match?(/\A(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*-\s*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\z/)
             start_ip, end_ip = range.split('-').map(&:strip)
             if start_ip.split('.')[0..2] == end_ip.split('.')[0..2]
               last_octet_end = end_ip.split('.').last

--- a/spec/models/mdm/workspace_spec.rb
+++ b/spec/models/mdm/workspace_spec.rb
@@ -56,6 +56,36 @@ RSpec.describe Mdm::Workspace, type: :model do
             expect(workspace.errors[:boundary]).to include(error)
           end
         end
+
+        context 'with invalid IP or range format' do
+          let(:boundary) do
+            '192.168.0.1-192.168.0.2'
+          end
+
+          let(:start_ip) do
+            '192.168.0.1'
+          end
+
+          let(:last_octet_end) do
+            '2'
+          end
+
+          it 'should record error that boundary must be a valid IP range and in the correct format' do
+            expect(workspace).not_to be_valid
+            expect(workspace.errors[:boundary]).to include("'#{boundary}' should be in the format '#{start_ip}-#{last_octet_end}'")
+          end
+        end
+
+        context 'with IPs from different subnets' do
+          let(:boundary) do
+            '192.168.0.1-192.169.0.2'
+          end
+
+          it 'should record error that boundary must be a valid IP range and in the same subnet' do
+            expect(workspace).not_to be_valid
+            expect(workspace.errors[:boundary]).to include("'#{boundary}' start and end IPs must be in the same subnet")
+          end
+        end
       end
 
       context 'when the workspace is not network limited' do


### PR DESCRIPTION
This PR enhances the IP range validation logic in Quick PenTest module, by introducing dynamic error messages that provide clearer guidance to users.

## Verification
- Add multiple target addresses
  - At least one with the range that consists of two full ip addresses (eg. '192.168.0.1 - 192.168.0.2')
  - At least one with the range that consists of two full ip addresses from a different subnet (eg '192.168.0.1-192.169.0.1')
- After starting the scan user should see individual error messages

<img width="821" alt="Screenshot 2025-01-21 at 22 54 07" src="https://github.com/user-attachments/assets/b5ab062e-3394-4a16-8ef8-54d170b25a79" />

