### PR TITLE
Updates the `reports_note` method to require a Hash

### DIFF
--- a/data/exploits/psnuffle/smb.rb
+++ b/data/exploits/psnuffle/smb.rb
@@ -185,19 +185,19 @@ class SnifferSMB < BaseProtocolParser
               report_note(
                 :host  => src_ip,
                 :type  => "smb_peer_os",
-                :data  => s[:peer_os]
+                :data  => { :peer_os => s[:peer_os] }
               ) if (s[:peer_os] and s[:peer_os].strip.length > 0)
 
               report_note(
                 :host  => src_ip,
                 :type  => "smb_peer_lm",
-                :data  => s[:peer_lm]
+                :data  => { :peer_lm => s[:peer_lm] }
               ) if (s[:peer_lm] and s[:peer_lm].strip.length > 0)
 
               report_note(
                 :host  => src_ip,
                 :type  => "smb_domain",
-                :data  => s[:domain]
+                :data  => { :domain => s[:domain] }
               ) if (s[:domain] and s[:domain].strip.length > 0)
 
             end

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -515,7 +515,7 @@ module Auxiliary::Report
 
     # This will probably evolve into a new database table
     report_note(
-      :data => full_path.dup,
+      :data => { :full_path => full_path.dup },
       :type => "#{ltype}.localpath"
     )
 
@@ -590,4 +590,3 @@ module Auxiliary::Report
 
 end
 end
-

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -143,6 +143,14 @@ module Msf::DBManager::Note
     end
 
     ntype  = opts.delete(:type) || opts.delete(:ntype) || (raise RuntimeError, "A note :type or :ntype is required")
+
+    unless opts[:data].is_a?(Hash)
+      message = "[DEPRECATION] Using #{method.inspect} with a non-hash data value is deprecated, please raise a Github issue with this output. Called from: #{caller(1, stack_size).to_a}"
+      print_warning message
+      # Additionally write to ~/.msf4/logs/framework.log - as this gets attached to Github issues etc
+      elog(message)
+    end
+
     data   = opts[:data]
     note   = nil
 

--- a/lib/msf/core/exploit/remote/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/remote/browser_autopwn2.rb
@@ -612,7 +612,7 @@ module Msf
       report_note(
         :host => ip,
         :type => 'bap.clicks',
-        :data => data,
+        :data => { :csv_data => data },
         :update => :unique)
     end
 

--- a/lib/msf/core/exploit/remote/dns/enumeration.rb
+++ b/lib/msf/core/exploit/remote/dns/enumeration.rb
@@ -246,7 +246,7 @@ module Enumeration
           }
           report_note(
             type: srv_record,
-            data: srv_record_data
+            data: { :srv_record_data => srv_record_data }
           )
         end
       end

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -381,7 +381,14 @@ module Exploit::Remote::HttpServer
     report_note(
       :host => address,
       :type => 'http.request',
-      :data => "#{address}: #{request.method} #{request.resource} #{client[:os_name]} #{client[:ua_name]} #{client[:ua_ver]}",
+      :data => {
+        :address => address,
+        :method => request.method,
+        :resource => request.resource,
+        :os_name => client[:os_name],
+        :ua_name => client[:ua_name],
+        :ua_ver => client[:ua_ver]
+      },
       :update => :unique_data
     )
     return host.merge(client)

--- a/lib/msf/core/exploit/remote/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/remote/smb/client/psexec.rb
@@ -233,7 +233,7 @@ module Exploit::Remote::SMB::Client::Psexec
         :rport => simple.port,
         :type  => 'psexec_command',
         :name => command,
-        :data => output
+        :data => { :command_output => output }
       )
     end
   end

--- a/lib/msf/core/exploit/remote/wdbrpc_client.rb
+++ b/lib/msf/core/exploit/remote/wdbrpc_client.rb
@@ -64,7 +64,7 @@ module Exploit::Remote::WDBRPC_Client
       :port   => rport,
       :proto  => 'udp',
       :type   => 'vxworks.target_info',
-      :data   => res,
+      :data   => { :target_info => res },
       :update => :unique
     )
   end
@@ -103,7 +103,7 @@ module Exploit::Remote::WDBRPC_Client
       :port   => rport,
       :proto  => 'udp',
       :type   => 'vxworks.target_info',
-      :data   => res,
+      :data   => { :target_info => res },
       :update => :unique
     )
   end
@@ -215,4 +215,3 @@ module Exploit::Remote::WDBRPC_Client
 
 end
 end
-

--- a/lib/msf/core/exploit/remote/x11/connect.rb
+++ b/lib/msf/core/exploit/remote/x11/connect.rb
@@ -49,7 +49,7 @@ module Msf::Exploit::Remote::X11::Connect
       sname: 'x11',
       port: port,
       type: 'x11.server_vendor',
-      data: "Open X Server (#{connection.body.vendor})"
+      data: { :server => connection.body.vendor }
     )
   end
 end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -347,7 +347,7 @@ class Db
 
       framework.db.hosts(address: host_search).each do |host|
         framework.db.update_host(host_data.merge(id: host.id))
-        framework.db.report_note(host: host.address, type: "host.#{attribute}", data: host_data[attribute])
+        framework.db.report_note(host: host.address, type: "host.#{attribute}", data: { :host_data => host_data[attribute] })
       end
     end
   end

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -20,17 +20,16 @@ class MetasploitModule < Msf::Auxiliary
           supplied.
         },
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
-        'License' => MSF_LICENSE,
         'Notes' => {
-          'Stability' => [CRASH_SAFE],
-          'SideEffects' => [IOC_IN_LOGS],
-          'Reliability' => []
-        }
+           'Stability' => [CRASH_SAFE],
+           'SideEffects' => [IOC_IN_LOGS],
+           'Reliability' => []
+        },
+        'License' => MSF_LICENSE
       )
     )
   end
 
-  # rubocop:disable Metrics/MethodLength
   def run
     print_status('Running MS SQL Server Enumeration...')
     if session
@@ -51,11 +50,13 @@ class MetasploitModule < Msf::Auxiliary
       print "[*]\t#{row}"
     end
     vernum = sqlversion.gsub("\n", ' ').scan(/SQL Server\s*(200\d)/m)
-    report_note(host: mssql_client.peerhost,
-                proto: 'TCP',
-                port: mssql_client.peerport,
-                type: 'MSSQL_ENUM',
-                data: "Version: #{sqlversion}")
+    report_note(
+      host: mssql_client.peerhost,
+      proto: 'TCP',
+      port: mssql_client.peerport,
+      type: 'MSSQL_ENUM',
+      data: { version: sqlversion }
+    )
 
     #---------------------------------------------------------
     # Check Configuration Parameters and check what is enabled
@@ -83,18 +84,22 @@ class MetasploitModule < Msf::Auxiliary
     # checking for C2 Audit Mode
     if sysconfig['c2 audit mode'] == 1
       print_status("\tC2 Audit Mode is Enabled")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'C2 Audit Mode is Enabled')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { c2_audit_mode: 'Enabled' }
+      )
     else
       print_status("\tC2 Audit Mode is Not Enabled")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'C2 Audit Mode is Not Enabled')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { c2_audit_mode: 'Disabled' }
+      )
     end
 
     #-------------------------------------------------------
@@ -102,35 +107,43 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != '2000'
       if sysconfig['xp_cmdshell'] == 1
         print_status("\txp_cmdshell is Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'xp_cmdshell is Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { xp_cmdshell: 'Enabled' }
+        )
       else
         print_status("\txp_cmdshell is Not Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'xp_cmdshell is Not Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { xp_cmdshell: 'Disabled' }
+        )
       end
     else
       xpspexist = mssql_query("select sysobjects.name from sysobjects where name = \'xp_cmdshell\'")[:rows]
       if !xpspexist.nil?
         print_status("\txp_cmdshell is Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'xp_cmdshell is Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { xp_cmdshell: 'Enabled' }
+        )
       else
         print_status("\txp_cmdshell is Not Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'xp_cmdshell is Not Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { xp_cmdshell: 'Disabled' }
+        )
       end
     end
 
@@ -138,36 +151,37 @@ class MetasploitModule < Msf::Auxiliary
     # check if remote access is enabled
     if sysconfig['remote access'] == 1
       print_status("\tremote access is Enabled")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'remote access is Enabled')
     else
       print_status("\tremote access is Not Enabled")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'remote access is not Enabled')
     end
+    report_note(
+      host: mssql_client.peerhost,
+      proto: 'TCP',
+      port: mssql_client.peerport,
+      type: 'MSSQL_ENUM',
+      data: { remote_access: 'Enabled' }
+    )
 
     #-------------------------------------------------------
     # check if updates are allowed
     if sysconfig['allow updates'] == 1
       print_status("\tallow updates is Enabled")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'allow updates is Enabled')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { allow_updates: 'Enabled' }
+      )
     else
       print_status("\tallow updates is Not Enabled")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'allow updates is not Enabled')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { allow_updates: 'Disabled' }
+      )
     end
 
     #-------------------------------------------------------
@@ -175,35 +189,43 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != '2000'
       if sysconfig['Database Mail XPs'] == 1
         print_status("\tDatabase Mail XPs is Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Database Mail XPs is Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { database_mail_xps: 'Enabled' }
+        )
       else
         print_status("\tDatabase Mail XPs is Not Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Database Mail XPs is not Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { database_mail_xps: 'Disabled' }
+        )
       end
     else
       mailexist = mssql_query("select sysobjects.name from sysobjects where name like \'%mail%\'")[:rows]
       if !mailexist.nil?
         print_status("\tDatabase Mail XPs is Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Database Mail XPs is Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { database_mail_xps: 'Enabled' }
+        )
       else
         print_status("\tDatabase Mail XPs is Not Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Database Mail XPs is not Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { database_mail_xps: 'Disabled' }
+        )
       end
     end
 
@@ -212,35 +234,43 @@ class MetasploitModule < Msf::Auxiliary
     if vernum.join != '2000'
       if sysconfig['Ole Automation Procedures'] == 1
         print_status("\tOle Automation Procedures are Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Ole Automation Procedures are Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { ole_automation_procedures: 'Enabled' }
+        )
       else
         print_status("\tOle Automation Procedures are Not Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Ole Automation Procedures are not Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { ole_automation_procedures: 'Disabled' }
+        )
       end
     else
       oleexist = mssql_query("select sysobjects.name from sysobjects where name like \'%sp_OA%\'")[:rows]
       if !oleexist.nil?
         print_status("\tOle Automation Procedures is Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Ole Automation Procedures are Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { ole_automation_procedures: 'Enabled' }
+        )
       else
         print_status("\tOle Automation Procedures are Not Enabled")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'Ole Automation Procedures are not Enabled')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { ole_automation_procedures: 'Disabled' }
+        )
       end
     end
 
@@ -257,11 +287,15 @@ class MetasploitModule < Msf::Auxiliary
           if !db_ind_files.nil?
             db_ind_files.each do |fn|
               print_status("\t\t#{fn.join}")
-              report_note(host: mssql_client.peerhost,
-                          proto: 'TCP',
-                          port: mssql_client.peerport,
-                          type: 'MSSQL_ENUM',
-                          data: "Database: #{dbn.strip} File: #{fn.join}")
+              report_note(
+                host: mssql_client.peerhost,
+                proto: 'TCP',
+                port: mssql_client.peerport,
+                type: 'MSSQL_ENUM',
+                data: {
+                  database: dbn.strip, file: fn.join
+                }
+              )
             end
           end
         else
@@ -269,11 +303,16 @@ class MetasploitModule < Msf::Auxiliary
           if !db_ind_files.nil?
             db_ind_files.each do |fn|
               print_status("\t\t#{fn.join.strip}")
-              report_note(host: mssql_client.peerhost,
-                          proto: 'TCP',
-                          port: mssql_client.peerport,
-                          type: 'MSSQL_ENUM',
-                          data: "Database: #{dbn.strip} File: #{fn.join}")
+              report_note(
+                host: mssql_client.peerhost,
+                proto: 'TCP',
+                port: mssql_client.peerport,
+                type: 'MSSQL_ENUM',
+                data: {
+                  database: dbn.strip,
+                  file: fn.join
+                }
+              )
             end
           end
         end
@@ -291,19 +330,23 @@ class MetasploitModule < Msf::Auxiliary
     if !syslogins.nil?
       syslogins.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Database: Master User: #{acc.join}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { database_master_user: acc.join }
+        )
       end
     else
       print_error("\tCould not enumerate System Logins!")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'Could not enumerate System Logins')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { logons: 'Could not enumerate System Logins' }
+      )
     end
 
     #-------------------------------------------------------
@@ -314,19 +357,23 @@ class MetasploitModule < Msf::Auxiliary
       if !disabledsyslogins.nil?
         disabledsyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(host: mssql_client.peerhost,
-                      proto: 'TCP',
-                      port: mssql_client.peerport,
-                      type: 'MSSQL_ENUM',
-                      data: "Disabled User: #{acc.join}")
+          report_note(
+            host: mssql_client.peerhost,
+            proto: 'TCP',
+            port: mssql_client.peerport,
+            type: 'MSSQL_ENUM',
+            data: { disabled_user: acc.join }
+          )
         end
       else
         print_status("\tNo Disabled Logins Found")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'No Disabled Logins Found')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { disabled_user: 'No Disabled Logins Found' }
