### PR TITLE
Extapi clipboard update

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -378,7 +378,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     tries_no = opts["tries_no"]
     tries = opts["tries"]
     force_overwrite = opts['force_overwrite'] || false
-
+    overwrite_existing = false
     src_fd = client.fs.file.new(src_file, "rb")
 
     # Check for changes
@@ -391,9 +391,9 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       end
       if !force_overwrite
         src_fd.close
-        return 'Overwrite attempt'
+        return 'Overwrite'
       else
-        stat.call("Overwriting existing file", src_file, dest_file)
+        overwrite_existing= true
       end
     end
 
@@ -484,7 +484,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
 
     # Clone the times from the remote file
     ::File.utime(src_stat.atime, src_stat.mtime, dest_file)
-    return 'Completed'
+    return overwrite_existing ? 'Overwritten' : 'Completed'
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -385,9 +385,15 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     src_stat = client.fs.filestat.new(src_file)
     if ::File.exist?(dest_file)
       dst_stat = ::File.stat(dest_file)
-      if (src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime) || (!force_overwrite)
+      if (src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime) 
         src_fd.close
         return 'Skipped'
+      end
+      if !force_overwrite
+        src_fd.close
+        return 'Overwrite attempt'
+      else
+        stat.call("Overwriting existing file", src_file, dest_file)
       end
     end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -304,7 +304,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       stat.call('Uploading', src, dest) if (stat)
 
       upload_file(dest, src)
-      stat.call('Completed', src, dest) if (stat)
+      stat.call(STEP_COMPLETED, src, dest) if (stat)
     }
   end
 
@@ -334,7 +334,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       src_fd.close unless src_fd.nil?
       dest_fd.close unless dest_fd.nil?
     end
-    stat.call('Completed', src_file, dest_file) if stat
+    stat.call(STEP_COMPLETED, src_file, dest_file) if stat
   end
 
   def File.is_glob?(name)
@@ -392,11 +392,11 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       dst_stat = ::File.stat(dest_file)
       if (src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime) 
         src_fd.close
-        return 'Skipped'
+        return STEP_SKIPPED
       end
       if !force_overwrite
         src_fd.close
-        return 'Overwrite'
+        return STEP_SKIPPED_WOULD_OVERWRITE
       else
         overwrite_existing= true
       end
@@ -489,7 +489,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
 
     # Clone the times from the remote file
     ::File.utime(src_stat.atime, src_stat.mtime, dest_file)
-    return overwrite_existing ? 'Overwritten' : 'Completed'
+    return overwrite_existing ? STEP_COMPLETED_OVERWRITTEN : STEP_COMPLETED
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -27,6 +27,11 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   include Rex::Post::File
 
   MIN_BLOCK_SIZE = 1024
+  STEP_SKIPPED_WOULD_OVERWRITE = 'Overwrite'
+  STEP_COMPLETED = 'Completed'
+  STEP_SKIPPED = 'Skipped'
+  STEP_COMPLETED_OVERWRITTEN = 'Overwritten'
+  
 
   class << self
     attr_accessor :client

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -10,574 +10,577 @@ require 'fileutils'
 require 'filesize'
 
 module Rex
