### PR TITLE
Make datastore to_h sane

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
     metasploit-payloads (2.0.189)
-    metasploit_data_models (6.0.5)
+    metasploit_data_models (6.0.6)
       activerecord (~> 7.0)
       activesupport (~> 7.0)
       arel-helpers

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -266,7 +266,7 @@ class DataStore
   def to_h
     datastore_hash = {}
     self.keys.each do |k|
-      datastore_hash[k.to_s] = self[k].to_s
+      datastore_hash[k.to_s] = self[k]
     end
     datastore_hash
   end

--- a/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
+++ b/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
@@ -672,8 +672,8 @@ RSpec.shared_examples_for 'a datastore' do
       it 'should return a Hash with correct values' do
         expected_to_h = {
           'SMBDomain' => 'WORKGROUP',
-          'SMBUser' => '',
-          'USER_ATTR' => ''
+          'SMBUser' => nil,
+          'USER_ATTR' => nil
         }
         expect(subject.to_h).to eq(expected_to_h)
       end
@@ -688,11 +688,11 @@ RSpec.shared_examples_for 'a datastore' do
         expected_to_h = {
           'NewOptionName' => 'overridden_default_new_option_name',
           'SMBDomain' => 'WORKGROUP',
-          'SMBUser' => '',
-          'USER_ATTR' => '',
+          'SMBUser' => nil,
+          'USER_ATTR' => nil,
           'foo' => 'overridden_default_foo',
           'bar' => 'default_bar_value',
-          'baz' => ''
+          'baz' => nil
         }
         expect(subject.to_h).to eq(expected_to_h)
       end


### PR DESCRIPTION
This PR bumps the metasploit_data_models gem version.
It also makes the datastore `to_h` method more sane, and removes the coalescing of values to a string, making this method more aligned with a programmer's expectations.

Requires the serialization changes from here:https://github.com/rapid7/metasploit_data_models/pull/207

## Verification

- [ ] Start `msfconsole`
- [ ] Ensure you can use, save & run a module with options
- [ ] Ensure you can get a session with specified options
- [ ] Passing CI

## Persistence Workflow
Persistence works as expected, with the steps taken from #19002 
![image](https://github.com/user-attachments/assets/577aa4bd-9161-4db9-ab66-b60f3f377c8f)
