### PR TITLE
Remove errant CVE reference.

### DIFF
--- a/modules/exploits/linux/local/progress_kemp_loadmaster_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_kemp_loadmaster_sudo_privesc_2024.rb
@@ -31,9 +31,9 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'License' => MSF_LICENSE,
         'References' => [
+          # The vendor declared this was not a vulnerability so no CVE has been assigned.
           ['URL', 'https://rhinosecuritylabs.com/research/cve-2024-1212unauthenticated-command-injection-in-progress-kemp-loadmaster/'],
-          ['URL', 'https://kemptechnologies.com/kemp-load-balancers'],
-          ['CVE', '2024-1212']
+          ['URL', 'https://kemptechnologies.com/kemp-load-balancers']
         ],
         'DisclosureDate' => '2024-03-19',
         'Notes' => {


### PR DESCRIPTION
I realized after I landed the fix for the check method in https://github.com/rapid7/metasploit-framework/pull/19810 that the CVE reference was for the cmd injection this privilege escalation was originally paired with.
IIRC, the vendor said that the movement from the `bal` user to `root` was not a security vulnerability because `bal` was already an admin user.  I don't believe this vulnerability will ever get a CVE.