### PR TITLE
Add NIST SP 800 Crypto Primitives

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -122,17 +122,21 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
 
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/7fd079ca-17e6-4f02-8449-46b606ea289c
       if @dialect == '0x0300' || @dialect == '0x0302'
-        @application_key = RubySMB::Crypto::KDF.counter_mode(
+        @application_key = Rex::Crypto::KeyDerivation::NIST_SP_800_108.counter_hmac(
           @session_key,
-          "SMB2APP\x00",
-          "SmbRpc\x00"
-        )
+          16,
+          'SHA256',
+          label: "SMB2APP\x00",
+          context: "SmbRpc\x00"
+        ).first
       else
-        @application_key = RubySMB::Crypto::KDF.counter_mode(
+        @application_key = Rex::Crypto::KeyDerivation::NIST_SP_800_108.counter_hmac(
           @session_key,
-          "SMBAppKey\x00",
-          @preauth_integrity_hash_value
-        )
+          16,
+          'SHA256',
+          label: "SMBAppKey\x00",
+          context: @preauth_integrity_hash_value
+        ).first
       end
       # otherwise, leave encryption to the default value that it was initialized to
     end

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -299,7 +299,8 @@ class MsfAutoload
       'smb_hash_capture' => 'SMBHashCapture',
       'rex_ntlm' => 'RexNTLM',
       'teamcity' => 'TeamCity',
-      'nist_sp_800_38f' => 'NIST_SP_800_38f'
+      'nist_sp_800_38f' => 'NIST_SP_800_38f',
+      'nist_sp_800_108' => 'NIST_SP_800_108'
     }
   end
 

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -298,7 +298,8 @@ class MsfAutoload
       'uds_errors' => 'UDSErrors',
       'smb_hash_capture' => 'SMBHashCapture',
       'rex_ntlm' => 'RexNTLM',
-      'teamcity' => 'TeamCity'
+      'teamcity' => 'TeamCity',
+      'nist_sp_800_38f' => 'NIST_SP_800_38f'
     }
   end
 

--- a/lib/rex/crypto/key_derivation.rb
+++ b/lib/rex/crypto/key_derivation.rb
@@ -1,0 +1,3 @@
+module Rex::Crypto::KeyDerivation
+  require 'rex/crypto/key_derivation/nist_sp_800_108'
+end

--- a/lib/rex/crypto/key_derivation/nist_sp_800_108.rb
+++ b/lib/rex/crypto/key_derivation/nist_sp_800_108.rb
@@ -1,0 +1,45 @@
+require 'openssl'
+
+module Rex::Crypto::KeyDerivation::NIST_SP_800_108
+
+  # Generates key material using the NIST SP 800-108 R1 counter mode KDF.
+  #
+  # @param length [Integer] The desired output length of each key in bytes.
+  # @param prf [Proc] The pseudorandom function used for key derivation.
+  # @param keys [Integer] The number of derived keys to generate.
+  # @param label [String] Optional label to distinguish different derivations.
+  # @param context [String] Optional context to bind the key derivation to specific information.
+  #
+  # @return [Array<String>] An array of derived keys as binary strings, regardless of the number requested.
+  def self.counter(length, prf, keys: 1, label: ''.b, context: ''.b)
+    key_block = ''
+
+    counter = 0
+    while key_block.length < (length * keys)
+      counter += 1
+      raise RangeError.new("counter overflow") if counter > 0xffffffff
+
+      info = [ counter ].pack('L>') + label + "\x00".b + context + [ length * keys * 8 ].pack('L>')
+      key_block << prf.call(info)
+    end
+
+    key_block.bytes.each_slice(length).to_a[...keys].map { |slice| slice.pack('C*') }
+  end
+
+  # Generates key material using the NIST SP 800-108 R1 counter mode KDF with HMAC.
+  #
+  # @param secret [String] The secret key used as the HMAC key.
+  # @param length [Integer] The desired output length of each key in bytes.
+  # @param algorithm [String, Symbol] The HMAC hash algorithm (e.g., `SHA256`, `SHA512`).
+  # @param keys [Integer] The number of derived keys to generate (default: 1).
+  # @param label [String] Optional label to distinguish different derivations.
+  # @param context [String] Optional context to bind the key derivation to specific information.
+  #
+  # @return [Array<String>] Returns an array of derived keys.
+  #
+  # @raise [ArgumentError] If the requested length is invalid or the algorithm is unsupported.
+  def self.counter_hmac(secret, length, algorithm, keys: 1, label: ''.b, context: ''.b)
+    prf = -> (data) { OpenSSL::HMAC.digest(algorithm, secret, data) }
+    counter(length, prf, keys: keys, label: label, context: context)
+  end
+end