+        )
       end
     end
 
@@ -338,19 +385,23 @@ class MetasploitModule < Msf::Auxiliary
       if !nopolicysyslogins.nil?
         nopolicysyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(host: mssql_client.peerhost,
-                      proto: 'TCP',
-                      port: mssql_client.peerport,
-                      type: 'MSSQL_ENUM',
-                      data: "None Policy Checked User: #{acc.join}")
+          report_note(
+            host: mssql_client.peerhost,
+            proto: 'TCP',
+            port: mssql_client.peerport,
+            type: 'MSSQL_ENUM',
+            data: { none_policy_checked_user: acc.join }
+          )
         end
       else
         print_status("\tAll System Accounts have the Windows Account Policy Applied to them.")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'All System Accounts have the Windows Account Policy Applied to them')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { none_policy_checked_user: 'All System Accounts have the Windows Account Policy Applied to them' }
+        )
       end
     end
 
@@ -362,19 +413,23 @@ class MetasploitModule < Msf::Auxiliary
       if !passexsyslogins.nil?
         passexsyslogins.each do |acc|
           print_status("\t#{acc.join}")
-          report_note(host: mssql_client.peerhost,
-                      proto: 'TCP',
-                      port: mssql_client.peerport,
-                      type: 'MSSQL_ENUM',
-                      data: "None Password Expiration User: #{acc.join}")
+          report_note(
+            host: mssql_client.peerhost,
+            proto: 'TCP',
+            port: mssql_client.peerport,
+            type: 'MSSQL_ENUM',
+            data: { none_password_expiration_user: acc.join }
+          )
         end
       else
         print_status("\tAll System Accounts are checked for Password Expiration.")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: 'All System Accounts are checked for Password Expiration')
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { none_password_expiration_user: 'All System Accounts are checked for Password Expiration' }
+        )
       end
     end
 
@@ -389,19 +444,23 @@ class MetasploitModule < Msf::Auxiliary
     if !sysadmins.nil?
       sysadmins.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Sysdba: #{acc.join}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { sysdba: acc.join }
+        )
       end
     else
       print_error("\tCould not enumerate sysadmin accounts!")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'Could not enumerate sysadmin accounts')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { sysdba: 'Could not enumerate sysadmin accounts' }
+      )
     end
 
     #-------------------------------------------------------
@@ -416,19 +475,23 @@ class MetasploitModule < Msf::Auxiliary
     if !winusers.nil?
       winusers.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Windows Logins: #{acc.join}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { windows_logins: acc.join }
+        )
       end
     else
       print_status("\tNo Windows logins found!")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'No Windows logins found')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { windows_logins: 'No Windows logins found' }
+      )
     end
 
     #-------------------------------------------------------
@@ -443,19 +506,23 @@ class MetasploitModule < Msf::Auxiliary
     if !wingroups.nil?
       wingroups.each do |acc|
         print_status("\t#{acc.join}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Windows Groups: #{acc.join}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { windows_groups: acc.join }
+        )
       end
     else
       print_status("\tNo Windows Groups where found with permission to login to system.")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'No Windows Groups where found with permission to login to system')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { windows_groups: 'No Windows Groups where found with permission to login to system' }
+      )
 
     end
 
@@ -472,19 +539,26 @@ class MetasploitModule < Msf::Auxiliary
     if !sameasuser.nil?
       sameasuser.each do |up|
         print_status("\t#{up.join}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Username: #{up.join} Password: #{up.join}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: {
+            username: up.join,
+            password: up.join
+          }
+        )
       end
     else
       print_status("\tNo Account with its password being the same as its username was found.")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'No Account with its password being the same as its username was found')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { credentials: 'No Account with its password being the same as its username was found' }
+      )
     end
 
     #-------------------------------------------------------
@@ -500,19 +574,26 @@ class MetasploitModule < Msf::Auxiliary
     if !blankpass.nil?
       blankpass.each do |up|
         print_status("\t#{up.join}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Username: #{up.join} Password: EMPTY ")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: {
+            username: up.join,
+            password: 'EMPTY'
+          }
+        )
       end
     else
       print_status("\tNo Accounts with empty passwords where found.")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'No Accounts with empty passwords where found')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { credentials: 'No Accounts with empty passwords where found' }
+      )
     end
 
     #-------------------------------------------------------
@@ -725,19 +806,23 @@ class MetasploitModule < Msf::Auxiliary
         next unless dangeroussp.include?(strp.strip)
 
         print_status("\t#{strp.strip}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Stored Procedures with Public Execute Permission #{strp.strip}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { stored_procedures_with_public_execute_permission: strp.strip }
+        )
       end
     else
       print_status("\tNo Dangerous Stored Procedure found with Public Execute.")
-      report_note(host: mssql_client.peerhost,
-                  proto: 'TCP',
-                  port: mssql_client.peerport,
-                  type: 'MSSQL_ENUM',
-                  data: 'No Dangerous Stored Procedure found with Public Execute')
+      report_note(
+        host: mssql_client.peerhost,
+        proto: 'TCP',
+        port: mssql_client.peerport,
+        type: 'MSSQL_ENUM',
+        data: { stored_procedures_with_public_execute_permission: 'No Dangerous Stored Procedure found with Public Execute' }
+      )
     end
 
     #-------------------------------------------------------
@@ -767,11 +852,13 @@ class MetasploitModule < Msf::Auxiliary
       instances.each do |i|
         print_status("\t#{i}")
         instancenames << i.strip
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Instance Name: #{i}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { instance_name: i }
+        )
       end
     else
       print_status('No instances found, possible permission problem')
@@ -784,11 +871,13 @@ class MetasploitModule < Msf::Auxiliary
     if !privdflt.nil?
       privdflt.each do |priv|
         print_status("\t#{priv[1]}")
-        report_note(host: mssql_client.peerhost,
-                    proto: 'TCP',
-                    port: mssql_client.peerport,
-                    type: 'MSSQL_ENUM',
-                    data: "Default Instance SQL Server running as: #{priv[1]}")
+        report_note(
+          host: mssql_client.peerhost,
+          proto: 'TCP',
+          port: mssql_client.peerport,
+          type: 'MSSQL_ENUM',
+          data: { default_instance_sql_server: priv[1] }
+        )
       end
     else
       print_status("\txp_regread might be disabled in this system")
@@ -804,11 +893,16 @@ class MetasploitModule < Msf::Auxiliary
           print_status("Instance #{i} SQL Server Service is running under the privilege of:")
           privinst.each do |p|
             print_status("\t#{p[1]}")
-            report_note(host: mssql_client.peerhost,
-                        proto: 'TCP',
-                        port: mssql_client.peerport,
-                        type: 'MSSQL_ENUM',
-                        data: "#{i} Instance SQL Server running as: #{p[1]}")
+            report_note(
+              host: mssql_client.peerhost,
+              proto: 'TCP',
+              port: mssql_client.peerport,
+              type: 'MSSQL_ENUM',
+              data: {
+                instance_sql_server: i,
+                port: p[1]
+              }
+            )
           end
         else
           print_status("\tCould not enumerate credentials for Instance.")
@@ -818,5 +912,4 @@ class MetasploitModule < Msf::Auxiliary
 
     disconnect
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -20,16 +20,17 @@ class MetasploitModule < Msf::Auxiliary
           supplied.
         },
         'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
+        'License' => MSF_LICENSE,
         'Notes' => {
            'Stability' => [CRASH_SAFE],
            'SideEffects' => [IOC_IN_LOGS],
            'Reliability' => []
-        },
-        'License' => MSF_LICENSE
+        }
       )
     )
   end
 
+  # rubocop:disable Metrics/MethodLength
   def run
     print_status('Running MS SQL Server Enumeration...')
     if session
@@ -912,4 +913,5 @@ class MetasploitModule < Msf::Auxiliary
 
     disconnect
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
         :sname => 'oracle',
         :port => datastore['RPORT'],
         :type => 'ORA_ENUM',
-        :data => "Component Version: #{v.chomp}",
+        :data => { :component_version => v.chomp },
         :update => :unique_data
       )
     end
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'oracle',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Audit Trail: Disabled",
+          :data => { :audit_trail => "Disabled" },
           :update => :unique_data
         )
       else
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'oracle',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Audit Trail: Enabled",
+          :data => { :audit_trail => "Enabled" },
           :update => :unique_data
         )
       end
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'oracle',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Audit SYS Ops: Disabled",
+          :data => { :audit_sys_ops => "Disabled" },
           :update => :unique_data
         )
       else

--- a/modules/auxiliary/admin/oracle/sid_brute.rb
+++ b/modules/auxiliary/admin/oracle/sid_brute.rb
@@ -62,7 +62,10 @@ class MetasploitModule < Msf::Auxiliary
           :host => rhost,
           :port => rport,
           :type => 'oracle_sid',
-          :data => "PORT=#{rport}, SID=#{sid.strip}",
+          :data => {
+            :port => rport,
+            :sid => sid.strip
+          },
           :update => :unique_data
         )
         print_good("#{rhost}:#{rport} Found SID '#{sid.strip}'")

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :sname => 'http',
         :ntype => 'scada.modicon.write-password',
-        :data => writecreds[1]
+        :data => { :write_creds => writecreds[1] }
       )
     end
 
@@ -230,7 +230,10 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :sname => 'ftp',
         :ntype => 'scada.modicon.ftp-password',
-        :data => "User:#{modicon_ftpuser} VXWorks_Password:#{modicon_ftppass}"
+        :data => {
+          :user => modicon_ftpuser,
+          :vxworks_passwords => modicon_ftppass
+        }
       )
       logins << ["VxWorks", modicon_ftpuser, modicon_ftppass]
 

--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -109,11 +109,11 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Output for \"#{datastore['COMMAND']}\":\n")
     print_line("#{output}\n")
     report_note(
-      rhost: datastore['RHOSTS'],
-      rport: datastore['RPORT'],
-      type: 'psexec_command',
-      name: datastore['COMMAND'],
-      data: output
+      :rhost => datastore['RHOSTS'],
+      :rport => datastore['RPORT'],
+      :type  => "psexec_command",
+      :name => datastore['COMMAND'],
+      :data => { :command_output => output }
     )
   end
 end

--- a/modules/auxiliary/cloud/aws/enum_ec2.rb
+++ b/modules/auxiliary/cloud/aws/enum_ec2.rb
@@ -81,27 +81,30 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         host: inst.private_ip_address,
         type: 'ec2.public_ip',
-        data: inst.public_ip_address
+        data: { :public_ip_address => inst.public_ip_address }
       )
     end
     # eips = inst.network_interfaces.map {|i| i.association && i.association.public_ip}.compact # <-- works in pry, breaks at runtime in AWS SDK
     # report_note(
     #  host: inst.private_ip_address,
     #  type: 'ec2.public_ips',
-    #  data: eips.join(' ')
-    # ) unless eips.empty?
+    #  data: { :eips => eips.join(' ') }
+    #) unless eips.empty?
     if inst.public_ip_address && !inst.public_dns_name.empty?
       report_note(
         host: inst.private_ip_address,
         type: 'ec2.public_dns',
-        data: "#{inst.public_dns_name} #{inst.public_ip_address}"
+        data: {
+          :public_dns_name => inst.public_dns_name,
+          :public_ip_address => inst.public_ip_address
+        }
       )
     end
     if inst.hypervisor
       report_note(
         host: inst.private_ip_address,
         type: 'ec2.hypervisor',
-        data: inst.hypervisor
+        data: { :hypervisor => inst.hypervisor }
       )
     end
     inst.security_groups.each do |s|
@@ -109,7 +112,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         host: inst.private_ip_address,
         type: "ec2.#{s.group_id}",
-        data: s.group_name
+        data: { :group_name => s.group_name }
       )
     end
     inst.tags.each do |t|
@@ -117,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         host: inst.private_ip_address,
         type: "ec2.tag #{t.key}",
-        data: t.value
+        data: { :tag => t.value }
       )
     end
   end

--- a/modules/auxiliary/cloud/aws/enum_ssm.rb
+++ b/modules/auxiliary/cloud/aws/enum_ssm.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         host: ssm_host['IpAddress'],
         type: ssm_host['AgentType'],
-        data: ssm_host['AgentVersion']
+        data: { agent_version: ssm_host['AgentVersion'] }
       )
       vprint_good("Found AWS SSM host #{ssm_host['InstanceId']} (#{ssm_host['ComputerName']}) - #{ssm_host['IpAddress']}")
       next unless datastore['CreateSession']

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -84,10 +84,10 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Found Byte-Range Header DOS at #{uri}")
 
       report_note(
-        host: rhost,
-        port: rport,
-        type: 'apache.killer',
-        data: "Apache Byte-Range DOS at #{uri}"
+        :host   => rhost,
+        :port   => rport,
+        :type   => 'apache.killer',
+        :data   => { :uri => uri }
       )
 
     else

--- a/modules/auxiliary/gather/billquick_txtid_sqli.rb
+++ b/modules/auxiliary/gather/billquick_txtid_sqli.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Auxiliary
     # all inject strings taken from sqlmap runs, using error page method
     database = sqli.current_database
     print_good("Current Database: #{database}")
-    report_note(host: rhost, port: rport, type: 'database', data: database)
+    report_note(host: rhost, port: rport, type: 'database', data: { database: database })
 
     banner = sqli.version.gsub('\n', "\n").gsub('\t', "\t")
     print_good("Banner: #{banner}")

