### PR TITLE
Fix byte to int conversion in MsAdts

### DIFF
--- a/lib/rex/crypto.rb
+++ b/lib/rex/crypto.rb
@@ -27,4 +27,27 @@ module Rex::Crypto
   def self.rc4(key, value)
     Rc4.rc4(key, value)
   end
+
+  # Returns an integer represented as a byte array. Useful for certain key-related operations.
+  #
+  # @param bytes [String] The bytes to convert
+  # @return [Integer] The converted value.
+  def self.bytes_to_int(bytes)
+    bytes.each_byte.reduce(0) { |acc, byte| (acc << 8) | byte }
+  end
+
+  # Returns a byte array represented as a big-endian integer. Useful for certain key-related operations.
+  #
+  # @param bytes [String] The bytes to convert
+  # @return [Integer] The converted value.
+  def self.int_to_bytes(num)
+    bytes = []
+
+    while num > 0
+      bytes.unshift(num & 0xff)
+      num >>= 8
+    end
+
+    bytes.pack("C*")
+  end
 end

--- a/lib/rex/proto/ms_adts/key_credential.rb
+++ b/lib/rex/proto/ms_adts/key_credential.rb
@@ -25,8 +25,8 @@ module Rex::Proto::MsAdts
       when KEY_USAGE_NGC
         result = Rex::Proto::BcryptPublicKey.new
         result.key_length = public_key.n.num_bits
-        n = self.class.int_to_bytes(public_key.n)
-        e = self.class.int_to_bytes(public_key.e)
+        n = Rex::Crypto.int_to_bytes(public_key.n.to_i)
+        e = Rex::Crypto.int_to_bytes(public_key.e.to_i)
         result.exponent = e
         result.modulus = n
         result.prime1 = ''
@@ -136,8 +136,8 @@ module Rex::Proto::MsAdts
       when KEY_USAGE_NGC
         if raw_key_material.start_with?([Rex::Proto::BcryptPublicKey::MAGIC].pack('I'))
           result = Rex::Proto::BcryptPublicKey.read(raw_key_material)
-          exponent = OpenSSL::ASN1::Integer.new(bytes_to_int(result.exponent))
-          modulus = OpenSSL::ASN1::Integer.new(bytes_to_int(result.modulus))
+          exponent = OpenSSL::ASN1::Integer.new(Rex::Crypto.bytes_to_int(result.exponent))
+          modulus = OpenSSL::ASN1::Integer.new(Rex::Crypto.bytes_to_int(result.modulus))
           # OpenSSL's API has changed over time - constructing from DER has been consistent
           data_sequence = OpenSSL::ASN1::Sequence([modulus, exponent])
 
@@ -163,16 +163,6 @@ module Rex::Proto::MsAdts
       else # Insert at start
         struct.credential_entries.insert(0, entry)
       end
-    end
-
-    def self.int_to_bytes(num)
-      str = num.to_s(16).rjust(2, '0')
-
-      [str].pack('H*')
-    end
-
-    def bytes_to_int(num)
-      num.unpack('H*')[0].to_i(16)
     end
 
     # Sets self.key_hash based on the credential_entries value in the provided parameter

--- a/spec/lib/rex/crypto_spec.rb
+++ b/spec/lib/rex/crypto_spec.rb
@@ -1,0 +1,33 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Crypto do
+  describe '.bytes_to_int' do
+    it 'converts an empty byte correctly' do
+      expect(subject.bytes_to_int("".b)).to eq(0)
+    end
+
+    it 'converts a single null byte correctly' do
+      expect(subject.bytes_to_int("\x00".b)).to eq(0)
+    end
+
+    it 'converts a single non-null byte correctly' do
+      expect(subject.bytes_to_int("\x01".b)).to eq(1)
+    end
+
+    it 'converts multiple bytes correctly' do
+      expect(subject.bytes_to_int("\x01\x02\x03\x04".b)).to eq(16909060)
+    end
+  end
+
+  describe '.int_to_bytes' do
+    it 'converts 0 to an empty byte' do
+      expect(subject.int_to_bytes(0)).to eq("".b)
+    end
+
+    it 'converts to bytes correctly' do
+      expect(subject.int_to_bytes(1)).to eq("\x01".b)
+      expect(subject.int_to_bytes(16909060)).to eq("\x01\x02\x03\x04".b)
+    end
+  end
+end


### PR DESCRIPTION
Converting bytes to ints is a common operation for low level PKI operations. This issue came up while working on another mixin that required the same functionality. While reviewing that, an issue was discovered that showed the `int_to_bytes` conversation was incorrect. The root cause was the padding causing a 4-bit misalignment for `v > 0xff` that do not have a bits set in the high nibble (`v & 0xf0`). This PR fixes the issue, moves the functionality to a common location for future use and adds specs to demonstrate correctness.

Bug demonstration:
In this example, the conversion of `0x01020304` to and from bytes results in the value being changed to `0x10203040`:

```
[13] pry(#<Msf::Modules::Auxiliary__Scanner__Dcerpc__Gkdi_testing::MetasploitModule>)> Rex::Proto::MsAdts::KeyCredential.new.send(:bytes_to_int, (Rex::Proto::MsAdts::KeyCredential.int_to_bytes(0x01020304))).to_s(16)
=> "10203040"
```

## Verification

- [ ] See the tests pass
- [ ] Retest the `shadow_creds` module which uses the `MsAdts` code that was fixed/refactored
