### PR TITLE
Fix missing #add_static API method

### DIFF
--- a/lib/msf/core/exploit/remote/dns/server.rb
+++ b/lib/msf/core/exploit/remote/dns/server.rb
@@ -52,11 +52,17 @@ module Server
       data = entries.split(';')
     end
     data.each do |entry|
-      next if entry.gsub(/\s/,'').empty?
-      addr, names = entry.split(' ', 2)
+      next if entry.gsub(/\s/, '').empty?
+
+      address, names = entry.split(' ', 2)
       names.split.each do |name|
-        name << '.' unless name[-1] == '.' or name == '*'
-        service.cache.add_static(name, addr, type)
+        name << '.' unless name.end_with?('.') || name == '*'
+
+        unless Rex::Socket.is_ip_addr?(address.to_s) && (name.to_s.match(MATCH_HOSTNAME) || name == '*')
+          raise "Invalid parameters for static entry - #{name}, #{address}, #{type}"
+        end
+
+        service.cache.cache_record(Dnsruby::RR.create(name: name, type: type, address: address), expire: false)
       end
     end
     service.cache.records.select {|r,e| e == 0}

--- a/lib/rex/proto/dns/cache.rb
+++ b/lib/rex/proto/dns/cache.rb
@@ -45,15 +45,22 @@ module DNS
     # Add record to cache, only when "running"
     #
     # @param record [Dnsruby::RR] Record to cache
-    def cache_record(record)
+    def cache_record(record, expire: true)
       return unless @monitor_thread
-      if record.is_a?(Dnsruby::RR) and
-      (!record.respond_to?(:address) or Rex::Socket.is_ip_addr?(record.address.to_s)) and
-      record.name.to_s.match(MATCH_HOSTNAME)
-        add(record, ::Time.now.to_i + record.ttl)
-      else
-        raise "Invalid record for cache entry - #{record.inspect}"
+
+      unless record.is_a?(Dnsruby::RR)
+        raise "Invalid record for cache entry (not an RR) - #{record.inspect}"
       end
+
+      unless (!record.respond_to?(:address) || Rex::Socket.is_ip_addr?(record.address.to_s))
+        raise "Invalid record for cache entry (no IP address) - #{record.inspect}"
+      end
+
+      unless record.name.to_s.match(MATCH_HOSTNAME)
+        raise "Invalid record for cache entry (invalid hostname) - #{record.inspect}"
+      end
+
+      add(record, expire ? (::Time.now.to_i + record.ttl) : 0)
     end
 
     #


### PR DESCRIPTION
In fcd84a41aae5683dfa6f7498cacd527ab5a768f3 I removed the `#add_static` API method without realizing that it was being used by the `Msf::Exploit::Remote::DNS::Server` mixin. I don't think it makes sense to revert the change and put it back because having the cache manage static hosts makes less sense now with the new DNS system added last year. This instead updates the mixin to create a record and call the `#cache_record` API to effectively do the same thing, enabling it to continue to use the cache as a pseudo static host definition manager. This in turn fixes the bug described in #19591. The `expire` keyword argument was added to allow the caller to specify if the cached record should expire. In most cases it should, but when it's used for a static definition, it should not.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Follow the steps to repruduce the bug as described in #19591
- [ ] See that the module works now (assuming that `msfconsole` was run with the necessary privileges)

## Demo

