### PR TITLE
Call #validate in run_simple like it is in call_simple

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -58,8 +58,9 @@ module Auxiliary
       raise MissingActionError, "Please use: #{mod.actions.collect {|e| e.name} * ", "}"
     end
 
-    # Verify the options
-    mod.options.validate(mod.datastore)
+    # Validate the option container state so that options will
+    # be normalized
+    mod.validate
 
     # Initialize user interaction
     if ! opts['Quiet']

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -79,7 +79,7 @@ module Exploit
       end
 
       # Verify the options
-      exploit.options.validate(exploit.datastore)
+      exploit.validate
 
       # Start it up
       driver = Msf::ExploitDriver.new(exploit.framework)

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -55,7 +55,7 @@ module Post
     end
 
     # Verify the options
-    mod.options.validate(mod.datastore)
+    mod.validate
 
     # Initialize user interaction
     if ! opts['Quiet']

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -101,12 +101,10 @@ class Auxiliary
       return false
     rescue ::Exception => e
       print_error("Auxiliary failed: #{e.class} #{e}")
-      if(e.class.to_s != 'Msf::OptionValidateError')
-        print_error("Call stack:")
-        e.backtrace.each do |line|
-          break if line =~ /lib.msf.base.simple/
-          print_error("  #{line}")
-        end
+      print_error("Call stack:")
+      e.backtrace.each do |line|
+        break if line =~ /lib.msf.base.simple/
+        print_error("  #{line}")
       end
 
       return false

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -61,13 +61,6 @@ class Auxiliary
     rhosts_walker = Msf::RhostsWalker.new(rhosts, mod_with_opts.datastore)
 
     begin
-      mod_with_opts.validate
-    rescue ::Msf::OptionValidateError => e
-      ::Msf::Ui::Formatter::OptionValidateError.print_error(mod_with_opts, e)
-      return false
-    end
-
-    begin
       # Check if this is a scanner module or doesn't target remote hosts
       if rhosts.blank? || mod.class.included_modules.include?(Msf::Auxiliary::Scanner)
         mod_with_opts.run_simple(
@@ -102,7 +95,8 @@ class Auxiliary
     rescue ::Interrupt
       print_error("Auxiliary interrupted by the console user")
     rescue ::Msf::OptionValidateError => e
-      ::Msf::Ui::Formatter::OptionValidateError.print_error(running_mod, e)
+      ::Msf::Ui::Formatter::OptionValidateError.print_error(mod_with_opts, e)
+      return false
     rescue ::Exception => e
       print_error("Auxiliary failed: #{e.class} #{e}")
       if(e.class.to_s != 'Msf::OptionValidateError')

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -72,6 +72,8 @@ class Auxiliary
         )
       # For multi target attempts with non-scanner modules.
       else
+        # When RHOSTS is split, the validation changes slightly, so perform it reports the host the validation failed for
+        mod_with_opts.validate
         rhosts_walker.each do |datastore|
           mod_with_opts = mod.replicant
           mod_with_opts.datastore.merge!(datastore)

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -40,9 +40,9 @@ class Exploit
   #
   # Launches an exploitation single attempt.
   #
-  def exploit_single(mod, opts)
+  def exploit_single(mod, opts, &block)
     begin
-      session = mod.exploit_simple(opts)
+      session = mod.exploit_simple(opts, &block)
     rescue ::Interrupt
       raise $!
     rescue ::Msf::OptionValidateError => e
@@ -136,13 +136,6 @@ class Exploit
       'Quiet'       => args[:quiet] || false
     }
 
-    begin
-      mod_with_opts.validate
-    rescue ::Msf::OptionValidateError => e
-      ::Msf::Ui::Formatter::OptionValidateError.print_error(mod_with_opts, e)
-      return false
-    end
-
     driver.run_single('reload_lib -a') if args[:reload_libs]
 
     if rhosts && has_rhosts_option
