### PR TITLE
Update ubuntu versions for Github actions

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - ubuntu-20.04
+          - ubuntu-latest
         ruby:
           - '3.2'
         include:
@@ -73,7 +73,7 @@ jobs:
           - { command_shell: { name: powershell }, os: windows-2022 }
 
           # Linux
-          - { command_shell: { name: linux }, os: ubuntu-20.04 }
+          - { command_shell: { name: linux }, os: ubuntu-latest }
 
           # CMD
           - { command_shell: { name: cmd }, os: windows-2019 }

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -69,12 +69,12 @@ jobs:
         os:
           - macos-13
           - windows-2019
-          - ubuntu-20.04
+          - ubuntu-latest
         ruby:
           - '3.2'
         meterpreter:
           # Python
-          - { name: python, runtime_version: 3.6 }
+          - { name: python, runtime_version: 3.8 }
           - { name: python, runtime_version: 3.11 }
 
           # Java
@@ -92,7 +92,7 @@ jobs:
 
           # Mettle
           - { meterpreter: { name: mettle }, os: macos-13 }
-          - { meterpreter: { name: mettle }, os: ubuntu-20.04 }
+          - { meterpreter: { name: mettle }, os: ubuntu-latest }
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,7 +64,6 @@ jobs:
           - '3.3'
           - '3.4'
         os:
-          - ubuntu-20.04
           - ubuntu-latest
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Update ubuntu versions for github actions

> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01


## Verification

Ensure CI passes