### PR TITLE
Feat/lib/adcs mm updates/2

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -13,7 +13,7 @@ module SessionDataProxy
   def report_session(opts)
     begin
       self.data_service_operation do |data_service|
-        add_opts_workspace(opts)
+        add_opts_workspace(opts, opts.fetch(:workspace, opts[:session]&.workspace))
         data_service.report_session(opts)
       end
     rescue => e

--- a/lib/msf/base/sessions/ldap.rb
+++ b/lib/msf/base/sessions/ldap.rb
@@ -42,7 +42,17 @@ class Msf::Sessions::LDAP
     session = self
     session.init_ui(user_input, user_output)
 
-    @info = "LDAP #{datastore['USERNAME']} @ #{@peer_info}"
+    username = datastore['USERNAME']
+    if username.blank?
+      begin
+        whoami = client.ldapwhoami
+      rescue Net::LDAP::Error => e
+        ilog('ldap session opened with no username and the target does not support the LDAP whoami extension')
+      else
+        username = whoami.delete_prefix('u:').split('\\').last
+      end
+    end
+    @info = "LDAP #{username} @ #{@peer_info}"
   end
 
   def execute_file(full_path, args)

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -307,13 +307,14 @@ module Auxiliary::Report
 
     # report_vuln is only called in an identified case, consider setting value reported here
     attempt_info = {
+        :workspace    => opts[:workspace],
         :vuln_id      => vuln.id,
         :attempted_at => timestamp || Time.now.utc,
         :exploited    => false,
         :fail_detail  => 'vulnerability identified',
         :fail_reason  => 'Untried', # Mdm::VulnAttempt::Status::UNTRIED, avoiding direct dependency on Mdm, used elsewhere in this module
         :module       => mname,
-        :username     => username  || "unknown",
+        :username     => username  || "unknown"
     }
 
     # TODO: figure out what opts are required and why the above logic doesn't match that of the db_manager method

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -30,6 +30,7 @@ module Exploit::Remote::MsIcpr
   class MsIcprError < StandardError; end
   class MsIcprConnectionError < MsIcprError; end
   class MsIcprAuthenticationError < MsIcprError; end
+  class MsIcprAuthorizationError < MsIcprError; end
   class MsIcprNotFoundError < MsIcprError; end
   class MsIcprUnexpectedReplyError < MsIcprError; end
   class MsIcprUnknownError < MsIcprError; end
@@ -91,7 +92,7 @@ module Exploit::Remote::MsIcpr
     rescue RubySMB::Error::UnexpectedStatusCode => e
       if e.status_code == ::WindowsError::NTStatus::STATUS_OBJECT_NAME_NOT_FOUND
         # STATUS_OBJECT_NAME_NOT_FOUND will be the status if Active Directory Certificate Service (AD CS) is not installed on the target
-        raise MsIcprNotFoundError, 'Connection failed (AD CS was not found)'
+        raise MsIcprNotFoundError, 'Connection failed (AD CS was not found).'
       end
 
       elog(e.message, error: e)
@@ -191,6 +192,17 @@ module Exploit::Remote::MsIcpr
         print_error('Error details:')
         print_error("  Source:  #{hresult.facility}") if hresult.facility
         print_error("  HRESULT: #{hresult}")
+      end
+
+      case hresult
+      when ::WindowsError::HResult::CERTSRV_E_ENROLL_DENIED
+        raise MsIcprAuthorizationError.new(hresult.description)
+      when ::WindowsError::HResult::CERTSRV_E_TEMPLATE_DENIED
+        raise MsIcprAuthorizationError.new(hresult.description)
+      when ::WindowsError::HResult::CERTSRV_E_UNSUPPORTED_CERT_TYPE
+        raise MsIcprNotFoundError.new(hresult.description)
+      else
+        raise MsIcprUnknownError.new(hresult.description)
       end
     end
 

