### PR TITLE
Msf::Post:Linux::System.get_sysinfo: Add support for several Linux distros

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -18,8 +18,35 @@ module Msf
           kernel_version = cmd_exec('uname -a')
           system_data[:kernel] = kernel_version
 
-          # Debian
-          if etc_files.include?('debian_version')
+          # The order of these checks is important.
+          # * Checks for Arch-based distros must be performed before the check for Arch.
+          # * Checks for Antix-based distros must be performed before the check for Antix.
+          # * Checks for Debian-based distros must be performed before the check for Debian.
+          # * Checks for distros which ship with '/etc/system-release' must be performed
+          #   prior to the 'system-release' check.
+          # * Checks for distros which ship with '/etc/issue' must be performed
+          #   prior to the Generic 'issue' check.
+
+          # MX Linux
+          if etc_files.include?('mx-version')
+            version = read_file('/etc/mx-version').gsub(/\n|\\n|\\l/, '').strip
+            system_data[:distro] = 'mxlinux'
+            system_data[:version] = version
+
+          # AntiX
+          elsif etc_files.include?('antix-version')
+            version = read_file('/etc/antix-version').gsub(/\n|\\n|\\l/, '').strip
+            system_data[:distro] = 'antix'
+            system_data[:version] = version
+
+          # OpenMandriva
+          elsif etc_files.include?('openmandriva-release')
+            version = read_file('/etc/openmandriva-release').gsub(/\n|\\n|\\l/, '').strip
+            system_data[:distro] = 'openmandriva'
+            system_data[:version] = version
+
+          # Debian / Ubuntu (and forks)
+          elsif etc_files.include?('debian_version')
             version = read_file('/etc/issue').gsub(/\n|\\n|\\l/, '').strip
             if kernel_version =~ /Ubuntu/
               system_data[:distro] = 'ubuntu'
@@ -62,6 +89,12 @@ module Msf
           elsif etc_files.include?('redhat-release')
             version = read_file('/etc/redhat-release').gsub(/\n|\\n|\\l/, '').strip
             system_data[:distro] = 'redhat'
+            system_data[:version] = version
+
+          # Manjaro
+          elsif etc_files.include?('manjaro-release')
+            version = read_file('/etc/manjaro-release').gsub(/\n|\\n|\\l/, '').strip
+            system_data[:distro] = 'manjaro'
             system_data[:version] = version
 
           # Arch


### PR DESCRIPTION

This whole method could do with an overhaul.

For now, these changes will prevent false identification of Amazon Linux:

```
# Before

[*] get_sysinfo: {:kernel=>"Linux openmandriva-5-0-20241228-x86-64 6.6.2-desktop-1omv2390 #1 SMP PREEMPT_DYNAMIC Mon Nov 20 19:43:20 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux", :distro=>"amazon", :version=>"OpenMandriva Lx release 5.0 (Iodine) Rock for x86_64"}


# After

[*] get_sysinfo: {:kernel=>"Linux openmandriva-5-0-20241228-x86-64 6.6.2-desktop-1omv2390 #1 SMP PREEMPT_DYNAMIC Mon Nov 20 19:43:20 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux", :distro=>"openmandriva", :version=>"OpenMandriva Lx release 5.0 (Iodine) Rock for x86_64"}
```

And correctly identify Manjaro Linux:

```
# Before
[*] get_sysinfo: {:kernel=>"Linux manjaro-xfce-21-3-7-220816 5.15.60-1-MANJARO #1 SMP PREEMPT Thu Aug 11 13:14:05 UTC 2022 x86_64 GNU/Linux", :distro=>"arch", :version=>"Manjaro Linux"}

# After
[*] get_sysinfo: {:kernel=>"Linux manjaro-xfce-21-3-7-220816 5.15.60-1-MANJARO #1 SMP PREEMPT Thu Aug 11 13:14:05 UTC 2022 x86_64 GNU/Linux", :distro=>"manjaro", :version=>"Manjaro Linux"}
```
