### PR TITLE
Split Stdapi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
       drb
       mutex_m
       railties (~> 7.0)
-    metasploit-payloads (2.0.232)
+    metasploit-payloads (2.0.234)
     metasploit_data_models (6.0.9)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.232)
+      metasploit-payloads (= 2.0.234)
       metasploit_data_models (>= 6.0.7)
       metasploit_payloads-mettle (= 1.0.45)
       mqtt

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.221)
+      metasploit-payloads (= 2.0.232)
       metasploit_data_models (>= 6.0.7)
       metasploit_payloads-mettle (= 1.0.45)
       mqtt
@@ -348,7 +348,7 @@ GEM
       drb
       mutex_m
       railties (~> 7.0)
-    metasploit-payloads (2.0.221)
+    metasploit-payloads (2.0.232)
     metasploit_data_models (6.0.9)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -98,7 +98,7 @@ metasploit-concern, 5.0.5, "New BSD"
 metasploit-credential, 6.0.16, "New BSD"
 metasploit-framework, 6.4.84, "New BSD"
 metasploit-model, 5.0.4, "New BSD"
-metasploit-payloads, 2.0.232, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.234, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.9, "New BSD"
 metasploit_payloads-mettle, 1.0.45, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -98,7 +98,7 @@ metasploit-concern, 5.0.5, "New BSD"
 metasploit-credential, 6.0.16, "New BSD"
 metasploit-framework, 6.4.84, "New BSD"
 metasploit-model, 5.0.4, "New BSD"
-metasploit-payloads, 2.0.221, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.232, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.9, "New BSD"
 metasploit_payloads-mettle, 1.0.45, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -137,6 +137,26 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
   end
 
+  def load_embedded_extensions
+
+    # First of all, let's see if we have stdapi.
+    commands = self.core.get_loaded_extension_commands('stdapi')
+    console.run_single("load stdapi") if commands.length > 0
+
+    return if self.platform != 'windows'
+
+    exts = Set.new
+    exts.merge(binary_suffix.map { |suffix| MetasploitPayloads.list_meterpreter_extensions(suffix) }.flatten)
+    exts = exts.sort.uniq
+
+    exts.each { |e| 
+      commands = self.core.get_loaded_extension_commands(e.downcase)
+      if commands.length > 0 && !e.downcase.starts_with?('stdapi')
+        console.run_single("load #{e.downcase}")
+      end
+    }
+  end
+
   def bootstrap(datastore = {}, handler = nil)
     session = self
 
@@ -180,6 +200,12 @@ class Meterpreter < Rex::Post::Meterpreter::Client
       print_warning('Meterpreter start up operations have been aborted. Use the session at your own risk.')
       return nil
     end
+
+    original = console.disable_output
+    console.disable_output = true
+
+    load_embedded_extensions
+
     extensions = datastore['AutoLoadExtensions']&.delete(' ').split(',') || []
 
     # BEGIN: This should be removed on MSF 7
@@ -190,8 +216,6 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     extensions.push('android') if session.platform == 'android'
     extensions = extensions.uniq
     # END
-    original = console.disable_output
-    console.disable_output = true
     # TODO: abstract this a little, perhaps a "post load" function that removes
     # platform-specific stuff?
     extensions.each do |extension|

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -173,6 +173,7 @@ private
     file_extension = 'x86.dll'
     file_extension = 'x64.dll' unless is_x86?
 
+    @opts[:extensions] = [] if @opts[:extensions].blank?
     prev_length = @opts[:extensions].length
     @opts[:extensions] = @opts[:extensions].select {|ext_name| ext_name.index('stdapi_') != 0}
     if prev_length != @opts[:extensions].length

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -173,6 +173,17 @@ private
     file_extension = 'x86.dll'
     file_extension = 'x64.dll' unless is_x86?
 
+    prev_length = @opts[:extensions].length
+    @opts[:extensions] = @opts[:extensions].select {|ext_name| ext_name.index('stdapi_') != 0}
+    if prev_length != @opts[:extensions].length
+      raise Msf::OptionValidateError.new(
+        {
+          'EXTENSIONS' => 'The extensions starting with stdapi_* are currently not supported.'
+        },
+        message: "The extensions starting with stdapi_* are currently not supported."
+      )
+    end
+
     (@opts[:extensions] || []).each do |e|
       config << extension_block(e, file_extension, debug_build: @opts[:debug_build])
     end

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -348,7 +348,7 @@ class ClientCore < Extension
 
     # if there are existing commands for the given extension, then we can use
     # what's already there
-    unless commands.length > 0
+    unless false #commands.length > 0
       image = nil
       path = nil
       # If client.sys isn't setup, it's a Windows meterpreter

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -403,12 +403,6 @@ class ClientCore < Extension
           'Extension'        => true,
           'SaveToDisk'       => opts['LoadFromDisk'])
     end
-
-    if skip_loading && client.platform == 'windows'
-      error = Rex::Post::Meterpreter::ExtensionLoadError.new(name: mod.downcase)
-      raise error, "Loading \"#{mod.downcase}\" not possible due to the presence of already loaded portions of the extension.", caller
-    end
-
     # wire the commands into the client
     client.add_extension(mod, commands)
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -346,9 +346,18 @@ class ClientCore < Extension
     # already loaded
     commands = get_loaded_extension_commands(mod.downcase)
 
-    # if there are existing commands for the given extension, then we can use
-    # what's already there
-    unless false #commands.length > 0
+    # This check is important to keep compatibility with Mettle:
+    # Mettle is the only meterpreter that has stdapi functions embedded in the metsrv.
+    # Double-loading of extensions is prevented by the lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb line: 1195
+    # However we need to add more flexibility here to allow users loading the split of stdapi in Windows Meterpreter. 
+    # reference: https://github.com/rapid7/metasploit-framework/pull/19975
+    # So here we are actively preventing loading of stdapi if some commands for that extension are already loaded.
+    # So we will not load stdapi if:
+    # - we are running mettle (which has by default those command registered)
+    # - we are running windows meterpreter with one of the stdapi namespace loaded (stdapi_net, stdapi_fs.... etc). 
+    #   partial loading of the other namespace is still possible, we can load stdapi_net and stdapi_fs later.
+    
+    unless commands.length > 0 && mod.downcase == 'stdapi'
       image = nil
       path = nil
       # If client.sys isn't setup, it's a Windows meterpreter

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -357,7 +357,7 @@ class ClientCore < Extension
     # - we are running windows meterpreter with one of the stdapi namespace loaded (stdapi_net, stdapi_fs.... etc). 
     #   partial loading of the other namespace is still possible, we can load stdapi_net and stdapi_fs later.
     
-    skip_loading = commands.length > 0 && mod.downcase.index('stdapi_') != 0
+    skip_loading = commands.length > 0 && !mod.downcase.start_with?('stdapi_')
     unless skip_loading
       image = nil
       path = nil