@@ -150,6 +143,8 @@ class Exploit
       rhosts_walker_count = rhosts_walker.count
       rhosts_walker = rhosts_walker.to_enum
     end
+
+    run_mod = nil
 
     # For multiple targets exploit attempts.
     if rhosts_walker && rhosts_walker_count > 1
@@ -163,7 +158,7 @@ class Exploit
         # Catch the interrupt exception to stop the whole module during exploit
         begin
           print_status("Exploiting target #{datastore['RHOSTS']}")
-          session = exploit_single(nmod, opts)
+          session = exploit_single(nmod, opts) { |mod| run_mod = mod }
         rescue ::Interrupt
           print_status("Stopping exploiting current target #{datastore['RHOSTS']}...")
           print_status("Control-C again to force quit exploiting all targets.")
@@ -185,7 +180,7 @@ class Exploit
       if rhosts_walker && rhosts_walker_count == 1
         nmod.datastore.merge!(rhosts_walker.next)
       end
-      session = exploit_single(nmod, opts)
+      session = exploit_single(nmod, opts) { |mod| run_mod = mod }
       # If we were given a session, let's see what we can do with it
       if session
         any_session = true
@@ -211,7 +206,7 @@ class Exploit
     end
 
     # If we didn't get any session and exploit ended launch.
-    unless any_session
+    unless any_session || run_mod&.error.is_a?(Msf::OptionValidateError)
     # If we didn't run a payload handler for this exploit it doesn't
     # make sense to complain to the user that we didn't get a session
       unless mod_with_opts.datastore["DisablePayloadHandler"]

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -96,6 +96,57 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
     mod
   end
 
+  let(:ex_mod_with_option_validation) do
+    mod_klass = Class.new(Msf::Exploit) do
+      def initialize(info = {})
+        super(
+          'Name' => 'mock smb module',
+          'Description' => 'mock smb module',
+          'Author' => ['Unknown'],
+          'License' => MSF_LICENSE,
+          'Arch' => ARCH_CMD,
+          'Platform' => ['unix'],
+          'Targets' => [['Automatic', {}]],
+          'DefaultTarget' => 0,
+        )
+
+        register_options(
+          [
+            Msf::OptString.new('USERNAME', [ true, 'Set me to be greeted']),
+            Msf::OptString.new('PASSWORD', [ false, 'Secret value' ])
+          ]
+        )
+      end
+
+      def validate
+        super
+
+        if datastore['PASSWORD'] != 'PleaseThrowTheBall'
+          raise Msf::OptionValidateError.new({'PASSWORD' => 'Nuh uh uh, you didn\'t say the magic word.'})
+        end
+      end
+
+      def check
+        print_status('Check completed!')
+      end
+
+      def run
+        print("Hello #{datastore['USERNAME']}")
+        print_status('Run completed!')
+      end
+
+      alias_method :exploit, :run
+    end
+
+    mod = mod_klass.new
+    datastore = Msf::ModuleDataStore.new(mod)
+    allow(mod).to receive(:framework).and_return(framework)
+    mod.send(:datastore=, datastore)
+    datastore.import_options(mod.options)
+    Msf::Simple::Framework.simplify_module(mod)
+    mod
+  end
+
   subject do
     instance = described_class.new(driver)
     instance
@@ -227,6 +278,40 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         ]
 
         expect(@combined_output).to match_array(expected_output)