--- a/modules/auxiliary/gather/elasticsearch_enum.rb
+++ b/modules/auxiliary/gather/elasticsearch_enum.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Auxiliary
         port: rport,
         proto: 'tcp',
         type: 'elasticsearch.index',
-        data: index[0],
+        data: { index: index[0] },
         update: :unique_data
       )
     end

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -158,19 +158,19 @@ class MetasploitModule < Msf::Auxiliary
 
     # Reporting found cookie name in database
     unless cookie_name.empty?
-      report_note(host: rhost, type: 'f5_load_balancer_cookie_name', data: cookie_name)
+      report_note(host: rhost, type: 'f5_load_balancer_cookie_name', data: {:cookie_name => cookie_name })
       # Reporting found pool name in database
       unless pool_name.empty?
-        report_note(host: rhost, type: 'f5_load_balancer_pool_name', data: pool_name)
+        report_note(host: rhost, type: 'f5_load_balancer_pool_name', data: { :pool_name => pool_name })
       end
       # Reporting found route domain in database
       unless route_domain.empty?
-        report_note(host: rhost, type: 'f5_load_balancer_route_domain', data: route_domain)
+        report_note(host: rhost, type: 'f5_load_balancer_route_domain', data: { :route_domain => route_domain })
       end
     end
     # Reporting found backends in database
     unless backends.empty?
-      report_note(host: rhost, type: 'f5_load_balancer_backends', data: backends)
+      report_note(host: rhost, type: 'f5_load_balancer_backends', data: { :backends => backends })
     end
   rescue ::Rex::ConnectionRefused, ::Rex::ConnectionError
     print_error('Network connection error')

--- a/modules/auxiliary/gather/huawei_wifi_info.rb
+++ b/modules/auxiliary/gather/huawei_wifi_info.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
     report_note(
       :host => rhost,
       :type => 'wifi_keys',
-      :data => log
+      :data => { :wifi_ssid => log }
     )
   end
 

--- a/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
+++ b/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
@@ -272,7 +272,7 @@ class MetasploitModule < Msf::Auxiliary
       :proto  => 'tcp',
       :sname  => 'sametime',
       :type   => 'ibm_lotus_sametime_user',
-      :data   => "#{username}",
+      :data   => { :username => username },
       :update => :unique_data
     )
   end

--- a/modules/auxiliary/gather/ibm_sametime_version.rb
+++ b/modules/auxiliary/gather/ibm_sametime_version.rb
@@ -254,7 +254,7 @@ class MetasploitModule < Msf::Auxiliary
       :port  => rport,
       :proto => 'http',
       :ntype => 'ibm_lotus_sametime_version',
-      :data  => @version_info['version']['sametimeVersion']
+      :data  => { :version => @version_info['version']['sametimeVersion'] }
     ) if @version_info['version']['sametimeVersion']
   end
 

--- a/modules/auxiliary/gather/ie_sandbox_findfiles.rb
+++ b/modules/auxiliary/gather/ie_sandbox_findfiles.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
       case request.uri
       when /^\/found\/\?f=/
         f = URI.decode_www_form(request.uri.split("/found/?").last).assoc('f').last
-        report_note(host: cli.peerhost, type: 'ie.filenames', data: f)
+        report_note(host: cli.peerhost, type: 'ie.filenames', data: { :filenames => f })
         print_good("Found file " + f)
         send_response(cli, '')
       when /^\/notfound\/\?f=/

--- a/modules/auxiliary/gather/ie_uxss_injection.rb
+++ b/modules/auxiliary/gather/ie_uxss_injection.rb
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
         report_note(
           :host => cli.peerhost,
           :type => 'ie.cookie',
-          :data => data
+          :data => { :cookie => data }
         )
         path = store_loot('ie_uxss_cookie', "text/plain", cli.peerhost, data, "#{cli.peerhost}_ie_cookie.txt", "IE Cookie")
         vprint_good("Cookie stored as: #{path}")

--- a/modules/auxiliary/gather/ms14_052_xmldom.rb
+++ b/modules/auxiliary/gather/ms14_052_xmldom.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
     unless files.empty?
       print_good("We have detected the following files:")
       files.each do |f|
-        report_note(host: cli.peerhost, type: 'ie.filenames', data: f)
+        report_note(host: cli.peerhost, type: 'ie.filenames', data: {:filename => f })
         print_good(f)
       end
     end

--- a/modules/auxiliary/gather/nis_bootparamd_domain.rb
+++ b/modules/auxiliary/gather/nis_bootparamd_domain.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
         port:  rport,
         proto: proto,
         type:  'nis.bootparamd.domain',
-        data:  msg
+        data:  { :message => msg }
       )
     end
   end

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -328,25 +328,25 @@ class MetasploitModule < Msf::Auxiliary
 
       username = cache_info.data.username.encode(::Encoding::UTF_8)
       info = []
-      info << ("Username: #{username}")
+      info << "Username: #{username}"
       if cache_info.iteration_count
-        info << ("Iteration count: #{cache_info.iteration_count} -> real #{cache_info.real_iteration_count}")
+        info << "Iteration count: #{cache_info.iteration_count} -> real #{cache_info.real_iteration_count}"
       end
-      info << ("Last login: #{cache_info.entry.last_access.to_time}")
+      info << "Last login: #{cache_info.entry.last_access.to_time}"
       dns_domain_name = cache_info.data.dns_domain_name.encode(::Encoding::UTF_8)
-      info << ("DNS Domain Name: #{dns_domain_name}")
-      info << ("UPN: #{cache_info.data.upn.encode(::Encoding::UTF_8)}")
-      info << ("Effective Name: #{cache_info.data.effective_name.encode(::Encoding::UTF_8)}")
-      info << ("Full Name: #{cache_info.data.full_name.encode(::Encoding::UTF_8)}")
-      info << ("Logon Script: #{cache_info.data.logon_script.encode(::Encoding::UTF_8)}")
-      info << ("Profile Path: #{cache_info.data.profile_path.encode(::Encoding::UTF_8)}")
-      info << ("Home Directory: #{cache_info.data.home_directory.encode(::Encoding::UTF_8)}")
-      info << ("Home Directory Drive: #{cache_info.data.home_directory_drive.encode(::Encoding::UTF_8)}")
-      info << ("User ID: #{cache_info.entry.user_id}")
-      info << ("Primary Group ID: #{cache_info.entry.primary_group_id}")
-      info << ("Additional groups: #{cache_info.data.groups.map(&:relative_id).join(' ')}")
+      info << "DNS Domain Name: #{dns_domain_name}"
+      info << "UPN: #{cache_info.data.upn.encode(::Encoding::UTF_8)}"
+      info << "Effective Name: #{cache_info.data.effective_name.encode(::Encoding::UTF_8)}"
+      info << "Full Name: #{cache_info.data.full_name.encode(::Encoding::UTF_8)}"
+      info << "Logon Script: #{cache_info.data.logon_script.encode(::Encoding::UTF_8)}"
+      info << "Profile Path: #{cache_info.data.profile_path.encode(::Encoding::UTF_8)}"
+      info << "Home Directory: #{cache_info.data.home_directory.encode(::Encoding::UTF_8)}"
+      info << "Home Directory Drive: #{cache_info.data.home_directory_drive.encode(::Encoding::UTF_8)}"
+      info << "User ID: #{cache_info.entry.user_id}"
+      info << "Primary Group ID: #{cache_info.entry.primary_group_id}"
+      info << "Additional groups: #{cache_info.data.groups.map(&:relative_id).join(' ')}"
       logon_domain_name = cache_info.data.logon_domain_name.encode(::Encoding::UTF_8)
-      info << ("Logon domain name: #{logon_domain_name}")
+      info << "Logon domain name: #{logon_domain_name}"
 
       report_info({ info: info.join('; ') }, 'user.cache_info')
       vprint_line(info.join("\n"))
@@ -626,7 +626,7 @@ class MetasploitModule < Msf::Auxiliary
     nb_digits = (Math.log10(users.length) + 1).floor
     users = users.each_with_index.map do |(rid, name), index|
       if index % progress_interval == 0
-        percent = format('%.2f', (index / users.length.to_f * 100)).rjust(5)
+        percent = format('%.2f', index / users.length.to_f * 100).rjust(5)
         print_status("SID enumeration progress - #{index.to_s.rjust(nb_digits)} / #{users.length} (#{percent}%)")
       end
       sid = @samr.samr_rid_to_sid(object_handle: @domain_handle, rid: rid)

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -265,7 +265,7 @@ class MetasploitModule < Msf::Auxiliary
       next unless !users[rid][:UserPasswordHint].nil? && !users[rid][:UserPasswordHint].empty?
 
       hint = "#{users[rid][:Name]}: \"#{users[rid][:UserPasswordHint]}\""
-      report_info(hint, 'user.password_hint')
+      report_info({ password_hint: hint }, 'user.password_hint')
       print_line(hint)
       hint_count += 1
     end
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Auxiliary
       logon_domain_name = cache_info.data.logon_domain_name.encode(::Encoding::UTF_8)
       info << ("Logon domain name: #{logon_domain_name}")
 
-      report_info(info.join('; '), 'user.cache_info')
+      report_info({ info: info.join('; ') }, 'user.cache_info')
       vprint_line(info.join("\n"))
 
       credential_opts = {
@@ -511,8 +511,8 @@ class MetasploitModule < Msf::Auxiliary
       # Decode the DPAPI Secrets
       machine_key = secret_item[4, 20]
       user_key = secret_item[24, 20]
-      report_info(machine_key.unpack('H*')[0], 'dpapi.machine_key')
-      report_info(user_key.unpack('H*')[0], 'dpapi.user_key')
+      report_info({ machine_key: machine_key.unpack('H*')[0] }, 'dpapi.machine_key')
+      report_info({ user_key: user_key.unpack('H*')[0] }, 'dpapi.user_key')
       secret = "dpapi_machinekey: 0x#{machine_key.unpack('H*')[0]}\ndpapi_userkey: 0x#{user_key.unpack('H*')[0]}"
     elsif upper_name.start_with?('$MACHINE.ACC')
       md4 = OpenSSL::Digest::MD4.digest(secret_item)
@@ -977,7 +977,7 @@ class MetasploitModule < Msf::Auxiliary
       extra_info << "IsDomainAdmin=#{info[:domain_admin]},"
       extra_info << "IsEnterpriseAdmin=#{info[:enterprise_admin]}"
       print_line(pwdump + extra_info + '::')
-      report_info("#{full_name} (#{sid}): #{extra_info}", 'user.info')
+      report_info({ fullname: full_name, sid: sid, extra_info: extra_info }, 'user.info')
     end
 
     print_line("\n# Account Info:")
@@ -1194,7 +1194,7 @@ class MetasploitModule < Msf::Auxiliary
                     'try DOMAIN action since it does not need BootKey')
         end
       end
-      report_info(boot_key.unpack('H*')[0], 'host.boot_key')
+      report_info({ boot_key: boot_key.unpack('H*')[0] }, 'host.boot_key')
     end
 
     check_lm_hash_not_stored if @winreg
@@ -1241,7 +1241,7 @@ class MetasploitModule < Msf::Auxiliary
               print_warning('This might be expected or you can still try again with the `INLINE` option set to false')
             end
           else
-            report_info(lsa_key.unpack('H*')[0], 'host.lsa_key')
+            report_info({ lsa_key: lsa_key.unpack('H*')[0] }, 'host.lsa_key')
             if ['ALL', 'LSA'].include?(action.name)
               dump_lsa_secrets(windows_reg, lsa_key)
             end
@@ -1253,7 +1253,7 @@ class MetasploitModule < Msf::Auxiliary
                   print_warning('This might be expected or you can still try again with the `INLINE` option set to false')
                 end
               else
-                report_info(nlkm_key.unpack('H*')[0], 'host.nlkm_key')
+                report_info({ nlkm_key: nlkm_key.unpack('H*')[0] }, 'host.nlkm_key')
                 dump_cached_hashes(windows_reg, nlkm_key)
               end
             end

--- a/modules/auxiliary/scanner/afp/afp_server_info.rb
+++ b/modules/auxiliary/scanner/afp/afp_server_info.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
       :proto => 'tcp',
       :port => datastore['RPORT'],
       :type => 'afp_server_info',
-      :data => response)
+      :data => { :server_info => response })
 
       report_service(
         :host => datastore['RHOST'],

--- a/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
+++ b/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
       :port   => datastore['RPORT'],
       :sname  => "energizer_duo",
       :type   => 'Energizer DUO Trojan',
-      :data   => files.inspect
+      :data   => { :energizer_duo_trojan => files.inspect }
     )
     disconnect
 

--- a/modules/auxiliary/scanner/db2/discovery.rb
+++ b/modules/auxiliary/scanner/db2/discovery.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto  => 'udp',
         :port   => datastore['RPORT'],
         :type   => 'SERVICE_INFO',
-        :data   => "#{res[2]}_#{res[1]}"
+        :data   => { :service_info => "#{res[2]}_#{res[1]}" }
         )
 
       report_service(

--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
           proto: 'tcp',
           port: datastore['RPORT'],
           type: "DCERPC HIDDEN: UUID #{id[0]} v#{id[1]}",
-          data: status
+          data: { :status => status }
         )
       end
     end