--- a/lib/rex/post/meterpreter/extensions/stdapi_audio/stdapi_audio.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_audio/stdapi_audio.rb
@@ -1,0 +1,71 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/mic/mic'
+require 'rex/post/meterpreter/extensions/stdapi/audio_output/audio_output'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Audio
+          module AudioOutput
+            include Rex::Post::Meterpreter::Extensions::Stdapi::AudioOutput
+          end
+          module Mic
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Mic
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+
+          ###
+          #
+          # Standard ruby interface to remote entities for meterpreter.  It provides
+          # basic access to files, network, system, and other properties of the remote
+          # machine that are fairly universal.
+          #
+          ###
+          class Stdapi_Audio < Extension
+
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
+
+            #
+            # Initializes an instance of the standard API extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_audio')
+
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => 'audio_output',
+                    'ext'  => Rex::Post::Meterpreter::Extensions::Stdapi_Audio::AudioOutput::AudioOutput.new(client)
+                  },
+                  {
+                    'name' => 'mic',
+                    'ext'  => Rex::Post::Meterpreter::Extensions::Stdapi_Audio::Mic::Mic.new(client)
+                  },
+                ])
+            end
+
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = self.client
+              return klass
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi_audio/stdapi_audio.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_audio/stdapi_audio.rb
@@ -35,7 +35,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard API extension.
+            # Initializes an instance of the standard Audio API extension.
             #
             def initialize(client)
               super(client, 'stdapi_audio')

--- a/lib/rex/post/meterpreter/extensions/stdapi_audio/stdapi_audio.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_audio/stdapi_audio.rb
@@ -21,13 +21,6 @@ module Rex
           end
           include Rex::Post::Meterpreter::Extensions::Stdapi
 
-          ###
-          #
-          # Standard ruby interface to remote entities for meterpreter.  It provides
-          # basic access to files, network, system, and other properties of the remote
-          # machine that are fairly universal.
-          #
-          ###
           class Stdapi_Audio < Extension
 
             def self.extension_id
@@ -35,7 +28,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard Audio API extension.
+            # Initializes an instance of the Standard API (Audio Namespace) extension.
             #
             def initialize(client)
               super(client, 'stdapi_audio')

--- a/lib/rex/post/meterpreter/extensions/stdapi_fs/stdapi_fs.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_fs/stdapi_fs.rb
@@ -21,13 +21,6 @@ module Rex
           end
           include Rex::Post::Meterpreter::Extensions::Stdapi
 
-          ###
-          #
-          # Standard ruby interface to remote entities for meterpreter.  It provides
-          # basic access to files, network, system, and other properties of the remote
-          # machine that are fairly universal.
-          #
-          ###
           class Stdapi_Fs < Extension
 
             def self.extension_id
@@ -35,7 +28,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard API extension.
+            # Initializes an instance of the Standard API (Fs Namespace) extension.
             #
             def initialize(client)
               super(client, 'stdapi_fs')

--- a/lib/rex/post/meterpreter/extensions/stdapi_fs/stdapi_fs.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_fs/stdapi_fs.rb
@@ -1,0 +1,94 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/stdapi'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/fs/dir'
+require 'rex/post/meterpreter/extensions/stdapi/fs/file'
+require 'rex/post/meterpreter/extensions/stdapi/fs/file_stat'
+require 'rex/post/meterpreter/extensions/stdapi/fs/mount'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Fs
+          module Fs
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Fs
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+
+          ###
+          #
+          # Standard ruby interface to remote entities for meterpreter.  It provides
+          # basic access to files, network, system, and other properties of the remote
+          # machine that are fairly universal.
+          #
+          ###
+          class Stdapi_Fs < Extension
+
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
+
+            #
+            # Initializes an instance of the standard API extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_fs')
+
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => 'fs',
+                    'ext'  => ObjectAliases.new(
+                      {
+                        'dir'      => self.dir,
+                        'file'     => self.file,
+                        'filestat' => self.filestat,
+                        'mount'    => Fs::Mount.new(client)
+                      })
+                  },
+                ])
+            end
+
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = self.client
+              return klass
+            end
+
+            #
+            # Returns a copy of the Dir class.
+            #
+            def dir
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Fs::Fs::Dir)
+            end
+
+            #
+            # Returns a copy of the File class.
+            #
+            def file
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Fs::Fs::File)
+            end
+
+            #
+            # Returns a copy of the FileStat class.
+            #
+            def filestat
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Fs::Fs::FileStat)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi_net/stdapi_net.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_net/stdapi_net.rb
@@ -1,0 +1,66 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/net/resolve'
+require 'rex/post/meterpreter/extensions/stdapi/net/config'
+require 'rex/post/meterpreter/extensions/stdapi/net/socket'
+module Rex
+module Post
+module Meterpreter
+module Extensions
+module Stdapi_Net
+  module Net
+    include Rex::Post::Meterpreter::Extensions::Stdapi::Net
+  end
+  include Rex::Post::Meterpreter::Extensions::Stdapi
+
+###
+#
+# Standard ruby interface to remote entities for meterpreter.  It provides
+# basic access to files, network, system, and other properties of the remote
+# machine that are fairly universal.
+#
+###
+class Stdapi_Net < Extension
+
+  def self.extension_id
+    Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+  end
+
+  #
+  # Initializes an instance of the standard API extension.
+  #
+  def initialize(client)
+    super(client, 'stdapi_net')
+
+    # Alias the following things on the client object so that they
+    # can be directly referenced
+    client.register_extension_aliases(
+      [
+        {
+          'name' => 'net',
+          'ext'  => ObjectAliases.new(
+            {
+              'config'   => Rex::Post::Meterpreter::Extensions::Stdapi::Net::Config.new(client),
+              'socket'   => Rex::Post::Meterpreter::Extensions::Stdapi::Net::Socket.new(client),
+              'resolve'  => Rex::Post::Meterpreter::Extensions::Stdapi::Net::Resolve.new(client)
+            })
+        }
+      ])
+  end
+
+  #
+  # Sets the client instance on a duplicated copy of the supplied class.
+  #
+  def brand(klass)
+    klass = klass.dup
+    klass.client = self.client
+    return klass
+  end
+end
+
+end; end; end; end; end

--- a/lib/rex/post/meterpreter/extensions/stdapi_net/stdapi_net.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_net/stdapi_net.rb
@@ -45,9 +45,9 @@ class Stdapi_Net < Extension
           'name' => 'net',
           'ext'  => ObjectAliases.new(
             {
-              'config'   => Rex::Post::Meterpreter::Extensions::Stdapi::Net::Config.new(client),
-              'socket'   => Rex::Post::Meterpreter::Extensions::Stdapi::Net::Socket.new(client),
-              'resolve'  => Rex::Post::Meterpreter::Extensions::Stdapi::Net::Resolve.new(client)
+              'config'   => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Config.new(client),
+              'socket'   => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Socket.new(client),
+              'resolve'  => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Resolve.new(client)
             })
         }
       ])

--- a/lib/rex/post/meterpreter/extensions/stdapi_net/stdapi_net.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_net/stdapi_net.rb
@@ -9,58 +9,53 @@ require 'rex/post/meterpreter/extensions/stdapi/net/resolve'
 require 'rex/post/meterpreter/extensions/stdapi/net/config'
 require 'rex/post/meterpreter/extensions/stdapi/net/socket'
 module Rex
-module Post
-module Meterpreter
-module Extensions
-module Stdapi_Net
-  module Net
-    include Rex::Post::Meterpreter::Extensions::Stdapi::Net
-  end
-  include Rex::Post::Meterpreter::Extensions::Stdapi
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Net
+          module Net
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Net
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+          class Stdapi_Net < Extension
 
