### PR TITLE
Fix ldap_login and smb_login

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -212,6 +212,23 @@ module Metasploit::Framework
     #   @return [Boolean]
     attr_accessor :anonymous_login
 
+    # @!attribute ignore_private
+    #   Whether to ignore private (password). This is usually set when Kerberos
+    #   or Schannel authentication is requested and the credentials are
+    #   retrieved from cache or from a file. This attribute should be true in
+    #   these scenarios, otherwise validation will fail since the password is not
+    #   provided.
+    #   @return [Boolean]
+    attr_accessor :ignore_private
+
+    # @!attribute ignore_public
+    #   Whether to ignore public (username). This is usually set when Schannel
+    #   authentication is requested and the credentials are retrieved from a
+    #   file (certificate). This attribute should be true in this case,
+    #   otherwise validation will fail since the password is not provided.
+    #   @return [Boolean]
+    attr_accessor :ignore_public
+
     # @option opts [Boolean] :blank_passwords See {#blank_passwords}
     # @option opts [String] :pass_file See {#pass_file}
     # @option opts [String] :password See {#password}
@@ -240,7 +257,13 @@ module Metasploit::Framework
     # @yieldparam credential [Metasploit::Framework::Credential]
     # @return [void]
     def each_filtered
-      if password_spray
+      if ignore_private
+        if ignore_public
+          yield Metasploit::Framework::Credential.new(public: nil, private: nil, realm: realm)
+        else
+          yield Metasploit::Framework::Credential.new(public: username, private: nil, realm: realm)
+        end
+      elsif password_spray
         each_unfiltered_password_first do |credential|
           next unless self.filter.nil? || self.filter.call(credential)
 
@@ -510,14 +533,14 @@ module Metasploit::Framework
     #
     # @return [Boolean]
     def has_users?
-      username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty?
+      username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty? || !!ignore_public
     end
 
     # Returns true when there are any private values set
     #
     # @return [Boolean]
     def has_privates?
-      super || userpass_file.present? || user_as_pass
+      super || userpass_file.present? || user_as_pass || !!ignore_private
     end
 
   end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -116,6 +116,15 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
+      if !datastore['PASSWORD']
+        # In case no password has been provided, we assume the user wants to use Kerberos tickets stored in cache
+        # Write mode is still enable in case new TGS tickets are retrieved.
+        ticket_storage = kerberos_ticket_storage({ read: true, write: true })
+      else
+        # Write only cache so we keep all gathered tickets but don't reuse them for auth while running the module
+        ticket_storage = kerberos_ticket_storage({ read: false, write: true })
+      end
+
       kerberos_authenticator_factory = lambda do |username, password, realm|
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::SMB.new(
           host: datastore['DomainControllerRhost'],
@@ -127,8 +136,7 @@ class MetasploitModule < Msf::Auxiliary
           framework: framework,
           framework_module: self,
           cache_file: datastore['Smb::Krb5Ccname'].blank? ? nil : datastore['Smb::Krb5Ccname'],
-          # Write only cache so we keep all gathered tickets but don't reuse them for auth while running the module
-          ticket_storage: kerberos_ticket_storage({ read: false, write: true })
+          ticket_storage: ticket_storage
         )
       end
     end
@@ -170,7 +178,8 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = build_credential_collection(
       realm: domain,
       username: datastore['SMBUser'],
-      password: datastore['SMBPass']
+      password: datastore['SMBPass'],
+      ignore_private: datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS && !datastore['PASSWORD']
     )
     cred_collection = prepend_db_hashes(cred_collection)
 
@@ -256,6 +265,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_creds(ip, port, result)
+    # Private can be nil if we authenticated with Kerberos and a cached ticket was used. No need to report this.
+    return unless result.credential.private
+
     if !datastore['RECORD_GUEST'] && (result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST)
       return
     end

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       prepended_creds: prepended_creds,
       additional_privates: additional_privates,
       additional_publics: additional_publics,
-      password_spray: password_spray
+      password_spray: password_spray,
+      ignore_public: ignore_public,
+      ignore_private: ignore_private
     )
   end
 
@@ -39,6 +41,8 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
   let(:additional_privates) { [] }
   let(:additional_publics) { [] }
   let(:password_spray) { false }
+  let(:ignore_public) { nil }
+  let(:ignore_private) { nil }
 
   describe "#each" do
     specify do
@@ -323,6 +327,34 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       end
     end
 
+    context 'when :ignore_public is true and :username is nil' do
+      let(:ignore_public) { true }
+      let(:username) { nil }
+      specify  do
+        expect { |b| collection.each(&b) }.to_not yield_control
+      end
+    end
+
+    context 'when :ignore_private is true and password is nil' do
+      let(:ignore_private) { true }
+      let(:password) { nil }
+      specify  do
+        expect { |b| collection.each(&b) }.to yield_successive_args(
+          Metasploit::Framework::Credential.new(public: username, private: nil)
+        )
+      end
+
+      context 'when :ignore_public is also true and username is nil' do
+        let(:ignore_public) { true }
+        let(:username) { nil }
+        specify  do
+          expect { |b| collection.each(&b) }.to yield_successive_args(
+            Metasploit::Framework::Credential.new(public: nil, private: nil)
+          )
+        end
+      end
+    end
+
   end
 
   describe "#empty?" do
@@ -392,6 +424,21 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
             expect(collection.empty?).to eq true
           end
         end