-module Post
-module Meterpreter
-module Extensions
-module Stdapi
-module Fs
-
-###
-#
-# This class implements the Rex::Post::File interface and wraps interaction
-# with files on the remote machine.
-#
-###
-class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
-
-  include Rex::Post::File
-
-  MIN_BLOCK_SIZE = 1024
-  STEP_SKIPPED_WOULD_OVERWRITE = 'Overwrite'
-  STEP_COMPLETED = 'Completed'
-  STEP_SKIPPED = 'Skipped'
-  STEP_COMPLETED_OVERWRITTEN = 'Overwritten'
-  
-
-  class << self
-    attr_accessor :client
-  end
-
-  #
-  # Return the directory separator, i.e.: "/" on unix, "\\" on windows
-  #
-  def File.separator()
-    # The separator won't change, so cache it to prevent sending
-    # unnecessary requests.
-    return @separator if @separator
-
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_SEPARATOR)
-
-    # Fall back to the old behavior of always assuming windows.  This
-    # allows meterpreter executables built before the addition of this
-    # command to continue functioning.
-    begin
-      response = client.send_request(request)
-      @separator = response.get_tlv_value(TLV_TYPE_STRING)
-    rescue RequestError
-      @separator = "\\"
-    end
-
-    return @separator
-  end
-
-  class << self
-    alias :Separator :separator
-    alias :SEPARATOR :separator
-  end
-
-  #
-  # Search for files matching +glob+ starting in directory +root+.
-  #
-  # Returns an Array (possibly empty) of Hashes. Each element has the following
-  # keys:
-  # 'path'::  The directory in which the file was found
-  # 'name'::  File name
-  # 'size'::  Size of the file, in bytes
-  #
-  # Example:
-  #    client.fs.file.search(client.fs.dir.pwd, "*.txt")
-  #    # => [{"path"=>"C:\\Documents and Settings\\user\\Desktop", "name"=>"foo.txt", "size"=>0}]
-  #
-  # Raises a RequestError if +root+ is not a directory.
-  #
-  def File.search( root=nil, glob="*.*", recurse=true, timeout=-1, modified_start_date=nil, modified_end_date=nil)
-
-    files = ::Array.new
-
-    request = Packet.create_request( COMMAND_ID_STDAPI_FS_SEARCH )
-
-    root = client.unicode_filter_decode(root) if root
-    root = root.chomp( self.separator ) if root && !root.eql?('/')
-
-    request.add_tlv( TLV_TYPE_SEARCH_ROOT, root )
-    request.add_tlv( TLV_TYPE_SEARCH_GLOB, glob )
-    request.add_tlv( TLV_TYPE_SEARCH_RECURSE, recurse )
-    request.add_tlv( TLV_TYPE_SEARCH_M_START_DATE, modified_start_date) if modified_start_date
-    request.add_tlv( TLV_TYPE_SEARCH_M_END_DATE, modified_end_date) if modified_end_date
-
-    # we set the response timeout to -1 to wait indefinitely as a
-    # search could take an indeterminate amount of time to complete.
-    response = client.send_request( request, timeout )
-    if( response.result == 0 )
-      response.each( TLV_TYPE_SEARCH_RESULTS ) do | results |
-        files << {
-          'path' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_PATH).chomp( self.separator )),
-          'name' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_NAME)),
-          'size' => results.get_tlv_value(TLV_TYPE_FILE_SIZE),
-          'mtime'=> results.get_tlv_value(TLV_TYPE_SEARCH_MTIME)
-        }
-      end
-    end
-
-    return files
-  end
-
-  #
-  # Returns the base name of the supplied file path to the caller.
-  #
-  def File.basename(*a)
-    path = a[0]
-
-    # Allow both kinds of dir serparators since lots and lots of code
-    # assumes one or the other so this ends up getting called with strings
-    # like: "C:\\foo/bar"
-    path =~ %r#.*[/\\](.*)$#
-
-    Rex::FileUtils.clean_path($1 || path)
-  end
-
-  #
-  # Expands a file path, substituting all environment variables, such as
-  # %TEMP% on Windows or $HOME on Unix
-  #
-  # Examples:
-  #    client.fs.file.expand_path("%appdata%")
-  #    # => "C:\\Documents and Settings\\user\\Application Data"
-  #    client.fs.file.expand_path("~")
-  #    # => "/home/user"
-  #    client.fs.file.expand_path("$HOME/dir")
-  #    # => "/home/user/dir"
-  #    client.fs.file.expand_path("asdf")
-  #    # => "asdf"
-  #
-  def File.expand_path(path)
-    case client.platform
-      when 'osx', 'freebsd', 'bsd', 'linux', 'android', 'apple_ios'
-        # For unix-based systems, do some of the work here
-        # First check for ~
-        path_components = path.split(separator)
-        if path_components.length > 0 && path_components[0] == '~'
-          path = "$HOME#{path[1..-1]}"
-        end
-
-        # Now find the environment variables we'll need from the client
-        env_regex = /\$(?:([A-Za-z0-9_]+)|\{([A-Za-z0-9_]+)\})/
-        matches = path.to_enum(:scan, env_regex).map { Regexp.last_match }
-        env_vars = matches.map { |match| (match[1] || match[2]).to_s }.uniq
-
-        # Retrieve them
-        env_vals = client.sys.config.getenvs(*env_vars)
-
-        # Now fill them in
-        path.gsub(env_regex) { |_z| envvar = $1; envvar = $2 if envvar == nil; env_vals[envvar] }
-      else
-        request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_EXPAND_PATH)
-
-        request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( path ))
-
-        response = client.send_request(request)
-
-        return client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_FILE_PATH))
-    end
-  end
-
-
-  #
-  # Calculates the MD5 (16-bytes raw) of a remote file
-  #
-  def File.md5(path)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_MD5)
-
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( path ))
-
-    response = client.send_request(request)
-
-    # older meterpreter binaries will send FILE_NAME containing the hash
-    hash = response.get_tlv_value(TLV_TYPE_FILE_HASH) ||
-      response.get_tlv_value(TLV_TYPE_FILE_NAME)
-    return hash
-  end
-
-  #
-  # Calculates the SHA1 (20-bytes raw) of a remote file
-  #
-  def File.sha1(path)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_SHA1)
-
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( path ))
-
-    response = client.send_request(request)
-
-    # older meterpreter binaries will send FILE_NAME containing the hash
-    hash = response.get_tlv_value(TLV_TYPE_FILE_HASH) ||
-      response.get_tlv_value(TLV_TYPE_FILE_NAME)
-    return hash
-  end
-
-  #
-  # Performs a stat on a file and returns a FileStat instance.
-  #
-  def File.stat(name)
-    return client.fs.filestat.new( name )
-  end
-
-  #
-  # Returns true if the remote file +name+ exists, false otherwise
-  #
-  def File.exist?(name)
-    r = client.fs.filestat.new(name) rescue nil
-    r ? true : false
-  end
-
-  #
-  # Performs a delete on the remote file +name+
-  #
-  def File.rm(name)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_DELETE_FILE)
-
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( name ))
-
-    response = client.send_request(request)
-
-    return response
-  end
-
-  class << self
-    alias unlink rm
-    alias delete rm
-  end
-
-  #
-  # Performs a rename from oldname to newname
-  #
-  def File.mv(oldname, newname)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_MOVE)
-
-    request.add_tlv(TLV_TYPE_FILE_NAME, client.unicode_filter_decode( oldname ))
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( newname ))
-
-    response = client.send_request(request)
-
-    return response
-  end
-
-  class << self
-    alias move mv
-    alias rename mv
-  end
-
-  #
-  # Performs a copy from oldname to newname
-  #
-  def File.cp(oldname, newname)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_COPY)
-
-    request.add_tlv(TLV_TYPE_FILE_NAME, client.unicode_filter_decode( oldname ))
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( newname ))
-
-    response = client.send_request(request)
-
-    return response
-  end
-
-  class << self
-    alias copy cp
-  end
-
-  #
-  # Performs a chmod on the remote file
-  #
-  def File.chmod(name, mode)
-    request = Packet.create_request(COMMAND_ID_STDAPI_FS_CHMOD)
-
-    request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( name ))
-    request.add_tlv(TLV_TYPE_FILE_MODE_T, mode)
-
-    response = client.send_request(request)
-
-    return response
-  end
-
-  #
-  # Upload one or more files to the remote remote directory supplied in
-  # +destination+.
-  #
-  # If a block is given, it will be called before each file is uploaded and
-  # again when each upload is complete.
-  #
-  def File.upload(dest, *src_files, &stat)
-    src_files.each { |src|
-      if (self.basename(dest) != ::File.basename(src))
-        dest += self.separator unless dest.end_with?(self.separator)
-        dest += ::File.basename(src)
-      end
-      stat.call('Uploading', src, dest) if (stat)
-
-      upload_file(dest, src)
-      stat.call(STEP_COMPLETED, src, dest) if (stat)
-    }
-  end
-
-  #
-  # Upload a single file.
-  #
-  def File.upload_file(dest_file, src_file, &stat)
-    # Open the file on the remote side for writing and read
-    # all of the contents of the local file
-    stat.call('Uploading', src_file, dest_file) if stat
-    dest_fd = nil
-    src_fd = nil
-    buf_size = 8 * 1024 * 1024
-
-    begin
-      dest_fd = client.fs.file.new(dest_file, "wb")
-      src_fd = ::File.open(src_file, "rb")
-      src_size = src_fd.stat.size
-      while (buf = src_fd.read(buf_size))
-        dest_fd.write(buf)
-        percent = dest_fd.pos.to_f / src_size.to_f * 100.0
-        msg = "Uploaded #{Filesize.new(dest_fd.pos).pretty} of " \
-          "#{Filesize.new(src_size).pretty} (#{percent.round(2)}%)"
-        stat.call(msg, src_file, dest_file) if stat
-      end
-    ensure
-      src_fd.close unless src_fd.nil?
-      dest_fd.close unless dest_fd.nil?
-    end
-    stat.call(STEP_COMPLETED, src_file, dest_file) if stat
-  end
-
-  def File.is_glob?(name)
-    /\*|\[|\?/ === name
-  end
-
-  #
-  # Download one or more files from the remote computer to the local
-  # directory supplied in destination.
-  #
-  # If a block is given, it will be called before each file is downloaded and
-  # again when each download is complete.
-  #
-  def File.download(dest, src_files, opts = {}, &stat)
-    dest.force_encoding('UTF-8')
-    timestamp = opts["timestamp"]
-    [*src_files].each { |src|
-      src.force_encoding('UTF-8')
-      if (::File.basename(dest) != File.basename(src))
-        # The destination when downloading is a local file so use this
-        # system's separator
-        dest += ::File::SEPARATOR unless dest.end_with?(::File::SEPARATOR)
-        dest += File.basename(src)
-      end
-
-      # XXX: dest can be the same object as src, so we use += instead of <<
-      if timestamp
-        dest += timestamp
-      end
-
-      stat.call('Downloading', src, dest) if (stat)
-      result = download_file(dest, src, opts, &stat)
-      stat.call(result, src, dest) if (stat)
-    }
-  end
-
-  #
-  # Download a single file.
-  #
-  def File.download_file(dest_file, src_file, opts = {}, &stat)
-    stat ||= lambda { |a,b,c| }
-
-    adaptive = opts["adaptive"]
-    block_size = opts["block_size"] || 1024 * 1024
-    continue = opts["continue"]
-    tries_no = opts["tries_no"]
-    tries = opts["tries"]
-    force_overwrite = opts['force_overwrite'] || false
-    overwrite_existing = false
-    src_fd = client.fs.file.new(src_file, "rb")
-
-    # Check for changes
-    src_stat = client.fs.filestat.new(src_file)
-    if ::File.exist?(dest_file)
-      dst_stat = ::File.stat(dest_file)
-      if (src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime) 
-        src_fd.close
-        return STEP_SKIPPED
-      end
-      if !force_overwrite
-        src_fd.close
-        return STEP_SKIPPED_WOULD_OVERWRITE
-      else
-        overwrite_existing= true
-      end
-    end
-
-    # Make the destination path if necessary
-    dir = ::File.dirname(dest_file)
-    ::FileUtils.mkdir_p(dir) if dir and not ::File.directory?(dir)
-
-    src_size = Filesize.new(src_stat.size).pretty
-
-    if continue
-      # continue downloading the file - skip downloaded part in the source
-      dst_fd = ::File.new(dest_file, "ab")
-      begin
-        dst_fd.seek(0, ::IO::SEEK_END)
-        in_pos = dst_fd.pos
-        src_fd.seek(in_pos)
-        stat.call("Continuing from #{Filesize.new(in_pos).pretty} of #{src_size}", src_file, dest_file)
-      rescue
-        # if we can't seek, download again
-        stat.call('Error continuing - downloading from scratch', src_file, dest_file)
-        dst_fd.close
-        dst_fd = ::File.new(dest_file, "wb")
-      end
-    else
-      dst_fd = ::File.new(dest_file, "wb")
-    end
-
-    # Keep transferring until EOF is reached...
-    begin
-      if tries
-        # resume when timeouts encountered
-        seek_back = false
-        adjust_block = false
-        tries_cnt = 0
-        begin # while
-          begin # exception
-            if seek_back
-              in_pos = dst_fd.pos
-              src_fd.seek(in_pos)
-              seek_back = false
-              stat.call("Resuming at #{Filesize.new(in_pos).pretty} of #{src_size}", src_file, dest_file)
-            else
-              # successfully read and wrote - reset the counter
-              tries_cnt = 0
-            end
-            adjust_block = true
-            data = src_fd.read(block_size)
-            adjust_block = false
-          rescue Rex::TimeoutError
-            # timeout encountered - either seek back and retry or quit
-            if (tries && (tries_no == 0 || tries_cnt < tries_no))
-              tries_cnt += 1
-              seek_back = true
-              # try a smaller block size for the next round
-              if adaptive && adjust_block
-                block_size = [block_size >> 1, MIN_BLOCK_SIZE].max
-                adjust_block = false
-                msg = "Error downloading, block size set to #{block_size} - retry # #{tries_cnt}"
-                stat.call(msg, src_file, dest_file)
-              else
-                stat.call("Error downloading - retry # #{tries_cnt}", src_file, dest_file)
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi
+          module Fs
+            ###
+            #
+            # This class implements the Rex::Post::File interface and wraps interaction
+            # with files on the remote machine.
+            #
+            ###
+            class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
+
+              include Rex::Post::File
+
+              MIN_BLOCK_SIZE = 1024
+              STEP_SKIPPED_WOULD_OVERWRITE = 'Overwrite'
+              STEP_COMPLETED = 'Completed'
+              STEP_SKIPPED = 'Skipped'
+              STEP_COMPLETED_OVERWRITTEN = 'Overwritten'
+
+              class << self
+                attr_accessor :client
               end
-              retry
-            else
-              stat.call('Error downloading - giving up', src_file, dest_file)
-              raise
+
+              #
+              # Return the directory separator, i.e.: "/" on unix, "\\" on windows
+              #
+              def self.separator
+                # The separator won't change, so cache it to prevent sending
+                # unnecessary requests.
+                return @separator if @separator
+
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_SEPARATOR)
+
+                # Fall back to the old behavior of always assuming windows.  This
+                # allows meterpreter executables built before the addition of this
+                # command to continue functioning.
+                begin
+                  response = client.send_request(request)
+                  @separator = response.get_tlv_value(TLV_TYPE_STRING)
+                rescue RequestError
+                  @separator = '\\'
+                end
+
+                return @separator
+              end
+
+              class << self
+                alias Separator separator
+                alias SEPARATOR separator
+              end
+
+              #
+              # Search for files matching +glob+ starting in directory +root+.
+              #
+              # Returns an Array (possibly empty) of Hashes. Each element has the following
+              # keys:
+              # 'path'::  The directory in which the file was found
+              # 'name'::  File name
+              # 'size'::  Size of the file, in bytes
+              #
+              # Example:
+              #    client.fs.file.search(client.fs.dir.pwd, "*.txt")
+              #    # => [{"path"=>"C:\\Documents and Settings\\user\\Desktop", "name"=>"foo.txt", "size"=>0}]
+              #
+              # Raises a RequestError if +root+ is not a directory.
+              #
+              def self.search(root = nil, glob = '*.*', recurse = true, timeout = -1, modified_start_date = nil, modified_end_date = nil)
+                files = ::Array.new
+
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_SEARCH)
+
+                root = client.unicode_filter_decode(root) if root
+                root = root.chomp(separator) if root && !root.eql?('/')
+
+                request.add_tlv(TLV_TYPE_SEARCH_ROOT, root)
+                request.add_tlv(TLV_TYPE_SEARCH_GLOB, glob)
+                request.add_tlv(TLV_TYPE_SEARCH_RECURSE, recurse)
+                request.add_tlv(TLV_TYPE_SEARCH_M_START_DATE, modified_start_date) if modified_start_date
+                request.add_tlv(TLV_TYPE_SEARCH_M_END_DATE, modified_end_date) if modified_end_date
+
+                # we set the response timeout to -1 to wait indefinitely as a
+                # search could take an indeterminate amount of time to complete.
+                response = client.send_request(request, timeout)
+                if (response.result == 0)
+                  response.each(TLV_TYPE_SEARCH_RESULTS) do |results|
+                    files << {
+                      'path' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_PATH).chomp(separator)),
+                      'name' => client.unicode_filter_encode(results.get_tlv_value(TLV_TYPE_FILE_NAME)),
+                      'size' => results.get_tlv_value(TLV_TYPE_FILE_SIZE),
+                      'mtime' => results.get_tlv_value(TLV_TYPE_SEARCH_MTIME)
+                    }
+                  end
+                end
+
+                return files
+              end
+
+              #
+              # Returns the base name of the supplied file path to the caller.
+              #
+              def self.basename(*a)
+                path = a[0]
+
+                # Allow both kinds of dir serparators since lots and lots of code
+                # assumes one or the other so this ends up getting called with strings
+                # like: "C:\\foo/bar"
+                path =~ %r{.*[/\\](.*)$}
+
+                Rex::FileUtils.clean_path(::Regexp.last_match(1) || path)
+              end
+
+              #
+              # Expands a file path, substituting all environment variables, such as
+              # %TEMP% on Windows or $HOME on Unix
+              #
+              # Examples:
+              #    client.fs.file.expand_path("%appdata%")
+              #    # => "C:\\Documents and Settings\\user\\Application Data"
+              #    client.fs.file.expand_path("~")
+              #    # => "/home/user"
+              #    client.fs.file.expand_path("$HOME/dir")
+              #    # => "/home/user/dir"
+              #    client.fs.file.expand_path("asdf")
+              #    # => "asdf"
+              #
+              def self.expand_path(path)
+                case client.platform
+                when 'osx', 'freebsd', 'bsd', 'linux', 'android', 'apple_ios'
+                  # For unix-based systems, do some of the work here
+                  # First check for ~
+                  path_components = path.split(separator)
+                  if path_components.length > 0 && path_components[0] == '~'
+                    path = "$HOME#{path[1..-1]}"
+                  end
+
+                  # Now find the environment variables we'll need from the client
+                  env_regex = /\$(?:([A-Za-z0-9_]+)|\{([A-Za-z0-9_]+)\})/
+                  matches = path.to_enum(:scan, env_regex).map { Regexp.last_match }
+                  env_vars = matches.map { |match| (match[1] || match[2]).to_s }.uniq
+
+                  # Retrieve them
+                  env_vals = client.sys.config.getenvs(*env_vars)
+
+                  # Now fill them in
+                  path.gsub(env_regex) do |_z|
+                    envvar = ::Regexp.last_match(1)
+                    envvar = ::Regexp.last_match(2) if envvar.nil?
+                    env_vals[envvar]
+                  end
+                else
+                  request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_EXPAND_PATH)
+
+                  request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(path))
+
+                  response = client.send_request(request)
+
+                  return client.unicode_filter_encode(response.get_tlv_value(TLV_TYPE_FILE_PATH))
+                end
+              end
+
+              #
+              # Calculates the MD5 (16-bytes raw) of a remote file
+              #
+              def self.md5(path)
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_MD5)
+
+                request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(path))
+
+                response = client.send_request(request)
+
+                # older meterpreter binaries will send FILE_NAME containing the hash
+                hash = response.get_tlv_value(TLV_TYPE_FILE_HASH) ||
+                       response.get_tlv_value(TLV_TYPE_FILE_NAME)
+                return hash
+              end
+
+              #
+              # Calculates the SHA1 (20-bytes raw) of a remote file
+              #
+              def self.sha1(path)
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_SHA1)
+
+                request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(path))
+
+                response = client.send_request(request)
+
+                # older meterpreter binaries will send FILE_NAME containing the hash
+                hash = response.get_tlv_value(TLV_TYPE_FILE_HASH) ||
+                       response.get_tlv_value(TLV_TYPE_FILE_NAME)
+                return hash
+              end
+
+              #
+              # Performs a stat on a file and returns a FileStat instance.
+              #
+              def self.stat(name)
+                return client.fs.filestat.new(name)
+              end
+
+              #
+              # Returns true if the remote file +name+ exists, false otherwise
+              #
+              def self.exist?(name)
+                r = begin
+                  client.fs.filestat.new(name)
+                rescue StandardError
+                  nil
+                end
+                r ? true : false
+              end
+
+              #
+              # Performs a delete on the remote file +name+
+              #
+              def self.rm(name)
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_DELETE_FILE)
+
+                request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(name))
+
+                response = client.send_request(request)
+
+                return response
+              end
+
+              class << self
+                alias unlink rm
+                alias delete rm
+              end
+
+              #
+              # Performs a rename from oldname to newname
+              #
+              def self.mv(oldname, newname)
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_MOVE)
+
+                request.add_tlv(TLV_TYPE_FILE_NAME, client.unicode_filter_decode(oldname))
+                request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(newname))
+
+                response = client.send_request(request)
+
+                return response
+              end
+
+              class << self
+                alias move mv
+                alias rename mv
+              end
+
+              #
+              # Performs a copy from oldname to newname
+              #
+              def self.cp(oldname, newname)
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_FILE_COPY)
+
+                request.add_tlv(TLV_TYPE_FILE_NAME, client.unicode_filter_decode(oldname))
+                request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(newname))
+
+                response = client.send_request(request)
+
+                return response
+              end
+
+              class << self
+                alias copy cp
+              end
+
+              #
+              # Performs a chmod on the remote file
+              #
+              def self.chmod(name, mode)
+                request = Packet.create_request(COMMAND_ID_STDAPI_FS_CHMOD)
+
+                request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode(name))
+                request.add_tlv(TLV_TYPE_FILE_MODE_T, mode)
+
+                response = client.send_request(request)
+
+                return response
+              end
+
+              #
+              # Upload one or more files to the remote remote directory supplied in
+              # +destination+.
+              #
+              # If a block is given, it will be called before each file is uploaded and
+              # again when each upload is complete.
+              #
+              def self.upload(dest, *src_files, &stat)
+                src_files.each do |src|
+                  if (basename(dest) != ::File.basename(src))
+                    dest += separator unless dest.end_with?(separator)
+                    dest += ::File.basename(src)
+                  end
+                  stat.call('Uploading', src, dest) if stat
+
+                  upload_file(dest, src)
+                  stat.call(STEP_COMPLETED, src, dest) if stat
+                end
+              end
+
+              #
+              # Upload a single file.
+              #
+              def self.upload_file(dest_file, src_file, &stat)
+                # Open the file on the remote side for writing and read
+                # all of the contents of the local file
+                stat.call('Uploading', src_file, dest_file) if stat
+                dest_fd = nil
+                src_fd = nil
+                buf_size = 8 * 1024 * 1024
+
+                begin
+                  dest_fd = client.fs.file.new(dest_file, 'wb')
+                  src_fd = ::File.open(src_file, 'rb')
+                  src_size = src_fd.stat.size
+                  while (buf = src_fd.read(buf_size))
+                    dest_fd.write(buf)
+                    percent = dest_fd.pos.to_f / src_size.to_f * 100.0
+                    msg = "Uploaded #{Filesize.new(dest_fd.pos).pretty} of " \
+                      "#{Filesize.new(src_size).pretty} (#{percent.round(2)}%)"
+                    stat.call(msg, src_file, dest_file) if stat
+                  end
+                ensure
+                  src_fd.close unless src_fd.nil?
+                  dest_fd.close unless dest_fd.nil?
+                end
+                stat.call(STEP_COMPLETED, src_file, dest_file) if stat
+              end
+
+              def self.is_glob?(name)
+                /\*|\[|\?/ === name
+              end
+
+              #
+              # Download one or more files from the remote computer to the local
+              # directory supplied in destination.
+              #
+              # If a block is given, it will be called before each file is downloaded and
+              # again when each download is complete.
+              #
+              def self.download(dest, src_files, opts = {}, &stat)
+                dest.force_encoding('UTF-8')
+                timestamp = opts['timestamp']
+                [*src_files].each do |src|
+                  src.force_encoding('UTF-8')
+                  if (::File.basename(dest) != File.basename(src))
+                    # The destination when downloading is a local file so use this
+                    # system's separator
+                    dest += ::File::SEPARATOR unless dest.end_with?(::File::SEPARATOR)
+                    dest += File.basename(src)
+                  end
+
+                  # XXX: dest can be the same object as src, so we use += instead of <<
+                  if timestamp
+                    dest += timestamp
+                  end
+
+                  stat.call('Downloading', src, dest) if stat
+                  result = download_file(dest, src, opts, &stat)
+                  stat.call(result, src, dest) if stat
+                end
+              end
+
+              #
+              # Download a single file.
+              #
+              def self.download_file(dest_file, src_file, opts = {}, &stat)
+                stat ||= ->(a, b, c) {}
+
+                adaptive = opts['adaptive']
+                block_size = opts['block_size'] || 1024 * 1024
+                continue = opts['continue']
+                tries_no = opts['tries_no']
+                tries = opts['tries']
+                force_overwrite = opts['force_overwrite'] || false
+                overwrite_existing = false
+                src_fd = client.fs.file.new(src_file, 'rb')
+
+                # Check for changes
+                src_stat = client.fs.filestat.new(src_file)
+                if ::File.exist?(dest_file)
+                  dst_stat = ::File.stat(dest_file)
+                  if src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime
+                    src_fd.close
+                    return STEP_SKIPPED
+                  end
+                  if !force_overwrite
+                    src_fd.close
+                    return STEP_SKIPPED_WOULD_OVERWRITE
+                  else
+                    overwrite_existing = true
+                  end
+                end
+
+                # Make the destination path if necessary
+                dir = ::File.dirname(dest_file)
+                ::FileUtils.mkdir_p(dir) if dir and !::File.directory?(dir)
+
+                src_size = Filesize.new(src_stat.size).pretty
+
+                if continue
+                  # continue downloading the file - skip downloaded part in the source
+                  dst_fd = ::File.new(dest_file, 'ab')
+                  begin
+                    dst_fd.seek(0, ::IO::SEEK_END)
+                    in_pos = dst_fd.pos
+                    src_fd.seek(in_pos)
+                    stat.call("Continuing from #{Filesize.new(in_pos).pretty} of #{src_size}", src_file, dest_file)
+                  rescue StandardError
+                    # if we can't seek, download again
+                    stat.call('Error continuing - downloading from scratch', src_file, dest_file)
+                    dst_fd.close
+                    dst_fd = ::File.new(dest_file, 'wb')
+                  end
+                else
+                  dst_fd = ::File.new(dest_file, 'wb')
+                end
+
+                # Keep transferring until EOF is reached...
+                begin
+                  if tries
+                    # resume when timeouts encountered
+                    seek_back = false
+                    adjust_block = false
+                    tries_cnt = 0
+                    begin # while
+                      begin # exception
+                        if seek_back
+                          in_pos = dst_fd.pos
+                          src_fd.seek(in_pos)
+                          seek_back = false
+                          stat.call("Resuming at #{Filesize.new(in_pos).pretty} of #{src_size}", src_file, dest_file)
+                        else
+                          # successfully read and wrote - reset the counter
+                          tries_cnt = 0
+                        end
+                        adjust_block = true
+                        data = src_fd.read(block_size)
+                        adjust_block = false
+                      rescue Rex::TimeoutError
+                        # timeout encountered - either seek back and retry or quit
+                        if (tries && (tries_no == 0 || tries_cnt < tries_no))
+                          tries_cnt += 1
+                          seek_back = true
+                          # try a smaller block size for the next round
+                          if adaptive && adjust_block
+                            block_size = [block_size >> 1, MIN_BLOCK_SIZE].max
+                            adjust_block = false
+                            msg = "Error downloading, block size set to #{block_size} - retry # #{tries_cnt}"
+                            stat.call(msg, src_file, dest_file)
+                          else
+                            stat.call("Error downloading - retry # #{tries_cnt}", src_file, dest_file)
+                          end
+                          retry
+                        else
+                          stat.call('Error downloading - giving up', src_file, dest_file)
+                          raise
+                        end
+                      end
+                      dst_fd.write(data) if !data.nil?
+                      percent = dst_fd.pos.to_f / src_stat.size.to_f * 100.0
+                      msg = "Downloaded #{Filesize.new(dst_fd.pos).pretty} of #{src_size} (#{percent.round(2)}%)"
+                      stat.call(msg, src_file, dest_file)
+                    end while (!data.nil?)
+                  else
+                    # do the simple copying quitting on the first error
+                    while ((data = src_fd.read(block_size)) != nil)
+                      dst_fd.write(data)
+                      percent = dst_fd.pos.to_f / src_stat.size.to_f * 100.0
+                      msg = "Downloaded #{Filesize.new(dst_fd.pos).pretty} of #{src_size} (#{percent.round(2)}%)"
+                      stat.call(msg, src_file, dest_file)
+                    end
+                  end
+                rescue EOFError
+                ensure
+                  src_fd.close
+                  dst_fd.close
+                end
+
+                # Clone the times from the remote file
+                ::File.utime(src_stat.atime, src_stat.mtime, dest_file)
+                return overwrite_existing ? STEP_COMPLETED_OVERWRITTEN : STEP_COMPLETED
+              end
+
+              #
+              # With no associated block, File.open is a synonym for ::new. If the optional
+              # code block is given, it will be passed the opened file as an argument, and
+              # the File object will automatically be closed when the block terminates. In
+              # this instance, File.open returns the value of the block.
+              #
+              # (doc stolen from http://www.ruby-doc.org/core-1.9.3/File.html#method-c-open)
+              #
+              def self.open(name, mode = 'r', perms = 0)
+                f = new(name, mode, perms)
+                if block_given?
+                  ret = yield f
+                  f.close
+                  return ret
+                else
+                  return f
+                end
+              end
+
+              ##
+              #
+              # Constructor
+              #
+              ##
+
+              #
+              # Initializes and opens the specified file with the specified permissions.
+              #
+              def initialize(name, mode = 'r', perms = 0)
+                self.client = self.class.client
+                self.filed = _open(name, mode, perms)
+              end
+
+              ##
+              #
+              # IO implementers
+              #
+              ##
+
+              #
+              # Returns whether or not the file has reach EOF.
+              #
+              def eof
+                return filed.eof
+              end
+
+              #
+              # Returns the current position of the file pointer.
+              #
+              def pos
+                return filed.tell
+              end
+
+              #
+              # Synonym for sysseek.
+              #
+              def seek(offset, whence = ::IO::SEEK_SET)
+                return sysseek(offset, whence)
+              end
+
+              #
+              # Seeks to the supplied offset based on the supplied relativity.
+              #
+              def sysseek(offset, whence = ::IO::SEEK_SET)
+                return filed.seek(offset, whence)
+              end
+
+              protected
+
+              ##
+              #
+              # Internal methods
+              #
+              ##
+
+              #
+              # Creates a File channel using the supplied information.
+              #
+              def _open(name, mode = 'r', perms = 0)
+                return Rex::Post::Meterpreter::Channels::Pools::File.open(
+                  client, name, mode, perms
+                )
+              end
+
+              attr_accessor :client # :nodoc:
+
             end
-          end
-          dst_fd.write(data) if (data != nil)
-          percent = dst_fd.pos.to_f / src_stat.size.to_f * 100.0
-          msg = "Downloaded #{Filesize.new(dst_fd.pos).pretty} of #{src_size} (#{percent.round(2)}%)"
-          stat.call(msg, src_file, dest_file)
-        end while (data != nil)
-      else
-        # do the simple copying quitting on the first error
-        while ((data = src_fd.read(block_size)) != nil)
-          dst_fd.write(data)
-          percent = dst_fd.pos.to_f / src_stat.size.to_f * 100.0
-          msg = "Downloaded #{Filesize.new(dst_fd.pos).pretty} of #{src_size} (#{percent.round(2)}%)"
-          stat.call(msg, src_file, dest_file)
-        end
-      end
-    rescue EOFError
-    ensure
-      src_fd.close
-      dst_fd.close
-    end
-
-    # Clone the times from the remote file
-    ::File.utime(src_stat.atime, src_stat.mtime, dest_file)
-    return overwrite_existing ? STEP_COMPLETED_OVERWRITTEN : STEP_COMPLETED
-  end
-
-  #
-  # With no associated block, File.open is a synonym for ::new. If the optional
-  # code block is given, it will be passed the opened file as an argument, and
-  # the File object will automatically be closed when the block terminates. In
-  # this instance, File.open returns the value of the block.
-  #
-  # (doc stolen from http://www.ruby-doc.org/core-1.9.3/File.html#method-c-open)
-  #
-  def File.open(name, mode="r", perms=0)
-    f = new(name, mode, perms)
-    if block_given?
-      ret = yield f
-      f.close
-      return ret
-    else
-      return f
-    end
-  end
-
-  ##
-  #
-  # Constructor
-  #
-  ##
-
-  #
-  # Initializes and opens the specified file with the specified permissions.
-  #
-  def initialize(name, mode = "r", perms = 0)
-    self.client = self.class.client
-    self.filed  = _open(name, mode, perms)
-  end
-
-  ##
-  #
-  # IO implementers
-  #
-  ##
-
-  #
-  # Returns whether or not the file has reach EOF.
-  #
-  def eof
-    return self.filed.eof
-  end
-
-  #
-  # Returns the current position of the file pointer.
-  #
-  def pos
-    return self.filed.tell
-  end
-
-  #
-  # Synonym for sysseek.
-  #
-  def seek(offset, whence = ::IO::SEEK_SET)
-    return self.sysseek(offset, whence)
-  end
-
-  #
-  # Seeks to the supplied offset based on the supplied relativity.
-  #
-  def sysseek(offset, whence = ::IO::SEEK_SET)
-    return self.filed.seek(offset, whence)
-  end
-
-protected
-
-  ##
-  #
-  # Internal methods
-  #
-  ##
-
-  #
-  # Creates a File channel using the supplied information.
-  #
-  def _open(name, mode = "r", perms = 0)
-    return Rex::Post::Meterpreter::Channels::Pools::File.open(
-        self.client, name, mode, perms)
-  end
-
-  attr_accessor :client # :nodoc:
-
-end
-
-end; end; end; end; end; end
-
+          end; end; end; end; end; end

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -377,6 +377,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     continue = opts["continue"]
     tries_no = opts["tries_no"]
     tries = opts["tries"]
+    force_overwrite = opts['force_overwrite'] || false
 
     src_fd = client.fs.file.new(src_file, "rb")
 
@@ -384,7 +385,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     src_stat = client.fs.filestat.new(src_file)
     if ::File.exist?(dest_file)
       dst_stat = ::File.stat(dest_file)
-      if src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime
+      if (src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime) || (!force_overwrite)
         src_fd.close
         return 'Skipped'
       end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -134,7 +134,7 @@ module Rex
           #
           @@monitor_start_opts = Rex::Parser::Arguments.new(
             '-h' => [ false, 'Help banner' ],
-            '--no-capture' => [ true, 'Do not capture image content when monitoring' ]
+            '--no-images' => [ true, 'Do not capture image content when monitoring' ]
           )
 
           #
@@ -160,7 +160,7 @@ module Rex
 
             @@monitor_start_opts.parse(args) do |opt, _idx, _val|
               case opt
-              when '--no-capture'
+              when '--no-images'
                 capture_images = false
               when '-h'
                 print_clipboard_monitor_start_usage
@@ -279,7 +279,7 @@ module Rex
             '-h' => [ false, 'Help banner' ],
             '--no-images' => [ false, "Indicate if captured image data shouldn't be downloaded" ],
             '--no-files' => [ false, "Indicate if captured file data shouldn't be downloaded" ],
-            '-p' => [ false, 'Purge the contents of the monitor once dumped' ],
+            '--no-purge' => [ false, "Indicate if the contents of the monitor shouldn't be purged once dumped" ],
             '-d' => [ true, 'Download non-text content to the specified folder' ],
             '--force' => [false, 'Force overwriting existing files']
           )