-###
-#
-# Standard ruby interface to remote entities for meterpreter.  It provides
-# basic access to files, network, system, and other properties of the remote
-# machine that are fairly universal.
-#
-###
-class Stdapi_Net < Extension
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
 
-  def self.extension_id
-    Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
-  end
+            #
+            # Initializes an instance of the Standard API (Net Namespace) extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_net')
 
-  #
-  # Initializes an instance of the standard API extension.
-  #
-  def initialize(client)
-    super(client, 'stdapi_net')
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => 'net',
+                    'ext'  => ObjectAliases.new(
+                      {
+                        'config'   => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Config.new(client),
+                        'socket'   => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Socket.new(client),
+                        'resolve'  => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Resolve.new(client)
+                      })
+                  }
+                ])
+            end
 
-    # Alias the following things on the client object so that they
-    # can be directly referenced
-    client.register_extension_aliases(
-      [
-        {
-          'name' => 'net',
-          'ext'  => ObjectAliases.new(
-            {
-              'config'   => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Config.new(client),
-              'socket'   => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Socket.new(client),
-              'resolve'  => Rex::Post::Meterpreter::Extensions::Stdapi_Net::Net::Resolve.new(client)
-            })
-        }
-      ])
-  end
-
-  #
-  # Sets the client instance on a duplicated copy of the supplied class.
-  #
-  def brand(klass)
-    klass = klass.dup
-    klass.client = self.client
-    return klass
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = self.client
+              return klass
+            end
+          end
+        end
+      end
+    end
   end
 end
-
-end; end; end; end; end

--- a/lib/rex/post/meterpreter/extensions/stdapi_railgun/stdapi_railgun.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_railgun/stdapi_railgun.rb
@@ -1,0 +1,63 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/railgun/railgun'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Railgun
+          module Railgun
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Railgun
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+
+          ###
+          #
+          # Standard ruby interface to remote entities for meterpreter.  It provides
+          # basic access to files, network, system, and other properties of the remote
+          # machine that are fairly universal.
+          #
+          ###
+          class Stdapi_Railgun < Extension
+
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
+
+            #
+            # Initializes an instance of the standard API extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_railgun')
+
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                    {
+                    'name' => 'railgun',
+                    'ext'  => Rex::Post::Meterpreter::Extensions::Stdapi_Railgun::Railgun::Railgun.new(client)
+                    },
+                ])
+            end
+
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = self.client
+              return klass
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi_railgun/stdapi_railgun.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_railgun/stdapi_railgun.rb
@@ -17,13 +17,6 @@ module Rex
           end
           include Rex::Post::Meterpreter::Extensions::Stdapi
 
-          ###
-          #
-          # Standard ruby interface to remote entities for meterpreter.  It provides
-          # basic access to files, network, system, and other properties of the remote
-          # machine that are fairly universal.
-          #
-          ###
           class Stdapi_Railgun < Extension
 
             def self.extension_id
@@ -31,7 +24,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard API extension.
+            # Initializes an instance of the Standard API (Railgun Namespace) extension.
             #
             def initialize(client)
               super(client, 'stdapi_railgun')

--- a/lib/rex/post/meterpreter/extensions/stdapi_sys/stdapi_sys.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_sys/stdapi_sys.rb
@@ -20,13 +20,6 @@ module Rex
           end
           include Rex::Post::Meterpreter::Extensions::Stdapi
 
-          ###
-          #
-          # Standard ruby interface to remote entities for meterpreter.  It provides
-          # basic access to files, network, system, and other properties of the remote
-          # machine that are fairly universal.
-          #
-          ###
           class Stdapi_Sys < Extension
 
             def self.extension_id
@@ -34,7 +27,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard API extension.
+            # Initializes an instance of the Standard API (Sys Namespace) extension.
             #
             def initialize(client)
               super(client, 'stdapi_sys')

--- a/lib/rex/post/meterpreter/extensions/stdapi_sys/stdapi_sys.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_sys/stdapi_sys.rb
@@ -1,0 +1,101 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/sys/config'
+require 'rex/post/meterpreter/extensions/stdapi/sys/process'
+require 'rex/post/meterpreter/extensions/stdapi/sys/registry'
+require 'rex/post/meterpreter/extensions/stdapi/sys/event_log'
+require 'rex/post/meterpreter/extensions/stdapi/sys/power'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Sys
+          module Sys
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Sys
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+
+          ###
+          #
+          # Standard ruby interface to remote entities for meterpreter.  It provides
+          # basic access to files, network, system, and other properties of the remote
+          # machine that are fairly universal.
+          #
+          ###
+          class Stdapi_Sys < Extension
+
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
+
+            #
+            # Initializes an instance of the standard API extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_sys')
+
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => 'sys',
+                    'ext'  => ObjectAliases.new(
+                      {
+                        'config'   => Rex::Post::Meterpreter::Extensions::Stdapi_Sys::Sys::Config.new(client),
+                        'process'  => self.process,
+                        'registry' => self.registry,
+                        'eventlog' => self.eventlog,
+                        'power'    => self.power
+                      })
+                  },
+                ])
+            end
+
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = self.client
+              return klass
+            end
+
+            #
+            # Returns a copy of the Process class.
+            #
+            def process
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Sys::Sys::Process)
+            end
+
+            #
+            # Returns a copy of the Registry class.
+            #
+            def registry
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Sys::Sys::Registry)
+            end
+
+            #
+            # Returns a copy of the EventLog class.
+            #
+            def eventlog
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Sys::Sys::EventLog)
+            end
+
+            #
+            # Returns a copy of the Power class.
+            #
+            def power
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Sys::Sys::Power)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi_ui/stdapi_ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_ui/stdapi_ui.rb
@@ -37,13 +37,6 @@ module Rex
           end
           include Rex::Post::Meterpreter::Extensions::Stdapi
 
-          ###
-          #
-          # Standard ruby interface to remote entities for meterpreter.  It provides
-          # basic access to files, network, system, and other properties of the remote
-          # machine that are fairly universal.
-          #
-          ###
           class Stdapi_Ui < Extension
 
             def self.extension_id
@@ -51,7 +44,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard API extension.
+            # Initializes an instance of the Standard API (Ui Namespace) extension.
             #
             def initialize(client)
               super(client, 'stdapi_ui')

