### PR TITLE
hash_cracker_validator script to verify hash cracking

### DIFF
--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -3,25 +3,23 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::PasswordCracker
 
   def initialize
     super(
-      'Name'            => 'Apply Pot File To Hashes',
-      'Description'     => %Q{
+      'Name' => 'Apply Pot File To Hashes',
+      'Description' => %(
           This module uses a John the Ripper or Hashcat .pot file to crack any password
         hashes in the creds database instantly.  JtR's --show functionality is used to
         help combine all the passwords into an easy to use format.
-      },
-      'Author'          => ['h00die'],
-      'License'         => MSF_LICENSE,
-      'Actions'         =>
-        [
-          ['john', 'Description' => 'Use John the Ripper'],
-          # ['hashcat', 'Description' => 'Use Hashcat'], # removed for simplicity
-        ],
+      ),
+      'Author' => ['h00die'],
+      'License' => MSF_LICENSE,
+      'Actions' => [
+        ['john', { 'Description' => 'Use John the Ripper' }],
+        # ['hashcat', 'Description' => 'Use Hashcat'], # removed for simplicity
+      ],
       'DefaultAction' => 'john',
     )
     deregister_options('ITERATION_TIMEOUT')
@@ -33,7 +31,6 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options('USE_DEFAULT_WORDLIST')
     deregister_options('USE_ROOT_WORDS')
     deregister_options('USE_HOSTNAMES')
-
   end
 
   # Not all hash formats include an 'id' field, which corresponds which db entry
@@ -41,10 +38,7 @@ class MetasploitModule < Msf::Auxiliary
   # is used as a salt.  Due to all the variations, we make a small HashLookup
   # class to handle all the fields for easier lookup later.
   class HashLookup
-    attr_accessor :db_hash
-    attr_accessor :jtr_hash
-    attr_accessor :username
-    attr_accessor :id
+    attr_accessor :db_hash, :jtr_hash, :username, :id
 
     def initialize(db_hash, jtr_hash, username, id)
       @db_hash = db_hash
@@ -56,6 +50,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def show_run_command(cracker_instance)
     return unless datastore['ShowCommand']
+
     cmd = cracker_instance.show_command
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
@@ -66,9 +61,10 @@ class MetasploitModule < Msf::Auxiliary
     lookups = []
 
     # create one massive hash file with all the hashes
-    hashlist = Rex::Quickfile.new("hashes_tmp")
+    hashlist = Rex::Quickfile.new('hashes_tmp')
     framework.db.creds(workspace: myworkspace).each do |core|
       next if core.private.type == 'Metasploit::Credential::Password'
+
       jtr_hash = Metasploit::Framework::PasswordCracker::JtR::Formatter.hash_to_jtr(core)
       hashlist.puts jtr_hash
       lookups << HashLookup.new(core.private.data, jtr_hash, core.public, core.id)
@@ -82,84 +78,91 @@ class MetasploitModule < Msf::Auxiliary
     # cracked passwords.  The advantage to this vs just comparing
     # john.pot to the hashes directly is we use jtr to recombine
     # lanman, and other assorted nuances
-    ['bcrypt', 'bsdicrypt', 'descrypt', 'lm',
-     'mscash', 'mscash2', 'netntlm', 'netntlmv2',
-     'md5crypt', 'mysql', 'mysql-sha1', 'mssql', 'mssql05', 'mssql12',
-     'oracle', 'oracle11', 'oracle12c', 'dynamic_1506', #oracles
-     'dynamic_1034', #postgres
-     # 'android-sha1', 'android-samsung-sha1', 'android-md5', # mobile is done with hashcat, so skip these
-     'PBKDF2-HMAC-SHA1', 'phpass', 'mediawiki', 'pbkdf2-sha256', # webapps
-     'xsha', 'xsha512', 'PBKDF2-HMAC-SHA512', # osx
-     'nt', # nt needs to be 2nd to last because it can hit on android hashes
-     'crypt' # crypt NEEDS TO BE LAST so it doesn't accidentally read in other compatible hashes
-      ].each do |format|
-
+    [
+      'bcrypt', 'bsdicrypt', 'descrypt', 'lm',
+      'mscash', 'mscash2', 'netntlm', 'netntlmv2',
+      'md5crypt', 'mysql', 'mysql-sha1', 'mssql', 'mssql05', 'mssql12',
+      'oracle', 'oracle11', 'oracle12c', 'dynamic_1506', # oracles
+      'dynamic_1034', # postgres
+      # 'android-sha1', 'android-samsung-sha1', 'android-md5', # mobile is done with hashcat, so skip these
+      'PBKDF2-HMAC-SHA1', 'phpass', 'mediawiki', 'pbkdf2-sha256', # webapps
+      'xsha', 'xsha512', 'PBKDF2-HMAC-SHA512', # osx
+      'nt', # nt needs to be 2nd to last because it can hit on android hashes
+      'crypt' # crypt NEEDS TO BE LAST so it doesn't accidentally read in other compatible hashes
+    ].each do |format|
       print_status("Checking #{format} hashes against pot file")
       cracker.format = format
       show_run_command(cracker)
       cracker.each_cracked_password.each do |password_line|
         password_line.chomp!
         next if password_line.blank? || password_line.nil?
-        fields = password_line.split(":")
+
+        fields = password_line.split(':')
         core_id = nil
         case format
         when 'descrypt'
-          next unless fields.count >=3
+          next unless fields.count >= 3
+
           username = fields.shift
-          core_id  = fields.pop
+          core_id = fields.pop
           4.times { fields.pop } # Get rid of extra :
         when 'netntlm', 'netntlmv2'
-          next unless fields.count >=7
+          next unless fields.count >= 7
+
           username = fields.shift
-          core_id  = fields.pop
+          core_id = fields.pop
           9.times { fields.pop }
-        when 'md5crypt', 'descrypt', 'bsdicrypt', 'crypt', 'bcrypt', 'xsha', 'xsha512'
-          puts fields
-          next unless fields.count >=7
+        when 'md5crypt', 'bsdicrypt', 'crypt', 'bcrypt', 'xsha', 'xsha512'
+          next unless fields.count >= 7
+
           username = fields.shift
-          core_id  = fields.pop
+          core_id = fields.pop
           4.times { fields.pop }
         when 'PBKDF2-HMAC-SHA512'
-          next unless fields.count >=2
+          next unless fields.count >= 2
+
           username = fields.shift
-          core_id  = fields.pop
+          core_id = fields.pop
         when 'mssql', 'mssql05', 'mssql12', 'mysql', 'mysql-sha1',
-             'oracle', 'dynamic_1506', 'oracle11', 'oracle12c', 
+             'oracle', 'dynamic_1506', 'oracle11', 'oracle12c',
              'PBKDF2-HMAC-SHA1', 'phpass', 'mediawiki', 'pbkdf2-sha256',
              'mscash', 'mscash2'
-          next unless fields.count >=3
+          next unless fields.count >= 3
+
           username = fields.shift
-          core_id  = fields.pop
-        when 'dynamic_1034' #postgres
-          next unless fields.count >=2
+          core_id = fields.pop
+        when 'dynamic_1034' # postgres
+          next unless fields.count >= 2
+
           username = fields.shift
-          password = fields.join(':')
+          fields.join(':')
           # unfortunately to match up all the fields we need to pull the hash
           # field as well, and it is only available in the pot file.
           pot = cracker.pot || cracker.john_pot_file
 
           File.open(pot, 'rb').each do |line|
-            if line.start_with?('$dynamic_1034$') #postgres format
-              lookups.each do |l|
-                pot_hash = line.split(":")[0]
-                raw_pot_hash = pot_hash.split('$')[2]
-                if l.username.to_s == username &&
-                     l.jtr_hash == "#{username}:$dynamic_1034$#{raw_pot_hash}" &&
-                     l.db_hash  == raw_pot_hash
-                   core_id = l.id
-                   break
-                end
-              end
+            next unless line.start_with?('$dynamic_1034$') # postgres format
+
+            lookups.each do |l|
+              pot_hash = line.split(':')[0]
+              raw_pot_hash = pot_hash.split('$')[2]
+              next unless l.username.to_s == username &&
+                          l.jtr_hash == "#{username}:$dynamic_1034$#{raw_pot_hash}" &&
+                          l.db_hash == raw_pot_hash
+
+              core_id = l.id
+              break
             end
           end
         when 'lm', 'nt'
-          next unless fields.count >=7
+          next unless fields.count >= 7
+
           username = fields.shift
           core_id = fields.pop
