### PR TITLE
Adds a shared pipeline for gems verify workflow

### DIFF
--- a/.github/workflows/shared_gem_verify.yml
+++ b/.github/workflows/shared_gem_verify.yml
@@ -1,0 +1,69 @@
+name: Shared Gem Verify
+on:
+  workflow_call:
+    inputs:
+      test_commands:
+        description: 'Test commands'
+        required: false
+        default: "bundle exec rspec"
+        type: string
+      dependencies:
+        description: 'Array of system dependencies to install'
+        required: false
+        default: "[]"
+        type: string
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.2'
+          - '3.3'
+          - '3.4'
+        os:
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-latest
+          - windows-2019
+          - macos-13
+
+    env:
+      RAILS_ENV: test
+
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
+    steps:
+      - name: Install system dependencies
+        if: ${{ inputs.dependencies != '[]' && !contains(matrix.os, 'macos') && !contains(matrix.os, 'windows') }}
+        run: |
+          dependencies=$(echo '${{ inputs.dependencies }}' | jq -r '.[]')
+          for dep in $dependencies; do
+            sudo apt-get -y --no-install-recommends install "$dep"
+          done
+        shell: bash
+
+      - name: Install system dependencies (Windows)
+        if: ${{ contains(matrix.os, 'windows') && inputs.dependencies != '[]' }}
+        run: |
+          $dependencies = (echo '${{ inputs.dependencies }}' | jq -r '.[]')
+          foreach ($dep in $dependencies) {
+            choco install $dep -y
+          }
+        shell: pwsh
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Test
+        run: ${{ inputs.test_commands }}

--- a/.github/workflows/shared_gem_verify_rails.yml
+++ b/.github/workflows/shared_gem_verify_rails.yml
@@ -1,0 +1,90 @@
+name: Shared Gem Verify Rails/PostgreSQL
+on:
+  workflow_call:
+    inputs:
+      test_commands:
+        description: 'Test commands'
+        required: false
+        default: "bundle exec rspec"
+        type: string
+      dependencies:
+        description: 'Array of system dependencies to install'
+        required: false
+        default: "[]"
+        type: string
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.2'
+          - '3.3'
+          - '3.4'
+        rails:
+          - '~> 7.0.0'
+          - '~> 7.1.0'
+          - '~> 7.2.0'
+        postgres:
+          - '9.6'
+          - '16.8'
+        os:
+          - ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }} - PostgreSQL ${{ matrix.postgres }}
+    steps:
+      - name: Install system dependencies
+        run: |
+          dependencies=$(echo '${{ inputs.dependencies }}' | jq -r '.[]')
+          for dep in $dependencies; do
+            sudo apt-get -y --no-install-recommends install "$dep"
+          done
+        shell: bash
+
+      - name: Set up PostgreSQL service
+        run: |
+          docker run --name postgres -d -p 5432:5432 \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            --health-cmd="pg_isready" \
+            --health-interval="10s" \
+            --health-timeout="5s" \
+            --health-retries=5 \
+            postgres:${{ matrix.postgres }}
+
+      - name: Wait for PostgreSQL to be healthy
+        run: |
+          docker exec postgres sh -c 'until pg_isready -U postgres; do echo waiting for postgres; sleep 2; done; echo postgres is ready'
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Update Rails version
+        run: |
+          # Add the gem explicitly if it doesn't exist
+          if ! grep -q "gem ['\"]rails['\"]" Gemfile; then
+            echo 'gem "rails"' >> Gemfile          
+          fi
+          
+          # Ensure the gem is on the latest version
+          ruby -pi -e "gsub(/gem ['\"]rails['\"](, *['\"].*['\"])?/, \"gem 'rails', '${{ matrix.rails }}'\")" Gemfile
+          bundle update
+          bundle install
+          bundle show rails
+        shell: bash
+
+      - name: Test
+        run: ${{ inputs.test_commands }}


### PR DESCRIPTION
This PR adds two new shared pipelines for testing gems. One for testing gems with Rails and another for without. The idea here was to now have one centralized point of truth for testing our gems.

The shared pipeline will support inputs for dependencies and testing commands e.g.
```
  build:
    uses: cgranleese-r7/metasploit-framework/.github/workflows/shared_gem_verify.yml@add-gem-verify-shared-pipeline
    with:
      dependencies: '["graphviz"]'
      test_commands: |
        bundle exec rake spec
        bundle exec rake cucumber
        bundle exec rake yard
```

Initially the corresponding gem PRs will point at these new pipelines on my @cgranleese-r7  repository for testing. Once this is landed, I will rebase those PRs.

Gems PRs:
- https://github.com/rapid7/metasploit-concern/pull/45
- https://github.com/rapid7/metasploit-credential/pull/189
- https://github.com/rapid7/metasploit-model/pull/73
- https://github.com/rapid7/metasploit_data_models/pull/216
- https://github.com/rapid7/rex-core/pull/43
- https://github.com/rapid7/rex-exploitation/pull/46/
- https://github.com/rapid7/rex-mime/pull/9
- https://github.com/rapid7/rex-powershell/pull/45
- https://github.com/rapid7/rex-random_identifier/pull/15
- https://github.com/rapid7/rex-socket/pull/73
- https://github.com/rapid7/rex-sslscan/pull/10
- https://github.com/rapid7/rex-text/pull/73




## Verification

- [ ] Ensure code changes are sane
- [ ] Verify gem PRs are passing and being tested as expected
