### PR TITLE
modules/nops: Resolve RuboCop violations

### DIFF
--- a/modules/nops/aarch64/simple.rb
+++ b/modules/nops/aarch64/simple.rb
@@ -15,20 +15,21 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'Simple',
-      'Alias'       => 'armle_simple',
+      'Name' => 'Simple',
+      'Alias' => 'armle_simple',
       'Description' => 'Simple NOP generator',
-      'License'     => MSF_LICENSE,
-      'Author'      => ['timwr'],
-      'Arch'        => ARCH_AARCH64)
+      'License' => MSF_LICENSE,
+      'Author' => ['timwr'],
+      'Arch' => ARCH_AARCH64)
     register_advanced_options(
       [
-        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
-      ])
+        OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ])
+      ]
+    )
   end
 
   def generate_sled(length, opts)
-    random   = opts['Random']   || datastore['RandomNops']
+    random = opts['Random'] || datastore['RandomNops']
     nops = [
       0xd503201f,          #  nop
       0xaa0103e1,          #  mov	x1, x1
@@ -37,8 +38,9 @@ class MetasploitModule < Msf::Nop
       0x2a0403e4,          #  mov	w4, w4
     ]
     if random
-      return ([nops[rand(nops.length)]].pack("V*") * (length/4))
+      return ([nops[rand(nops.length)]].pack('V*') * (length / 4))
     end
-    return ([nops[0]].pack("V*") * (length/4))
+
+    return ([nops[0]].pack('V*') * (length / 4))
   end
 end

--- a/modules/nops/armle/simple.rb
+++ b/modules/nops/armle/simple.rb
@@ -15,24 +15,23 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'Simple',
-      'Alias'       => 'armle_simple',
+      'Name' => 'Simple',
+      'Alias' => 'armle_simple',
       'Description' => 'Simple NOP generator',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_ARMLE)
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_ARMLE)
 
     register_advanced_options(
       [
-        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
-      ])
+        OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ])
+      ]
+    )
   end
 
-
   def generate_sled(length, opts)
-
-    badchars = opts['BadChars'] || ''
-    random   = opts['Random']   || datastore['RandomNops']
+    opts['BadChars'] || ''
+    random = opts['Random'] || datastore['RandomNops']
 
     nops = [
       0xe1a01001,
@@ -49,9 +48,9 @@ class MetasploitModule < Msf::Nop
     ]
 
     if random
-      return ([nops[rand(nops.length)]].pack("V*") * (length/4))
+      return ([nops[rand(nops.length)]].pack('V*') * (length / 4))
     end
 
-    return ([nops[0]].pack("V*") * (length/4))
+    return ([nops[0]].pack('V*') * (length / 4))
   end
 end

--- a/modules/nops/mipsbe/better.rb
+++ b/modules/nops/mipsbe/better.rb
@@ -15,88 +15,85 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'Better',
-      'Alias'       => 'mipsbe_better',
+      'Name' => 'Better',
+      'Alias' => 'mipsbe_better',
       'Description' => 'Better NOP generator',
-      'Author'      => 'jm',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_MIPSBE)
+      'Author' => 'jm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_MIPSBE)
 
     register_advanced_options(
       [
-        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
-      ])
+        OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ])
+      ]
+    )
   end
 
-  def get_register()
-      return rand(27) + 1
+  def get_register
+    return rand(1..27)
   end
 
-  def make_bne(reg)
+  def make_bne(_reg)
     op = 0x14000000
 
-    reg = get_register()
+    rand_reg = get_register
     offset = rand(65536)
 
-    op = op | ( reg << 21 ) | ( reg << 16 ) | offset
+    op = op | (rand_reg << 21) | (rand_reg << 16) | offset
     return op
   end
 
   def make_or(reg)
     op = 0x00000025
 
-    op = op | ( reg << 21 ) | ( reg << 11 )
+    op = op | (reg << 21) | (reg << 11)
     return op
   end
 
   def make_sll(reg)
     op = 0x00000000
 
-    op = op | ( reg << 16 ) | ( reg << 11 )
+    op = op | (reg << 16) | (reg << 11)
     return op
   end
 
   def make_sra(reg)
     op = 0x00000003
 
-    op = op | ( reg << 16 ) | ( reg << 11 )
+    op = op | (reg << 16) | (reg << 11)
     return op
   end
 
   def make_srl(reg)
     op = 0x00000002
 
-    op = op | ( reg << 16 ) | ( reg << 11 )
+    op = op | (reg << 16) | (reg << 11)
     return op
   end
 
   def make_xori(reg)
     op = 0x38000000
 
-    op = op | ( reg << 21 ) | ( reg << 16 )
+    op = op | (reg << 21) | (reg << 16)
     return op
   end
 
   def make_ori(reg)
     op = 0x34000000
 
-    op = op | ( reg << 21 ) | ( reg << 16 )
+    op = op | (reg << 21) | (reg << 16)
     return op
   end
 
   def generate_sled(length, opts)
+    nop_fn = %i[make_bne make_or make_sll make_sra make_srl make_xori make_ori]
+    sled = ''
 
-    badchars = opts['BadChars'] || ''
-    random   = opts['Random']   || datastore['RandomNops']
-    nop_fn   = [ :make_bne, :make_or, :make_sll, :make_sra, :make_srl, :make_xori, :make_ori ]
-    sled     = ''
-
-    for i in 1..length/4 do
-        n = nop_fn.sample
-        sled << [send(n, get_register())].pack("N*")
+    for _ in 1..length / 4 do
+      n = nop_fn.sample
+      sled << [send(n, get_register)].pack('N*')
     end
 
     return sled
   end
 end
-

--- a/modules/nops/php/generic.rb
+++ b/modules/nops/php/generic.rb
@@ -12,16 +12,16 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'PHP Nop Generator',
-      'Alias'       => 'php_generic',
+      'Name' => 'PHP Nop Generator',
+      'Alias' => 'php_generic',
       'Description' => 'Generates harmless padding for PHP scripts',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_PHP)
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_PHP)
   end
 
   # Generate valid PHP code up to the requested length