--- a/modules/auxiliary/scanner/dcerpc/management.rb
+++ b/modules/auxiliary/scanner/dcerpc/management.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto  => 'tcp',
           :port   => datastore['RPORT'],
           :type   => "DCERPC UUID #{id[0]} v#{id[1]}",
-          :data   => reportdata
+          :data   => { :report_data => reportdata }
         )
 
       end

--- a/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
@@ -275,8 +275,10 @@ class MetasploitModule < Msf::Auxiliary
           end
           access = call ? "GRANTED" : "DENIED"
           print_line("#{ip} - UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['RPORT']} ACCESS #{access} #{data.unpack("H*")[0]}")
-          data_report="OPEN VIA #{datastore['RPORT']} ACCESS #{access} #{data.unpack("H*")[0]}"
-
+          data_report = {
+            :port => datastore['RPORT'],
+            :access => "#{access} #{data.unpack("H*")[0]}"
+          }
           ## Add Report
           report_note(
             :host   => ip,

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
           company = OUI_LIST::lookup_oui_company_name(reply.arp_saddr_mac)
           print_good("#{reply.arp_saddr_ip} appears to be up (#{company}).")
           report_host(:host => reply.arp_saddr_ip, :mac=>reply.arp_saddr_mac)
-          report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => company)
+          report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => { :company => company })
         end
 
       end
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         company = OUI_LIST::lookup_oui_company_name(reply.arp_saddr_mac)
         print_good("#{reply.arp_saddr_ip} appears to be up (#{company}).")
         report_host(:host => reply.arp_saddr_ip, :mac=>reply.arp_saddr_mac)
-        report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => company)
+        report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => { :company => company })
       end
       Kernel.select(nil, nil, nil, 0.50)
     end

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -137,7 +137,11 @@ class MetasploitModule < Msf::Auxiliary
           report_note(
             :host   => addr[:ipv4],
             :type   => 'host.ipv4.ipv6.mapping',
-            :data   => "system with IPv4 address #{addr[:ipv4]} matches to IPv6 address #{addr[:ipv6]}"
+            :data   => {
+              :ipv4_address => addr[:ipv4],
+              :ipv6_address => addr[:ipv6],
+              :matches => "true"
+            }
           )	# with this we have the results in our database
 
         end

--- a/modules/auxiliary/scanner/http/canon_wireless.rb
+++ b/modules/auxiliary/scanner/http/canon_wireless.rb
@@ -127,14 +127,24 @@ class MetasploitModule < Msf::Auxiliary
     ns = get_network_settings
     return if ns.nil?
 
-    good_string = "#{rhost}:#{rport} Option: #{ns[0]}"
+    data = {
+      :rhost => rhost,
+      :rport => rport,
+      :option => ns[0]
+    }
     if ns[0] == 'Use wireless LAN'
       wireless_key = get_wireless_key
-      good_string += "\tSSID: #{ns[1]}\tEncryption Type: #{wireless_key[0]}\tKey: #{wireless_key[1]}"
+      data.merge!(
+        {
+          :ssid => ns[1],
+          :encryption_type => wireless_key[0],
+          :key => wireless_key[1]
+        }
+      )
     end
 
     report_note({
-      :data => good_string,
+      :data => data,
       :type => 'canon.wireless',
       :host => ip,
       :port => rport

--- a/modules/auxiliary/scanner/http/chromecast_wifi.rb
+++ b/modules/auxiliary/scanner/http/chromecast_wifi.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
         :port => rport,
         :proto => 'tcp',
         :type => 'chromecast.wifi',
-        :data => waps_table.to_csv
+        :data => { :csv_table => waps_table.to_csv }
       )
     end
   end

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Auxiliary
         do_logout(res.get_cookies)
 
         report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
-        report_note(ip: rhost, type: 'cisco.cred.group', data: "User: #{user} / Group: #{group}")
+        report_note(ip: rhost, type: 'cisco.cred.group', data: { :user => user, :group => group })
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/coldfusion_version.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_version.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
           :port  => datastore['RPORT'],
           :proto => 'tcp',
           :ntype => 'cfversion',
-          :data  => out
+          :data  => { :version => out }
         )
       end
     elsif(res.code.to_i == 403 and datastore['VERBOSE'])

--- a/modules/auxiliary/scanner/http/dir_scanner.rb
+++ b/modules/auxiliary/scanner/http/dir_scanner.rb
@@ -165,7 +165,9 @@ class MetasploitModule < Msf::Auxiliary
                 :proto => 'tcp',
                 :sname	=> (ssl ? 'https' : 'http'),
                 :type	=> 'WWW_AUTHENTICATE',
-                :data	=> "#{tpath}#{testfdir} Auth: #{res.headers['WWW-Authenticate']}",
+                :data	=> {
+                  :path => "#{tpath}#{testfdir}",
+                  :auth => res.headers['WWW-Authenticate'] },
                 :update => :unique_data
               )
 

--- a/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
@@ -171,7 +171,10 @@ class MetasploitModule < Msf::Auxiliary
               :sname => (ssl ? 'https' : 'http'),
               :port	=> rport,
               :type	=> 'UNICODE_WEBDAV_BYPASS',
-              :data	=> "#{tpath}%c0%af#{testfdir} Code: #{res.code}",
+              :data	=> {
+                :path => "#{tpath}%c0%af#{testfdir}",
+                :code => res.code
+              },
               :update => :unique_data
             )
 

--- a/modules/auxiliary/scanner/http/docker_version.rb
+++ b/modules/auxiliary/scanner/http/docker_version.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
         :port  => rport,
         :proto => 'tcp',
         :ntype => 'docker_version',
-        :data  => result['Version'],
+        :data  => { :version => result['Version'] },
         :info  => "Docker Server v.#{result['Version']}"
     )
     print_status("Saving host information.")

--- a/modules/auxiliary/scanner/http/emby_version_ssrf.rb
+++ b/modules/auxiliary/scanner/http/emby_version_ssrf.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Identifying Media Server Version on #{peer}")
     print_good("[Media Server] URI: http://#{peer}#{datastore['TARGETURI']}")
     print_good("[Media Server] Version: #{result['Version']}")
-    print_good("[Media Server] Internal IP: #{result['LocalAddress']}") if (result['LocalAddress']).to_s != ''
-    print_good('*** Vulnerable to SSRF module auxiliary/scanner/http/emby_ssrf_scanner! ***') if Rex::Version.new((result['Version']).to_s) < Rex::Version.new('4.5.0')
+    print_good("[Media Server] Internal IP: #{result['LocalAddress']}") if result['LocalAddress'].to_s != ''
+    print_good('*** Vulnerable to SSRF module auxiliary/scanner/http/emby_ssrf_scanner! ***') if Rex::Version.new(result['Version'].to_s) < Rex::Version.new('4.5.0')
     report_service(
       host: rhost,
       port: rport,

--- a/modules/auxiliary/scanner/http/emby_version_ssrf.rb
+++ b/modules/auxiliary/scanner/http/emby_version_ssrf.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
       port: rport,
       proto: 'tcp',
       ntype: 'server_version',
-      data: result['Version'],
+      data: { version: result['Version'] },
       info: "Media Server v.#{result['Version']}"
     )
     vprint_status('Saving host information.')

--- a/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/fortinet_ssl_vpn.rb
@@ -148,11 +148,11 @@ class MetasploitModule < Msf::Auxiliary
         if datastore['DOMAIN'].nil? || datastore['DOMAIN'].empty?
           print_good("SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
           report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
-          report_note(ip: rhost, type: "fortinet.ssl.vpn",data: "User: #{user}")
+          report_note(ip: rhost, type: "fortinet.ssl.vpn", data: { :user => user })
         else
           print_good("SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}:#{datastore["DOMAIN"]}")
           report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
-          report_note(ip: rhost, type: "fortinet.ssl.vpn",data: "User: #{user} / Domain: #{datastore["DOMAIN"]}")
+          report_note(ip: rhost, type: "fortinet.ssl.vpn", data: { :user => user, :domain => datastore["DOMAIN"] })
         end
 
         return :next_user

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
             :proto => 'tcp',
             :sname => (ssl ? 'https' : 'http'),
             :type  => 'FrontPage Author',
-            :data  => "#{info}#{fpauthor}"
+            :data  => { :author => "#{info}#{fpauthor}" }
           }
           opts[:port] = datastore['RPORT'] if not port.empty?
           report_note(opts)

--- a/modules/auxiliary/scanner/http/gitlab_version.rb
+++ b/modules/auxiliary/scanner/http/gitlab_version.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         port: datastore['RPORT'],
         proto: ssl ? 'https' : 'http',
         ntype: 'gitlab.version',
-        data: version
+        data: { version: version }
       )
     else
       print_error("Unable to find Gitlab version for #{ip}.")

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Auxiliary
     report_note(
       :host => ip,
       :type => "system.name",
-      :data => sys_name
+      :data => { :system_name => sys_name }
     )
 
     if anonymous_access?(res)

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
 
       report_note(
         :type => "http.header.#{rport}.#{counter}",
-        :data => header_string,
+        :data => { :header_string => header_string },
         :host => ip,
         :port => rport
       )

--- a/modules/auxiliary/scanner/http/http_hsts.rb
+++ b/modules/auxiliary/scanner/http/http_hsts.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
         if hsts
           print_good("#{ip}:#{rport} - Strict-Transport-Security:#{hsts}")
           report_note({
-            :data => hsts,
+            :data => { :data => hsts },
             :type => "hsts.data",
             :host => ip,
             :port => rport

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
           proto: 'tcp',
           sname: (ssl ? 'https' : 'http'),
           type: 'iis.ip',
-          data: result.first
+          data: { :ip => result.first }
         })
       end
     end

--- a/modules/auxiliary/scanner/http/jboss_status.rb
+++ b/modules/auxiliary/scanner/http/jboss_status.rb
@@ -100,7 +100,11 @@ class MetasploitModule < Msf::Auxiliary
         :sname => (ssl ? 'https' : 'http'),
         :port  => rport,
         :type  => 'JBoss application server info',
-        :data  => "#{rhost}:#{rport} #{r[2]}"
+        :data  => {
+          :rhost => rhost,
+          :rport => rport,
+          :request => r[2]
+        }
       })
     end
 

--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -104,7 +104,8 @@ class MetasploitModule < Msf::Auxiliary
         :data  => {
           :uri => full_uri,
           :uri_path => uri_path,
-          :response_code => "200"
+          :response_code => "200",
+          :description => "#{full_uri} - #{uri_path} does not require authentication (200)"
         },
         :update => :unique_data
       })

--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -101,7 +101,11 @@ class MetasploitModule < Msf::Auxiliary
         :host  => rhost,
         :port  => rport,
         :proto => 'tcp',
-        :data  => "#{full_uri} - #{uri_path} does not require authentication (200)",
+        :data  => {
+          :uri => full_uri,
+          :uri_path => uri_path,
+          :response_code => "200"
+        },
         :update => :unique_data
       })
       case app

--- a/modules/auxiliary/scanner/http/joomla_pages.rb
+++ b/modules/auxiliary/scanner/http/joomla_pages.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto  => 'tcp',
         :sname  => 'http',
         :ntype  => 'joomla_page',
-        :data   => msg,
+        :data   => { :message => msg },
         :update => :unique_data
       )
     elsif (res.code == 403)

--- a/modules/auxiliary/scanner/http/joomla_plugins.rb
+++ b/modules/auxiliary/scanner/http/joomla_plugins.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
         :port  => rport,
         :proto => 'http',
         :ntype => 'joomla_plugin',
-        :data  => "#{tpath}#{papp}",
+        :data  => { :path => "#{tpath}#{papp}" },
         :update => :unique_data
       )
 
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
             :port  => datastore['RPORT'],
             :proto => 'http',
             :ntype => 'joomla_page',
-            :data  => "Page: #{tpath}index.php?option=com_#{pages}",
+            :data  => { :page => "#{tpath}index.php?option=com_#{pages}" },
             :update => :unique_data
           )
         else

--- a/modules/auxiliary/scanner/http/joomla_version.rb
+++ b/modules/auxiliary/scanner/http/joomla_version.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         port: datastore['RPORT'],
         proto: ssl ? 'https' : 'http',
         ntype: 'joomla.version',
-        data: version
+        data: { :version => version }
       )
     else
       print_error("Unable to find Joomla version.")

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
             :proto  => 'tcp',
             :sname  => (ssl ? 'https' : 'http'),
             :type   => 'OPEN HTTP PROXY',
-            :data   => 'Open http proxy (CONNECT)'
+            :data   => { :open_http_proxy => "CONNECT" }
           )
 
         end
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Auxiliary
             :proto  => 'tcp',
             :sname  => (ssl ? 'https' : 'http'),
             :type   => 'OPEN HTTP PROXY',
-            :data   => 'Open http proxy (GET)'
+            :data   => { :open_http_proxy => "GET" }
           )
 
         end

--- a/modules/auxiliary/scanner/http/options.rb
+++ b/modules/auxiliary/scanner/http/options.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
       sname: (ssl ? 'https' : 'http'),
       port: rport,
       type: 'HTTP_OPTIONS',
-      data: allowed_methods
+      data: { :allowed_methods => allowed_methods }
     )
 
     if allowed_methods.index('TRACE')

