### PR TITLE
Add TeamCity Login Scanner spec test

### DIFF
--- a/lib/metasploit/framework/login_scanner/teamcity.rb
+++ b/lib/metasploit/framework/login_scanner/teamcity.rb
@@ -125,7 +125,9 @@ module Metasploit
         LIKELY_SERVICE_NAMES = [
           # Comes from nmap 7.95 on MacOS
           'skynetflow',
-          'teamcity'
+          'teamcity',
+          'http',
+          'https'
         ]
         PRIVATE_TYPES        = [:password]
         REALM_KEY            = nil

--- a/spec/modules/auxiliary/scanner/teamcity/teamcity_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/teamcity/teamcity_login_spec.rb
@@ -3,6 +3,10 @@ require 'metasploit/framework/login_scanner/teamcity'
 
 RSpec.describe Metasploit::Framework::LoginScanner::TeamCity do
 
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base', has_realm_key: false, has_default_realm: false
+  it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+  it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
+
   let(:subject) { described_class.new }
 
   # Sample public key taken from a running instance of TeamCity


### PR DESCRIPTION
This is a quick PR to add in the base Login Scanner tests for TeamCity, which I have missed on the initial iteration and only implemented unit tests.

This PR also adds in the `http` and `https` service tags to allow the login scanner to be run in Pro automatically, allowing us to revert the explicit TeamCity service tag.

## Verification

- [x] Start `msfconsole`
- [x] Set up a TeamCity server
- [x] `use teamcity login_scanner`
- [x] Run the module
- [x] **Verify** it works
- [x] **Verify** I did not break the module