### PR TITLE
allow workflow content write

### DIFF
--- a/.github/workflows/weekly-data-and-external-tool-updater.yml
+++ b/.github/workflows/weekly-data-and-external-tool-updater.yml
@@ -4,7 +4,7 @@ name: Weekly Data and External Tool Updater
 permissions:
   actions: none
   checks: none
-  contents: none
+  contents: write
   deployments: none
   id-token: none
   issues: none


### PR DESCRIPTION
To enabled branch and commit `content` must be added

## Verification

This can be tested in a fork using a manual trigger when "Settings -> Actions -> Workflow Permissions" is set to "Read repository contents and packages permissions".