### PR TITLE
modules/evasion: Resolve RuboCop violations

### DIFF
--- a/modules/evasion/windows/applocker_evasion_install_util.rb
+++ b/modules/evasion/windows/applocker_evasion_install_util.rb
@@ -5,25 +5,26 @@
 
 class MetasploitModule < Msf::Evasion
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'        => 'Applocker Evasion - .NET Framework Installation Utility',
-      'Description' => %q(
-         This module will assist you in evading Microsoft Windows
-         Applocker and Software Restriction Policies.
-         This technique utilises the Microsoft signed binary
-         InstallUtil.exe to execute user supplied code.
-      ),
-      'Author'      =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Applocker Evasion - .NET Framework Installation Utility',
+        'Description' => %q{
+          This module will assist you in evading Microsoft Windows
+          Applocker and Software Restriction Policies.
+          This technique utilises the Microsoft signed binary
+          InstallUtil.exe to execute user supplied code.
+        },
+        'Author' => [
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # install_util bypass research
         ],
-      'License'     => 'MSF_LICENSE',
-      'Platform'    => 'win',
-      'Arch'        => [ARCH_X86, ARCH_X64],
-      'Targets'     => [['Microsoft Windows', {}]],
-      'References'  => [['URL', 'https://attack.mitre.org/techniques/T1118/']]
+        'License' => 'MSF_LICENSE',
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [['Microsoft Windows', {}]],
+        'References' => [['URL', 'https://attack.mitre.org/techniques/T1118/']]
       )
     )
 

--- a/modules/evasion/windows/applocker_evasion_msbuild.rb
+++ b/modules/evasion/windows/applocker_evasion_msbuild.rb
@@ -6,24 +6,26 @@
 class MetasploitModule < Msf::Evasion
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Applocker Evasion - MSBuild',
-      'Description' => %(
-         This module will assist you in evading Microsoft
-         Windows Applocker and Software Restriction Policies.
-         This technique utilises the Microsoft signed binary
-         MSBuild.exe to execute user supplied code.
-       ),
-      'Author'      =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Applocker Evasion - MSBuild',
+        'Description' => %q{
+          This module will assist you in evading Microsoft
+          Windows Applocker and Software Restriction Policies.
+          This technique utilises the Microsoft signed binary
+          MSBuild.exe to execute user supplied code.
+        },
+        'Author' => [
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # msbuild bypass research
         ],
