### PR TITLE
Update the Ivanti and Sonicwall Bruteforce modules

### DIFF
--- a/documentation/modules/auxiliary/scanner/ivanti/ivanti_login.md
+++ b/documentation/modules/auxiliary/scanner/ivanti/ivanti_login.md
@@ -9,7 +9,7 @@ It allows to attack both regular user and admin as well - you can select which t
 
 ## Verification Steps
 
-1. `use auxiliary/scanner/ivanti/login_scanner`
+1. `use auxiliary/scanner/ivanti/ivanti_login`
 2. `set RHOSTS [IP]`
 3. either `set USERNAME [username]` or `set USERPASS_FILE [usernames file]`
 4. either `set PASSWORD [password]` or `set PASS_FILE [passwords file]`

--- a/documentation/modules/auxiliary/scanner/sonicwall/sonicwall_login.md
+++ b/documentation/modules/auxiliary/scanner/sonicwall/sonicwall_login.md
@@ -1,7 +1,7 @@
 ## Description
 
-The module performs bruteforce attack against SonicWall NSv (Network Security Virtual).
-It allows to attack both regular SSLVPN user and admin as well. The module will automatically perform attack against SSLVPN user if `DOMAIN` parameter is not empty.
+The module will perform a bruteforce attack against SonicWall NSv (Network Security Virtual).
+It allows attacking both regular SSLVPN users and as well as admins. The module will automatically target SSLVPN users if the `DOMAIN` parameter is not empty.
 
 ## Vulnerable Application
 
@@ -9,7 +9,7 @@ It allows to attack both regular SSLVPN user and admin as well. The module will 
 
 ## Verification Steps
 
-1. `use auxiliary/scanner/sonicwall/login_scanner`
+1. `use auxiliary/scanner/sonicwall/sonicwall_login`
 2. `set RHOSTS [IP]`
 3. either `set USERNAME [username]` or `set USERPASS_FILE [usernames file]`
 4. either `set PASSWORD [password]` or `set PASS_FILE [passwords file]`

--- a/lib/metasploit/framework/login_scanner/ivanti_login.rb
+++ b/lib/metasploit/framework/login_scanner/ivanti_login.rb
@@ -16,10 +16,7 @@ module Metasploit
         PRIVATE_TYPES = [:password]
         REALM_KEY = nil
 
-        def initialize(scanner_config, admin)
-          @admin = admin
-          super(scanner_config)
-        end
+        attr_accessor :use_admin_endpoint
 
         def check_setup
           request_params = {
@@ -138,7 +135,7 @@ module Metasploit
 
         def do_login(username, password)
           protocol = ssl ? 'https' : 'http'
-          peer = "#{host}:#{port}"
+          peer = Rex::Socket.to_authority(host, port)
           user_req = create_user_request(username, password, protocol, peer)
           begin
             res = send_request(user_req)
@@ -178,7 +175,7 @@ module Metasploit
             service_name: 'ivanti'
           }
 
-          if @admin
+          if @use_admin_endpoint
             login_result = do_admin_login(credential.public, credential.private)
           else
             login_result = do_login(credential.public, credential.private)

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -16,10 +16,7 @@ module Metasploit
         PRIVATE_TYPES = [:password]
         REALM_KEY = nil
 
-        def initialize(scanner_config, domain)
-          @domain = domain
-          super(scanner_config)
-        end
+        attr_accessor :domain
 
         def req_params_base
           {
@@ -38,7 +35,7 @@ module Metasploit
           # Admin and SSLVPN user login procedure differs only in usage of domain field in JSON data
           #
           params.merge!({
-            'data' => JSON.pretty_generate(@domain.empty? ? {
+            'data' => JSON.pretty_generate(@domain.blank? ? {
               'override' => false,
               'snwl' => true
             } : { 'domain' => @domain, 'override' => false, 'snwl' => true })

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -95,7 +95,11 @@ module Metasploit
           return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Waiting too long in lockout' } if depth >= 2
 
           #-- get authentication details from first request
-          res = get_auth_details(username, password)
+          begin
+            res = get_auth_details(username, password)
+          rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError => e
+            return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e }
+          end
 
           return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Invalid response' } unless res
           return { status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Failed to receive a authentication details' } unless res&.headers && res.headers.key?('X-SNWL-Authenticate')

--- a/modules/auxiliary/scanner/ivanti/ivanti_login.rb
+++ b/modules/auxiliary/scanner/ivanti/ivanti_login.rb
@@ -9,13 +9,16 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::ReportSummary
 
+  include Msf::Exploit::Deprecated
+  moved_from 'auxiliary/scanner/ivanti/login_scanner'
+
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Ivanti Connect Secure HTTP Scanner',
         'Description' => %q{
-          This module will perform authentication scanning against Ivanti Connect Secure
+          This module will perform authentication scanning against Ivanti Connect Secure.
         },
         'Author' => ['msutovsky-r7'],
         'License' => MSF_LICENSE,

--- a/modules/auxiliary/scanner/ivanti/login_scanner.rb
+++ b/modules/auxiliary/scanner/ivanti/login_scanner.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       )
          )
     register_options([
-      OptBool.new('ADMIN', [true, 'Select whether to test admin account', false])
+      OptBool.new('ADMIN', [true, 'Select whether to target the admin login endpoint', false])
     ])
   end
 
@@ -51,9 +51,10 @@ class MetasploitModule < Msf::Auxiliary
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: datastore['HttpClientTimeout'] || 5
+      connection_timeout: datastore['HttpClientTimeout'] || 5,
+      use_admin_endpoint: datastore['ADMIN']
     )
-    return Metasploit::Framework::LoginScanner::Ivanti.new(configuration, datastore['ADMIN'])
+    return Metasploit::Framework::LoginScanner::Ivanti.new(configuration)
   end
 
   def process_credential(credential_data)

--- a/modules/auxiliary/scanner/sonicwall/sonicwall_login.rb
+++ b/modules/auxiliary/scanner/sonicwall/sonicwall_login.rb
@@ -8,6 +8,9 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
+  include Msf::Exploit::Deprecated
+  moved_from 'auxiliary/scanner/sonicwall/login_scanner'
+
   def initialize(info = {})
     super(
       update_info(
@@ -47,9 +50,10 @@ class MetasploitModule < Msf::Auxiliary
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: datastore['HttpClientTimeout']
+      connection_timeout: datastore['HttpClientTimeout'],
+      domain: datastore['DOMAIN']
     )
-    Metasploit::Framework::LoginScanner::SonicWall.new(configuration, datastore['DOMAIN'])
+    Metasploit::Framework::LoginScanner::SonicWall.new(configuration)
   end
 
   def process_credential(credential_data)


### PR DESCRIPTION
This updates the Ivanti and Sonicwall Bruteforce modules to use an `#initialize` method that accepts a single argument as the LoginScanner classes should. It also renames them to be consistent with other bruteforce modules that are named after their service and suffixed with `_login`.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ivanti/ivanti_login`
- [x] Test that the module still works