--- a/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
+++ b/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
@@ -199,7 +199,10 @@ class MetasploitModule < Msf::Auxiliary
           :proto  => 'tcp',
           :port   => rport,
           :sname  => "RFCode Reader",
-          :data   => "Release Version: #{release_ver}, Product: #{product_name}",
+          :data   => {
+            :release_version => release_ver,
+            :product  => product_name
+          },
           :type	=> 'Info'
         )
       end
@@ -225,7 +228,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto  => 'tcp',
           :port   => rport,
           :sname	=> "RFCode Reader",
-          :data   => "User List & Roles: #{userlist}",
+          :data   => { :user_list => userlist },
           :type	=> 'Info'
         )
       end
@@ -251,7 +254,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto	=> 'tcp',
           :port	=> rport,
           :sname	=> "RFCode Reader",
-          :data	=> "Interface eth0: #{eth0_info}",
+          :data	=> { :eth0 => eth0_info },
           :type	=> 'Info'
         )
       end

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto => 'tcp',
           :sname	=> (ssl ? 'https' : 'http'),
           :type	=> 'ROBOTS_TXT',
-          :data	=> u,
+          :data	=> { :file => u },
           :update => :unique_data
         )
       end

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
           :port    => rport,
           :proto   => 'tcp',
           :type    => "http.scraper.#{rport}",
-          :data    => u
+          :data    => { :scraped_data => u }
         )
 
         report_web_vuln(

--- a/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'tcp',
         :port  => rport,
         :type  => 'supermicro.ipmi.ssl.certificate.pkey_hash',
-        :data  => digest
+        :data  => { :digest => digest }
       )
 
       report_vuln({

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -180,7 +180,10 @@ class MetasploitModule < Msf::Auxiliary
                 sname: (ssl ? 'https' : 'http'),
                 port: rport,
                 type: "SOAPAction: #{v}#{n}",
-                data: "SOAPAction: #{v}#{n} with HTTP: #{res.code} #{res.message}."
+                data: {
+                  :soapaction => "#{v}#{n}",
+                  :response_code => res.code,
+                  :response_message => res.message }
               )
               if datastore['DISPLAYHTML']
                 print_status('The HTML content follows:')

--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => (ssl ? 'https' : 'http'),
               :port	=> rport,
               :type	=> 'USERNAME',
-              :data	=> slastauthor,
+              :data	=> { :username => slastauthor },
               :update => :unique_data
             )
 
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Auxiliary
                 :sname => (ssl ? 'https' : 'http'),
                 :port	=> rport,
                 :type	=> 'DIRECTORY',
-                :data	=> sname,
+                :data	=> { :directory => sname },
                 :update => :unique_data
               )
             end
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Auxiliary
                 :sname => (ssl ? 'https' : 'http'),
                 :port	=> rport,
                 :type	=> 'FILE',
-                :data	=> sname,
+                :data	=> { :file => sname },
                 :update => :unique_data
               )
 
@@ -221,7 +221,10 @@ class MetasploitModule < Msf::Auxiliary
                       :sname => (ssl ? 'https' : 'http'),
                       :port	=> rport,
                       :type	=> 'SOURCE_CODE',
-                      :data	=> "#{sname} Code: #{srcres.body}",
+                      :data	=> {
+                        :file => sname,
+                        :code => srcres.body
+                      },
                       :update => :unique_data
                     )
                   end

--- a/modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto => 'tcp',
           :sname => (ssl ? 'https' : 'http'),
           :type => 'svn_wc_database',
-          :data => "SVN wc.db database is stored in #{file}"
+          :data => { :path => file }
         )
       else
         vprint_error("SVN wc.db database not found on #{vhost}:#{rport}")

--- a/modules/auxiliary/scanner/http/trace_axd.rb
+++ b/modules/auxiliary/scanner/http/trace_axd.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => (ssl ? 'https' : 'http'),
             :port	=> rport,
             :type	=> 'TRACE_AXD',
-            :data	=> "#{tpath}trace.axd",
+            :data	=> { :path => "#{tpath}trace.axd" },
             :update => :unique_data
           )
 

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -61,7 +61,10 @@ class MetasploitModule < Msf::Auxiliary
       :sname  => (ssl ? 'https' : 'http'),
       :port   => rport,
       :type   => 'WWW_AUTHENTICATE',
-      :data   => "#{target_uri.path} Realm: #{res.headers['WWW-Authenticate']}",
+      :data   => {
+        :uri_path => target_uri.path,
+        :realm => res.headers['WWW-Authenticate']
+      },
       :update => :unique_data
     )
 
@@ -86,7 +89,10 @@ class MetasploitModule < Msf::Auxiliary
           :sname  => (ssl ? 'https' : 'http'),
           :port   => rport,
           :type   => 'AUTH_BYPASS_VERB',
-          :data   => "#{target_uri.path} Verb: #{tv}",
+          :data   => {
+            :uri_path => target_uri.path,
+            :verb => tv
+          },
           :update => :unique_data
         )
       end

--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
                 :sname => (ssl ? 'https' : 'http'),
                 :port	=> rport,
                 :type	=> 'VHOST',
-                :data	=> thost,
+                :data	=> { :vhost => thost },
                 :update => :unique_data
               )
 

--- a/modules/auxiliary/scanner/http/web_vulndb.rb
+++ b/modules/auxiliary/scanner/http/web_vulndb.rb
@@ -154,7 +154,10 @@ class MetasploitModule < Msf::Auxiliary
                   :sname => (ssl ? 'https' : 'http'),
                   :port	=> rport,
                   :type	=> 'FILE',
-                  :data	=> "#{tpath}#{testfvuln} Code: #{res.code}"
+                  :data	=> {
+                    :path => "#{tpath}#{testfvuln}",
+                    :status => res.code
+                  }
                 )
               end
             end
@@ -168,7 +171,10 @@ class MetasploitModule < Msf::Auxiliary
                   :sname => (ssl ? 'https' : 'http'),
                   :port	=> rport,
                   :type	=> 'FILE',
-                  :data	=> "#{tpath}#{testfvuln} Code: #{res.code}"
+                  :data	=> {
+                    :path => "#{tpath}#{testfvuln}",
+                    :status => res.code
+                  }
               )
             else
               if dm == false

--- a/modules/auxiliary/scanner/http/webdav_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/webdav_internal_ip.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => (ssl ? 'https' : 'http'),
             :port	=> rport,
             :type	=> 'INTERNAL_IP',
-            :data	=> addr
+            :data	=> { :ip => addr }
           )
         end
       end

--- a/modules/auxiliary/scanner/http/webdav_scanner.rb
+++ b/modules/auxiliary/scanner/http/webdav_scanner.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => (ssl ? 'https' : 'http'),
               :port   => rport,
               :type   => wdtype,
-              :data   => datastore['PATH']
+              :data   => { :path => datastore['PATH'] }
             })
 
         else

--- a/modules/auxiliary/scanner/http/webdav_website_content.rb
+++ b/modules/auxiliary/scanner/http/webdav_website_content.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => (ssl ? 'https' : 'http'),
             :port	=> rport,
             :type	=> 'WEBDAV_FILE_DIRECTORY',
-            :data	=> u
+            :data	=> { :path => u }
           )
 
         end

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
           sname: (ssl ? 'https' : 'http'),
           port: rport,
           type: "Wordpress #{version_string}",
-          data: target_uri.to_s
+          data: { :target_uri => target_uri.to_s }
         }
       )
       if datastore['THEMES']

--- a/modules/auxiliary/scanner/ip/ipidseq.rb
+++ b/modules/auxiliary/scanner/ip/ipidseq.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
       :host	=> ip,
       :proto	=> 'ip',
       :type	=> 'IPID sequence',
-      :data	=> "IPID sequence class: #{analyze(ipids)}"
+      :data	=> { :ipid_sequence_class => analyze(ipids) }
     )
   end
 

--- a/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => (ssl ? "https" : "http"),
               :port	=> rport,
               :type => 'lotusdomino.version.current',
-              :data => server1.strip
+              :data => { :version => server1.strip }
                 )
             if currentversion.empty? then
               currentversion << server1.strip
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => (ssl ? "https" : "http"),
               :port	=> rport,
               :type => 'lotusdomino.version.releasenotes',
-              :data => server2.strip
+              :data => { :version_release_notes => server2.strip }
                 )
           else
             ''
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => (ssl ? "https" : "http"),
               :port	=> rport,
               :type => 'lotusdomino.version.base',
-              :data => server3.strip
+              :data => { :version_base => server3.strip }
                 )
             if baseversion.empty? then
               baseversion << server3.strip

--- a/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
@@ -55,7 +55,11 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    info = "PPPOE credentials for #{rhost}, user: #{user}, password: #{password}"
+    info = {
+      :host => rhost,
+      :username => user,
+      :password => password
+    }
 
     report_note({
       :host   => rhost,
@@ -96,7 +100,11 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    info = "DDNS credentials for #{hostname}, user: #{user}, password: #{password}"
+    info = {
+      :host => hostname,
+      :user => user,
+      :password => password
+    }
 
     report_note({
       :host   => rhost,

--- a/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
+++ b/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
             :proto	=> 'udp',
             :port	=> datastore['RPORT'],
             :type	=> 'SERVICE',
-            :data	=> 'Motorola Timbuktu Service Detection'
+            :data	=> { :service => 'Motorola Timbuktu Service Detection' }
           )
           print_status("Motorola Timbuktu Detected on host #{ip}.")
         else

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host  => mssql_client.peerhost,
         :type  => "mssql.db.schema",
-        :data  => db,
+        :data  => { :database => db },
         :port  => mssql_client.peerport,
         :proto => 'tcp',
         :update => :unique_data

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host  => mysql_conn.peerhost,
         :type  => "filesystem.dir",
-        :data  => "#{dir} is a directory and exists",
+        :data  => { :directory => dir },
         :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host  => mysql_conn.peerhost,
         :type  => "filesystem.file",
-        :data  => "#{dir} is a file and exists",
+        :data  => { :directory => dir },
         :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host  => mysql_conn.peerhost,
         :type  => "filesystem.file",
-        :data  => "#{dir} is a file and exists",
+        :data  => { :file => dir },
         :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host  => mysql_conn.peerhost,
         :type  => "mysql.db.schema",
-        :data  => db,
+        :data  => { :database => db },
         :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -71,7 +71,10 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         :host  => mysql_conn.peerhost,
         :type  => "filesystem.file",
-        :data  => "#{dir} is writeable",
+        :data  => {
+          :dir => dir,
+          :permissions => "writeable",
+        },
         :port  => mysql_conn.peerport,
         :proto => 'tcp',
         :update => :unique_data

--- a/modules/auxiliary/scanner/oracle/emc_sid.rb
+++ b/modules/auxiliary/scanner/oracle/emc_sid.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
               :port	=> datastore['RPORT'],
               :proto	=> 'tcp',
               :type	=> 'oracle_sid',
-              :data	=> sid,
+              :data	=> { :sid => sid },
               :update => :unique_data
           )
           print_status("Discovered SID: '#{sid}' for host #{ip}")

--- a/modules/auxiliary/scanner/oracle/isqlplus_login.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_login.rb
@@ -218,12 +218,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_oracle_sid(ip,sid)
+    sid_res = ((sid.nil? || sid.empty?) ? "*BLANK*" : sid)
     report_note(
       :host => ip,
       :proto => 'tcp',
       :port => rport,
       :type => "oracle.sid",
-      :data => ((sid.nil? || sid.empty?) ? "*BLANK*" : sid),
+      :data => { :sid => sid_res },
       :update => :unique_data
     )
   end

--- a/modules/auxiliary/scanner/oracle/oracle_login.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_login.rb
@@ -175,7 +175,7 @@ class MetasploitModule < Msf::Auxiliary
         if oline =~ /Login correct/
           if not @oracle_reported
             report_service(:host => addr, :port => port, :proto => "tcp", :name => "oracle")
-            report_note(:host => addr, :port => port, :proto => "tcp", :type => "oracle.sid", :data => sid, :update => :unique_data)
+            report_note(:host => addr, :port => port, :proto => "tcp", :type => "oracle.sid", :data => { :sid => sid }, :update => :unique_data)
             @oracle_reported = true
           end
           user,pass = extract_creds(oline)
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Auxiliary
         elsif oline =~ /Account locked/
           if not @oracle_reported
             report_service(:host => addr, :port => port, :proto => "tcp", :name => "oracle")
-            report_note(:host => addr, :port => port, :proto => "tcp", :type => "oracle.sid", :data => sid, :update => :unique_data)
+            report_note(:host => addr, :port => port, :proto => "tcp", :type => "oracle.sid", :data => { :sid => sid }, :update => :unique_data)
             @oracle_reported = true
           end
           user = extract_creds(oline)[0]

--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :sname => 'oracle',
           :type => "oracle.sid",
-          :data => sid,
+          :data => { :sid => sid },
           :update => :unique_data
         )
         return :success

--- a/modules/auxiliary/scanner/oracle/sid_enum.rb
+++ b/modules/auxiliary/scanner/oracle/sid_enum.rb
@@ -51,7 +51,10 @@ class MetasploitModule < Msf::Auxiliary
                   :host   => ip,
                   :port	=> rport,
                   :type   => "oracle_sid",
-                  :data   => "PORT=#{rport}, SID=#{s}",
+                  :data   => {
+                    :port => rport,
+                    :sid => s
+                  },
                   :update	=> :unique_data
                 )
                 print_good("Identified SID for #{ip}:#{rport} #{s}")