--- a/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
@@ -139,9 +139,9 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-  rescue MsSamrConnectionError, MsIcprConnectionError => e
+  rescue MsSamrConnectionError, MsIcprConnectionError, SmbIpcConnectionError => e
     fail_with(Failure::Unreachable, e.message)
-  rescue MsSamrAuthenticationError, MsIcprAuthenticationError => e
+  rescue MsSamrAuthenticationError, MsIcprAuthenticationError, MsIcprAuthorizationError, SmbIpcAuthenticationError => e
     fail_with(Failure::NoAccess, e.message)
   rescue MsSamrNotFoundError, MsIcprNotFoundError => e
     fail_with(Failure::NotFound, e.message)

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -51,9 +51,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     send("action_#{action.name.downcase}")
-  rescue MsIcprConnectionError => e
+  rescue MsIcprConnectionError, SmbIpcConnectionError => e
     fail_with(Failure::Unreachable, e.message)
-  rescue MsIcprAuthenticationError => e
+  rescue MsIcprAuthenticationError, MsIcprAuthorizationError, SmbIpcAuthenticationError => e
     fail_with(Failure::NoAccess, e.message)
   rescue MsIcprNotFoundError => e
     fail_with(Failure::NotFound, e.message)

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -616,16 +616,17 @@ class MetasploitModule < Msf::Auxiliary
           info = nil if info.blank?
 
           hash[:ca_servers].each_value do |ca_server|
-            service = report_service({
+            service = report_service(
               host: ca_server[:ip_address],
               port: 445,
               proto: 'tcp',
               name: 'AD CS',
               info: "AD CS CA name: #{ca_server[:name]}"
-            })
+            )
 
             if ca_server[:ip_address].present?
               vuln = report_vuln(
+                workspace: myworkspace,
                 host: ca_server[:ip_address],
                 port: 445,
                 proto: 'tcp',

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -218,9 +218,16 @@ class MetasploitModule < Msf::Auxiliary
   def map_sids_to_names(sids_array)
     mapped = []
     sids_array.each do |sid|
-      # this common SID doesn't always have an entry
-      if sid == Rex::Proto::Secauthz::WellKnownSids::SECURITY_AUTHENTICATED_USER_SID
+      # these common SIDs don't always have an entry
+      case sid
+      when Rex::Proto::Secauthz::WellKnownSids::SECURITY_AUTHENTICATED_USER_SID
         mapped << SID.new(sid, 'Authenticated Users')
+        next
+      when Rex::Proto::Secauthz::WellKnownSids::SECURITY_ENTERPRISE_CONTROLLERS_SID
+        mapped << SID.new(sid, 'Enterprise Domain Controllers')
+        next
+      when Rex::Proto::Secauthz::WellKnownSids::SECURITY_LOCAL_SYSTEM_SID
+        mapped << SID.new(sid, 'Local System')
         next
       end
 

--- a/spec/lib/msf/base/sessions/ldap_spec.rb
+++ b/spec/lib/msf/base/sessions/ldap_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Msf::Sessions::LDAP do
     allow(client).to receive(:peerinfo).and_return(peer_info)
     allow(client).to receive(:peerhost).and_return(address)
     allow(client).to receive(:peerport).and_return(port)
+    allow(client).to receive(:ldapwhoami).and_return("u:WORKGROUP\\Administrator")
   end
 
   it_behaves_like 'client session'


### PR DESCRIPTION
This improves AD CS workflows by adding:
* additional well-known SIDs that aren't always able to be mapped in AD
* additional error handling, particularly for throwing authorization errors so when the user does not have the necessary permissions, it's propagated upwards
* additional error handling for catching exceptions


## Verification

List the steps needed to make sure this thing works

- [x] Test the `ldap_esc_vulnerable_cert` finder module still works
- [x] Test the `icpr_cert` module
    - [x] Try and issue a certificate like `SubCA` where you (probably) don't have the permissions and see that it fails with `no-access` after throwing the new `MsIcprAuthorizationError`
    - [x] Try and connect to a bad host, see that you get a connection error instead of a stack trace