-  def generate_sled(length, opts = {})
-    Array.new(length) { ["\t", " ", "\n", "\r", ";"].sample }.join
+  def generate_sled(length, _opts = {})
+    Array.new(length) { ["\t", ' ', "\n", "\r", ';'].sample }.join
   end
 end

--- a/modules/nops/ppc/simple.rb
+++ b/modules/nops/ppc/simple.rb
@@ -13,36 +13,34 @@
 ###
 class MetasploitModule < Msf::Nop
 
-
   def initialize
     super(
-      'Name'        => 'Simple',
-      'Alias'       => 'ppc_simple',
+      'Name' => 'Simple',
+      'Alias' => 'ppc_simple',
       'Description' => 'Simple NOP generator',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_PPC)
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_PPC)
 
     register_advanced_options(
       [
-        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
-      ])
+        OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ])
+      ]
+    )
   end
 
-
   def generate_sled(length, opts)
-
     badchars = opts['BadChars'] || ''
-    random   = opts['Random']   || datastore['RandomNops']
+    random = opts['Random'] || datastore['RandomNops']
 
     if random
-      1.upto(1024) do |i|
+      1.upto(1024) do |_i|
         regs_d = (rand(0x8000 - 0x0800) + 0x0800).to_i
         regs_b = [regs_d].pack('n').unpack('B*')[0][1, 15]
         flag_o = rand(2).to_i
         flag_r = rand(2).to_i
 
-        pcword = ["011111#{regs_b}#{flag_o}100001010#{flag_r}"].pack("B*")
+        pcword = ["011111#{regs_b}#{flag_o}100001010#{flag_r}"].pack('B*')
         failed = false
 
         pcword.each_byte do |c|

--- a/modules/nops/sparc/random.rb
+++ b/modules/nops/sparc/random.rb
@@ -14,9 +14,9 @@
 class MetasploitModule < Msf::Nop
 
   # Nop types
-  InsSethi      = 0
+  InsSethi = 0
   InsArithmetic = 1
-  InsBranch     = 2
+  InsBranch = 2
 
   # Generator table
   SPARC_Table = [
@@ -69,44 +69,41 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'SPARC NOP Generator',
-      'Alias'       => 'sparc_simple',
+      'Name' => 'SPARC NOP Generator',
+      'Alias' => 'sparc_simple',
       'Description' => 'SPARC NOP generator',
-      'Author'      => 'vlad902',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_SPARC)
+      'Author' => 'vlad902',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_SPARC)
 
     register_advanced_options(
       [
-        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
-      ])
+        OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ])
+      ]
+    )
   end
-
-
 
   # Nops are always random...
   def generate_sled(length, opts)
-
     badchars = opts['BadChars'] || ''
-    random   = opts['Random']   || datastore['RandomNops']
-    blen     = length
+    blen = length
 
-    buff  = ''
+    buff = ''
     count = 0
     while (buff.length < blen)
-      r = SPARC_Table[ rand(SPARC_Table.length) ]
+      r = SPARC_Table[rand(SPARC_Table.length)]
       t = ''
 
       case r[0]
-        when InsSethi
-          t = ins_sethi(r[1], blen - buff.length)
-        when InsArithmetic
-          t = ins_arithmetic(r[1], blen - buff.length)
-        when InsBranch
-          t = ins_branch(r[1], blen - buff.length)
-        else
-          print_status("Invalid opcode type")
-          raise RuntimeError
+      when InsSethi
+        t = ins_sethi(r[1], blen - buff.length)
+      when InsArithmetic
+        t = ins_arithmetic(r[1], blen - buff.length)
+      when InsBranch
+        t = ins_branch(r[1], blen - buff.length)
+      else
+        print_status('Invalid opcode type')
+        raise RuntimeError
       end
 
       failed = false
@@ -115,16 +112,17 @@ class MetasploitModule < Msf::Nop
         failed = true if badchars.include?(c.chr)
       end
 
-      if (not failed)
+      if !failed
         buff << t
         count = -100
       end
 
       if (count > length + 1000)
-        if(buff.length != 0)
+        if !buff.empty?
           return buff.slice(0, 4) * (blen / 4)
         end
-        print_status("The SPARC nop generator could not create a usable sled")
+
+        print_status('The SPARC nop generator could not create a usable sled')
         raise RuntimeError
       end
 
@@ -145,12 +143,12 @@ class MetasploitModule < Msf::Nop
     return rand(32).to_i
   end
 
-  def ins_sethi(ref, len=0)
-    [(get_dst_reg() << 25) | (4 << 22) | rand(1 << 22)].pack('N')
+  def ins_sethi(_ref, _len = 0)
+    [(get_dst_reg << 25) | (4 << 22) | rand(1 << 22)].pack('N')
   end
 
-  def ins_arithmetic(ref, len=0)
-    dst = get_dst_reg()
+  def ins_arithmetic(ref, _len = 0)
+    dst = get_dst_reg
     ver = ref[0]
 
     # WRY fixups
@@ -161,13 +159,13 @@ class MetasploitModule < Msf::Nop
 
     # 0, ~1, !2, ~3, !4
     # Use one src reg with a signed 13-bit immediate (non-0)
-    if((ver == 0 && rand(2)) || ver == 1)
+    if (ver == 0 && rand(2)) || ver == 1
       return [
-        (2 << 30)               |
-        (dst << 25)             |
-        (ref[1] << 19)          |
-        (get_src_reg() << 14)   |
-        (1 << 13)               |
+        (2 << 30) |
+        (dst << 25) |
+        (ref[1] << 19) |
+        (get_src_reg << 14) |
+        (1 << 13) |
         (rand((1 << 13) - 1) + 1)
       ].pack('N')
     end
@@ -183,8 +181,8 @@ class MetasploitModule < Msf::Nop
       (2 << 30) |
       (dst << 25) |
       (ref[1] << 19) |
-      (get_src_reg() << 14) |
-      get_src_reg()
+      (get_src_reg << 14) |
+      get_src_reg
     ].pack('N')
   end
 
@@ -194,6 +192,7 @@ class MetasploitModule < Msf::Nop
     len = (len / 4) - 1
 
     return '' if len == 0
