### PR TITLE
Vulnerability reporting updates for ESC flaws

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -14,12 +14,12 @@ class MetasploitModule < Msf::Auxiliary
   ADS_GROUP_TYPE_UNIVERSAL_GROUP = 0x00000008
 
   REFERENCES = {
-    'ESC1' => [ 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
-    'ESC2' => [ 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
-    'ESC3' => [ 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
-    'ESC4' => [ 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
-    'ESC13' => [ 'https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53' ],
-    'ESC15' => [ 'https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc' ]
+    'ESC1' => [ SiteReference.new('URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2') ],
+    'ESC2' => [ SiteReference.new('URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2') ],
+    'ESC3' => [ SiteReference.new('URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2') ],
+    'ESC4' => [ SiteReference.new('URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2') ],
+    'ESC13' => [ SiteReference.new('URL', 'https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53') ],
+    'ESC15' => [ SiteReference.new('URL', 'https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc') ]
   }.freeze
 
   SID = Struct.new(:value, :name) do
@@ -63,11 +63,7 @@ class MetasploitModule < Msf::Auxiliary
           'Spencer McIntyre', # ESC13 and ESC15 updates
           'jheysel-r7' # ESC4 update
         ],
-        'References' => [
-          [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
-          [ 'URL', 'https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53' ], # ESC13
-          [ 'URL', 'https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc' ] # ESC15
-        ],
+        'References' => REFERENCES.values.flatten.map { |r| [ r.ctx_id, r.ctx_val ] }.uniq,
         'DisclosureDate' => '2021-06-17',
         'License' => MSF_LICENSE,
         'DefaultOptions' => {


### PR DESCRIPTION
When the vulnerabilities were originally `report_vuln`'ed they were using the URL which resulted in that being populated in the database. URLs should actually be reported as `SiteReference` instances which ensures that what goes into the database is the URL with the `URL-` prefix, noting that it's an explicit URL instead of something else like a CVE ID. This fixes how cross referencing works in certain locations where vulnerability references are matched to modules which use the proper SiteReference from their module metadata.

The changes also reduce copy-pasta in the `auxiliary/gather/ldap_esc_vulnerable_cert_finder` module itself by referencing all of the ESC flaws and merging their reference URLs.

~~Lastly, there's a change to `do_report_failure_or_success` that enables the caller to specify the `last_fail_reason` which is noted in the database for flaws we're confident are not exploitable. This should probably be used in instances where an exploit module fails with `NotVulnerable` but that would require additional testing so in the mean time, it's available for callers to use explicitly moving forward.~~ Nevermind, it doesn't look like this is supposed to be exposed here.

## Testing
- [x] Run the `auxiliary/gather/ldap_esc_vulnerable_cert_finder` module
- [x] See vulnerabilities with references, URLs should now be prefixed with `URL-`

## Demo

```
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_esc_vulnerable_cert_finder) > vulns

Vulnerabilities
===============

Timestamp                Host           Name                    References
---------                ----           ----                    ----------
2025-03-12 19:10:28 UTC  10.140.10.201  ESC1 - ESC1             URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
2025-03-12 19:10:28 UTC  10.140.10.201  ESC13 - ESC13           URL-https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
2025-03-12 19:10:28 UTC  10.140.10.201  ESC15 - ESC15           URL-https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc
2025-03-12 19:10:28 UTC  10.140.10.201  ESC2 - ESC2             URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
2025-03-12 19:10:28 UTC  10.140.10.201  ESC3 - ESC3_TEMPLATE_1  URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
2025-03-12 19:10:28 UTC  10.140.10.201  ESC4 - ESC4             URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
```