### PR TITLE
Add some more LoginScanner tests

### DIFF
--- a/lib/metasploit/framework/login_scanner.rb
+++ b/lib/metasploit/framework/login_scanner.rb
@@ -19,15 +19,7 @@ module Metasploit
       #   classes that will probably give useful results when run
       #   against `service`.
       def self.classes_for_service(service)
-
-        unless @required
-          # Make sure we've required all the scanner classes
-          dir = File.expand_path("../login_scanner/", __FILE__)
-          Dir.glob(File.join(dir, "*.rb")).each do |f|
-            require f if File.file?(f)
-          end
-          @required = true
-        end
+        require_login_scanners
 
         self.constants.map{|sym| const_get(sym)}.select do |const|
           next unless const.kind_of?(Class)
@@ -42,6 +34,34 @@ module Metasploit
         end
       end
 
+      def self.all_service_names
+        require_login_scanners
+
+        service_names = Set.new
+        self.constants.map{|sym| const_get(sym)}.select do |const|
+          next unless const.kind_of?(Class)
+          next unless const.const_defined?(:LIKELY_SERVICE_NAMES)
+
+          const.const_get(:LIKELY_SERVICE_NAMES).each do |service_name|
+            service_names << service_name
+          end
+        end
+
+        service_names
+      end
+      
+      private
+      
+      def self.require_login_scanners
+        unless @required
+          # Make sure we've required all the scanner classes
+          dir = File.expand_path("../login_scanner/", __FILE__)
+          Dir.glob(File.join(dir, "*.rb")).each do |f|
+            require f if File.file?(f)
+          end
+          @required = true
+        end
+      end
     end
   end
 end

--- a/spec/lib/metasploit/framework/login_scanner_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner_spec.rb
@@ -53,4 +53,57 @@ RSpec.describe Metasploit::Framework::LoginScanner do
     end
   end
 
+  describe '.all_service_names' do
+    let(:service_names) { described_class.all_service_names }
+
+    it 'returns a set of service names' do
+      expect(service_names).to be_a Set
+    end
+
+    it 'returns a populated set' do
+      expect(service_names).to_not be_empty
+    end
+
+    it 'includes common services names' do
+      expect(service_names).to include 'http'
+      expect(service_names).to include 'https'
+      expect(service_names).to include 'smb'
+    end
+  end
+
+  describe '.classes_for_service' do
+    described_class.all_service_names.each do |service_name|
+      context "with service #{service_name}" do
+        let(:name) { service_name }
+        let(:login_scanners) { described_class.classes_for_service(service) }
+
+        it 'returns at least one class' do
+          expect(login_scanners).to_not be_empty
+        end
+
+
+        MockService = Struct.new(:name, :port)
+
+        described_class.classes_for_service(MockService.new(name: service_name)).each do |login_scanner|
+          context "when the login scanner is #{login_scanner.name}" do
+            it 'is a LoginScanner' do
+              expect(login_scanner).to include Metasploit::Framework::LoginScanner::Base
+            end
+
+            it 'can be initialized with a single argument' do
+              expect {
+                # here we emulate how Pro will initialize the class by passing a single configuration hash argument
+                login_scanner.new({
+                  bruteforce_speed: 5,
+                  host: '192.0.2.1',
+                  port: 1234,
+                  stop_on_success: true
+                })
+              }.to_not raise_error
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds some new tests for LoginScanners. It ensures that the LoginScanners follow a common interface for initialization, most notably that they take a single argument containing the configuration as a hash.

Should help to prevent additional instances of #19987 in the future.

## Verification

- [x] Watch the tests pass