### PR TITLE
Restrict weekly data PR tooling to rapid7 repo

### DIFF
--- a/.github/workflows/weekly-data-and-external-tool-updater.yml
+++ b/.github/workflows/weekly-data-and-external-tool-updater.yml
@@ -26,6 +26,8 @@ jobs:
   update-data-files:
     runs-on: ubuntu-latest
 
+    if: github.repository_owner == 'rapid7'
+
     env:
       BUNDLE_WITHOUT: "coverage development pcap"
 


### PR DESCRIPTION
Actions are inherited by forks if they merge in upstream. This revision limits the new scheduled action to only run in the `rapid7` repository to avoid forks creating PR to themselves weekly if a user has actions enabled in the fork.

The cron job will still trigger for all forks that include this flow on their primary branch, with the restriction these will be marked a skipped instead of generating PRs for forks.