### PR TITLE
Fixes modules that were causing Rubocop to fail

### DIFF
--- a/modules/exploits/unix/webapp/phpbb_highlight.rb
+++ b/modules/exploits/unix/webapp/phpbb_highlight.rb
@@ -44,6 +44,12 @@ class MetasploitModule < Msf::Exploit::Remote
             }
         },
       'Platform'       => 'unix',
+      'Notes' =>
+        {
+          'Stability' => [Msf::CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
       'Arch'           => ARCH_CMD,
       'Targets'        =>
         [

--- a/modules/exploits/windows/smb/ms10_061_spoolss.rb
+++ b/modules/exploits/windows/smb/ms10_061_spoolss.rb
@@ -36,6 +36,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'License'        => MSF_LICENSE,
       'Platform'       => 'win',
+      'Notes' => {
+        'Stability' => [Msf::CRASH_SAFE],
+        'SideEffects' => [Msf::ARTIFACTS_ON_DISK],
+        'Reliability' => []
+      },
       'References'     =>
         [
           [ 'OSVDB', '67988' ],


### PR DESCRIPTION
Fixes failing tests in https://github.com/rapid7/metasploit-framework/pull/19900.

Reasoning for this I believe is due to when the Rubocop rule was added as part of this [PR](https://github.com/rapid7/metasploit-framework/pull/17804) to catch any Excellent ranking modules that were missing `CRASH_SAFE`, this would be called out so it could be updated. I'm assuming these two modules were missed as part of that update.

Had a go at assigning the appropriate notes values, happy for feedback on this if they aren't quite correct.

## Verification

- [ ] CI passes
- [ ] Notes make sense in the context of the module