--- a/lib/rex/crypto/key_wrap.rb
+++ b/lib/rex/crypto/key_wrap.rb
@@ -1,0 +1,3 @@
+module Rex::Crypto::KeyWrap
+  require 'rex/crypto/key_wrap/nist_sp_800_38f'
+end

--- a/lib/rex/crypto/key_wrap/nist_sp_800_38f.rb
+++ b/lib/rex/crypto/key_wrap/nist_sp_800_38f.rb
@@ -1,0 +1,52 @@
+# see: [NIST SP 800-38F, Section 6.2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38F.pdf)
+module Rex; end
+module Rex::Crypto; end
+module Rex::Crypto::KeyWrap; end
+
+module Rex::Crypto::KeyWrap::NIST_SP_800_38f
+
+  # Performs AES key unwrapping from NIST SP 800-38F.
+  #
+  # @param kek [String] The key-encryption key (KEK) used to unwrap the ciphertext.
+  # @param key_data [String] The wrapped key data.
+  # @param authenticate [Boolean] Whether to check the data integrity or not.
+  # @return [String, nil] The unwrapped key on success, or nil if unwrapping fails.
+  #
+  # @see https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38F.pdf
+  def self.aes_unwrap(kek, key_data, authenticate: true)
+    # padded mode as described in Section 6.3 is not supported at this time
+    raise Rex::ArgumentError.new('kek must be 16, 24 or 32-bytes long') unless [16, 24, 32].include?(kek.length)
+    raise Rex::ArgumentError.new('key_data length must be a multiple of 8') unless key_data.length % 8 == 0
+    icv1 = ("\xa6".b * 8)
+
+    r = key_data.bytes.each_slice(8).map { |c| c.pack('C*') }
+    a = r.shift
+
+    ciph = -> (data) do
+      # per-section 5.1, AES is the only suitable block cipher
+      cipher = OpenSSL::Cipher::AES.new(kek.length * 8, :ECB).decrypt
+      cipher.key = kek
+      cipher.padding = 0
+      cipher.update(data)
+    end
+
+    n = r.length
+
+    5.downto(0) do |j|
+      (n - 1).downto(0) do |i|
+        atr = [a.unpack1('Q>') ^ ((n * j) + i + 1)].pack('Q>') + r[i]
+
+        b = ciph.call(atr)
+        a = b[...8]
+        r[i] = b[-8...]
+      end
+    end
+
+    # setting authenticate to true effectively switches the operation from Section 6.2 algorithm #2 to algorithm #4
+    if authenticate && a != icv1
+      raise Rex::RuntimeError.new('ICV1 integrity check failed in KW-AD(C)')
+    end
+
+    r.join('')
+  end
+end