--- a/lib/rex/post/meterpreter/extensions/stdapi_ui/stdapi_ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_ui/stdapi_ui.rb
@@ -1,0 +1,136 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/mic/mic'
+require 'rex/post/meterpreter/extensions/stdapi/audio_output/audio_output'
+require 'rex/post/meterpreter/extensions/stdapi/webcam/webcam'
+require 'rex/post/meterpreter/extensions/stdapi/sys/config'
+require 'rex/post/meterpreter/extensions/stdapi/sys/process'
+require 'rex/post/meterpreter/extensions/stdapi/sys/registry'
+require 'rex/post/meterpreter/extensions/stdapi/sys/event_log'
+require 'rex/post/meterpreter/extensions/stdapi/sys/power'
+require 'rex/post/meterpreter/extensions/stdapi/ui'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Ui
+          module AudioOutput
+            include Rex::Post::Meterpreter::Extensions::Stdapi::AudioOutput
+          end
+
+          module Mic
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Mic
+          end
+
+          module Webcam
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Webcam
+          end
+
+          module Sys
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Sys
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+
+          ###
+          #
+          # Standard ruby interface to remote entities for meterpreter.  It provides
+          # basic access to files, network, system, and other properties of the remote
+          # machine that are fairly universal.
+          #
+          ###
+          class Stdapi_Ui < Extension
+
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
+
+            #
+            # Initializes an instance of the standard API extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_ui')
+
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => 'audio_output',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi_Ui::AudioOutput::AudioOutput.new(client)
+                  },
+                  {
+                    'name' => 'mic',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Mic::Mic.new(client)
+                  },
+                  {
+                    'name' => 'sys',
+                    'ext' => ObjectAliases.new(
+                      {
+                        'config' => Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Sys::Config.new(client),
+                        'process' => process,
+                        'registry' => registry,
+                        'eventlog' => eventlog,
+                        'power' => power
+                      }
+                    )
+                  },
+                  {
+                    'name' => 'ui',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi::UI.new(client)
+                  },
+                  {
+                    'name' => 'webcam',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Webcam::Webcam.new(client)
+                  },
+                ]
+              )
+            end
+
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = client
+              return klass
+            end
+
+            #
+            # Returns a copy of the Process class.
+            #
+            def process
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Sys::Process)
+            end
+
+            #
+            # Returns a copy of the Registry class.
+            #
+            def registry
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Sys::Registry)
+            end
+
+            #
+            # Returns a copy of the EventLog class.
+            #
+            def eventlog
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Sys::EventLog)
+            end
+
+            #
+            # Returns a copy of the Power class.
+            #
+            def power
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Ui::Sys::Power)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi_webcam/stdapi_webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_webcam/stdapi_webcam.rb
@@ -1,0 +1,131 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/object_aliases'
+require 'rex/post/meterpreter/extension'
+require 'rex/post/meterpreter/extensions/stdapi/constants'
+require 'rex/post/meterpreter/extensions/stdapi/tlv'
+require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/meterpreter/extensions/stdapi/mic/mic'
+require 'rex/post/meterpreter/extensions/stdapi/audio_output/audio_output'
+require 'rex/post/meterpreter/extensions/stdapi/webcam/webcam'
+require 'rex/post/meterpreter/extensions/stdapi/sys/config'
+require 'rex/post/meterpreter/extensions/stdapi/sys/process'
+require 'rex/post/meterpreter/extensions/stdapi/sys/registry'
+require 'rex/post/meterpreter/extensions/stdapi/sys/event_log'
+require 'rex/post/meterpreter/extensions/stdapi/sys/power'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Extensions
+        module Stdapi_Webcam
+          module AudioOutput
+            include Rex::Post::Meterpreter::Extensions::Stdapi::AudioOutput
+          end
+
+          module Mic
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Mic
+          end
+
+          module Webcam
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Webcam
+          end
+
+          module Sys
+            include Rex::Post::Meterpreter::Extensions::Stdapi::Sys
+          end
+          include Rex::Post::Meterpreter::Extensions::Stdapi
+
+          ###
+          #
+          # Standard ruby interface to remote entities for meterpreter.  It provides
+          # basic access to files, network, system, and other properties of the remote
+          # machine that are fairly universal.
+          #
+          ###
+          class Stdapi_Webcam < Extension
+
+            def self.extension_id
+              Rex::Post::Meterpreter::Extensions::Stdapi::EXTENSION_ID_STDAPI
+            end
+
+            #
+            # Initializes an instance of the standard API extension.
+            #
+            def initialize(client)
+              super(client, 'stdapi_webcam')
+
+              # Alias the following things on the client object so that they
+              # can be directly referenced
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => 'audio_output',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::AudioOutput::AudioOutput.new(client)
+                  },
+                  {
+                    'name' => 'mic',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Mic::Mic.new(client)
+                  },
+                  {
+                    'name' => 'sys',
+                    'ext' => ObjectAliases.new(
+                      {
+                        'config' => Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Sys::Config.new(client),
+                        'process' => process,
+                        'registry' => registry,
+                        'eventlog' => eventlog,
+                        'power' => power
+                      }
+                    )
+                  },
+                  {
+                    'name' => 'webcam',
+                    'ext' => Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Webcam::Webcam.new(client)
+                  },
+                ]
+              )
+            end
+
+            #
+            # Sets the client instance on a duplicated copy of the supplied class.
+            #
+            def brand(klass)
+              klass = klass.dup
+              klass.client = client
+              return klass
+            end
+
+            #
+            # Returns a copy of the Process class.
+            #
+            def process
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Sys::Process)
+            end
+
+            #
+            # Returns a copy of the Registry class.
+            #
+            def registry
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Sys::Registry)
+            end
+
+            #
+            # Returns a copy of the EventLog class.
+            #
+            def eventlog
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Sys::EventLog)
+            end
+
+            #
+            # Returns a copy of the Power class.
+            #
+            def power
+              brand(Rex::Post::Meterpreter::Extensions::Stdapi_Webcam::Sys::Power)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi_webcam/stdapi_webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi_webcam/stdapi_webcam.rb
@@ -36,13 +36,6 @@ module Rex
           end
           include Rex::Post::Meterpreter::Extensions::Stdapi
 
-          ###
-          #
-          # Standard ruby interface to remote entities for meterpreter.  It provides
-          # basic access to files, network, system, and other properties of the remote
-          # machine that are fairly universal.
-          #
-          ###
           class Stdapi_Webcam < Extension
 
             def self.extension_id
@@ -50,7 +43,7 @@ module Rex
             end
 
             #
-            # Initializes an instance of the standard API extension.
+            # Initializes an instance of the Standard API (Webcam Namespace) extension.
             #
             def initialize(client)
               super(client, 'stdapi_webcam')

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1196,6 +1196,16 @@ class Console::CommandDispatcher::Core
         print_warning("The \"#{md}\" extension has already been loaded.")
         next
       end
+      
+      if extensions.include?('stdapi') && md.starts_with?('stdapi_')
+        print_error("Full extension of stdapi has already been loaded.")
+        next
+      end
+
+      if extensions.select { |e| e.starts_with?('stdapi_')}.any? && md == 'stdapi'
+        print_error("Partial extension of stdapi has already been loaded.")
+        next
+      end
 
       print("Loading extension #{md}...")
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1202,16 +1202,22 @@ class Console::CommandDispatcher::Core
         next
       end
 
-      if extensions.select { |e| e.starts_with?('stdapi_')}.any? && md == 'stdapi'
+      loaded_stdapi_namespaces = extensions.select { |e| e.starts_with?('stdapi_')}
+
+      if loaded_stdapi_namespaces.length > 0 && md == 'stdapi'
         print_error("Partial extension of stdapi has already been loaded.")
         next
       end
+
+      client_load = (md == 'stdapi_audio' && loaded_stdapi_namespaces.select {|e| ['stdapi_webcam', 'stdapi_ui'].include?(e)}.any?)
+                    (md == 'stdapi_sys'   && loaded_stdapi_namespaces.select {|e| ['stdapi_webcam', 'stdapi_ui'].include?(e)}.any?)
+                    (md == 'stdapi_webcam' && loaded_stdapi_namespaces.select {|e| ['stdapi_ui'].include?(e)}.any?)
 
       print("Loading extension #{md}...")
 
       begin
         # Use the remote side, then load the client-side
