### PR TITLE
Fixes crash when searching by target

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -179,17 +179,17 @@ module Msf::Modules::Metadata::Search
             when 'aka'
               match = [keyword, search_term] if (module_metadata.notes['AKA'] || []).any? { |aka| aka =~ regex }
             when 'author', 'authors'
-              match = [keyword, search_term] if module_metadata.author && module_metadata.author.any? { |author| author =~ regex }
+              match = [keyword, search_term] if module_metadata.author.any? { |author| author =~ regex }
             when 'arch'
               match = [keyword, search_term] if module_metadata.arch =~ regex
             when 'cve'
-              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^cve\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^cve\-/i and ref =~ regex }
             when 'osvdb'
-              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^osvdb\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^osvdb\-/i and ref =~ regex }
             when 'bid'
-              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^bid\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^bid\-/i and ref =~ regex }
             when 'edb'
-              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^edb\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^edb\-/i and ref =~ regex }
             when 'check'
               if module_metadata.check
                 matches_check = %w(true yes).any? { |val| val =~ regex}

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -179,17 +179,17 @@ module Msf::Modules::Metadata::Search
             when 'aka'
               match = [keyword, search_term] if (module_metadata.notes['AKA'] || []).any? { |aka| aka =~ regex }
             when 'author', 'authors'
-              match = [keyword, search_term] if module_metadata.author.any? { |author| author =~ regex }
+              match = [keyword, search_term] if module_metadata.author && module_metadata.author.any? { |author| author =~ regex }
             when 'arch'
               match = [keyword, search_term] if module_metadata.arch =~ regex
             when 'cve'
-              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^cve\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^cve\-/i and ref =~ regex }
             when 'osvdb'
-              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^osvdb\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^osvdb\-/i and ref =~ regex }
             when 'bid'
-              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^bid\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^bid\-/i and ref =~ regex }
             when 'edb'
-              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ /^edb\-/i and ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ /^edb\-/i and ref =~ regex }
             when 'check'
               if module_metadata.check
                 matches_check = %w(true yes).any? { |val| val =~ regex}
@@ -255,9 +255,9 @@ module Msf::Modules::Metadata::Search
             when 'ref', 'ref_name'
               match = [keyword, search_term] if module_metadata.ref_name =~ regex
             when 'reference', 'references'
-              match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ regex }
+              match = [keyword, search_term] if module_metadata.references && module_metadata.references.any? { |ref| ref =~ regex }
             when 'target', 'targets'
-              match = [keyword, search_term] if module_metadata.targets.any? { |target| target =~ regex }
+              match = [keyword, search_term] if module_metadata.targets && module_metadata.targets.any? { |target| target =~ regex }
             when 'type'
               match = [keyword, search_term] if Msf::MODULE_TYPES.any? { |module_type| search_term == module_type and module_metadata.type == module_type }
           else

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -380,7 +380,7 @@ module Msf
             print_line
             print_line "Keywords:"
             {
-              'adapter'     => 'Modules with a matching adater reference name',
+              'adapter'     => 'Modules with a matching adapter reference name',
               'aka'         => 'Modules with a matching AKA (also-known-as) name',
               'author'      => 'Modules written by this author',
               'arch'        => 'Modules affecting this architecture',

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("session_type:Meterpreter ")).to eq({"session_type"=>[["meterpreter"], []]}) }
     it { expect(described_class.parse_search_string("session_type:shell ")).to eq({"session_type"=>[["shell"], []]}) }
     it { expect(described_class.parse_search_string("action:forge_golden ")).to eq({"action"=>[["forge_golden"], []]}) }
+    it { expect(described_class.parse_search_string("targets:windows ")).to eq({"targets"=>[["windows"], []]}) }
+    it { expect(described_class.parse_search_string("targets:osx ")).to eq({"targets"=>[["osx"], []]}) }
+    it { expect(described_class.parse_search_string("targets:ubuntu ")).to eq({"targets"=>[["ubuntu"], []]}) }
   end
 
   describe '#find' do
@@ -229,6 +232,30 @@ RSpec.describe Msf::Modules::Metadata::Search do
       let(:opts) { { 'session_types' => ['mssql'] } }
       accept = %w[session_type:mssql]
       reject = %w[session_type:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #targets of ["windows"]' do
+      let(:opts) { { 'targets' => ['windows'] } }
+      accept = %w[targets:windows]
+      reject = %w[targets:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #targets of ["osx"]' do
+      let(:opts) { { 'targets' => ['osx'] } }
+      accept = %w[targets:osx]
+      reject = %w[targets:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #targets of ["ubuntu"]' do
+      let(:opts) { { 'targets' => ['ubuntu'] } }
+      accept = %w[targets:ubuntu]
+      reject = %w[targets:unrelated]
 
       it_should_behave_like 'search_filter', accept: accept, reject: reject
     end

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -154,6 +154,13 @@ RSpec.describe Msf::Modules::Metadata::Search do
       it_should_behave_like 'search_filter', :accept => accept, :reject => reject
     end
 
+    context 'on a module with a #author of nil' do
+      let(:opts) { ({ 'author' => [nil] }) }
+      reject = %w(author:foo)
+
+      it_should_behave_like 'search_filter', :reject => reject
+    end
+
     context 'on a module with the authors "joev" and "blarg"' do
       let(:opts) { ({ 'author' => ['joev', 'blarg'] }) }
       accept = %w(author:joev author:joe)
@@ -258,6 +265,22 @@ RSpec.describe Msf::Modules::Metadata::Search do
       reject = %w[targets:unrelated]
 
       it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #targets of ["ubuntu", "windows", "osx"]' do
+      let(:opts) { { 'targets' => %w[ubuntu windows osx] } }
+      accept = %w[targets:osx]
+      reject = %w[targets:unrelated]
+
+      it_should_behave_like 'search_filter', accept: accept, reject: reject
+    end
+
+    context 'on a module with a #targets of nil' do
+      let(:opts) { { 'targets' => nil } }
+
+      reject = %w[targets:foo]
+
+      it_should_behave_like 'search_filter', reject: reject
     end
 
     context 'on a module that supports the osx platform' do
@@ -385,6 +408,14 @@ RSpec.describe Msf::Modules::Metadata::Search do
           it_should_behave_like 'search_filter', :accept => accept, :reject => reject
         end
       end
+    end
+
+    context 'on a module with a #reference of nil' do
+      let(:opts) { { 'references' => nil } }
+
+      reject = %w[reference:foo]
+
+      it_should_behave_like 'search_filter', reject: reject
     end
 
     REF_TYPES.each do |ref_type|


### PR DESCRIPTION
This PR fixes https://github.com/rapid7/metasploit-framework/issues/19904.

I believe the issue was when attempting to call `.any?` on module metadata values that could be `nil`. I have updated any values that call `.any?` to also check they are available as part of an AND statement.

## Before 
![image](https://github.com/user-attachments/assets/e61538c6-542a-416e-abeb-d8e773acd7ba)

## After
![image](https://github.com/user-attachments/assets/2c17b230-dd64-457d-98c6-696a62fb8860)

I also added some tests to `spec/lib/msf/core/modules/metadata/search_spec.rb` for searching by targets as it seemed it wasn't being tested, test for the `nil` scenario was also added for anywhere I thought it was needed. 

I also fixed a random typo in `lib/msf/ui/console/command_dispatcher/modules.rb` I seen on my travels.

## Verification

- [ ] **Replicate** the issue on master
- [ ]  **Verify** the issue no longer exists on this branch