### PR TITLE
Add support for network capture decryption

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,7 +427,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.32)
+    rex-core (0.1.33)
     rex-encoder (0.1.8)
       metasm
       rex-arch
@@ -457,7 +457,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.59)
+    rex-socket (0.1.60)
       dnsruby
       rex-core
     rex-sslscan (0.1.11)

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -50,6 +50,7 @@ module Exploit::Remote::HttpClient
         OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
         OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu']),
         OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
+        OptString.new('SSLKeyLogFile', [ false, 'The SSL key log file', ENV['SSLKeyLogFile']]),
       ], self.class
     )
 
@@ -167,7 +168,8 @@ module Exploit::Remote::HttpClient
       client_username,
       client_password,
       comm: opts['comm'],
-      subscriber: http_logger_subscriber
+      subscriber: http_logger_subscriber,
+      sslkeylogfile: sslkeylogfile
     )
 
 
@@ -699,6 +701,14 @@ module Exploit::Remote::HttpClient
   #
   def ssl_version
     datastore['SSLVersion']
+  end
+
+  #
+  # Returns the SSL key log file path
+  #
+  # @return [String]
+  def sslkeylogfile
+    datastore['SSLKeyLogFile']
   end
 
   #

--- a/lib/msf/core/exploit/remote/tcp.rb
+++ b/lib/msf/core/exploit/remote/tcp.rb
@@ -67,6 +67,7 @@ module Exploit::Remote::Tcp
         Opt::SSLVersion,
         OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),
+        OptString.new('SSLKeyLogFile', [ false, 'The SSL key log file', ENV['SSLKeyLogFile']]),
         Opt::Proxies,
         Opt::CPORT,
         Opt::CHOST,
@@ -108,6 +109,7 @@ module Exploit::Remote::Tcp
       'SSL'           =>  dossl,
       'SSLVersion'    =>  opts['SSLVersion'] || ssl_version,
       'SSLVerifyMode' =>  opts['SSLVerifyMode'] || ssl_verify_mode,
+      'SSLKeyLogFile' =>  opts['SSLKeyLogFile'] || sslkeylogfile,
       'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
       'Proxies'       => proxies,
       'Timeout'       => (opts['ConnectTimeout'] || connect_timeout || 10).to_i,
@@ -313,6 +315,14 @@ module Exploit::Remote::Tcp
   #
   def ssl_verify_mode
     datastore['SSLVerifyMode']
+  end
+
+  #
+  # Returns the SSL key log file path
+  #
+  # @return [String]
+  def sslkeylogfile
+    datastore['SSLKeyLogFile']
   end
 
   #

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -22,7 +22,7 @@ module Rex
         # @param http_trace_proc_request [Proc] A proc object passed to log HTTP requests if HTTP-Trace is set
         # @param http_trace_proc_response [Proc] A proc object passed to log HTTP responses if HTTP-Trace is set
         #
-        def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', kerberos_authenticator: nil, comm: nil, subscriber: nil)
+        def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', kerberos_authenticator: nil, comm: nil, subscriber: nil, sslkeylogfile: nil)
           self.hostname = host
           self.port = port.to_i
           self.context = context
@@ -34,6 +34,7 @@ module Rex
           self.kerberos_authenticator = kerberos_authenticator
           self.comm = comm
           self.subscriber = subscriber || HttpSubscriber.new
+          self.sslkeylogfile = sslkeylogfile
 
           # Take ClientRequest's defaults, but override with our own
           self.config = Http::ClientRequest::DefaultConfig.merge({
@@ -183,6 +184,7 @@ module Rex
             'Context' => context,
             'SSL' => ssl,
             'SSLVersion' => ssl_version,
+            'SSLKeyLogFile' => sslkeylogfile,
             'Proxies' => proxies,
             'Timeout' => timeout,
             'Comm' => comm
@@ -728,6 +730,12 @@ module Rex
         attr_accessor :ssl, :ssl_version # :nodoc:
 
         attr_accessor :hostname, :port # :nodoc:
+
+        #
+        # The SSL key log file for the connected socket.
+        #
+        # @return [String]
+        attr_accessor :sslkeylogfile
 
         #
         # The established NTLM connection info


### PR DESCRIPTION
Needed to support changes made in https://github.com/rapid7/rex-socket/pull/74.

This pull request adds enhanced support for network capture decryption. By writing to the sslkeylogfile it enable network capture decryption which is useful to decrypt TLS traffic in wireshark.

Needs tested with the above rex-text changes, to do this add the following to the Metasploit-Framework Gemfile:
```
gem "rex-socket", path: "../rex-socket"
```

Then `bundle install`.

## Verification
- [ ] Start msfconsole
- [ ] Use `scanner/http/title`
- [ ] Run `run rhosts=https://www.google.com verbose=true httptrace=true sslkeylogfile=./sslkeylogfile.txt`
- [ ] The module should complete
- [ ] Run `ls -la` and you should now see a file called `sslkeylogfile.txt`