@@ -289,7 +289,7 @@ module Rex
           #
           def print_clipboard_monitor_dump_usage
             print(
-              "\nUsage: clipboard_monitor_dump [-p] [-d downloaddir] [-h]\n\n" +
+              "\nUsage: clipboard_monitor_dump [-d downloaddir] [-h]\n\n" +
               "Dump the capture clipboard contents to the local machine..\n\n" +
               @@monitor_dump_opts.usage + "\n"
             )
@@ -299,7 +299,7 @@ module Rex
           # Dump the clipboard monitor contents to the local machine.
           #
           def cmd_clipboard_monitor_dump(*args)
-            purge = false
+            purge = true
             download_images = true
             download_files = true
             download_path = nil
@@ -313,8 +313,8 @@ module Rex
                 download_images = false
               when '--no-files'
                 download_files = false
-              when '-p'
-                purge = true
+              when '--no-purge'
+                purge = false
               when '--force'
                 force_overwrite = true
               when '-h'
@@ -335,10 +335,12 @@ module Rex
             })
 
             res = parse_dump(dump, download_images, download_files, download_path, force_overwrite: force_overwrite)
+            print_good('Clipboard monitor dumped')
+
             if !res && purge
               client.extapi.clipboard.monitor_purge
+              print_good('Captured clipboard contents purged successfully')
             end