-        if (client.core.use(modulenameprovided) == true)
+        if (client_load || client.core.use(modulenameprovided) == true)
           add_extension_client(md)
 
           if md == 'stdapi' && (client.exploit_datastore && !client.exploit_datastore['AutoLoadStdapi'] && client.exploit_datastore['AutoSystemInfo'])

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1640,13 +1640,14 @@ class Console::CommandDispatcher::Core
     if status.nil?
       # Check to see if we can find this command in another extension. This relies on the core extension being the last
       # in the dispatcher stack which it should be since it's the first loaded.
-      Rex::Post::Meterpreter::ExtensionMapper.get_extension_names.each do |ext_name|
+      Rex::Post::Meterpreter::ExtensionMapper.get_extension_names.select{ | ext_name | !ext_name.starts_with?('stdapi_')}.each do |ext_name|
         next if extensions.include?(ext_name)
         ext_klass = get_extension_client_class(ext_name)
         next if ext_klass.nil?
 
         if ext_klass.has_command?(cmd)
-          print_error("The \"#{cmd}\" command requires the \"#{ext_name}\" extension to be loaded (run: `load #{ext_name}`)")
+          print_error("The \"#{cmd}\" command requires the \"#{ext_name}\" extension to be loaded (run: `load #{ext_name}`)") if ext_name != "stdapi"
+          print_error("The \"#{cmd}\" command requires the stdapi extension to be loaded or the relative subcomponent (run: `load stdapi` or `load stdapi_audio/_fs/_net/_sys/_railgun/_ui/_webcam`)") if ext_name == "stdapi"
           return :handled
         end
       end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_audio.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_audio.rb
@@ -1,0 +1,75 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+###
+#
+# Standard API extension.
+#
+###
+class Console::CommandDispatcher::Stdapi_Audio
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/mic'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output'
+
+  Klass = Console::CommandDispatcher::Stdapi_Audio
+
+  Dispatchers =
+    [
+      Console::CommandDispatcher::Stdapi::Mic,
+      Console::CommandDispatcher::Stdapi::AudioOutput
+    ]
+
+  include Console::CommandDispatcher
+
+  def self.has_command?(name)
+    Dispatchers.any? { |klass| klass.has_command?(name) }
+  end
+
+  #
+  # Initializes an instance of the stdapi command interaction.
+  #
+  def initialize(shell)
+    super
+
+    Dispatchers.each { |d|
+      shell.enstack_dispatcher(d)
+    }
+    str_dispatchers = []
+    uniq_dispatchers = []
+    idx = 0
+    while idx < shell.dispatcher_stack.length
+      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+      end
+      idx += 1
+    end
+    shell.dispatcher_stack = uniq_dispatchers
+  end
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    {
+    }
+  end
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    "Standard Audio extension"
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_audio.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_audio.rb
@@ -2,74 +2,71 @@
 require 'rex/post/meterpreter'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # Standard Audio API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Audio
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/mic'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output'
 
-###
-#
-# Standard API extension.
-#
-###
-class Console::CommandDispatcher::Stdapi_Audio
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/mic'
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output'
+          Klass = Console::CommandDispatcher::Stdapi_Audio
 
-  Klass = Console::CommandDispatcher::Stdapi_Audio
+          Dispatchers =
+            [
+              Console::CommandDispatcher::Stdapi::Mic,
+              Console::CommandDispatcher::Stdapi::AudioOutput
+            ]
 
-  Dispatchers =
-    [
-      Console::CommandDispatcher::Stdapi::Mic,
-      Console::CommandDispatcher::Stdapi::AudioOutput
-    ]
+          include Console::CommandDispatcher
 
-  include Console::CommandDispatcher
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
 
-  def self.has_command?(name)
-    Dispatchers.any? { |klass| klass.has_command?(name) }
-  end
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
 
-  #
-  # Initializes an instance of the stdapi command interaction.
-  #
-  def initialize(shell)
-    super
+            Dispatchers.each { |d|
+              shell.enstack_dispatcher(d)
+            }
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
 
-    Dispatchers.each { |d|
-      shell.enstack_dispatcher(d)
-    }
-    str_dispatchers = []
-    uniq_dispatchers = []
-    idx = 0
-    while idx < shell.dispatcher_stack.length
-      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
-        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
-        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+          #
+          # List of supported commands.
+          #
+          def commands
+            {
+            }
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            "Standard Audio extension"
+          end
+        end
       end
-      idx += 1
     end
-    shell.dispatcher_stack = uniq_dispatchers
   end
-
-  #
-  # List of supported commands.
-  #
-  def commands
-    {
-    }
-  end
-
-  #
-  # Name for this dispatcher
-  #
-  def name
-    "Standard Audio extension"
-  end
-
-end
-
-end
-end
-end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_fs.rb
@@ -2,72 +2,69 @@
 require 'rex/post/meterpreter'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # Standard Fs API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Fs
 
-###
-#
-# Standard API extension.
-#
-###
-class Console::CommandDispatcher::Stdapi_Fs
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs'
+          Klass = Console::CommandDispatcher::Stdapi_Fs
 
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs'
-  Klass = Console::CommandDispatcher::Stdapi_Fs
+          Dispatchers =
+            [
+              Console::CommandDispatcher::Stdapi::Fs,
+            ]
 
-  Dispatchers =
-    [
-      Console::CommandDispatcher::Stdapi::Fs,
-    ]
+          include Console::CommandDispatcher
 
-  include Console::CommandDispatcher
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
 
-  def self.has_command?(name)
-    Dispatchers.any? { |klass| klass.has_command?(name) }
-  end
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
 
-  #
-  # Initializes an instance of the stdapi command interaction.
-  #
-  def initialize(shell)
-    super
+            Dispatchers.each { |d|
+              shell.enstack_dispatcher(d)
+            }
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
 
-    Dispatchers.each { |d|
-      shell.enstack_dispatcher(d)
-    }
-    str_dispatchers = []
-    uniq_dispatchers = []
-    idx = 0
-    while idx < shell.dispatcher_stack.length
-      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
-        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
-        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+          #
+          # List of supported commands.
+          #
+          def commands
+            {
+            }
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            "Standard FS extension"
+          end
+        end
       end
-      idx += 1
     end
-    shell.dispatcher_stack = uniq_dispatchers
   end
-
-  #
-  # List of supported commands.
-  #
-  def commands
-    {
-    }
-  end
-
-  #
-  # Name for this dispatcher
-  #
-  def name
-    "Standard FS extension"
-  end
-
-end
-
-end
-end
-end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_fs.rb
@@ -1,0 +1,62 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+###
+#
+# Standard API extension.
+#
+###
+class Console::CommandDispatcher::Stdapi_Fs
+
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs'
+  Klass = Console::CommandDispatcher::Stdapi_Fs
+
+  Dispatchers =
+    [
+      Console::CommandDispatcher::Stdapi::Fs,
+    ]
+
+  include Console::CommandDispatcher
+
+  def self.has_command?(name)
+    Dispatchers.any? { |klass| klass.has_command?(name) }
+  end
+
+  #
+  # Initializes an instance of the stdapi command interaction.
+  #
+  def initialize(shell)
+    super
+
+    Dispatchers.each { |d|
+      shell.enstack_dispatcher(d)
+    }
+  end
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    {
+    }
+  end
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    "Standard FS extension"
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_fs.rb
@@ -37,6 +37,17 @@ class Console::CommandDispatcher::Stdapi_Fs
     Dispatchers.each { |d|
       shell.enstack_dispatcher(d)
     }
