### PR TITLE
Fix check method for Windows Kernel Time of Check Time of Use LPE (CVE-2024-30038)

### DIFF
--- a/modules/exploits/windows/local/cve_2024_30088_authz_basep.rb
+++ b/modules/exploits/windows/local/cve_2024_30088_authz_basep.rb
@@ -71,7 +71,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def target_compatible?(version)
     # NOTE: Win10_1607 = Server2016 and Win10_1809 = Server2019. Both Server and Desktop version are supposed to be affected.
-    return (version.build_number == Msf::WindowsVersion::Win10_1809 && version.revision_number < 5936) ||
+    #
+    return (version.build_number == Msf::WindowsVersion::Win10_1507 && version.revision_number < 20680) ||
+           (version.build_number == Msf::WindowsVersion::Win10_1607 && version.revision_number < 7070) ||
+           (version.build_number == Msf::WindowsVersion::Win10_1809 && version.revision_number < 5936) ||
            (version.build_number == Msf::WindowsVersion::Win10_21H2 && version.revision_number < 4529) ||
            (version.build_number == Msf::WindowsVersion::Win10_22H2 && version.revision_number < 4529) ||
            (version.build_number == Msf::WindowsVersion::Win11_21H2 && version.revision_number < 3019) ||

--- a/modules/exploits/windows/local/cve_2024_30088_authz_basep.rb
+++ b/modules/exploits/windows/local/cve_2024_30088_authz_basep.rb
@@ -71,27 +71,24 @@ class MetasploitModule < Msf::Exploit::Local
 
   def target_compatible?(version)
     # NOTE: Win10_1607 = Server2016 and Win10_1809 = Server2019. Both Server and Desktop version are supposed to be affected.
-    return true if version.build_number.between?(Msf::WindowsVersion::Win10_1507, Rex::Version.new('10.0.10240.20680')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win10_1607, Rex::Version.new('10.0.14393.7070')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win10_1809, Rex::Version.new('10.0.17763.5936')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win10_21H2, Rex::Version.new('10.0.19044.4529')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win10_22H2, Rex::Version.new('10.0.19045.4529')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win11_21H2, Rex::Version.new('10.0.22000.3019')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win11_22H2, Rex::Version.new('10.0.22621.3737')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Win11_23H2, Rex::Version.new('10.0.22631.3737')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Server2022, Rex::Version.new('10.0.20348.2522')) ||
-                   version.build_number.between?(Msf::WindowsVersion::Server2022_23H2, Rex::Version.new('10.0.25398.950'))
-
-    false
+    return (version.build_number == Msf::WindowsVersion::Win10_1809 && version.revision_number < 5936) ||
+           (version.build_number == Msf::WindowsVersion::Win10_21H2 && version.revision_number < 4529) ||
+           (version.build_number == Msf::WindowsVersion::Win10_22H2 && version.revision_number < 4529) ||
+           (version.build_number == Msf::WindowsVersion::Win11_21H2 && version.revision_number < 3019) ||
+           (version.build_number == Msf::WindowsVersion::Win11_22H2 && version.revision_number < 3737) ||
+           (version.build_number == Msf::WindowsVersion::Win11_23H2 && version.revision_number < 3737) ||
+           (version.build_number == Msf::WindowsVersion::Server2019 && version.revision_number < 5936) ||
+           (version.build_number == Msf::WindowsVersion::Server2022 && version.revision_number < 2522) ||
+           (version.build_number == Msf::WindowsVersion::Server2022_23H2 && version.revision_number < 950)
   end
 
   def check
     return Exploit::CheckCode::Safe('Non Windows systems are not affected') unless session.platform == 'windows'
 
     version = get_version_info
-    return Exploit::CheckCode::Appears("Version detected: #{version}") if target_compatible?(version)
+    return Exploit::CheckCode::Appears("Version detected: #{version}. Revision number detected: #{version.revision_number}") if target_compatible?(version)
 
-    CheckCode::Safe("Version detected: #{version}")
+    CheckCode::Safe("Version detected: #{version}. Revision number detected: #{version.revision_number}.")
   end
 
   def get_winlogon_pid


### PR DESCRIPTION
The `target_compatible?` method was not working as expected due to the fact that `version.build_number.between` ignores the revision number. This fixes that issue. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a session on a vulnerable windows host
- [ ] `use exploit/windows/local/cve_2024_30088_authz_basep`
- [ ] `set session -1`
- [ ] **Verify** that check method properly takes into consideration the revision number
