### PR TITLE
Resolve host mixin

### DIFF
--- a/lib/msf/core/post/dns.rb
+++ b/lib/msf/core/post/dns.rb
@@ -1,0 +1,4 @@
+# -*- coding: binary -*-
+
+module Msf::Post::DNS
+end

--- a/lib/msf/core/post/dns/resolve_host.rb
+++ b/lib/msf/core/post/dns/resolve_host.rb
@@ -13,9 +13,9 @@ module Msf
         #
         # @param [String] host Hostname
         # @return [Array, nil] result[:ips], ips The resolved IPs
-        def resolve_host(host)
+        def resolve_host(host, family)
           if client.respond_to?(:net) && client.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_NET_RESOLVE_HOST)
-            result = client.net.resolve.resolve_host(host)
+            result = client.net.resolve.resolve_host(host, family)
             result[:ips]
           else
             ips = []

--- a/lib/msf/core/post/dns/resolve_host.rb
+++ b/lib/msf/core/post/dns/resolve_host.rb
@@ -1,0 +1,39 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Post
+    module DNS
+      ###
+      #
+      # This module resolves session DNS
+      #
+      ###
+      module ResolveHost
+        # Takes the host name and makes use of nslookup to resolve the IP
+        #
+        # @param [String] host Hostname
+        # @return [Array, nil] result[:ips], ips The resolved IPs
+        def resolve_host(host)
+          if client.respond_to?(:net) && client.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_NET_RESOLVE_HOST)
+            result = client.net.resolve.resolve_host(host)
+            result[:ips]
+          else
+            ips = []
+            data = cmd_exec("nslookup #{host}")
+            if data =~ /Name/
+              # Remove unnecessary data and get the section with the addresses
+              returned_data = data.split(/Name:/)[1]
+              # check each element of the array to see if they are IP
+              returned_data.gsub(/\r\n\t |\r\n|Aliases:|Addresses:|Address:/, ' ').split(' ').each do |e|
+                if Rex::Socket.dotted_ip?(e)
+                  ips << e
+                end
+              end
+            end
+            ips
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/post/dns/resolve_host.rb
+++ b/lib/msf/core/post/dns/resolve_host.rb
@@ -9,28 +9,57 @@ module Msf
       #
       ###
       module ResolveHost
-        # Takes the host name and makes use of nslookup to resolve the IP
+        # Takes the host name and resolves the IP
         #
-        # @param [String] host Hostname
-        # @return [Array, nil] result[:ips], ips The resolved IPs
+        # @param [String] host
+        # @param [Integer] family
+        # @return [Hash] The resolved IPs
         def resolve_host(host, family)
           if client.respond_to?(:net) && client.commands.include?(Rex::Post::Meterpreter::Extensions::Stdapi::COMMAND_ID_STDAPI_NET_RESOLVE_HOST)
-            result = client.net.resolve.resolve_host(host, family)
-            result[:ips]
+            resolved_host = client.net.resolve.resolve_host(host, family)
+            # We want to only return the array off IPs
+            resolved_host.reject { |k, _v| k == :ip }
           else
             ips = []
             data = cmd_exec("nslookup #{host}")
             if data =~ /Name/
               # Remove unnecessary data and get the section with the addresses
-              returned_data = data.split(/Name:/)[1]
+              returned_data = data.split(/Name:/)[1..]
               # check each element of the array to see if they are IP
-              returned_data.gsub(/\r\n\t |\r\n|Aliases:|Addresses:|Address:/, ' ').split(' ').each do |e|
-                if Rex::Socket.dotted_ip?(e)
-                  ips << e
+              returned_data.each do |entry|
+                _host, ip = entry.gsub(/\r\n\t |\r\n|Aliases:|Addresses:|Address:/, ' ').split(' ')
+                filtered_ip = filter_ips(ip, family)
+                ips << filtered_ip unless filtered_ip.nil?
+              end
+              # If nslookup responds with "no answer", fall back to resolving via host command
+            elsif data =~ /No answer/
+              data = cmd_exec("host #{host}")
+              if data =~ /has address/
+                # Remove unnecessary data and get the section with the addresses
+                returned_data = data.split("\n")[...-1]
+                # check each element of the array to see if they are IP
+                returned_data.each do |entry|
+                  ip = entry.split(' ').last
+                  filtered_ip = filter_ips(ip, family)
+                  ips << filtered_ip unless filtered_ip.nil?
                 end
               end
             end