+
     len = 0x3fffff if (len >= 0x400000)
 
     a = rand(2).floor
@@ -201,9 +200,9 @@ class MetasploitModule < Msf::Nop
     c = rand(len - 1).floor
 
     return [
-      (a << 29)  |
-      (b << 25)  |
-      (2 << 22)  |
+      (a << 29) |
+      (b << 25) |
+      (2 << 22) |
       c + 1
     ].pack('N')
   end

--- a/modules/nops/tty/generic.rb
+++ b/modules/nops/tty/generic.rb
@@ -12,17 +12,17 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'TTY Nop Generator',
-      'Alias'       => 'tty_generic',
+      'Name' => 'TTY Nop Generator',
+      'Alias' => 'tty_generic',
       'Description' => 'Generates harmless padding for TTY input',
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_TTY)
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_TTY)
   end
 
   # Generate valid PHP code up to the requested length
-  def generate_sled(length, opts = {})
+  def generate_sled(length, _opts = {})
     # Default to just spaces for now
-    " " * length
+    ' ' * length
   end
 end

--- a/modules/nops/x64/simple.rb
+++ b/modules/nops/x64/simple.rb
@@ -7,154 +7,155 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'Simple',
-      'Alias'       => 'x64_simple',
+      'Name' => 'Simple',
+      'Alias' => 'x64_simple',
       'Description' => 'An x64 single/multi byte NOP instruction generator.',
-      'Author'      => [ 'sf' ],
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_X64 )
+      'Author' => [ 'sf' ],
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_X64)
 
-    register_advanced_options( [ OptBool.new( 'RandomNops', [ false, "Generate a random NOP sled", true ] ) ])
-    register_advanced_options( [ OptBool.new( 'MultiByte',  [ false, "Generate a multi byte instruction NOP sled", false ] ) ])
+    register_advanced_options([ OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ]) ])
+    register_advanced_options([ OptBool.new('MultiByte', [ false, 'Generate a multi byte instruction NOP sled', false ]) ])
   end
 
   # This instruction list is far from complete (Only single byte instructions and some multi byte ADD/MOV instructions are used).
   # A more complete list might warrant an pseudo assembler (Rex::Arch::X64) instead of hardcoding these.
