### PR TITLE
Add support for RHOSTS using LDAP URIs

### DIFF
--- a/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-LDAP.md
@@ -34,6 +34,13 @@ use auxiliary/gather/ldap_query
 run rhost=192.168.123.13 username=Administrator@domain.local password=p4$$w0rd action=ENUM_ACCOUNTS
 ```
 
+Alternatively, the URI syntax can be used:
+
+```
+use auxiliary/gather/ldap_query
+run ldap://domain.local;Administrator:p4$$w0rd@192.168.123.13/dc=domain,dc=local action=ENUM_ACCOUNTS
+```
+
 Example output:
 
 ```msf

--- a/docs/metasploit-framework.wiki/Metasploit-Guide-Setting-Module-Options.md
+++ b/docs/metasploit-framework.wiki/Metasploit-Guide-Setting-Module-Options.md
@@ -124,6 +124,8 @@ The following protocols are currently supported, and described in more detail be
 - file - Load a series of RHOST values separated by newlines from a file. This file can also include URI strings
 - http
 - https
+- ldap
+- ldaps
 - mysql
 - postgres
 - smb


### PR DESCRIPTION
This adds support for RHOST URIs to be specified with an `ldap` or `ldaps` schema.  There's a [RFC 4516](https://datatracker.ietf.org/doc/html/rfc4516#page-2) that defines the LDAP URI schema. This implementation is the basics with the following changes:

* A domain can be prepended to the username, separated by `;` like it can be for SMB URIs.
* Path components after the DN are ignored, only specifying the DN is supported. It doesn't make much sense to allow setting the attributes and search scope because the modules typically know what they're looking for.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_query`
- [ ] Run it with a URI for options
- [ ] Try a few combinations to see what's supported

## Demo

```
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_query) > run ldaps://MSFLAB;smcintyre:Password1!@192.168.159.10
[*] Running module against 192.168.159.10
[+] Successfully bound to the LDAP server!
[*] 192.168.159.10:636 Discovered base DN: DC=msflab,DC=local
DC=msflab,DC=local
==================

 Name                       Attributes
 ----                       ----------
 lockoutduration            0:00:30:00
 lockoutthreshold           0
 maxpwdage                  42:00:00:00
 minpwdage                  1:00:00:00
 minpwdlength               7
 ms-ds-machineaccountquota  10
 name                       msflab
 objectsid                  S-1-5-21-3978004297-3499718965-4169012971

[*] Query returned 1 result.
[*] Auxiliary module execution completed
metasploit-framework (S:0 J:0) auxiliary(gather/ldap_query) > 
```