+
+        context "and :ignore_public is set" do
+          let(:ignore_public) { true }
+          specify do
+            expect(collection.empty?).to eq true
+          end
+
+          context "and :ignore_private is also set" do
+            let(:ignore_private) { true }
+            specify do
+              expect(collection.empty?).to eq false
+            end
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/19743.
This also apply the same fix to the `smb_login` login scanner.

The problem is that now, some login scanner modules are not only used to discover and report valid credentials, but also to get a session (e.g. SMB session, LDAP session). This means, if Kerberos is used as the authentication method, the user can omit the password and reuse tickets from the cache. Also, if the authentication method is Schannel (LDAP), the username can also be omitted since the certificate will contain everything needed to authenticate. 

This causes issues with the validation and when the scanner iterates over the possible credentials to test. To fix, this, this PR introduces two new boolean attributes in the `CredentialCollection` class:
- `:ignore_private`: Whether to ignore private (password).
- `:ignore_public`: Whether to ignore public (username).

By setting these attributes to true, the scanner knows the password and/or the username can be nil and will carry-on.

## Verification
Make sure the `smb_session_type` and `ldap_session_type` features are enabled with the `features` command.

### LDAP login scanner with Kerberos authentication
- [x] `use scanner/ldap/ldap_login`
- [x] First run to get Kerberos tickets: `run verbose=true rhost=<remote host> domain=<domain> LDAP::Auth=kerberos LDAP::Rhostname=<DC hostname> DomainControllerRhost=<DC IP address> CreateSession=true username=<admin username> password=<admin password>`
- [x] **Verify** the tickets were retrieved with `klist`
- [x] **Verify** an LDAP session has been established
- [x] Retry without password: `run verbose=true rhost=<remote host> domain=<domain> LDAP::Auth=kerberos LDAP::Rhostname=<DC hostname> DomainControllerRhost=<DC IP address> CreateSession=true username=<admin username>`
- [x] **Verify** the cached credentials were used (`[*] Using cached credential for ...`)
- [x] **Verify** another LDAP session has been established
- [x] Retry without username: `run verbose=true rhost=<remote host> domain=<domain> LDAP::Auth=kerberos LDAP::Rhostname=<DC hostname> DomainControllerRhost=<DC IP address> CreateSession=true`
- [x] **Verify** a validation error is returned

### LDAP login scanner with Schannel authentication
- [x] Get a certificate:
- [x] `use admin/dcerpc/icpr_cert`
- [x] `run verbose=true CA=<CA> RHOSTS=<remote host> username=<admin username> password=<admin password> CERT_TEMPLATE=User`
- [x] Run the LDAP login scanner without credentials:
- [x] `use scanner/ldap/ldap_login`
- [x] `run verbose=true rhost=<target host> domain=<domain> LDAP::Auth=schannel rport=389 ssl=true LDAP::CertFile=<certificate filepath> CreateSession=true`
- [x] **Verify** an LDAP session has been established

### SMB login scanner with Kerberos authentication
- [x] `use scanner/smb/smb_login`
- [x] First run to get Kerberos tickets: `run verbose=true rhost=<remote host> domain=<domain> SMB::Auth=kerberos SMB::Rhostname=<DC hostname> DomainControllerRhost=<DC IP address> CreateSession=true username=<admin username> password=<admin password>`
- [x] **Verify** the tickets were retrieved with `klist`
- [x] **Verify** a SMB session has been established
- [x] Retry without password: `run verbose=true rhost=<remote host> domain=<domain> SMB::Auth=kerberos SMB::Rhostname=<DC hostname> DomainControllerRhost=<DC IP address> CreateSession=true username=<admin username>`
- [x] **Verify** the cached credentials were used (`[*] Using cached credential for ...`)
- [x] **Verify** another LDAP session has been established
- [x] Retry without username: `run verbose=true rhost=<remote host> domain=<domain> SMB::Auth=kerberos SMB::Rhostname=<DC hostname> DomainControllerRhost=<DC IP address> CreateSession=true`
- [x] **Verify** a validation error is returned

# Scenarios
## Without the fix
```
msf6 auxiliary(scanner/ldap/ldap_login) > run verbose=true rhost=10.187.44.121 domain=mydomain.local LDAP::Auth=schannel rport=389 ssl=true LDAP::CertFile=/home/n00tmeg/.msf4/loot/20250129113440_default_10.187.44.121_windows.ad.cs_600851.pfx
[*] Error: 10.187.44.121: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank (Metasploit::Framework::LoginScanner::LDAP)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Bruteforce completed, 0 credentials were successful.
[*] 0 LDAP sessions were opened successfully.
[*] Auxiliary module execution completed
```

## With the fix
```
msf6 auxiliary(scanner/ldap/ldap_login) > run verbose=true rhost=10.187.44.121 domain=mydomain.local LDAP::Auth=schannel rport=389 ssl=true LDAP::CertFile=/home/n00tmeg/.msf4/loot/20250129113440_default_10.187.44.121_windows.ad.cs_600851.pfx
[+] Success: 'Cert File /home/n00tmeg/.msf4/loot/20250129113440_default_10.187.44.121_windows.ad.cs_600851.pfx'
[*] LDAP session 7 opened (192.168.211.69:41643 -> 10.187.44.121:389) at 2025-01-29 11:37:46 +0100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Bruteforce completed, 1 credential was successful.
[*] 1 LDAP session was opened successfully.
[*] Auxiliary module execution completed
```