-      'License'     => 'MSF_LICENSE',
-      'Platform'    => 'win',
-      'Arch'        => [ARCH_X86, ARCH_X64],
-      'Targets'     => [['Microsoft Windows', {}]],
-      'References'  => [['URL', 'https://attack.mitre.org/techniques/T1127/']])
+        'License' => 'MSF_LICENSE',
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [['Microsoft Windows', {}]],
+        'References' => [['URL', 'https://attack.mitre.org/techniques/T1127/']]
+      )
     )
 
     register_options(

--- a/modules/evasion/windows/applocker_evasion_presentationhost.rb
+++ b/modules/evasion/windows/applocker_evasion_presentationhost.rb
@@ -6,23 +6,25 @@
 class MetasploitModule < Msf::Evasion
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Applocker Evasion - Windows Presentation Foundation Host',
-      'Description' => %(
-         This module will assist you in evading Microsoft
-         Windows Applocker and Software Restriction Policies.
-         This technique utilises the Microsoft signed binary
-         PresentationHost.exe to execute user supplied code.
-                        ),
-      'Author'      =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Applocker Evasion - Windows Presentation Foundation Host',
+        'Description' => %q{
+          This module will assist you in evading Microsoft
+          Windows Applocker and Software Restriction Policies.
+          This technique utilises the Microsoft signed binary
+          PresentationHost.exe to execute user supplied code.
+        },
+        'Author' => [
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # presentationhost bypass research
         ],
-      'License'     => 'MSF_LICENSE',
-      'Platform'    => 'win',
-      'Arch'        => [ARCH_X86],
-      'Targets'     => [['Microsoft Windows', {}]])
+        'License' => 'MSF_LICENSE',
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86],
+        'Targets' => [['Microsoft Windows', {}]]
+      )
     )
 
     register_options(

--- a/modules/evasion/windows/applocker_evasion_regasm_regsvcs.rb
+++ b/modules/evasion/windows/applocker_evasion_regasm_regsvcs.rb
@@ -6,24 +6,26 @@
 class MetasploitModule < Msf::Evasion
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Applocker Evasion - Microsoft .NET Assembly Registration Utility',
-      'Description' => %(
-         This module will assist you in evading Microsoft
-         Windows Applocker and Software Restriction Policies.
-         This technique utilises the Microsoft signed binaries
-         RegAsm.exe or RegSvcs.exe to execute user supplied code.
-                        ),
-      'Author'      =>
-      [
-        'Nick Tyrer <@NickTyrer>', # module development
-        'Casey Smith' # regasm_regsvcs bypass research
-      ],
-      'License'     => 'MSF_LICENSE',
-      'Platform'    => 'win',
-      'Arch'        => [ARCH_X86, ARCH_X64],
-      'Targets'     => [['Microsoft Windows', {}]],
-      'References'  => [['URL', 'https://attack.mitre.org/techniques/T1121/']])
+    super(
+      update_info(
+        info,
+        'Name' => 'Applocker Evasion - Microsoft .NET Assembly Registration Utility',
+        'Description' => %q{
+          This module will assist you in evading Microsoft
+          Windows Applocker and Software Restriction Policies.
+          This technique utilises the Microsoft signed binaries
+          RegAsm.exe or RegSvcs.exe to execute user supplied code.
+        },
+        'Author' => [
+          'Nick Tyrer <@NickTyrer>', # module development
+          'Casey Smith' # regasm_regsvcs bypass research
+        ],
+        'License' => 'MSF_LICENSE',
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [['Microsoft Windows', {}]],
+        'References' => [['URL', 'https://attack.mitre.org/techniques/T1121/']]
+      )
     )
 
     register_options(

--- a/modules/evasion/windows/applocker_evasion_workflow_compiler.rb
+++ b/modules/evasion/windows/applocker_evasion_workflow_compiler.rb
@@ -6,24 +6,28 @@
 class MetasploitModule < Msf::Evasion
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Applocker Evasion - Microsoft Workflow Compiler',
-      'Description' => %(
-         This module will assist you in evading Microsoft
-         Windows Applocker and Software Restriction Policies.
-         This technique utilises the Microsoft signed binaries
-         Microsoft.Workflow.Compiler.exe to execute user supplied code.
-                        ),
-      'Author'      =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Applocker Evasion - Microsoft Workflow Compiler',
+        'Description' => %q{
+          This module will assist you in evading Microsoft
+          Windows Applocker and Software Restriction Policies.
+          This technique utilises the Microsoft signed binaries
+          Microsoft.Workflow.Compiler.exe to execute user supplied code.
+        },
+        'Author' => [
           'Nick Tyrer <@NickTyrer>', # module development
           'Matt Graeber' # workflow_compiler bypass research
         ],
-      'License'     => 'MSF_LICENSE',
-      'Platform'    => 'win',
-      'Arch'        => [ARCH_X86, ARCH_X64],
-      'Targets'     => [['Microsoft Windows', {}]],
-      'References'  => [['URL', 'https://posts.specterops.io/arbitrary-unsigned-code-execution-vector-in-microsoft-workflow-compiler-exe-3d9294bc5efb']])
+        'License' => 'MSF_LICENSE',
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [['Microsoft Windows', {}]],
+        'References' => [
+          ['URL', 'https://posts.specterops.io/arbitrary-unsigned-code-execution-vector-in-microsoft-workflow-compiler-exe-3d9294bc5efb']
+        ]
+      )
     )
 
     register_options(

--- a/modules/evasion/windows/windows_defender_exe.rb
+++ b/modules/evasion/windows/windows_defender_exe.rb
@@ -7,24 +7,27 @@ require 'metasploit/framework/compiler/windows'
 
 class MetasploitModule < Msf::Evasion
 
-  def initialize(info={})
-    super(merge_info(info,
-      'Name'        => 'Microsoft Windows Defender Evasive Executable',
-      'Description' => %q{
-        This module allows you to generate a Windows EXE that evades against Microsoft
-        Windows Defender. Multiple techniques such as shellcode encryption, source code
-        obfuscation, Metasm, and anti-emulation are used to achieve this.
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Microsoft Windows Defender Evasive Executable',
+        'Description' => %q{
+          This module allows you to generate a Windows EXE that evades against Microsoft
+          Windows Defender. Multiple techniques such as shellcode encryption, source code
+          obfuscation, Metasm, and anti-emulation are used to achieve this.
 
-        For best results, please try to use payloads that use a more secure channel
-        such as HTTPS or RC4 in order to avoid the payload network traffic getting
-        caught by antivirus better.
-      },
-      'Author'      => [ 'sinn3r' ],
-      'License'     => MSF_LICENSE,
-      'Platform'    => 'win',
-      'Arch'        => ARCH_X86,
-      'Targets'     => [ ['Microsoft Windows', {}] ]
-    ))
+          For best results, please try to use payloads that use a more secure channel
+          such as HTTPS or RC4 in order to avoid the payload network traffic getting
+          caught by antivirus better.
+        },
+        'Author' => [ 'sinn3r' ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X86,
+        'Targets' => [ ['Microsoft Windows', {}] ]
+      )
+    )
   end
 
   def rc4_key
