### PR TITLE
Skip loading external modules with unsupported runtimes

### DIFF
--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -472,9 +472,9 @@ class Msf::Modules::Loader::Base
   #                   the path is not hidden (starts with '.')
   # @return [false] otherwise
   def module_path?(path)
-    path.ends_with?(MODULE_EXTENSION) &&
+    path.end_with?(MODULE_EXTENSION) &&
       File.file?(path) &&
-      !path.starts_with?(".") &&
+      !path.start_with?(".") &&
       !path.match?(UNIT_TEST_REGEX) &&
       !script_path?(path)
   end

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -12,8 +12,13 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
     File.directory?(path)
   end
 
-  def loadable_module?(parent_path, type, module_reference_name)
-    full_path = module_path(parent_path, type, module_reference_name)
+  # @param [String] parent_path Root directory to load modules from
+  # @param [String] type Such as auxiliary, exploit, etc
+  # @param [String] module_reference_name The module reference name, without the type prefix
+  # @param [nil,Msf::Modules::Metadata::Obj] cached_metadata
+  # @return [Boolean] True this loader can load the module, false otherwise
+  def loadable_module?(parent_path, type, module_reference_name, cached_metadata: nil)
+    full_path = cached_metadata&.path || module_path(parent_path, type, module_reference_name)
     module_path?(full_path)
   end
 

--- a/spec/lib/msf/core/modules/loader/directory_spec.rb
+++ b/spec/lib/msf/core/modules/loader/directory_spec.rb
@@ -1,160 +1,158 @@
 # -*- coding:binary -*-
 require 'spec_helper'
 RSpec.describe Msf::Modules::Loader::Directory do
-  context 'instance methods' do
-    include_context 'Msf::Modules::Loader::Base'
+  include_context 'Msf::Modules::Loader::Base'
 
-    let(:module_manager) do
-      double('Module Manager')
-    end
+  let(:module_manager) do
+    instance_double(Msf::ModuleManager)
+  end
 
-    let(:module_path) do
-      "#{parent_path}/exploits/#{module_reference_name}.rb"
-    end
+  let(:module_path) do
+    "#{parent_path}/exploits/#{module_reference_name}.rb"
+  end
 
-    let(:type) do
-      'exploit'
-    end
+  let(:type) do
+    'exploit'
+  end
 
-    subject do
-      described_class.new(module_manager)
-    end
+  subject do
+    described_class.new(module_manager)
+  end
 
-    context '#load_module' do
-      context 'with existent module_path' do
-        include_context 'Metasploit::Framework::Spec::Constants cleaner'
+  describe '#load_module' do
+    context 'with existent module_path' do
+      include_context 'Metasploit::Framework::Spec::Constants cleaner'
 
-        let(:framework) do
-          framework = double('Msf::Framework', datastore: Msf::DataStore.new)
+      let(:framework) do
+        framework = double('Msf::Framework', datastore: Msf::DataStore.new)
 
-          events = double('Events')
-          allow(events).to receive(:on_module_load)
-          allow(events).to receive(:on_module_created)
-          allow(framework).to receive(:events).and_return(events)
+        events = double('Events')
+        allow(events).to receive(:on_module_load)
+        allow(events).to receive(:on_module_created)
+        allow(framework).to receive(:events).and_return(events)
 