+    str_dispatchers = []
+    uniq_dispatchers = []
+    idx = 0
+    while idx < shell.dispatcher_stack.length
+      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+      end
+      idx += 1
+    end
+    shell.dispatcher_stack = uniq_dispatchers
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_net.rb
@@ -2,73 +2,70 @@
 require 'rex/post/meterpreter'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # Standard Net API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Net
 
-###
-#
-# Standard API extension.
-#
-###
-class Console::CommandDispatcher::Stdapi_Net
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net'
 
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net'
+          Klass = Console::CommandDispatcher::Stdapi_Net
 
-  Klass = Console::CommandDispatcher::Stdapi_Net
+          Dispatchers =
+            [
+              Console::CommandDispatcher::Stdapi::Net,
+            ]
 
-  Dispatchers =
-    [
-      Console::CommandDispatcher::Stdapi::Net,
-    ]
+          include Console::CommandDispatcher
 
-  include Console::CommandDispatcher
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
 
-  def self.has_command?(name)
-    Dispatchers.any? { |klass| klass.has_command?(name) }
-  end
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
 
-  #
-  # Initializes an instance of the stdapi command interaction.
-  #
-  def initialize(shell)
-    super
+            Dispatchers.each { |d|
+              shell.enstack_dispatcher(d)
+            }
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
 
-    Dispatchers.each { |d|
-      shell.enstack_dispatcher(d)
-    }
-    str_dispatchers = []
-    uniq_dispatchers = []
-    idx = 0
-    while idx < shell.dispatcher_stack.length
-      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
-        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
-        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+          #
+          # List of supported commands.
+          #
+          def commands
+            {
+            }
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            "Standard Net extension"
+          end
+        end
       end
-      idx += 1
     end
-    shell.dispatcher_stack = uniq_dispatchers
   end
-
-  #
-  # List of supported commands.
-  #
-  def commands
-    {
-    }
-  end
-
-  #
-  # Name for this dispatcher
-  #
-  def name
-    "Standard Net extension"
-  end
-
-end
-
-end
-end
-end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_net.rb
@@ -1,0 +1,63 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+###
+#
+# Standard API extension.
+#
+###
+class Console::CommandDispatcher::Stdapi_Net
+
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net'
+
+  Klass = Console::CommandDispatcher::Stdapi_Net
+
+  Dispatchers =
+    [
+      Console::CommandDispatcher::Stdapi::Net,
+    ]
+
+  include Console::CommandDispatcher
+
+  def self.has_command?(name)
+    Dispatchers.any? { |klass| klass.has_command?(name) }
+  end
+
+  #
+  # Initializes an instance of the stdapi command interaction.
+  #
+  def initialize(shell)
+    super
+
+    Dispatchers.each { |d|
+      shell.enstack_dispatcher(d)
+    }
+  end
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    {
+    }
+  end
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    "Standard Net extension"
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_net.rb
@@ -38,6 +38,17 @@ class Console::CommandDispatcher::Stdapi_Net
     Dispatchers.each { |d|
       shell.enstack_dispatcher(d)
     }
+    str_dispatchers = []
+    uniq_dispatchers = []
+    idx = 0
+    while idx < shell.dispatcher_stack.length
+      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+      end
+      idx += 1
+    end
+    shell.dispatcher_stack = uniq_dispatchers
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_railgun.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_railgun.rb
@@ -2,70 +2,68 @@
 require 'rex/post/meterpreter'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
+  module Post
+    module Meterpreter
+      module Ui
 
-###
-#
-# Standard API extension.
-#
-###
-class Console::CommandDispatcher::Stdapi_Railgun
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+        ###
+        #
+        # Standard Railgun API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Railgun
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
 
-  Klass = Console::CommandDispatcher::Stdapi_Railgun
+          Klass = Console::CommandDispatcher::Stdapi_Railgun
 
-  Dispatchers =
-    [
-    ]
+          Dispatchers =
+            [
+            ]
 
-  include Console::CommandDispatcher
+          include Console::CommandDispatcher
 
-  def self.has_command?(name)
-    Dispatchers.any? { |klass| klass.has_command?(name) }
-  end
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
 
-  #
-  # Initializes an instance of the stdapi command interaction.
-  #
-  def initialize(shell)
-    super
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
 
-    Dispatchers.each { |d|
-      shell.enstack_dispatcher(d)
-    }
-    str_dispatchers = []
-    uniq_dispatchers = []
-    idx = 0
-    while idx < shell.dispatcher_stack.length
-      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
-        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
-        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+            Dispatchers.each { |d|
+              shell.enstack_dispatcher(d)
+            }
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            {
+            }
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            "Standard Railgun extension"
+          end
+        end
       end
-      idx += 1
     end
-    shell.dispatcher_stack = uniq_dispatchers
   end
-
-  #
-  # List of supported commands.
-  #
-  def commands
-    {
-    }
-  end
-
-  #
-  # Name for this dispatcher
-  #
-  def name
-    "Standard Railgun extension"
-  end
-
-end
-
-end
-end
-end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_railgun.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_railgun.rb
@@ -1,0 +1,71 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+###
+#
+# Standard API extension.
+#
+###
+class Console::CommandDispatcher::Stdapi_Railgun
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+
+  Klass = Console::CommandDispatcher::Stdapi_Railgun
+
+  Dispatchers =
+    [
+    ]
+
+  include Console::CommandDispatcher
+
+  def self.has_command?(name)
+    Dispatchers.any? { |klass| klass.has_command?(name) }
+  end
+
+  #
+  # Initializes an instance of the stdapi command interaction.
+  #
+  def initialize(shell)
+    super
+
+    Dispatchers.each { |d|
+      shell.enstack_dispatcher(d)
+    }
+    str_dispatchers = []
+    uniq_dispatchers = []
+    idx = 0
+    while idx < shell.dispatcher_stack.length
+      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+      end
+      idx += 1
+    end
+    shell.dispatcher_stack = uniq_dispatchers
+  end
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    {
+    }
+  end
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    "Standard Railgun extension"
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_sys.rb
@@ -2,72 +2,71 @@
 require 'rex/post/meterpreter'
 
 module Rex
-module Post
-module Meterpreter
-module Ui
+  module Post
+    module Meterpreter
+      module Ui
 
-###
-#
-# Standard API extension.
-#
-###
-class Console::CommandDispatcher::Stdapi_Sys
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
-  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys'
+        ###
+        #
+        # Standard Sys API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Sys
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys'
 
-  Klass = Console::CommandDispatcher::Stdapi_Sys
+          Klass = Console::CommandDispatcher::Stdapi_Sys
 
-  Dispatchers =
-    [
-      Console::CommandDispatcher::Stdapi::Sys,
-    ]
+          Dispatchers =
+            [
+              Console::CommandDispatcher::Stdapi::Sys,
+            ]
 
-  include Console::CommandDispatcher
+          include Console::CommandDispatcher
 
-  def self.has_command?(name)
-    Dispatchers.any? { |klass| klass.has_command?(name) }
-  end
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
 
