### PR TITLE
Add a warning for MS08-068 when applicable

### DIFF
--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -29,8 +29,12 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
         return super(request, session)
       end
 
-
       logger.print_status("Relaying to next target #{session.metadata[:relay_target]}")
+
+      if session.metadata[:relay_target].protocol == :smb && session.metadata[:relay_target].ip == peerhost
+        logger.print_warning('Relaying SMB to SMB on the same host will not work if the target has been patched for MS08-068')
+      end
+
       relayed_connection = create_relay_client(
         session.metadata[:relay_target],
         @relay_timeout


### PR DESCRIPTION
This adds a warning that intends to help users that are performing relay attacks. It notes that the attack won't work when relaying SMB to SMB on the same host if the [MS08-068](https://learn.microsoft.com/en-us/security-updates/SecurityBulletins/2008/ms08-068) patch has been applied. I think it still makes sense to attempt the attack in case port forwarding is in use, or the target maybe isn't Windows.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/smb_relay`
- [x] Set the `RHOSTS` to a target you can login to
- [x] Login to that target and use `net use` to trigger an authentication attempt to Metasploit and see a helpful error message that it probably wont work
- [x] See the attack fail because we try anyways

## Demo

![image](https://github.com/user-attachments/assets/41e69566-c57a-4092-a09b-1ebe996c3ef2)