-            print_good('Clipboard monitor dumped')
           end
 
           #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -388,11 +388,14 @@ class Console::CommandDispatcher::Extapi::Clipboard
     }
     
     
-    if download_path.nil? 
-      print_error("You need to specify download directory.")
+    if download_path.nil? && (download_images || download_files) 
+      #allow user to stop monitoring if they don't wish to download anything
+      client.extapi.clipboard.monitor_stop({
+        :dump           => dump_data,
+      })
+      print_good("Clipboard monitor stopped without downloading data. Specify destination folder to download loot.")
       return true
     end
-
   
     dump = client.extapi.clipboard.monitor_stop({
       :dump           => dump_data,

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -1,521 +1,522 @@
 # -*- coding: binary -*-
+
 require 'rex/post/meterpreter'
 require 'rex/post/meterpreter/extensions/extapi/command_ids'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
-###
-#
-# Extended API window management user interface.
-#
-###
-class Console::CommandDispatcher::Extapi::Clipboard
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # Extended API window management user interface.
+        #
+        ###
+        class Console::CommandDispatcher::Extapi::Clipboard
 
-  Klass = Console::CommandDispatcher::Extapi::Clipboard
-  
-  include Console::CommandDispatcher
-  include Rex::Post::Meterpreter::Extensions::Extapi
-  
-  #
-  # List of supported commands.
-  #
-  def commands
-    all = {
-      'clipboard_get_data'       => "Read the target's current clipboard (text, files, images)",
-      'clipboard_set_text'       => "Write text to the target's clipboard",
-      'clipboard_monitor_start'  => 'Start the clipboard monitor',
-      'clipboard_monitor_pause'  => 'Pause the active clipboard monitor',
-      'clipboard_monitor_resume' => 'Resume the paused clipboard monitor',
-      'clipboard_monitor_dump'   => 'Dump all captured clipboard content',
-      'clipboard_monitor_purge'  => 'Delete all captured clipboard content without dumping it',
-      'clipboard_monitor_stop'   => 'Stop the clipboard monitor'
-    }
-    reqs = {
-      'clipboard_get_data'       => [COMMAND_ID_EXTAPI_CLIPBOARD_GET_DATA],
-      'clipboard_set_text'       => [COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA],
-      'clipboard_monitor_start'  => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_START],
-      'clipboard_monitor_pause'  => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_PAUSE],
-      'clipboard_monitor_resume' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_RESUME],
-      'clipboard_monitor_dump'   => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_DUMP],
-      'clipboard_monitor_purge'  => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_PURGE],
-      'clipboard_monitor_stop'   => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_STOP],
-    }
-    filter_commands(all, reqs)
-  end
+          Klass = Console::CommandDispatcher::Extapi::Clipboard
 