-  INSTRUCTIONS = [	[ "\x90",             0, "nop" ],
-            [ "\x91",             0, "xchg eax, ecx" ],
-            [ "\x92",             0, "xchg eax, edx" ],
-            [ "\x93",             0, "xchg eax, ebx" ],
-            [ "\x94",             0, "xchg eax, esp" ],
-            [ "\x95",             0, "xchg eax, ebp" ],
-            [ "\x96",             0, "xchg eax, esi" ],
-            [ "\x97",             0, "xchg eax, edi" ],
-            [ "\x98",             0, "cwde" ],
-            [ "\x99",             0, "cdq" ],
-            [ "\x9B",             0, "wait" ],
-            [ "\x9C",             0, "pushfq" ],
-            [ "\x9D",             0, "popfq" ],
-            [ "\x9E",             0, "sahf" ],
-            [ "\x9F",             0, "lahf" ],
-            [ "\xFC",             0, "cld" ],
-            [ "\xFD",             0, "std" ],
-            [ "\xF8",             0, "clc" ],
-            [ "\xF9",             0, "cmc" ],
-            [ "\x50",             0, "push rax" ],
-            [ "\x51",             0, "push rcx" ],
-            [ "\x52",             0, "push rdx" ],
-            [ "\x53",             0, "push rbx" ],
-            [ "\x54",             0, "push rsp" ],
-            [ "\x55",             0, "push rbp" ],
-            [ "\x56",             0, "push rsi" ],
-            [ "\x57",             0, "push rdi" ],
-            [ "\x58",             0, "pop rax" ],
-            [ "\x59",             0, "pop rcx" ],
-            [ "\x5A",             0, "pop rdx" ],
-            [ "\x5B",             0, "pop rbx" ],
-            [ "\x5C",             0, "pop rsp" ],
-            [ "\x5D",             0, "pop rbp" ],
-            [ "\x5E",             0, "pop rsi" ],
-            [ "\x5F",             0, "pop rdi" ],
-            [ "\x04",             1, "add al, 0x??" ],
-            [ "\x80\xC3",         1, "add bl, 0x??" ],
-            [ "\x80\xC1",         1, "add cl, 0x??" ],
-            [ "\x80\xC2",         1, "add dl, 0x??" ],
-            [ "\x80\xC4",         1, "add ah, 0x??" ],
-            [ "\x80\xC7",         1, "add bh, 0x??" ],
-            [ "\x80\xC5",         1, "add ch, 0x??" ],
-            [ "\x80\xC6",         1, "add dh, 0x??" ],
-            [ "\x66\x05",         2, "add ax, 0x????" ],
-            [ "\x66\x81\xC3",     2, "add bx, 0x????" ],
-            [ "\x66\x81\xC1",     2, "add cx, 0x????" ],
-            [ "\x66\x81\xC2",     2, "add dx, 0x????" ],
-            [ "\x66\x81\xC6",     2, "add si, 0x????" ],
-            [ "\x66\x81\xC7",     2, "add di, 0x????" ],
-            [ "\x66\x41\x81\xC0", 2, "add r8w, 0x????" ],
-            [ "\x66\x41\x81\xC1", 2, "add r9w, 0x????" ],
-            [ "\x66\x41\x81\xC2", 2, "add r10w, 0x????" ],
-            [ "\x66\x41\x81\xC3", 2, "add r11w, 0x????" ],
-            [ "\x66\x41\x81\xC4", 2, "add r12w, 0x????" ],
-            [ "\x66\x41\x81\xC5", 2, "add r13w, 0x????" ],
-            [ "\x66\x41\x81\xC6", 2, "add r14w, 0x????" ],
-            [ "\x66\x41\x81\xC7", 2, "add r15w, 0x????" ],
-            [ "\x05",             4, "add eax, 0x????????" ],
-            [ "\x81\xC3",         4, "add ebx, 0x????????" ],
-            [ "\x81\xC1",         4, "add ecx, 0x????????" ],
-            [ "\x81\xC2",         4, "add edx, 0x????????" ],
-            [ "\x81\xC6",         4, "add esi, 0x????????" ],
-            [ "\x81\xC7",         4, "add edi, 0x????????" ],
-            [ "\x41\x81\xC0",     4, "add r8d, 0x????????" ],
-            [ "\x41\x81\xC1",     4, "add r9d, 0x????????" ],
-            [ "\x41\x81\xC2",     4, "add r10d, 0x????????" ],
-            [ "\x41\x81\xC3",     4, "add r11d, 0x????????" ],
-            [ "\x41\x81\xC4",     4, "add r12d, 0x????????" ],
-            [ "\x41\x81\xC5",     4, "add r13d, 0x????????" ],
-            [ "\x41\x81\xC6",     4, "add r14d, 0x????????" ],
-            [ "\x41\x81\xC7",     4, "add r15d, 0x????????" ],
-            [ "\x48\xB8",         8, "mov rax, 0x????????????????" ],
-            [ "\x48\xBB",         8, "mov rbx, 0x????????????????" ],
-            [ "\x48\xB9",         8, "mov rcx, 0x????????????????" ],
-            [ "\x48\xBA",         8, "mov rdx, 0x????????????????" ],
-            [ "\x48\xBE",         8, "mov rsi, 0x????????????????" ],
-            [ "\x48\xBF",         8, "mov rdi, 0x????????????????" ],
-            [ "\x49\xB8",         8, "mov r8, 0x????????????????" ],
-            [ "\x49\xB9",         8, "mov r8, 0x????????????????" ],
-            [ "\x49\xBA",         8, "mov r10, 0x????????????????" ],
-            [ "\x49\xBB",         8, "mov r11, 0x????????????????" ],
-            [ "\x49\xBC",         8, "mov r12, 0x????????????????" ],
-            [ "\x49\xBD",         8, "mov r13, 0x????????????????" ],
-            [ "\x49\xBE",         8, "mov r14, 0x????????????????" ],
-            [ "\x49\xBF",         8, "mov r15, 0x????????????????" ],
+  INSTRUCTIONS = [
+    [ "\x90", 0, 'nop' ],
+    [ "\x91", 0, 'xchg eax, ecx' ],
+    [ "\x92", 0, 'xchg eax, edx' ],
+    [ "\x93", 0, 'xchg eax, ebx' ],
+    [ "\x94", 0, 'xchg eax, esp' ],
+    [ "\x95", 0, 'xchg eax, ebp' ],
+    [ "\x96", 0, 'xchg eax, esi' ],
+    [ "\x97", 0, 'xchg eax, edi' ],
+    [ "\x98", 0, 'cwde' ],
+    [ "\x99", 0, 'cdq' ],
+    [ "\x9B", 0, 'wait' ],
+    [ "\x9C", 0, 'pushfq' ],
+    [ "\x9D", 0, 'popfq' ],
+    [ "\x9E", 0, 'sahf' ],
+    [ "\x9F", 0, 'lahf' ],
+    [ "\xFC", 0, 'cld' ],
+    [ "\xFD", 0, 'std' ],
+    [ "\xF8", 0, 'clc' ],
+    [ "\xF9", 0, 'cmc' ],
+    [ "\x50", 0, 'push rax' ],
+    [ "\x51", 0, 'push rcx' ],
+    [ "\x52", 0, 'push rdx' ],
+    [ "\x53", 0, 'push rbx' ],
+    [ "\x54", 0, 'push rsp' ],
+    [ "\x55", 0, 'push rbp' ],
+    [ "\x56", 0, 'push rsi' ],
+    [ "\x57", 0, 'push rdi' ],
+    [ "\x58", 0, 'pop rax' ],
+    [ "\x59", 0, 'pop rcx' ],
+    [ "\x5A", 0, 'pop rdx' ],
+    [ "\x5B", 0, 'pop rbx' ],
+    [ "\x5C", 0, 'pop rsp' ],
+    [ "\x5D", 0, 'pop rbp' ],
+    [ "\x5E", 0, 'pop rsi' ],
+    [ "\x5F", 0, 'pop rdi' ],
+    [ "\x04", 1, 'add al, 0x??' ],
+    [ "\x80\xC3", 1, 'add bl, 0x??' ],
+    [ "\x80\xC1", 1, 'add cl, 0x??' ],
+    [ "\x80\xC2", 1, 'add dl, 0x??' ],
+    [ "\x80\xC4", 1, 'add ah, 0x??' ],
+    [ "\x80\xC7", 1, 'add bh, 0x??' ],
+    [ "\x80\xC5", 1, 'add ch, 0x??' ],
+    [ "\x80\xC6", 1, 'add dh, 0x??' ],
+    [ "\x66\x05", 2, 'add ax, 0x????' ],
+    [ "\x66\x81\xC3", 2, 'add bx, 0x????' ],
+    [ "\x66\x81\xC1", 2, 'add cx, 0x????' ],
+    [ "\x66\x81\xC2", 2, 'add dx, 0x????' ],
+    [ "\x66\x81\xC6", 2, 'add si, 0x????' ],
+    [ "\x66\x81\xC7", 2, 'add di, 0x????' ],
+    [ "\x66\x41\x81\xC0", 2, 'add r8w, 0x????' ],
+    [ "\x66\x41\x81\xC1", 2, 'add r9w, 0x????' ],
+    [ "\x66\x41\x81\xC2", 2, 'add r10w, 0x????' ],
+    [ "\x66\x41\x81\xC3", 2, 'add r11w, 0x????' ],
+    [ "\x66\x41\x81\xC4", 2, 'add r12w, 0x????' ],
+    [ "\x66\x41\x81\xC5", 2, 'add r13w, 0x????' ],
+    [ "\x66\x41\x81\xC6", 2, 'add r14w, 0x????' ],
+    [ "\x66\x41\x81\xC7", 2, 'add r15w, 0x????' ],
+    [ "\x05", 4, 'add eax, 0x????????' ],
+    [ "\x81\xC3", 4, 'add ebx, 0x????????' ],
+    [ "\x81\xC1", 4, 'add ecx, 0x????????' ],
+    [ "\x81\xC2", 4, 'add edx, 0x????????' ],
+    [ "\x81\xC6", 4, 'add esi, 0x????????' ],
+    [ "\x81\xC7", 4, 'add edi, 0x????????' ],
+    [ "\x41\x81\xC0", 4, 'add r8d, 0x????????' ],
+    [ "\x41\x81\xC1", 4, 'add r9d, 0x????????' ],
+    [ "\x41\x81\xC2", 4, 'add r10d, 0x????????' ],
+    [ "\x41\x81\xC3", 4, 'add r11d, 0x????????' ],
+    [ "\x41\x81\xC4", 4, 'add r12d, 0x????????' ],
+    [ "\x41\x81\xC5", 4, 'add r13d, 0x????????' ],
+    [ "\x41\x81\xC6", 4, 'add r14d, 0x????????' ],
+    [ "\x41\x81\xC7", 4, 'add r15d, 0x????????' ],
+    [ "\x48\xB8", 8, 'mov rax, 0x????????????????' ],
+    [ "\x48\xBB", 8, 'mov rbx, 0x????????????????' ],
+    [ "\x48\xB9", 8, 'mov rcx, 0x????????????????' ],
+    [ "\x48\xBA", 8, 'mov rdx, 0x????????????????' ],
+    [ "\x48\xBE", 8, 'mov rsi, 0x????????????????' ],
+    [ "\x48\xBF", 8, 'mov rdi, 0x????????????????' ],
+    [ "\x49\xB8", 8, 'mov r8, 0x????????????????' ],
+    [ "\x49\xB9", 8, 'mov r8, 0x????????????????' ],
+    [ "\x49\xBA", 8, 'mov r10, 0x????????????????' ],
+    [ "\x49\xBB", 8, 'mov r11, 0x????????????????' ],
+    [ "\x49\xBC", 8, 'mov r12, 0x????????????????' ],
+    [ "\x49\xBD", 8, 'mov r13, 0x????????????????' ],
+    [ "\x49\xBE", 8, 'mov r14, 0x????????????????' ],
+    [ "\x49\xBF", 8, 'mov r15, 0x????????????????' ],
   ]
 
-  I_OP   = 0
+  I_OP = 0
   I_SIZE = 1
   I_TEXT = 2
 
-  REGISTERS = [		[ "rsp", "esp", "sp" ],
-            [ "rbp", "ebp", "bp" ],
-            [ "rax", "eax", "ax", "al", "ah" ],
-            [ "rbx", "ebx", "bx", "bl", "bh" ],
-            [ "rcx", "ecx", "cx", "cl", "ch" ],
-            [ "rdx", "edx", "dx", "dl", "dh" ],
-            [ "rsi", "esi", "si" ],
-            [ "rdi", "edi", "di" ],
-            [ "r8", "r8d", "r8w", "r8b" ],
-            [ "r9", "r9d", "r9w", "r9b" ],
-            [ "r10", "r10d", "r10w", "r10b" ],
-            [ "r11", "r11d", "r11w", "r11b" ],
-            [ "r12", "r12d", "r12w", "r12b" ],
-            [ "r13", "r13d", "r13w", "r13b" ],
-            [ "r14", "r14d", "r14w", "r14b" ],
-            [ "r15", "r15d", "r15w", "r15b" ],
+  REGISTERS = [
+    [ 'rsp', 'esp', 'sp' ],
+    [ 'rbp', 'ebp', 'bp' ],
+    [ 'rax', 'eax', 'ax', 'al', 'ah' ],
+    [ 'rbx', 'ebx', 'bx', 'bl', 'bh' ],
+    [ 'rcx', 'ecx', 'cx', 'cl', 'ch' ],
+    [ 'rdx', 'edx', 'dx', 'dl', 'dh' ],
+    [ 'rsi', 'esi', 'si' ],
+    [ 'rdi', 'edi', 'di' ],
+    [ 'r8', 'r8d', 'r8w', 'r8b' ],
+    [ 'r9', 'r9d', 'r9w', 'r9b' ],
+    [ 'r10', 'r10d', 'r10w', 'r10b' ],
+    [ 'r11', 'r11d', 'r11w', 'r11b' ],
+    [ 'r12', 'r12d', 'r12w', 'r12b' ],
+    [ 'r13', 'r13d', 'r13w', 'r13b' ],
+    [ 'r14', 'r14d', 'r14w', 'r14b' ],
+    [ 'r15', 'r15d', 'r15w', 'r15b' ],
   ]
 
-  def generate_random_sled( length, instructions, badchars, badregs )
+  def generate_random_sled(length, instructions, badchars, badregs)
     opcodes_stack = []
-    total_size    = 0
-    sled          = ''
-    try_count     = 0
-    good_bytes    = []
+    total_size = 0
+    sled = ''
+    try_count = 0
 
     # Fixup SaveRegisters so for example, if we wish to preserve RSP we also should also preserve ESP and SP
-    REGISTERS.each { | reg | reg.each { |x| badregs += reg if badregs.include?( x ) } }
-    badregs = badregs.uniq()
+    REGISTERS.each { |reg| reg.each { |x| badregs += reg if badregs.include?(x) } }
+    badregs = badregs.uniq
 
     # If we are preserving RSP we should avoid all PUSH/POP instructions...
-    if badregs.include?( "rsp" )
-      badregs.push( 'push' )
-      badregs.push( 'pop' )
+    if badregs.include?('rsp')
+      badregs.push('push')
+      badregs.push('pop')
     end
 
     # Loop while we still have bytes to fill in the sled...
-    while true
+    loop do
       # Pick a random instruction and see if we can use it...
-      instruction = instructions[ rand(instructions.length) ]
+      instruction = instructions[rand(instructions.length)]
 
       # Avoid using any bad mnemonics/registers...
       try_another = false
-      badregs.each do | bad |
-        try_another = true if instruction[I_TEXT].include?( bad.downcase() )
+      badregs.each do |bad|
+        try_another = true if instruction[I_TEXT].include?(bad.downcase)
         break if try_another
       end
       next if try_another
@@ -163,8 +164,8 @@ class MetasploitModule < Msf::Nop
       opcodes = instruction[I_OP]
 
       # If their are additional bytes to append, do it now...
-      1.upto( instruction[I_SIZE] ) do | i |
-        opcodes += Rex::Text.rand_char( badchars )
+      1.upto(instruction[I_SIZE]) do |_i|
+        opcodes += Rex::Text.rand_char(badchars)
       end
 
       # If we have gone over the requested sled length, try again.
@@ -174,8 +175,8 @@ class MetasploitModule < Msf::Nop
         # If we have tried unsuccessfully 32 times we start unwinding the chosen opcode_stack to speed things up
         if try_count == 0
           pop_count = 4
-          while opcodes_stack.length and pop_count
-            total_size -= opcodes_stack.pop().length
+          while opcodes_stack.length && pop_count
+            total_size -= opcodes_stack.pop.length
             pop_count -= 1
           end
         end
@@ -186,7 +187,7 @@ class MetasploitModule < Msf::Nop
       try_count = 32
 
       # save the opcodes we just generated.
-      opcodes_stack.push( opcodes )
+      opcodes_stack.push(opcodes)
 
       # Increment the total size appropriately.
       total_size += opcodes.length
@@ -196,48 +197,48 @@ class MetasploitModule < Msf::Nop
     end
 
     # Now that we have chosen all the instructions to use we must generate the actual sled.
-    opcodes_stack.each do | opcodes_ |
+    opcodes_stack.each do |opcodes_|
       sled += opcodes_
     end
 
     return sled
   end
 
-  def generate_sled( length, opts )
-    badchars  = opts['BadChars'] || ''
-    random    = opts['Random'] || datastore['RandomNops']
-    badregs   = opts['SaveRegisters'] || []
+  def generate_sled(length, opts)
+    badchars = opts['BadChars'] || ''
+    random = opts['Random'] || datastore['RandomNops']
+    badregs = opts['SaveRegisters'] || []
     good_instructions = []
-    sled      = ''
+    sled = ''
 
     # Weed out any instructions which will contain a bad char/instruction...
-    INSTRUCTIONS.each do | instruction |
-      good = true;
+    INSTRUCTIONS.each do |instruction|
+      good = true
       # If the instruction contains some bad chars we wont use it...
-      badchars.each_char do | bc |
-        if instruction[I_OP].include?( bc )
+      badchars.each_char do |bc|
+        if instruction[I_OP].include?(bc)
           good = false
           break
         end
       end
       # if we are only to generate single byte instructions, weed out the multi byte ones...
-      good = false if instruction[I_SIZE] > 0 and not datastore['MultiByte']
+      good = false if (instruction[I_SIZE] > 0) && !datastore['MultiByte']
 
-      good_instructions.push( instruction ) if good
+      good_instructions.push(instruction) if good
     end
 
     # After we have pruned the instruction list we can proceed to generate a sled...
     if good_instructions.empty?
       # If we are left with no valid instructions to use we simple can't generate a sled.
       sled = nil
-    elsif not random
-      if not badchars.include?( "\x90" )
+    elsif !random
+      if !badchars.include?("\x90")
         sled += "\x90" * length
       else
         sled = nil
       end
     else
-      sled += generate_random_sled( length, good_instructions, badchars, badregs )
+      sled += generate_random_sled(length, good_instructions, badchars, badregs)
     end
 
     return sled

--- a/modules/nops/x86/opty2.rb
+++ b/modules/nops/x86/opty2.rb
@@ -5,7 +5,6 @@
 
 require 'rex/nop/opty2'
 
-
 ###
 #
 # Opty2
@@ -19,17 +18,18 @@ class MetasploitModule < Msf::Nop
 
   def initialize
     super(
-      'Name'        => 'Opty2',
+      'Name' => 'Opty2',
       'Description' => 'Opty2 multi-byte NOP generator',
-      'Author'      => [ 'spoonm', 'optyx' ],
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_X86)
+      'Author' => [ 'spoonm', 'optyx' ],
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_X86)
   end
 
   def generate_sled(length, opts = {})
     opty = Rex::Nop::Opty2.new(
       opts['BadChars'] || '',
-      opts['SaveRegisters'])
+      opts['SaveRegisters']
+    )
 
     opty.generate_sled(length)
   end