@@ -62,7 +65,10 @@ class MetasploitModule < Msf::Auxiliary
                   :host   => ip,
                   :port	=> rport,
                   :type   => "oracle_service_name",
-                  :data   => "PORT=#{rport}, SERVICE_NAME=#{s}",
+                  :data   => {
+                    :port => rport,
+                    :service_name => s
+                  },
                   :update	=> :unique_data
                 )
                 print_status("Identified SERVICE_NAME for #{ip}:#{rport} #{s}")

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
               :port	=> datastore['RPORT'],
               :proto	=> 'tcp',
               :type	=> 'oracle_sid',
-              :data	=> "#{sid.uniq}",
+              :data	=> { :sid => sid.uniq.to_s },
               :update	=> :unique_data
           )
         print_good("#{rhost}:#{rport} Discovered SID: '#{sid.uniq}'")

--- a/modules/auxiliary/scanner/oracle/xdb_sid.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
               :port => datastore['RPORT'],
               :proto	=> 'tcp',
               :type	=> 'oracle_sid',
-              :data	=> sid,
+              :data	=> { :sid => sid },
               :update => :unique_data
             )
           print_status("Discovered SID: '#{sid}' for host #{ip}:#{datastore['RPORT']} with #{datastore['DBUSER']} / #{datastore['DBPASS']}")

--- a/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto	=> 'tcp',
           :port => datastore['RPORT'],
           :type => 'SERVICE_NAME',
-          :data => sid,
+          :data => { :sid => sid },
           :update => :unique_data
         )
         print_good("Discovered SID: '#{sid[0]}' for host #{ip}:#{datastore['RPORT']} with #{dbuser} / #{dbpass}")
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
               :proto => 'tcp',
               :port => datastore['RPORT'],
               :type => 'ORA_ENUM',
-              :data => "Component Version: #{p}#{v}",
+              :data => { :component_version => "#{p}#{v}" },
               :update => :unique_data
             )
             print_good("\t#{p}\t\t#{v}\t(#{s})")
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => 'xdb',
               :port => datastore['RPORT'],
               :type => 'ORA_ENUM',
-              :data => "Component Version: #{b}",
+              :data => { :component_version => b },
               :update => :unique_data
             )
             print_good("\t#{b}")
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Auxiliary
                 :port => datastore['RPORT'],
                 :sname => 'xdb',
                 :type => 'oracle_sid',
-                :data => sid,
+                :data => { :sid => sid },
                 :update => :unique_data
               )
             else
@@ -259,7 +259,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => 'xdb',
               :port => datastore['RPORT'],
               :type => 'ORA_ENUM',
-              :data => "Active Account #{u}:#{h}:#{as}",
+              :data => { :active_account => "#{u}:#{h}:#{as}" },
               :update => :unique_data
             )
           else
@@ -269,7 +269,7 @@ class MetasploitModule < Msf::Auxiliary
               :sname => 'xdb',
               :port => datastore['RPORT'],
               :type => 'ORA_ENUM',
-              :data => "Disabled Account #{u}:#{h}:#{as}",
+              :data => { :disabled_account => "#{u}:#{h}:#{as}" },
               :update => :unique_data
             )
           end
@@ -331,7 +331,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'xdb',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Password Maximum Reuse Time: #{prm}",
+          :data => { :password_maximum_reuse_time => prm },
           :update => :unique_data
         )
         report_note(
@@ -340,7 +340,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'xdb',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Password Reuse Time: #{prt}",
+          :data => { :password_reuse_time => prt },
           :update => :unique_data
         )
         report_note(
@@ -349,7 +349,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'xdb',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Password Life Time: #{plit}",
+          :data => { :password_life_time => plit },
           :update => :unique_data
         )
         report_note(
@@ -358,7 +358,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'xdb',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Account Fail Logins Permitted: #{fla}",
+          :data => { :account_fail_logins_permitted => fla },
           :update => :unique_data
         )
         report_note(
@@ -367,7 +367,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'xdb',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Account Lockout Time: #{plot}",
+          :data => { :account_lockout_time => plot },
           :update => :unique_data
         )
         report_note(
@@ -376,7 +376,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'xdb',
           :port => datastore['RPORT'],
           :type => 'ORA_ENUM',
-          :data => "Account Password Grace Time: #{pgt}",
+          :data => { :account_password_grace_time => pgt },
           :update => :unique_data
         )
       end

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -96,7 +96,10 @@ class MetasploitModule < Msf::Auxiliary
             :proto	=> 'tcp',
             :port	=> dport,
             :type	=> "TCP UNFILTERED #{dhost}:#{dport}",
-            :data	=> "TCP UNFILTERED #{dhost}:#{dport}"
+            :data	=> {
+              :host => dhost,
+              :port => dport
+            }
           )
 
         rescue ::Exception

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -95,7 +95,10 @@ class MetasploitModule < Msf::Auxiliary
             :proto	=> 'tcp',
             :port	=> dport,
             :type	=> "TCP OPEN|FILTERED #{dhost}:#{dport}",
-            :data	=> "TCP OPEN|FILTERED #{dhost}:#{dport}"
+            :data	=> {
+              :host => dhost,
+              :port => dport
+            }
           )
 
         rescue ::Exception

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       report_note(
         host: rhost,
         type: 'postgres.db.schema',
-        data: db,
+        data: { :database => db },
         port: rport,
         proto: 'tcp',
         update: :unique_data

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'postgres',
           :port => rport,
           :ntype => 'postgresql.fingerprint',
-          :data => "Unknown Pre-Auth fingerprint: #{result[:unknown]}"
+          :data => { :unknown_pre_auth_fingerprint => result[:unknown] }
         )
       end
 

--- a/modules/auxiliary/scanner/printer/printer_env_vars.rb
+++ b/modules/auxiliary/scanner/printer/printer_env_vars.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
         :port => rport,
         :proto => "tcp",
         :type => "printer.env.vars",
-        :data => env_vars
+        :data => { :environment_variables => env_vars}
       )
     end
   end

--- a/modules/auxiliary/scanner/printer/printer_list_dir.rb
+++ b/modules/auxiliary/scanner/printer/printer_list_dir.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
         :port => rport,
         :proto => "tcp",
         :type => "printer.dir.listing",
-        :data => listing
+        :data => { :listing => listing }
       )
     end
   end

--- a/modules/auxiliary/scanner/printer/printer_list_volumes.rb
+++ b/modules/auxiliary/scanner/printer/printer_list_volumes.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
         :port => rport,
         :proto => "tcp",
         :type => "printer.vol.listing",
-        :data => listing
+        :data => { :listing => listing }
       )
     end
   end

--- a/modules/auxiliary/scanner/printer/printer_ready_message.rb
+++ b/modules/auxiliary/scanner/printer/printer_ready_message.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
         :port => rport,
         :proto => "tcp",
         :type => "printer.rdymsg",
-        :data => rdymsg
+        :data => { :rdymsg => rdymsg }
       )
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_icf_public_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_icf_public_info.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     nil
   end
 
-  def report_note_sap(type, data, value)
+  def report_note_sap(type, data, key, value)
     # create note
     report_note(
       :host => rhost,
@@ -57,8 +57,8 @@ class MetasploitModule < Msf::Auxiliary
       :proto => 'tcp',
       :sname => 'sap',
       :type => type,
-      :data => data + value
-    ) if data
+      :data => { key => value, info: data + value }
+    )
     # update saptbl for output
     @saptbl << [ data, value ]
   end
@@ -115,32 +115,32 @@ class MetasploitModule < Msf::Auxiliary
     rfcipv6addr = extract_field(response, 'rfcipv6addr')
 
     # report notes / create saptbl output
-    report_note_sap('sap.version.release','Release Status of SAP System: ',rfcsaprl) if rfcsaprl
-    report_note_sap('sap.version.rfc_log','RFC Log Version: ',rfcproto) if rfcproto
-    report_note_sap('sap.version.kernel','Kernel Release: ',rfckernrl) if rfckernrl
-    report_note_sap('system.os','Operating System: ',rfcopsys) if rfcopsys
-    report_note_sap('sap.db.hostname','Database Host: ',rfcdbhost) if rfcdbhost
-    report_note_sap('sap.db_system','Central Database System: ',rfcdbsys) if rfcdbsys
-    report_note_sap('system.hostname','Hostname: ',rfchost) if rfchost
-    report_note_sap('system.ip.v4','IPv4 Address: ',rfcipaddr) if rfcipaddr
-    report_note_sap('system.ip.v6','IPv6 Address: ',rfcipv6addr) if rfcipv6addr
-    report_note_sap('sap.instance','System ID: ',rfcsysid) if rfcsysid
-    report_note_sap('sap.rfc.destination','RFC Destination: ',rfcdest) if rfcdest
-    report_note_sap('system.timezone','Timezone (diff from UTC in seconds): ',rfctzone.gsub(/\s+/, "")) if rfctzone
-    report_note_sap('system.charset','Character Set: ',rfcchartyp) if rfcchartyp
-    report_note_sap('sap.daylight_saving_time','Daylight Saving Time: ',rfcdayst) if rfcdayst
-    report_note_sap('sap.machine_id','Machine ID: ',rfcmach.gsub(/\s+/,"")) if rfcmach
+    report_note_sap('sap.version.release','Release Status of SAP System: ', :version_release, rfcsaprl) if rfcsaprl
+    report_note_sap('sap.version.rfc_log','RFC Log Version: ', :rfc_log_version, rfcproto) if rfcproto
+    report_note_sap('sap.version.kernel','Kernel Release: ', :kernel_release, rfckernrl) if rfckernrl
+    report_note_sap('system.os','Operating System: ', :operating_system, rfcopsys) if rfcopsys
+    report_note_sap('sap.db.hostname','Database Host: ', :database_hostname, rfcdbhost) if rfcdbhost
+    report_note_sap('sap.db_system','Central Database System: ', :database_system, rfcdbsys) if rfcdbsys
+    report_note_sap('system.hostname','Hostname: ', :hostname, rfchost) if rfchost
+    report_note_sap('system.ip.v4','IPv4 Address: ', :ipv4_address, rfcipaddr) if rfcipaddr
+    report_note_sap('system.ip.v6','IPv6 Address: ', :ipv6_address, rfcipv6addr) if rfcipv6addr
+    report_note_sap('sap.instance','System ID: ', :system_id, rfcsysid) if rfcsysid
+    report_note_sap('sap.rfc.destination','RFC Destination: ', :rfc_destination, rfcdest) if rfcdest
+    report_note_sap('system.timezone','Timezone (diff from UTC in seconds): ', :timezone, rfctzone.gsub(/\s+/, "")) if rfctzone
+    report_note_sap('system.charset','Character Set: ', :character_set, rfcchartyp) if rfcchartyp
+    report_note_sap('sap.daylight_saving_time','Daylight Saving Time: ', :daylight_savings_time, rfcdayst) if rfcdayst
+    report_note_sap('sap.machine_id','Machine ID: ', :machine_id, rfcmach.gsub(/\s+/,"")) if rfcmach
 
     if rfcinttyp == 'LIT'
-      report_note_sap('system.endianness','Integer Format: ', 'Little Endian')
+      report_note_sap('system.endianness','Integer Format: ', :integer_format, 'Little Endian')
     elsif rfcinttyp
-      report_note_sap('system.endianness','Integer Format: ', 'Big Endian')
+      report_note_sap('system.endianness','Integer Format: ', :integer_format, 'Big Endian')
     end
 
     if rfcflotyp == 'IE3'
-      report_note_sap('system.float_type','Float Type Format: ', 'IEEE')
+      report_note_sap('system.float_type','Float Type Format: ', :float_format, 'IEEE')
     elsif rfcflotyp
-      report_note_sap('system.float_type','Float Type Format: ', 'IBM/370')
+      report_note_sap('system.float_type','Float Type Format: ', :float_format, 'IBM/370')
     end
 
     # output table

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'SOAP',
         :port => rport,
         :type => 'SAP Version',
-        :data => "SAP Version: #{version}"
+        :data => { :version => version }
       )
 
       report_note(
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto => 'SOAP',
         :port => rport,
         :type => 'SAP SID',
-        :data => "SAP SID: #{sapsid.upcase}"
+        :data => { :sap_sid => sapsid.upcase }
       )
 
       return

--- a/modules/auxiliary/scanner/sap/sap_service_discovery.rb
+++ b/modules/auxiliary/scanner/sap/sap_service_discovery.rb
@@ -230,7 +230,7 @@ class MetasploitModule < Msf::Auxiliary
               :host => "#{ip}",
               :port => "#{port}",
               :type => 'SAP',
-              :data => "#{service}",
+              :data => { :service => service },
               :update => :unique_data
             )
             r << [ip,port,"open", service]

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :sname => 'sap',
           :type => 'sap.services.available',
-          :data => "The Remote Function Call (RFC) Service is available through the SOAP service."
+          :data => { :service => "The Remote Function Call (RFC) Service is available through the SOAP service." }
         )
         return
       else

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     nil
   end
 
