### PR TITLE
include ERB::Util for html_escape

### DIFF
--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 require 'rex/socket'
-include ERB::Util
 
 
 module Rex
@@ -214,7 +213,7 @@ class Server
       "<title>404 Not Found</title>" +
       "</head><body>" +
       "<h1>Not found</h1>" +
-      "The requested URL #{html_escape(request.resource)} was not found on this server.<p><hr>" +
+      "The requested URL #{ERB::Util.html_escape(request.resource)} was not found on this server.<p><hr>" +
       "</body></html>"
 
     # Send the response to the client like what

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'rex/socket'
+include ERB::Util
 
 
 module Rex


### PR DESCRIPTION
```
[03/04/2025 12:02:03] [e(0)] rex: Failed to find handler for resource: /
[03/04/2025 12:02:03] [e(0)] core: Error in stream server client monitor: undefined method `html_escape' for #<Rex::Proto::Http::Server https://192.168.63.3:443 [  ]>

Call stack:
/usr/src/metasploit-framework/lib/rex/proto/http/server.rb:216:in `send_e404'
/usr/src/metasploit-framework/lib/rex/proto/http/server.rb:321:in `dispatch_request'
/usr/src/metasploit-framework/lib/rex/proto/http/server.rb:250:in `on_client_data'
/usr/src/metasploit-framework/lib/rex/proto/http/server.rb:109:in `block in start'
/usr/local/bundle/gems/rex-core-0.1.32/lib/rex/io/stream_server.rb:42:in `on_client_data'
/usr/local/bundle/gems/rex-core-0.1.32/lib/rex/io/stream_server.rb:185:in `block in monitor_clients'
/usr/local/bundle/gems/rex-core-0.1.32/lib/rex/io/stream_server.rb:184:in `each'
/usr/local/bundle/gems/rex-core-0.1.32/lib/rex/io/stream_server.rb:184:in `monitor_clients'
/usr/local/bundle/gems/rex-core-0.1.32/lib/rex/io/stream_server.rb:64:in `block in start'
/usr/src/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'
/usr/src/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[03/04/2025 12:12:03] [e(0)] core: The accept() returned nil in stream server listener monitor
[03/04/2025 12:12:03] [e(0)] core: The accept() returned nil in stream server listener monitor
[03/04/2025 12:12:03] [e(0)] rex: Failed to find handler for resource: /
[03/04/2025 12:12:03] [e(0)] core: Error in stream server client monitor: undefined method `html_escape' for #<Rex::Proto::Http::Server https://192.168.63.3:443 [  ]>
```
`html_escape` seems to be not defined in `/usr/src/metasploit-framework/lib/rex/proto/http/server.rb`

`include ERB::Util` fixed the issue for me