### PR TITLE
documentation: Fix 404 link in eicar.txt

### DIFF
--- a/data/eicar.txt
+++ b/data/eicar.txt
@@ -13,4 +13,4 @@ responsible for corrupting the Metasploit Framework installation.
 
 For more information about EICAR, please see the following web site:
 
-http://www.eicar.org/anti_virus_test_file.htm
+https://www.eicar.org/download-anti-malware-testfile/


### PR DESCRIPTION
Updated the link to EICAR's test-file as the old one returns 404. Based on webarchive, it looks like the page moved somewhat 12 years ago with HTTP 302 redirect to[ the page about the intended usage](http://www.eicar.org/86-0-Intended-use.html), then it moved again in around 2021 to the [page 3950](http://www.eicar.org/?page_id=3950), which was functionally the same [as the new one](https://www.eicar.org/download-anti-malware-testfile/).

The page isn't exactly the same as the one from 2005, but it's the closest they have and it explains how this file works.

As `eicar.txt` doesn't affect any functionality, therefore I don't think any checks or tests are necessary.

Last commit to this file was 14 years ago, so I don't think creating a separate branch for this fix is required either, as it very unlikely to cause any merge conflicts.