-          2.times{ fields.pop }
+          2.times { fields.pop }
           # get the NT and LM hashes
           nt_hash = fields.pop
-          lm_hash = fields.pop
+          fields.pop
           core_id = fields.pop
           password = fields.join(':')
           if format == 'lm'
@@ -173,17 +176,22 @@ class MetasploitModule < Msf::Auxiliary
             password = john_lm_upper_to_ntlm(password, nt_hash)
             next if password.nil?
           end
-          fields = password.split(':') #for consistency on the following join out of the case
+          fields = password.split(':') # for consistency on the following join out of the case
         end
-        unless core_id.nil?
-          password = fields.join(':')
-          print_good "#{username}:#{password}"
-          # android hashes will also crack here, but the output fields are in a different order
-          # check if core_id is an int or not, for android hashes it wont convert
-          core_id_int = Integer(core_id) rescue nil
-          next if core_id_int.nil?
-          create_cracked_credential( username: username, password: password, core_id: core_id)
+        next if core_id.nil?
+
+        password = fields.join(':')
+        print_good "#{username}:#{password}"
+        # android hashes will also crack here, but the output fields are in a different order
+        # check if core_id is an int or not, for android hashes it wont convert
+        core_id_int = begin
+          Integer(core_id)
+        rescue StandardError
+          nil
         end
+        next if core_id_int.nil?
+
+        create_cracked_credential(username: username, password: password, core_id: core_id)
       end
     end
     if datastore['DeleteTempFiles']

--- a/tools/dev/hash_cracker_validator.rb
+++ b/tools/dev/hash_cracker_validator.rb
@@ -1,0 +1,904 @@
+#!/usr/bin/env ruby
+
+# This script is used to validate the hash cracking capabilities of metasploit
+# https://github.com/rapid7/metasploit-framework/pull/17667 shows the complexity
+# of trying to insert hashes, run the appropriate hash cracking module, and verify the hashes are cracked.
+# this automates everything and checks the output of the hash cracking modules to ensure they are working as expected
+# author: h00die
+
+require 'open3'
+require 'tempfile'
+require 'optparse'
+
+options = { test: 'all', verbose: false }
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    hash_cracker_validator.rb - A Script to verify hash cracking in Metasploit.
+
+    Based on passwords/hashes from https://docs.metasploit.com/docs/using-metasploit/intermediate/hashes-and-password-cracking.html#hashes
+
+    Usage: hash_cracker_validator.rb [options]
+  BANNER
+  opts.on('--verbose', 'Enable verbose output.') do
+    options[:verbose] = true
+  end
+  opts.on('--test LIST', "Which tests to conduct. Takes a list of numbers (comma-separated), defaults to 'all'",
+          'Test 1: Test database connection',
+          'Test 2: *nix    hashes in john wordlist mode',
+          'Test 3: windows hashes in john wordlist mode',
+          'Test 4: sql     hashes in john wordlist mode',
+          'Test 5: mobile  hashes in john wordlist mode',
+          'Test 6: osx     hashes in john wordlist mode',
+          'Test 7: webapp  hashes in john wordlist mode',
+          'Test 8: *nix    hashes in hashcat wordlist mode',
+          'Test 9: windows hashes in hashcat wordlist mode',
+          'Test 10: sql    hashes in hashcat wordlist mode',
+          'Test 11: mobile hashes in hashcat wordlist mode',
+          'Test 12: osx    hashes in hashcat wordlist mode',
+          'Test 13: webapp hashes in hashcat wordlist mode',
+          'Test 14: *nix    hashes in john pot mode',
+          'Test 15: windows hashes in john pot mode',
+          'Test 16: sql     hashes in john pot mode',
+          'Test 17: mobile  hashes in john pot mode',
+          'Test 18: osx     hashes in john pot mode',
+          'Test 19: webapp  hashes in john pot mode',
+          'Test 20: *nix    hashes in hashcat pot mode',
+          'Test 21: windows hashes in hashcat pot mode',
+          'Test 22: sql    hashes in hashcat pot mode',
+          'Test 23: mobile hashes in hashcat pot mode',
+          'Test 24: osx    hashes in hashcat pot mode',
+          'Test 25: webapp hashes in hashcat pot mode') do |list|
+    options[:test] = begin
+      list.split(',').map(&:strip).map(&:to_i)
+    rescue StandardError
+      'all'
+    end
+  end
+end.parse!
+
+# colors and puts templates from msftidy.rb
+
+class String
+  def red
+    "\e[1;31;40m#{self}\e[0m"
+  end
+
+  def yellow
+    "\e[1;33;40m#{self}\e[0m"
+  end
+
+  def green
+    "\e[1;32;40m#{self}\e[0m"
+  end
+
+  def cyan
+    "\e[1;36;40m#{self}\e[0m"
+  end
+end
+
+def cleanup_text(txt)
+  txt
+end
+
+#
+# Display an error message, given some text
+#
+def good(txt)
+  puts "[#{'GOOD'.green}] #{cleanup_text(txt)}"
+end
+
+#
+# Display an error message, given some text
+#
+def error(txt)
+  puts "[#{'ERROR'.red}] #{cleanup_text(txt)}"
+end
+
+#
+# Display a warning message, given some text
+#
+def warning(txt)
+  puts "[#{'WARNING'.yellow}] #{cleanup_text(txt)}"
+end
+
+#
+# Display a info message, given some text
+#
+def info(txt)
+  puts "[#{'INFO'.cyan}] #{cleanup_text(txt)}"
+end
+
+warning 'WARNING: All credentials will be deleted as part of this script execution!'
+
+start_time = Time.now
+
+def run_msfconsole(command, expected_output_regexes)
+  section_start_time = Time.now
+  stdout, stderr = Open3.capture3("./msfconsole -qx \"#{command}\"")
+
+  failing_regex = expected_output_regexes.find { |regex| !stdout.match?(regex) }
+
+  if failing_regex.nil?
+    good '  SUCCESS: All expected outputs found.'
+    good "  Section Runtime: #{Time.now - section_start_time} seconds"
+    return true
+  else
+    error "  FAILURE: Expected output not found for regex: #{failing_regex.inspect}"
+    error "  STDOUT: #{stdout}"
+    error "  Section Runtime: #{Time.now - section_start_time} seconds"
+    error "  STDERR: #{stderr}"
+    return false
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(1)
+  info '[1/25] Checking Metasploit database connection...'
+  db_status_command = 'db_status; exit'
+  db_expected_output_regex = [/Connected to .+\. Connection type: .+\./]
+  unless run_msfconsole(db_status_command, db_expected_output_regex)
+    error 'Database connection check failed. Exiting.'
+    exit 1
+  end
+end
+
+wordlist = Tempfile.new('wordlist')
+File.open(wordlist, 'w') { |file| file.write("password\nhashcat\ntest1\ntoto\nfoo\nPassword1!\nprobe\ntere\na\nTHALES\nepsilon\n1234\nTestPass123#\npasswor\nd\n") }
+info "Wordlist file created at: #{wordlist.path}"
+
+if options[:test] == 'all' || options[:test].include?(2)
+  info '[2/25] Running *nix hashes in john wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
+  creds_command << ' set SHA256 true;'
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
+  creds_command << ' set SHA512 true;'
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
+  creds_command << ' set BLOWFISH true;'
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_command << ' use auxiliary/analyze/crack_linux;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(3)
+  info '[3/25] Running windows hashes in john wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_windows;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(4)
+  info '[4/25] Running sql hashes in john wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
+  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
+  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  # can't escape ;?
+  # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+
+  creds_command << ' use auxiliary/analyze/crack_databases;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(5)
+  info '[5/25] Running mobile hashes in john wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
+  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
+  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
+  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
+  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
+  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
+  creds_command << ' use auxiliary/analyze/crack_mobile;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(6)
+  info '[6/25] Running osx hashes in john wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_osx;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(7)
+  info '[7/25] Running webapp hashes in john wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
+  creds_command << ' use auxiliary/analyze/crack_webapps;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(8)
+  info '[8/25] Running *nix hashes in hashcat wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
+  creds_command << ' set SHA256 true;'
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
+  creds_command << ' set SHA512 true;'
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
+  creds_command << ' set BLOWFISH true;'
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_command << ' use auxiliary/analyze/crack_linux;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(9)
+  info '[9/25] Running windows hashes in hashcat wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+PASSWORD/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_windows;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(10)
+  info '[10/25] Running sql hashes in hashcat wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  # hashcat des,oracle is a no go: https://github.com/rapid7/metasploit-framework/blob/7a7b009161d6b0839653f21296864da3365402a0/lib/metasploit/framework/password_crackers/cracker.rb#L152-L155
+  # creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
+  # creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  # creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
+  # creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  # can't escape ;?
+  # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+
+  creds_command << ' use auxiliary/analyze/crack_databases;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(11)
+  info '[11/25] Running mobile hashes in hashcat wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
+  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
+  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
+  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
+  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
+  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
+  creds_command << ' use auxiliary/analyze/crack_mobile;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(12)
+  info '[12/25] Running osx hashes in hashcat wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_osx;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+if options[:test] == 'all' || options[:test].include?(13)
+  info '[13/25] Running webapp hashes in hashcat wordlist mode...'
+  tempfile = Tempfile.new('john_pot')
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
+  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
+  creds_command << ' use auxiliary/analyze/crack_webapps;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{tempfile.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    tempfile.close!
+    tempfile.unlink
+    error "\nCredential verification failed. Exiting."
+    exit 1
+  end
+  tempfile.close!
+  tempfile.unlink
+end
+
+wordlist.close!
+wordlist.unlink
+
+pot_file = Tempfile.new('john_pot')
+File.open(pot_file, 'w') { |file| file.write("$1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/:password\nrEK1ecacw.7.c:password\n_J9..K0AyUubDrfOgO4s:password\n$2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe:password\n$5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5:password\n$6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1:password\n$LM$4a3b108f3fa6cb6d:D\n$LM$e52cac67419a9a22:PASSWOR\n$NT$8846f7eaee8fb117ad06bdd830b7586c:password\nM$test1#64cd29e36a8431a2b111378564a10631:test1\n$DCC2$10240#tom#e4e938d12fe5974dc42a90120bd9c90f:hashcat\n$NETNTLM$cb8086049ec4736c338d08f8e26de933$9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:hashcat\n$NETNTLMv2$ADMINN46iSNekpT$08ca45b7d7ea58ee$88dcbe4446168966a153a0064958dac6$5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030:hashcat\n0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254:FOO\n0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908:toto\n0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16:Password1!\n445ff82636a7ba59:probe\n*5AD8F88516BD021DD43F171E2C785C69F8E54ADB:tere\nO$SIMON#4f8bc1809cb2af77:A\nO$SYSTEM#9eedfa0ad26c6d52:THALES\n9860a48ca459d054f3fef0f8518cf6872923dae2:81fcb23bcadd6c5:1234\nd1b19a90b87fc10c304e657f37162445dae27d16:a006983800cc3dd1:1234\n1c0a0fdb673fba36beaeb078322c7393:81fcb23bcadd6c5:1234\n1430823483D07626EF8BE3FDA2FF056D0DFD818DBFE47683:hashcat\n$LION$648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d:hashcat\n$pbkdf2-hmac-sha512$35460.93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05.752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222:hashcat\n$pbkdf2-hmac-sha1$10000$37323237333437363735323036323731$d0c38acef03f149b4b37c5a8319feeefcbd34912127ba96f3dfa5c22f49bbc1a:hashcat\n$H$984478476IagS59wHZvyQMArzfx58u.:hashcat\n$P$984478476IagS59wHZvyQMArzfx58u.:hashcat\n$B$56668501$0ce106caa70af57fd525aeaf80ef2898:hashcat\ne52cac67419a9a22:PASSWOR\n4a3b108f3fa6cb6d:D\n8846f7eaee8fb117ad06bdd830b7586c:password\n64cd29e36a8431a2b111378564a10631:test1:test1\nu4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c:hashcat\nADMIN::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030:hashcat\n5ad8f88516bd021dd43f171e2c785c69f8e54adb:tere\n648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d:hashcat\n$ml$35460$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222:hashcat\n{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa:hashcat\n") }
+info "john.pot file created at: #{pot_file.path}"
+
+if options[:test] == 'all' || options[:test].include?(14)
+  info '[14/25] Running *nix hashes in john pot mode...'
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
+  creds_command << ' set SHA256 true;'
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
+  creds_command << ' set SHA512 true;'
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
+  creds_command << ' set BLOWFISH true;'
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_command << ' use auxiliary/analyze/crack_linux;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(15)
+  info '[15/25] Running windows hashes in john pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_windows;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(16)
+  info '[16/25] Running sql hashes in john pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
+  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
+  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  # can't escape ;?
+  # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+
+  creds_command << ' use auxiliary/analyze/crack_databases;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(17)
+  info '[17/25] Running mobile hashes in john pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
+  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
+  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
+  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
+  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
+  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
+  creds_command << ' use auxiliary/analyze/crack_mobile;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(18)
+  info '[18/25] Running osx hashes in john pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_osx;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(19)
+  info '[19/25] Running webapp hashes in john pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
+  creds_command << ' use auxiliary/analyze/crack_webapps;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(20)
+  info '[20/25] Running *nix hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
+  creds_command << ' set SHA256 true;'
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
+  creds_command << ' set SHA512 true;'
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
+  creds_command << ' set BLOWFISH true;'
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_command << ' use auxiliary/analyze/crack_linux;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(21)
+  info '[21/25] Running windows hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+PASSWORD/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_windows;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(22)
+  info '[22/25] Running sql hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  # hashcat des,oracle is a no go: https://github.com/rapid7/metasploit-framework/blob/7a7b009161d6b0839653f21296864da3365402a0/lib/metasploit/framework/password_crackers/cracker.rb#L152-L155
+  # creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
+  # creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  # creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
+  # creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  # can't escape ;?
+  # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+
+  creds_command << ' use auxiliary/analyze/crack_databases;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(23)
+  info '[23/25] Running mobile hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
+  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
+  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
+  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
+  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
+  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
+  creds_command << ' use auxiliary/analyze/crack_mobile;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(24)
+  info '[24/25] Running osx hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
+  creds_command << ' use auxiliary/analyze/crack_osx;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(25)
+  info '[25/25] Running webapp hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
+  creds_command << ' use auxiliary/analyze/crack_webapps;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    error "\nCredential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+pot_file.close!
+pot_file.unlink
+
+puts '-------------------------------'
+good 'All checks passed successfully!'
+info "Script runtime: #{Time.now - start_time} seconds"