--- a/modules/nops/x86/single_byte.rb
+++ b/modules/nops/x86/single_byte.rb
@@ -11,126 +11,126 @@
 ###
 class MetasploitModule < Msf::Nop
 
-SINGLE_BYTE_SLED =
-  {
-    # opcode  affected registers
-    # ------  ------------------
-    "\x90" => nil               , # nop
-    "\x97" => [ 'eax', 'edi'   ], # xchg eax,edi
-    "\x96" => [ 'eax', 'esi'   ], # xchg eax,esi
-    "\x95" => [ 'eax', 'ebp'   ], # xchg eax,ebp
-    "\x93" => [ 'eax', 'ebx'   ], # xchg eax,ebx
-    "\x92" => [ 'eax', 'edx'   ], # xchg eax,edx
-    "\x91" => [ 'eax', 'ecx'   ], # xchg eax,ecx
-    "\x99" => [ 'edx'          ], # cdq
-    "\x4d" => [ 'ebp'          ], # dec ebp
-    "\x48" => [ 'eax'          ], # dec eax
-    "\x47" => [ 'edi'          ], # inc edi
-    "\x4f" => [ 'edi'          ], # dec edi
-    "\x40" => [ 'eax'          ], # inc eax
-    "\x41" => [ 'ecx'          ], # inc ecx
-    "\x37" => [ 'eax'          ], # aaa
-    "\x3f" => [ 'eax'          ], # aas
-    "\x27" => [ 'eax'          ], # daa
-    "\x2f" => [ 'eax'          ], # das
-    "\x46" => [ 'esi'          ], # inc esi
-    "\x4e" => [ 'esi'          ], # dec esi
-    "\xfc" => nil               , # cld
-    "\xfd" => nil               , # std
-    "\xf8" => nil               , # clc
-    "\xf9" => nil               , # stc
-    "\xf5" => nil               , # cmc
-    "\x98" => [ 'eax'          ], # cwde
-    "\x9f" => [ 'eax'          ], # lahf
-    "\x4a" => [ 'edx'          ], # dec edx
-    "\x44" => [ 'esp', 'align' ], # inc esp
-    "\x42" => [ 'edx'          ], # inc edx
-    "\x43" => [ 'ebx'          ], # inc ebx
-    "\x49" => [ 'ecx'          ], # dec ecx
-    "\x4b" => [ 'ebx'          ], # dec ebx
-    "\x45" => [ 'ebp'          ], # inc ebp
-    "\x4c" => [ 'esp', 'align' ], # dec esp
-    "\x9b" => nil               , # wait
-    "\x60" => [ 'esp'          ], # pusha
-    "\x0e" => [ 'esp', 'align' ], # push cs
-    "\x1e" => [ 'esp', 'align' ], # push ds
-    "\x50" => [ 'esp'          ], # push eax
-    "\x55" => [ 'esp'          ], # push ebp
-    "\x53" => [ 'esp'          ], # push ebx
-    "\x51" => [ 'esp'          ], # push ecx
-    "\x57" => [ 'esp'          ], # push edi
-    "\x52" => [ 'esp'          ], # push edx
-    "\x06" => [ 'esp', 'align' ], # push es
-    "\x56" => [ 'esp'          ], # push esi
-    "\x54" => [ 'esp'          ], # push esp
-    "\x16" => [ 'esp', 'align' ], # push ss
-    "\x58" => [ 'esp', 'eax'   ], # pop eax
-    "\x5d" => [ 'esp', 'ebp'   ], # pop ebp
-    "\x5b" => [ 'esp', 'ebx'   ], # pop ebx
-    "\x59" => [ 'esp', 'ecx'   ], # pop ecx
-    "\x5f" => [ 'esp', 'edi'   ], # pop edi
-    "\x5a" => [ 'esp', 'edx'   ], # pop edx
-    "\x5e" => [ 'esp', 'esi'   ], # pop esi
-    "\xd6" => [ 'eax'          ], # salc
-  }
+  SINGLE_BYTE_SLED =
+    {
+      # opcode  affected registers
+      # ------  ------------------
+      "\x90" => nil, # nop
+      "\x97" => [ 'eax', 'edi' ], # xchg eax,edi
+      "\x96" => [ 'eax', 'esi' ], # xchg eax,esi
+      "\x95" => [ 'eax', 'ebp' ], # xchg eax,ebp
+      "\x93" => [ 'eax', 'ebx' ], # xchg eax,ebx
+      "\x92" => [ 'eax', 'edx' ], # xchg eax,edx
+      "\x91" => [ 'eax', 'ecx' ], # xchg eax,ecx
+      "\x99" => [ 'edx' ], # cdq
+      "\x4d" => [ 'ebp' ], # dec ebp
+      "\x48" => [ 'eax' ], # dec eax
+      "\x47" => [ 'edi' ], # inc edi
+      "\x4f" => [ 'edi' ], # dec edi
+      "\x40" => [ 'eax' ], # inc eax
+      "\x41" => [ 'ecx' ], # inc ecx
+      "\x37" => [ 'eax' ], # aaa
+      "\x3f" => [ 'eax' ], # aas
+      "\x27" => [ 'eax' ], # daa
+      "\x2f" => [ 'eax' ], # das
+      "\x46" => [ 'esi' ], # inc esi
+      "\x4e" => [ 'esi' ], # dec esi
+      "\xfc" => nil, # cld
+      "\xfd" => nil, # std
+      "\xf8" => nil, # clc
+      "\xf9" => nil, # stc
+      "\xf5" => nil, # cmc
+      "\x98" => [ 'eax' ], # cwde
+      "\x9f" => [ 'eax' ], # lahf
+      "\x4a" => [ 'edx' ], # dec edx
+      "\x44" => [ 'esp', 'align' ], # inc esp
+      "\x42" => [ 'edx' ], # inc edx
+      "\x43" => [ 'ebx' ], # inc ebx
+      "\x49" => [ 'ecx' ], # dec ecx
+      "\x4b" => [ 'ebx' ], # dec ebx
+      "\x45" => [ 'ebp' ], # inc ebp
+      "\x4c" => [ 'esp', 'align' ], # dec esp
+      "\x9b" => nil, # wait
+      "\x60" => [ 'esp' ], # pusha
+      "\x0e" => [ 'esp', 'align' ], # push cs
+      "\x1e" => [ 'esp', 'align' ], # push ds
+      "\x50" => [ 'esp' ], # push eax
+      "\x55" => [ 'esp' ], # push ebp
+      "\x53" => [ 'esp' ], # push ebx
+      "\x51" => [ 'esp' ], # push ecx
+      "\x57" => [ 'esp' ], # push edi
+      "\x52" => [ 'esp' ], # push edx
+      "\x06" => [ 'esp', 'align' ], # push es
+      "\x56" => [ 'esp' ], # push esi
+      "\x54" => [ 'esp' ], # push esp
+      "\x16" => [ 'esp', 'align' ], # push ss
+      "\x58" => [ 'esp', 'eax' ], # pop eax
+      "\x5d" => [ 'esp', 'ebp' ], # pop ebp
+      "\x5b" => [ 'esp', 'ebx' ], # pop ebx
+      "\x59" => [ 'esp', 'ecx' ], # pop ecx
+      "\x5f" => [ 'esp', 'edi' ], # pop edi
+      "\x5a" => [ 'esp', 'edx' ], # pop edx
+      "\x5e" => [ 'esp', 'esi' ], # pop esi
+      "\xd6" => [ 'eax' ] # salc
+    }
 
   def initialize
     super(
-      'Name'        => 'Single Byte',
-      'Alias'       => 'ia32_singlebyte',
+      'Name' => 'Single Byte',
+      'Alias' => 'ia32_singlebyte',
       'Description' => 'Single-byte NOP generator',
-      'Author'      => 'spoonm',
-      'License'     => MSF_LICENSE,
-      'Arch'        => ARCH_X86)
+      'Author' => 'spoonm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_X86)
 
     register_advanced_options(
       [
-        OptBool.new('RandomNops', [ false, "Generate a random NOP sled", true ])
-      ])
+        OptBool.new('RandomNops', [ false, 'Generate a random NOP sled', true ])
+      ]
+    )
   end
 
   # Generate a single-byte NOP sled for X86
   def generate_sled(length, opts = {})