-  #
-  # Name for this dispatcher
-  #
-  def name
-    'Extapi: Clipboard Management'
-  end
+          include Console::CommandDispatcher
+          include Rex::Post::Meterpreter::Extensions::Extapi
 
-  #
-  # Options for the clipboard_get_data command.
-  #
-  @@get_data_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ],
-    "-d" => [ true, "Download non-text content to the specified folder (default: current dir)", nil ]
-  )
-
-  def print_clipboard_get_data_usage
-    print(
-      "\nUsage: clipboard_get_data [-h] [-d]\n\n" +
-      "Attempts to read the data from the target's clipboard. If the data is in a\n" +
-      "supported format, it is read and returned to the user.\n" +
-      @@get_data_opts.usage + "\n")
-  end
-
-  #
-  # Get the data from the target's clipboard
-  #
-  def cmd_clipboard_get_data(*args)
-    download_content = false
-    download_path = nil
-    @@get_data_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-d"
-        download_content = true
-        download_path = val
-      when "-h"
-        print_clipboard_get_data_usage
-        return true
-      end
-    }
-
-    dump = client.extapi.clipboard.get_data(download_content)
-
-    if dump.length == 0
-      print_error( "The current Clipboard data format is not supported." )
-      return false
-    end
-
-    parse_dump(dump, download_content, download_content, download_path)
-    return true
-  end
-
-  #
-  # Options for the clipboard_set_text command.
-  #
-  @@set_text_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ]
-  )
-
-  def print_clipboard_set_text_usage
-    print(
-      "\nUsage: clipboard_set_text [-h] <text>\n\n" +
-      "Set the target's clipboard to the given text value.\n\n")
-  end
-
-  #
-  # Set the clipboard data to the given text.
-  #
-  def cmd_clipboard_set_text(*args)
-    args.unshift "-h" if args.length == 0
-
-    @@set_text_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-h"
-        print_clipboard_set_text_usage
-        return true
-      end
-    }
-
-  return client.extapi.clipboard.set_text(args.join(" "))
-  end
-
-  #
-  # Options for the clipboard_monitor_start command.
-  #
-  @@monitor_start_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ],
-    "--no-capture" => [ true, "Do not capture image content when monitoring" ]
-  )
-
-  #
-  # Help for the clipboard_monitor_start command.
-  #
-  def print_clipboard_monitor_start_usage
-    print(
-      "\nUsage: clipboard_monitor_start  [-h]\n\n" +
-      "Starts a background clipboard monitoring thread. The thread watches\n" +
-      "the clipboard on the target, under the context of the current desktop, and when\n" +
-      "changes are detected the contents of the clipboard are captured. Contents can be\n" +
-      "dumped periodically. Image content can be captured as well (and will be by default)\n" +
-      "however this can consume quite a bit of memory.\n\n" +
-      @@monitor_start_opts.usage + "\n")
-  end
-
-  #
-  # Start the clipboard monitor.
-  #
-  def cmd_clipboard_monitor_start(*args)
-    capture_images = true
-
-    @@monitor_start_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "--no-capture"
-        capture_images = false
-      when "-h"
-        print_clipboard_monitor_start_usage
-        return true
-      end
-    }
-
-    client.extapi.clipboard.monitor_start({
-      # random class and window name so that it isn't easy
-      # to track via a script
-      :wincls  => Rex::Text.rand_text_alpha(8),
-      :cap_img => capture_images
-    })
-
-    print_good("Clipboard monitor started")
-  end
-
-  #
-  # Options for the clipboard_monitor_purge command.
-  #
-  @@monitor_purge_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ]
-  )
-
-  #
-  # Help for the clipboard_monitor_purge command.
-  #
-  def print_clipboard_monitor_purge_usage
-    print("\nUsage: clipboard_monitor_purge [-h]\n\n" +
-      "Purge the captured contents from the monitor. This does not stop\n" +
-      "the monitor from running, it just removes captured content.\n\n" +
-      @@monitor_purge_opts.usage + "\n")
-  end
-
-  #
-  # Purge the clipboard monitor captured contents
-  #
-  def cmd_clipboard_monitor_purge(*args)
-    @@monitor_purge_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-h"
-        print_clipboard_monitor_purge_usage
-        return true
-      end
-    }
-    client.extapi.clipboard.monitor_purge
-    print_good("Captured clipboard contents purged successfully")
-  end
-
-  #
-  # Options for the clipboard_monitor_pause command.
-  #
-  @@monitor_pause_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ]
-  )
-
-  #
-  # Help for the clipboard_monitor_pause command.
-  #
-  def print_clipboard_monitor_pause_usage
-    print("\nUsage: clipboard_monitor_pause [-h]\n\n" +
-      "Pause the currently running clipboard monitor thread.\n\n" +
-      @@monitor_pause_opts.usage + "\n")
-  end
-
-  #
-  # Pause the clipboard monitor captured contents
-  #
-  def cmd_clipboard_monitor_pause(*args)
-    @@monitor_pause_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-h"
-        print_clipboard_monitor_pause_usage
-        return true
-      end
-    }
-    client.extapi.clipboard.monitor_pause
-    print_good("Clipboard monitor paused successfully")
-  end
-
-  #
-  # Options for the clipboard_monitor_resumse command.
-  #
-  @@monitor_resume_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ]
-  )
-
-  #
-  # Help for the clipboard_monitor_resume command.
-  #
-  def print_clipboard_monitor_resume_usage
-    print("\nUsage: clipboard_monitor_resume [-h]\n\n" +
-      "Resume the currently paused clipboard monitor thread.\n\n" +
-      @@monitor_resume_opts.usage + "\n")
-  end
-
-  #
-  # resume the clipboard monitor captured contents
-  #
-  def cmd_clipboard_monitor_resume(*args)
-    @@monitor_resume_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-h"
-        print_clipboard_monitor_resume_usage
-        return true
-      end
-    }
-    client.extapi.clipboard.monitor_resume
-    print_good("Clipboard monitor resumed successfully")
-  end
-
-  #
-  # Options for the clipboard_monitor_dump command.
-  #
-  @@monitor_dump_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ],
-    "--no-images" => [ false,  "Indicate if captured image data shouldn't be downloaded" ],
-    "--no-files" => [ false,  "Indicate if captured file data shouldn't be downloaded" ],
-    "-p" => [ false,  "Purge the contents of the monitor once dumped" ],
-    "-d" => [ true,  "Download non-text content to the specified folder" ],
-    '--force' => [false, "Force overwriting existing files"]
-  )
-
-  #
-  # Help for the clipboard_monitor_dump command.
-  #
-  def print_clipboard_monitor_dump_usage
-    print(
-      "\nUsage: clipboard_monitor_dump [-p] [-d downloaddir] [-h]\n\n" +
-      "Dump the capture clipboard contents to the local machine..\n\n" +
-      @@monitor_dump_opts.usage + "\n")
-  end
-
-  #
-  # Dump the clipboard monitor contents to the local machine.
-  #
-  def cmd_clipboard_monitor_dump(*args)
-    purge = false
-    download_images = true
-    download_files = true
-    download_path = nil
-    force_overwrite = false
-
-    @@monitor_dump_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-d"
-        download_path = val
-      when "--no-images"
-        download_images = false
-      when "--no-files"
-        download_files = false
-      when "-p"
-        purge = true
-      when '--force'
-        force_overwrite = true
-      when "-h"
-        print_clipboard_monitor_dump_usage
-        return true
-      end
-    }
-    
-    if download_path.nil? 
-      print_error("You have to specify destination directory to download loot.")
-      return true
-    end
-
-    # do something with dump
-    dump = client.extapi.clipboard.monitor_dump({
-      :include_images => download_images,
-      :purge => false
-    })
-    
-    res = parse_dump(dump, download_images, download_files, download_path, force_overwrite: force_overwrite)
-    if !res && purge
-      client.extapi.clipboard.monitor_purge()
-    end
-    print_good("Clipboard monitor dumped")
-  end
-
-  #
-  # Options for the clipboard_monitor_stop command.
-  #
-  @@monitor_stop_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner" ],
-    "--no-dump" => [ false,  "Indicate if captured clipboard data shouldn't be dumped" ],
-    "--no-images" => [ false,  "Indicate if captured image data shouldn't be downloaded" ],
-    "--no-files" => [ false,  "Indicate if captured file data shouldn't be downloaded" ],
-    "-d" => [ true,  "Download non-text content to the specified folder" ],
-    '--force' => [false, "Force overwriting existing files"]
-  )
-
-  #
-  # Help for the clipboard_monitor_stop command.
-  #
-  def print_clipboard_monitor_stop_usage
-    print(
-      "\nUsage: clipboard_monitor_stop [-d downloaddir] [-h]\n\n" +
-      "Stops a clipboard monitor thread and returns the captured data to the local machine.\n\n" +
-      @@monitor_stop_opts.usage + "\n")
-  end
-
-  #
-  # Stop the clipboard monitor.
-  #
-  def cmd_clipboard_monitor_stop(*args)
-    dump_data = true
-    download_images = true
-    download_files = true
-    download_path = nil
-    force_overwrite = false
-
-    @@monitor_stop_opts.parse(args) { |opt, idx, val|
-      case opt
-      when "-d"
-        download_path = val
-      when "--no-dump"
-        dump_data = false
-      when "--no-images"
-        download_images = false
-      when "--no-files"
-        download_files = false
-      when '--force'
-        force_overwrite = true
-      when "-h"
-        print_clipboard_monitor_stop_usage
-        return true
-      end
-    }
-   
-    #you can't download stuff if you don't specify destination directory
-    # todo: is there more ruby way to do this
-    download_images = download_images && download_path.nil? ? false : download_images
-
-    dump = client.extapi.clipboard.monitor_stop({
-      :dump           => dump_data,
-      :include_images => download_images
-    })
-    
-
-    parse_dump(dump, download_images, download_files, download_path, force_overwrite: force_overwrite) if dump_data
-
-    print_good("Clipboard monitor stopped")
-  end
-
-private
-
-  def download_file( dest_folder, source, force_overwrite=false )
-    stat = client.fs.file.stat( source )
-    base = ::Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File.basename( source )
-    attempted_overwrite = false
-
-    # Basename ends up with a single name/folder. This is the only point where it
-    # may be possible to do a dir trav up one folder. We need to check to make sure
-    # that the basename doesn't result in a traversal
-    return false, attempted_overwrite if base == '..'
-
-    local_dest_path = File.join( dest_folder, base )
-    local_dest_path = ::File.expand_path(local_dest_path)
-   
-    return false, attempted_overwrite unless local_dest_path.start_with?(::File.expand_path(dest_folder)+::File::SEPARATOR)
-    
-    if stat.directory?
-      client.fs.dir.download( local_dest_path, source, {"force_overwrite" => force_overwrite, "recursive" => true} ) { |step, src, dst|
-            
-            attempted_overwrite ||= (step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE)
-
-            if step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE
-              print_line( "#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
-            elsif step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED_OVERWRITTEN
-              print_line( "#{Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
-            else
-              print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
-            end
-            client.framework.events.on_session_download( client, src, local_dest_path ) if msf_loaded?
-      }
-    elsif stat.file?
-      client.fs.file.download( local_dest_path, source, {"force_overwrite" => force_overwrite} ) { |step, src, dst|
-          attempted_overwrite ||= (step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE)
-          
-          if step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE
-            print_line( "#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
-          elsif step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED_OVERWRITTEN
-            print_line( "#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
-          else
-            print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
+          #
+          # List of supported commands.
+          #
+          def commands
+            all = {
+              'clipboard_get_data' => "Read the target's current clipboard (text, files, images)",
+              'clipboard_set_text' => "Write text to the target's clipboard",
+              'clipboard_monitor_start' => 'Start the clipboard monitor',
+              'clipboard_monitor_pause' => 'Pause the active clipboard monitor',
+              'clipboard_monitor_resume' => 'Resume the paused clipboard monitor',
+              'clipboard_monitor_dump' => 'Dump all captured clipboard content',
+              'clipboard_monitor_purge' => 'Delete all captured clipboard content without dumping it',
+              'clipboard_monitor_stop' => 'Stop the clipboard monitor'
+            }
+            reqs = {
+              'clipboard_get_data' => [COMMAND_ID_EXTAPI_CLIPBOARD_GET_DATA],
+              'clipboard_set_text' => [COMMAND_ID_EXTAPI_CLIPBOARD_SET_DATA],
+              'clipboard_monitor_start' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_START],
+              'clipboard_monitor_pause' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_PAUSE],
+              'clipboard_monitor_resume' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_RESUME],
+              'clipboard_monitor_dump' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_DUMP],
+              'clipboard_monitor_purge' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_PURGE],
+              'clipboard_monitor_stop' => [COMMAND_ID_EXTAPI_CLIPBOARD_MONITOR_STOP]
+            }
+            filter_commands(all, reqs)
           end