-  def report_note_sap(type, data, value)
+  def report_note_sap(type, data, key, value)
     # create note
     report_note(
       :host => rhost,
@@ -64,8 +64,8 @@ class MetasploitModule < Msf::Auxiliary
       :proto => 'tcp',
       :sname => 'sap',
       :type => type,
-      :data => data + value
-    ) if data
+      :data => { key => value, info: data + value }
+    )
     # update saptbl for output
     @saptbl << [ data, value ]
   end
@@ -148,32 +148,32 @@ class MetasploitModule < Msf::Auxiliary
     rfcipv6addr = extract_field(response, 'rfcipv6addr')
 
     # report notes / create saptbl output
-    report_note_sap('sap.version.release','Release Status of SAP System: ',rfcsaprl) if rfcsaprl
-    report_note_sap('sap.version.rfc_log','RFC Log Version: ',rfcproto) if rfcproto
-    report_note_sap('sap.version.kernel','Kernel Release: ',rfckernrl) if rfckernrl
-    report_note_sap('system.os','Operating System: ',rfcopsys) if rfcopsys
-    report_note_sap('sap.db.hostname','Database Host: ',rfcdbhost) if rfcdbhost
-    report_note_sap('sap.db_system','Central Database System: ',rfcdbsys) if rfcdbsys
-    report_note_sap('system.hostname','Hostname: ',rfchost) if rfchost
-    report_note_sap('system.ip.v4','IPv4 Address: ',rfcipaddr) if rfcipaddr
-    report_note_sap('system.ip.v6','IPv6 Address: ',rfcipv6addr) if rfcipv6addr
-    report_note_sap('sap.instance','System ID: ',rfcsysid) if rfcsysid
-    report_note_sap('sap.rfc.destination','RFC Destination: ',rfcdest) if rfcdest
-    report_note_sap('system.timezone','Timezone (diff from UTC in seconds): ',rfctzone.gsub(/\s+/, "")) if rfctzone
-    report_note_sap('system.charset','Character Set: ',rfcchartyp) if rfcchartyp
-    report_note_sap('sap.daylight_saving_time','Daylight Saving Time: ',rfcdayst) if rfcdayst
-    report_note_sap('sap.machine_id','Machine ID: ',rfcmach.gsub(/\s+/,"")) if rfcmach
+    report_note_sap('sap.version.release','Release Status of SAP System: ', :sap_system_release_status ,rfcsaprl) if rfcsaprl
+    report_note_sap('sap.version.rfc_log','RFC Log Version: ', :rfc_log_version, rfcproto) if rfcproto
+    report_note_sap('sap.version.kernel','Kernel Release: ', :kernel_release, rfckernrl) if rfckernrl
+    report_note_sap('system.os','Operating System: ', :operating_system, rfcopsys) if rfcopsys
+    report_note_sap('sap.db.hostname','Database Host: ', :database_hostname, rfcdbhost) if rfcdbhost
+    report_note_sap('sap.db_system','Central Database System: ', :db_system, rfcdbsys) if rfcdbsys
+    report_note_sap('system.hostname','Hostname: ', :hostname, rfchost) if rfchost
+    report_note_sap('system.ip.v4','IPv4 Address: ', :ipv4_address, rfcipaddr) if rfcipaddr
+    report_note_sap('system.ip.v6','IPv6 Address: ', :ipv6_address, rfcipv6addr) if rfcipv6addr
+    report_note_sap('sap.instance','System ID: ', :system_id, rfcsysid) if rfcsysid
+    report_note_sap('sap.rfc.destination','RFC Destination: ', :rfc_destination, rfcdest) if rfcdest
+    report_note_sap('system.timezone','Timezone (diff from UTC in seconds): ', :timezone, rfctzone.gsub(/\s+/, "")) if rfctzone
+    report_note_sap('system.charset','Character Set: ', :character_set, rfcchartyp) if rfcchartyp
+    report_note_sap('sap.daylight_saving_time','Daylight Saving Time: ', :daylight_savings_time ,rfcdayst) if rfcdayst
+    report_note_sap('sap.machine_id','Machine ID: ', :machine_id, rfcmach.gsub(/\s+/,"")) if rfcmach
 
     if rfcinttyp == 'LIT'
-      report_note_sap('system.endianness','Integer Format: ', 'Little Endian')
+      report_note_sap('system.endianness','Integer Format: ', :integer_format, 'Little Endian')
     elsif rfcinttyp
-      report_note_sap('system.endianness','Integer Format: ', 'Big Endian')
+      report_note_sap('system.endianness','Integer Format: ', :integer_format, 'Big Endian')
     end
 
     if rfcflotyp == 'IE3'
-      report_note_sap('system.float_type','Float Type Format: ', 'IEEE')
+      report_note_sap('system.float_type','Float Type Format: ', :float_format, 'IEEE')
     elsif rfcflotyp
-      report_note_sap('system.float_type','Float Type Format: ', 'IBM/370')
+      report_note_sap('system.float_type','Float Type Format: ', :float_format, 'IBM/370')
     end
 
     # output table

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :sname => 'sap',
           :type => 'os.kernel.version',
-          :data => "OS Kernel version: #{kern_comp_on}"
+          :data => { :os_kernel_version => kern_comp_on }
         )
 
         report_note(
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :sname => 'sap',
           :type => 'sap.time.compile',
-          :data => "SAP compile time: #{kern_comp_time}"
+          :data => { :sap_compile_time => kern_comp_time }
         )
 
         report_note(
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :sname => 'sap',
           :type => 'sap.db.version',
-          :data => "DB version: #{kern_dblib}"
+          :data => { :db_version => kern_dblib }
         )
 
         report_note(
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :sname => 'sap',
           :type => 'sap.version.patch_level',
-          :data => "SAP patch level: #{kern_patchlevel}"
+          :data => { :sap_patch_level => kern_patchlevel }
         )
 
         report_note(
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto => 'tcp',
           :port => rport,
           :type => 'sap.version',
-          :data => "SAP Version: #{kern_rel}"
+          :data => { :sap_version => kern_rel }
         )
 
       elsif res and res.code == 500

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
           port: rport,
           sname: 'modbus',
           type: "modbus.#{object['name'].downcase}",
-          data: object['str_value']
+          data: { modbus_object: object['str_value'] }
         )
       end
     rescue ::Interrupt

--- a/modules/auxiliary/scanner/sip/enumerator.rb
+++ b/modules/auxiliary/scanner/sip/enumerator.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Auxiliary
         :sname	=> 'sip',
         :port	=> rport,
         :type	=> "Found user: #{testn} [Auth]",
-        :data	=> "Found user: #{testn} [Auth]"
+        :data	=> { :user => testn }
       )
     when 200
       print_good("Found user: #{testn} [Open]")
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Auxiliary
         :sname	=> 'sip',
         :port	=> rport,
         :type	=> "Found user: #{testn} [Open]",
-        :data	=> "Found user: #{testn} [Open]"
+        :data	=> { :user => testn }
       )
     else
       #print_error("Undefined error code: #{resp.to_i}"

--- a/modules/auxiliary/scanner/sip/enumerator_tcp.rb
+++ b/modules/auxiliary/scanner/sip/enumerator_tcp.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto	=> 'sip',
         :port	=> rport,
         :type	=> "Found user: #{testn} [Auth]",
-        :data	=> "Found user: #{testn} [Auth]"
+        :data	=> { :user => testn }
       )
     when /^200/
       print_good("Found user: #{testn} [Open]")
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
         :proto	=> 'sip',
         :port	=> rport,
         :type	=> "Found user: #{testn} [Open]",
-        :data	=> "Found user: #{testn} [Open]"
+        :data	=> { :user => testn }
       )
     else
       #print_error("Undefined error code: #{resp.to_i}"

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
         :sname	=> 'smb',
         :port	=> rport,
         :type	=> 'Pipes Found',
-        :data	=> "Pipes: #{pipes.join(", ")}"
+        :data	=> { :pipes => pipes.join(", ") }
       )
     end
   end

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -309,7 +309,10 @@ class MetasploitModule < Msf::Auxiliary
           sname: 'smb',
           port: rport,
           type: "UUID #{uuid[0]} #{uuid[1]}",
-          data: "UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}"
+          data: {
+            :uuid => "#{uuid[0]} #{uuid[1]}",
+            :smb_pipe => datastore['SMBPIPE']
+          }
         )
       rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
         print_line("UUID #{uuid[0]} #{uuid[1]} ERROR 0x%.8x" % e.error_code)

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -112,7 +112,10 @@ class MetasploitModule < Msf::Auxiliary
       :sname => 'smb',
       :port => rport,
       :type => 'smb.domain.loggedusers',
-      :data => "#{username} is logged in",
+      :data => {
+        :user => username,
+        :status => "Logged in"
+      },
       :update => :unique_data
     )
   end

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
       :proto => 'tcp',
       :port => self.simple.peerport,
       :type => 'smb.domain.lookupsid',
-      :data => info[:domain]
+      :data => { :domain => info[:domain] }
     )
 
     pipe_info = "PIPE(#{lsarpc_pipe.name})"

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Auxiliary
               proto: 'tcp',
               sname: 'smb',
               type:  'MS17-010 Named Pipe',
-              data:  pipe_name
+              data:  { :pipe_name => pipe_name }
             )
           end
         end

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -327,7 +327,7 @@ class MetasploitModule < Msf::Auxiliary
             port: rport,
             proto: 'tcp',
             ntype: 'fingerprint.match',
-            data: nd_fingerprint_match
+            data: { :finger_print => nd_fingerprint_match }
           )
         elsif smb1_fingerprint['native_os'] || smb1_fingerprint['native_lm']
           desc = "#{smb1_fingerprint['native_os']} (#{smb1_fingerprint['native_lm']})"
@@ -352,7 +352,7 @@ class MetasploitModule < Msf::Auxiliary
           port: rport,
           proto: 'tcp',
           ntype: 'smb.fingerprint',
-          data: nd_smb_fingerprint
+          data: { :finger_print => nd_smb_fingerprint }
         )
 
         disconnect

--- a/modules/auxiliary/scanner/snmp/aix_version.rb
+++ b/modules/auxiliary/scanner/snmp/aix_version.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname  => 'snmp',
             :port   => datastore['RPORT'],
             :type   => 'AIX',
-            :data   => version
+            :data   => { :version => version }
         )
 
         status = "#{ip} (#{description}) is running: "

--- a/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
+++ b/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => 'snmp',
             :port  => datastore['RPORT'].to_i,
             :type  => "snmp.#{k}",
-            :data  => v
+            :data  => { :data => v }
           )
 
           line << sprintf("%s%s: %s\n", k, " "*([0,width-k.length].max), v)

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -814,7 +814,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => 'snmp',
             :port  => datastore['RPORT'].to_i,
             :type  => "snmp.#{k}",
-            :data  => content
+            :data  => { :content => content }
           )
 
           line << "\n[*] #{k}:\n\n#{content}"
@@ -832,7 +832,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => 'snmp',
             :port  => datastore['RPORT'].to_i,
             :type  => "snmp.#{k}",
-            :data  => content
+            :data  => { :content => content }
           )
 
           line << "\n[*] #{k}:\n\n#{content}"
@@ -848,7 +848,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname => 'snmp',
             :port  => datastore['RPORT'].to_i,
             :type  => "snmp.#{k}",
-            :data  => v
+            :data  => { :content => v }
           )
 
           k = truncate_to_twidth(k,twidth)

--- a/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
         sname: 'snmp',
         update: :unique_data,
         type: 'snmp.users',
-        data: users
+        data: { :users => users }
       )
     rescue SNMP::ParseError
       print_error("#{ip} Encountered an SNMP parsing error while trying to enumerate the host.")

--- a/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
           :sname => 'snmp',
           :update => :unique_data,
           :type => 'xerox.workcenter.user',
-          :data => user)
+          :data => { :user => user })
         end
       end
 

--- a/modules/auxiliary/scanner/telephony/wardial.rb
+++ b/modules/auxiliary/scanner/telephony/wardial.rb
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Auxiliary
             initmodem(modem, initstring)
             num_carriers += 1
             note = dialrange[dialnum][:result] + "\n" + dialrange[dialnum][:banner]
-            report_note(:host => dialnum, :type => "wardial_result", :data => note)
+            report_note(:host => dialnum, :type => "wardial_result", :data => { :result => note })
             log_result(dialrange[dialnum])
           when /HK_CARRIER/i
             print_status( "Carrier: #{result}" )
@@ -260,7 +260,7 @@ class MetasploitModule < Msf::Auxiliary
             initmodem(modem, initstring)
             num_carriers += 1
             note = dialrange[dialnum][:result] + "\n" + dialrange[dialnum][:banner]
-            report_note(:host => dialnum, :type => "wardial_result", :data => note)
+            report_note(:host => dialnum, :type => "wardial_result", :data => { :result => note })
             log_result(dialrange[dialnum])
           when /\+FCO/i
             print_status( "Fax: #{result}" )
@@ -272,7 +272,7 @@ class MetasploitModule < Msf::Auxiliary
             initmodem(modem, initstring)
             num_faxes += 1
             note = dialrange[dialnum][:result] + "\n" + dialrange[dialnum][:banner]
-            report_note(:host => dialnum, :type => "wardial_result", :data => note)
+            report_note(:host => dialnum, :type => "wardial_result", :data => { :result => note })
             log_result(dialrange[dialnum])
           when /VOICE/i
             print_status( "Voice" )