-    sled_hash    = SINGLE_BYTE_SLED
+    sled_hash = SINGLE_BYTE_SLED
     sled_max_idx = sled_hash.length
     sled_cur_idx = 0
-    out_sled     = ''
+    out_sled = ''
 
-    random   = opts['Random']
-    badchars = opts['BadChars']      || ''
-    badregs  = opts['SaveRegisters'] || []
+    random = opts['Random']
+    badchars = opts['BadChars'] || ''
+    badregs = opts['SaveRegisters'] || []
 
     # Did someone specify random NOPs in the environment?
-    if (!random and datastore['RandomNops'])
+    if !random && datastore['RandomNops']
       random = datastore['RandomNops']
     end
 
     # Generate the whole sled...
-    1.upto(length) { |current|
-
-      cur_char  = nil
+    1.upto(length) do |_current|
+      cur_char = nil
       threshold = 0
 
       # Keep snagging characters until we find one that satisfies both the
       # bad character and bad register requirements
-      begin
-        sled_cur_idx  = rand(sled_max_idx) if (random == true)
-        cur_char      = sled_hash.keys[sled_cur_idx]
+      loop do
+        sled_cur_idx = rand(sled_max_idx) if (random == true)
+        cur_char = sled_hash.keys[sled_cur_idx]
         sled_cur_idx += 1 if (random == false)
-        sled_cur_idx  = 0 if (sled_cur_idx >= sled_max_idx)
+        sled_cur_idx = 0 if (sled_cur_idx >= sled_max_idx)
 
         # Make sure that we haven't gone over the sled repeat threshold
-        if ((threshold += 1) > self.nop_repeat_threshold)
+        if ((threshold += 1) > nop_repeat_threshold)
           return nil
         end
-
-      end while ((badchars.include?(cur_char)) or
-        ((sled_hash[cur_char]) and
-          ((sled_hash[cur_char] & badregs).length > 0)))
+        break unless badchars.include?(cur_char) ||
+                     ((sled_hash[cur_char]) &&
+                       !(sled_hash[cur_char] & badregs).empty?)
+      end
 
       # Add the character to the sled now that it's passed our checks
       out_sled += cur_char
-    }
+    end
 
     # If the sled fails to entirely generate itself, then that's bogus,
     # man...