-          
-          client.framework.events.on_session_download( client, src, local_dest_path ) if msf_loaded?
-        }
-    end
 
-    return true, attempted_overwrite
-  end
+          #
+          # Name for this dispatcher
+          #
+          def name
+            'Extapi: Clipboard Management'
+          end
 
-  def parse_dump(dump, get_images, get_files, loot_dir, force_overwrite: false)
+          #
+          # Options for the clipboard_get_data command.
+          #
+          @@get_data_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ],
+            '-d' => [ true, 'Download non-text content to the specified folder (default: current dir)', nil ]
+          )
 
-    overwrite_attempt = false
-    
-    if (get_images || get_files ) && loot_dir.nil?
-      print_error("You have to specify destination directory to download loot.")
-      return true
-    end
+          def print_clipboard_get_data_usage
+            print(
+              "\nUsage: clipboard_get_data [-h] [-d]\n\n" +
+              "Attempts to read the data from the target's clipboard. If the data is in a\n" +
+              "supported format, it is read and returned to the user.\n" +
+              @@get_data_opts.usage + "\n"
+            )
+          end
 
-    if (get_images || get_files) && !::File.directory?( loot_dir )
-      ::FileUtils.mkdir_p( loot_dir )
-    end
-
-    dump.each do |ts, elements|
-      elements.each do |type, v|
-        title = "#{type} captured at #{ts}"
-        under = "=" * title.length
-        print_line(title)
-        print_line(under)
-
-        case type
-        when 'Text'
-          print_line(v)
-
-        when 'Files'
-          v.each do |f|
-            print_line("Remote Path : #{f[:name]}")
-            print_line("File size   : #{f[:size]} bytes")
-            if get_files
-              download_status, attempt = download_file(loot_dir, f[:name],force_overwrite)
-              #if once set to true, leave it true
-              overwrite_attempt ||= attempt
-
-              unless download_status
-                print_error("Download of #{f[:name]} failed.")
+          #
+          # Get the data from the target's clipboard
+          #
+          def cmd_clipboard_get_data(*args)
+            download_content = false
+            download_path = nil
+            @@get_data_opts.parse(args) do |opt, _idx, val|
+              case opt
+              when '-d'
+                download_content = true
+                download_path = val
+              when '-h'
+                print_clipboard_get_data_usage
+                return true
               end
             end
-            print_line
+
+            dump = client.extapi.clipboard.get_data(download_content)
+
+            if dump.length == 0
+              print_error('The current Clipboard data format is not supported.')
+              return false
+            end
+
+            parse_dump(dump, download_content, download_content, download_path)
+            return true
           end
 
-        when 'Image'
-          print_line("Dimensions : #{v[:width]} x #{v[:height]}")
-          if get_images and !v[:data].nil?
-            file = "#{ts.gsub(/\D+/, '')}-#{Rex::Text.rand_text_alpha(8)}.jpg"
-            path = File.join(loot_dir, file)
-            path = ::File.expand_path(path)
-            if ::File.file?(path) && !force_overwrite
-                overwrite_attempt = true 
-            else
-              ::File.binwrite(path, v[:data])
-              print_line("Downloaded : #{path}")
-            end
+          #
+          # Options for the clipboard_set_text command.
+          #
+          @@set_text_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ]
+          )
+
+          def print_clipboard_set_text_usage
+            print(
+              "\nUsage: clipboard_set_text [-h] <text>\n\n" +
+              "Set the target's clipboard to the given text value.\n\n"
+            )
           end