--- a/tools/dev/hash_cracker_validator.rb
+++ b/tools/dev/hash_cracker_validator.rb
@@ -23,32 +23,31 @@ OptionParser.new do |opts|
   opts.on('--verbose', 'Enable verbose output.') do
     options[:verbose] = true
   end
-  opts.on('--test LIST', "Which tests to conduct. Takes a list of numbers (comma-separated), defaults to 'all'",
+  opts.on('-t', '--test LIST', "Which tests to conduct. Takes a list of numbers (comma-separated), defaults to 'all'",
           'Test 1: Test database connection',
-          'Test 2: *nix    hashes in john wordlist mode',
-          'Test 3: windows hashes in john wordlist mode',
-          'Test 4: sql     hashes in john wordlist mode',
-          'Test 5: mobile  hashes in john wordlist mode',
-          'Test 6: osx     hashes in john wordlist mode',
-          'Test 7: webapp  hashes in john wordlist mode',
-          'Test 8: *nix    hashes in hashcat wordlist mode',
-          'Test 9: windows hashes in hashcat wordlist mode',
-          'Test 10: sql    hashes in hashcat wordlist mode',
-          'Test 11: mobile hashes in hashcat wordlist mode',
-          'Test 12: osx    hashes in hashcat wordlist mode',
-          'Test 13: webapp hashes in hashcat wordlist mode',
-          'Test 14: *nix    hashes in john pot mode',
-          'Test 15: windows hashes in john pot mode',
-          'Test 16: sql     hashes in john pot mode',
-          'Test 17: mobile  hashes in john pot mode',
-          'Test 18: osx     hashes in john pot mode',
-          'Test 19: webapp  hashes in john pot mode',
-          'Test 20: *nix    hashes in hashcat pot mode',
-          'Test 21: windows hashes in hashcat pot mode',
-          'Test 22: sql    hashes in hashcat pot mode',
-          'Test 23: mobile hashes in hashcat pot mode',
-          'Test 24: osx    hashes in hashcat pot mode',
-          'Test 25: webapp hashes in hashcat pot mode') do |list|
+          'Test 2: *nix     hashes in john wordlist mode',
+          'Test 3: windows  hashes in john wordlist mode',
+          'Test 4: sql      hashes in john wordlist mode',
+          'Test 5: osx      hashes in john wordlist mode',
+          'Test 6: webapp   hashes in john wordlist mode',
+          'Test 7: *nix     hashes in hashcat wordlist mode',
+          'Test 8: windows  hashes in hashcat wordlist mode',
+          'Test 9: sql      hashes in hashcat wordlist mode',
+          'Test 10: mobile  hashes in hashcat wordlist mode',
+          'Test 11: osx     hashes in hashcat wordlist mode',
+          'Test 12: webapp  hashes in hashcat wordlist mode',
+          'Test 13: *nix    hashes in john pot mode',
+          'Test 14: windows hashes in john pot mode',
+          'Test 15: sql     hashes in john pot mode',
+          'Test 16: osx     hashes in john pot mode',
+          'Test 17: webapp  hashes in john pot mode',
+          'Test 18: *nix    hashes in hashcat pot mode',
+          'Test 19: windows hashes in hashcat pot mode',
+          'Test 20: sql    hashes in hashcat pot mode',
+          'Test 21: mobile hashes in hashcat pot mode',
+          'Test 22: osx    hashes in hashcat pot mode',
+          'Test 23: webapp hashes in hashcat pot mode',
+          'Test 24: all    hashes in john apply_pot mode') do |list|
     options[:test] = begin
       list.split(',').map(&:strip).map(&:to_i)
     rescue StandardError
