### PR TITLE
Fix jtr_format assignment in HashCapture module

### DIFF
--- a/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
+++ b/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
@@ -41,7 +41,6 @@ module Msf
         print_line
       end
     end
-
     def report_ntlm_type3(address:, ntlm_type1:, ntlm_type2:, ntlm_type3:)
       ntlm_message = ntlm_type3
       hash_type = nil
@@ -54,12 +53,14 @@ module Msf
       case ntlm_message.ntlm_version
       when :ntlmv1, :ntlm2_session
         hash_type = 'NTLMv1-SSP'
+        jtr_format = Metasploit::Framework::Hashes::JTR_NTLMV1
         client_hash = "#{bin_to_hex(ntlm_message.lm_response)}:#{bin_to_hex(ntlm_message.ntlm_response)}"
 
         combined_hash << ":#{client_hash}"
         combined_hash << ":#{bin_to_hex(challenge)}"
       when :ntlmv2
         hash_type = 'NTLMv2-SSP'
+        jtr_format = Metasploit::Framework::Hashes::JTR_NTLMV2
         client_hash = "#{bin_to_hex(ntlm_message.ntlm_response[0...16])}:#{bin_to_hex(ntlm_message.ntlm_response[16..-1])}"
 
         combined_hash << ":#{bin_to_hex(challenge)}"
@@ -67,8 +68,6 @@ module Msf
       end
 
       return if hash_type.nil?
-
-      jtr_format = ntlm_message.ntlm_version == :ntlmv1 ? Metasploit::Framework::Hashes::JTR_NTLMV1 : Metasploit::Framework::Hashes::JTR_NTLMV2
 
       if active_db?
         origin = create_credential_origin_service(

--- a/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
+++ b/lib/msf/core/exploit/remote/smb/server/hash_capture.rb
@@ -41,6 +41,7 @@ module Msf
         print_line
       end
     end
+
     def report_ntlm_type3(address:, ntlm_type1:, ntlm_type2:, ntlm_type3:)
       ntlm_message = ntlm_type3
       hash_type = nil


### PR DESCRIPTION
When setting the `JOHNPWFILE` datastore option in a module that includes the `Msf::Exploit::Remote::SMB::Server::HashCapture`, NTLMv1 hashes were incorrectly being placed in the NTLMv2 hash file. 

The ternary operator that was previously assigning `jtr_format` wasn't evaluating whether or not the `ntlm_message.ntlm_version` was `ntlm2_session`. 

The case statement seems to be a better place to handle the `jtr_format` assignment as it's already evaluating `ntlm_message.ntlm_version` and checking for `ntlm2_session`.

## Verification

Verify this change makes sense and CI tests pass (I think this is sufficient for such a small change?)

<details>
<summary>Testing steps to reproduce this issue and verify this change works</summary>

<p> 

Verify NTLMv1 hashes are placed in the correct jtr file on disk. This can be done in a number of ways, including testing the new `smb_to_ldap` module (#19832)

- Start the relay server with JOHNPWFILE set
```
msf6 auxiliary(server/relay/smb_to_ldap) > run JOHNPWFILE=johnfile RELAY_TARGETS=172.16.199.200
[*] Auxiliary module running as background job 1.

[*] JTR hashes will be split into two files depending on the hash format.
[*] /Users/jheysel/rapid7/metasploit-framework/johnfile_netntlm for NTLMv1 hashes.
[*] /Users/jheysel/rapid7/metasploit-framework/johnfile_netntlmv2 for NTLMv2 hashes.

[*] SMB Server is running. Listening on 0.0.0.0:445
msf6 auxiliary(server/relay/smb_to_ldap) > [*] Server started.
```

- Send NTLM hash to msfconsole via the Windows `net use` command:
```
net use \\172.16.199.1\foo /u:Administrator 123456
```

- Receive NTLMv1 hash (ensure Windows is configured to send NTLMv1 hashes):
```
msf6 auxiliary(server/relay/smb_to_ldap) >
[*] New request from 172.16.199.139
[*] Received request for \Administrator
[*] Relaying to next target ldap://172.16.199.200:389
[+] Identity: \Administrator - Successfully authenticated against relay target ldap://172.16.199.200:389
[SMB] NTLMv1-SSP Client     : 172.16.199.200
[SMB] NTLMv1-SSP Username   : \Administrator
[SMB] NTLMv1-SSP Hash       : Administrator:::7f3d181906b7a3df00000000000000000000000000000000:3fa4e56e7d9be163b3be20d25481b836083e400c29499e9d:5bf1ae799e5c492c
```

- Verify the NTLMv1 hash is placed in the file: `johnfile_netntlm` - (not `johnfile_netntlmv2`)
```
➜  metasploit-framework git:(f839d581a58) ✗ cat johnfile_netntlm
Administrator:::7f3d181906b7a3df00000000000000000000000000000000:3fa4e56e7d9be163b3be20d25481b836083e400c29499e9d:5bf1ae799e5c492c
```

</p>

</details>
