### PR TITLE
Fix Exploit::Remote::HttpClient#connect_ws to be spec compliant

### DIFF
--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -236,7 +236,7 @@ module Exploit::Remote::HttpClient
   # @return [Rex::Proto::Http::WebSocket::Interface]
   def connect_ws(opts={}, timeout = 20)
     # As per the spec (RFC6455 Section 11.3.1), a Sec-WebSocket-Key is a 16 byte value that has been Base64 encoded.
-    ws_key = Rex::Text.encode_base64(Rex::Text.rand_text_alphanumeric(16))
+    ws_key = Rex::Text.encode_base64(SecureRandom.bytes(16))
     opts['headers'] = opts.fetch('headers', {}).merge({
       'Connection' => 'Upgrade',
       'Upgrade' => 'WebSocket',

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -235,7 +235,8 @@ module Exploit::Remote::HttpClient
   # @raise [Rex::Proto::Http::WebSocket::WebSocketError] raises an exception if the connection fails
   # @return [Rex::Proto::Http::WebSocket::Interface]
   def connect_ws(opts={}, timeout = 20)
-    ws_key = Rex::Text.rand_text_alphanumeric(20)
+    # As per the spec (RFC6455 Section 11.3.1), a Sec-WebSocket-Key is a 16 byte value that has been Base64 encoded.
+    ws_key = Rex::Text.encode_base64(Rex::Text.rand_text_alphanumeric(16))
     opts['headers'] = opts.fetch('headers', {}).merge({
       'Connection' => 'Upgrade',
       'Upgrade' => 'WebSocket',


### PR DESCRIPTION
I am writing an exploit that leverages WebSockets, and have been using the `Rex::Proto::Http::WebSocket` mixin. There is a helper method called `connect_ws` in the `Exploit::Remote::HttpClient` module that will bootstrap a new WebSocket connection by making the initial HTTP request to upgrade a HTTP connection to a WebSocket connection.

It turns out that `connect_ws` was not being spec compliant. During the HTTP upgrade, a client passes a HTTP header value called `Sec-WebSocket-Key`, currently this is generated as a 20 character string, however this is not what the spec wants, and a server that honors the spec will not accepts a request like this.

The [spec states](https://datatracker.ietf.org/doc/html/rfc6455#section-11.3.1):
> The request MUST include a header field with the name |Sec-WebSocket-Key|.  The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]).  The nonce MUST be selected randomly for each connection.

This pull request fixes `connect_ws` by honoring the spec and generating a `Sec-WebSocket-Key` that is a Base64 encoded 16 byte value.