@@ -115,7 +114,7 @@ start_time = Time.now
 
 def run_msfconsole(command, expected_output_regexes)
   section_start_time = Time.now
-  stdout, stderr = Open3.capture3("./msfconsole -qx \"#{command}\"")
+  stdout, stderr = Open3.capture3("./msfconsole --defer-module-loads -qx \"#{command}\"")
 
   failing_regex = expected_output_regexes.find { |regex| !stdout.match?(regex) }
 
@@ -133,10 +132,11 @@ def run_msfconsole(command, expected_output_regexes)
 end
 
 if options[:test] == 'all' || options[:test].include?(1)
-  info '[1/25] Checking Metasploit database connection...'
+  info '[1/24] Checking Metasploit database connection...'
   db_status_command = 'db_status; exit'
   db_expected_output_regex = [/Connected to .+\. Connection type: .+\./]
   unless run_msfconsole(db_status_command, db_expected_output_regex)
+    puts '-------------------------------'
     error 'Database connection check failed. Exiting.'
     exit 1
   end
@@ -147,25 +147,25 @@ File.open(wordlist, 'w') { |file| file.write("password\nhashcat\ntest1\ntoto\nfo
 info "Wordlist file created at: #{wordlist.path}"
 
 if options[:test] == 'all' || options[:test].include?(2)
-  info '[2/25] Running *nix hashes in john wordlist mode...'
+  info '[2/24] Running *nix hashes in john wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
-  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password$/
   creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
-  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password$}
   creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
-  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password$/
   creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
   creds_command << ' set SHA256 true;'
-  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password$}
   creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
   creds_command << ' set SHA512 true;'
-  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password$}
   creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
   creds_command << ' set BLOWFISH true;'
-  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password$}
   creds_command << ' use auxiliary/analyze/crack_linux;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -174,7 +174,8 @@ if options[:test] == 'all' || options[:test].include?(2)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
@@ -182,22 +183,22 @@ if options[:test] == 'all' || options[:test].include?(2)
 end
 
 if options[:test] == 'all' || options[:test].include?(3)
-  info '[3/25] Running windows hashes in john wordlist mode...'
+  info '[3/24] Running windows hashes in john wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
-  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
   creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
-  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
   creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
-  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat$/
   creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
-  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat$/
   creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
-  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1$/
   creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
-  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   creds_command << ' use auxiliary/analyze/crack_windows;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -206,7 +207,8 @@ if options[:test] == 'all' || options[:test].include?(3)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
@@ -214,33 +216,33 @@ if options[:test] == 'all' || options[:test].include?(3)
 end
 
 if options[:test] == 'all' || options[:test].include?(4)
-  info '[4/25] Running sql hashes in john wordlist mode...'
+  info '[4/24] Running sql hashes in john wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
-  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto$/
   creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
-  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO$/
   creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
-  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!$/
   creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
-  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe$/
   creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
-  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere$/
   creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
-  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A$/
   creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
-  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES$/
   # can't escape ;?
   # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
-  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password$/
 
   creds_command << ' use auxiliary/analyze/crack_databases;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
@@ -250,7 +252,8 @@ if options[:test] == 'all' || options[:test].include?(4)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
@@ -258,42 +261,16 @@ if options[:test] == 'all' || options[:test].include?(4)
 end
 
 if options[:test] == 'all' || options[:test].include?(5)
-  info '[5/25] Running mobile hashes in john wordlist mode...'
-  tempfile = Tempfile.new('john_pot')
-  creds_expected_output_regex = []
-  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
-  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
-  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
-  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
-  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
-  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
-  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
-  creds_command << ' use auxiliary/analyze/crack_mobile;'
-  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
-  creds_command << " set POT #{tempfile.path};"
-  creds_command << ' run; creds -d; exit;'
-  info "Run Command: #{creds_command}" if options[:verbose]
-  unless run_msfconsole(creds_command, creds_expected_output_regex)
-    tempfile.close!
-    tempfile.unlink
-    error "\nCredential verification failed. Exiting."
-    exit 1
-  end
-  tempfile.close!
-  tempfile.unlink
-end
-
-if options[:test] == 'all' || options[:test].include?(6)
-  info '[6/25] Running osx hashes in john wordlist mode...'
+  info '[5/24] Running osx hashes in john wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
-  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat$/
   creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
-  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat$/
   creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
-  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat$/
   creds_command << ' use auxiliary/analyze/crack_osx;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -302,26 +279,27 @@ if options[:test] == 'all' || options[:test].include?(6)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(7)
-  info '[7/25] Running webapp hashes in john wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(6)
+  info '[6/24] Running webapp hashes in john wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
-  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat$/
   creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
   creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
   creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
-  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat$}
   creds_command << ' use auxiliary/analyze/crack_webapps;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -330,33 +308,34 @@ if options[:test] == 'all' || options[:test].include?(7)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(8)
-  info '[8/25] Running *nix hashes in hashcat wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(7)
+  info '[7/24] Running *nix hashes in hashcat wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
-  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password$/
   creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
-  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password$}
   creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
-  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password$/
   creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
   creds_command << ' set SHA256 true;'
-  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password$}
   creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
   creds_command << ' set SHA512 true;'
-  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password$}
   creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
   creds_command << ' set BLOWFISH true;'
-  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password$}
   creds_command << ' use auxiliary/analyze/crack_linux;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -366,30 +345,31 @@ if options[:test] == 'all' || options[:test].include?(8)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(9)
-  info '[9/25] Running windows hashes in hashcat wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(8)
+  info '[8/24] Running windows hashes in hashcat wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
-  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+PASSWORD/
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+PASSWORD$/
   creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
-  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
   creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
-  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat$/
   creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
-  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat$/
   creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
-  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1$/
   creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
-  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   creds_command << ' use auxiliary/analyze/crack_windows;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -399,42 +379,43 @@ if options[:test] == 'all' || options[:test].include?(9)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(10)
-  info '[10/25] Running sql hashes in hashcat wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(9)
+  info '[9/24] Running sql hashes in hashcat wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
-  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto$/
   creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
-  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO$/
   creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
-  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!$/
   creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
-  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe$/
   creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
-  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere$/
   # hashcat des,oracle is a no go: https://github.com/rapid7/metasploit-framework/blob/7a7b009161d6b0839653f21296864da3365402a0/lib/metasploit/framework/password_crackers/cracker.rb#L152-L155
   # creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
-  # creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  # creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A$/
   # creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
-  # creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  # creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES$/
   # can't escape ;?
   # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
-  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password$/
 
   creds_command << ' use auxiliary/analyze/crack_databases;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
@@ -445,24 +426,25 @@ if options[:test] == 'all' || options[:test].include?(10)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(11)
-  info '[11/25] Running mobile hashes in hashcat wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(10)
+  info '[10/24] Running mobile hashes in hashcat wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
-  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
+  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234$/
   creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
-  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
+  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234$/
   creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
-  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
+  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234$/
   creds_command << ' use auxiliary/analyze/crack_mobile;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -472,24 +454,25 @@ if options[:test] == 'all' || options[:test].include?(11)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(12)
-  info '[12/25] Running osx hashes in hashcat wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(11)
+  info '[11/24] Running osx hashes in hashcat wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
-  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat$/
   creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
-  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat$/
   creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
