### PR TITLE
Fix check_simple arg & searching by port integer

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -158,7 +158,7 @@ module Auxiliary
   #
   # Calls the class method.
   #
-  def check_simple(opts)
+  def check_simple(opts = {})
     Msf::Simple::Auxiliary.check_simple(self, opts)
   end
 

--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -103,7 +103,7 @@ module Evasion
     nil
   end
 
-  def run_simple(opts, &block)
+  def run_simple(opts = {}, &block)
     Msf::Simple::Evasion.run_simple(self, opts, &block)
   end
 

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -222,7 +222,7 @@ module Exploit
   #
   # Calls the class method.
   #
-  def check_simple(opts)
+  def check_simple(opts = {})
     Msf::Simple::Exploit.check_simple(self, opts)
   end
 

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -282,7 +282,7 @@ module Msf::Modules::Metadata::Search
 
   def as_regex(search_term)
     # Convert into a case-insensitive regex
-    utf8_buf = search_term.dup.force_encoding('UTF-8')
+    utf8_buf = search_term.to_s.dup.force_encoding('UTF-8')
     if utf8_buf.valid_encoding?
        Regexp.new(Regexp.escape(utf8_buf), Regexp::IGNORECASE)
     else


### PR DESCRIPTION
This PR fixes two issues (which aren't related) which introduce some quality of life changes for developers.

## Issue 1
Using `mod.run_simple` and `mod.check_simple` is inconsistent. Currently, you would need to pass an explicit `opts = {}` arg to `check_simple`:
```ruby
mod.run_simple => works
mod.check_simple => doesn't work
mod.check_simple({}) => works
```
With this change:
```ruby
mod.run_simple => works
mod.check_simple => works
```

To reproduce this in msfconsole with a currently-selected module in IRB (you may need to set some options such as rhost etc.):
```ruby
self.check_simple
```
Example output before:
```ruby
metasploit-framework/lib/msf/base/simple/exploit.rb:225:in `check_simple': wrong number of arguments (given 0, expected 1) (ArgumentError)
```
Example output after:
```ruby
#<struct Msf::Exploit::CheckCode code="unknown", message="Cannot reliably check exploitability.", reason=nil, details={}>
```

## Issue 2
Using the module metadata cache to search modules with a matching port breaks when the port provided is an integer.

Before:
```ruby
Msf::Modules::Metadata::Cache.instance.find('type' => [['auxiliary'], []], 'port' => [[8080], []]) => breaks
Msf::Modules::Metadata::Cache.instance.find('type' => [['auxiliary'], []], 'port' => [['8080'], []]) => works
```

After:
No need to use `to_s` on the rport integer:
```ruby
Msf::Modules::Metadata::Cache.instance.find('type' => [['auxiliary'], []], 'port' => [[8080], []]) => works
Msf::Modules::Metadata::Cache.instance.find('type' => [['auxiliary'], []], 'port' => [['8080'], []]) => works
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `irb`
- [ ] Confirm that running the `find` command on the metadata cache instance works, like in the example above
- [ ] Confirm you can run `self.check_simple` on auxiliary and exploit modules