### PR TITLE
Improve module search performance

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -113,8 +113,11 @@ module Msf::Modules::Metadata::Search
     raise ArgumentError if params.any? && VALID_PARAMS.none? { |k| params.key?(k) }
     search_results = []
 
+    regex_cache = Hash.new do |hash, search_term|
+      hash[search_term] = as_regex(search_term)
+    end
     get_metadata.each { |module_metadata|
-      if is_match(params, module_metadata)
+      if is_match(params, module_metadata, regex_cache)
         unless fields.empty?
           module_metadata = get_fields(module_metadata, fields)
         end
@@ -128,7 +131,7 @@ module Msf::Modules::Metadata::Search
   private
   #######
 
-  def is_match(params, module_metadata)
+  def is_match(params, module_metadata, regex_cache)
     return true if params.empty?
 
     param_hash = params
@@ -149,7 +152,7 @@ module Msf::Modules::Metadata::Search
           end
 
           param_hash[keyword][mode].each do |search_term|
-            has_match = text_segments.any? { |text_segment| text_segment =~ as_regex(search_term) }
+            has_match = text_segments.any? { |text_segment| text_segment =~ regex_cache[search_term] }
             match = [keyword, search_term] if has_match
             if mode == SearchMode::INCLUDE && !has_match
               return false
@@ -168,7 +171,7 @@ module Msf::Modules::Metadata::Search
           # Reset the match flag for each keyword for inclusive search
           match = false if mode == SearchMode::INCLUDE
 
-          regex = as_regex(search_term)
+          regex = regex_cache[search_term]
           case keyword
             when 'action'
               match = [keyword, search_term] if (module_metadata&.actions || []).any? { |action| action.any? { |k, v| k =~ regex || v =~ regex } }


### PR DESCRIPTION
Improve msfconsole's module search performance by caching search regexes

## Verification

```
time search type:exploit path:-auxiliary/pro/ path:-auxiliary/gather/http_pdf_authors path:-/telephony/ path:-/test/ date:2020 path:http target:tp-link
```

```diff
diff --git a/lib/msf/core/modules/metadata/search.rb b/lib/msf/core/modules/metadata/search.rb
index e3bb87f375..f3403f770e 100644
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -113,6 +113,8 @@ module Msf::Modules::Metadata::Search
     raise ArgumentError if params.any? && VALID_PARAMS.none? { |k| params.key?(k) }
     search_results = []
 
+    require 'metasploit/framework/profiler'
+    Metasploit::Framework::Profiler.record_cpu do
     get_metadata.each { |module_metadata|
       if is_match(params, module_metadata)
         unless fields.empty?
@@ -121,6 +123,7 @@ module Msf::Modules::Metadata::Search
         search_results << module_metadata
       end
     }
+    end
     return search_results
   end
```

### Before

Duplicated effort creating regexes

![image](https://github.com/user-attachments/assets/6cd9ca7d-6bf9-4f90-a96a-b1f22f720dc6)

### After

Regexes no longer created

![image](https://github.com/user-attachments/assets/2fc0b6db-5c54-41c6-af76-6f605e483bf7)
