### PR TITLE
Fix crash when running mssql payload against sessions

### DIFF
--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if session
-      set_session(session.client)
+      set_mssql_session(session.client)
     else
       unless mssql_login_datastore
         print_status("Invalid SQL Server credentials")


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/19931

Fixes a crash when running the `exploits/windows/mssql/mssql_payload` module against previously opened Microsoft SQL Server sessions

## Verification

Before - crash

```
msf6 exploit(windows/mssql/mssql_payload) > run session=-1
[*] Started reverse TCP handler on 10.4.230.124:4444 
[!] SESSION may not be compatible with this module:
[!]  * incompatible session architecture: x86_64
[!]  * incompatible session platform: Linux. This module works with: Windows.
[-] Exploit failed: NoMethodError undefined method `set_session' for #<Module:exploit/windows/mssql/mssql_payload datastore=[#<Msf::ModuleDataStore:0x000000010e79b4b8 @options={"WORKSPACE"=>#<Msf::OptString:0x000000010f6b2f00 @name
```

After - no crash

```
msf6 exploit(windows/mssql/mssql_payload) > run session=-1
[*] Started reverse TCP handler on 10.4.230.124:4444 
[!] SESSION may not be compatible with this module:
[!]  * incompatible session architecture: x86_64
[!]  * incompatible session platform: Linux. This module works with: Windows.
[*] Using existing session 1
[*] Generated command stager:
...
```