### PR TITLE
Add osvdb search to msfconsole

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -25,6 +25,7 @@ module Msf::Modules::Metadata::Search
       mod_time
       name
       os
+      osvdb
       path
       platform
       port
@@ -180,6 +181,8 @@ module Msf::Modules::Metadata::Search
               match = [keyword, search_term] if module_metadata.arch =~ regex
             when 'cve'
               match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^cve\-/i and ref =~ regex }
+            when 'osvdb'
+              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^osvdb\-/i and ref =~ regex }
             when 'bid'
               match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^bid\-/i and ref =~ regex }
             when 'edb'
@@ -291,6 +294,7 @@ module Msf::Modules::Metadata::Search
     aliases = {
         :cve => 'references',
         :edb => 'references',
+        :osvdb => 'references',
         :bid => 'references',
         :os => 'platform',
         :port => 'rport',

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -385,6 +385,7 @@ module Msf
               'author'      => 'Modules written by this author',
               'arch'        => 'Modules affecting this architecture',
               'bid'         => 'Modules with a matching Bugtraq ID',
+              'osvdb'       => 'Modules with a matching OSVDB ID',
               'cve'         => 'Modules with a matching CVE ID',
               'edb'         => 'Modules with a matching Exploit-DB ID',
               'check'       => 'Modules that support the \'check\' method',

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Msf::Modules::Metadata::Search do
   end
 
   describe '#find' do
-    REF_TYPES = %w(CVE BID EDB)
+    REF_TYPES = %w(CVE BID EDB OSVDB)
 
     shared_examples "search_filter" do |opts|
       accept = opts[:accept] || []


### PR DESCRIPTION
Add OSVDB search functionality to msfconsole with `search osvdb:67241` - to align with other reference searching functionality, i.e. `search cve:2024-22729`

## Verification

Open msfconsole
Search for reference

```
search osvdb:67241
```

See a result:

```
> search osvdb:67241

Matching Modules
================

   #  Name                                         Disclosure Date  Rank    Check  Description
   -  ----                                         ---------------  ----    -----  -----------
   0  exploit/windows/fileformat/a_pdf_wav_to_mp3  2010-08-17       normal  No     A-PDF WAV to MP3 v1.0.0 Buffer Overflow


```