@@ -32,7 +35,7 @@ class MetasploitModule < Msf::Evasion
   end
 
   def get_payload
-    @c_payload ||= lambda {
+    @get_payload ||= lambda {
       opts = { format: 'rc4', key: rc4_key }
       junk = Rex::Text.rand_text(10..1024)
       p = payload.encoded + junk
@@ -45,7 +48,7 @@ class MetasploitModule < Msf::Evasion
   end
 
   def c_template
-    @c_template ||= %Q|#include <Windows.h>
+    @c_template ||= %|#include <Windows.h>
 #include <rc4.h>
 
 // The encrypted code allows us to get around static scanning

--- a/modules/evasion/windows/windows_defender_js_hta.rb
+++ b/modules/evasion/windows/windows_defender_js_hta.rb
@@ -5,35 +5,38 @@
 
 class MetasploitModule < Msf::Evasion
 
-  def initialize(info={})
-    super(merge_info(info,
-      'Name'        =>  'Microsoft Windows Defender Evasive JS.Net and HTA',
-      'Description' =>  %q{
-        This module will generate an HTA file that writes and compiles a JScript.NET file
-        containing shellcode on the target machine. After compilation, the generated EXE will
-        execute the shellcode without interference from Windows Defender.
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Microsoft Windows Defender Evasive JS.Net and HTA',
+        'Description' => %q{
+          This module will generate an HTA file that writes and compiles a JScript.NET file
+          containing shellcode on the target machine. After compilation, the generated EXE will
+          execute the shellcode without interference from Windows Defender.
 
-        It is recommended that you use a payload that uses RC4 or HTTPS for best experience.
-      },
-      'Author'      =>
-        [
-          'sinmygit',    # PoC
-          'Shelby Pace'  # Metasploit Module
+          It is recommended that you use a payload that uses RC4 or HTTPS for best experience.
+        },
+        'Author' => [
+          'sinmygit', # PoC
+          'Shelby Pace' # Metasploit Module
         ],
-      'License'     =>  MSF_LICENSE,
-      'Platform'    =>  'win',
-      'Arch'        =>  ARCH_X64,
-      'Targets'     =>  [ [ 'Microsoft Windows', {} ] ]
-    ))
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X64,
+        'Targets' => [ [ 'Microsoft Windows', {} ] ]
+      )
+    )
 
     register_options([
       OptString.new(
         'FILENAME',
-          [
-            true,
-            'Filename for the evasive file (default: random)',
-            "#{Rex::Text.rand_text_alpha(3..10)}.hta"
-          ])
+        [
+          true,
+          'Filename for the evasive file (default: random)',
+          "#{Rex::Text.rand_text_alpha(3..10)}.hta"
+        ]
+      )
     ])
   end
 
@@ -43,15 +46,15 @@ class MetasploitModule < Msf::Evasion
     evasion_shellcode_path = File.join(Msf::Config.data_directory, 'exploits', 'evasion_shellcode.js')
     jsnet_code = File.read(evasion_shellcode_path)
     fail_with(Failure::NotFound, 'The JScript.NET file was not found.') unless File.exist?(evasion_shellcode_path)
-    js_file = ERB.new(jsnet_code).result(binding())
+    js_file = ERB.new(jsnet_code).result(binding)
     jsnet_encoded = Rex::Text.encode_base64(js_file)
     # This is used in the ERB template
     fname = Rex::Text.rand_text_alpha(6)
-    arch = ["x86", "x64"].include?(payload.arch.first) ? payload.arch.first : "anycpu"
+    arch = ['x86', 'x64'].include?(payload.arch.first) ? payload.arch.first : 'anycpu'
     hta_path = File.join(Msf::Config.data_directory, 'exploits', 'hta_evasion.hta')
     hta = File.read(hta_path)
     fail_with(Failure::NotFound, 'The HTA file was not found.') unless File.exist?(hta_path)
-    hta_file = ERB.new(hta).result(binding())
+    hta_file = ERB.new(hta).result(binding)
     file_create(hta_file)
   end
 end


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, with the exception of:

```
modules/evasion/windows/windows_defender_exe.rb:38:5: C: [Correctable] Naming/MemoizedInstanceVariableName: Memoized variable @c_payload does not match method name get_payload. Use @get_payload instead.
    @c_payload ||= lambda {
```

Applying this change manually had no visible effect on the output of this module.