--- a/spec/lib/rex/crypto/key_derivation/nist_sp_800_108_spec.rb
+++ b/spec/lib/rex/crypto/key_derivation/nist_sp_800_108_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'rex/crypto/key_derivation/nist_sp_800_108'
+
+RSpec.describe Rex::Crypto::KeyDerivation::NIST_SP_800_108 do
+  describe '.counter' do
+    let(:secret) { [ '000102030405060708090A0B0C0D0E0F' ].pack('H*') }
+    let(:prf) { RSpec::Mocks::Double.new('prf') }
+    let(:length) { 32 }
+    let(:label) { "RSpec Test Label\0" }
+    let(:context) { "RSpec Test Context\0" }
+
+    it 'builds the context block correctly for the prf' do
+      info = [ 1 ].pack('L>') + label + "\x00".b + context + [ length * 8 ].pack('L>')
+      expect(prf).to receive(:call).with(info).and_return(OpenSSL::HMAC.digest('SHA256', secret, info))
+      described_class.counter(length, prf, label: label, context: context)
+    end
+  end
+
+  describe '.counter_hmac' do
+    let(:secret) { [ '000102030405060708090A0B0C0D0E0F' ].pack('H*') }
+    let(:length) { 32 }
+    let(:label) { "RSpec Test Label\0" }
+    let(:context) { "RSpec Test Context\0" }
+
+    context 'when the algorithm is invalid' do
+      let(:algorithm) { 'InvalidAlgorithm' }
+
+      it 'raises an error' do
+        expect { described_class.counter_hmac(secret, length, algorithm, label: label, context: context) }.to raise_error(RuntimeError, /digest algorithm/)
+      end
+    end
+
+    context 'when the algorithm is SHA256' do
+      let(:algorithm) { 'SHA256' }
+      before(:each) { expect(OpenSSL::HMAC).to receive(:digest).at_least(:once).with(algorithm, secret, anything).and_call_original }
+      before(:each) { expect(described_class).to receive(:counter).with(length, anything, context: context, label: label, keys: instance_of(Integer)).and_call_original }
+
+      it 'uses SHA256 to calculate 1 key' do
+        keys = described_class.counter_hmac(secret, length, algorithm, label: label, context: context)
+        expect(keys.length).to eq 1
+        expect(keys[0]).to eq ['5889a9fe18d9d51b5eb95272088acbe38bd2ea82517f1956b919dc549a945aa0'].pack('H*')
+      end
+
+      it 'uses SHA256 to calculate 2 keys' do
+        keys = described_class.counter_hmac(secret, length, algorithm, label: label, context: context, keys: 2)
+        expect(keys.length).to eq 2
+        expect(keys[0]).to eq ['2060ea190b9ac147ccfbe2c094c49be04dcac80db6d05b1c32c54529caf24d43'].pack('H*')
+        expect(keys[1]).to eq ['f66a460fc1d03451c1ef669ee10953815460d368668be13301d6314878ed771d'].pack('H*')
+      end
+    end
+  end
+end

