### PR TITLE
Update ldap vuln cert finder report notes

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -552,7 +552,7 @@ class MetasploitModule < Msf::Auxiliary
             })
 
             report_note({
-              data: ca_server[:dn][0].to_s,
+              data: { dn: ca_server[:dn][0].to_s },
               service: service,
               host: ca_server_ip_address,
               ntype: 'windows.ad.cs.ca.dn'
@@ -643,7 +643,7 @@ class MetasploitModule < Msf::Auxiliary
             end
 
             report_note({
-              data: hash[:dn],
+              data: { dn: hash[:dn] },
               service: service,
               host: ca_fqdn.to_s,
               ntype: 'windows.ad.cs.ca.template.dn',


### PR DESCRIPTION
Update the ldap_esc_vulnerable_cert_finder to report a hash of notes instead of a string to avoid crashes

For a future PR we should lock this down to be validated:

https://github.com/rapid7/metasploit_data_models/blob/e48d4ee2ae5926e7e6a938affa01436c35865a3e/app/models/mdm/note.rb#L61C1-L64C21

As it looks like some modules are accidentally reporting strings 

## Verification

### Before

Crash when running the module in the context of Metasploit Pro

![image](https://github.com/user-attachments/assets/ab48966e-11da-4b55-a27f-864fd915feb0)

### After

No crash and notes work

![image](https://github.com/user-attachments/assets/e8a8eb39-97ef-499c-9360-f3be20a808ce)