-          framework
-        end
-
-        let(:module_full_name) do
-          "#{type}/#{module_reference_name}"
-        end
-
-        let(:module_manager) do
-          Msf::ModuleManager.new(framework)
-        end
-
-        let(:module_reference_name) do
-          'windows/smb/ms08_067_netapi'
-        end
-
-        it 'should load a module that can be created' do
-          expect(subject.load_module(parent_path, type, module_reference_name)).to be_truthy
-
-          created_module = module_manager.create(module_full_name)
-
-          expect(created_module.name).to eq 'MS08-067 Microsoft Server Service Relative Path Stack Corruption'
-        end
-
-        context 'with module previously loaded' do
-          before(:example) do
-            subject.load_module(parent_path, type, module_reference_name)
-          end
-
-          # Payloads are defined as ruby Modules so they can behave differently
-          context 'with payload' do
-            let(:reference_name) do
-              'stages/windows/x64/vncinject'
-            end
-
-            let(:type) do
-              'payload'
-            end
-
-            it 'should not load the module' do
-              expect(subject.load_module(parent_path, type, module_reference_name)).to be_falsey
-            end
-          end
-
-          # Non-payloads are defined as ruby Classes
-          context 'without payload' do
-            let(:reference_name) do
-              'windows/smb/ms08_067_netapi'
-            end
-
-            let(:type) do
-              'exploit'
-            end
-
-            it 'should not load the module' do
-              expect(subject.load_module(parent_path, type, module_reference_name)).to be_falsey
-            end
-          end
-        end
+        framework
       end
 
-      context 'without existent module_path' do
-        let(:module_reference_name) do
-          'osx/armle/safari_libtiff'
-        end
+      let(:module_full_name) do
+        "#{type}/#{module_reference_name}"
+      end
 
-        let(:error) do
-          Errno::ENOENT.new(module_path)
-        end
+      let(:module_manager) do
+        Msf::ModuleManager.new(framework)
+      end
 
+      let(:module_reference_name) do
+        'windows/smb/ms08_067_netapi'
+      end
+
+      it 'should load a module that can be created' do
+        expect(subject.load_module(parent_path, type, module_reference_name)).to be_truthy
+
+        created_module = module_manager.create(module_full_name)
+
+        expect(created_module.name).to eq 'MS08-067 Microsoft Server Service Relative Path Stack Corruption'
+      end
+
+      context 'with module previously loaded' do
         before(:example) do
-          allow(module_manager).to receive(:file_changed?).and_return(true)
-          allow(module_manager).to receive(:module_load_error_by_path).and_return({})
+          subject.load_module(parent_path, type, module_reference_name)
         end
 
-        it 'should not raise an error' do
-          expect(File.exist?(module_path)).to be_falsey
+        # Payloads are defined as ruby Modules so they can behave differently
+        context 'with payload' do
+          let(:reference_name) do
+            'stages/windows/x64/vncinject'
+          end
 
-          expect {
-            subject.load_module(parent_path, type, module_reference_name)
-          }.to_not raise_error
+          let(:type) do
+            'payload'
+          end
+
+          it 'should not load the module' do
+            expect(subject.load_module(parent_path, type, module_reference_name)).to be_falsey
+          end
         end
 
-        it 'should return false' do
-          expect(File.exist?(module_path)).to be_falsey
+        # Non-payloads are defined as ruby Classes
+        context 'without payload' do
+          let(:reference_name) do
+            'windows/smb/ms08_067_netapi'
+          end
 
-          expect(subject.load_module(parent_path, type, module_reference_name)).to be_falsey
+          let(:type) do
+            'exploit'
+          end
+
+          it 'should not load the module' do
+            expect(subject.load_module(parent_path, type, module_reference_name)).to be_falsey
+          end
         end
       end
     end
 
-    context '#read_module_content' do
-      context 'with non-existent module_path' do
-        let(:module_reference_name) do
-          'osx/armle/safari_libtiff'
-        end
+    context 'without existent module_path' do
+      let(:module_reference_name) do
+        'osx/armle/safari_libtiff'
+      end
 
