### PR TITLE
Add Powershell Windows signature for SSH platform identification

### DIFF
--- a/lib/metasploit/framework/ssh/platform.rb
+++ b/lib/metasploit/framework/ssh/platform.rb
@@ -52,7 +52,7 @@ module Metasploit
                 info = info.map { |item| item.strip }
                 info = info.join(', ').to_s
                 # Windows
-              elsif info =~ /command not found|is not recognized as an internal or external command|is not recognized as the name of a cmdlet, function, script file, or operable program./
+              elsif info =~ /command not found|is not recognized as an internal or external command|is not recognized as the name of a cmdlet, function, script file, or operable/
                 info = ssh_socket.exec!("systeminfo\n").to_s
                 /OS Name:\s+(?<os_name>.+)$/ =~ info
                 /OS Version:\s+(?<os_num>.+)$/ =~ info

--- a/lib/metasploit/framework/ssh/platform.rb
+++ b/lib/metasploit/framework/ssh/platform.rb
@@ -52,7 +52,7 @@ module Metasploit
                 info = info.map { |item| item.strip }
                 info = info.join(', ').to_s
                 # Windows
-              elsif info =~ /command not found|is not recognized as an internal or external command/
+              elsif info =~ /command not found|is not recognized as an internal or external command|is not recognized as the name of a cmdlet, function, script file, or operable program./
                 info = ssh_socket.exec!("systeminfo\n").to_s
                 /OS Name:\s+(?<os_name>.+)$/ =~ info
                 /OS Version:\s+(?<os_num>.+)$/ =~ info


### PR DESCRIPTION
Add another windows signature

```
msf6 auxiliary(scanner/ssh/ssh_login) > run
[*] XX.XX.XX.XX - Starting bruteforce
[+] XX.XX.XX.XX - Success: 'test:test' 'id : The term 'id' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the   spelling of the name, or if a path was included, verify that the path is correct and try again.  At line:1 char:1  + id  + ~~      + CategoryInfo          : ObjectNotFound: (id:String) [], CommandNotFoundException      + FullyQualifiedErrorId : CommandNotFoundException     '
[-] XX.XX.XX.XX  - While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with device details so it can be handled in the future.
```