--- a/spec/lib/rex/crypto/key_wrap/nist_sp_800_38f_spec.rb
+++ b/spec/lib/rex/crypto/key_wrap/nist_sp_800_38f_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'rex/crypto/key_wrap/nist_sp_800_38f'
+
+RSpec.describe Rex::Crypto::KeyWrap::NIST_SP_800_38f do
+  let(:expected_plaintext) { [ '00112233445566778899AABBCCDDEEFF' ].pack('H*') }
+
+  # Test vector from RFC 3394, Section 4.1 - 128-bit KEK
+  let(:kek_128) { [ '000102030405060708090A0B0C0D0E0F' ].pack('H*') }
+  let(:ciphertext_128) { [ '1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5' ].pack('H*') }
+
+  # Test vector from RFC 3394, Section 4.2 - 192-bit KEK
+  let(:kek_192) { [ '000102030405060708090A0B0C0D0E0F1011121314151617' ].pack('H*') }
+  let(:ciphertext_192) { [ '96778B25AE6CA435F92B5B97C050AED2468AB8A17AD84E5D' ].pack('H*') }
+
+  # Test vector from RFC 3394, Section 4.3 - 256-bit KEK
+  let(:kek_256) { [ '000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F' ].pack('H*') }
+  let(:ciphertext_256) { [ '64E8C3F9CE0F5BA263E9777905818A2A93C8191E7D6E8AE7' ].pack('H*') }
+
+  describe '.aes_unwrap' do
+    it 'successfully unwraps a 128-bit key with a 128-bit KEK (RFC 3394, Section 4.1)' do
+      unwrapped_key = described_class.aes_unwrap(kek_128, ciphertext_128)
+      expect(unwrapped_key).to eq(expected_plaintext)
+    end
+
+    it 'successfully unwraps a 128-bit key with a 192-bit KEK (RFC 3394, Section 4.2)' do
+      unwrapped_key = described_class.aes_unwrap(kek_192, ciphertext_192)
+      expect(unwrapped_key).to eq(expected_plaintext)
+    end
+
+    it 'successfully unwraps a 128-bit key with a 256-bit KEK (RFC 3394, Section 4.3)' do
+      unwrapped_key = described_class.aes_unwrap(kek_256, ciphertext_256)
+      expect(unwrapped_key).to eq(expected_plaintext)
+    end
+
+    context 'when the wrapped key is corrupted' do
+      let(:corrupted_wrapped_key) { ['64E8C3F9CE0F5BA2A521427441A552DA'].pack('H*') }
+
+      context 'when authenticate is true' do
+        it 'raises an exception' do
+          expect { described_class.aes_unwrap(kek_128, corrupted_wrapped_key, authenticate: true) }.to raise_error(Rex::RuntimeError, /integrity check failed/)
+        end
+      end
+
+     context 'when authenticate is false' do
+        it 'successfully unwraps the key' do
+          unwrapped_key = described_class.aes_unwrap(kek_128, corrupted_wrapped_key, authenticate: false)
+          expect(unwrapped_key).to eq ['3078ea9fbd99e7d7'].pack('H*')
+        end
+      end
+    end
+
+    context 'when the wrapped key is invalid' do
+      let(:invalid_wrapped_key) { ['64E8C3F9CE0F5B'].pack('H*') } # Not a multiple of 8
+
+      it 'rejects keys with invalid ciphertext length' do
+        expect { described_class.aes_unwrap(kek_128, invalid_wrapped_key, authenticate: false) }.to raise_error(Rex::ArgumentError, /must be a multiple of 8/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds Crypto primitives for AES key derivation ([NIST SP 800 108](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf)) and AES key unwrapping ([NIST SP 800 38f](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38F.pdf)). Right now, only the KDF is used, replacing RubySMB's implementation which does not support all of the parameters. It doesn't seem like a good use for RubySMB to include crypto graphic primitives that intend to be feature complete. The key wrapping isn't required by RubySMB at all, and placing the key derivation in RubySMB would thus split the functionality.

## Key Derivation
The implementation contains a KDF function in counter mode using HMAC as the PRF (Pseudo Random Function). It allows the caller to specify the PRF, set an an algorithm, define the length of keys they need and how many keys they need. This is similar to what's offered by RubySMB but has more features. At least the ability to specify the HMAC digest algorithm is needed for in progress work.

## Key Unwrapping
The implementation supports unwrapping, unpadded AES keys with optional authentication of the IV. This is effectively algorithms numbered 2 and 4 from sections 6.1 and 6.2 respectively. The forward operation of wrapping a key is currently unimplemented, as is handling padded values that are not a multiple fo 8 bytes. Included in this PR are test vectors taken from [RFC 3394 Section 4](https://datatracker.ietf.org/doc/html/rfc3394#section-4) to demonstrate correctness.

NIST SP 800 38f Section 3.2 (Related Specifications) notes the relationship between it and RFC 3394 is "essentially equivalent". The NIST document specifies additional processing and rules such as the authentication mode and padding.
> In 2002, two industry groups published specifications of key-wrap algorithms that were based on
the specification that NIST posted. First, the Internet Engineering Task Force (IETF) developed
an essentially equivalent specification in Request For Comments (RFC) 3394 [11]. 

## Verification

- [x] Verify AES Key Unwrapping
    - [x] See that the unit tests pass and that they line up with the vectors from RFC 3394
- [x] Verify AES Key Derivation
    - [x] Test SMB authentication with Kerberos