-  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat$/
   creds_command << ' use auxiliary/analyze/crack_osx;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -499,26 +482,27 @@ if options[:test] == 'all' || options[:test].include?(12)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
   tempfile.unlink
 end
 
-if options[:test] == 'all' || options[:test].include?(13)
-  info '[13/25] Running webapp hashes in hashcat wordlist mode...'
+if options[:test] == 'all' || options[:test].include?(12)
+  info '[12/24] Running webapp hashes in hashcat wordlist mode...'
   tempfile = Tempfile.new('john_pot')
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST true; setg verbose true;'
   creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
-  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat$/
   creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
   creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
   creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
-  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat$}
   creds_command << ' use auxiliary/analyze/crack_webapps;'
   creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{tempfile.path};"
@@ -528,7 +512,8 @@ if options[:test] == 'all' || options[:test].include?(13)
   unless run_msfconsole(creds_command, creds_expected_output_regex)
     tempfile.close!
     tempfile.unlink
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     exit 1
   end
   tempfile.close!
@@ -542,31 +527,62 @@ pot_file = Tempfile.new('john_pot')
 File.open(pot_file, 'w') { |file| file.write("$1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/:password\nrEK1ecacw.7.c:password\n_J9..K0AyUubDrfOgO4s:password\n$2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe:password\n$5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5:password\n$6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1:password\n$LM$4a3b108f3fa6cb6d:D\n$LM$e52cac67419a9a22:PASSWOR\n$NT$8846f7eaee8fb117ad06bdd830b7586c:password\nM$test1#64cd29e36a8431a2b111378564a10631:test1\n$DCC2$10240#tom#e4e938d12fe5974dc42a90120bd9c90f:hashcat\n$NETNTLM$cb8086049ec4736c338d08f8e26de933$9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:hashcat\n$NETNTLMv2$ADMINN46iSNekpT$08ca45b7d7ea58ee$88dcbe4446168966a153a0064958dac6$5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030:hashcat\n0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254:FOO\n0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908:toto\n0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16:Password1!\n445ff82636a7ba59:probe\n*5AD8F88516BD021DD43F171E2C785C69F8E54ADB:tere\nO$SIMON#4f8bc1809cb2af77:A\nO$SYSTEM#9eedfa0ad26c6d52:THALES\n9860a48ca459d054f3fef0f8518cf6872923dae2:81fcb23bcadd6c5:1234\nd1b19a90b87fc10c304e657f37162445dae27d16:a006983800cc3dd1:1234\n1c0a0fdb673fba36beaeb078322c7393:81fcb23bcadd6c5:1234\n1430823483D07626EF8BE3FDA2FF056D0DFD818DBFE47683:hashcat\n$LION$648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d:hashcat\n$pbkdf2-hmac-sha512$35460.93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05.752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222:hashcat\n$pbkdf2-hmac-sha1$10000$37323237333437363735323036323731$d0c38acef03f149b4b37c5a8319feeefcbd34912127ba96f3dfa5c22f49bbc1a:hashcat\n$H$984478476IagS59wHZvyQMArzfx58u.:hashcat\n$P$984478476IagS59wHZvyQMArzfx58u.:hashcat\n$B$56668501$0ce106caa70af57fd525aeaf80ef2898:hashcat\ne52cac67419a9a22:PASSWOR\n4a3b108f3fa6cb6d:D\n8846f7eaee8fb117ad06bdd830b7586c:password\n64cd29e36a8431a2b111378564a10631:test1:test1\nu4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c:hashcat\nADMIN::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030:hashcat\n5ad8f88516bd021dd43f171e2c785c69f8e54adb:tere\n648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d:hashcat\n$ml$35460$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222:hashcat\n{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa:hashcat\n") }
 info "john.pot file created at: #{pot_file.path}"
 
-if options[:test] == 'all' || options[:test].include?(14)
-  info '[14/25] Running *nix hashes in john pot mode...'
+if options[:test] == 'all' || options[:test].include?(13)
+  info '[13/24] Running *nix hashes in john pot mode...'
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
   creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
-  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password$/
   creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
-  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password$}
   creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
-  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password$/
   creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
   creds_command << ' set SHA256 true;'
-  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password$}
   creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
   creds_command << ' set SHA512 true;'
-  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password$}
   creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
   creds_command << ' set BLOWFISH true;'
-  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password$}
   creds_command << ' use auxiliary/analyze/crack_linux;'
   creds_command << " set POT #{pot_file.path};"
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(14)
+  info '[14/24] Running windows hashes in john pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat$/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat$/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1$/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
+  creds_command << ' use auxiliary/analyze/crack_windows;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -574,28 +590,42 @@ if options[:test] == 'all' || options[:test].include?(14)
 end
 
 if options[:test] == 'all' || options[:test].include?(15)
-  info '[15/25] Running windows hashes in john pot mode...'
+  info '[15/24] Running sql hashes in john pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
-  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
-  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
-  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
-  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
-  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
-  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
-  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
-  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
-  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
-  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
-  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
-  creds_command << ' use auxiliary/analyze/crack_windows;'
+  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto$/
+  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO$/
+  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!$/
+  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe$/
+  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere$/
+  creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
+  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A$/
+  creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
+  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES$/
+  # can't escape ;?
+  # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
+  # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
+  # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
+  # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password$/
+
+  creds_command << ' use auxiliary/analyze/crack_databases;'
+  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
   creds_command << " set POT #{pot_file.path};"
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -603,41 +633,23 @@ if options[:test] == 'all' || options[:test].include?(15)
 end
 
 if options[:test] == 'all' || options[:test].include?(16)
-  info '[16/25] Running sql hashes in john pot mode...'
+  info '[16/24] Running osx hashes in john pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
-  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
-  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
-  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
-  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
-  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
-  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
-  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
-  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
-  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
-  creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
-  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
-  creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
-  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
-  # can't escape ;?
-  # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
-  # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
-  # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
-  # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
-  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
-
-  creds_command << ' use auxiliary/analyze/crack_databases;'
-  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat$/
+  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat$/
+  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat$/
+  creds_command << ' use auxiliary/analyze/crack_osx;'
   creds_command << " set POT #{pot_file.path};"
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -645,23 +657,25 @@ if options[:test] == 'all' || options[:test].include?(16)
 end
 
 if options[:test] == 'all' || options[:test].include?(17)
-  info '[17/25] Running mobile hashes in john pot mode...'
+  info '[17/24] Running webapp hashes in john pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
-  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
-  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
-  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
-  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
-  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
-  creds_command << ' use auxiliary/analyze/crack_mobile;'
-  creds_command << " set CUSTOM_WORDLIST #{wordlist.path};"
+  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat$/
+  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
+  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
+  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat$}
+  creds_command << ' use auxiliary/analyze/crack_webapps;'
   creds_command << " set POT #{pot_file.path};"
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -669,22 +683,33 @@ if options[:test] == 'all' || options[:test].include?(17)
 end
 
 if options[:test] == 'all' || options[:test].include?(18)
-  info '[18/25] Running osx hashes in john pot mode...'
+  info '[18/24] Running *nix hashes in hashcat pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
-  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
-  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
-  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
-  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
-  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
-  creds_command << ' use auxiliary/analyze/crack_osx;'
+  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password$/
+  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password$}
+  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password$/
+  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
+  creds_command << ' set SHA256 true;'
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password$}
+  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
+  creds_command << ' set SHA512 true;'
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password$}
+  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
+  creds_command << ' set BLOWFISH true;'
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password$}
+  creds_command << ' use auxiliary/analyze/crack_linux;'
   creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -692,24 +717,30 @@ if options[:test] == 'all' || options[:test].include?(18)
 end
 
 if options[:test] == 'all' || options[:test].include?(19)
-  info '[19/25] Running webapp hashes in john pot mode...'
+  info '[19/24] Running windows hashes in hashcat pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
-  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
-  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
-  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
-  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
-  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
-  creds_command << ' use auxiliary/analyze/crack_webapps;'
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+PASSWORD$/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat$/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat$/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1$/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
+  creds_command << ' use auxiliary/analyze/crack_windows;'
   creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -717,97 +748,34 @@ if options[:test] == 'all' || options[:test].include?(19)
 end
 
 if options[:test] == 'all' || options[:test].include?(20)
