### PR TITLE
Improve support for finding available HTTP login scanners

### DIFF
--- a/lib/metasploit/framework/login_scanner.rb
+++ b/lib/metasploit/framework/login_scanner.rb
@@ -34,6 +34,24 @@ module Metasploit
         end
       end
 
+      # Gather a list of LoginScanner classes that can potentially be
+      # used against an HTTP service
+      #
+      # @return [Array<LoginScanner::Base>] A collection of LoginScanner
+      #   classes that will probably give useful results when run
+      #   against an HTTP service
+      def self.all_http_classes
+        require_login_scanners
+
+        http_base_class = Metasploit::Framework::LoginScanner::HTTP
+        Metasploit::Framework::LoginScanner.constants.sort.filter_map do |sym|
+          const = Metasploit::Framework::LoginScanner.const_get(sym)
+          next unless const.kind_of?(Class) && const.ancestors.include?(http_base_class) && const != http_base_class
+
+          const
+        end
+      end
+
       def self.all_service_names
         require_login_scanners
 
@@ -49,9 +67,9 @@ module Metasploit
 
         service_names
       end
-      
+
       private
-      
+
       def self.require_login_scanners
         unless @required
           # Make sure we've required all the scanner classes

--- a/lib/metasploit/framework/login_scanner/ivanti_login.rb
+++ b/lib/metasploit/framework/login_scanner/ivanti_login.rb
@@ -9,8 +9,8 @@ module Metasploit
       class Ivanti < HTTP
 
         DEFAULT_SSL_PORT = 443
-        LIKELY_PORTS = [443]
-        LIKELY_SERVICE_NAMES = [
+        LIKELY_PORTS =  self.superclass::LIKELY_PORTS + [443]
+        LIKELY_SERVICE_NAMES = self.superclass::LIKELY_SERVICE_NAMES + [
           'Ivanti Connect Secure'
         ]
         PRIVATE_TYPES = [:password]

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -13,6 +13,7 @@ module Metasploit
 
         LIKELY_PORTS         = [ 389, 636 ]
         LIKELY_SERVICE_NAMES = [ 'ldap', 'ldaps', 'ldapssl' ]
+        PRIVATE_TYPES = [:password, :ntlm_hash]
 
         attr_accessor :opts, :realm_key
         # @!attribute use_client_as_proof

--- a/lib/metasploit/framework/login_scanner/nessus.rb
+++ b/lib/metasploit/framework/login_scanner/nessus.rb
@@ -9,7 +9,7 @@ module Metasploit
 
         DEFAULT_PORT  = 8834
         PRIVATE_TYPES = [ :password ]
-        LIKELY_SERVICE_NAMES = [ 'nessus' ]
+        LIKELY_SERVICE_NAMES = self.superclass::LIKELY_SERVICE_NAMES + [ 'nessus' ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -8,9 +8,8 @@ module Metasploit
       # - Admin Login
       class SonicWall < HTTP
 
-        DEFAULT_SSL_PORT = [443, 4433]
-        LIKELY_PORTS = [443, 4433]
-        LIKELY_SERVICE_NAMES = [
+        LIKELY_PORTS = self.superclass::LIKELY_PORTS + [4433]
+        LIKELY_SERVICE_NAMES = self.superclass::LIKELY_SERVICE_NAMES + [
           'SonicWall Network Security'
         ]
         PRIVATE_TYPES = [:password]

--- a/lib/metasploit/framework/login_scanner/teamcity.rb
+++ b/lib/metasploit/framework/login_scanner/teamcity.rb
@@ -121,13 +121,11 @@ module Metasploit
         include Crypto
 
         DEFAULT_PORT         = 8111
-        LIKELY_PORTS         = [8111]
-        LIKELY_SERVICE_NAMES = [
+        LIKELY_PORTS         = self.superclass::LIKELY_PORTS + [8111]
+        LIKELY_SERVICE_NAMES = self.superclass::LIKELY_SERVICE_NAMES + [
           # Comes from nmap 7.95 on MacOS
           'skynetflow',
-          'teamcity',
-          'http',
-          'https'
+          'teamcity'
         ]
         PRIVATE_TYPES        = [:password]
         REALM_KEY            = nil


### PR DESCRIPTION
Improve support for finding available HTTP login scanners

This PR:
- Adds a new API for returning only HTTP scanners
- Aligns HTTP scanner metadata, as scanners weren't always running against targets in Metasploit Pro

![image](https://github.com/user-attachments/assets/01ac40e7-7307-4eac-b0f1-137af0b4afbe)

## Verification

- Ensure CI passes
- Tested on the command line:
```
>> Metasploit::Framework::LoginScanner.all_http_classes
=> 
[Metasploit::Framework::LoginScanner::AdvantechWebAccess,
 Metasploit::Framework::LoginScanner::Axis2,
 Metasploit::Framework::LoginScanner::BavisionCameras,
 Metasploit::Framework::LoginScanner::Buffalo,
 Metasploit::Framework::LoginScanner::Caidao,
 Metasploit::Framework::LoginScanner::ChefWebUI,
 ... etc ...
```