-  #
-  # Initializes an instance of the stdapi command interaction.
-  #
-  def initialize(shell)
-    super
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
 
-    Dispatchers.each { |d|
-      shell.enstack_dispatcher(d)
-    }
-    str_dispatchers = []
-    uniq_dispatchers = []
-    idx = 0
-    while idx < shell.dispatcher_stack.length
-      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
-        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
-        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+            Dispatchers.each { |d|
+              shell.enstack_dispatcher(d)
+            }
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            {
+            }
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            "Standard Sys extension"
+          end
+
+        end
       end
-      idx += 1
     end
-    shell.dispatcher_stack = uniq_dispatchers
   end
-
-  #
-  # List of supported commands.
-  #
-  def commands
-    {
-    }
-  end
-
-  #
-  # Name for this dispatcher
-  #
-  def name
-    "Standard Sys extension"
-  end
-
-end
-
-end
-end
-end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_sys.rb
@@ -1,0 +1,73 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+###
+#
+# Standard API extension.
+#
+###
+class Console::CommandDispatcher::Stdapi_Sys
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+  require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys'
+
+  Klass = Console::CommandDispatcher::Stdapi_Sys
+
+  Dispatchers =
+    [
+      Console::CommandDispatcher::Stdapi::Sys,
+    ]
+
+  include Console::CommandDispatcher
+
+  def self.has_command?(name)
+    Dispatchers.any? { |klass| klass.has_command?(name) }
+  end
+
+  #
+  # Initializes an instance of the stdapi command interaction.
+  #
+  def initialize(shell)
+    super
+
+    Dispatchers.each { |d|
+      shell.enstack_dispatcher(d)
+    }
+    str_dispatchers = []
+    uniq_dispatchers = []
+    idx = 0
+    while idx < shell.dispatcher_stack.length
+      unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+        str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+        uniq_dispatchers.push(shell.dispatcher_stack[idx])
+      end
+      idx += 1
+    end
+    shell.dispatcher_stack = uniq_dispatchers
+  end
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    {
+    }
+  end
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    "Standard Sys extension"
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_ui.rb
@@ -8,7 +8,7 @@ module Rex
       module Ui
         ###
         #
-        # Standard API extension.
+        # Standard Ui API extension.
         #
         ###
         class Console::CommandDispatcher::Stdapi_Ui

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_ui.rb
@@ -1,0 +1,71 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # Standard API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Ui
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui'
+
+          Klass = Console::CommandDispatcher::Stdapi_Ui
+
+          Dispatchers =
+            [
+              Console::CommandDispatcher::Stdapi::Ui,
+            ]
+
+          include Console::CommandDispatcher
+
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
+
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
+
+            Dispatchers.each do |d|
+              shell.enstack_dispatcher(d)
+            end
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            {}
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            'Standard Ui extension'
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_webcam.rb
@@ -8,7 +8,7 @@ module Rex
       module Ui
         ###
         #
-        # Standard API extension.
+        # Standard Webcam API extension.
         #
         ###
         class Console::CommandDispatcher::Stdapi_Webcam

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi_webcam.rb
@@ -1,0 +1,71 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter'
+
+module Rex
+  module Post
+    module Meterpreter
+      module Ui
+        ###
+        #
+        # Standard API extension.
+        #
+        ###
+        class Console::CommandDispatcher::Stdapi_Webcam
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi'
+          require 'rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam'
+
+          Klass = Console::CommandDispatcher::Stdapi_Webcam
+
+          Dispatchers =
+            [
+              Console::CommandDispatcher::Stdapi::Webcam,
+            ]
+
+          include Console::CommandDispatcher
+
+          def self.has_command?(name)
+            Dispatchers.any? { |klass| klass.has_command?(name) }
+          end
+
+          #
+          # Initializes an instance of the stdapi command interaction.
+          #
+          def initialize(shell)
+            super
+
+            Dispatchers.each do |d|
+              shell.enstack_dispatcher(d)
+            end
+            str_dispatchers = []
+            uniq_dispatchers = []
+            idx = 0
+            while idx < shell.dispatcher_stack.length
+              unless str_dispatchers.include?(shell.dispatcher_stack[idx].class.to_s)
+                str_dispatchers.push(shell.dispatcher_stack[idx].class.to_s)
+                uniq_dispatchers.push(shell.dispatcher_stack[idx])
+              end
+              idx += 1
+            end
+            shell.dispatcher_stack = uniq_dispatchers
+          end
+
+          #
+          # List of supported commands.
+          #
+          def commands
+            {}
+          end
+
+          #
+          # Name for this dispatcher
+          #
+          def name
+            'Standard Webcam extension'
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.232'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.234'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.45'
   # Needed by msfgui and other rpc components

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.221'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.232'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.45'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 34928
+  CachedSize = 36032
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 177734
+  CachedSize = 188998
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 177734
+  CachedSize = 188998
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 178780
+  CachedSize = 190044
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 178780
+  CachedSize = 190044
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 177734
+  CachedSize = 188998
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 251982
+  CachedSize = 188998
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 177734
+  CachedSize = 251982
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 203846
+  CachedSize = 230982
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 203846
+  CachedSize = 230982
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 204892
+  CachedSize = 232028
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 204892
+  CachedSize = 232028
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 203846
+  CachedSize = 230982
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 203846
+  CachedSize = 291406
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 291406
+  CachedSize = 230982
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows


### PR DESCRIPTION
Framework side PR for https://github.com/rapid7/metasploit-payloads/pull/744

This PR allows to load portion of `stdapi` by using namespace-specific dlls.