-  info '[20/25] Running *nix hashes in hashcat pot mode...'
-
-  creds_expected_output_regex = []
-  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
-  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
-  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
-  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password}
-  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
-  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password/
-  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
-  creds_command << ' set SHA256 true;'
-  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password}
-  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
-  creds_command << ' set SHA512 true;'
-  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password}
-  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
-  creds_command << ' set BLOWFISH true;'
-  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password}
-  creds_command << ' use auxiliary/analyze/crack_linux;'
-  creds_command << " set POT #{pot_file.path};"
-  creds_command << ' set action hashcat;'
-  creds_command << ' run; creds -d; exit;'
-  info "Run Command: #{creds_command}" if options[:verbose]
-  unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
-    pot_file.close!
-    pot_file.unlink
-    exit 1
-  end
-end
-
-if options[:test] == 'all' || options[:test].include?(21)
-  info '[21/25] Running windows hashes in hashcat pot mode...'
-
-  creds_expected_output_regex = []
-  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
-  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+PASSWORD/
-  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
-  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password/
-  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
-  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat/
-  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
-  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat/
-  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
-  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1/
-  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
-  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
-  creds_command << ' use auxiliary/analyze/crack_windows;'
-  creds_command << " set POT #{pot_file.path};"
-  creds_command << ' set action hashcat;'
-  creds_command << ' run; creds -d; exit;'
-  info "Run Command: #{creds_command}" if options[:verbose]
-  unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
-    pot_file.close!
-    pot_file.unlink
-    exit 1
-  end
-end
-
-if options[:test] == 'all' || options[:test].include?(22)
-  info '[22/25] Running sql hashes in hashcat pot mode...'
+  info '[20/24] Running sql hashes in hashcat pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
   creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
-  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto/
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto$/
   creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
-  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO/
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO$/
   creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
-  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!/
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!$/
   creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
-  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe/
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe$/
   creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
-  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere/
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere$/
   # hashcat des,oracle is a no go: https://github.com/rapid7/metasploit-framework/blob/7a7b009161d6b0839653f21296864da3365402a0/lib/metasploit/framework/password_crackers/cracker.rb#L152-L155
   # creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
-  # creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A/
+  # creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A$/
   # creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
-  # creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES/
+  # creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES$/
   # can't escape ;?
   # creds_command << ' creds add user:DEMO hash:\'S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A;H:DC9894A01797D91D92ECA1DA66242209;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C\' jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:oracle11_epsilon hash:"S:8F2D65FB5547B71C8DA3760F10960428CD307B1C6271691FC55C1F56554A\\\\;H:DC9894A01797D91D92ECA1DA66242209\\\\;T:23D1F8CAC9001F69630ED2DD8DF67DD3BE5C470B5EA97B622F757FE102D8BF14BEDC94A3CC046D10858D885DB656DC0CBF899A79CD8C76B788744844CADE54EEEB4FDEC478FB7C7CBFBBAC57BA3EF22C" jtr:raw-sha1,oracle;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:oracle12c_epsilon hash:"H:DC9894A01797D91D92ECA1DA66242209\\\\;T:E3243B98974159CC24FD2C9A8B30BA62E0E83B6CA2FC7C55177C3A7F82602E3BDD17CEB9B9091CF9DAD672B8BE961A9EAC4D344BDBA878EDC5DCB5899F689EBD8DD1BE3F67BFF9813A464382381AB36B" jtr:pbkdf2,oracle12c;'
-  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat/
+  # creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
   # creds_command << ' creds add user:example postgres:md5be86a79bf2043622d58d5453c47d4860;'
-  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password/
+  # creds_expected_output_regex << /example\s+md5be86a79bf2043622d58d5453c47d4860\s+Postgres md5\s+raw-md5,postgres\s+password$/
 
   creds_command << ' use auxiliary/analyze/crack_databases;'
   creds_command << " set POT #{pot_file.path};"
@@ -815,7 +783,58 @@ if options[:test] == 'all' || options[:test].include?(22)
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(21)
+  info '[21/24] Running mobile hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
+  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234$/
+  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
+  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234$/
+  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
+  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234$/
+  creds_command << ' use auxiliary/analyze/crack_mobile;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
+    pot_file.close!
+    pot_file.unlink
+    exit 1
+  end
+end
+
+if options[:test] == 'all' || options[:test].include?(22)
+  info '[22/24] Running osx hashes in hashcat pot mode...'
+
+  creds_expected_output_regex = []
+  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat$/
+  creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat$/
+  creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat$/
+  creds_command << ' use auxiliary/analyze/crack_osx;'
+  creds_command << " set POT #{pot_file.path};"
+  creds_command << ' set action hashcat;'
+  creds_command << ' run; creds -d; exit;'
+  info "Run Command: #{creds_command}" if options[:verbose]
+  unless run_msfconsole(creds_command, creds_expected_output_regex)
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -823,23 +842,26 @@ if options[:test] == 'all' || options[:test].include?(22)
 end
 
 if options[:test] == 'all' || options[:test].include?(23)
-  info '[23/25] Running mobile hashes in hashcat pot mode...'
+  info '[23/24] Running webapp hashes in hashcat pot mode...'
 
   creds_expected_output_regex = []
   creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
-  creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
-  creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234/
-  creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
-  creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234/
-  creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
-  creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234/
-  creds_command << ' use auxiliary/analyze/crack_mobile;'
+  creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat$/
+  creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
+  creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
+  creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat$}
+  creds_command << ' use auxiliary/analyze/crack_webapps;'
   creds_command << " set POT #{pot_file.path};"
   creds_command << ' set action hashcat;'
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1
@@ -847,49 +869,76 @@ if options[:test] == 'all' || options[:test].include?(23)
 end
 
 if options[:test] == 'all' || options[:test].include?(24)
-  info '[24/25] Running osx hashes in hashcat pot mode...'
+  info '[24/24] Running all hashes in john apply_pot mode...'
 
   creds_expected_output_regex = []