-        before(:example) do
-          allow(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
-        end
+      let(:error) do
+        Errno::ENOENT.new(module_path)
+      end
 
-        # this ensures that the File.exist?(module_path) checks are checking the same path as the code under test
-        it 'should attempt to open the expected module_path' do
-          expect(File).to receive(:open).with(module_path, 'rb')
-          expect(File.exist?(module_path)).to be_falsey
+      before(:example) do
+        allow(module_manager).to receive(:file_changed?).and_return(true)
+        allow(module_manager).to receive(:module_load_error_by_path).and_return({})
+      end
 
+      it 'should not raise an error' do
+        expect(File.exist?(module_path)).to be_falsey
+
+        expect {
+          subject.load_module(parent_path, type, module_reference_name)
+        }.to_not raise_error
+      end
+
+      it 'should return false' do
+        expect(File.exist?(module_path)).to be_falsey
+
+        expect(subject.load_module(parent_path, type, module_reference_name)).to be_falsey
+      end
+    end
+  end
+
+  describe '#read_module_content' do
+    context 'with non-existent module_path' do
+      let(:module_reference_name) do
+        'osx/armle/safari_libtiff'
+      end
+
+      before(:example) do
+        allow(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
+      end
+
+      # this ensures that the File.exist?(module_path) checks are checking the same path as the code under test
+      it 'should attempt to open the expected module_path' do
+        expect(File).to receive(:open).with(module_path, 'rb')
+        expect(File.exist?(module_path)).to be_falsey
+
+        subject.send(:read_module_content, parent_path, type, module_reference_name)
+      end
+
+      it 'should not raise an error' do
+        expect {
           subject.send(:read_module_content, parent_path, type, module_reference_name)
-        end
+        }.to_not raise_error
+      end
 
-        it 'should not raise an error' do
-          expect {
-            subject.send(:read_module_content, parent_path, type, module_reference_name)
-          }.to_not raise_error
-        end
+      it 'should return an empty string' do
+        expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
+      end
 
-        it 'should return an empty string' do
-          expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
-        end
+      it 'should record the load error' do
+        expect(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
 
-        it 'should record the load error' do
-          expect(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
-
-          expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
-        end
+        expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
       end
     end
   end

--- a/spec/lib/msf/core/modules/loader/executable_spec.rb
+++ b/spec/lib/msf/core/modules/loader/executable_spec.rb
@@ -1,0 +1,168 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+require 'rex/file'
+
+RSpec.describe Msf::Modules::Loader::Executable do
+  include_context 'Msf::Modules::Loader::Base'
+
+  let(:module_manager) do
+    instance_double(Msf::ModuleManager)
+  end
+
+  let(:module_path) do
+    "#{parent_path}/#{type}/#{module_reference_name}.go"
+  end
+
+  let(:type) do
+    'auxiliary'
+  end
+
+  subject do
+    described_class.new(module_manager)
+  end
+
+  describe '#read_script_env_runtime' do
+    [
+      {
+        value: '//usr/bin/env go run "$0" "$@"; exit "$?"',
+        expected: 'go'
+      },
+      { value: '#!/usr/bin/env python3', expected: 'python3' },
+      { value: '#!/usr/bin/env ruby', expected: 'ruby' },
+      # Not supported; Might need to be supported in the future
+      { value: '#!/usr/bin/python3', expected: nil },
+      { value: '#!/usr/bin/ruby', expected: nil },
+      { value: '', expected: nil },
+    ].each do |test|
+      it "detects #{test[:value].inspect} as #{test[:expected]}" do
+        path = 'mock_path'
+        allow(File).to receive(:open).and_call_original
+        allow(File).to receive(:open).with(path, 'rb') do |&block|
+          block.call StringIO.new(test[:value])
+        end
+        expect(subject.send(:read_script_env_runtime, path)).to eq test[:expected]
+      end
+    end
+  end
+
+  describe '#loadable_module?' do
+    context 'when the language runtime is not available' do
+      let(:module_reference_name) do
+        'scanner/msmail/non_existent_module'
+      end
+
+      let(:module_content) do
+        <<~EOF.strip
+          //usr/bin/env go run "$0" "$@"; exit "$?"
+          
+          package main 
+        EOF
+      end
+
+      let(:temp_file) do
+        Tempfile.new.tap do |f|
+          f.write(module_content)
+          f.flush
+        end
+      end
+
+      let(:module_path) do
+        temp_file.path
+      end
+
+      before(:example) do
+        allow(subject).to receive(:module_path).with(parent_path, type, module_reference_name).and_return(module_path)
+        allow(File).to receive(:executable?).with(module_path).and_return(true)
+        expect(::Rex::FileUtils).to_not receive(:find_full_path)
+      end
+
+      it 'should return true - even though the runtime is not supported, so that later read_module_content can return a human readable error' do
+        expect(subject.loadable_module?(parent_path, type, module_reference_name)).to be(true)
+      end
+    end
+  end
+
+  describe '#read_module_content' do
+    context 'with non-existent module_path' do
+      let(:module_reference_name) do
+        'scanner/msmail/non_existent_module'
+      end
+
+      before(:example) do
+        allow(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
+        allow(subject).to receive(:module_path).with(parent_path, type, module_reference_name).and_return(module_path)
+      end
+
+      # this ensures that the File.exist?(module_path) checks are checking the same path as the code under test
+      it 'should attempt to open the expected module_path' do
+        expect(File.exist?(module_path)).to be_falsey
+
+        subject.send(:read_module_content, parent_path, type, module_reference_name)
+      end
+
+      it 'should not raise an error' do
+        expect {
+          subject.send(:read_module_content, parent_path, type, module_reference_name)
+        }.to_not raise_error
+      end
+
+      it 'should return an empty string' do
+        expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
+      end
+
+      it 'should record the load error' do
+        expect(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
+
+        expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
+      end
+    end
+
+    context 'when the language runtime is not available' do
+      let(:module_reference_name) do
+        'scanner/msmail/non_existent_module'
+      end
+
+      let(:module_content) do
+        <<~EOF.strip
+          //usr/bin/env go run "$0" "$@"; exit "$?"
+          
+          package main 
+        EOF
+      end
+
+      let(:temp_file) do
+        Tempfile.new.tap do |f|
+          f.write(module_content)
+          f.flush
+        end
+      end
+
+      let(:module_path) do
+        temp_file.path
+      end
+
+      before(:example) do
+        allow(subject).to receive(:load_error).with(module_path, RuntimeError.new("Unable to load module as the following runtime was not found on the path: go"))
+        allow(subject).to receive(:module_path).with(parent_path, type, module_reference_name).and_return(module_path)
+        allow(File).to receive(:executable?).with(module_path).and_return(true)
+        expect(::Rex::FileUtils).to receive(:find_full_path).with('go').and_return(false)
+      end
+
+      it 'should not raise an error' do
+        expect {
+          subject.send(:read_module_content, parent_path, type, module_reference_name)
+        }.to_not raise_error
+      end
+
+      it 'should return an empty string' do
+        expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
+      end
+
+      it 'should record the load error' do
+        expect(subject).to receive(:load_error).with(module_path, RuntimeError.new("Unable to load module as the following runtime was not found on the path: go"))
+
+        expect(subject.send(:read_module_content, parent_path, type, module_reference_name)).to eq ''
+      end
+    end
+  end
+end

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -179,11 +179,11 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
         it 'should enumerate loaders until if it find the one where loadable?(parent_path) is true' do
           # Only the first one gets it since it finds the module
           first_loader = module_manager.send(:loaders).first
-          expect(first_loader).to receive(:loadable_module?).with(parent_path, type, reference_name).and_return(false)
-          expect(first_loader).not_to receive(:load_module)
+          expect(first_loader).to receive(:loadable_module?).with(parent_path, type, reference_name, cached_metadata: nil).and_return(false)
+          expect(first_loader).to_not receive(:load_module)
 
           second_loader = module_manager.send(:loaders).second
-          expect(second_loader).to receive(:loadable_module?).with(parent_path, type, reference_name).and_return(true)
+          expect(second_loader).to receive(:loadable_module?).with(parent_path, type, reference_name, cached_metadata: nil).and_return(true)
           expect(second_loader).to receive(:load_module).with(parent_path, type, reference_name, force: true, cached_metadata: nil).and_call_original
 
           load_cached_module
@@ -246,11 +246,12 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
         include_context 'Metasploit::Framework::Spec::Constants cleaner'
 
         it 'should enumerate loaders until if it find the one where loadable?(parent_path) is true' do
-          # Only the first one gets it since it finds the module
           first_loader = module_manager.send(:loaders).first
-          expect(first_loader).to receive(:load_module).with(parent_path, type, reference_name, force: true, cached_metadata: instance_of(Msf::Modules::Metadata::Obj)).and_return(false)
+          expect(first_loader).to receive(:loadable_module?).with(parent_path, type, reference_name, cached_metadata: instance_of(Msf::Modules::Metadata::Obj)).and_return(false)
+          expect(first_loader).to_not receive(:load_module)
 
           second_loader = module_manager.send(:loaders).second
+          expect(second_loader).to receive(:loadable_module?).with(parent_path, type, reference_name, cached_metadata: instance_of(Msf::Modules::Metadata::Obj)).and_return(true)
           expect(second_loader).to receive(:load_module).with(parent_path, type, reference_name, force: true, cached_metadata: instance_of(Msf::Modules::Metadata::Obj)).and_call_original
 
           load_cached_module

--- a/spec/support/shared/examples/msf/module_manager/loading.rb
+++ b/spec/support/shared/examples/msf/module_manager/loading.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Loading' do
     [basename_prefix, '.rb']
   end
 
-  context '#load_error_by_name' do
+  describe '#load_error_by_name' do
     it 'should return errors associated with that module' do
       Tempfile.open(module_basename) do |tempfile|
         module_path = tempfile.path
@@ -87,7 +87,7 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Loading' do
     end
   end
 
-  context '#file_changed?' do
+  describe '#file_changed?' do
     let(:module_basename) do
       [basename_prefix, '.rb']
     end
@@ -165,7 +165,7 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Loading' do
     end
   end
 
-  context '#on_module_load' do
+  describe '#on_module_load' do
     def on_module_load
       module_manager.on_module_load(klass, type, reference_name, options)
     end


### PR DESCRIPTION
Skip loading external modules with unsupported runtimes

## Verification

Verify the user is now told about missing runtime support for languages:

Missing Go:

```
msf6 auxiliary(gather/ldap_query) > use exchange_enum

Matching Modules
================

   #  Name                                    Disclosure Date  Rank    Check  Description
   -  ----                                    ---------------  ----    -----  -----------
   0  auxiliary/scanner/msmail/exchange_enum  2018-11-06       normal  No     Exchange email enumeration


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/msmail/exchange_enum

[*] Using auxiliary/scanner/msmail/exchange_enum
[-] Failed to load module: RuntimeError Unable to load module as the following runtime was not found on the path: go
msf6 auxiliary(gather/ldap_query) > 
```

Missing hypothetical python 9001 version (i.e. script header with `#!/usr/bin/env python9001`):

```
msf6 auxiliary(gather/ldap_query) > use att_open_proxy

Matching Modules
================

   #  Name                                     Disclosure Date  Rank    Check  Description
   -  ----                                     ---------------  ----    -----  -----------
   0  auxiliary/scanner/wproxy/att_open_proxy  2017-08-31       normal  No     Open WAN-to-LAN proxy on AT&T routers
   1    \_ AKA: SharknAT&To                    .                .       .      .
   2    \_ AKA: sharknatto                     .                .       .      .


Interact with a module by name or index. For example info 2, use 2 or use auxiliary/scanner/wproxy/att_open_proxy

[*] Using auxiliary/scanner/wproxy/att_open_proxy
[-] Failed to load module: RuntimeError Unable to load module as the following runtime was not found on the path: python9001

```