### PR TITLE
Ldap vulnerable cert finder minor fix for ESC13 detection

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -453,7 +453,8 @@ class MetasploitModule < Msf::Auxiliary
       groups = []
       entry['mspki-certificate-policy'].each do |certificate_policy_oid|
         policy = get_pki_object_by_oid(certificate_policy_oid)
-        next if policy['msds-oidtogrouplink'].blank?
+
+        next if policy&.[]('msds-oidtogrouplink').blank?
 
         # get the group and check it for two conditions
         group = get_group_by_dn(policy['msds-oidtogrouplink'].first)


### PR DESCRIPTION
If you create and issue a certificate template with an issuance policy that has not linked to a group in active directory, and then try to scan the target with `ldap_esc_vulnerable_cert_finder`, the module will fail as `policy['msds-oidtogrouplink'].blank?` doesn't not guard against `policy` being `nil`. This PR fixes the issue. 

## Before 
```
msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run domain=kerberos.issue rhost=172.16.199.200 username=administrator password=N0tpassword!
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[-] Auxiliary failed: NoMethodError undefined method `[]' for nil:NilClass
[-] Call stack:
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:456:in `block (2 levels) in find_esc13_vuln_cert_templates'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:454:in `each'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:454:in `block in find_esc13_vuln_cert_templates'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:449:in `each'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:449:in `find_esc13_vuln_cert_templates'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:823:in `block in run'
```

## After
```
msf6 auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run domain=kerberos.issue rhost=172.16.199.200 username=administrator password=N0tpassword!
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[+] Template: EFS
[*]   Distinguished Name: CN=EFS,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[*]   Manager Approval: Disabled
[*]   Required Signatures: 0
[+]   Vulnerable to: ESC4
...
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use ldap_esc_vulenrable_cert_finder`
- [ ] run the module against a target that issues a certificate with the aforementioned config and or verify this one line change looks good