-  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_command = 'setg verbose true;'
+  creds_command << ' creds add user:des_password hash:rEK1ecacw.7.c jtr:des;'
+  creds_expected_output_regex << /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password$/
+  creds_command << ' creds add user:md5_password hash:\$1\$O3JMY.Tw\$AdLnLjQ/5jXF9.MTp3gHv/ jtr:md5;'
+  creds_expected_output_regex << %r{md5_password\s+\$1\$O3JMY\.Tw\$AdLnLjQ/5jXF9\.MTp3gHv/\s+Nonreplayable hash\s+md5\s+password$}
+  creds_command << ' creds add user:bsdi_password hash:_J9..K0AyUubDrfOgO4s jtr:bsdi;'
+  creds_expected_output_regex << /bsdi_password\s+_J9\.\.K0AyUubDrfOgO4s\s+Nonreplayable hash\s+bsdi\s+password$/
+  creds_command << ' creds add user:sha256_password hash:\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5 jtr:sha256,crypt;'
+  creds_expected_output_regex << %r{sha256_password\s+\$5\$MnfsQ4iN\$ZMTppKN16y/tIsUYs/obHlhdP\.Os80yXhTurpBMUbA5\s+Nonreplayable hash\s+sha256,crypt\s+password$}
+  creds_command << ' creds add user:sha512_password hash:\$6\$zWwwXKNj\$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1 jtr:sha512,crypt;'
+  creds_expected_output_regex << %r{sha512_password\s+\$6\$zWwwXKNj\$gLAOoZCjcr8p/\.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV \(TRUNCATED\)\s+Nonreplayable hash\s+sha512,crypt\s+password$}
+  creds_command << ' creds add user:blowfish_password hash:\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe jtr:bf;'
+  creds_expected_output_regex << %r{blowfish_password\s+\$2a\$05\$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe\s+Nonreplayable hash\s+bf\s+password$}
+  creds_command << ' creds add user:lm_password ntlm:E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C jtr:lm;'
+  creds_expected_output_regex << /lm_password\s+e52cac67419a9a224a3b108f3fa6cb6d:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
+  creds_command << ' creds add user:nt_password ntlm:AAD3B435B51404EEAAD3B435B51404EE:8846F7EAEE8FB117AD06BDD830B7586C jtr:nt;'
+  creds_expected_output_regex << /nt_password\s+aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c\s+NTLM hash\s+nt,lm\s+password$/
+  creds_command << ' creds add user:u4-netntlm hash:u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41:cb8086049ec4736c jtr:netntlm;'
+  creds_expected_output_regex << /u4-netntlm\s+u4-netntlm::kNS:338d08f8e26de93300000000000000000000000000000000:9526fb8c23a \(TRUNCATED\)\s+Nonreplayable hash\s+netntlm\s+hashcat$/
+  creds_command << ' creds add user:admin hash:admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030 jtr:netntlmv2;'
+  creds_expected_output_regex << /admin\s+admin::N46iSNekpT:08ca45b7d7ea58ee:88dcbe4446168966a153a0064958dac6:5c783031 \(TRUNCATED\)\s+Nonreplayable hash\s+netntlmv2\s+hashcat$/
+  creds_command << ' creds add user:mscash-test1 hash:M\$test1#64cd29e36a8431a2b111378564a10631 jtr:mscash;'
+  creds_expected_output_regex << /mscash-test1\s+M\$test1\#64cd29e36a8431a2b111378564a10631\s+Nonreplayable hash\s+mscash\s+test1$/
+  creds_command << ' creds add user:mscash2-hashcat hash:\$DCC2\$10240#tom#e4e938d12fe5974dc42a90120bd9c90f jtr:mscash2;'
+  creds_expected_output_regex << /mscash2-hashcat\s+\$DCC2\$10240\#tom\#e4e938d12fe5974dc42a90120bd9c90f\s+Nonreplayable hash\s+mscash2\s+hashcat$/
+  creds_command << ' creds add user:mssql05_toto hash:0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908 jtr:mssql05;'
+  creds_expected_output_regex << /mssql05_toto\s+0x01004086CEB6BF932BC4151A1AF1F13CD17301D70816A8886908\s+Nonreplayable hash\s+mssql05\s+toto$/
+  creds_command << ' creds add user:mssql_foo hash:0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6913CE747006A2E3254 jtr:mssql;'
+  creds_expected_output_regex << /mssql_foo\s+0x0100A607BA7C54A24D17B565C59F1743776A10250F581D482DA8B6D6261460D3F53B279CC6 \(TRUNCATED\)\s+Nonreplayable hash\s+mssql\s+FOO$/
+  creds_command << ' creds add user:mssql12_Password1! hash:0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE92CC9347ECCB34C3EFADAF2FD99BFFECD8D9150DD6AACB5D409A9D2652A4E0AF16 jtr:mssql12;'
+  creds_expected_output_regex << /mssql12_Password1!\s+0x0200F733058A07892C5CACE899768F89965F6BD1DED7955FE89E1C9A10E27849B0B213B5CE \(TRUNCATED\)\s+Nonreplayable hash\s+mssql12\s+Password1!$/
+  creds_command << ' creds add user:mysql_probe hash:445ff82636a7ba59 jtr:mysql;'
+  creds_expected_output_regex << /mysql_probe\s+445ff82636a7ba59\s+Nonreplayable hash\s+mysql\s+probe$/
+  creds_command << ' creds add user:mysql-sha1_tere hash:*5AD8F88516BD021DD43F171E2C785C69F8E54ADB jtr:mysql-sha1;'
+  creds_expected_output_regex << /mysql-sha1_tere\s+\*5AD8F88516BD021DD43F171E2C785C69F8E54ADB\s+Nonreplayable hash\s+mysql-sha1\s+tere$/
+  creds_command << ' creds add user:simon hash:4F8BC1809CB2AF77 jtr:des,oracle;'
+  creds_expected_output_regex << /simon\s+4F8BC1809CB2AF77\s+Nonreplayable hash\s+des,oracle\s+A$/
+  creds_command << ' creds add user:SYSTEM hash:9EEDFA0AD26C6D52 jtr:des,oracle;'
+  creds_expected_output_regex << /SYSTEM\s+9EEDFA0AD26C6D52\s+Nonreplayable hash\s+des,oracle\s+THALES$/
+  # mobile is done on hashcat, not john, so skip these
+  # creds_command << ' creds add user:samsungsha1 hash:D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1 jtr:android-samsung-sha1;'
+  # creds_expected_output_regex << /samsungsha1\s+D1B19A90B87FC10C304E657F37162445DAE27D16:a006983800cc3dd1\s+Nonreplayable hash\s+android-samsung-sha1\s+1234$/
+  # creds_command << ' creds add user:androidsha1 hash:9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5 jtr:android-sha1;'
+  # creds_expected_output_regex << /androidsha1\s+9860A48CA459D054F3FEF0F8518CF6872923DAE2:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-sha1\s+1234$/
+  # creds_command << ' creds add user:androidmd5 hash:1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5 jtr:android-md5;'
+  # creds_expected_output_regex << /androidmd5\s+1C0A0FDB673FBA36BEAEB078322C7393:81fcb23bcadd6c5\s+Nonreplayable hash\s+android-md5\s+1234$/
   creds_command << ' creds add user:xsha_hashcat hash:1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683 jtr:xsha;'
-  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat/
+  creds_expected_output_regex << /xsha_hashcat\s+1430823483d07626ef8be3fda2ff056d0dfd818dbfe47683\s+Nonreplayable hash\s+xsha\s+hashcat$/
   creds_command << ' creds add user:pbkdf2_hashcat hash:\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$752351df64dd2ce9dc9c64a72ad91de6581a15c19176266b44d98919dfa81f0f96cbcb20a1ffb400718c20382030f637892f776627d34e021bad4f81b7de8222 jtr:PBKDF2-HMAC-SHA512;'
-  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat/
+  creds_expected_output_regex << /pbkdf2_hashcat\s+\$ml\$35460\$93a94bd24b5de64d79a5e49fa372827e739f4d7b6975c752c9a0ff1e5cf72e05\$7 \(TRUNCATED\)\s+Nonreplayable hash\s+PBKDF2-HMAC-SHA512\s+hashcat$/
   creds_command << ' creds add user:xsha512_hashcat hash:648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c007db6882680b09962d16fd9c45568260531bdb34804a5e31c22b4cfeb32d jtr:xsha512;'
-  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat/
-  creds_command << ' use auxiliary/analyze/crack_osx;'
-  creds_command << " set POT #{pot_file.path};"
-  creds_command << ' set action hashcat;'
-  creds_command << ' run; creds -d; exit;'
-  info "Run Command: #{creds_command}" if options[:verbose]
-  unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
-    pot_file.close!
-    pot_file.unlink
-    exit 1
-  end
-end
-
-if options[:test] == 'all' || options[:test].include?(25)
-  info '[25/25] Running webapp hashes in hashcat pot mode...'
-
-  creds_expected_output_regex = []
-  creds_command = 'setg INCREMENTAL false;setg USE_CREDS false; setg USE_DB_INFO false; setg USE_DEFAULT_WORDLIST false; setg USE_HOSTNAMES false; setg USE_ROOT_WORDS false; setg WORDLIST false; setg verbose true;'
+  creds_expected_output_regex << /xsha512_hashcat\s+648742485c9b0acd786a233b2330197223118111b481abfa0ab8b3e8ede5f014fc7c523991c0 \(TRUNCATED\)\s+Nonreplayable hash\s+xsha512\s+hashcat$/
   creds_command << ' creds add user:mediawiki_hashcat hash:\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898 jtr:mediawiki;'
-  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat/
+  creds_expected_output_regex << /mediawiki_hashcat\s+\$B\$56668501\$0ce106caa70af57fd525aeaf80ef2898\s+Nonreplayable hash\s+mediawiki\s+hashcat$/
   creds_command << ' creds add user:phpass_p_hashcat hash:\$P\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_expected_output_regex << /phpass_p_hashcat\s+\$P\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
   creds_command << ' creds add user:phpass_h_hashcat hash:\$H\$984478476IagS59wHZvyQMArzfx58u. jtr:phpass;'
-  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat/
+  creds_expected_output_regex << /phpass_h_hashcat\s+\$H\$984478476IagS59wHZvyQMArzfx58u\.\s+Nonreplayable hash\s+phpass\s+hashcat$/
   creds_command << ' creds add user:atlassian_hashcat hash:{PKCS5S2}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa jtr:PBKDF2-HMAC-SHA1;'
-  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat}
-  creds_command << ' use auxiliary/analyze/crack_webapps;'
+  creds_expected_output_regex << %r{atlassian_hashcat\s+\{PKCS5S2\}NzIyNzM0NzY3NTIwNjI3MdDDis7wPxSbSzfFqDGf7u/L00kSEnupbz36XCL0m7wa\s+Nonreplayable\s+hash\s+PBKDF2-HMAC-SHA1\s+hashcat$}
+  creds_command << ' use auxiliary/analyze/apply_pot;'
   creds_command << " set POT #{pot_file.path};"
-  creds_command << ' set action hashcat;'
   creds_command << ' run; creds -d; exit;'
   info "Run Command: #{creds_command}" if options[:verbose]
   unless run_msfconsole(creds_command, creds_expected_output_regex)
-    error "\nCredential verification failed. Exiting."
+    puts '-------------------------------'
+    error "Credential verification failed. Exiting."
     pot_file.close!
     pot_file.unlink
     exit 1