### PR DESCRIPTION
All violations were resolved with `rubocop -A`, with the exception of:

```
modules/nops/mipsbe/better.rb:39:5: W: Lint/ShadowedArgument: Argument reg was shadowed by a local variable before it was used.
    reg = get_register
    ^^^^^^^^^^^^^^^^^^
```

This highlighted a shadowed variable which is also potentially redundant code in `make_bne(reg)`:

https://github.com/rapid7/metasploit-framework/blob/41361db5660740eaa2b3ec8a22aa9c0d7121adbc/modules/nops/mipsbe/better.rb#L35-L43

Unlike every other method, this method ignores the provided `reg` argument and instead clobbers the value with `get_register()` (which simply returns a random number). This is strange, as the `reg` argument provided to this method is always generated from `get_register()`:

https://github.com/rapid7/metasploit-framework/blob/41361db5660740eaa2b3ec8a22aa9c0d7121adbc/modules/nops/mipsbe/better.rb#L91-L97

Regardless, I have left the code intact, based on the assumption that should this method ever be called with a `reg` value which is not a valid random register as generated by `get_register()`, the value should be ignored and replaced. The `reg` argument has been renamed to `_reg` to show that it is ignored.

---

**Edit**: For reference, the following 9 violations were not resolved with `-a` and were instead resolved with `-A`:

```
# rubocop -a modules/nops/
Inspecting 14 files
....W....C.C.W

Offenses:

modules/nops/mipsbe/better.rb:39:5: W: Lint/ShadowedArgument: Argument reg was shadowed by a local variable before it was used.
    reg = get_register
    ^^^^^^^^^^^^^^^^^^
modules/nops/sparc/random.rb:122:13: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length != 0.
        if (buff.length != 0)
            ^^^^^^^^^^^^^^^^
modules/nops/x64/simple.rb:151:5: C: [Correctable] Style/InfiniteLoop: Use Kernel#loop for infinite loops.
    while true
    ^^^^^
modules/nops/x64/simple.rb:178:38: C: [Correctable] Style/AndOr: Use && instead of and.
          while opcodes_stack.length and pop_count
                                     ^^^
modules/nops/x64/simple.rb:225:47: C: [Correctable] Style/AndOr: Use && instead of and.
      good = false if instruction[I_SIZE] > 0 and !datastore['MultiByte']
                                              ^^^
modules/nops/x86/single_byte.rb:105:17: C: [Correctable] Style/AndOr: Use && instead of and.
    if (!random and datastore['RandomNops'])
                ^^^
modules/nops/x86/single_byte.rb:126:11: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
      end while (badchars.include?(cur_char) or
          ^^^^^
modules/nops/x86/single_byte.rb:126:46: C: [Correctable] Style/AndOr: Use || instead of or.
      end while (badchars.include?(cur_char) or
                                             ^^
modules/nops/x86/single_byte.rb:127:32: C: [Correctable] Style/AndOr: Use && instead of and.
        ((sled_hash[cur_char]) and
                               ^^^
modules/nops/x86/single_byte.rb:128:12: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
          ((sled_hash[cur_char] & badregs).length > 0)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

14 files inspected, 10 offenses detected, 9 more offenses can be corrected with `rubocop -A`
```