```
metasploit-framework (S:0 J:0) auxiliary(spoof/dns/native_spoofer) > show options 

Module options (auxiliary/spoof/dns/native_spoofer):

   Name              Current Setting      Required  Description
   ----              ---------------      --------  -----------
   DISABLE_NS_CACHE  false                no        Disable DNS response caching
   DISABLE_RESOLVER  false                no        Disable DNS request forwarding
   DOMAIN                                 no        The target domain name
   FILTER            dst port 53          no        The filter string for capturing traffic
   INTERFACE                              no        The name of the interface
   NS                                     no        Specify the nameservers to use for queries, space separated
   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
   RPORT             53                   yes       The target port (TCP)
   SEARCHLIST                             no        DNS domain search list, comma separated
   SNAPLEN           65535                yes       The number of bytes to capture
   SRVHOST           127.0.2.2            yes       The local host to listen on for DNS services.
   SRVPORT           53                   yes       The local port to listen on.
   STATIC_ENTRIES    1.2.3.4 example.com  no        DNS domain search list (hosts file or space/semicolon separate entries)
   THREADS           32                   yes       Number of threads to use in threaded queries
   TIMEOUT           500                  yes       The number of seconds to wait for new data


Auxiliary action:

   Name     Description
   ----     -----------
   Service  Serve DNS entries



View the full module info with the info, or info -d command.

metasploit-framework (S:0 J:0) auxiliary(spoof/dns/native_spoofer) > run
[*] Auxiliary module running as background job 1.
metasploit-framework (S:0 J:1) auxiliary(spoof/dns/native_spoofer) > jobs -K
[*] Caching response ssl.gstatic.com:2607:F8B0:4009:819::2003 AAAA
[+] Sent packet with header:
--EthHeader-----------------------------------
  eth_dst   00:0c:29:37:a1:b8 PacketFu::EthMac
  eth_src   02:42:bb:9f:4a:28 PacketFu::EthMac
  eth_proto 0x0800            StructFu::Int16 
--IPHeader------------------------------------
  ip_v      4                 Integer         
  ip_hl     5                 Integer         
  ip_tos    0                 StructFu::Int8  
  ip_len    300               StructFu::Int16 
  ip_id     0xa639            StructFu::Int16 
  ip_frag   0                 StructFu::Int16 
  ip_ttl    64                StructFu::Int8  
  ip_proto  17                StructFu::Int8  
  ip_sum    0x5dab            StructFu::Int16 
  ip_src    192.168.250.4     PacketFu::Octets
  ip_dst    192.168.250.134   PacketFu::Octets
--UDPHeader-----------------------------------
  udp_src   53                StructFu::Int16 
  udp_dst   41190             StructFu::Int16 
  udp_len   280               StructFu::Int16 
  udp_sum   0xf1df            StructFu::Int16 
------------------------------------------------------------------
00-01-02-03-04-05-06-07-08-09-0a-0b-0c-0d-0e-0f---0123456789abcdef
------------------------------------------------------------------
53 f7 81 80 00 01 00 01 00 0d 00 00 03 73 73 6c   S............ssl
07 67 73 74 61 74 69 63 03 63 6f 6d 00 00 1c 00   .gstatic.com....
01 c0 0c 00 1c 00 01 00 00 00 a6 00 10 26 07 f8   .............&..
b0 40 09 08 19 00 00 00 00 00 00 20 03 00 00 02   .@......... ....
00 01 00 02 cf cf 00 14 01 6a 0c 72 6f 6f 74 2d   .........j.root-
73 65 72 76 65 72 73 03 6e 65 74 00 00 00 02 00   servers.net.....
01 00 02 cf cf 00 04 01 6d c0 4a 00 00 02 00 01   ........m.J.....
00 02 cf cf 00 04 01 61 c0 4a 00 00 02 00 01 00   .......a.J......
02 cf cf 00 04 01 66 c0 4a 00 00 02 00 01 00 02   ......f.J.......
cf cf 00 04 01 67 c0 4a 00 00 02 00 01 00 02 cf   .....g.J........
cf 00 04 01 69 c0 4a 00 00 02 00 01 00 02 cf cf   ....i.J.........
00 04 01 64 c0 4a 00 00 02 00 01 00 02 cf cf 00   ...d.J..........
04 01 6b c0 4a 00 00 02 00 01 00 02 cf cf 00 04   ..k.J...........
01 65 c0 4a 00 00 02 00 01 00 02 cf cf 00 04 01   .e.J............
6c c0 4a 00 00 02 00 01 00 02 cf cf 00 04 01 68   l.J............h
c0 4a 00 00 02 00 01 00 02 cf cf 00 04 01 62 c0   .J............b.
4a 00 00 02 00 01 00 02 cf cf 00 04 01 63 c0 4a   J............c.J
[+] Spoofed records for ssl.gstatic.com to 192.168.250.134:41190
[+] Sent packet with header:
--EthHeader-----------------------------------
  eth_dst   00:0c:29:37:a1:b8 PacketFu::EthMac
  eth_src   02:42:bb:9f:4a:28 PacketFu::EthMac
  eth_proto 0x0800            StructFu::Int16 
--IPHeader------------------------------------
  ip_v      4                 Integer         
  ip_hl     5                 Integer         
  ip_tos    0                 StructFu::Int8  
  ip_len    89                StructFu::Int16 
  ip_id     0x8c02            StructFu::Int16 
  ip_frag   16384             StructFu::Int16 
  ip_ttl    64                StructFu::Int8  
  ip_proto  17                StructFu::Int8  
  ip_sum    0x38b5            StructFu::Int16 
  ip_src    192.168.250.4     PacketFu::Octets
  ip_dst    192.168.250.134   PacketFu::Octets
--UDPHeader-----------------------------------
  udp_src   53                StructFu::Int16 
  udp_dst   55087             StructFu::Int16 
  udp_len   69                StructFu::Int16 
  udp_sum   0xd37d            StructFu::Int16 
------------------------------------------------------------------
00-01-02-03-04-05-06-07-08-09-0a-0b-0c-0d-0e-0f---0123456789abcdef
------------------------------------------------------------------
53 f7 81 00 00 01 00 01 00 00 00 00 03 73 73 6c   S............ssl
07 67 73 74 61 74 69 63 03 63 6f 6d 00 00 1c 00   .gstatic.com....
01 c0 0c 00 1c 00 01 00 00 00 a6 00 10 26 07 f8   .............&..
b0 40 09 08 19 00 00 00 00 00 00 20 03            .@......... .
[+] Spoofed records for ssl.gstatic.com to 192.168.250.134:55087

Stopping all jobs...
[*] Server stopped.
metasploit-framework (S:0 J:0) auxiliary(spoof/dns/native_spoofer) > 
```