### PR TITLE
Enable longpaths

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -126,6 +126,11 @@ jobs:
         with:
           path: metasploit-framework
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
@@ -174,6 +179,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ldap_acceptance.yml
+++ b/.github/workflows/ldap_acceptance.yml
@@ -72,6 +72,11 @@ jobs:
           docker compose build
           docker compose up --wait -d
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM
@@ -120,6 +125,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/mssql_acceptance.yml
+++ b/.github/workflows/mssql_acceptance.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM
@@ -137,6 +142,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/mysql_acceptance.yml
+++ b/.github/workflows/mysql_acceptance.yml
@@ -80,6 +80,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM
@@ -136,6 +141,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/postgres_acceptance.yml
+++ b/.github/workflows/postgres_acceptance.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM
@@ -138,6 +143,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -190,6 +190,11 @@ jobs:
           path: metasploit-framework
           ref: ${{ inputs.metasploit_framework_commit }}
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
@@ -343,6 +348,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/shared_smb_acceptance.yml
+++ b/.github/workflows/shared_smb_acceptance.yml
@@ -74,6 +74,11 @@ jobs:
           docker compose build
           docker compose up --wait -d
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM
@@ -142,6 +147,11 @@ jobs:
       - name: Install system dependencies (Linux)
         if: always()
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
 
       - name: Setup Ruby
         if: always()

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,6 +88,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Ruby
         env:
           # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM


### PR DESCRIPTION
Enable longpaths - which is required for testing the metasploit_data_models gem on windows:

i.e. Adding a custom branch to the gemfile:

```
gem 'metasploit_data_models', git: 'https://github.com/rapid7/metasploit_data_models.git', branch: 'add-coder-to-mdm-payload'
```

Without these changes would result in:

```
Git error: command `git reset --hard 34fc27d3059c919eac98cf2a8061c31146189a26`
in directory
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/bundler/gems/metasploit_data_models-34fc27d3059c
has failed.
error: unable to create file
spec/support/shared/examples/metasploit_data_models/search/visitor/includes/visit/with_metasploit_model_search_operation_base.rb:
Filename too long
error: unable to create file
spec/support/shared/examples/metasploit_data_models/search/visitor/where/visit/with_metasploit_model_search_group_base.rb:
Filename too long
fatal: Could not reset index file to revision
'34fc27d3059c919eac98cf2a8061c31146189a26'.
Error: The process 'C:\hostedtoolcache\windows\Ruby\3.2.5\x64\bin\bundle.bat' failed with exit code 11
```