+      end
+    end
+
+    context 'when running an exploit module with option validation' do
+      let(:current_mod) { ex_mod_with_option_validation }
+
+      it 'reports options that fail validation' do
+        allow(current_mod).to receive(:check).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'ThrowTheBall'
+        subject.cmd_check
+        expected_output = [
+          'Msf::OptionValidateError The following options failed to validate:',
+          'Invalid option PASSWORD: Nuh uh uh, you didn\'t say the magic word.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
+      end
+
+      it 'runs when validation passes' do
+        allow(current_mod).to receive(:check).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'PleaseThrowTheBall'
+        subject.cmd_check
+        expected_output = [
+          'Check completed!',
+          'Check failed: The state could not be determined.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
       end
     end
   end
@@ -506,6 +591,41 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         ]
 
         expect(@combined_output).to match_array(expected_output)
+      end
+    end
+
+    context 'when running an exploit module with option validation' do
+      let(:current_mod) { ex_mod_with_option_validation }
+
+      it 'reports options that fail validation' do
+        allow(current_mod).to receive(:run).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'ThrowTheBall'
+        subject.cmd_run
+        expected_output = [
+          'Msf::OptionValidateError The following options failed to validate:',
+          'Invalid option PASSWORD: Nuh uh uh, you didn\'t say the magic word.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
+      end
+
+      it 'runs when validation passes' do
+        allow(current_mod).to receive(:run).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'PleaseThrowTheBall'
+        subject.cmd_run
+        expected_output = [
+          'Hello Jackson',
+          'Run completed!',
+          'Exploit completed, but no session was created.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
       end
     end
   end

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -284,7 +284,6 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = '192.0.2.1'
         subject.cmd_run
         expected_output = [
-          'Exploit completed, but no session was created.',
           'Msf::OptionValidateError One or more options failed to validate: REQUIRED_PAYLOAD_OPTION.'
         ]
 


### PR DESCRIPTION
This causes `#validate` to be called from the `_simple` method for `run_simple` as it is for `check_simple`. This ensures that the module's `#validate` method is consistently called from the necessary contexts.

## Verification

- [ ] Load the provided demo module
- [ ] Set the password to anything but the "secret" value
- [ ] Run the modules `run` method, see that validation fails
- [ ] Run the modules `check` method, see that validation fails

<details>
<summary>test.rb</summary>

```ruby
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

class MetasploitModule < Msf::Auxiliary

  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Test',
        'Description' => %q{
        },
        'Author' => [
          'Spencer McIntyre', # Metasploit module
        ],
        'License' => MSF_LICENSE,
        'Notes' => {
          'Stability' => [ CRASH_SAFE ],
          'SideEffects' => [ ],
          'Reliability' => [ ]
        }
      )
    )

    register_options(
      [
        OptString.new('USERNAME', [ true, 'Set me to be greeted']),
        OptString.new('PASSWORD', [ false, 'Secret value' ])
      ]
    )
  end

  def validate
    super

    if datastore['PASSWORD'] != 'Password1!'
      raise OptionValidateError.new({'PASSWORD' => 'Nuh uh uh, you didn\'t say the magic word.'})
    end
  end

  def check
    print_status('Check completed!')
  end

  def run
    print("Hello #{datastore['USERNAME']}")
    print_status('Run completed!')
  end
end

```
</details>

## Demo

```
metasploit-framework (S:0 J:0) auxiliary(test) > show options 

Module options (auxiliary/test):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   PASSWORD  foobar           no        Secret value
   USERNAME                   yes       Set me to be greeted


View the full module info with the info, or info -d command.

metasploit-framework (S:0 J:0) auxiliary(test) > run
[-] Msf::OptionValidateError One or more options failed to validate: USERNAME.
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(test) > check
[-] Msf::OptionValidateError One or more options failed to validate: USERNAME.
metasploit-framework (S:0 J:0) auxiliary(test) > set USERNAME Spencer
USERNAME => Spencer
metasploit-framework (S:0 J:0) auxiliary(test) > run
[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option PASSWORD: Nuh uh uh, you didn't say the magic word.
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(test) > check
[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option PASSWORD: Nuh uh uh, you didn't say the magic word.
metasploit-framework (S:0 J:0) auxiliary(test) > set PASSWORD Password1!
PASSWORD => Password1!
metasploit-framework (S:0 J:0) auxiliary(test) > run
[*] Hello Spencer
[*] Run completed!
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(test) > check
[*] Check completed!
[-] Check failed: The state could not be determined.
metasploit-framework (S:0 J:0) auxiliary(test) > 
```