--- a/modules/auxiliary/scanner/tftp/tftpbrute.rb
+++ b/modules/auxiliary/scanner/tftp/tftpbrute.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
             :sname	=> 'tftp',
             :port	=> datastore['RPORT'],
             :type	=> "Found #{filename}",
-            :data	=> "Found #{filename}"
+            :data	=> { :filename => filename }
           )
         end
       end

--- a/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
         report_note(
           :host  => rhost,
           :type  => "vmware.esx.vm",
-          :data  => vm,
+          :data  => { :virtual_machine => vm },
           :port  => rport,
           :proto => 'tcp',
           :update => :unique_data

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -197,10 +197,10 @@ class MetasploitModule < Msf::Auxiliary
 
     if !cookies.empty?
       report_note(
-        host: cli.peerhost,
-        type: 'http_cookies',
-        data: hhead + ' ' + cookies,
-        update: :unique_data
+        :host => cli.peerhost,
+        :type => "http_cookies",
+        :data => { :cookies => hhead + " " + cookies },
+        :update => :unique_data
       )
     end
 
@@ -218,10 +218,10 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       report_note(
-        host: cli.peerhost,
-        type: 'http_auth_extra',
-        data: req.resource.to_s,
-        update: :unique_data
+        :host     => cli.peerhost,
+        :type     => "http_auth_extra",
+        :data     => { :auth_extra => req.resource.to_s },
+        :update => :unique_data
       )
       print_good("HTTP LOGIN #{cli.peerhost} > #{hhead}:#{@myport} #{user} / #{pass} => #{req.resource}")
     end
@@ -243,10 +243,10 @@ class MetasploitModule < Msf::Auxiliary
       data = Rex::Text.uri_decode(::Regexp.last_match(1)).split("\x00").join(', ')
 
       report_note(
-        host: cli.peerhost,
-        type: 'http_formdata',
-        data: hhead + ' ' + data,
-        update: :unique_data
+        :host => cli.peerhost,
+        :type => "http_formdata",
+        :data => { :formdata => hhead + " " + data },
+        :update => :unique_data
       )
 
       res =
@@ -262,10 +262,10 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     report_note(
-      host: cli.peerhost,
-      type: 'http_request',
-      data: "#{hhead}:#{@myport} #{req.method} #{req.resource} #{os_name} #{ua_name} #{ua_vers}",
-      update: :unique_data
+      :host => cli.peerhost,
+      :type => "http_request",
+      :data => { :request => "#{hhead}:#{@myport} #{req.method} #{req.resource} #{os_name} #{ua_name} #{ua_vers}" },
+      :update => :unique_data
     )
 
     print_status("HTTP REQUEST #{cli.peerhost} > #{hhead}:#{@myport} #{req.method} #{req.resource} #{os_name} #{ua_name} #{ua_vers} cookies=#{cookies}")

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
         report_note(
           host: @state[client][:ip],
           type: 'smtp_message',
-          data: @state[client][:data_buff][0, idx]
+          data: { :message => @state[client][:data_buff][0, idx] }
         )
         @state[client][:data_buff][0, idx].split("\n").each do |line|
           print_status("SMTP: #{@state[client][:name]} EMAIL: #{line.strip}")

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -253,7 +253,10 @@ class MetasploitModule < Msf::Auxiliary
         report_note(
           :host => addr[3],
           :type => "dns_lookup",
-          :data => "#{addr[3]}:#{addr[1]} XID #{request.id} (#{lst.join(", ")})"
+          :data => {
+            :host => "#{addr[3]}:#{addr[1]}",
+            :xid => "#{request.id} (#{lst.join(", ")})"
+          }
         ) if lst.length > 0
       end
 

--- a/modules/auxiliary/server/pxeexploit.rb
+++ b/modules/auxiliary/server/pxeexploit.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
           "(#{Rex::Socket.addr_ntoa(ip)})")
       report_note(
         :type => 'PXE.client',
-        :data => mac.unpack('H2H2H2H2H2H2').join(':')
+        :data => { :client => mac.unpack('H2H2H2H2H2H2').join(':') }
       )
     end
     @dhcp.start

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -278,7 +278,7 @@ class MetasploitModule < Msf::Exploit::Remote
     report_note(
       host: rhost,
       type: 'glassfish.banner',
-      data: banner,
+      data: { :banner => banner },
       update: :unique_data
     )
   end

--- a/modules/exploits/multi/http/rails_double_tap.rb
+++ b/modules/exploits/multi/http/rails_double_tap.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rails_root_node = html.at('//code[contains(text(), "Rails.root:")]')
     fail_with(Failure::NotVulnerable, NO_RAILS_ROOT_MSG) unless rails_root_node
     root_info_value = rails_root_node.text.scan(/Rails.root: (.+)/).flatten.first
-    report_note(host: rhost, type: 'rails.root_info', data: root_info_value, update: :unique_data)
+    report_note(host: rhost, type: 'rails.root_info', data: { :root_info_value => root_info_value }, update: :unique_data)
     root_info_value
   end
 

--- a/modules/exploits/windows/fileformat/office_ole_multiple_dll_hijack.rb
+++ b/modules/exploits/windows/fileformat/office_ole_multiple_dll_hijack.rb
@@ -234,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Remote
     full_path = ::File.expand_path(path)
     File.open(full_path, "wb") { |fd| fd.write(data) }
 
-    report_note(:data => full_path.dup, :type => "#{ltype}.localpath")
+    report_note(:data => { :full_path => full_path.dup }, :type => "#{ltype}.localpath")
 
     full_path.dup
   end

--- a/modules/exploits/windows/fileformat/proshow_load_bof.rb
+++ b/modules/exploits/windows/fileformat/proshow_load_bof.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
     full_path = ::File.expand_path(path)
     File.open(full_path, "wb") { |fd| fd.write(data) }
 
-    report_note(:data => full_path.dup, :type => "#{ltype}.localpath")
+    report_note(:data => { :full_path => full_path.dup }, :type => "#{ltype}.localpath")
 
     print_good "#{fname} stored at #{full_path}"
 

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
                 "(#{Rex::Socket.addr_ntoa(item[1])})")
             report_note({
               :type => 'PXE.client',
-              :data => item[0].unpack('H2H2H2H2H2H2').join(':')
+              :data => { :client => item[0].unpack('H2H2H2H2H2H2').join(':') }
             })
           end
         rescue ::Interrupt
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
           "(#{Rex::Socket.addr_ntoa(ip)})")
       report_note({
         :type => 'PXE.client',
-        :data => mac.unpack('H2H2H2H2H2H2').join(':')
+        :data => { :client => mac.unpack('H2H2H2H2H2H2').join(':') }
       })
     end
     @dhcp.start

--- a/modules/post/multi/gather/check_malware.rb
+++ b/modules/post/multi/gather/check_malware.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Post
     report_note({
       host: session,
       type: 'malware.sample',
-      data: tbl.to_csv
+      data: { :csv_table => tbl.to_csv }
     })
     print_status tbl.to_s
   end

--- a/modules/post/multi/gather/saltstack_salt.rb
+++ b/modules/post/multi/gather/saltstack_salt.rb
@@ -232,7 +232,10 @@ class MetasploitModule < Msf::Post
                       proto: 'TCP',
                       port: port,
                       type: 'SSH Key Password',
-                      data: "#{priv} => #{priv_pass}")
+                      data: {
+                        ssh_key: priv,
+                        password: priv_pass
+                      })
         end
 
         host_info = {

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Post
       report_note(
         host: session,
         type: 'host.escalation',
-        data: "User `#{session.exploit_datastore['USERNAME']}' sudo'ed to a root shell"
+        data: { :escalation => "User `#{session.exploit_datastore['USERNAME']}' sudo'ed to a root shell" }
       )
     else
       print_error "SUDO: Didn't work out, still a mere user."

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -260,7 +260,7 @@ class MetasploitModule < Msf::Post
     report_note(
       host: session.session_host,
       type: 'local.suggested_exploits',
-      data: report_data
+      data: { :suggested_exploits => report_data }
     )
   end
 

--- a/modules/post/solaris/escalate/pfexec.rb
+++ b/modules/post/solaris/escalate/pfexec.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Post
     report_note(
       host: session,
       type: 'host.escalation',
-      data: "User `#{user}' pfexec'ed to a root shell"
+      data: { :escalation => "User `#{user}' pfexec'ed to a root shell" }
     )
   end
 end

--- a/modules/post/windows/gather/arp_scanner.rb
+++ b/modules/post/windows/gather/arp_scanner.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Post
             report_host(host: ip_text, mac: mac_text)
             next if company.nil?
 
-            report_note(host: ip_text, type: 'mac_oui', data: company)
+            report_note(host: ip_text, type: 'mac_oui', data: { :company => company })
           end
         end
       end

--- a/modules/post/windows/gather/bloodhound.rb
+++ b/modules/post/windows/gather/bloodhound.rb
@@ -185,7 +185,10 @@ class MetasploitModule < Msf::Post
       if datastore['EncryptZip']
         print_good "Zip password: #{zip_pass}"
         report_note(host: session,
-                    data: "Bloodhound/Sharphound loot #{p} password is #{zip_pass}",
+                    data: {
+                      loot: p,
+                      password: zip_pass
+                    },
                     type: 'Sharphound Zip Password')
       end
       break

--- a/modules/post/windows/gather/enum_chocolatey_applications.rb
+++ b/modules/post/windows/gather/enum_chocolatey_applications.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Post
     report_note(
       host: session.session_host,
       type: 'chocolatey.software.enum',
-      data: items,
+      data: { software: items },
       update: :unique_data
     )
   end

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Post
     report_note(
       host: session,
       type: 'domain.hosts',
-      data: tbl.to_csv
+      data: { :hosts => tbl.to_csv }
     )
   end
 end

--- a/modules/post/windows/gather/enum_domains.rb
+++ b/modules/post/windows/gather/enum_domains.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Post
         report_note(
           host: session,
           type: 'domain.hostnames',
-          data: dc[:name],
+          data: { :hostnames => dc[:name] },
           update: :unique_data
         )
       end

--- a/modules/post/windows/gather/enum_tokens.rb
+++ b/modules/post/windows/gather/enum_tokens.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Post
       report_note(
         host: session.session_host,
         type: 'pid',
-        data: tbl_pids.to_csv
+        data: { :pids => tbl_pids.to_csv }
       )
     end
   end

--- a/modules/post/windows/gather/local_admin_search_enum.rb
+++ b/modules/post/windows/gather/local_admin_search_enum.rb
@@ -150,14 +150,18 @@ class MetasploitModule < Msf::Post
 
           # Check if enumerated user's domain matches supplied domain, if there was
           # an error, or if option disabled
-          data = ''
+          data = {
+            :domain => temp[:domain],
+            :user => temp[:user]
+          }
+
           if (datastore['DOMAIN'].upcase == temp[:domain].upcase) && !@dc_error && datastore['ENUM_GROUPS']
-            data << " - Groups: #{enum_groups(temp[:user]).chomp(', ')}"
+            data.merge!({ :enum_groups => enum_groups(temp[:user]).chomp(', ') })
           end
           line = "\tLogged in user:\t#{temp[:domain]}\\#{temp[:user]}#{data}\n"
 
           # Write user and groups to notes database
-          db_note(host, "#{temp[:domain]}\\#{temp[:user]}#{data}", 'localadmin.user.loggedin')
+          db_note(host, data, 'localadmin.user.loggedin')
           userlist << line unless userlist.include? line
 
         end

--- a/modules/post/windows/manage/pxeexploit.rb
+++ b/modules/post/windows/manage/pxeexploit.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Post
             "(#{Rex::Socket.addr_ntoa(item[1])})")
         report_note({
           type: 'PXE.client',
-          data: item[0].unpack('H2H2H2H2H2H2').join(':')
+          data: { :client => item[0].unpack('H2H2H2H2H2H2').join(':') }
         })
       end
     rescue ::Interrupt


### PR DESCRIPTION
Part of https://github.com/rapid7/metasploit-framework/issues/19874 (Don't want to close as it'll be used to track any occurrences of module still using anything other than a hash for the data attribute)

This PR makes changes to update the `reports_notes` method to now only accept a Hash value. If a Hash is not being passed a deprecation message will be displayed. 

## Changes
Will now show the deprecation message, as well as validating the data attribute.
```
msf6 auxiliary(admin/mssql/mssql_enum) > run
[*] Running MS SQL Server Enumeration...
[*] Using existing session 1
[*] Version:
[*]	Microsoft SQL Server 2022 (RTM-CU9) (KB5030731) - 16.0.4085.2 (X64)
[*]		Sep 27 2023 12:05:43
[*]		Copyright (C) 2022 Microsoft Corporation
[*]		Enterprise Evaluation Edition (64-bit) on Linux (Ubuntu 22.04.3 LTS) <X64>
The data option for Msf::DBManager::Note#report_note should be passed a Hash.
If you see this message in an existing module, please use the following link to tell us ,so modules can be appropriately updated:
  https://github.com/rapid7/metasploit-framework/issues/19874
```


## Verification
- [ ] Code review
- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/mssql/mssql_enum` (or any module that has been updated)
- [ ] **Verify** the module works as expected when a Hash is passed into the data attribute
- [ ] **Verify** the module now returns a deprecation message when a Hash is not passed into the data attribute