+
+          #
+          # Set the clipboard data to the given text.
+          #
+          def cmd_clipboard_set_text(*args)
+            args.unshift '-h' if args.length == 0
+
+            @@set_text_opts.parse(args) do |opt, _idx, _val|
+              case opt
+              when '-h'
+                print_clipboard_set_text_usage
+                return true
+              end
+            end
+
+            return client.extapi.clipboard.set_text(args.join(' '))
+          end
+
+          #
+          # Options for the clipboard_monitor_start command.
+          #
+          @@monitor_start_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ],
+            '--no-capture' => [ true, 'Do not capture image content when monitoring' ]
+          )
+
+          #
+          # Help for the clipboard_monitor_start command.
+          #
+          def print_clipboard_monitor_start_usage
+            print(
+              "\nUsage: clipboard_monitor_start  [-h]\n\n" +
+              "Starts a background clipboard monitoring thread. The thread watches\n" +
+              "the clipboard on the target, under the context of the current desktop, and when\n" +
+              "changes are detected the contents of the clipboard are captured. Contents can be\n" +
+              "dumped periodically. Image content can be captured as well (and will be by default)\n" +
+              "however this can consume quite a bit of memory.\n\n" +
+              @@monitor_start_opts.usage + "\n"
+            )
+          end
+
+          #
+          # Start the clipboard monitor.
+          #
+          def cmd_clipboard_monitor_start(*args)
+            capture_images = true
+
+            @@monitor_start_opts.parse(args) do |opt, _idx, _val|
+              case opt
+              when '--no-capture'
+                capture_images = false
+              when '-h'
+                print_clipboard_monitor_start_usage
+                return true
+              end
+            end
+
+            client.extapi.clipboard.monitor_start({
+              # random class and window name so that it isn't easy
+              # to track via a script
+              wincls: Rex::Text.rand_text_alpha(8),
+              cap_img: capture_images
+            })
+
+            print_good('Clipboard monitor started')
+          end
+
+          #
+          # Options for the clipboard_monitor_purge command.
+          #
+          @@monitor_purge_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ]
+          )
+
+          #
+          # Help for the clipboard_monitor_purge command.
+          #
+          def print_clipboard_monitor_purge_usage
+            print("\nUsage: clipboard_monitor_purge [-h]\n\n" +
+              "Purge the captured contents from the monitor. This does not stop\n" +
+              "the monitor from running, it just removes captured content.\n\n" +
+              @@monitor_purge_opts.usage + "\n")
+          end
+
+          #
+          # Purge the clipboard monitor captured contents
+          #
+          def cmd_clipboard_monitor_purge(*args)
+            @@monitor_purge_opts.parse(args) do |opt, _idx, _val|
+              case opt
+              when '-h'
+                print_clipboard_monitor_purge_usage
+                return true
+              end
+            end
+            client.extapi.clipboard.monitor_purge
+            print_good('Captured clipboard contents purged successfully')
+          end
+
+          #
+          # Options for the clipboard_monitor_pause command.
+          #
+          @@monitor_pause_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ]
+          )
+
+          #
+          # Help for the clipboard_monitor_pause command.
+          #
+          def print_clipboard_monitor_pause_usage
+            print("\nUsage: clipboard_monitor_pause [-h]\n\n" +
+              "Pause the currently running clipboard monitor thread.\n\n" +
+              @@monitor_pause_opts.usage + "\n")
+          end
+
+          #
+          # Pause the clipboard monitor captured contents
+          #
+          def cmd_clipboard_monitor_pause(*args)
+            @@monitor_pause_opts.parse(args) do |opt, _idx, _val|
+              case opt
+              when '-h'
+                print_clipboard_monitor_pause_usage
+                return true
+              end
+            end
+            client.extapi.clipboard.monitor_pause
+            print_good('Clipboard monitor paused successfully')
+          end
+
+          #
+          # Options for the clipboard_monitor_resumse command.
+          #
+          @@monitor_resume_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ]
+          )
+
+          #
+          # Help for the clipboard_monitor_resume command.
+          #
+          def print_clipboard_monitor_resume_usage
+            print("\nUsage: clipboard_monitor_resume [-h]\n\n" +
+              "Resume the currently paused clipboard monitor thread.\n\n" +
+              @@monitor_resume_opts.usage + "\n")
+          end
+
+          #
+          # resume the clipboard monitor captured contents
+          #
+          def cmd_clipboard_monitor_resume(*args)
+            @@monitor_resume_opts.parse(args) do |opt, _idx, _val|
+              case opt
+              when '-h'
+                print_clipboard_monitor_resume_usage
+                return true
+              end
+            end
+            client.extapi.clipboard.monitor_resume
+            print_good('Clipboard monitor resumed successfully')
+          end
+
+          #
+          # Options for the clipboard_monitor_dump command.
+          #
+          @@monitor_dump_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ],
+            '--no-images' => [ false, "Indicate if captured image data shouldn't be downloaded" ],
+            '--no-files' => [ false, "Indicate if captured file data shouldn't be downloaded" ],
+            '-p' => [ false, 'Purge the contents of the monitor once dumped' ],
+            '-d' => [ true, 'Download non-text content to the specified folder' ],
+            '--force' => [false, 'Force overwriting existing files']
+          )
+
+          #
+          # Help for the clipboard_monitor_dump command.
+          #
+          def print_clipboard_monitor_dump_usage
+            print(
+              "\nUsage: clipboard_monitor_dump [-p] [-d downloaddir] [-h]\n\n" +
+              "Dump the capture clipboard contents to the local machine..\n\n" +
+              @@monitor_dump_opts.usage + "\n"
+            )
+          end
+
+          #
+          # Dump the clipboard monitor contents to the local machine.
+          #
+          def cmd_clipboard_monitor_dump(*args)
+            purge = false
+            download_images = true
+            download_files = true
+            download_path = nil
+            force_overwrite = false
+
+            @@monitor_dump_opts.parse(args) do |opt, _idx, val|
+              case opt
+              when '-d'
+                download_path = val
+              when '--no-images'
+                download_images = false
+              when '--no-files'
+                download_files = false
+              when '-p'
+                purge = true
+              when '--force'
+                force_overwrite = true
+              when '-h'
+                print_clipboard_monitor_dump_usage
+                return true
+              end
+            end
+
+            if download_path.nil?
+              print_error('You have to specify destination directory to download loot.')
+              return true
+            end
+
+            # do something with dump
+            dump = client.extapi.clipboard.monitor_dump({
+              include_images: download_images,
+              purge: false
+            })
+
+            res = parse_dump(dump, download_images, download_files, download_path, force_overwrite: force_overwrite)
+            if !res && purge
+              client.extapi.clipboard.monitor_purge
+            end
+            print_good('Clipboard monitor dumped')
+          end
+
+          #
+          # Options for the clipboard_monitor_stop command.
+          #
+          @@monitor_stop_opts = Rex::Parser::Arguments.new(
+            '-h' => [ false, 'Help banner' ],
+            '--no-dump' => [ false, "Indicate if captured clipboard data shouldn't be dumped" ],
+            '--no-images' => [ false, "Indicate if captured image data shouldn't be downloaded" ],
+            '--no-files' => [ false, "Indicate if captured file data shouldn't be downloaded" ],
+            '-d' => [ true, 'Download non-text content to the specified folder' ],
+            '--force' => [false, 'Force overwriting existing files']
+          )
+
+          #
+          # Help for the clipboard_monitor_stop command.
+          #
+          def print_clipboard_monitor_stop_usage
+            print(
+              "\nUsage: clipboard_monitor_stop [-d downloaddir] [-h]\n\n" +
+              "Stops a clipboard monitor thread and returns the captured data to the local machine.\n\n" +
+              @@monitor_stop_opts.usage + "\n"
+            )
+          end
+
+          #
+          # Stop the clipboard monitor.
+          #
+          def cmd_clipboard_monitor_stop(*args)
+            dump_data = true
+            download_images = true
+            download_files = true
+            download_path = nil
+            force_overwrite = false
+
+            @@monitor_stop_opts.parse(args) do |opt, _idx, val|
+              case opt
+              when '-d'
+                download_path = val
+              when '--no-dump'
+                dump_data = false
+              when '--no-images'
+                download_images = false
+              when '--no-files'
+                download_files = false
+              when '--force'
+                force_overwrite = true
+              when '-h'
+                print_clipboard_monitor_stop_usage
+                return true
+              end
+            end
+
+            # you can't download stuff if you don't specify destination directory
+            # todo: is there more ruby way to do this
+            download_images = download_images && download_path.nil? ? false : download_images
+
+            dump = client.extapi.clipboard.monitor_stop({
+              dump: dump_data,
+              include_images: download_images
+            })
+
+            parse_dump(dump, download_images, download_files, download_path, force_overwrite: force_overwrite) if dump_data
+
+            print_good('Clipboard monitor stopped')
+          end
+
+          private
+
+          def download_file(dest_folder, source, force_overwrite = false)
+            stat = client.fs.file.stat(source)
+            base = ::Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File.basename(source)
+            attempted_overwrite = false
+
+            # Basename ends up with a single name/folder. This is the only point where it
+            # may be possible to do a dir trav up one folder. We need to check to make sure
+            # that the basename doesn't result in a traversal
+            return false, attempted_overwrite if base == '..'
+
+            local_dest_path = File.join(dest_folder, base)
+            local_dest_path = ::File.expand_path(local_dest_path)
+
+            return false, attempted_overwrite unless local_dest_path.start_with?(::File.expand_path(dest_folder) + ::File::SEPARATOR)
+
+            if stat.directory?
+              client.fs.dir.download(local_dest_path, source, { 'force_overwrite' => force_overwrite, 'recursive' => true }) do |step, src, dst|
+                attempted_overwrite ||= (step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE)
+
+                if step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE
+                  print_line("#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}")
+                elsif step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED_OVERWRITTEN
+                  print_line("#{Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}")
+                else
+                  print_line("#{step.ljust(11)} : #{src} -> #{dst}")
+                end
+                client.framework.events.on_session_download(client, src, local_dest_path) if msf_loaded?
+              end
+            elsif stat.file?
+              client.fs.file.download(local_dest_path, source, { 'force_overwrite' => force_overwrite }) do |step, src, dst|
+                attempted_overwrite ||= (step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE)
+
+                if step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE
+                  print_line("#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}")
+                elsif step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED_OVERWRITTEN
+                  print_line("#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}")
+                else
+                  print_line("#{step.ljust(11)} : #{src} -> #{dst}")
+                end
+
+                client.framework.events.on_session_download(client, src, local_dest_path) if msf_loaded?
+              end
+            end
+
+            return true, attempted_overwrite
+          end
+
+          def parse_dump(dump, get_images, get_files, loot_dir, force_overwrite: false)
+            overwrite_attempt = false
+
+            if (get_images || get_files) && loot_dir.nil?
+              print_error('You have to specify destination directory to download loot.')
+              return true
+            end
+
+            if (get_images || get_files) && !::File.directory?(loot_dir)
+              ::FileUtils.mkdir_p(loot_dir)
+            end
+
+            dump.each do |ts, elements|
+              elements.each do |type, v|
+                title = "#{type} captured at #{ts}"
+                under = '=' * title.length
+                print_line(title)
+                print_line(under)
+
+                case type
+                when 'Text'
+                  print_line(v)
+
+                when 'Files'
+                  v.each do |f|
+                    print_line("Remote Path : #{f[:name]}")
+                    print_line("File size   : #{f[:size]} bytes")
+                    if get_files
+                      download_status, attempt = download_file(loot_dir, f[:name], force_overwrite)
+                      # if once set to true, leave it true
+                      overwrite_attempt ||= attempt
+
+                      unless download_status
+                        print_error("Download of #{f[:name]} failed.")
+                      end
+                    end
+                    print_line
+                  end
+
+                when 'Image'
+                  print_line("Dimensions : #{v[:width]} x #{v[:height]}")
+                  if get_images and !v[:data].nil?
+                    file = "#{ts.gsub(/\D+/, '')}-#{Rex::Text.rand_text_alpha(8)}.jpg"
+                    path = File.join(loot_dir, file)
+                    path = ::File.expand_path(path)
+                    if ::File.file?(path) && !force_overwrite
+                      overwrite_attempt = true
+                    else
+                      ::File.binwrite(path, v[:data])
+                      print_line("Downloaded : #{path}")
+                    end
+                  end
+                end
+                print_line(under)
+                print_line
+              end
+            end
+            return overwrite_attempt
+          end
+
         end
-        print_line(under)
-        print_line
       end
     end
-    return overwrite_attempt
   end
-
 end
-
-end
-end
-end
-end
-

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -14,7 +14,11 @@ module Ui
 class Console::CommandDispatcher::Extapi::Clipboard
 
   Klass = Console::CommandDispatcher::Extapi::Clipboard