-            ips
+            {:hostname=>host, :ips=>ips}
+          end
+        end
+
+        # Takes the host and family and returns the IP address if it matches the appropriate family
+        # Needed to handle request that fallback to nslookup or host, as they return both IPV4 and IPV6.
+        #
+        # @param [String] ip
+        # @param [Integer] family
+        # @return [String] ip
+        def filter_ips(ip, family)
+          if family == AF_INET
+            ip if !!(ip =~ Resolv::IPv4::Regex)
+          elsif family == AF_INET6
+            ip if !!(ip =~ Resolv::IPv6::Regex)
           end
         end
       end

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Post
 
   # Takes the host name and makes use of nslookup to resolve the IP
   #
-  # @param [String] host Hostname
+  # @param [Object] hostname
+  # @param [Object] family
   # @return [String] ip The resolved IP
   def gethost(hostname, family)
     ## get IP for host
@@ -106,7 +107,6 @@ class MetasploitModule < Msf::Post
       end
 
       begin
-        hostname = "google.com"
         hostipv6 = gethost(hostname, AF_INET6)
       rescue Rex::Post::Meterpreter::RequestError => e
         meterpreter_dns_resolving_errors << "IPV6: #{hostname} could not be resolved - #{e}"

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Registry
+  include Msf::Post::DNS::ResolveHost
 
   def initialize(info = {})
     super(
@@ -60,34 +61,16 @@ class MetasploitModule < Msf::Post
   #
   # @param [String] host Hostname
   # @return [String] ip The resolved IP
-  def resolve_host(host)
-    vprint_status("Looking up IP for #{host}")
-    return host if Rex::Socket.dotted_ip?(host)
-
-    ip = []
-    data = cmd_exec("nslookup #{host}")
-    if data =~ /Name/
-      # Remove unnecessary data and get the section with the addresses
-      returned_data = data.split(/Name:/)[1]
-      # check each element of the array to see if they are IP
-      returned_data.gsub(/\r\n\t |\r\n|Aliases:|Addresses:|Address:/, ' ').split(' ').each do |e|
-        if Rex::Socket.dotted_ip?(e)
-          ip << e
-        end
-      end
-    end
-
-    if ip.blank?
-      'Not resolvable'
-    else
-      ip.join(', ')
-    end
+  def gethost(hostname)
+    ## get IP for host
+    vprint_status("Looking up IP for #{hostname}")
+    resolve_host(hostname).join(', ')
   end
 
   def get_domain_computers
     computer_list = []
     divisor = "-------------------------------------------------------------------------------\r\n"
-    net_view_response = cmd_exec('net view')
+    net_view_response = cmd_exec("cmd.exe", "/c net view")
     unless net_view_response.include?(divisor)
       print_error("The net view command failed with: #{net_view_response}")
       return []
@@ -115,7 +98,7 @@ class MetasploitModule < Msf::Post
         ]
     )
     hosts.each do |hostname|
-      hostip = resolve_host(hostname)
+      hostip = gethost(hostname)
       tbl << [domain, hostname, hostip]
     end
 