- [ ] Make sure meterpreter with default `AutoLoadExtension` values works
- [ ] Make sure meterpreter with empty `AutoLoadExtension` and load different `stdapi_` extensions
- [ ] Make sure linux meterpreter still works
- [ ] Make sure the embedded extensions still works
```
msf6 payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > help

Core Commands
=============

    Command                   Description
    -------                   -----------
    ?                         Help menu
    background                Backgrounds the current session
    bg                        Alias for background
    bgkill                    Kills a background meterpreter script
    bglist                    Lists running background scripts
    bgrun                     Executes a meterpreter script as a background thread
    channel                   Displays information or control active channels
    close                     Closes a channel
    detach                    Detach the meterpreter session (for http/https)
    disable_unicode_encoding  Disables encoding of unicode strings
    enable_unicode_encoding   Enables encoding of unicode strings
    exit                      Terminate the meterpreter session
    get_timeouts              Get the current session timeout values
    guid                      Get the session GUID
    help                      Help menu
    info                      Displays information about a Post module
    irb                       Open an interactive Ruby shell on the current session
    load                      Load one or more meterpreter extensions
    machine_id                Get the MSF ID of the machine attached to the session
    migrate                   Migrate the server to another process
    pivot                     Manage pivot listeners
    pry                       Open the Pry debugger on the current session
    quit                      Terminate the meterpreter session
    read                      Reads data from a channel
    resource                  Run the commands stored in a file
    run                       Executes a meterpreter script or Post module
    secure                    (Re)Negotiate TLV packet encryption on the session
    sessions                  Quickly switch to another session
    set_timeouts              Set the current session timeout values
    sleep                     Force Meterpreter to go quiet, then re-establish session
    ssl_verify                Modify the SSL certificate verification setting
    transport                 Manage the transport mechanisms
    use                       Deprecated alias for "load"
    uuid                      Get the UUID for the current session
    write                     Writes data to a channel

For more info on a specific command, use <command> -h or help <command>.

meterpreter > ls
[-] The "ls" command requires the "stdapi_fs" extension to be loaded (run: `load stdapi_fs`)
meterpreter > load stdapi_fs
Loading extension stdapi_fs...WARNING: Local file /home/kali/Documents/github/metasploit-framework/data/meterpreter/ext_server_stdapi_fs.x64.dll is being used
Success.
meterpreter > help

Core Commands
=============

    Command                   Description
    -------                   -----------
    ?                         Help menu
    background                Backgrounds the current session
    bg                        Alias for background
    ...
    write                     Writes data to a channel


Stdapi: File system Commands
============================

    Command                   Description
    -------                   -----------
    cat                       Read the contents of a file to the screen
    cd                        Change directory
    checksum                  Retrieve the checksum of a file
    cp                        Copy source to destination
    del                       Delete the specified file
    dir                       List files (alias for ls)
    download                  Download a file or directory
    edit                      Edit a file
    getlwd                    Print local working directory (alias for lpwd)
    getwd                     Print working directory
    lcat                      Read the contents of a local file to the screen
    lcd                       Change local working directory
    ldir                      List local files (alias for lls)
    lls                       List local files
    lmkdir                    Create new directory on local machine
    lpwd                      Print local working directory
    ls                        List files
    mkdir                     Make directory
    mv                        Move source to destination
    pwd                       Print working directory
    rm                        Delete the specified file
    rmdir                     Remove directory
    search                    Search for files
    show_mount                List all mount points/logical drives
    upload                    Upload a file or directory

For more info on a specific command, use <command> -h or help <command>.

meterpreter > sysinfo
[-] The "sysinfo" command requires the "stdapi_sys" extension to be loaded (run: `load stdapi_sys`)
meterpreter > load stdapi_sys
Loading extension stdapi_sys...WARNING: Local file /home/kali/Documents/github/metasploit-framework/data/meterpreter/ext_server_stdapi_sys.x64.dll is being used
Success.
meterpreter > help

Core Commands
=============

    Command                   Description
    -------                   -----------
    ?                         Help menu
    background                Backgrounds the current session
    bg                        Alias for background
    ....
    write                     Writes data to a channel


Stdapi: File system Commands
============================

    Command                   Description
    -------                   -----------
    cat                       Read the contents of a file to the screen
    cd                        Change directory
    ...
    upload                    Upload a file or directory


Stdapi: System Commands
=======================

    Command                   Description
    -------                   -----------
    clearev                   Clear the event log
    drop_token                Relinquishes any active impersonation token.
    execute                   Execute a command
    getenv                    Get one or more environment variable values
    getpid                    Get the current process identifier
    getprivs                  Attempt to enable all privileges available to the current process
    getsid                    Get the SID of the user that the server is running as
    getuid                    Get the user that the server is running as
    kill                      Terminate a process
    localtime                 Displays the target system local date and time
    pgrep                     Filter processes by name
    pkill                     Terminate processes by name
    ps                        List running processes
    reboot                    Reboots the remote computer
    reg                       Modify and interact with the remote registry
    rev2self                  Calls RevertToSelf() on the remote machine
    shell                     Drop into a system command shell
    shutdown                  Shuts down the remote computer
    steal_token               Attempts to steal an impersonation token from the target process
    suspend                   Suspends or resumes a list of processes
    sysinfo                   Gets information about the remote system, such as OS

For more info on a specific command, use <command> -h or help <command>.

meterpreter > arp
[-] The "arp" command requires the "stdapi_net" extension to be loaded (run: `load stdapi_net`)
meterpreter > load stdapi_net
Loading extension stdapi_net...WARNING: Local file /home/kali/Documents/github/metasploit-framework/data/meterpreter/ext_server_stdapi_net.x64.dll is being used
Success.
meterpreter > help

Core Commands
=============

    Command                   Description
    -------                   -----------
    ?                         Help menu
    background                Backgrounds the current session
    bg                        Alias for background
    ...
    write                     Writes data to a channel


Stdapi: File system Commands
============================

    Command                   Description
    -------                   -----------
    cat                       Read the contents of a file to the screen
    cd                        Change directory
    ...
    upload                    Upload a file or directory


Stdapi: System Commands
=======================

    Command                   Description
    -------                   -----------
    clearev                   Clear the event log
    drop_token                Relinquishes any active impersonation token.
    ...
    sysinfo                   Gets information about the remote system, such as OS


Stdapi: Networking Commands
===========================

    Command                   Description
    -------                   -----------
    arp                       Display the host ARP cache
    getproxy                  Display the current proxy configuration
    ifconfig                  Display interfaces
    ipconfig                  Display interfaces
    netstat                   Display the network connections
    portfwd                   Forward a local port to a remote service
    resolve                   Resolve a set of host names on the target
    route                     View and modify the routing table

For more info on a specific command, use <command> -h or help <command>.

meterpreter > ls
Listing: C:\Users\User
======================

Mode              Size     Type  Last modified              Name
----              ----     ----  -------------              ----
040777/rwxrwxrwx  0        dir   2024-09-10 04:48:08 -0400  .chocolatey
100666/rw-rw-rw-  20       fil   2025-03-11 10:59:44 -0400  .lesshst
040777/rwxrwxrwx  0        dir   2024-09-23 06:11:45 -0400  .ssh
040777/rwxrwxrwx  0        dir   2024-09-19 09:00:41 -0400  .vscode
040777/rwxrwxrwx  0        dir   2024-09-06 09:11:30 -0400  AppData
040777/rwxrwxrwx  0        dir   2024-09-06 09:11:30 -0400  Application Data
040555/r-xr-xr-x  0        dir   2024-09-06 09:22:22 -0400  Contacts
040777/rwxrwxrwx  0        dir   2024-09-06 09:11:30 -0400  Cookies
040555/r-xr-xr-x  4096     dir   2025-02-20 09:09:11 -0500  Desktop
040555/r-xr-xr-x  4096     dir   2024-09-24 08:33:33 -0400  Documents
040555/r-xr-xr-x  4096     dir   2025-02-18 06:38:23 -0500  Downloads
040555/r-xr-xr-x  0        dir   2024-09-06 09:22:22 -0400  Favorites
040555/r-xr-xr-x  0        dir   2024-09-06 09:22:22 -0400  Links
040777/rwxrwxrwx  0        dir   2024-09-06 09:11:30 -0400  Local Settings
040555/r-xr-xr-x  0        dir   2024-09-06 09:22:22 -0400  Music
040777/rwxrwxrwx  0        dir   2024-09-06 09:11:30 -0400  My Documents
.....
040777/rwxrwxrwx  0        dir   2024-09-11 08:13:29 -0400  source

meterpreter > sysinfo
Computer        : WINVM01
OS              : Windows 11 (10.0 Build 22631).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > arp

ARP cache
=========

    IP address       MAC address        Interface
    ----------       -----------        ---------
    224.0.0.22       00:00:00:00:00:00  Software Loopback Interface 1
    239.255.255.250  00:00:00:00:00:00  Software Loopback Interface 1
    ....
    255.255.255.255  ff:ff:ff:ff:ff:ff  Microsoft Hyper-V Network Adapter

meterpreter >
```