### PR DESCRIPTION
As seen in #17667 validating that hash cracking is working successfully in MSF is long and cumbersome. With the hopefully soon to be automated inclusion of #19779 (weekly updater), we need a better way to check that changes to the crackers is working.  This PR adds a script to do that.

## Successful Run

```
$ tools/dev/hash_cracker_validator.rb 
[WARNING] WARNING: All credentials will be deleted as part of this script execution!
[INFO] [1/24] Checking Metasploit database connection...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 4.950661692 seconds
[INFO] Wordlist file created at: /tmp/wordlist20250228-693264-3sj77k
[INFO] [2/24] Running *nix hashes in john wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 11.262455612 seconds
[INFO] [3/24] Running windows hashes in john wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 9.642663838 seconds
[INFO] [4/24] Running sql hashes in john wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 9.864589686 seconds
[INFO] [5/24] Running osx hashes in john wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 7.918455912 seconds
[INFO] [6/24] Running webapp hashes in john wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 8.358848852 seconds
[INFO] [7/24] Running *nix hashes in hashcat wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 84.350098113 seconds
[INFO] [8/24] Running windows hashes in hashcat wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 24.398359488 seconds
[INFO] [9/24] Running sql hashes in hashcat wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 20.903051387 seconds
[INFO] [10/24] Running mobile hashes in hashcat wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 18.712022663 seconds
[INFO] [11/24] Running osx hashes in hashcat wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 15.163747315 seconds
[INFO] [12/24] Running webapp hashes in hashcat wordlist mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 15.970887896 seconds
[INFO] john.pot file created at: /tmp/john_pot20250228-693264-udv5jn
[INFO] [13/24] Running *nix hashes in john pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.255989481 seconds
[INFO] [14/24] Running windows hashes in john pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.292916553 seconds
[INFO] [15/24] Running sql hashes in john pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.287442623 seconds
[INFO] [16/24] Running osx hashes in john pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 7.059469146 seconds
[INFO] [17/24] Running webapp hashes in john pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 5.870106183 seconds
[INFO] [18/24] Running *nix hashes in hashcat pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 7.221386971 seconds
[INFO] [19/24] Running windows hashes in hashcat pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 7.212911127 seconds
[INFO] [20/24] Running sql hashes in hashcat pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.916962891 seconds
[INFO] [21/24] Running mobile hashes in hashcat pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.330068139 seconds
[INFO] [22/24] Running osx hashes in hashcat pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.380563284 seconds
[INFO] [23/24] Running webapp hashes in hashcat pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 6.426694704 seconds
[INFO] [24/24] Running all hashes in john apply_pot mode...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 8.879158432 seconds
-------------------------------
[GOOD] All checks passed successfully!
[INFO] Script runtime: 312.636031216 seconds
```

## Error Run

```
[WARNING] WARNING: All credentials will be deleted as part of this script execution!
[INFO] [1/25] Checking Metasploit database connection...
[GOOD]   SUCCESS: All expected outputs found.
[GOOD]   Section Runtime: 11.76054354 seconds
[INFO] Wordlist file created at: /tmp/wordlist20250226-18112-bro2r4
[INFO] [2/25] Running *nix hashes in john wordlist mode...
[ERROR]   FAILURE: Expected output not found for regex: /des_password\s+rEK1ecacw\.7\.c\s+Nonreplayable hash\s+des\s+password/
[ERROR]   STDOUT: [*] Processing /home/h00die/.msf4/msfconsole.rc for ERB directives.
[*] Starting persistent handler(s)...
INCREMENTAL => false
USE_CREDS => false
USE_DB_INFO => false
USE_DEFAULT_WORDLIST => false
USE_HOSTNAMES => false
USE_ROOT_WORDS => false
WORDLIST => true
verbose => true
SHA256 => true
SHA512 => true
BLOWFISH => true
[*] Using action john - view all 2 actions with the show actions command
CUSTOM_WORDLIST => /tmp/wordlist20250226-18112-bro2r4
POT => /tmp/john_pot20250226-18112-vo6eef
[+] john Version Detected: 1.9.0-jumbo-1+bleeding-aec1328d6c 2021-11-02 10:45:52 +0100 OMP
[*] Wordlist file written out to /tmp/jtrtmp20250226-18235-pru55u
[*] Checking md5crypt hashes already cracked...
[*] Cracking md5crypt hashes in single mode...
[*]    Cracking Command: /usr/sbin/john --session=BZ60Ck65 --no-log --config=/home/h00die/metasploit-framework/data/jtr/john.conf --pot=/tmp/john_pot20250226-18112-vo6eef --format=md5crypt --wordlist=/tmp/jtrtmp20250226-18235-pru55u --rules=single /tmp/hashes_md5crypt_20250226-18235-tjkou
[*] Loaded 1 password hash (md5crypt, crypt(3) $1$ (and variants) [MD5 256/256 AVX2 8x3])
[*] password         (md5_password)     
[+] Cracked Hashes
==============

 DB ID  Hash Type  Username      Cracked Password  Method
 -----  ---------  --------      ----------------  ------
 377    md5crypt   md5_password  password          Single

```
...snip...
```

[+] Cracked Hashes
==============

 DB ID  Hash Type    Username           Cracked Password  Method
 -----  ---------    --------           ----------------  ------
 377    md5crypt     md5_password       password          Single
 378    bsdicrypt    bsdi_password      password          Single
 379    sha256crypt  sha256_password    password          Single
 380    sha512crypt  sha512_password    password          Single
 381    bcrypt       blowfish_password  password          Single

[*] Auxiliary module execution completed
Credentials
===========

host  origin  service  public             private                                                                                   realm  private_type        JtR Format    cracked_password
----  ------  -------  ------             -------                                                                                   -----  ------------        ----------    ----------------
                       des_password       rEK1ecacw.7.d                                                                                    Nonreplayable hash  des
                       md5_password       $1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/                                                               Nonreplayable hash  md5           password
                       bsdi_password      _J9..K0AyUubDrfOgO4s                                                                             Nonreplayable hash  bsdi          password
                       sha256_password    $5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5                                          Nonreplayable hash  sha256,crypt  password
                       sha512_password    $6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcV (TRUNCATED)         Nonreplayable hash  sha512,crypt  password
                       blowfish_password  $2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe                                     Nonreplayable hash  bf            password

[*] Deleted 11 creds

[ERROR]   Section Runtime: 15.987648727 seconds
[ERROR]   STDERR: Using default input encoding: UTF-8
Will run 20 OpenMP threads
Press Ctrl-C to abort, or send SIGUSR1 to john process for status
1g 0:00:00:00 DONE (2025-02-26 21:21) 100.0g/s 192000p/s 192000c/s 192000C/s password..Dd
Use the "--show" option to display all of the cracked passwords reliably
Session completed. 
Using default input encoding: UTF-8
Using default input encoding: UTF-8
Using default input encoding: UTF-8
Using default input encoding: UTF-8
Will run 20 OpenMP threads
Press Ctrl-C to abort, or send SIGUSR1 to john process for status
1g 0:00:00:00 DONE (2025-02-26 21:21) 33.33g/s 170666p/s 170666c/s 170666C/s password..`toto
Use the "--show" option to display all of the cracked passwords reliably
Session completed. 
Using default input encoding: UTF-8
Will run 20 OpenMP threads
Press Ctrl-C to abort, or send SIGUSR1 to john process for status
1g 0:00:00:00 DONE (2025-02-26 21:21) 25.00g/s 4500p/s 4500c/s 4500C/s password..Testpass7
Use the "--show" option to display all of the cracked passwords reliably
Session completed. 
Using default input encoding: UTF-8
Will run 20 OpenMP threads
Press Ctrl-C to abort, or send SIGUSR1 to john process for status
1g 0:00:00:00 DONE (2025-02-26 21:21) 2.173g/s 22260p/s 22260c/s 22260C/s password..Testpass123#62
Use the "--show" option to display all of the cracked passwords reliably
Session completed. 
Using default input encoding: UTF-8
Will run 20 OpenMP threads
Press Ctrl-C to abort, or send SIGUSR1 to john process for status
1g 0:00:00:00 DONE (2025-02-26 21:21) 5.263g/s 13473p/s 13473c/s 13473C/s password..D<
Use the "--show" option to display all of the cracked passwords reliably
Session completed. 
[ERROR] 
Credential verification failed. Exiting.
```

# Verification Steps
- [ ] make sure you have hashcat working, i recommend kali.
- [ ] run the script and verify you get a `[GOOD] All checks passed successfully!`