--- a/spec/support/acceptance/command_shell/cmd.rb
+++ b/spec/support/acceptance/command_shell/cmd.rb
@@ -18,6 +18,38 @@ module Acceptance::Session
     ],
     module_tests: [
       {
+        name: 'post/test/resolve_host',
+        platforms: [
+          [
+            :linux,
+            {
+              skip: true,
+              reason: 'Payload not compiled for platform'
+            }
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: 'Payload not compiled for platform'
+            }
+          ],
+          :windows
+        ],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: 'post/test/cmd_exec',
         platforms: [
           [

--- a/spec/support/acceptance/command_shell/linux.rb
+++ b/spec/support/acceptance/command_shell/linux.rb
@@ -50,6 +50,32 @@ module Acceptance::Session
         }
       },
       {
+        name: "post/test/resolve_host",
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: "post/test/cmd_exec",
         platforms: [
           :linux,

--- a/spec/support/acceptance/command_shell/powershell.rb
+++ b/spec/support/acceptance/command_shell/powershell.rb
@@ -18,6 +18,38 @@ module Acceptance::Session
     ],
     module_tests: [
       {
+        name: 'post/test/resolve_host',
+        platforms: [
+          [
+            :linux,
+            {
+              skip: true,
+              reason: 'Payload not compiled for platform'
+            }
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: 'Payload not compiled for platform'
+            }
+          ],
+          :windows
+        ],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: 'post/test/cmd_exec',
         platforms: [
           [

--- a/spec/support/acceptance/session/java.rb
+++ b/spec/support/acceptance/session/java.rb
@@ -74,6 +74,22 @@ module Acceptance::Session
         }
       },
       {
+        name: "post/test/resolve_host",
+        platforms: [:linux, :osx, :windows],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: "post/test/cmd_exec",
         platforms: [:linux, :osx, :windows],
         skipped: false,

--- a/spec/support/acceptance/session/mettle.rb
+++ b/spec/support/acceptance/session/mettle.rb
@@ -70,6 +70,32 @@ module Acceptance::Session
         }
       },
       {
+        name: "post/test/resolve_host",
+        platforms: [
+          :linux,
+          :osx,
+          [
+            :windows,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ]
+        ],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: "post/test/cmd_exec",
         platforms: [
           :linux,

--- a/spec/support/acceptance/session/php.rb
+++ b/spec/support/acceptance/session/php.rb
@@ -61,6 +61,23 @@ module Acceptance::Session
         }
       },
       {
+        name: "post/test/resolve_host",
+        platforms: [:linux, :osx, :windows],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: [
+            ]
+          }
+        }
+      },
+      {
         name: "post/test/cmd_exec",
         platforms: [:linux, :osx, :windows],
         skipped: false,

--- a/spec/support/acceptance/session/python.rb
+++ b/spec/support/acceptance/session/python.rb
@@ -73,6 +73,22 @@ module Acceptance::Session
         }
       },
       {
+        name: "post/test/resolve_host",
+        platforms: [:linux, :osx, :windows],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: "post/test/cmd_exec",
         platforms: [:linux, :osx, :windows],
         skipped: false,

--- a/spec/support/acceptance/session/windows_meterpreter.rb
+++ b/spec/support/acceptance/session/windows_meterpreter.rb
@@ -54,6 +54,38 @@ module Acceptance::Session
         }
       },
       {
+        name: "post/test/resolve_host",
+        platforms: [
+          [
+            :linux,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          [
+            :osx,
+            {
+              skip: true,
+              reason: "Payload not compiled for platform"
+            }
+          ],
+          :windows
+        ],
+        skipped: false,
+        lines: {
+          linux: {
+            known_failures: []
+          },
+          osx: {
+            known_failures: []
+          },
+          windows: {
+            known_failures: []
+          }
+        }
+      },
+      {
         name: "post/test/cmd_exec",
         platforms: [
           [

--- a/test/modules/post/test/resolve_host.rb
+++ b/test/modules/post/test/resolve_host.rb
@@ -1,0 +1,89 @@
+require 'rex'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+
+lib = File.join(Msf::Config.install_root, 'test', 'lib')
+$LOAD_PATH.push(lib) unless $LOAD_PATH.include?(lib)
+require 'module_test'
+
+class MetasploitModule < Msf::Post
+  include Msf::ModuleTest::PostTest
+  include Msf::Post::DNS::ResolveHost
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Meterpreter resolve_host test',
+        'Description' => %q{ This module will test the meterpreter resolve_host API },
+        'License' => MSF_LICENSE,
+        'Platform' => [ 'windows', 'linux', 'unix', 'java', 'osx' ],
+        'SessionTypes' => ['meterpreter', 'shell', 'powershell']
+      )
+    )
+  end
+
+  def test_resolve_host
+    vprint_status('Starting resolve_host tests')
+
+    it 'should return a Hash' do
+      # TODO: UPDATE TO NOT POINT AT GOOGLE
+      hostname = 'google.com'
+      family = AF_INET6
+
+      resolved_host = resolve_host(hostname, family)
+      resolved_host.is_a?(Hash)
+    end
+
+    it 'should return a valid IPV4 host' do
+      hostname = 'google.com'
+      family = AF_INET
+
+      resolved_host = resolve_host(hostname, family)
+      puts resolved_host[:ips]
+      if resolved_host[:ips].empty?
+        false
+      else
+        resolved_host[:ips].each do |ip|
+          !!(ip =~ Resolv::IPv4::Regex)
+        end
+      end
+    end
+
+    it 'should return a valid IPV6 host' do
+      hostname = 'google.com'
+      family = AF_INET6
+
+      resolved_host = resolve_host(hostname, family)
+      puts resolved_host[:ips]
+      if resolved_host[:ips].empty?
+        false
+      else
+        resolved_host[:ips].each do |ip|
+          !!(ip =~ Resolv::IPv6::Regex)
+        end
+      end
+    end
+
+    it 'should handle an invalid IPV4 host' do
+      hostname = 'foo.bar'
+      family = AF_INET
+
+      begin
+        resolve_host(hostname, family)
+      rescue Rex::Post::Meterpreter::RequestError => e
+        e.instance_of?(Rex::Post::Meterpreter::RequestError)
+      end
+    end
+
+    it 'should handle an invalid IPV6 host' do
+      hostname = 'foo.bar'
+      family = AF_INET6
+
+      begin
+        resolve_host(hostname, family)
+      rescue Rex::Post::Meterpreter::RequestError => e
+        e.instance_of?(Rex::Post::Meterpreter::RequestError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
> [!NOTE]
TODO: Update tests to not resolve against google.com
This PR builds on a previous [PR](https://github.com/rapid7/metasploit-framework/pull/18383), specifically this [comment thread](https://github.com/rapid7/metasploit-framework/pull/18383#discussion_r1332908107).

This new mixin allows for DNS resolution for modules with multiple session types. E.g. [`modules/post/windows/gather/enum_computers.rb`](https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/enum_computers.rb) supports multiple sessions:
```
'SessionTypes' => %w[meterpreter powershell shell]
```
However the resolution across these session requires different logic. Meterpreter will now make use of the new Meterpreter API changes that will **_NEED_** to be landed before this PR can land.

metasploit-payloads PR - https://github.com/rapid7/metasploit-payloads/pull/681
metasploit-framework PR - https://github.com/rapid7/metasploit-framework/pull/18499

The mixin will check if we have a Meterpreter session with access to the `net` library and use the new Meterpreter API if so, otherwise fallback to `nslookup` if not.

## Note
A rescue was added to the `enum_computers` module to allow for instances when the DNS isn't able to be resolved via the meterpreter API. This is due to inconsistent resolving methods in the runtime languages. 

### With no errors
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/3e5117ac-b642-4875-967f-0d4a92af6d83)

### With every entry returning an error
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/e1f912cc-8269-412a-b446-04db923d55f3)

### Mixed results
![image](https://github.com/rapid7/metasploit-framework/assets/69522014/f9bb23f9-b9f4-4089-9ca4-598aac9147f0)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use post/windows/gather/enum_computers.rb`
- [ ] **Target** a machine with multiple computers available
- [ ] Get a Meterpreter session
- [ ] **Verify** the module now list all expected computers as part of that domain
Example:
```
List of identified Hosts.
=========================

 Domain  Hostname  IPs
 ------  --------  ---
 VB      DC1       192.168.175.201, 192.168.175.200, 192.168.175.135
```