### PR TITLE
Enable LDAP sessions by default

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -94,8 +94,8 @@ module Msf
         name: LDAP_SESSION_TYPE,
         description: 'When enabled will allow for the creation/use of LDAP sessions',
         requires_restart: true,
-        default_value: false,
-        developer_notes: 'To be enabled by default after appropriate testing'
+        default_value: true,
+        developer_notes: 'Enabled in Metasploit 6.4.52'
       }.freeze,
       {
         name: SHOW_SUCCESSFUL_LOGINS,


### PR DESCRIPTION
This switches the LDAP session feature to be enabled by default. It's been around for about 11 months and I've at least been using it quite a bit. I've encountered one issue which I resolved in #19744.

## Verification

- [ ] Start Metasploit with a default configuraiton
- [ ] See the new feature is enabled by default
- [ ] Use the `ldap_login` module and set `CreateSession` to `true` and use it to open a session, showing that it works