-  STEP_SKIPPED_WOULD_OVERWRITE = "Overwrite attempt"
+  
+  STEP_SKIPPED_WOULD_OVERWRITE = 'Overwrite'
+  STEP_COMPLETED = 'Completed'
+  STEP_SKIPPED = 'Skipped'
+  STEP_COMPLETED_OVERWRITTEN = 'Overwritten'
   
   include Console::CommandDispatcher
   include Rex::Post::Meterpreter::Extensions::Extapi
@@ -388,6 +392,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
       :dump           => dump_data,
       :include_images => download_images
     })
+    
 
     parse_dump(dump, download_images, download_files, download_path, force_overwrite) if dump_data
 
@@ -415,8 +420,11 @@ private
       client.fs.dir.download( local_dest_path, source, {"force_overwrite" => force_overwrite, "recursive" => true} ) { |step, src, dst|
             
             attempted_overwrite ||= (step == STEP_SKIPPED_WOULD_OVERWRITE)
+
             if step == STEP_SKIPPED_WOULD_OVERWRITE
-              print_line( "Skipped : Would overwrite existing file #{dst}" )
+              print_line( "#{STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
+            elsif step == STEP_COMPLETED_OVERWRITTEN
+              print_line( "#{STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
             else
               print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
             end
@@ -427,7 +435,9 @@ private
           attempted_overwrite ||= (step == STEP_SKIPPED_WOULD_OVERWRITE)
           
           if step == STEP_SKIPPED_WOULD_OVERWRITE
-            print_line( "Skipped : Would overwrite existing file #{dst}" )
+            print_line( "#{STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
+          elsif step == STEP_COMPLETED_OVERWRITTEN
+            print_line( "#{STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
           else
             print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
           end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -428,12 +428,12 @@ private
     if stat.directory?
       client.fs.dir.download( local_dest_path, source, {"force_overwrite" => force_overwrite, "recursive" => true} ) { |step, src, dst|
             
-            attempted_overwrite ||= (step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE)
+            attempted_overwrite ||= (step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE)
 
-            if step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE
-              print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
-            elsif step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED_OVERWRITTEN
-              print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
+            if step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE
+              print_line( "#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
+            elsif step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED_OVERWRITTEN
+              print_line( "#{Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
             else
               print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
             end
@@ -441,12 +441,12 @@ private
       }
     elsif stat.file?
       client.fs.file.download( local_dest_path, source, {"force_overwrite" => force_overwrite} ) { |step, src, dst|
-          attempted_overwrite ||= (step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE)
+          attempted_overwrite ||= (step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE)
           
-          if step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE
-            print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
-          elsif step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED_OVERWRITTEN
-            print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
+          if step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED_WOULD_OVERWRITE
+            print_line( "#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
+          elsif step == Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED_OVERWRITTEN
+            print_line( "#{Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
           else
             print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
           end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -17,11 +17,6 @@ class Console::CommandDispatcher::Extapi::Clipboard
 
   include Console::CommandDispatcher
   include Rex::Post::Meterpreter::Extensions::Extapi
-
-  def initialize(s)
-    super
-    @loot_directory = "~/.msf4/clipboard_loot"
-  end
   
   #
   # List of supported commands.

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -407,8 +407,8 @@ private
 
     local_dest_path = File.join( dest_folder, base )
     local_dest_path = ::File.expand_path(local_dest_path)
-    
-    return false, attempted_overwrite unless local_dest_path.start_with?(::File.expand_path(dest_folder)+'/')
+   
+    return false, attempted_overwrite unless local_dest_path.start_with?(::File.expand_path(dest_folder)+::File::SEPARATOR)
     
     if stat.directory?
       client.fs.dir.download( local_dest_path, source, {"force_overwrite" => force_overwrite, "recursive" => true} ) { |step, src, dst|

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -281,7 +281,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
     "-h" => [ false, "Help banner" ],
     "-i" => [ true,  "Indicate if captured image data should be downloaded (default: true)" ],
     "-f" => [ true,  "Indicate if captured file data should be downloaded (default: true)" ],
-    "-p" => [ true,  "Purge the contents of the monitor once dumped (default: true)" ],
+    "-p" => [ false,  "Purge the contents of the monitor once dumped (default: true)" ],
     "-d" => [ true,  "Download non-text content to the specified folder" ],
     '--force' => [false, "Force overwriting existing files"]
   )

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -282,7 +282,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
     "-i" => [ true,  "Indicate if captured image data should be downloaded (default: true)" ],
     "-f" => [ true,  "Indicate if captured file data should be downloaded (default: true)" ],
     "-p" => [ true,  "Purge the contents of the monitor once dumped (default: true)" ],
-    "-d" => [ true,  "Download non-text content to the specified folder (default: current dir)" ],
+    "-d" => [ true,  "Download non-text content to the specified folder" ],
     '--force' => [false, "Force overwriting existing files"]
   )
 
@@ -324,6 +324,11 @@ class Console::CommandDispatcher::Extapi::Clipboard
       end
     }
     
+    if download_path.nil? 
+      print_error("You need to specify download directory.")
+      return 1
+    end
+
     # do something with dump
     dump = client.extapi.clipboard.monitor_dump({
       :include_images => download_images,
@@ -345,7 +350,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
     "-x" => [ true,  "Indicate if captured clipboard data should be dumped (default: true)" ],
     "-i" => [ true,  "Indicate if captured image data should be downloaded (default: true)" ],
     "-f" => [ true,  "Indicate if captured file data should be downloaded (default: true)" ],
-    "-d" => [ true,  "Download non-text content to the specified folder (default: current dir)" ],
+    "-d" => [ true,  "Download non-text content to the specified folder" ],
     '--force' => [false, "Force overwriting existing files"]
   )
 
@@ -387,7 +392,13 @@ class Console::CommandDispatcher::Extapi::Clipboard
       end
     }
     
+    
+    if download_path.nil? 
+      print_error("You need to specify download directory.")
+      return 1
+    end
 
+  
     dump = client.extapi.clipboard.monitor_stop({
       :dump           => dump_data,
       :include_images => download_images

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -410,7 +410,7 @@ private
   end
 
   def parse_dump(dump, get_images, get_files, download_path)
-    loot_dir = download_path || "."
+    loot_dir = download_path || "~/.msf4/loot/"
     if (get_images || get_files) && !::File.directory?( loot_dir )
       ::FileUtils.mkdir_p( loot_dir )
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -18,6 +18,10 @@ class Console::CommandDispatcher::Extapi::Clipboard
   include Console::CommandDispatcher
   include Rex::Post::Meterpreter::Extensions::Extapi
 
+  def initialize
+    @loot_directory = "~/.msf4/clipboard_loot"
+  end
+  
   #
   # List of supported commands.
   #
@@ -411,7 +415,7 @@ private
 
   def parse_dump(dump, get_images, get_files, download_path)
 
-    loot_dir = download_path || ::File.expand_path("~/.msf4/clipboard_loot/")
+    loot_dir = download_path || ::File.expand_path(@loot_directory)
     # prevent writing into existing directory without file download enabled
     if ::File.directory?(loot_dir) && !get_files
       print_error("Cannot write to existing directory if file download is not enabled")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -15,11 +15,6 @@ class Console::CommandDispatcher::Extapi::Clipboard
 
   Klass = Console::CommandDispatcher::Extapi::Clipboard
   
-  STEP_SKIPPED_WOULD_OVERWRITE = 'Overwrite'
-  STEP_COMPLETED = 'Completed'
-  STEP_SKIPPED = 'Skipped'
-  STEP_COMPLETED_OVERWRITTEN = 'Overwritten'
-  
   include Console::CommandDispatcher
   include Rex::Post::Meterpreter::Extensions::Extapi
   
@@ -326,7 +321,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
     
     if download_path.nil? 
       print_error("You need to specify download directory.")
-      return 1
+      return true
     end
 
     # do something with dump
@@ -395,7 +390,7 @@ class Console::CommandDispatcher::Extapi::Clipboard
     
     if download_path.nil? 
       print_error("You need to specify download directory.")
-      return 1
+      return true
     end
 
   
@@ -430,12 +425,12 @@ private
     if stat.directory?
       client.fs.dir.download( local_dest_path, source, {"force_overwrite" => force_overwrite, "recursive" => true} ) { |step, src, dst|
             
-            attempted_overwrite ||= (step == STEP_SKIPPED_WOULD_OVERWRITE)
+            attempted_overwrite ||= (step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE)
 
-            if step == STEP_SKIPPED_WOULD_OVERWRITE
-              print_line( "#{STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
-            elsif step == STEP_COMPLETED_OVERWRITTEN
-              print_line( "#{STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
+            if step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE
+              print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
+            elsif step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED_OVERWRITTEN
+              print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
             else
               print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
             end
@@ -443,12 +438,12 @@ private
       }
     elsif stat.file?
       client.fs.file.download( local_dest_path, source, {"force_overwrite" => force_overwrite} ) { |step, src, dst|
-          attempted_overwrite ||= (step == STEP_SKIPPED_WOULD_OVERWRITE)
+          attempted_overwrite ||= (step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE)
           
-          if step == STEP_SKIPPED_WOULD_OVERWRITE
-            print_line( "#{STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
-          elsif step == STEP_COMPLETED_OVERWRITTEN
-            print_line( "#{STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
+          if step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED_WOULD_OVERWRITE
+            print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_SKIPPED.ljust(11)} : Would overwrite existing file #{dst}" )
+          elsif step == Meterpreter::Extensions::Stdapi::Fs::Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED_OVERWRITTEN
+            print_line( "#{Meterpreter::Extensions::Stdapi::Fs::STEP_COMPLETED.ljust(11)} : Overwrote existing file #{dst}" )
           else
             print_line( "#{step.ljust(11)} : #{src} -> #{dst}" )
           end


### PR DESCRIPTION
This PR introduces major changes in clipboard functionality. There are several changes in argument format for `clipboard_monitor_start`, `clipboard_monitor_dump` and `clipboard_monitor_stop`. It removes arguments in format `-f [true/false]`, substituting it for `--no-files`. In the current state, it is possible to overwrite sensitive files such as `msfconsole`, `.bashrc` or files in`lib/` from clipboard files. This is potentially dangerous behavior as it might lead to attack on Metasploit user. The default download location is `./`, therefore, in current state, running `clipboard_monitor_dump` or `clipboard_monitor_stop` can overwrite sensitive files in current working directory on Metasploit machine. This PR tries to address this issue, for example, with changing default save directory to `~/.msf4/clipboard_loot` or with changing default settings for file download to `false` for prevent writing into already existing directories unless user allows it.