### PR TITLE
modules/encoders: Resolve RuboCop violations

### DIFF
--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -26,8 +26,7 @@ class MetasploitModule < Msf::Encoder
     register_advanced_options(
       [
         OptString.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
-      ],
-      self.class
+      ]
     )
   end
 

--- a/modules/encoders/cmd/brace.rb
+++ b/modules/encoders/cmd/brace.rb
@@ -10,14 +10,14 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'        => 'Bash Brace Expansion Command Encoder',
+      'Name' => 'Bash Brace Expansion Command Encoder',
       'Description' => %q{
         This encoder uses brace expansion in Bash and other shells
         to avoid whitespace without being overly fancy.
       },
-      'Author'      => ['wvu', 'egypt'],
-      'Platform'    => %w[ linux unix ],
-      'Arch'        => ARCH_CMD,
+      'Author' => ['wvu', 'egypt'],
+      'Platform' => %w[linux unix],
+      'Arch' => ARCH_CMD,
       'EncoderType' => Msf::Encoder::Type::CmdPosixBrace
     )
   end

--- a/modules/encoders/cmd/echo.rb
+++ b/modules/encoders/cmd/echo.rb
@@ -8,61 +8,50 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'Echo Command Encoder',
-      'Description'      => %q{
+      'Name' => 'Echo Command Encoder',
+      'Description' => %q{
         This encoder uses echo and backlash escapes to avoid commonly restricted characters.
       },
-      'Author'           => 'hdm',
-      'Arch'             => ARCH_CMD,
-      'Platform'         => %w[ linux unix ],
-      'EncoderType'      => Msf::Encoder::Type::CmdPosixEcho)
+      'Author' => 'hdm',
+      'Arch' => ARCH_CMD,
+      'Platform' => %w[linux unix],
+      'EncoderType' => Msf::Encoder::Type::CmdPosixEcho)
   end
-
 
   #
   # Encodes the payload
   #
   def encode_block(state, buf)
     # Skip encoding for empty badchars
-    if state.badchars.length == 0
-      return buf
-    end
+    return buf if state.badchars.empty?
 
-    if state.badchars.include?("-")
-      raise EncodingError
-    else
-      # Without an escape character we can't escape anything, so echo
-      # won't work.
-      if state.badchars.include?("\\")
-        raise EncodingError
-      else
-        buf = encode_block_bash_echo(state,buf)
-      end
-    end
+    raise EncodingError if state.badchars.include?('-')
 
-    return buf
+    # echo won't work without an escape character
+    raise EncodingError if state.badchars.include?('\\')
+
+    encode_block_bash_echo(state, buf)
   end
 
   #
   # Uses bash's echo -ne command to hex encode the command string
   #
   def encode_block_bash_echo(state, buf)
-
     hex = ''
 
     # Can we use single quotes to enclose the echo arguments?
     if state.badchars.include?("'")
-      hex = buf.unpack('C*').collect { |c| "\\\\\\x%.2x" % c }.join
+      hex = buf.unpack('C*').collect { |c| '\\\\\\x%.2x' % c }.join
     else
-      hex = "'" + buf.unpack('C*').collect { |c| "\\x%.2x" % c }.join + "'"
+      hex = "'" + buf.unpack('C*').collect { |c| '\\x%.2x' % c }.join + "'"
     end
 
     # Are pipe characters restricted?
-    if state.badchars.include?("|")
+    if state.badchars.include?('|')
       # How about backticks?
-      if state.badchars.include?("`")
+      if state.badchars.include?('`')
         # Last ditch effort, dollar paren
-        if state.badchars.include?("$") or state.badchars.include?("(")
+        if state.badchars.include?('$') || state.badchars.include?('(')
           raise EncodingError
         else
           buf = "$(/bin/echo -ne #{hex})"
@@ -75,7 +64,7 @@ class MetasploitModule < Msf::Encoder
     end
 
     # Remove spaces from the command string
-    if state.badchars.include?(" ")
+    if state.badchars.include?(' ')
       buf.gsub!(/\s/, '${IFS}')
     end
 

--- a/modules/encoders/cmd/ifs.rb
+++ b/modules/encoders/cmd/ifs.rb
@@ -10,14 +10,14 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'        => 'Bourne ${IFS} Substitution Command Encoder',
+      'Name' => 'Bourne ${IFS} Substitution Command Encoder',
       'Description' => %q{
         This encoder uses Bourne ${IFS} substitution to avoid whitespace
         without being overly fancy.
       },
-      'Author'      => ['egypt', 'wvu'],
-      'Platform'    => %w[ linux unix ],
-      'Arch'        => ARCH_CMD,
+      'Author' => ['egypt', 'wvu'],
+      'Platform' => %w[linux unix],
+      'Arch' => ARCH_CMD,
       'EncoderType' => Msf::Encoder::Type::CmdPosixIFS
     )
   end

--- a/modules/encoders/cmd/perl.rb
+++ b/modules/encoders/cmd/perl.rb
@@ -8,31 +8,29 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'Perl Command Encoder',
-      'Description'      => %q{
+      'Name' => 'Perl Command Encoder',
+      'Description' => %q{
         This encoder uses perl to avoid commonly restricted characters.
       },
-      'Author'           => 'hdm',
-      'Arch'             => ARCH_CMD,
-      'Platform'         => %w[ linux unix ],
-      'EncoderType'      => Msf::Encoder::Type::CmdPosixPerl)
+      'Author' => 'hdm',
+      'Arch' => ARCH_CMD,
+      'Platform' => %w[linux unix],
+      'EncoderType' => Msf::Encoder::Type::CmdPosixPerl)
   end
-
 
   #
   # Encodes the payload
   #
   def encode_block(state, buf)
-
     # Skip encoding for empty badchars
-    if state.badchars.length == 0
+    if state.badchars.empty?
       return buf
     end
 
-    if state.badchars.include?("-")
+    if state.badchars.include?('-')
       raise EncodingError
     else
-      buf = encode_block_perl(state,buf)
+      buf = encode_block_perl(state, buf)
     end
 
     return buf
@@ -42,39 +40,37 @@ class MetasploitModule < Msf::Encoder
   # Uses the perl command to hex encode the command string
   #
   def encode_block_perl(state, buf)
-
-    hex = buf.unpack("H*").join
+    hex = buf.unpack('H*').join
     cmd = 'perl -e '
     qot = ',-:.=+!@#$%^&'
 
     # Convert spaces to IFS...
-    if state.badchars.include?(" ")
+    if state.badchars.include?(' ')
       if state.badchars.match(/[${IFS}]/n)
         raise EncodingError
       end
+
       cmd.gsub!(/\s/, '${IFS}')
     end
 
     # Can we use single quotes to enclose the command string?
     if state.badchars.include?("'")
-      if (state.badchars.match(/[()\\]/))
+      if state.badchars.match(/[()\\]/)
         cmd << perl_e(state, qot, hex)
       else
         # Without quotes, we can use backslash to escape parens so the
         # shell doesn't try to interpreter them.
         cmd << "system\\(pack\\(#{perl_qq(state, qot, hex)}\\)\\)"
       end
-    else
+    elsif state.badchars.match(/[()]/n)
       # Quotes are ok, but we still need parens or spaces
-      if (state.badchars.match(/[()]/n))
-        if state.badchars.include?(" ")
-          cmd << perl_e(state, qot, hex)
-        else
-          cmd << "'system pack #{perl_qq(state, qot, hex)}'"
-        end
+      if state.badchars.include?(' ')
+        cmd << perl_e(state, qot, hex)
       else
-        cmd << "'system(pack(#{perl_qq(state, qot, hex)}))'"
+        cmd << "'system pack #{perl_qq(state, qot, hex)}'"
       end
+    else
+      cmd << "'system(pack(#{perl_qq(state, qot, hex)}))'"
     end
 
     return cmd
@@ -85,8 +81,8 @@ class MetasploitModule < Msf::Encoder
     # barewords on the commandline for the argument to the pack
     # function. As a consequence, we can't use things that the shell
     # would interpret, so $ and & become badchars.
-    qot.delete("$")
-    qot.delete("&")
+    qot.delete('$')
+    qot.delete('&')
 
     # Perl chains -e with newlines, but doesn't automatically add
     # semicolons, so the following will result in the interpreter
@@ -98,22 +94,21 @@ class MetasploitModule < Msf::Encoder
     # $_ when no args are given like many other perl functions),
     # this works out to do what we need.
     cmd = "system -e pack -e #{perl_qq(state, qot, hex)}"
-    if state.badchars.include?(" ")
+    if state.badchars.include?(' ')
       # We already tested above to make sure that these chars are ok
       # if space isn't.
-      cmd.gsub!(" ", "${IFS}")
+      cmd.gsub!(' ', '${IFS}')
     end
 
     cmd
   end
 
   def perl_qq(state, qot, hex)
-
     # Find a quoting character to use
     state.badchars.unpack('C*') { |c| qot.delete(c.chr) }
 
     # Throw an error if we ran out of quotes
-    raise EncodingError if qot.length == 0
+    raise EncodingError if qot.empty?
 
     sep = qot[0].chr
     # Use an explicit length for the H specifier instead of just "H*"

--- a/modules/encoders/cmd/powershell_base64.rb
+++ b/modules/encoders/cmd/powershell_base64.rb
@@ -2,28 +2,29 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-include Msf::Post::Windows
+
 class MetasploitModule < Msf::Encoder
   Rank = ExcellentRanking
 
+  include Msf::Post::Windows
+
   def initialize
     super(
-      'Name'             => 'Powershell Base64 Command Encoder',
-      'Description'      => %q{
+      'Name' => 'Powershell Base64 Command Encoder',
+      'Description' => %q{
         This encodes the command as a base64 encoded command for powershell.
       },
-      'Author'           => 'Ben Campbell',
-      'Arch'             => ARCH_CMD,
-      'Platform'         => 'win')
+      'Author' => 'Ben Campbell',
+      'Arch' => ARCH_CMD,
+      'Platform' => 'win')
   end
-
 
   #
   # Encodes the payload
   #
   def encode_block(state, buf)
     # Skip encoding for empty badchars
-    if state.badchars.length == 0
+    if state.badchars.empty?
       return buf
     end
 
@@ -34,10 +35,10 @@ class MetasploitModule < Msf::Encoder
     cmd = encode_buf(buf)
 
     if state.badchars.include? '='
-        while cmd.include? '='
-          buf << " "
-          cmd = encode_buf(buf)
-        end
+      while cmd.include? '='
+        buf << ' '
+        cmd = encode_buf(buf)
+      end
     end
 
     cmd
@@ -45,6 +46,6 @@ class MetasploitModule < Msf::Encoder
 
   def encode_buf(buf)
     base64 = Rex::Text.encode_base64(Rex::Text.to_unicode("cmd.exe /c '#{Msf::Post::Windows.escape_powershell_literal(buf)}'"))
-    cmd = "powershell -w hidden -nop -e #{base64}"
+    "powershell -w hidden -nop -e #{base64}"
   end
 end

--- a/modules/encoders/cmd/printf_php_mq.rb
+++ b/modules/encoders/cmd/printf_php_mq.rb
@@ -18,58 +18,56 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'printf(1) via PHP magic_quotes Utility Command Encoder',
-      'Description'      => %q{
+      'Name' => 'printf(1) via PHP magic_quotes Utility Command Encoder',
+      'Description' => %q{
           This encoder uses the printf(1) utility to avoid restricted
         characters. Some shell variable substitution may also be used
         if needed symbols are blacklisted. Some characters are intentionally
         left unescaped since it is assumed that PHP with magic_quotes_gpc
         enabled will escape them during request handling.
       },
-      'Author'           => 'jduck',
-      'Arch'             => ARCH_CMD,
-      'Platform'         => 'unix',
-      'EncoderType'      => Msf::Encoder::Type::PrintfPHPMagicQuotes)
+      'Author' => 'jduck',
+      'Arch' => ARCH_CMD,
+      'Platform' => 'unix',
+      'EncoderType' => Msf::Encoder::Type::PrintfPHPMagicQuotes)
   end
-
 
   #
   # Encodes the payload
   #
   def encode_block(state, buf)
-
     # Skip encoding for empty badchars
-    if(state.badchars.length == 0)
+    if state.badchars.empty?
       return buf
     end
 
     # If backslash is bad, we are screwed.
-    if (state.badchars.include?("\\")) or
-      (state.badchars.include?("|")) or
-      # We must have at least ONE of these two..
-      (state.badchars.include?("x") and state.badchars.include?("0"))
+    if state.badchars.include?('\\') ||
+       state.badchars.include?('|') ||
+       # We must have at least ONE of these two..
+       (state.badchars.include?('x') && state.badchars.include?('0'))
       raise EncodingError
     end
 
     # Now we build a string of the original payload with bad characters
     # into \0<NNN> or \x<HH>
-    if (state.badchars.include?('x'))
-      hex = buf.unpack('C*').collect { |c| "\\0%o" % c }.join
+    if state.badchars.include?('x')
+      hex = buf.unpack('C*').collect { |c| '\\0%o' % c }.join
     else
-      hex = buf.unpack('C*').collect { |c| "\\x%x" % c }.join
+      hex = buf.unpack('C*').collect { |c| '\\x%x' % c }.join
     end
 
     # Build the final output
-    ret = "printf"
+    ret = 'printf'
 
     # Special case: <SPACE>, try to use ${IFS}
-    if (state.badchars.include?(" "))
+    if state.badchars.include?(' ')
       ret << '${IFS}'
     else
-      ret << " "
+      ret << ' '
     end
 
-    ret << hex << "|sh"
+    ret << hex << '|sh'
 
     return ret
   end

--- a/modules/encoders/generic/eicar.rb
+++ b/modules/encoders/generic/eicar.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'The EICAR Encoder',
-      'Description'      => %q{
+      'Name' => 'The EICAR Encoder',
+      'Description' => %q{
         This encoder merely replaces the given payload with the EICAR test string.
         Note, this is sure to ruin your payload.
 
@@ -21,18 +21,17 @@ class MetasploitModule < Msf::Encoder
         standards should alert and do what it would normally do when malware is
         transmitted across the wire.
       },
-      'Author'           => 'todb',
-      'License'          => MSF_LICENSE,
-      'Arch'             => ARCH_ALL,
-      'EncoderType'      => Msf::Encoder::Type::Unspecified)
-
+      'Author' => 'todb',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_ALL,
+      'EncoderType' => Msf::Encoder::Type::Unspecified)
   end
 
   # Avoid stating the string directly, don't want to get caught by local
   # antivirus!
   def eicar_test_string
-    obfus_eicar = ["x5o!p%@ap[4\\pzx54(p^)7cc)7}$eicar", "standard", "antivirus", "test", "file!$h+h*"]
-    obfus_eicar.join("-").upcase
+    obfus_eicar = ['x5o!p%@ap[4\\pzx54(p^)7cc)7}$eicar', 'standard', 'antivirus', 'test', 'file!$h+h*']
+    obfus_eicar.join('-').upcase
   end
 
   # TODO: add an option to merely prepend and not delete, using
@@ -40,7 +39,7 @@ class MetasploitModule < Msf::Encoder
   # and not part of a larger whole. Problem is, OptBool is
   # acting funny here as an encoder option.
   #
-  def encode_block(state, buf)
-    buf = eicar_test_string
+  def encode_block(_state, _buf)
+    eicar_test_string
   end
 end

--- a/modules/encoders/generic/none.rb
+++ b/modules/encoders/generic/none.rb
@@ -7,20 +7,20 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'The "none" Encoder',
-      'Description'      => %q{
+      'Name' => 'The "none" Encoder',
+      'Description' => %q{
         This "encoder" does not transform the payload in any way.
       },
-      'Author'           => 'spoonm',
-      'License'          => MSF_LICENSE,
-      'Arch'             => ARCH_ALL,
-      'EncoderType'      => Msf::Encoder::Type::Raw)
+      'Author' => 'spoonm',
+      'License' => MSF_LICENSE,
+      'Arch' => ARCH_ALL,
+      'EncoderType' => Msf::Encoder::Type::Raw)
   end
 
   #
   # Simply return the buf straight back.
   #
-  def encode_block(state, buf)
+  def encode_block(_state, buf)
     buf
   end
 end

--- a/modules/encoders/mipsbe/byte_xori.rb
+++ b/modules/encoders/mipsbe/byte_xori.rb
@@ -10,26 +10,24 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Byte XORi Encoder',
-      'Description'      => %q{
+      'Name' => 'Byte XORi Encoder',
+      'Description' => %q{
         Mips Web server exploit friendly xor encoder. This encoder has been found useful on
         situations where '&' (0x26) is a badchar. Since 0x26 is the xor's opcode on MIPS
         architectures, this one is based on the xori instruction.
       },
-      'Author'           =>
-        [
-          'Julien Tinnes <julien[at]cr0.org>',  # original longxor encoder, which this one is based on
-          'juan vazquez',                       # byte_xori encoder
-          'Pedro Ribeiro <pedrib@gmail.com>',   # fix for Linux >= 2.6.11 (set up cacheflush() args properly)
-        ],
-      'Arch'             => ARCH_MIPSBE,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'   => 1,
-          'BlockSize' => 1,
-          'KeyPack'   => 'C',
-        })
+      'Author' => [
+        'Julien Tinnes <julien[at]cr0.org>',  # original longxor encoder, which this one is based on
+        'juan vazquez',                       # byte_xori encoder
+        'Pedro Ribeiro <pedrib@gmail.com>',   # fix for Linux >= 2.6.11 (set up cacheflush() args properly)
+      ],
+      'Arch' => ARCH_MIPSBE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 1,
+        'BlockSize' => 1,
+        'KeyPack' => 'C'
+      })
   end
 
   #
@@ -37,80 +35,78 @@ class MetasploitModule < Msf::Encoder::Xor
   # being encoded.
   #
   def decoder_stub(state)
-
     # add 4 number of passes  for the space reserved for the key, at the end of the decoder stub
     # (see commented source)
-    number_of_passes=state.buf.length+4
-    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
+    number_of_passes = state.buf.length + 4
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if number_of_passes > 32766
 
     # 16-bits not (again, see also commented source)
-    reg_14 = (number_of_passes+1)^0xFFFF
-    reg_5 = state.buf.length^0xFFFF
+    reg_14 = (number_of_passes + 1) ^ 0xFFFF
+    reg_5 = state.buf.length ^ 0xFFFF
 
-    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:big), <<EOS).encoded.data
-main:
+    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:big), <<~EOS).encoded.data
+      main:
 
-li macro reg, imm
-  addiu reg, $0, imm                     ; 0x24xxyyyy - xx: reg #, yyyy: imm # imm must be equal or less than 0x7fff
-endm
+      li macro reg, imm
+        addiu reg, $0, imm                     ; 0x24xxyyyy - xx: reg #, yyyy: imm # imm must be equal or less than 0x7fff
+      endm
 
-  li      ($14, #{reg_14})               ; 0x240exxxx - store in $14 the number of passes (two's complement) - xxxx (number of passes)
-  nor     $14, $14, $0                   ; 0x01c07027 - get in $14 the number of passes
-  li      ($11,-84)                      ; 0x240bffac - store in $11 the offset to the end of the decoder (two's complement) (from the addu instr)
+        li      ($14, #{reg_14})               ; 0x240exxxx - store in $14 the number of passes (two's complement) - xxxx (number of passes)
+        nor     $14, $14, $0                   ; 0x01c07027 - get in $14 the number of passes
+        li      ($11,-84)                      ; 0x240bffac - store in $11 the offset to the end of the decoder (two's complement) (from the addu instr)
 
-; acts as getpc
-next:
-  bltzal  $8, next                       ; 0x0510ffff - branch to next if $8 < 0, store return address in $31 ($ra); pipelining executes next instr.
-  slti    $8, $0, 0x#{slti_imm(state)}   ; 0x2808xxxx - Set $8 = 0; Set $8 = 1 if $0 < imm; else $8 = 0 / xxxx: imm
+      ; acts as getpc
+      next:
+        bltzal  $8, next                       ; 0x0510ffff - branch to next if $8 < 0, store return address in $31 ($ra); pipelining executes next instr.
+        slti    $8, $0, 0x#{slti_imm(state)}   ; 0x2808xxxx - Set $8 = 0; Set $8 = 1 if $0 < imm; else $8 = 0 / xxxx: imm
 
-  nor     $11, $11, $0                   ; 0x01605827 - get in $11 the offset to the end of the decoder (from the addu instr)
-  addu    $25, $31, $11                  ; 0x03ebc821 - get in $25 a pointer to the end of the decoder stub
-  addu	  $16, $31, $11		             ; $16 too (used to set up the cacheflush() arg down below)
+        nor     $11, $11, $0                   ; 0x01605827 - get in $11 the offset to the end of the decoder (from the addu instr)
+        addu    $25, $31, $11                  ; 0x03ebc821 - get in $25 a pointer to the end of the decoder stub
+        addu	  $16, $31, $11		             ; $16 too (used to set up the cacheflush() arg down below)
 
-  slti    $23, $0, 0x#{slti_imm(state)}  ; 0x2817xxxx - Set $23 = 0 (Set $23 = 1 if $0 < imm; else $23 = 0) / xxxx: imm
-  lb      $17, -1($25)                   ; 0x8f31fffc - Load xor key in $17 (stored on the last byte of the decoder stub)
+        slti    $23, $0, 0x#{slti_imm(state)}  ; 0x2817xxxx - Set $23 = 0 (Set $23 = 1 if $0 < imm; else $23 = 0) / xxxx: imm
+        lb      $17, -1($25)                   ; 0x8f31fffc - Load xor key in $17 (stored on the last byte of the decoder stub)
 
-; Init $6 and $15
-  li      ($13, -4)                      ; 0x240dfffc - $13 = -4
-  nor     $6, $13, $0                    ; 0x01a03027 - $6 = 3 ; used to easily get the cacheflush parameter
-  addi    $15, $6, -2                    ; 0x20cffffe - $15 = 1 ($15 = decoding loop counter increment)
+      ; Init $6 and $15
+        li      ($13, -4)                      ; 0x240dfffc - $13 = -4
+        nor     $6, $13, $0                    ; 0x01a03027 - $6 = 3 ; used to easily get the cacheflush parameter
+        addi    $15, $6, -2                    ; 0x20cffffe - $15 = 1 ($15 = decoding loop counter increment)
 
-; In order avoid null bytes, decode also the xor key, so memory can be
-; referenced with offset -1
-loop:
-  lb      $8, -4($25)                    ; 0x8f28fffc - Load in $8 the byte to decode
-  addu    $23, $23, $15                  ; 0x02efb821 - Increment the counter ($23)
-  xori    $3, $8, 0x#{padded_key(state)} ; 0x01111826 - xori decoding instruction, store the decoded byte on $3
-  #{set_on_less_than(state)}             ; 0x02eef0xx - $30 = 1 if $23 < $14; else $30 = 0 (update branch condition) / xx: 0x2b if slti, 0x2a if slt
-  sb      $3, -4($25)                    ; 0xaf23fffc - Store decoded byte on memory
-  bne     $0, $30, loop                  ; 0x17c0fff9 - branch to loop if $30 != 0 (ranch while bytes to decode)
-  addu    $25, $25, $15                  ; 0x032dc821 - next instruction to decode, executed because of the pipelining
+      ; In order avoid null bytes, decode also the xor key, so memory can be
+      ; referenced with offset -1
+      loop:
+        lb      $8, -4($25)                    ; 0x8f28fffc - Load in $8 the byte to decode
+        addu    $23, $23, $15                  ; 0x02efb821 - Increment the counter ($23)
+        xori    $3, $8, 0x#{padded_key(state)} ; 0x01111826 - xori decoding instruction, store the decoded byte on $3
+        #{set_on_less_than(state)}             ; 0x02eef0xx - $30 = 1 if $23 < $14; else $30 = 0 (update branch condition) / xx: 0x2b if slti, 0x2a if slt
+        sb      $3, -4($25)                    ; 0xaf23fffc - Store decoded byte on memory
+        bne     $0, $30, loop                  ; 0x17c0fff9 - branch to loop if $30 != 0 (ranch while bytes to decode)
+        addu    $25, $25, $15                  ; 0x032dc821 - next instruction to decode, executed because of the pipelining
 
-  addiu	$4, $16, -4                      ; cacheflush() addr parameter
-  li(      $10,#{reg_5})                 ; cacheflush() nbytes parameter
-  nor   $5, $10, $0                      ; same as above
+        addiu	$4, $16, -4                      ; cacheflush() addr parameter
+        li(      $10,#{reg_5})                 ; cacheflush() nbytes parameter
+        nor   $5, $10, $0                      ; same as above
 
-  li      ($2, 4147)                     ; 0x24021033 - cacheflush system call
-  syscall 0x52950                        ; 0x014a540c
-  nop                                    ; encoded shellcoded must be here (xor key right here ;) after decoding will result in a nop
-EOS
+        li      ($2, 4147)                     ; 0x24021033 - cacheflush system call
+        syscall 0x52950                        ; 0x014a540c
+        nop                                    ; encoded shellcoded must be here (xor key right here ;) after decoding will result in a nop
+    EOS
 
     return decoder
   end
 
-
-  def padded_key(state, size=1)
+  def padded_key(state, size = 1)
     key = Rex::Text.rand_text(size, state.badchars)
-    key << [state.key].pack("C")
-    return key.unpack("n")[0].to_s(16)
+    key << [state.key].pack('C')
+    return key.unpack('n')[0].to_s(16)
   end
 
   # Returns an two-bytes immediate value without badchars. The value must be
   # on the 0x8000-0x8fff so it is used as negative value by slti (set less
   # than signed immediate)
   def slti_imm(state)
-    imm = Rex::Text.rand_text(2, state.badchars + (0x00..0x7f).to_a.pack("C*"))
-    return imm.unpack("n")[0].to_s(16)
+    imm = Rex::Text.rand_text(2, state.badchars + (0x00..0x7f).to_a.pack('C*'))
+    return imm.unpack('n')[0].to_s(16)
   end
 
   # Since 0x14 contains the number of passes, and because of the li macro, can't be
@@ -118,18 +114,18 @@ EOS
   # here
   def set_on_less_than(state)
     instructions = {
-      "sltu   $30, $23, $14" => "\x02\xee\xf0\x2b", # set less than unsigned
-      "slt    $30, $23, $14" => "\x02\xee\xf0\x2a"  # set less than
+      'sltu   $30, $23, $14' => "\x02\xee\xf0\x2b", # set less than unsigned
+      'slt    $30, $23, $14' => "\x02\xee\xf0\x2a"  # set less than
     }
 
-    instructions.each do |k,v|
-      if Rex::Text.badchar_index(v, state.badchars) == nil
+    instructions.each do |k, v|
+      if Rex::Text.badchar_index(v, state.badchars).nil?
         return k
       end
     end
 
     raise BadcharError.new,
-          "The #{self.name} encoder failed to encode the decoder stub without bad characters.",
+          "The #{name} encoder failed to encode the decoder stub without bad characters.",
           caller
   end
 

--- a/modules/encoders/mipsbe/longxor.rb
+++ b/modules/encoders/mipsbe/longxor.rb
@@ -9,22 +9,21 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'XOR Encoder',
-      'Description'      => %q{
-        Mips Web server exploit friendly xor encoder
+      'Name' => 'XOR Encoder',
+      'Description' => %q{
+        Mips Web server exploit friendly xor encoder.
       },
-      'Author'           =>
-        [   'Julien Tinnes <julien[at]cr0.org>',   # original shellcode
-            'Pedro Ribeiro <pedrib@gmail.com>',    # fix Linux >= 2.6.11 and toupper() compat
-        ],
-      'Arch'             => ARCH_MIPSBE,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'   => 4,
-          'BlockSize' => 4,
-          'KeyPack'   => 'N',
-        })
+      'Author' => [
+        'Julien Tinnes <julien[at]cr0.org>',  # original shellcode
+        'Pedro Ribeiro <pedrib@gmail.com>',   # fix Linux >= 2.6.11 and toupper() compat
+      ],
+      'Arch' => ARCH_MIPSBE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'N'
+      })
   end
 
   #
@@ -32,114 +31,113 @@ class MetasploitModule < Msf::Encoder::Xor
   # being encoded.
   #
   def decoder_stub(state)
-
     # add one xor operation for the key (see comment below)
-    number_of_passes=state.buf.length/4+1
-    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 10240
-    raise EncodingError.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
+    number_of_passes = state.buf.length / 4 + 1
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if number_of_passes > 10240
+    raise EncodingError, "The payload is not padded to 4-bytes (#{state.buf.length} bytes)" if state.buf.length % 4 != 0
 
     # 16-bits not (again, see below)
-    reg_10 = (number_of_passes+1)^0xFFFF
-    reg_5 = state.buf.length^0xFFFF
-    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:big), <<EOS).encoded.data
-;
-; MIPS nul-free xor decoder
-;
-; (C) 2006 Julien TINNES
-; <julien at cr0.org>
-;
-; The first four bytes in encoded shellcode must be the xor key
-; This means that you have to put the xor key right after
-; this xor decoder
-; This key will be considered part of the encoded shellcode
-; by this decoder and will be xored, thus becoming 4NULs, meaning nop
-;
-; This is Linux-only because I use the cacheflush system call
-;
-; You can use shellforge to assemble this, but be sure to discard all
-; the nul bytes at the end (everything after x01\\x4a\\x54\\x0c)
-;
-; change 2 bytes in the first instruction's opcode with the number of passes
-; the number of passes is the number of xor operations to apply, which should be
-; 1 (for the key) + the number of 4-bytes words you have in your shellcode
-; you must encode ~(number_of_passes + 1) (to ensure that you're nul-free)
+    reg_10 = (number_of_passes + 1) ^ 0xFFFF
+    reg_5 = state.buf.length ^ 0xFFFF
+    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:big), <<~EOS).encoded.data
+      ;
+      ; MIPS nul-free xor decoder
+      ;
+      ; (C) 2006 Julien TINNES
+      ; <julien at cr0.org>
+      ;
+      ; The first four bytes in encoded shellcode must be the xor key
+      ; This means that you have to put the xor key right after
+      ; this xor decoder
+      ; This key will be considered part of the encoded shellcode
+      ; by this decoder and will be xored, thus becoming 4NULs, meaning nop
+      ;
+      ; This is Linux-only because I use the cacheflush system call
+      ;
+      ; You can use shellforge to assemble this, but be sure to discard all
+      ; the nul bytes at the end (everything after x01\\x4a\\x54\\x0c)
+      ;
+      ; change 2 bytes in the first instruction's opcode with the number of passes
+      ; the number of passes is the number of xor operations to apply, which should be
+      ; 1 (for the key) + the number of 4-bytes words you have in your shellcode
+      ; you must encode ~(number_of_passes + 1) (to ensure that you're nul-free)
 
 
-;.text
-;.align	2
-;.globl	main
-;.ent	main
-;.type		 main,@function
+      ;.text
+      ;.align	2
+      ;.globl	main
+      ;.ent	main
+      ;.type		 main,@function
 
-main:
+      main:
 
-li macro reg, imm
-;	lui reg, ((imm) >> 16) & 0ffffh
-;	ori reg, reg, (imm) & 0ffffh
-  addiu reg, $0, imm		    ; sufficient if imm.abs <= 0x7fff
-endm
+      li macro reg, imm
+      ;	lui reg, ((imm) >> 16) & 0ffffh
+      ;	ori reg, reg, (imm) & 0ffffh
+        addiu reg, $0, imm		    ; sufficient if imm.abs <= 0x7fff
+      endm
 
-  li(	$10, #{reg_10})		    ; load number of passes ^ 0xffff
-  nor	$10, $10, $0		      ; put number of passes in $10
+        li(	$10, #{reg_10})		    ; load number of passes ^ 0xffff
+        nor	$10, $10, $0		      ; put number of passes in $10
 
-  li(	$11,-89)		          ; addend to calculated PC is 73
-;.set noreorder
-next:
-  bltzal  $8, next
-;.set reorder
-  slti    $8, $0, 0x8282
-  nor     $11, $11, $0	    ; addend in $9
-  addu	$25, $31, $11		    ; $25 points to encoded shellcode +4
-  addu	$16, $31, $11		    ; $16 too (used to set up the cacheflush() arg down below)
+        li(	$11,-89)		          ; addend to calculated PC is 73
+      ;.set noreorder
+      next:
+        bltzal  $8, next
+      ;.set reorder
+        slti    $8, $0, 0x8282
+        nor     $11, $11, $0	    ; addend in $9
+        addu	$25, $31, $11		    ; $25 points to encoded shellcode +4
+        addu	$16, $31, $11		    ; $16 too (used to set up the cacheflush() arg down below)
 
-;	lui	$2, 0xDDDD     		    ; first part of the xor (old method)
-  slti	$23, $0, 0x8282     ; store 0 in $23 (our counter)
-;	ori	$17, $2, 0xDDDD 	    ; second part of the xor (old method)
-  lw	$17, -4($25)		      ; load xor key in $17
-
-
-  li(	$9, -5)
-  nor	$9, $9, $0		        ; 4 in $9
-
-  addi	$15, $9, -3		      ; 1 in $15
-loop:
-  lw	$8, -4($25)
-
-  addu	$23, $23, $15		    ; increment counter
-  xor	$3, $8, $17
-  sltu	$30, $23, $10		    ; enough loops?
-  sw	$3, -4($25)
-  addi	$6, $9, -1		      ; 3 in $6 (for cacheflush)
-  bne	$0, $30, loop
-  addu	$25, $25, $9		    ; next instruction to decode :)
+      ;	lui	$2, 0xDDDD     		    ; first part of the xor (old method)
+        slti	$23, $0, 0x8282     ; store 0 in $23 (our counter)
+      ;	ori	$17, $2, 0xDDDD 	    ; second part of the xor (old method)
+        lw	$17, -4($25)		      ; load xor key in $17
 
 
-  addiu	$4, $16, -4         ; cacheflush() addr parameter
-  li(      $10,#{reg_5})    ; cacheflush() nbytes parameter
-  nor   $5, $10, $0         ; same as above
-;   li      $6,3            ; $6 is set above, 3rd arg for cacheflush()
+        li(	$9, -5)
+        nor	$9, $9, $0		        ; 4 in $9
 
-;	.set    noreorder
-  li(     $2, 4147)         ; cacheflush
-;   .ascii "\\x01JT\\x0c"   ; nul-free syscall
-  syscall 0x52950
-;	.set    reorder
+        addi	$15, $9, -3		      ; 1 in $15
+      loop:
+        lw	$8, -4($25)
 
-
-; write last decoder opcode and decoded shellcode
-;	li      $4,1              ; stdout
-;	addi	$5, $16, -8
-;	li      $6,40             ; how much to write
-;	.set    noreorder
-;	li      $2, 4004          ; write
-;	syscall
-;	.set    reorder
+        addu	$23, $23, $15		    ; increment counter
+        xor	$3, $8, $17
+        sltu	$30, $23, $10		    ; enough loops?
+        sw	$3, -4($25)
+        addi	$6, $9, -1		      ; 3 in $6 (for cacheflush)
+        bne	$0, $30, loop
+        addu	$25, $25, $9		    ; next instruction to decode :)
 
 
-  nop				                ; encoded shellcoded must be here (xor key right here ;)
-; $t9 (aka $25) points here
+        addiu	$4, $16, -4         ; cacheflush() addr parameter
+        li(      $10,#{reg_5})    ; cacheflush() nbytes parameter
+        nor   $5, $10, $0         ; same as above
+      ;   li      $6,3            ; $6 is set above, 3rd arg for cacheflush()
 
-EOS
+      ;	.set    noreorder
+        li(     $2, 4147)         ; cacheflush
+      ;   .ascii "\\x01JT\\x0c"   ; nul-free syscall
+        syscall 0x52950
+      ;	.set    reorder
+
+
+      ; write last decoder opcode and decoded shellcode
+      ;	li      $4,1              ; stdout
+      ;	addi	$5, $16, -8
+      ;	li      $6,40             ; how much to write
+      ;	.set    noreorder
+      ;	li      $2, 4004          ; write
+      ;	syscall
+      ;	.set    reorder
+
+
+        nop				                ; encoded shellcoded must be here (xor key right here ;)
+      ; $t9 (aka $25) points here
+
+    EOS
     # put the key at the end of the decoder
     state.decoder_key_offset = decoder.length - 4
 

--- a/modules/encoders/mipsle/byte_xori.rb
+++ b/modules/encoders/mipsle/byte_xori.rb
@@ -10,26 +10,24 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Byte XORi Encoder',
-      'Description'      => %q{
+      'Name' => 'Byte XORi Encoder',
+      'Description' => %q{
         Mips Web server exploit friendly xor encoder. This encoder has been found useful on
         situations where '&' (0x26) is a badchar. Since 0x26 is the xor's opcode on MIPS
         architectures, this one is based on the xori instruction.
       },
-      'Author'           =>
-        [
-          'Julien Tinnes <julien[at]cr0.org>',  # original longxor encoder, which this one is based on
-          'juan vazquez',                       # byte_xori encoder
-          'Pedro Ribeiro <pedrib@gmail.com>',   # fix for Linux >= 2.6.11 (set up cacheflush() args properly)
-        ],
-      'Arch'             => ARCH_MIPSLE,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'   => 1,
-          'BlockSize' => 1,
-          'KeyPack'   => 'C',
-        })
+      'Author' => [
+        'Julien Tinnes <julien[at]cr0.org>', # original longxor encoder, which this one is based on
+        'juan vazquez',                      # byte_xori encoder
+        'Pedro Ribeiro <pedrib@gmail.com>',  # fix for Linux >= 2.6.11 (set up cacheflush() args properly)
+      ],
+      'Arch' => ARCH_MIPSLE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 1,
+        'BlockSize' => 1,
+        'KeyPack' => 'C'
+      })
   end
 
   #
@@ -37,80 +35,78 @@ class MetasploitModule < Msf::Encoder::Xor
   # being encoded.
   #
   def decoder_stub(state)
-
     # add 4 number of passes  for the space reserved for the key, at the end of the decoder stub
     # (see commented source)
-    number_of_passes=state.buf.length+4
-    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
+    number_of_passes = state.buf.length + 4
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if number_of_passes > 32766
 
     # 16-bits not (again, see also commented source)
-    reg_14 = (number_of_passes+1)^0xFFFF
-    reg_5 = state.buf.length^0xFFFF
+    reg_14 = (number_of_passes + 1) ^ 0xFFFF
+    reg_5 = state.buf.length ^ 0xFFFF
 
-    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:little), <<EOS).encoded.data
-main:
+    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:little), <<~EOS).encoded.data
+      main:
 
-li macro reg, imm
-  addiu reg, $0, imm                     ; 0xYYYYXX24 - xx: reg #, yyyy: imm # imm must be equal or less than 0x7fff
-endm
+      li macro reg, imm
+        addiu reg, $0, imm                     ; 0xYYYYXX24 - xx: reg #, yyyy: imm # imm must be equal or less than 0x7fff
+      endm
 
-  li      ($14, #{reg_14})               ; 0xXXXX0e24 - store in $14 the number of passes (two's complement) - xxxx (number of passes)
-  nor     $14, $14, $0                   ; 0x2770c001 - get in $14 the number of passes
-  li      ($11,-84)                      ; 0xacff0b24 - store in $11 the offset to the end of the decoder (two's complement) (from the addu instr)
+        li      ($14, #{reg_14})               ; 0xXXXX0e24 - store in $14 the number of passes (two's complement) - xxxx (number of passes)
+        nor     $14, $14, $0                   ; 0x2770c001 - get in $14 the number of passes
+        li      ($11,-84)                      ; 0xacff0b24 - store in $11 the offset to the end of the decoder (two's complement) (from the addu instr)
 
-; acts as getpc
-next:
-  bltzal  $8, next                       ; 0xffff1005 - branch to next if $8 < 0, store return address in $31 ($ra); pipelining executes next instr.
-  slti    $8, $0, 0x#{slti_imm(state)}   ; 0xXXXX0828 - Set $8 = 0; Set $8 = 1 if $0 < imm; else $8 = 0 / xxxx: imm
+      ; acts as getpc
+      next:
+        bltzal  $8, next                       ; 0xffff1005 - branch to next if $8 < 0, store return address in $31 ($ra); pipelining executes next instr.
+        slti    $8, $0, 0x#{slti_imm(state)}   ; 0xXXXX0828 - Set $8 = 0; Set $8 = 1 if $0 < imm; else $8 = 0 / xxxx: imm
 
-  nor     $11, $11, $0                   ; 0x27586001 - get in $11 the offset to the end of the decoder (from the addu instr)
-  addu    $25, $31, $11                  ; 0x21c8eb03 - get in $25 a pointer to the end of the decoder stub
-  addu	  $16, $31, $11		               ; $16 too (used to set up the cacheflush() arg down below)
+        nor     $11, $11, $0                   ; 0x27586001 - get in $11 the offset to the end of the decoder (from the addu instr)
+        addu    $25, $31, $11                  ; 0x21c8eb03 - get in $25 a pointer to the end of the decoder stub
+        addu	  $16, $31, $11		               ; $16 too (used to set up the cacheflush() arg down below)
 
-  slti    $23, $0, 0x#{slti_imm(state)}  ; 0xXXXX1728 - Set $23 = 0 (Set $23 = 1 if $0 < imm; else $23 = 0) / xxxx: imm
-  lb      $17, -1($25)                   ; 0xffff3183 - Load xor key in $17 (stored on the last byte of the decoder stub)
+        slti    $23, $0, 0x#{slti_imm(state)}  ; 0xXXXX1728 - Set $23 = 0 (Set $23 = 1 if $0 < imm; else $23 = 0) / xxxx: imm
+        lb      $17, -1($25)                   ; 0xffff3183 - Load xor key in $17 (stored on the last byte of the decoder stub)
 
-; Init $6 and $15
-  li      ($13, -4)                      ; 0xfcff0d24 - $13 = -4
-  nor     $6, $13, $0                    ; 0x2730a001 - $6 = 3 ; used to easily get the cacheflush parameter
-  addi    $15, $6, -2                    ; 0xfeffcf20 - $15 = 1 ($15 = decoding loop counter increment)
+      ; Init $6 and $15
+        li      ($13, -4)                      ; 0xfcff0d24 - $13 = -4
+        nor     $6, $13, $0                    ; 0x2730a001 - $6 = 3 ; used to easily get the cacheflush parameter
+        addi    $15, $6, -2                    ; 0xfeffcf20 - $15 = 1 ($15 = decoding loop counter increment)
 
-; In order avoid null bytes, decode also the xor key, so memory can be
-; referenced with offset -1
-loop:
-  lb      $8, -4($25)                    ; 0xfcff2883 - Load in $8 the byte to decode
-  addu    $23, $23, $15                  ; 0x21b8ef02 - Increment the counter ($23)
-  xori    $3, $8, 0x#{padded_key(state)} ; 0xf2610339 - xori decoding instruction, store the decoded byte on $3
-  #{set_on_less_than(state)}             ; 0xXXf0ee02 - $30 = 1 if $23 < $14; else $30 = 0 (update branch condition) / xx: 0x2b if slti, 0x2a if slt
-  sb      $3, -4($25)                    ; 0xfcff23a3 - Store decoded byte on memory
-  bne     $0, $30, loop                  ; 0xfaffc017 - branch to loop if $30 != 0 (ranch while bytes to decode)
-  addu    $25, $25, $15                  ; 0x21c82f03 - next instruction to decode, executed because of the pipelining
+      ; In order avoid null bytes, decode also the xor key, so memory can be
+      ; referenced with offset -1
+      loop:
+        lb      $8, -4($25)                    ; 0xfcff2883 - Load in $8 the byte to decode
+        addu    $23, $23, $15                  ; 0x21b8ef02 - Increment the counter ($23)
+        xori    $3, $8, 0x#{padded_key(state)} ; 0xf2610339 - xori decoding instruction, store the decoded byte on $3
+        #{set_on_less_than(state)}             ; 0xXXf0ee02 - $30 = 1 if $23 < $14; else $30 = 0 (update branch condition) / xx: 0x2b if slti, 0x2a if slt
+        sb      $3, -4($25)                    ; 0xfcff23a3 - Store decoded byte on memory
+        bne     $0, $30, loop                  ; 0xfaffc017 - branch to loop if $30 != 0 (ranch while bytes to decode)
+        addu    $25, $25, $15                  ; 0x21c82f03 - next instruction to decode, executed because of the pipelining
 
-  addiu	$4, $16, -4                      ; cacheflush() addr parameter
-  li(      $10,#{reg_5})                 ; cacheflush() nbytes parameter
-  nor   $5, $10, $0                      ; same as above
+        addiu	$4, $16, -4                      ; cacheflush() addr parameter
+        li(      $10,#{reg_5})                 ; cacheflush() nbytes parameter
+        nor   $5, $10, $0                      ; same as above
 
-  li      ($2, 4147)                     ; 0x33100224 - cacheflush system call
-  syscall 0x52950                        ; 0x0c544a01
-  nop                                    ; encoded shellcoded must be here (xor key right here ;) after decoding will result in a nop
-EOS
+        li      ($2, 4147)                     ; 0x33100224 - cacheflush system call
+        syscall 0x52950                        ; 0x0c544a01
+        nop                                    ; encoded shellcoded must be here (xor key right here ;) after decoding will result in a nop
+    EOS
 
     return decoder
   end
 
-
-  def padded_key(state, size=1)
+  def padded_key(state, size = 1)
     key = Rex::Text.rand_text(size, state.badchars)
-    key << [state.key].pack("C")
-    return key.unpack("n")[0].to_s(16)
+    key << [state.key].pack('C')
+    return key.unpack('n')[0].to_s(16)
   end
 
   # Returns an two-bytes immediate value without badchars. The value must be
   # on the 0x8000-0x8fff so it is used as negative value by slti (set less
   # than signed immediate)
   def slti_imm(state)
-    imm = Rex::Text.rand_text(2, state.badchars + (0x00..0x7f).to_a.pack("C*"))
-    return imm.unpack("n")[0].to_s(16)
+    imm = Rex::Text.rand_text(2, state.badchars + (0x00..0x7f).to_a.pack('C*'))
+    return imm.unpack('n')[0].to_s(16)
   end
 
   # Since 0x14 contains the number of passes, and because of the li macro, can't be
@@ -118,18 +114,18 @@ EOS
   # here
   def set_on_less_than(state)
     instructions = {
-      "sltu   $30, $23, $14" => "\x2b\xf0\xee\x02", # set less than unsigned
-      "slt    $30, $23, $14" => "\x2a\xf0\xee\x02"  # set less than
+      'sltu   $30, $23, $14' => "\x2b\xf0\xee\x02", # set less than unsigned
+      'slt    $30, $23, $14' => "\x2a\xf0\xee\x02"  # set less than
     }
 
-    instructions.each do |k,v|
-      if Rex::Text.badchar_index(v, state.badchars) == nil
+    instructions.each do |k, v|
+      if Rex::Text.badchar_index(v, state.badchars).nil?
         return k
       end
     end
 
     raise BadcharError.new,
-          "The #{self.name} encoder failed to encode the decoder stub without bad characters.",
+          "The #{name} encoder failed to encode the decoder stub without bad characters.",
           caller
   end
 

--- a/modules/encoders/mipsle/longxor.rb
+++ b/modules/encoders/mipsle/longxor.rb
@@ -9,22 +9,22 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'XOR Encoder',
-      'Description'      => %q{
-        Mips Web server exploit friendly xor encoder
+      'Name' => 'XOR Encoder',
+      'Description' => %q{
+        Mips Web server exploit friendly xor encoder.
       },
-      'Author'           =>
-        [   'Julien Tinnes <julien[at]cr0.org>',   # original shellcode
-            'Pedro Ribeiro <pedrib@gmail.com>',    # fix Linux >= 2.6.11 and toupper() compat
-        ],
-      'Arch'             => ARCH_MIPSLE,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'   => 4,
-          'BlockSize' => 4,
-          'KeyPack'   => 'V',
-        })
+      'Author' => [
+        'Julien Tinnes <julien[at]cr0.org>', # original shellcode
+        'Pedro Ribeiro <pedrib@gmail.com>' # fix Linux >= 2.6.11 and toupper() compat
+      ],
+      'Arch' => ARCH_MIPSLE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
   end
 
   #
@@ -32,114 +32,113 @@ class MetasploitModule < Msf::Encoder::Xor
   # being encoded.
   #
   def decoder_stub(state)
-
     # add one xor operation for the key (see comment below)
-    number_of_passes=state.buf.length/4+1
-    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 10240
-    raise EncodingError.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
+    number_of_passes = state.buf.length / 4 + 1
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if number_of_passes > 10240
+    raise EncodingError, "The payload is not padded to 4-bytes (#{state.buf.length} bytes)" if state.buf.length % 4 != 0
 
     # 16-bits not (again, see below)
-    reg_10 = (number_of_passes+1)^0xFFFF
-    reg_5 = state.buf.length^0xFFFF
-    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:little), <<EOS).encoded.data
-;
-; MIPS nul-free xor decoder
-;
-; (C) 2006 Julien TINNES
-; <julien at cr0.org>
-;
-; The first four bytes in encoded shellcode must be the xor key
-; This means that you have to put the xor key right after
-; this xor decoder
-; This key will be considered part of the encoded shellcode
-; by this decoder and will be xored, thus becoming 4NULs, meaning nop
-;
-; This is Linux-only because I use the cacheflush system call
-;
-; You can use shellforge to assemble this, but be sure to discard all
-; the nul bytes at the end (everything after x01\\x4a\\x54\\x0c)
-;
-; change 2 bytes in the first instruction's opcode with the number of passes
-; the number of passes is the number of xor operations to apply, which should be
-; 1 (for the key) + the number of 4-bytes words you have in your shellcode
-; you must encode ~(number_of_passes + 1) (to ensure that you're nul-free)
+    reg_10 = (number_of_passes + 1) ^ 0xFFFF
+    reg_5 = state.buf.length ^ 0xFFFF
+    decoder = Metasm::Shellcode.assemble(Metasm::MIPS.new(:little), <<~EOS).encoded.data
+      ;
+      ; MIPS nul-free xor decoder
+      ;
+      ; (C) 2006 Julien TINNES
+      ; <julien at cr0.org>
+      ;
+      ; The first four bytes in encoded shellcode must be the xor key
+      ; This means that you have to put the xor key right after
+      ; this xor decoder
+      ; This key will be considered part of the encoded shellcode
+      ; by this decoder and will be xored, thus becoming 4NULs, meaning nop
+      ;
+      ; This is Linux-only because I use the cacheflush system call
+      ;
+      ; You can use shellforge to assemble this, but be sure to discard all
+      ; the nul bytes at the end (everything after x01\\x4a\\x54\\x0c)
+      ;
+      ; change 2 bytes in the first instruction's opcode with the number of passes
+      ; the number of passes is the number of xor operations to apply, which should be
+      ; 1 (for the key) + the number of 4-bytes words you have in your shellcode
+      ; you must encode ~(number_of_passes + 1) (to ensure that you're nul-free)
 
 
-;.text
-;.align	2
-;.globl	main
-;.ent	main
-;.type		 main,@function
+      ;.text
+      ;.align	2
+      ;.globl	main
+      ;.ent	main
+      ;.type		 main,@function
 
-main:
+      main:
 
-li macro reg, imm
-;	lui reg, ((imm) >> 16) & 0ffffh
-;	ori reg, reg, (imm) & 0ffffh
-  addiu reg, $0, imm		    ; sufficient if imm.abs <= 0x7fff
-endm
+      li macro reg, imm
+      ;	lui reg, ((imm) >> 16) & 0ffffh
+      ;	ori reg, reg, (imm) & 0ffffh
+        addiu reg, $0, imm		    ; sufficient if imm.abs <= 0x7fff
+      endm
 
-  li(	$10, #{reg_10})		    ; load number of passes ^ 0xffff
-  nor	$10, $10, $0		      ; put number of passes in $10
+        li(	$10, #{reg_10})		    ; load number of passes ^ 0xffff
+        nor	$10, $10, $0		      ; put number of passes in $10
 
-  li(	$11,-89)		          ; addend to calculated PC is 73
-;.set noreorder
-next:
-  bltzal  $8, next
-;.set reorder
-  slti    $8, $0, 0x8282
-  nor     $11, $11, $0	    ; addend in $9
-  addu	$25, $31, $11		    ; $25 points to encoded shellcode +4
-  addu	$16, $31, $11		    ; $16 too (used to set up the cacheflush() arg down below)
+        li(	$11,-89)		          ; addend to calculated PC is 73
+      ;.set noreorder
+      next:
+        bltzal  $8, next
+      ;.set reorder
+        slti    $8, $0, 0x8282
+        nor     $11, $11, $0	    ; addend in $9
+        addu	$25, $31, $11		    ; $25 points to encoded shellcode +4
+        addu	$16, $31, $11		    ; $16 too (used to set up the cacheflush() arg down below)
 
-;	lui	$2, 0xDDDD     		    ; first part of the xor (old method)
-  slti	$23, $0, 0x8282     ; store 0 in $23 (our counter)
-;	ori	$17, $2, 0xDDDD 	    ; second part of the xor (old method)
-  lw	$17, -4($25)		      ; load xor key in $17
-
-
-  li(	$9, -5)
-  nor	$9, $9, $0		        ; 4 in $9
-
-  addi	$15, $9, -3		      ; 1 in $15
-loop:
-  lw	$8, -4($25)
-
-  addu	$23, $23, $15		    ; increment counter
-  xor	$3, $8, $17
-  sltu	$30, $23, $10		    ; enough loops?
-  sw	$3, -4($25)
-  addi	$6, $9, -1		      ; 3 in $6 (for cacheflush)
-  bne	$0, $30, loop
-  addu	$25, $25, $9		    ; next instruction to decode :)
+      ;	lui	$2, 0xDDDD     		    ; first part of the xor (old method)
+        slti	$23, $0, 0x8282     ; store 0 in $23 (our counter)
+      ;	ori	$17, $2, 0xDDDD 	    ; second part of the xor (old method)
+        lw	$17, -4($25)		      ; load xor key in $17
 
 
-  addiu	$4, $16, -4         ; cacheflush() addr parameter
-  li(      $10,#{reg_5})    ; cacheflush() nbytes parameter
-  nor   $5, $10, $0         ; same as above
-;   li      $6,3            ; $6 is set above, 3rd arg for cacheflush()
+        li(	$9, -5)
+        nor	$9, $9, $0		        ; 4 in $9
 
-;	.set    noreorder
-  li(     $2, 4147)         ; cacheflush
-;   .ascii "\\x01JT\\x0c"   ; nul-free syscall
-  syscall 0x52950
-;	.set    reorder
+        addi	$15, $9, -3		      ; 1 in $15
+      loop:
+        lw	$8, -4($25)
 
-
-; write last decoder opcode and decoded shellcode
-;	li      $4,1              ; stdout
-;	addi	$5, $16, -8
-;	li      $6,40             ; how much to write
-;	.set    noreorder
-;	li      $2, 4004          ; write
-;	syscall
-;	.set    reorder
+        addu	$23, $23, $15		    ; increment counter
+        xor	$3, $8, $17
+        sltu	$30, $23, $10		    ; enough loops?
+        sw	$3, -4($25)
+        addi	$6, $9, -1		      ; 3 in $6 (for cacheflush)
+        bne	$0, $30, loop
+        addu	$25, $25, $9		    ; next instruction to decode :)
 
 
-  nop				                ; encoded shellcoded must be here (xor key right here ;)
-; $t9 (aka $25) points here
+        addiu	$4, $16, -4         ; cacheflush() addr parameter
+        li(      $10,#{reg_5})    ; cacheflush() nbytes parameter
+        nor   $5, $10, $0         ; same as above
+      ;   li      $6,3            ; $6 is set above, 3rd arg for cacheflush()
 
-EOS
+      ;	.set    noreorder
+        li(     $2, 4147)         ; cacheflush
+      ;   .ascii "\\x01JT\\x0c"   ; nul-free syscall
+        syscall 0x52950
+      ;	.set    reorder
+
+
+      ; write last decoder opcode and decoded shellcode
+      ;	li      $4,1              ; stdout
+      ;	addi	$5, $16, -8
+      ;	li      $6,40             ; how much to write
+      ;	.set    noreorder
+      ;	li      $2, 4004          ; write
+      ;	syscall
+      ;	.set    reorder
+
+
+        nop				                ; encoded shellcoded must be here (xor key right here ;)
+      ; $t9 (aka $25) points here
+
+    EOS
     # put the key at the end of the decoder
     state.decoder_key_offset = decoder.length - 4
 

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -20,8 +20,8 @@ class MetasploitModule < Msf::Encoder
     register_options(
       [
         OptBool.new('Compress', [ true, 'Compress the payload with zlib', false ]) # Disabled by default as it relies on having php compiled with zlib, which might not be available on come exotic setups.
-      ],
-      self.class)
+      ]
+    )
   end
 
   def encode_block(state, buf)
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Encoder
     # Modern versions of PHP choke on unquoted literal strings.
     quote = "'"
     if state.badchars.include?("'")
-      raise BadcharError.new, "The #{self.name} encoder failed to encode the decoder stub without bad characters." if state.badchars.include?('"')
+      raise BadcharError.new, "The #{name} encoder failed to encode the decoder stub without bad characters." if state.badchars.include?('"')
 
       quote = '"'
     end

--- a/modules/encoders/php/hex.rb
+++ b/modules/encoders/php/hex.rb
@@ -20,8 +20,7 @@ class MetasploitModule < Msf::Encoder
     register_options(
       [
         OptBool.new('Compress', [ true, 'Compress the payload with zlib', false ]) # Disabled by default as it relies on having php compiled with zlib, which might not be available on come exotic setups.
-      ],
-      self.class
+      ]
     )
   end
 

--- a/modules/encoders/ppc/longxor.rb
+++ b/modules/encoders/ppc/longxor.rb
@@ -7,27 +7,26 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'PPC LongXOR Encoder',
-      'Description'      => %q{
+      'Name' => 'PPC LongXOR Encoder',
+      'Description' => %q{
         This encoder is ghandi's PPC dword xor encoder with some size tweaks
         by HDM.
       },
-      'Author'           => [ 'ddz', 'hdm' ],
-      'Arch'             => ARCH_PPC,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'    => 4,
-          'BlockSize'  => 4,
-          'KeyPack'    => 'N',
-        })
+      'Author' => [ 'ddz', 'hdm' ],
+      'Arch' => ARCH_PPC,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'N'
+      })
   end
 
   #
   # Returns the decoder stub that is adjusted for the size of
   # the buffer being encoded
   #
-  def decoder_stub(state)
+  def decoder_stub(_state)
     [
       0x7ca52a79,     # 0x1da8 <main>:          xor.    r5,r5,r5
       0x4082fffd,     # 0x1dac <main+4>:        bnel+   0x1da8 <main>
@@ -48,7 +47,7 @@ class MetasploitModule < Msf::Encoder::Xor
       0x7ffff215,     # 0x1de8 <main+64>:       add.    r31,r31,r30
       0x4220ffe0,     # 0x1dec <main+68>:       bdnz-   0x1dcc <main+36>
       0x4cff012c,     # 0x1df0 <main+72>:       isync
-    ].pack("N*")
+    ].pack('N*')
   end
 
   #
@@ -57,7 +56,7 @@ class MetasploitModule < Msf::Encoder::Xor
   def encode_finalize_stub(state, stub)
     icount = state.buf.length / 4
 
-    stub[30, 2] = [ 1974 + icount  ].pack('n')
+    stub[30, 2] = [ 1974 + icount ].pack('n')
     stub[22, 2] = [ state.key.to_i ].pack('N')[0, 2]
     stub[26, 2] = [ state.key.to_i ].pack('N')[2, 2]
 

--- a/modules/encoders/ppc/longxor_tag.rb
+++ b/modules/encoders/ppc/longxor_tag.rb
@@ -7,25 +7,24 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'PPC LongXOR Encoder',
-      'Description'      => %q{
+      'Name' => 'PPC LongXOR Encoder',
+      'Description' => %q{
         This encoder is ghandi's PPC dword xor encoder but uses a tag-based
         terminator rather than a length.
       },
-      'Author'           => [ 'ddz', 'hdm' ],
-      'Arch'             => ARCH_PPC,
-      'Decoder'          =>
-        {
-          'KeySize'    => 4,
-          'BlockSize'  => 4,
-          'KeyPack'    => 'N',
-        })
+      'Author' => [ 'ddz', 'hdm' ],
+      'Arch' => ARCH_PPC,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'N'
+      })
   end
 
   #
   # Returns the decoder stub
   #
-  def decoder_stub(state)
+  def decoder_stub(_state)
     [
       0x7ca52a79,     # 0x1da4 <main>:          xor.    r5,r5,r5
       0x4082fffd,     # 0x1da8 <main+4>:        bnel+   0x1da4 <main>
@@ -44,7 +43,7 @@ class MetasploitModule < Msf::Encoder::Xor
       0x7ffff214,     # 0x1ddc <main+56>:       add     r31,r31,r30
       0x4082ffe0,     # 0x1de0 <main+60>:       bne+    0x1dc0 <main+28>
       0x4cff012c,     # 0x1de4 <main+64>:       isync
-    ].pack("N*")
+    ].pack('N*')
   end
 
   #

--- a/modules/encoders/ruby/base64.rb
+++ b/modules/encoders/ruby/base64.rb
@@ -8,18 +8,18 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'Ruby Base64 Encoder',
-      'Description'      => %q{
+      'Name' => 'Ruby Base64 Encoder',
+      'Description' => %q{
         This encoder returns a base64 string encapsulated in
         eval(%(base64 encoded string).unpack(%(m0)).first).
       },
-      'Author'           => 'Robin Stenvi <robin.stenvi[at]gmail.com>',
-      'License'          => BSD_LICENSE,
-      'Arch'             => ARCH_RUBY)
+      'Author' => 'Robin Stenvi <robin.stenvi[at]gmail.com>',
+      'License' => BSD_LICENSE,
+      'Arch' => ARCH_RUBY)
   end
 
   def encode_block(state, buf)
-    %w{( ) . % e v a l u n p c k m 0 f i r s t}.each do |c|
+    %w[( ) . % e v a l u n p c k m 0 f i r s t].each do |c|
       raise BadcharError if state.badchars.include?(c)
     end
 
@@ -29,6 +29,6 @@ class MetasploitModule < Msf::Encoder
       raise BadcharError if b64.include?(byte.chr)
     end
 
-    return "eval(%(" + b64 + ").unpack(%(m0)).first)"
+    return 'eval(%(' + b64 + ').unpack(%(m0)).first)'
   end
 end

--- a/modules/encoders/sparc/longxor_tag.rb
+++ b/modules/encoders/sparc/longxor_tag.rb
@@ -7,19 +7,18 @@ class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
 
   def initialize
     super(
-      'Name'             => 'SPARC DWORD XOR Encoder',
-      'Description'      => %q{
+      'Name' => 'SPARC DWORD XOR Encoder',
+      'Description' => %q{
         This encoder is optyx's 48-byte SPARC encoder with some tweaks.
       },
-      'Author'           => [ 'optyx', 'hdm' ],
-      'Arch'             => ARCH_SPARC,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'    => 4,
-          'BlockSize'  => 4,
-          'KeyPack'    => 'N',
-        })
+      'Author' => [ 'optyx', 'hdm' ],
+      'Arch' => ARCH_SPARC,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'N'
+      })
   end
 
   #
@@ -27,16 +26,16 @@ class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
   #
   def decoder_stub(state)
     Rex::Arch::Sparc.set_dword(state.key, 'l1') +
-    "\x20\xbf\xff\xff" +   # bn,a  _start - 4
-    "\x20\xbf\xff\xff" +   # bn,a  _start
-    "\x7f\xff\xff\xff" +   # call  _start + 4
-    "\xea\x03\xe0\x20" +   # ld    [%o7 + 0x20],%l7
-    "\xaa\x9d\x40\x11" +   # xorcc %l5,%l1,%l5
-    "\xea\x23\xe0\x20" +   # st    %l5,[%o7 + 0x20]
-    "\xa2\x04\x40\x15" +   # add   %l1,%l5,%l1
-    "\x81\xdb\xe0\x20" +   # flush %o7 + 0x20
-    "\x12\xbf\xff\xfb" +   # bnz   dec_loop
-    "\x9e\x03\xe0\x04"     # add   %o7,4,%o7
+      "\x20\xbf\xff\xff" +   # bn,a  _start - 4
+      "\x20\xbf\xff\xff" +   # bn,a  _start
+      "\x7f\xff\xff\xff" +   # call  _start + 4
+      "\xea\x03\xe0\x20" +   # ld    [%o7 + 0x20],%l7
+      "\xaa\x9d\x40\x11" +   # xorcc %l5,%l1,%l5
+      "\xea\x23\xe0\x20" +   # st    %l5,[%o7 + 0x20]
+      "\xa2\x04\x40\x15" +   # add   %l1,%l5,%l1
+      "\x81\xdb\xe0\x20" +   # flush %o7 + 0x20
+      "\x12\xbf\xff\xfb" +   # bnz   dec_loop
+      "\x9e\x03\xe0\x04"     # add   %o7,4,%o7
   end
 
   #
@@ -50,10 +49,14 @@ class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
   # Verify that the chosen key doesn't become an invalid byte due to
   # the set_dword() result (22/10 bit split)
   #
-  def find_key_verify(buf, key_bytes, badchars)
-    return ( has_badchars?(
+  def find_key_verify(_buf, key_bytes, badchars)
+    return (if has_badchars?(
       Rex::Arch::Sparc.set_dword(key_bytes_to_integer(key_bytes), 'l1'),
       badchars
-    ) ? false : true)
+    )
+              false
+            else
+              true
+            end)
   end
 end

--- a/modules/encoders/x64/xor.rb
+++ b/modules/encoders/x64/xor.rb
@@ -7,19 +7,19 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'XOR Encoder',
-      'Description'      => 'An x64 XOR encoder. Uses an 8 byte key and takes advantage of x64 relative addressing.',
-      'Author'           => [ 'sf' ],
-      'Arch'             => ARCH_X64,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'      => 8,
-          'KeyPack'      => 'Q',
-          'BlockSize'    => 8,
-        }
+      'Name' => 'XOR Encoder',
+      'Description' => 'An x64 XOR encoder. Uses an 8 byte key and takes advantage of x64 relative addressing.',
+      'Author' => [ 'sf' ],
+      'Arch' => ARCH_X64,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 8,
+        'KeyPack' => 'Q',
+        'BlockSize' => 8
+      }
       )
   end
+
   # Indicate that this module can preserve some registers
   # ...which is currently not true. This is a temp fix
   # until the full preserve_registers functionality is
@@ -28,20 +28,19 @@ class MetasploitModule < Msf::Encoder::Xor
     true
   end
 
-  def decoder_stub( state )
-
+  def decoder_stub(state)
     # calculate the (negative) block count . We should check this against state.badchars.
-    block_count = [-( ( (state.buf.length - 1) / state.decoder_key_size) + 1)].pack( "V" )
+    block_count = [-(((state.buf.length - 1) / state.decoder_key_size) + 1)].pack('V')
 
-    decoder =   "\x48\x31\xC9" +                 # xor rcx, rcx
-          "\x48\x81\xE9" + block_count +   # sub ecx, block_count
-          "\x48\x8D\x05\xEF\xFF\xFF\xFF" + # lea rax, [rel 0x0]
-          "\x48\xBBXXXXXXXX" +             # mov rbx, 0x????????????????
-          "\x48\x31\x58\x27" +             # xor [rax+0x27], rbx
-          "\x48\x2D\xF8\xFF\xFF\xFF" +     # sub rax, -8
-          "\xE2\xF4"                       # loop 0x1B
+    decoder = "\x48\x31\xC9" + # xor rcx, rcx
+              "\x48\x81\xE9" + block_count +   # sub ecx, block_count
+              "\x48\x8D\x05\xEF\xFF\xFF\xFF" + # lea rax, [rel 0x0]
+              "\x48\xBBXXXXXXXX" +             # mov rbx, 0x????????????????
+              "\x48\x31\x58\x27" +             # xor [rax+0x27], rbx
+              "\x48\x2D\xF8\xFF\xFF\xFF" +     # sub rax, -8
+              "\xE2\xF4"                       # loop 0x1B
 
-    state.decoder_key_offset = decoder.index( 'XXXXXXXX' )
+    state.decoder_key_offset = decoder.index('XXXXXXXX')
 
     return decoder
   end

--- a/modules/encoders/x64/xor_context.rb
+++ b/modules/encoders/x64/xor_context.rb
@@ -7,46 +7,48 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Hostname-based Context Keyed Payload Encoder',
-      'Description'      => 'Context-Keyed Payload Encoder based on hostname and x64 XOR encoder.',
-      'Author'           => [ 'sf' 'oso' ],
-      'Arch'             => ARCH_X64,
-      'License'          => MSF_LICENSE,
-      'Platform'         => 'linux',
-      'Decoder'          =>
-        {
-          'KeySize'      => 8,
-          'KeyPack'      => 'Q',
-          'BlockSize'    => 8,
-        }
+      'Name' => 'Hostname-based Context Keyed Payload Encoder',
+      'Description' => 'Context-Keyed Payload Encoder based on hostname and x64 XOR encoder.',
+      'Author' => [
+        'sf',
+        'oso'
+      ],
+      'Arch' => ARCH_X64,
+      'License' => MSF_LICENSE,
+      'Platform' => 'linux',
+      'Decoder' => {
+        'KeySize' => 8,
+        'KeyPack' => 'Q',
+        'BlockSize' => 8
+      }
       )
 
-    register_options([ OptString.new('C_HOSTNAME',[ true, "Context Hostname.", "hostname"])])
+    register_options([ OptString.new('C_HOSTNAME', [ true, 'Context Hostname.', 'hostname'])])
   end
 
-  def obtain_key(buf, badchars, state)
+  def obtain_key(_buf, _badchars, state)
     # TODO: Currently only first 8 chars are taken as key. We should include the other chars in the key.
-    state.key = datastore['C_HOSTNAME'][0..8].reverse!.unpack('H*')[0].to_i(base=16)
+    state.key = datastore['C_HOSTNAME'][0..8].reverse!.unpack('H*')[0].to_i(16)
   end
 
-  def decoder_stub( state )
+  def decoder_stub(state)
     # calculate the (negative) block count . We should check this against state.badchars.
-    block_count = [-( ( (state.buf.length - 1) / state.decoder_key_size) + 1)].pack( "V" )
+    block_count = [-(((state.buf.length - 1) / state.decoder_key_size) + 1)].pack('V')
 
-    decoder = ""+
-      # get hostname
-      "\x6a\x3f\x58" +                  # push 0x3f; pop rax
-      "\x48\x8D\x3C\x24" +              # lea rdi, [rsp]
-      "\x0F\x05" +                      # syscall ; LINUX - sys_uname
-      "\x48\x8B\x5F\x41" +              # movq rbx, [rdi+0x41]; hostname
+    decoder = '' +
+              # get hostname
+              "\x6a\x3f\x58" +                  # push 0x3f; pop rax
+              "\x48\x8D\x3C\x24" +              # lea rdi, [rsp]
+              "\x0F\x05" +                      # syscall ; LINUX - sys_uname
+              "\x48\x8B\x5F\x41" +              # movq rbx, [rdi+0x41]; hostname
 
-      # loop
-      "\x48\x31\xC9" +                  # xor rcx, rcx
-      "\x48\x81\xE9" + block_count +    # sub ecx, block_count
-      "\x48\x8D\x05\xEF\xFF\xFF\xFF" +  # lea rax, [rip - 0x01]
-      "\x48\x31\x58\x1d" +              # xor [rax+0x1d], rbx
-      "\x48\x2D\xF8\xFF\xFF\xFF" +      # sub rax, -8
-      "\xE2\xF4"                        # loop 0x1B
+              # loop
+              "\x48\x31\xC9" +                  # xor rcx, rcx
+              "\x48\x81\xE9" + block_count +    # sub ecx, block_count
+              "\x48\x8D\x05\xEF\xFF\xFF\xFF" +  # lea rax, [rip - 0x01]
+              "\x48\x31\x58\x1d" +              # xor [rax+0x1d], rbx
+              "\x48\x2D\xF8\xFF\xFF\xFF" +      # sub rax, -8
+              "\xE2\xF4"                        # loop 0x1B
     return decoder
   end
 end

--- a/modules/encoders/x64/xor_dynamic.rb
+++ b/modules/encoders/x64/xor_dynamic.rb
@@ -7,11 +7,11 @@ class MetasploitModule < Msf::Encoder::XorDynamic
 
   def initialize
     super(
-      'Name'             => 'Dynamic key XOR Encoder',
-      'Description'      => 'An x64 XOR encoder with dynamic key size',
-      'Author'           => [ 'lupman', 'phra' ],
-      'Arch'             => ARCH_X64,
-      'License'          => MSF_LICENSE
+      'Name' => 'Dynamic key XOR Encoder',
+      'Description' => 'An x64 XOR encoder with dynamic key size',
+      'Author' => [ 'lupman', 'phra' ],
+      'Arch' => ARCH_X64,
+      'License' => MSF_LICENSE
       )
   end
 
@@ -24,29 +24,29 @@ class MetasploitModule < Msf::Encoder::XorDynamic
   end
 
   def stub
-    "\xeb\x27" +             #        jmp    _call
-    "\x5b" +                 # _ret:  pop    rbx
-    "\x53" +                 #        push   rbx
-    "\x5f" +                 #        pop    rdi
-    "\xb0\x41" +             #        mov    al, 'A'
-    "\xfc" +                 #        cld
-    "\xae" +                 # _lp1:  scas   al, BYTE PTR es:[rdi]
-    "\x75\xfd" +             #        jne    _lp1
-    "\x57" +                 #        push   rdi
-    "\x59" +                 #        pop    rcx
-    "\x53" +                 # _lp2:  push   rbx
-    "\x5e" +                 #        pop    rsi
-    "\x8a\x06" +             # _lp3:  mov    al, BYTE PTR [rsi]
-    "\x30\x07" +             #        xor    BYTE PTR [rdi], al
-    "\x48\xff\xc7" +         #        inc    rdi
-    "\x48\xff\xc6" +         #        inc    rsi
-    "\x66\x81\x3f\x42\x42" + #        cmp    WORD PTR [rdi], 'BB'
-    "\x74\x07" +             #        je     _jmp
-    "\x80\x3e\x41" +         #        cmp    BYTE PTR [rsi], 'A'
-    "\x75\xea" +             #        jne    _lp3
-    "\xeb\xe6" +             #        jmp    _lp2
-    "\xff\xe1" +             # _jmp:  jmp    rcx
-    "\xe8\xd4\xff\xff\xff"   # _call: call   _ret
+    "\xeb\x27" +               #        jmp    _call
+      "\x5b" +                 # _ret:  pop    rbx
+      "\x53" +                 #        push   rbx
+      "\x5f" +                 #        pop    rdi
+      "\xb0\x41" +             #        mov    al, 'A'
+      "\xfc" +                 #        cld
+      "\xae" +                 # _lp1:  scas   al, BYTE PTR es:[rdi]
+      "\x75\xfd" +             #        jne    _lp1
+      "\x57" +                 #        push   rdi
+      "\x59" +                 #        pop    rcx
+      "\x53" +                 # _lp2:  push   rbx
+      "\x5e" +                 #        pop    rsi
+      "\x8a\x06" +             # _lp3:  mov    al, BYTE PTR [rsi]
+      "\x30\x07" +             #        xor    BYTE PTR [rdi], al
+      "\x48\xff\xc7" +         #        inc    rdi
+      "\x48\xff\xc6" +         #        inc    rsi
+      "\x66\x81\x3f\x42\x42" + #        cmp    WORD PTR [rdi], 'BB'
+      "\x74\x07" +             #        je     _jmp
+      "\x80\x3e\x41" +         #        cmp    BYTE PTR [rsi], 'A'
+      "\x75\xea" +             #        jne    _lp3
+      "\xeb\xe6" +             #        jmp    _lp2
+      "\xff\xe1" +             # _jmp:  jmp    rcx
+      "\xe8\xd4\xff\xff\xff"   # _call: call   _ret
   end
 
   def stub_key_term

--- a/modules/encoders/x64/zutto_dekiru.rb
+++ b/modules/encoders/x64/zutto_dekiru.rb
@@ -11,64 +11,62 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Zutto Dekiru',
-      'Version'          => '$Revision: 14774 $',
-      'Description'      => 'Inspired by shikata_ga_nai using fxsave64 to work under x64 systems.',
-      'Author'           => 'agix',
-      'Arch'             => ARCH_X64,
-      'License'          => MSF_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::Raw,
-      'Decoder'          =>
-      {
-        'KeySize'    => 8,
-        'KeyPack'    => 'Q<'
+      'Name' => 'Zutto Dekiru',
+      'Version' => '$Revision: 14774 $',
+      'Description' => 'Inspired by shikata_ga_nai using fxsave64 to work under x64 systems.',
+      'Author' => 'agix',
+      'Arch' => ARCH_X64,
+      'License' => MSF_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::Raw,
+      'Decoder' => {
+        'KeySize' => 8,
+        'KeyPack' => 'Q<'
       }
     )
   end
 
-  @@cpu64 = Metasm::X86_64.new
-  def assemble(src, cpu=@@cpu64)
+  @cpu64 = Metasm::X86_64.new
+  def assemble(src, cpu = @cpu64)
     Metasm::Shellcode.assemble(cpu, src).encode_string
   end
 
-
   def fxsave64(reg)
     case reg
-    when "rax"
+    when 'rax'
       return "\x48\x0f\xae\x00"
-    when "rbx"
+    when 'rbx'
       return "\x48\x0f\xae\x03"
-    when "rcx"
+    when 'rcx'
       return "\x48\x0f\xae\x01"
-    when "rdx"
+    when 'rdx'
       return "\x48\x0f\xae\x02"
-    when "rsi"
+    when 'rsi'
       return "\x48\x0f\xae\x06"
-    when "rdi"
+    when 'rdi'
       return "\x48\x0f\xae\x07"
-    when "rbp"
+    when 'rbp'
       return "\x48\x0f\xae\x45\x00"
-    when "r8"
+    when 'r8'
       return "\x49\x0f\xae\x00"
-    when "r9"
+    when 'r9'
       return "\x49\x0f\xae\x01"
-    when "r10"
+    when 'r10'
       return "\x49\x0f\xae\x02"
-    when "r11"
+    when 'r11'
       return "\x49\x0f\xae\x03"
-    when "r12"
+    when 'r12'
       return "\x49\x0f\xae\x04\x24"
-    when "r13"
+    when 'r13'
       return "\x49\x0f\xae\x45\x00"
-    when "r14"
+    when 'r14'
       return "\x49\x0f\xae\x06"
-    when "r15"
+    when 'r15'
       return "\x49\x0f\xae\x07"
     end
   end
 
-  def nop(length,save_registers=[])
-    test = Rex::Nop::Opty2.new('',save_registers)
+  def nop(length, save_registers = [])
+    test = Rex::Nop::Opty2.new('', save_registers)
     return test.generate_sled(length)
   end
 
@@ -76,6 +74,7 @@ class MetasploitModule < Msf::Encoder::Xor
   def can_preserve_registers?
     true
   end
+
   #
   # Returns the set of FPU instructions that can be used for the FPU block of
   # the decoder stub.
@@ -96,27 +95,27 @@ class MetasploitModule < Msf::Encoder::Xor
     fpus << "\xd9\xe5"
 
     # This FPU instruction seems to fail consistently on Linux
-    #fpus << "\xdb\xe1"
+    # fpus << "\xdb\xe1"
 
     fpus
   end
 
   def rand_string(length)
-    o = [('0'..'9'),('a'..'z'),('A'..'Z')].map{|i| i.to_a}.flatten;
-    string = (0..(length-1)).map{ o[rand(o.length)] }.join;
+    o = [('0'..'9'), ('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
+    string = (0..(length - 1)).map { o[rand(o.length)] }.join
 
     return string
   end
 
-  def xor_string(text,key)
-    text.length.times {|n| text[n] = (text[n].ord^key[n.modulo(key.length)].ord).chr }
+  def xor_string(text, key)
+    text.length.times { |n| text[n] = (text[n].ord ^ key[n.modulo(key.length)].ord).chr }
     return text
   end
 
-
-  def ordered_random_merge(a,b)
-    a, b = a.dup, b.dup
-    a.map{rand(b.size+1)}.sort.reverse.each do |index|
+  def ordered_random_merge(array1, array2)
+    a = array1.dup
+    b = array2.dup
+    a.map { rand(b.size + 1) }.sort.reverse.each do |index|
       b.insert(index, a.pop)
     end
     b
@@ -124,115 +123,113 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def encode_block(state, block)
     allowed_reg = [
-      ["rax",  "eax",  "ax",   "al"  ],
-      ["rbx",  "ebx",  "bx",   "bl"  ],
-      ["rcx",  "ecx",  "cx",   "cl"  ],
-      ["rdx",  "edx",  "dx",   "dl"  ],
-      ["rsi",  "esi",  "si",   "sil" ],
-      ["rdi",  "edi",  "di",   "dil" ],
-      ["rbp",  "ebp",  "bp",   "bpl" ],
-      ["r8",   "r8d",  "r8w",  "r8b" ],
-      ["r9",   "r9d",  "r9w",  "r9b" ],
-      ["r10",  "r10d", "r10w", "r10b"],
-      ["r11",  "r11d", "r11w", "r11b"],
-      ["r12",  "r12d", "r12w", "r12b"],
-      ["r13",  "r13d", "r13w", "r13b"],
-      ["r14",  "r14d", "r14w", "r14b"],
-      ["r15",  "r15d", "r15w", "r15b"],
+      ['rax', 'eax', 'ax', 'al' ],
+      ['rbx', 'ebx', 'bx', 'bl' ],
+      ['rcx', 'ecx', 'cx', 'cl' ],
+      ['rdx', 'edx', 'dx', 'dl' ],
+      ['rsi', 'esi', 'si', 'sil' ],
+      ['rdi', 'edi', 'di', 'dil' ],
+      ['rbp', 'ebp', 'bp', 'bpl' ],
+      ['r8', 'r8d', 'r8w', 'r8b' ],
+      ['r9', 'r9d', 'r9w', 'r9b' ],
+      ['r10', 'r10d', 'r10w', 'r10b'],
+      ['r11', 'r11d', 'r11w', 'r11b'],
+      ['r12', 'r12d', 'r12w', 'r12b'],
+      ['r13', 'r13d', 'r13w', 'r13b'],
+      ['r14', 'r14d', 'r14w', 'r14b'],
+      ['r15', 'r15d', 'r15w', 'r15b'],
     ]
     allowed_reg.delete_if { |reg| datastore['SaveRegisters'] && datastore['SaveRegisters'].include?(reg.first) }
     allowed_reg.shuffle!
 
-    if block.length%8 != 0
-      block += nop(8-(block.length%8))
+    if block.length % 8 != 0
+      block += nop(8 - (block.length % 8))
     end
 
     reg_type = 3
 
-    if (block.length/8) > 0xff
+    if (block.length / 8) > 0xff
       reg_type = 2
     end
 
-    if (block.length/8) > 0xffff
+    if (block.length / 8) > 0xffff
       reg_type = 1
     end
 
-    if (block.length/8) > 0xffffffff
+    if (block.length / 8) > 0xffffffff
       reg_type = 0
     end
 
-    reg_key  = allowed_reg[0][0]
+    reg_key = allowed_reg[0][0]
     reg_size = allowed_reg[3]
-    reg_rip  = allowed_reg[1][0]
-    reg_env  = allowed_reg[2]
+    reg_rip = allowed_reg[1][0]
+    reg_env = allowed_reg[2]
 
     flip_coin = rand(2)
 
     fpu_opcode = Rex::Poly::LogicalBlock.new('fpu',
-                                            *fpu_instructions)
+                                             *fpu_instructions)
 
     fpu = []
-    fpu << ["fpu",fpu_opcode.generate([], nil, state.badchars)]
+    fpu << ['fpu', fpu_opcode.generate([], nil, state.badchars)]
 
-    sub = (rand(0xd00)&0xfff0)+0xf000
+    sub = (rand(0xd00) & 0xfff0) + 0xf000
     lea = []
-    if flip_coin==0
-      lea << ["lea",  assemble("mov %s, rsp"%reg_env[0])]
-      lea << ["lea1", assemble("and "+reg_env[2]+", 0x%x"%sub)]
+    if flip_coin == 0
+      lea << ['lea', assemble('mov %s, rsp' % reg_env[0])]
+      lea << ['lea1', assemble('and ' + reg_env[2] + ', 0x%x' % sub)]
     else
-      lea << ["lea",  assemble("push rsp")]
-      lea << ["lea1", assemble("pop "+reg_env[0])]
-      lea << ["lea2", assemble("and "+reg_env[2]+", 0x%x"%sub)]
+      lea << ['lea', assemble('push rsp')]
+      lea << ['lea1', assemble('pop ' + reg_env[0])]
+      lea << ['lea2', assemble('and ' + reg_env[2] + ', 0x%x' % sub)]
     end
 
     fpu_lea = ordered_random_merge(fpu, lea)
-    fpu_lea << ["fpu1", fxsave64(reg_env[0])] # fxsave64 doesn't seem to exist in metasm
+    fpu_lea << ['fpu1', fxsave64(reg_env[0])] # fxsave64 doesn't seem to exist in metasm
 
-    key_ins = [["key",  assemble("mov "+reg_key+", 0x%x"%state.key)]]
+    key_ins = [['key', assemble('mov ' + reg_key + ', 0x%x' % state.key)]]
 
     size = []
-    size << ["size", assemble("xor "+reg_size[0]+", "+reg_size[0])]
-    size << ["size", assemble("mov "+reg_size[reg_type]+", 0x%x"% (block.length/8))]
+    size << ['size', assemble('xor ' + reg_size[0] + ', ' + reg_size[0])]
+    size << ['size', assemble('mov ' + reg_size[reg_type] + ', 0x%x' % (block.length / 8))]
 
-    getrip=0
+    getrip = 0
 
     a = ordered_random_merge(size, key_ins)
     decode_head_tab = ordered_random_merge(a, fpu_lea)
 
-    decode_head_tab.length.times { |i| getrip = i if decode_head_tab[i][0] == "fpu"}
+    decode_head_tab.length.times { |i| getrip = i if decode_head_tab[i][0] == 'fpu' }
 
-    decode_head = decode_head_tab.map { |j,i| i.to_s }.join
+    decode_head = decode_head_tab.map { |_j, i| i.to_s }.join
 
     flip_coin = rand(2)
 
-    if flip_coin==0
-      decode_head += assemble("mov "+reg_rip+", ["+reg_env[0]+" + 0x8]")
+    if flip_coin == 0
+      decode_head += assemble('mov ' + reg_rip + ', [' + reg_env[0] + ' + 0x8]')
     else
-      decode_head += assemble("add "+reg_env[0]+", 0x8")
-      decode_head += assemble("mov "+reg_rip+", ["+reg_env[0]+"]")
+      decode_head += assemble('add ' + reg_env[0] + ', 0x8')
+      decode_head += assemble('mov ' + reg_rip + ', [' + reg_env[0] + ']')
     end
-
 
     decode_head_size = decode_head.length
     getrip.times { |i| decode_head_size -= decode_head_tab[i][1].length }
 
-    loop_code =  assemble("dec "+reg_size[0])
-    loop_code += assemble("xor ["+reg_rip+"+("+reg_size[0]+"*8) + 0x7f], "+reg_key)
-    loop_code += assemble("test "+reg_size[0]+", "+reg_size[0])
+    loop_code = assemble('dec ' + reg_size[0])
+    loop_code += assemble('xor [' + reg_rip + '+(' + reg_size[0] + '*8) + 0x7f], ' + reg_key)
+    loop_code += assemble('test ' + reg_size[0] + ', ' + reg_size[0])
 
-    payload_offset = decode_head_size+loop_code.length+2
+    payload_offset = decode_head_size + loop_code.length + 2
 
-    loop_code =  assemble("dec "+reg_size[0])
-    loop_code += assemble("xor ["+reg_rip+"+("+reg_size[0]+"*8) + 0x"+payload_offset.to_s(16)+"], "+reg_key)
-    loop_code += assemble("test "+reg_size[0]+", "+reg_size[0])
+    loop_code = assemble('dec ' + reg_size[0])
+    loop_code += assemble('xor [' + reg_rip + '+(' + reg_size[0] + '*8) + 0x' + payload_offset.to_s(16) + '], ' + reg_key)
+    loop_code += assemble('test ' + reg_size[0] + ', ' + reg_size[0])
 
-    jnz = "\x75"+(0x100-(loop_code.length+2)).chr
+    jnz = "\x75" + (0x100 - (loop_code.length + 2)).chr
 
-    decode = decode_head+loop_code+jnz
+    decode = decode_head + loop_code + jnz
     encode = xor_string(block, [state.key].pack('Q'))
 
     return decode + encode
   end
-
 
 end

--- a/modules/encoders/x86/add_sub.rb
+++ b/modules/encoders/x86/add_sub.rb
@@ -8,139 +8,140 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'Add/Sub Encoder',
-      'Description'      => %q{
+      'Name' => 'Add/Sub Encoder',
+      'Description' => %q{
           Encodes payload with add or sub instructions. This idea came
           from (offensive-security) muts' hp nnm 7.5.1 exploit.
       },
-      'Author'           => 'Melih Sarica <ms[at]sevure.com>',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'BlockSize'  => 4
-        })
+      'Author' => 'Melih Sarica <ms[at]sevure.com>',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'BlockSize' => 4
+      })
   end
 
   def add_or_sub(avchars)
     add = [0x05, 0x50, 0x58, 0x25, 0x54, 0x5C]
     sub = [0x2D, 0x50, 0x58, 0x25, 0x54, 0x5C]
-    return 1 if add.all?{|ch|avchars.include?ch.chr}
-    return 2 if sub.all?{|ch|avchars.include?ch.chr}
+    return 1 if add.all? { |ch| avchars.include? ch.chr }
+    return 2 if sub.all? { |ch| avchars.include? ch.chr }
+
     return 0
   end
 
   def write_inst(inst, mcode)
     @data << inst
     if mcode != 0
-      for i in 0...4
-        t = mcode & 0x000000FF;
+      for _ in 0...4
+        t = mcode & 0x000000FF
         @data << t
-        mcode = mcode >> 8;
+        mcode >>= 8
       end
     end
   end
 
-  def rand_with_av_chars()
+  def rand_with_av_chars
     t2 = 0
-    for i in 0...4
-      c = @avchars[rand(@avchars.size)].ord.to_i()
-      t2 = t2 <<8
+    for _ in 0...4
+      c = @avchars[rand(@avchars.size)].ord.to_i
+      t2 <<= 8
       t2 += c
     end
     return t2
   end
 
   def check_non_av_chars(target)
-    for i in 0...4
-      t = target & 0x000000FF;
-      return true if not @avchars.include?t.chr
-      target = target >> 8;
+    for _ in 0...4
+      t = target & 0x000000FF
+      return true if !@avchars.include? t.chr
+
+      target >>= 8
     end
     return false
   end
 
   def encode_inst(target)
-    begin
-      a = rand_with_av_chars()
-      b = rand_with_av_chars()
+    loop do
+      a = rand_with_av_chars
+      b = rand_with_av_chars
       c = target - a - b if @set == 1
       c = 0 - target - a - b if @set == 2
-      c = c%(0xFFFFFFFF+1)
-    end while check_non_av_chars(c) == true
-    write_inst(@inst["opcode"], a)
-    write_inst(@inst["opcode"], b)
-    write_inst(@inst["opcode"], c)
+      c %= (0xFFFFFFFF + 1)
+      break unless check_non_av_chars(c) == true
+    end
+    write_inst(@inst['opcode'], a)
+    write_inst(@inst['opcode'], b)
+    write_inst(@inst['opcode'], c)
   end
 
   def encode_shellcode(target, z1, z2)
-    write_inst(@inst["and"], z1);
-    write_inst(@inst["and"], z2);
-    encode_inst(target);
-    write_inst(@inst["push"], 0);
+    write_inst(@inst['and'], z1)
+    write_inst(@inst['and'], z2)
+    encode_inst(target)
+    write_inst(@inst['push'], 0)
   end
 
   def decoder_stub(state)
-    buf = ""
+    buf = ''
     shellcode = state.buf.split(//)
-    while shellcode.size>0
-      buf << shellcode.pop(4).join
-    end
+    buf << shellcode.pop(4).join until shellcode.empty?
     state.buf = buf
-    @data = ""
-    @avchars = ""
+    @data = ''
+    @avchars = ''
     for i in 0..255
-      @avchars = @avchars + i.chr.to_s if not state.badchars.include?i.chr.to_s
+      @avchars += i.chr.to_s if !state.badchars.include? i.chr.to_s
     end
     offset = (datastore['BufferOffset'] || 0).to_i
     @inst = {}
     @set = add_or_sub(@avchars)
-    if @set == 0 then
-      raise EncodingError, "Bad character list includes essential characters."
-      exit
-    elsif @set == 1 then #add
-      @inst["opcode"] = 0x05
-    else #sub
-      @inst["opcode"] = 0x2d
+    if @set == 0
+      raise EncodingError, 'Bad character list includes essential characters.'
+    elsif @set == 1 # add
+      @inst['opcode'] = 0x05
+    else # sub
+      @inst['opcode'] = 0x2d
     end
-    @inst["push"] = 0x50
-    @inst["pop"] = 0x58
-    @inst["and"] = 0x25
-    @inst["push_esp"] = 0x54
-    @inst["pop_esp"] = 0x5c
-    if state.buf.size%4 != 0 then
-      raise EncodingError, "Shellcode size must be divisible by 4, try nop padding."
-      exit
+
+    @inst['push'] = 0x50
+    @inst['pop'] = 0x58
+    @inst['and'] = 0x25
+    @inst['push_esp'] = 0x54
+    @inst['pop_esp'] = 0x5c
+    if state.buf.size % 4 != 0
+      raise EncodingError, 'Shellcode size must be divisible by 4, try nop padding.'
     end
-    #init
-    write_inst(@inst["push_esp"], 0)
-    write_inst(@inst["pop"], 0)
+
+    # init
+    write_inst(@inst['push_esp'], 0)
+    write_inst(@inst['pop'], 0)
     encode_inst(offset)
-    write_inst(@inst["push"], 0)
-    write_inst(@inst["pop_esp"], 0)
-    #zeroing registers
-    begin
-      @z1 = rand_with_av_chars()
-      @z2 = rand_with_av_chars()
-    end while @z1&@z2 != 0
+    write_inst(@inst['push'], 0)
+    write_inst(@inst['pop_esp'], 0)
+    # zeroing registers
+    loop do
+      @z1 = rand_with_av_chars
+      @z2 = rand_with_av_chars
+      break unless @z1 & @z2 != 0
+    end
     decoder = @data
     return decoder
   end
 
-  def encode_block(state, block)
-    #encoding shellcode
-    @data = ""
+  def encode_block(_state, block)
+    # encoding shellcode
+    @data = ''
     target = block.split(//)
-    return if target.size<4
+    return if target.size < 4
+
     t = 0
     for i in 0..3
-      t1 = target[3-i][0].ord.to_i
-      t = t<<8
-      t = t + t1
+      t1 = target[3 - i][0].ord.to_i
+      t <<= 8
+      t += t1
     end
-    encode_shellcode(t, @z1, @z2);
+    encode_shellcode(t, @z1, @z2)
     encoded = @data
     return encoded
   end
 end
-

--- a/modules/encoders/x86/alpha_upper.rb
+++ b/modules/encoders/x86/alpha_upper.rb
@@ -10,22 +10,21 @@ class MetasploitModule < Msf::Encoder::Alphanum
 
   def initialize
     super(
-      'Name'             => "Alpha2 Alphanumeric Uppercase Encoder",
-      'Description'      => %q{
+      'Name' => 'Alpha2 Alphanumeric Uppercase Encoder',
+      'Description' => %q{
         Encodes payloads as alphanumeric uppercase text.  This encoder uses
         SkyLined's Alpha2 encoding suite.
         A pure alpha encoder is impossible without having a register that points at or near the shellcode.
         In a default configuration the first few bytes at the beginning are an fnstenv getpc stub (the same as used in shikata_ga_nai) and thus are not alphanumeric.
         You can set BufferRegister for full alpha (see Encoder options for details).
       },
-      'Author'           => [ 'pusscat', 'skylined' ],
-      'Arch'             => ARCH_X86,
-      'License'          => BSD_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::AlphanumUpper,
-      'Decoder'          =>
-        {
-          'BlockSize' => 1,
-        })
+      'Author' => [ 'pusscat', 'skylined' ],
+      'Arch' => ARCH_X86,
+      'License' => BSD_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::AlphanumUpper,
+      'Decoder' => {
+        'BlockSize' => 1
+      })
   end
 
   #
@@ -39,34 +38,36 @@ class MetasploitModule < Msf::Encoder::Alphanum
     buf = ''
 
     # We need to create a GetEIP stub for the exploit
-    if (not reg)
-      if(datastore['AllowWin32SEH'] and datastore['AllowWin32SEH'].to_s =~ /^(t|y|1)/i)
+    if !reg
+      if datastore['AllowWin32SEH'] && datastore['AllowWin32SEH'].to_s =~ (/^(t|y|1)/i)
         buf = 'VTX630WTX638VXH49HHHPVX5AAQQPVX5YYYYP5YYYD5KKYAPTTX638TDDNVDDX4Z4A63861816'
         reg = 'ECX'
         off = 0
-        modified_registers.concat (
+        modified_registers.concat(
           [
             Rex::Arch::X86::ESP,
             Rex::Arch::X86::EDI,
             Rex::Arch::X86::ESI,
             Rex::Arch::X86::EAX
-          ])
+          ]
+        )
       else
         res = Rex::Arch::X86.geteip_fpu(state.badchars, modified_registers)
-        if (not res)
-          raise EncodingError, "Unable to generate geteip code"
+        if !res
+          raise EncodingError, 'Unable to generate geteip code'
         end
-      buf, reg, off = res
+
+        buf, reg, off = res
       end
     else
       reg.upcase!
     end
 
-    stub = buf + Rex::Encoder::Alpha2::AlphaUpper::gen_decoder(reg, off, modified_registers)
+    stub = buf + Rex::Encoder::Alpha2::AlphaUpper.gen_decoder(reg, off, modified_registers)
 
     # Sanity check that saved_registers doesn't overlap with modified_registers
     modified_registers.uniq!
-    if (modified_registers & saved_registers).length > 0
+    if !(modified_registers & saved_registers).empty?
       raise BadGenerateError
     end
 
@@ -78,14 +79,14 @@ class MetasploitModule < Msf::Encoder::Alphanum
   # payload.
   #
   def encode_block(state, block)
-    return Rex::Encoder::Alpha2::AlphaUpper::encode_byte(block.unpack('C')[0], state.badchars)
+    return Rex::Encoder::Alpha2::AlphaUpper.encode_byte(block.unpack('C')[0], state.badchars)
   end
 
   #
   # Tack on our terminator
   #
   def encode_end(state)
-    state.encoded += Rex::Encoder::Alpha2::AlphaUpper::add_terminator()
+    state.encoded += Rex::Encoder::Alpha2::AlphaUpper.add_terminator
   end
 
   # Indicate that this module can preserve some registers

--- a/modules/encoders/x86/bloxor.rb
+++ b/modules/encoders/x86/bloxor.rb
@@ -25,25 +25,24 @@ require 'rex/encoder/bloxor/bloxor'
 
 class MetasploitModule < Rex::Encoder::BloXor
 
-  # Note: Currently set to manual, bump it up to automatically get selected by the framework.
+  # NOTE: Currently set to manual, bump it up to automatically get selected by the framework.
   # Note: BloXor by design is slow due to its exhaustive search for a solution.
   Rank = ManualRanking
 
   def initialize
     super(
-      'Name'        => 'BloXor - A Metamorphic Block Based XOR Encoder',
+      'Name' => 'BloXor - A Metamorphic Block Based XOR Encoder',
       'Description' => 'A Metamorphic Block Based XOR Encoder.',
-      'Author'      => [ 'sf' ],
-      'Arch'        => ARCH_X86,
-      'License'     => MSF_LICENSE,
+      'Author' => [ 'sf' ],
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
       'EncoderType' => Msf::Encoder::Type::Unspecified
       )
   end
 
-  def compute_decoder( state )
+  def compute_decoder(state)
+    @machine = Rex::Poly::MachineX86.new(state.badchars)
 
-    @machine = Rex::Poly::MachineX86.new( state.badchars )
-
-    super( state )
+    super(state)
   end
 end

--- a/modules/encoders/x86/bmp_polyglot.rb
+++ b/modules/encoders/x86/bmp_polyglot.rb
@@ -67,6 +67,7 @@ class SizeCalculator
   def initialize(size, minimum_jump)
     @original_size = size
     raise if minimum_jump < 0 || minimum_jump > 0xff
+
     @minimum_jump = minimum_jump
   end
 
@@ -76,7 +77,8 @@ class SizeCalculator
     possibles << size unless size.nil?
     size = new_size_short
     possibles << size unless size.nil?
-    return if possibles.length == 0
+    return if possibles.empty?
+
     possibles.min
   end
 
@@ -91,7 +93,7 @@ class SizeCalculator
       byte_4 = size[i + 4].to_i
       min_jmp = (@minimum_jump - 5 - i)
 
-      if byte_2 + byte_3 + byte_4 > 0  # this jmp would be too large
+      if byte_2 + byte_3 + byte_4 > 0 # this jmp would be too large
         if byte_0 > 0xfd
           size = increment_size(size, i)
         end
@@ -114,7 +116,8 @@ class SizeCalculator
   end
 
   def new_size_short
-    return if @minimum_jump > 0x81  # short won't make it in this case (0x7f + 0.upto(2).to_a.max)
+    return if @minimum_jump > 0x81 # short won't make it in this case (0x7f + 0.upto(2).to_a.max)
+
     size = [ @original_size ].pack('V').unpack('CCCC')
 
     0.upto(2) do |i|
@@ -146,12 +149,12 @@ class SizeCalculator
     packed = [ size, 0 ].pack('VV')
 
     until [ "\xe9", "\xeb" ].include?(packed[0])
-      packed = packed[1..-1]
+      packed = packed[1..]
       jmp += 1
     end
 
     if packed[0] == "\xe9"
-      jmp +=  packed[1..4].unpack('V')[0]
+      jmp += packed[1..4].unpack('V')[0]
       jmp += 5
     elsif packed[0] == "\xeb"
       jmp += packed[1].unpack('C')[0]
@@ -184,8 +187,8 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'BMP Polyglot',
-      'Description'      => %q{
+      'Name' => 'BMP Polyglot',
+      'Description' => %q{
         Encodes a payload in such a way that the resulting binary blob is both
         valid x86 shellcode and a valid bitmap image file (.bmp). The selected
         bitmap file to inject into must use the BM (Windows 3.1x/95/NT) header
@@ -194,20 +197,19 @@ class MetasploitModule < Msf::Encoder
         compression. This encoder makes absolutely no effort to remove any
         invalid characters.
       },
-      'Author'           => 'Spencer McIntyre',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'References'       =>
-        [
-          [ 'URL'        => 'https://warroom.securestate.com/bmp-x86-polyglot/' ]
-        ]
+      'Author' => 'Spencer McIntyre',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'References' => [
+        [ 'URL' => 'https://warroom.securestate.com/bmp-x86-polyglot/' ]
+      ]
     )
 
     register_options(
       [
         OptString.new('BitmapFile', [ true, 'The .bmp file to inject into' ])
-      ],
-      self.class)
+      ]
+    )
   end
 
   def can_preserve_registers?
@@ -219,7 +221,7 @@ class MetasploitModule < Msf::Encoder
   end
 
   def make_pad(size)
-    (0...size).map { (rand(0x100)).chr }.join
+    (0...size).map { rand(0x100).chr }.join
   end
 
   def modified_registers
@@ -236,7 +238,7 @@ class MetasploitModule < Msf::Encoder
   #   - large enough to store all of the image data and the assembly stub
   #   - is also a valid x86 jmp instruction to land on the assembly stub
   def calc_new_size(orig_size, stub_length)
-    minimum_jump = BM_HEADER_SIZE + DIB_HEADER_SIZE - 2  # -2 for the offset of the size in the BM header
+    minimum_jump = BM_HEADER_SIZE + DIB_HEADER_SIZE - 2 # -2 for the offset of the size in the BM header
     calc = SizeCalculator.new(orig_size + stub_length, minimum_jump)
     size = calc.calculate.to_i
     raise EncodingError, 'Bad .bmp, failed to calculate jmp for size' if size < orig_size
@@ -244,7 +246,7 @@ class MetasploitModule < Msf::Encoder
     jump = calc.size_to_jmp(size)
     pre_pad = jump - minimum_jump
     post_pad = size - orig_size - stub_length - pre_pad
-    return { :new_size => size, :post_pad => post_pad, :pre_pad => pre_pad }
+    return { new_size: size, post_pad: post_pad, pre_pad: pre_pad }
   end
 
   # calculate the least number of bits that must be modified to place the
@@ -253,13 +255,15 @@ class MetasploitModule < Msf::Encoder
     return 1 if sc_len * 8 <= data_len
     return 2 if sc_len * 4 <= data_len
     return 4 if sc_len * 2 <= data_len
+
     raise EncodingError, 'Bad .bmp, not enough image data for stego operation'
   end
 
   # asm stub that will extract the payload from the least significant bits of
   # the binary data which directly follows it
   def make_destego_stub(shellcode_size, padding, lsbs = 1)
-    raise RuntimeError, 'Invalid number of storage bits' unless [1, 2, 4].include?(lsbs)
+    raise 'Invalid number of storage bits' unless [1, 2, 4].include?(lsbs)
+
     gen_regs = [ 'eax', 'ebx', 'ecx', 'edx' ].shuffle
     ptr_regs = [ 'edi', 'esi' ].shuffle
     # declare logical registers
@@ -271,79 +275,69 @@ class MetasploitModule < Msf::Encoder
 
     endb = Rex::Poly::SymbolicBlock::End.new
 
-    get_eip_nop = Proc.new { |b| [0x90, 0x40 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample), 0x48 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample)].sample.chr }
-    get_eip = Proc.new { |b|
+    get_eip_nop = proc { |b| [0x90, 0x40 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample), 0x48 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample)].sample.chr }
+    get_eip = proc do |e|
       [
-        Proc.new { |b| "\xe8" + [0, 1].sample.chr + "\x00\x00\x00" + get_eip_nop.call(b) + (0x58 + b.regnum_of(src_addr_reg)).chr },
-        Proc.new { |b| "\xe8\xff\xff\xff\xff" + (0xc0 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample)).chr + (0x58 + b.regnum_of(src_addr_reg)).chr },
-      ].sample.call(b)
-    }
-    set_src_addr = Proc.new { |b, o| "\x83" + (0xc0 + b.regnum_of(src_addr_reg)).chr + [ b.offset_of(endb) + o ].pack('c') }
-    set_dst_addr = Proc.new { |b| "\x89" + (0xc0 + (b.regnum_of(src_addr_reg) << 3) + b.regnum_of(dst_addr_reg)).chr }
-    set_byte_ctr = Proc.new { |b| (0xb8 + b.regnum_of(ctr_reg)).chr + [ shellcode_size ].pack('V') }
-    adjust_src_addr = Proc.new { |b| "\x81" + (0xc0 + b.regnum_of(src_addr_reg)).chr + [ padding ].pack('V') }
+        proc { |b| "\xe8" + [0, 1].sample.chr + "\x00\x00\x00" + get_eip_nop.call(b) + (0x58 + b.regnum_of(src_addr_reg)).chr },
+        proc { |b| "\xe8\xff\xff\xff\xff" + (0xc0 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample)).chr + (0x58 + b.regnum_of(src_addr_reg)).chr },
+      ].sample.call(e)
+    end
+    set_src_addr = proc { |b, o| "\x83" + (0xc0 + b.regnum_of(src_addr_reg)).chr + [ b.offset_of(endb) + o ].pack('c') }
+    set_dst_addr = proc { |b| "\x89" + (0xc0 + (b.regnum_of(src_addr_reg) << 3) + b.regnum_of(dst_addr_reg)).chr }
+    set_byte_ctr = proc { |b| (0xb8 + b.regnum_of(ctr_reg)).chr + [ shellcode_size ].pack('V') }
+    adjust_src_addr = proc { |b| "\x81" + (0xc0 + b.regnum_of(src_addr_reg)).chr + [ padding ].pack('V') }
     initialize = Rex::Poly::LogicalBlock.new('initialize',
-      Proc.new { |b| "\x60" + get_eip.call(b) + set_src_addr.call(b, -6) + set_dst_addr.call(b) + adjust_src_addr.call(b) + set_byte_ctr.call(b) },
-      Proc.new { |b| "\x60" + get_eip.call(b) + set_src_addr.call(b, -6) + set_dst_addr.call(b) + set_byte_ctr.call(b) + adjust_src_addr.call(b) },
-      Proc.new { |b| "\x60" + get_eip.call(b) + set_src_addr.call(b, -6) + set_byte_ctr.call(b) + set_dst_addr.call(b) + adjust_src_addr.call(b) },
-      Proc.new { |b| "\x60" + get_eip.call(b) + set_byte_ctr.call(b) + set_src_addr.call(b,  -6) + set_dst_addr.call(b) + adjust_src_addr.call(b) },
-      Proc.new { |b| "\x60" + set_byte_ctr.call(b) + get_eip.call(b) + set_src_addr.call(b, -11) + set_dst_addr.call(b) + adjust_src_addr.call(b) },
-    )
+                                             proc { |b| "\x60" + get_eip.call(b) + set_src_addr.call(b, -6) + set_dst_addr.call(b) + adjust_src_addr.call(b) + set_byte_ctr.call(b) },
+                                             proc { |b| "\x60" + get_eip.call(b) + set_src_addr.call(b, -6) + set_dst_addr.call(b) + set_byte_ctr.call(b) + adjust_src_addr.call(b) },
+                                             proc { |b| "\x60" + get_eip.call(b) + set_src_addr.call(b, -6) + set_byte_ctr.call(b) + set_dst_addr.call(b) + adjust_src_addr.call(b) },
+                                             proc { |b| "\x60" + get_eip.call(b) + set_byte_ctr.call(b) + set_src_addr.call(b, -6) + set_dst_addr.call(b) + adjust_src_addr.call(b) },
+                                             proc { |b| "\x60" + set_byte_ctr.call(b) + get_eip.call(b) + set_src_addr.call(b, -11) + set_dst_addr.call(b) + adjust_src_addr.call(b) })
 
-    clr_byte_reg = Proc.new { |b| [0x29, 0x2b, 0x31, 0x33].sample.chr + (0xc0 + (b.regnum_of(byte_reg) << 3) + b.regnum_of(byte_reg)).chr }
-    clr_ctr = Proc.new { |b| [0x29, 0x2b, 0x31, 0x33].sample.chr + (0xc0 + (b.regnum_of(ctr_reg) << 3) + b.regnum_of(ctr_reg)).chr }
-    backup_byte_ctr = Proc.new { |b| (0x50 + b.regnum_of(ctr_reg)).chr }
-    set_bit_ctr = Proc.new { |b| (0xb0 + b.regnum_of(ctr_reg)).chr + (8 / lsbs).chr }
+    clr_byte_reg = proc { |b| [0x29, 0x2b, 0x31, 0x33].sample.chr + (0xc0 + (b.regnum_of(byte_reg) << 3) + b.regnum_of(byte_reg)).chr }
+    clr_ctr = proc { |b| [0x29, 0x2b, 0x31, 0x33].sample.chr + (0xc0 + (b.regnum_of(ctr_reg) << 3) + b.regnum_of(ctr_reg)).chr }
+    backup_byte_ctr = proc { |b| (0x50 + b.regnum_of(ctr_reg)).chr }
+    set_bit_ctr = proc { |b| (0xb0 + b.regnum_of(ctr_reg)).chr + (8 / lsbs).chr }
     get_byte_loop = Rex::Poly::LogicalBlock.new('get_byte_loop',
-      Proc.new { |b| clr_byte_reg.call(b) + backup_byte_ctr.call(b) + clr_ctr.call(b) + set_bit_ctr.call(b) },
-      Proc.new { |b| backup_byte_ctr.call(b) + clr_byte_reg.call(b) + clr_ctr.call(b) + set_bit_ctr.call(b) },
-      Proc.new { |b| backup_byte_ctr.call(b) + clr_ctr.call(b) + clr_byte_reg.call(b) + set_bit_ctr.call(b) },
-      Proc.new { |b| backup_byte_ctr.call(b) + clr_ctr.call(b) + set_bit_ctr.call(b) + clr_byte_reg.call(b) },
-    )
+                                                proc { |b| clr_byte_reg.call(b) + backup_byte_ctr.call(b) + clr_ctr.call(b) + set_bit_ctr.call(b) },
+                                                proc { |b| backup_byte_ctr.call(b) + clr_byte_reg.call(b) + clr_ctr.call(b) + set_bit_ctr.call(b) },
+                                                proc { |b| backup_byte_ctr.call(b) + clr_ctr.call(b) + clr_byte_reg.call(b) + set_bit_ctr.call(b) },
+                                                proc { |b| backup_byte_ctr.call(b) + clr_ctr.call(b) + set_bit_ctr.call(b) + clr_byte_reg.call(b) })
     get_byte_loop.depends_on(initialize)
 
     shift_byte_reg = Rex::Poly::LogicalBlock.new('shift_byte_reg',
-      Proc.new { |b| "\xc1" + (0xe0 + b.regnum_of(byte_reg)).chr + lsbs.chr }
-    )
+                                                 proc { |b| "\xc1" + (0xe0 + b.regnum_of(byte_reg)).chr + lsbs.chr })
     read_byte = Rex::Poly::LogicalBlock.new('read_byte',
-      Proc.new { |b| "\x8a" + ((b.regnum_of(bit_reg) << 3) + b.regnum_of(src_addr_reg)).chr }
-    )
+                                            proc { |b| "\x8a" + ((b.regnum_of(bit_reg) << 3) + b.regnum_of(src_addr_reg)).chr })
     inc_src_reg = Rex::Poly::LogicalBlock.new('inc_src_reg',
-      Proc.new { |b| (0x40 + b.regnum_of(src_addr_reg)).chr }
-    )
+                                              proc { |b| (0x40 + b.regnum_of(src_addr_reg)).chr })
     inc_src_reg.depends_on(read_byte)
     get_lsb = Rex::Poly::LogicalBlock.new('get_lsb',
-      Proc.new { |b| "\x80" + (0xe0 + b.regnum_of(bit_reg)).chr + (0xff >> (8 - lsbs)).chr }
-    )
+                                          proc { |b| "\x80" + (0xe0 + b.regnum_of(bit_reg)).chr + (0xff >> (8 - lsbs)).chr })
     get_lsb.depends_on(read_byte)
     put_lsb = Rex::Poly::LogicalBlock.new('put_lsb',
-      Proc.new { |b| "\x08"+ (0xc0 + (b.regnum_of(bit_reg) << 3) + b.regnum_of(byte_reg)).chr }
-    )
+                                          proc { |b| "\x08" + (0xc0 + (b.regnum_of(bit_reg) << 3) + b.regnum_of(byte_reg)).chr })
     put_lsb.depends_on(get_lsb, shift_byte_reg)
     jmp_bit_loop_body = Rex::Poly::LogicalBlock.new('jmp_bit_loop_body')
     jmp_bit_loop_body.depends_on(put_lsb, inc_src_reg)
 
     jmp_bit_loop = Rex::Poly::LogicalBlock.new('jmp_bit_loop',
-      Proc.new { |b| (0x48 + b.regnum_of(ctr_reg)).chr + "\x75" + (0xfe + -12).chr }
-    )
+                                               proc { |b| (0x48 + b.regnum_of(ctr_reg)).chr + "\x75" + (0xfe + -12).chr })
     jmp_bit_loop.depends_on(jmp_bit_loop_body)
 
     get_bit_loop = Rex::Poly::LogicalBlock.new('get_bit_loop_body', jmp_bit_loop.generate([ Rex::Arch::X86::EBP, Rex::Arch::X86::ESP ]))
     get_bit_loop.depends_on(get_byte_loop)
 
-    put_byte = Proc.new { |b| "\x88" + (0x00 + (b.regnum_of(byte_reg) << 3) + b.regnum_of(dst_addr_reg)).chr }
-    inc_dst_reg = Proc.new { |b| (0x40 + b.regnum_of(dst_addr_reg)).chr }
-    restore_byte_ctr = Proc.new { |b| (0x58 + b.regnum_of(ctr_reg)).chr }
+    put_byte = proc { |b| "\x88" + (0x00 + (b.regnum_of(byte_reg) << 3) + b.regnum_of(dst_addr_reg)).chr }
+    inc_dst_reg = proc { |b| (0x40 + b.regnum_of(dst_addr_reg)).chr }
+    restore_byte_ctr = proc { |b| (0x58 + b.regnum_of(ctr_reg)).chr }
     get_byte_post = Rex::Poly::LogicalBlock.new('get_byte_post',
-      Proc.new { |b| put_byte.call(b) + inc_dst_reg.call(b) + restore_byte_ctr.call(b) },
-      Proc.new { |b| put_byte.call(b) + restore_byte_ctr.call(b) + inc_dst_reg.call(b) },
-      Proc.new { |b| restore_byte_ctr.call(b) + put_byte.call(b) + inc_dst_reg.call(b) },
-    )
+                                                proc { |b| put_byte.call(b) + inc_dst_reg.call(b) + restore_byte_ctr.call(b) },
+                                                proc { |b| put_byte.call(b) + restore_byte_ctr.call(b) + inc_dst_reg.call(b) },
+                                                proc { |b| restore_byte_ctr.call(b) + put_byte.call(b) + inc_dst_reg.call(b) })
     get_byte_post.depends_on(get_bit_loop)
 
     jmp_byte_loop_body = Rex::Poly::LogicalBlock.new('jmp_byte_loop_body',
-      Proc.new { |b| (0x48 + b.regnum_of(ctr_reg)).chr + "\x75" + (0xfe + -26).chr  }
-    )
+                                                     proc { |b| (0x48 + b.regnum_of(ctr_reg)).chr + "\x75" + (0xfe + -26).chr })
     jmp_byte_loop_body.depends_on(get_byte_post)
 
     finalize = Rex::Poly::LogicalBlock.new('finalize', "\x61")
@@ -374,13 +368,13 @@ class MetasploitModule < Msf::Encoder
   end
 
   def validate_dib_header(dib_header)
-    size, _, _, _, bbp, compression, _, _, _, _, _ = dib_header.unpack('VVVvvVVVVVV')
+    size, _, _, _, bbp, compression, *_rest = dib_header.unpack('VVVvvVVVVVV')
     raise EncodingError, 'Bad .bmp DIB header, must be 40-byte BITMAPINFOHEADER' if size != DIB_HEADER_SIZE
     raise EncodingError, 'Bad .bmp DIB header, bits per pixel must be must be either 24 or 32' if bbp != 24 && bbp != 32
     raise EncodingError, 'Bad .bmp DIB header, compression can not be used' if compression != 0
   end
 
-  def encode(buf, badchars = nil, state = nil, platform = nil)
+  def encode(buf, _badchars = nil, _state = nil, _platform = nil)
     in_bmp = File.open(datastore['BitmapFile'], 'rb')
 
     header = in_bmp.read(BM_HEADER_SIZE)
@@ -390,6 +384,7 @@ class MetasploitModule < Msf::Encoder
 
     header, original_size, _, _, original_offset = header.unpack('vVvvV')
     raise EncodingError, 'Bad .bmp header, must be 0x424D (BM)' if header != 0x4d42
+
     validate_dib_header(dib_header)
 
     lsbs = calc_required_lsbs(buf.length, image_data.length)

--- a/modules/encoders/x86/call4_dword_xor.rb
+++ b/modules/encoders/x86/call4_dword_xor.rb
@@ -7,16 +7,15 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Call+4 Dword XOR Encoder',
-      'Description'      => 'Call+4 Dword XOR Encoder',
-      'Author'           => [ 'hdm', 'spoonm' ],
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'    => 4,
-          'BlockSize'  => 4,
-        })
+      'Name' => 'Call+4 Dword XOR Encoder',
+      'Description' => 'Call+4 Dword XOR Encoder',
+      'Author' => [ 'hdm', 'spoonm' ],
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4
+      })
   end
 
   #
@@ -24,21 +23,20 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded
   #
   def decoder_stub(state)
-
     # Sanity check that saved_registers doesn't overlap with modified_registers
-    if (modified_registers & saved_registers).length > 0
+    if !(modified_registers & saved_registers).empty?
       raise BadGenerateError
     end
 
     decoder =
       Rex::Arch::X86.sub(-(((state.buf.length - 1) / 4) + 1), Rex::Arch::X86::ECX,
-        state.badchars) +
+                         state.badchars) +
       "\xe8\xff\xff\xff" + # call $+4
-      "\xff\xc0"         + # inc eax
-      "\x5e"             + # pop esi
+      "\xff\xc0" + # inc eax
+      "\x5e" + # pop esi
       "\x81\x76\x0eXORK" + # xor [esi + 0xe], xork
-      "\x83\xee\xfc"     + # sub esi, -4
-      "\xe2\xf4"           # loop xor
+      "\x83\xee\xfc" + # sub esi, -4
+      "\xe2\xf4" # loop xor
 
     # Calculate the offset to the XOR key
     state.decoder_key_offset = decoder.index('XORK')

--- a/modules/encoders/x86/context_stat.rb
+++ b/modules/encoders/x86/context_stat.rb
@@ -14,30 +14,32 @@ class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
 
   def initialize
     super(
-      'Name'             => 'stat(2)-based Context Keyed Payload Encoder',
-      'Description'      => %q{
+      'Name' => 'stat(2)-based Context Keyed Payload Encoder',
+      'Description' => %q{
         This is a Context-Keyed Payload Encoder based on stat(2)
         and Shikata Ga Nai.
       },
-      'Author'           => 'Dimitris Glynos',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'    => 4,
-          'BlockSize'  => 4
-        })
+      'Author' => 'Dimitris Glynos',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4
+      })
 
     register_options(
       [
-        OptString.new('STAT_KEY', [ true,
-          "STAT key from target host (see tools/context/stat-key utility)",
-          "0x00000000" ]),
-        OptString.new('STAT_FILE', [ true, "name of file to stat(2)", "/bin/ls" ]),
-      ])
+        OptString.new('STAT_KEY', [
+          true,
+          'STAT key from target host (see tools/context/stat-key utility)',
+          '0x00000000'
+        ]),
+        OptString.new('STAT_FILE', [ true, 'name of file to stat(2)', '/bin/ls' ]),
+      ]
+    )
   end
 
-  def obtain_key(buf, badchars, state)
+  def obtain_key(_buf, _badchars, state)
     state.key = datastore['STAT_KEY'].hex
     return state.key
   end
@@ -48,11 +50,11 @@ class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
   def decoder_stub(state)
     # If the decoder stub has not already been generated for this state, do
     # it now.  The decoder stub method may be called more than once.
-    if (state.decoder_stub == nil)
+    if state.decoder_stub.nil?
       # Shikata will only cut off the last 1-4 bytes of it's own end
       # depending on the alignment of the original buffer
       cutoff = 4 - (state.buf.length & 3)
-      block = keygen_stub() + generate_shikata_block(state, state.buf.length + cutoff, cutoff) || (raise BadGenerateError)
+      block = keygen_stub + generate_shikata_block(state, state.buf.length + cutoff, cutoff) || (raise BadGenerateError)
 
       # Take the last 1-4 bytes of shikata and prepend them to the buffer
       # that is going to be encoded to make it align on a 4-byte boundary.
@@ -67,21 +69,21 @@ class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
     state.decoder_stub
   end
 
-protected
+  protected
+
   def keygen_stub
     fname = datastore['STAT_FILE']
     flen = fname.length
 
-    payload =
-      "\xd9\xee" +            # fldz
+    "\xd9\xee" + # fldz
       "\xd9\x74\x24\xf4" +    # fnstenv -0xc(%esp)
       "\x5b" +                # pop %ebx
-      Rex::Arch::X86.jmp_short(flen) +    # jmp over
+      Rex::Arch::X86.jmp_short(flen) + # jmp over
       fname +                 # the filename
       "\x83\xc3\x09" +        # over: add $9, %ebx
       "\x8d\x53" +  	         # lea filelen(%ebx), %edx
-      Rex::Arch::X86.pack_lsb(flen) +    #
-      "\x31\xc0" +	         # xor %eax,%eax
+      Rex::Arch::X86.pack_lsb(flen) +
+      "\x31\xc0" + # xor %eax,%eax
       "\x88\x02" +            # mov %al,(%edx)
       "\x8d\x4c\x24\xa8" +    # lea -0x58(%esp),%ecx
       "\xb0\xc3" +            # mov $0xc3, %al
@@ -110,7 +112,7 @@ protected
     fpus << "\xd9\xe5"
 
     # This FPU instruction seems to fail consistently on Linux
-    #fpus << "\xdb\xe1"
+    # fpus << "\xdb\xe1"
 
     fpus
   end
@@ -122,8 +124,8 @@ protected
   def generate_shikata_block(state, length, cutoff)
     # Declare logical registers
     key_reg = Rex::Poly::LogicalRegister::X86.new('key', 'eax')
-    count_reg = Rex::Poly::LogicalRegister::X86.new('count', 'ecx')
-    addr_reg  = Rex::Poly::LogicalRegister::X86.new('addr')
+    Rex::Poly::LogicalRegister::X86.new('count', 'ecx')
+    addr_reg = Rex::Poly::LogicalRegister::X86.new('addr')
 
     # Declare individual blocks
     endb = Rex::Poly::SymbolicBlock::End.new
@@ -134,14 +136,14 @@ protected
 
     # Get EIP off the stack
     popeip = Rex::Poly::LogicalBlock.new('popeip',
-      Proc.new { |b| (0x58 + b.regnum_of(addr_reg)).chr })
+                                         proc { |b| (0x58 + b.regnum_of(addr_reg)).chr })
 
     # Clear the counter register
     clear_register = Rex::Poly::LogicalBlock.new('clear_register',
-      "\x31\xc9",
-      "\x29\xc9",
-      "\x33\xc9",
-      "\x2b\xc9")
+                                                 "\x31\xc9",
+                                                 "\x29\xc9",
+                                                 "\x33\xc9",
+                                                 "\x2b\xc9")
 
     # Initialize the counter after zeroing it
     init_counter = Rex::Poly::LogicalBlock.new('init_counter')
@@ -162,26 +164,27 @@ protected
     # Decoder loop block
     loop_block = Rex::Poly::LogicalBlock.new('loop_block')
 
-    xor  = Proc.new { |b| "\x31" + (0x40 + b.regnum_of(addr_reg) + (8 * b.regnum_of(key_reg))).chr }
-    xor1 = Proc.new { |b| xor.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - cutoff) ].pack('c') }
-    xor2 = Proc.new { |b| xor.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - 4 - cutoff) ].pack('c') }
-    add  = Proc.new { |b| "\x03" + (0x40 + b.regnum_of(addr_reg) + (8 * b.regnum_of(key_reg))).chr }
-    add1 = Proc.new { |b| add.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - cutoff) ].pack('c') }
-    add2 = Proc.new { |b| add.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - 4 - cutoff) ].pack('c') }
-    sub4 = Proc.new { |b| "\x83" + (0xe8 + b.regnum_of(addr_reg)).chr + "\xfc" }
-    add4 = Proc.new { |b| "\x83" + (0xc0 + b.regnum_of(addr_reg)).chr + "\x04" }
+    xor = proc { |b| "\x31" + (0x40 + b.regnum_of(addr_reg) + (8 * b.regnum_of(key_reg))).chr }
+    xor1 = proc { |b| xor.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - cutoff) ].pack('c') }
+    xor2 = proc { |b| xor.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - 4 - cutoff) ].pack('c') }
+    add = proc { |b| "\x03" + (0x40 + b.regnum_of(addr_reg) + (8 * b.regnum_of(key_reg))).chr }
+    add1 = proc { |b| add.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - cutoff) ].pack('c') }
+    add2 = proc { |b| add.call(b) + [ (b.offset_of(endb) - b.offset_of(fpu) - 4 - cutoff) ].pack('c') }
+    sub4 = proc { |b| "\x83" + (0xe8 + b.regnum_of(addr_reg)).chr + "\xfc" }
+    add4 = proc { |b| "\x83" + (0xc0 + b.regnum_of(addr_reg)).chr + "\x04" }
 
     loop_block.add_perm(
-      Proc.new { |b| xor1.call(b) + add1.call(b) + sub4.call(b) },
-      Proc.new { |b| xor1.call(b) + sub4.call(b) + add2.call(b) },
-      Proc.new { |b| sub4.call(b) + xor2.call(b) + add2.call(b) },
-      Proc.new { |b| xor1.call(b) + add1.call(b) + add4.call(b) },
-      Proc.new { |b| xor1.call(b) + add4.call(b) + add2.call(b) },
-      Proc.new { |b| add4.call(b) + xor2.call(b) + add2.call(b) })
+      proc { |b| xor1.call(b) + add1.call(b) + sub4.call(b) },
+      proc { |b| xor1.call(b) + sub4.call(b) + add2.call(b) },
+      proc { |b| sub4.call(b) + xor2.call(b) + add2.call(b) },
+      proc { |b| xor1.call(b) + add1.call(b) + add4.call(b) },
+      proc { |b| xor1.call(b) + add4.call(b) + add2.call(b) },
+      proc { |b| add4.call(b) + xor2.call(b) + add2.call(b) }
+    )
 
     # Loop instruction block
     loop_inst = Rex::Poly::LogicalBlock.new('loop_inst',
-      "\xe2\xf5")
+                                            "\xe2\xf5")
 
     # Define block dependencies
     fnstenv.depends_on(fpu)
@@ -194,6 +197,7 @@ protected
     loop_inst.generate([
       Rex::Arch::X86::EAX,
       Rex::Arch::X86::ESP,
-      Rex::Arch::X86::ECX ], nil, state.badchars)
+      Rex::Arch::X86::ECX
+    ], nil, state.badchars)
   end
 end

--- a/modules/encoders/x86/countdown.rb
+++ b/modules/encoders/x86/countdown.rb
@@ -7,18 +7,17 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Single-byte XOR Countdown Encoder',
-      'Description'      => %q{
+      'Name' => 'Single-byte XOR Countdown Encoder',
+      'Description' => %q{
         This encoder uses the length of the payload as a position-dependent
         encoder key to produce a small decoder stub.
       },
-      'Author'           => 'vlad902',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'BlockSize' => 1,
-        })
+      'Author' => 'vlad902',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'BlockSize' => 1
+      })
   end
 
   #
@@ -26,17 +25,18 @@ class MetasploitModule < Msf::Encoder::Xor
   # being encoded.
   #
   def decoder_stub(state)
-
     # Sanity check that saved_registers doesn't overlap with modified_registers
-    if (modified_registers & saved_registers).length > 0
+    if !(modified_registers & saved_registers).empty?
       raise BadGenerateError
     end
+
     begin
       decoder =
         Rex::Arch::X86.set(
           Rex::Arch::X86::ECX,
           state.buf.length - 1,
-          state.badchars) +
+          state.badchars
+        ) +
         "\xe8\xff\xff\xff" +  # call $+4
         "\xff\xc1" +          # inc ecx
         "\x5e" +              # pop esi
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Encoder::Xor
       # Initialize the state context to 1
       state.context = 1
     rescue RuntimeError => e
-      raise BadcharError if e.message == "No valid set instruction could be created!"
+      raise BadcharError if e.message == 'No valid set instruction could be created!'
     end
     return decoder
   end

--- a/modules/encoders/x86/fnstenv_mov.rb
+++ b/modules/encoders/x86/fnstenv_mov.rb
@@ -7,19 +7,18 @@ class MetasploitModule < Msf::Encoder::Xor
 
   def initialize
     super(
-      'Name'             => 'Variable-length Fnstenv/mov Dword XOR Encoder',
-      'Description'      => %q{
+      'Name' => 'Variable-length Fnstenv/mov Dword XOR Encoder',
+      'Description' => %q{
         This encoder uses a variable-length mov equivalent instruction
         with fnstenv for getip.
       },
-      'Author'           => 'spoonm',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'KeySize'   => 4,
-          'BlockSize' => 4,
-        })
+      'Author' => 'spoonm',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4
+      })
   end
 
   #
@@ -27,9 +26,8 @@ class MetasploitModule < Msf::Encoder::Xor
   # being encoded.
   #
   def decoder_stub(state)
-
     # Sanity check that saved_registers doesn't overlap with modified_registers
-    if (modified_registers & saved_registers).length > 0
+    if !(modified_registers & saved_registers).empty?
       raise BadGenerateError
     end
 
@@ -37,7 +35,8 @@ class MetasploitModule < Msf::Encoder::Xor
       Rex::Arch::X86.set(
         Rex::Arch::X86::ECX,
         (((state.buf.length - 1) / 4) + 1),
-        state.badchars) +
+        state.badchars
+      ) +
       "\xd9\xee" +              # fldz
       "\xd9\x74\x24\xf4" +      # fnstenv [esp - 12]
       "\x5b" +                  # pop ebx

--- a/modules/encoders/x86/jmp_call_additive.rb
+++ b/modules/encoders/x86/jmp_call_additive.rb
@@ -6,34 +6,33 @@
 class MetasploitModule < Msf::Encoder::XorAdditiveFeedback
 
   # Uncomment when we get the poly stuff working again.
-  #Rank = GreatRanking
+  # Rank = GreatRanking
 
   def initialize
     super(
-      'Name'             => 'Jump/Call XOR Additive Feedback Encoder',
-      'Description'      => 'Jump/Call XOR Additive Feedback',
-      'Author'           => 'skape',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'Decoder'          =>
-        {
-          'Stub'       =>
-            "\xfc"                + # cld
-            "\xbbXORK"            + # mov ebx, key
-            "\xeb\x0c"            + # jmp short 0x14
-            "\x5e"                + # pop esi
-            "\x56"                + # push esi
-            "\x31\x1e"            + # xor [esi], ebx
-            "\xad"                + # lodsd
-            "\x01\xc3"            + # add ebx, eax
-            "\x85\xc0"            + # test eax, eax
-            "\x75\xf7"            + # jnz 0xa
-            "\xc3"                + # ret
+      'Name' => 'Jump/Call XOR Additive Feedback Encoder',
+      'Description' => 'Jump/Call XOR Additive Feedback',
+      'Author' => 'skape',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'Stub' =>
+          "\xfc" +                  # cld
+            "\xbbXORK" +            # mov ebx, key
+            "\xeb\x0c" +            # jmp short 0x14
+            "\x5e" +                # pop esi
+            "\x56" +                # push esi
+            "\x31\x1e" +            # xor [esi], ebx
+            "\xad" +                # lodsd
+            "\x01\xc3" +            # add ebx, eax
+            "\x85\xc0" +            # test eax, eax
+            "\x75\xf7" +            # jnz 0xa
+            "\xc3" +                # ret
             "\xe8\xef\xff\xff\xff", # call 0x8
-          'KeyOffset' => 2,
-          'KeySize'   => 4,
-          'BlockSize' => 4,
-        })
+        'KeyOffset' => 2,
+        'KeySize' => 4,
+        'BlockSize' => 4
+      })
   end
 
   #

--- a/modules/encoders/x86/nonalpha.rb
+++ b/modules/encoders/x86/nonalpha.rb
@@ -10,21 +10,20 @@ class MetasploitModule < Msf::Encoder::NonAlpha
 
   def initialize
     super(
-      'Name'             => "Non-Alpha Encoder",
-      'Description'      => %q{
+      'Name' => 'Non-Alpha Encoder',
+      'Description' => %q{
           Encodes payloads as non-alpha based bytes. This allows
         payloads to bypass both toupper() and tolower() calls,
         but will fail isalpha(). Table based design from
         Russel Sanford.
       },
-      'Author'           => [ 'pusscat'],
-      'Arch'             => ARCH_X86,
-      'License'          => BSD_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::NonAlpha,
-      'Decoder'          =>
-        {
-          'BlockSize' => 1,
-        })
+      'Author' => [ 'pusscat'],
+      'Arch' => ARCH_X86,
+      'License' => BSD_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::NonAlpha,
+      'Decoder' => {
+        'BlockSize' => 1
+      })
   end
 
   #
@@ -32,9 +31,9 @@ class MetasploitModule < Msf::Encoder::NonAlpha
   # being encoded.
   #
   def decoder_stub(state)
-    state.key                   = ""
-    state.decoder_key_size      = 0
-    Rex::Encoder::NonAlpha::gen_decoder()
+    state.key = ''
+    state.decoder_key_size = 0
+    Rex::Encoder::NonAlpha.gen_decoder
   end
 
   #
@@ -43,9 +42,9 @@ class MetasploitModule < Msf::Encoder::NonAlpha
   #
   def encode_block(state, block)
     begin
-      newchar, state.key, state.decoder_key_size = Rex::Encoder::NonAlpha::encode_byte(block.unpack('C')[0], state.key, state.decoder_key_size)
+      newchar, state.key, state.decoder_key_size = Rex::Encoder::NonAlpha.encode_byte(block.unpack('C')[0], state.key, state.decoder_key_size)
     rescue RuntimeError => e
-      raise BadcharError if e.message == "BadChar"
+      raise BadcharError if e.message == 'BadChar'
     end
     return newchar
   end
@@ -55,7 +54,7 @@ class MetasploitModule < Msf::Encoder::NonAlpha
   #
   def encode_end(state)
     state.encoded.gsub!(/A/, state.decoder_key_size.chr)
-    state.encoded.gsub!(/B/, (state.decoder_key_size+5).chr)
+    state.encoded.gsub!(/B/, (state.decoder_key_size + 5).chr)
     state.encoded[0x24, 0] = state.key
   end
 end

--- a/modules/encoders/x86/nonupper.rb
+++ b/modules/encoders/x86/nonupper.rb
@@ -10,20 +10,19 @@ class MetasploitModule < Msf::Encoder::NonUpper
 
   def initialize
     super(
-      'Name'             => "Non-Upper Encoder",
-      'Description'      => %q{
+      'Name' => 'Non-Upper Encoder',
+      'Description' => %q{
           Encodes payloads as non-alpha based bytes. This allows
         payloads to bypass tolower() calls, but will fail isalpha().
         Table based design from Russel Sanford.
       },
-      'Author'           => [ 'pusscat'],
-      'Arch'             => ARCH_X86,
-      'License'          => BSD_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::NonUpper,
-      'Decoder'          =>
-        {
-          'BlockSize' => 1,
-        })
+      'Author' => [ 'pusscat'],
+      'Arch' => ARCH_X86,
+      'License' => BSD_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::NonUpper,
+      'Decoder' => {
+        'BlockSize' => 1
+      })
   end
 
   #
@@ -31,9 +30,9 @@ class MetasploitModule < Msf::Encoder::NonUpper
   # being encoded.
   #
   def decoder_stub(state)
-    state.key                   = ""
-    state.decoder_key_size      = 0
-    Rex::Encoder::NonUpper::gen_decoder()
+    state.key = ''
+    state.decoder_key_size = 0
+    Rex::Encoder::NonUpper.gen_decoder
   end
 
   #
@@ -43,14 +42,14 @@ class MetasploitModule < Msf::Encoder::NonUpper
   def encode_block(state, block)
     begin
       newchar, state.key, state.decoder_key_size =
-        Rex::Encoder::NonUpper::encode_byte(datastore['BadChars'], block.unpack('C')[0], state.key, state.decoder_key_size)
+        Rex::Encoder::NonUpper.encode_byte(datastore['BadChars'], block.unpack('C')[0], state.key, state.decoder_key_size)
     rescue RuntimeError => e
       # This is a bandaid to deal with the fact that, since it's in
       # the Rex namespace, the encoder itself doesn't have access to the
       # Msf exception classes.  Turn it into an actual EncodingError
       # exception so the encoder doesn't look broken when it just fails
       # to encode.
-      raise BadcharError if e.message == "BadChar"
+      raise BadcharError if e.message == 'BadChar'
     end
     return newchar
   end
@@ -60,7 +59,7 @@ class MetasploitModule < Msf::Encoder::NonUpper
   #
   def encode_end(state)
     state.encoded.gsub!(/A/, state.decoder_key_size.chr)
-    state.encoded.gsub!(/B/, (state.decoder_key_size+5).chr)
+    state.encoded.gsub!(/B/, (state.decoder_key_size + 5).chr)
     state.encoded[0x24, 0] = state.key
   end
 end

--- a/modules/encoders/x86/service.rb
+++ b/modules/encoders/x86/service.rb
@@ -7,125 +7,125 @@ require 'metasm'
 
 class MetasploitModule < Msf::Encoder
 
-    Rank = ManualRanking
+  Rank = ManualRanking
 
-    def initialize
-        super(
-            'Name'             => 'Register Service',
-            'Version'          => '$Revision: 14774 $',
-            'Description'      => 'Register service if used with psexec for example',
-            'Author'           => 'agix',
-            'Arch'             => ARCH_X86,
-            'License'          => MSF_LICENSE,
-            'EncoderType'      => Msf::Encoder::Type::Raw
-            )
+  def initialize
+    super(
+      'Name' => 'Register Service',
+      'Version' => '$Revision: 14774 $',
+      'Description' => 'Register service if used with psexec for example',
+      'Author' => 'agix',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::Raw
+        )
+  end
+
+  @cpu32 = Metasm::Ia32.new
+  def assemble(src, cpu = @cpu32)
+    Metasm::Shellcode.assemble(cpu, src).encode_string
+  end
+
+  def can_preserve_registers?
+    true
+  end
+
+  def modified_registers
+    []
+  end
+
+  def preserves_stack?
+    true
+  end
+
+  def string_to_pushes(string)
+    str = string.dup
+    # Align string to 4 bytes
+    rem = str.length % 4
+    if rem > 0
+      str << "\x00" * (4 - rem)
+      pushes = ''
+    else
+      pushes = "h\x00\x00\x00\x00"
+    end
+    # string is now 4 bytes aligned with null byte
+
+    # push string to stack, starting at the back
+    until str.empty?
+      four = 'h' + str.slice!(-4, 4)
+      pushes << four
     end
 
-    @@cpu32 = Metasm::Ia32.new
-    def assemble(src, cpu=@@cpu32)
-        Metasm::Shellcode.assemble(cpu, src).encode_string
+    pushes
+  end
+
+  def encode_block(_state, block)
+    rand(0x2fffffff)
+
+    push_registers = ''
+    pop_registers = ''
+    if datastore['SaveRegisters']
+      datastore['SaveRegisters'].split(' ').each do |reg|
+        push_registers += assemble('push %s' % reg)
+        pop_registers = assemble('pop %s' % reg) + pop_registers
+      end
     end
 
-    def can_preserve_registers?
-        true
-    end
+    name = ENV['MSF_SERVICENAME']
+    name ||= Rex::Text.rand_text_alpha(8)
+    pushed_service_name = string_to_pushes(name)
 
-    def modified_registers
-        []
-    end
+    precode_size = 0xc6
+    svcmain_code_offset = precode_size + pushed_service_name.length
 
-    def preserves_stack?
-        true
-    end
+    precode_size = 0xcc
+    hash_code_offset = precode_size + pushed_service_name.length
 
-    def string_to_pushes(string)
-        str = string.dup
-        # Align string to 4 bytes
-        rem = (str.length) % 4
-        if rem > 0
-          str << "\x00" * (4 - rem)
-          pushes = ''
-        else
-          pushes = "h\x00\x00\x00\x00"
-        end
-        # string is now 4 bytes aligned with null byte
+    precode_size = 0xbf
+    svcctrlhandler_code_offset = precode_size + pushed_service_name.length
 
-        # push string to stack, starting at the back
-        while str.length > 0
-          four = 'h'+str.slice!(-4,4)
-          pushes << four
-        end
+    code_service_stopped =
+      "\xE8\x00\x00\x00\x00\x5F\xEB\x07\x58\x58\x58\x58\x31\xC0\xC3" \
+      "#{pushed_service_name}\x89\xE1\x8D\x47\x03\x6A\x00" \
+      "\x50\x51\x68\x0B\xAA\x44\x52\xFF\xD5\x6A\x00\x6A\x00\x6A\x00\x6A" \
+      "\x00\x6A\x00\x6A\x00\x6A\x01\x6A\x10\x89\xE1\x6A\x00\x51\x50\x68" \
+      "\xC6\x55\x37\x7D\xFF\xD5\x57\x68\xF0\xB5\xA2\x56\xFF\xD5"
 
-        pushes
-    end
+    precode_size = 0x42
+    shellcode_code_offset = code_service_stopped.length + precode_size
 
-    def encode_block(state, block)
-        nb_iter = rand(0x2fffffff)+0xfffffff
+    # code_service could be encoded in the future
+    code_service =
+      "\xFC\xE8\x89\x00\x00\x00\x60\x89\xE5\x31\xD2\x64\x8B\x52\x30\x8B" \
+      "\x52\x0C\x8B\x52\x14\x8B\x72\x28\x0F\xB7\x4A\x26\x31\xFF\x31\xC0" \
+      "\xAC\x3C\x61\x7C\x02\x2C\x20\xC1\xCF\x0D\x01\xC7\xE2\xF0\x52\x57" \
+      "\x8B\x52\x10\x8B\x42\x3C\x01\xD0\x8B\x40\x78\x85\xC0\x74\x4A\x01" \
+      "\xD0\x50\x8B\x48\x18\x8B\x58\x20\x01\xD3\xE3\x3C\x49\x8B\x34\x8B" \
+      "\x01\xD6\x31\xFF\x31\xC0\xAC\xC1\xCF\x0D\x01\xC7\x38\xE0\x75\xF4" \
+      "\x03\x7D\xF8\x3B\x7D\x24\x75\xE2\x58\x8B\x58\x24\x01\xD3\x66\x8B" \
+      "\x0C\x4B\x8B\x58\x1C\x01\xD3\x8B\x04\x8B\x01\xD0\x89\x44\x24\x24" \
+      "\x5B\x5B\x61\x59\x5A\x51\xFF\xE0\x58\x5F\x5A\x8B\x12\xEB\x86\x5D" \
+      "\x6A\x00\x68\x70\x69\x33\x32\x68\x61\x64\x76\x61\x54\x68\x4C\x77" \
+      "\x26\x07\xFF\xD5#{pushed_service_name}\x89\xE1" \
+      "\x8D\x85#{[svcmain_code_offset].pack('I<')}\x6A\x00\x50\x51\x89\xE0\x6A\x00\x50\x68" \
+      "\xFA\xF7\x72\xCB\xFF\xD5\x6A\x00\x68\xF0\xB5\xA2\x56\xFF\xD5\x58" \
+      "\x58\x58\x58\x31\xC0\xC3\xFC\xE8\x00\x00\x00\x00\x5D\x81\xED" \
+      "#{[hash_code_offset].pack('I<') + pushed_service_name}\x89\xE1\x8D" \
+      "\x85#{[svcctrlhandler_code_offset].pack('I<')}\x6A\x00\x50\x51\x68\x0B\xAA\x44\x52\xFF\xD5" \
+      "\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x04\x6A\x10" \
+      "\x89\xE1\x6A\x00\x51\x50\x68\xC6\x55\x37\x7D\xFF\xD5\x31\xFF\x6A" \
+      "\x04\x68\x00\x10\x00\x00\x6A\x54\x57\x68\x58\xA4\x53\xE5\xFF\xD5" \
+      "\xC7\x00\x44\x00\x00\x00\x8D\x70\x44\x57\x68\x2E\x65\x78\x65\x68" \
+      "\x6C\x6C\x33\x32\x68\x72\x75\x6E\x64\x89\xE1\x56\x50\x57\x57\x6A" \
+      "\x44\x57\x57\x57\x51\x57\x68\x79\xCC\x3F\x86\xFF\xD5\x8B\x0E\x6A" \
+      "\x40\x68\x00\x10\x00\x00\x68#{[block.length].pack('I<')}\x57\x51\x68\xAE\x87" \
+      "\x92\x3F\xFF\xD5\xE8\x00\x00\x00\x00\x5A\x89\xC7\x8B\x0E\x81\xC2" \
+      "#{[shellcode_code_offset].pack('I<')}\x54\x68#{[block.length].pack('I<')}" \
+      "\x52\x50\x51\x68\xC5\xD8\xBD\xE7\xFF" \
+      "\xD5\x31\xC0\x8B\x0E\x50\x50\x50\x57\x50\x50\x51\x68\xC6\xAC\x9A" \
+      "\x79\xFF\xD5\x8B\x0E\x51\x68\xC6\x96\x87\x52\xFF\xD5\x8B\x4E\x04" \
+      "\x51\x68\xC6\x96\x87\x52\xFF\xD5#{code_service_stopped}"
 
-        push_registers = ''
-        pop_registers  = ''
-        if datastore['SaveRegisters']
-            datastore['SaveRegisters'].split(" ").each { |reg|
-                push_registers += assemble("push %s"%reg)
-                pop_registers   = assemble("pop %s"%reg) + pop_registers
-            }
-        end
-
-        name = ENV['MSF_SERVICENAME']
-        name ||= Rex::Text.rand_text_alpha(8)
-        pushed_service_name = string_to_pushes(name)
-
-        precode_size = 0xc6
-        svcmain_code_offset = precode_size + pushed_service_name.length
-
-        precode_size = 0xcc
-        hash_code_offset = precode_size + pushed_service_name.length
-
-        precode_size = 0xbf
-        svcctrlhandler_code_offset = precode_size + pushed_service_name.length
-
-        code_service_stopped =
-            "\xE8\x00\x00\x00\x00\x5F\xEB\x07\x58\x58\x58\x58\x31\xC0\xC3" +
-            "#{pushed_service_name}\x89\xE1\x8D\x47\x03\x6A\x00" +
-            "\x50\x51\x68\x0B\xAA\x44\x52\xFF\xD5\x6A\x00\x6A\x00\x6A\x00\x6A" +
-            "\x00\x6A\x00\x6A\x00\x6A\x01\x6A\x10\x89\xE1\x6A\x00\x51\x50\x68" +
-            "\xC6\x55\x37\x7D\xFF\xD5\x57\x68\xF0\xB5\xA2\x56\xFF\xD5"
-
-        precode_size = 0x42
-        shellcode_code_offset = code_service_stopped.length + precode_size
-
-        # code_service could be encoded in the future
-        code_service =
-            "\xFC\xE8\x89\x00\x00\x00\x60\x89\xE5\x31\xD2\x64\x8B\x52\x30\x8B" +
-            "\x52\x0C\x8B\x52\x14\x8B\x72\x28\x0F\xB7\x4A\x26\x31\xFF\x31\xC0" +
-            "\xAC\x3C\x61\x7C\x02\x2C\x20\xC1\xCF\x0D\x01\xC7\xE2\xF0\x52\x57" +
-            "\x8B\x52\x10\x8B\x42\x3C\x01\xD0\x8B\x40\x78\x85\xC0\x74\x4A\x01" +
-            "\xD0\x50\x8B\x48\x18\x8B\x58\x20\x01\xD3\xE3\x3C\x49\x8B\x34\x8B" +
-            "\x01\xD6\x31\xFF\x31\xC0\xAC\xC1\xCF\x0D\x01\xC7\x38\xE0\x75\xF4" +
-            "\x03\x7D\xF8\x3B\x7D\x24\x75\xE2\x58\x8B\x58\x24\x01\xD3\x66\x8B" +
-            "\x0C\x4B\x8B\x58\x1C\x01\xD3\x8B\x04\x8B\x01\xD0\x89\x44\x24\x24" +
-            "\x5B\x5B\x61\x59\x5A\x51\xFF\xE0\x58\x5F\x5A\x8B\x12\xEB\x86\x5D" +
-            "\x6A\x00\x68\x70\x69\x33\x32\x68\x61\x64\x76\x61\x54\x68\x4C\x77" +
-            "\x26\x07\xFF\xD5#{pushed_service_name}\x89\xE1" +
-            "\x8D\x85#{[svcmain_code_offset].pack('I<')}\x6A\x00\x50\x51\x89\xE0\x6A\x00\x50\x68" +
-            "\xFA\xF7\x72\xCB\xFF\xD5\x6A\x00\x68\xF0\xB5\xA2\x56\xFF\xD5\x58" +
-            "\x58\x58\x58\x31\xC0\xC3\xFC\xE8\x00\x00\x00\x00\x5D\x81\xED" +
-            "#{[hash_code_offset].pack('I<') + pushed_service_name}\x89\xE1\x8D" +
-            "\x85#{[svcctrlhandler_code_offset].pack('I<')}\x6A\x00\x50\x51\x68\x0B\xAA\x44\x52\xFF\xD5" +
-            "\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x04\x6A\x10" +
-            "\x89\xE1\x6A\x00\x51\x50\x68\xC6\x55\x37\x7D\xFF\xD5\x31\xFF\x6A" +
-            "\x04\x68\x00\x10\x00\x00\x6A\x54\x57\x68\x58\xA4\x53\xE5\xFF\xD5" +
-            "\xC7\x00\x44\x00\x00\x00\x8D\x70\x44\x57\x68\x2E\x65\x78\x65\x68" +
-            "\x6C\x6C\x33\x32\x68\x72\x75\x6E\x64\x89\xE1\x56\x50\x57\x57\x6A" +
-            "\x44\x57\x57\x57\x51\x57\x68\x79\xCC\x3F\x86\xFF\xD5\x8B\x0E\x6A" +
-            "\x40\x68\x00\x10\x00\x00\x68#{[block.length].pack('I<')}\x57\x51\x68\xAE\x87" +
-            "\x92\x3F\xFF\xD5\xE8\x00\x00\x00\x00\x5A\x89\xC7\x8B\x0E\x81\xC2" +
-            "#{[shellcode_code_offset].pack('I<')}\x54\x68#{[block.length].pack('I<')}" +
-            "\x52\x50\x51\x68\xC5\xD8\xBD\xE7\xFF" +
-            "\xD5\x31\xC0\x8B\x0E\x50\x50\x50\x57\x50\x50\x51\x68\xC6\xAC\x9A" +
-            "\x79\xFF\xD5\x8B\x0E\x51\x68\xC6\x96\x87\x52\xFF\xD5\x8B\x4E\x04" +
-            "\x51\x68\xC6\x96\x87\x52\xFF\xD5#{code_service_stopped}"
-
-        return push_registers + code_service + pop_registers + block
-    end
+    return push_registers + code_service + pop_registers + block
+  end
 end

--- a/modules/encoders/x86/single_static_bit.rb
+++ b/modules/encoders/x86/single_static_bit.rb
@@ -18,12 +18,12 @@ class MetasploitModule < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'Single Static Bit',
-      'Description'      => 'Static value for specific bit',
-      'Author'           => 'jduck',
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::SingleStaticBit
+      'Name' => 'Single Static Bit',
+      'Description' => 'Static value for specific bit',
+      'Author' => 'jduck',
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::SingleStaticBit
       )
 
     # this shouldn't be present in the decoder stub.
@@ -35,9 +35,8 @@ class MetasploitModule < Msf::Encoder
   # the buffer being encoded
   #
   def decoder_stub(state)
-
     bit_num = (datastore['BitNumber'] || 5).to_i
-    bit_val = (datastore['BitValue'] || true)
+    datastore['BitValue'] || true
 
     # variables:
     # bit to ignore                                  (global - hardcoded)
@@ -48,7 +47,7 @@ class MetasploitModule < Msf::Encoder
     # number of bits accumulated                     (global - ebp) ?
     # current source byte                            (outer  - al)
     # bit index (for this byte)                      (inner  - cl)  ?
-    pre_init = ""
+    pre_init = ''
     pre_init << "\x31\xed"        # xor ebp, ebp               - no bits accumulated
     pre_init << "\x83\xe1\x01"    # and ecx, $0x1              - init inner loop counter (set to 0/1)
     pre_init << "\x83\xe3\x01"    # and ebx, $0x1              - init buffer length
@@ -56,7 +55,7 @@ class MetasploitModule < Msf::Encoder
     pre_init << "\x66\x81\xf3" + [@key_marker].pack('v')     # - xor decrypt buffer length
 
     # we stored an entire byte, move to the next one
-    next_byte = ""
+    next_byte = ''
     next_byte << "\x83\xef\xff"  # sub edi, 0xffffffff         - increment dst pointer
     next_byte << "\x31\xed"      # xor ebp, ebp                - no bits accumulated
 
@@ -65,14 +64,14 @@ class MetasploitModule < Msf::Encoder
     #
     # ecx-1  - bit number to extract
     # al     - byte to extract it from
-    get_a_bit = ""
+    get_a_bit = ''
     get_a_bit << "\x60"          # pusha                       - save all registers
     get_a_bit << "\x83\xe9\x01"  # sub ecx, 1                  - account for 1-based counting
     get_a_bit << "\x74\x06"      # jz +6                       - skip dividing if bit zero
     get_a_bit << "\xb3\x02"      # mov bl, 2                   - set divisor to 2
     # divide_it:
-    get_a_bit << "\xf6\xf3"      # div bl                      - do the division
-    get_a_bit << "\xe2" + [-1 * (2+2)].pack('C')             # - divide again..
+    get_a_bit << "\xf6\xf3" # div bl                      - do the division
+    get_a_bit << "\xe2" + [-1 * (2 + 2)].pack('C') # - divide again..
     # store_bit:
     get_a_bit << "\x83\xe0\x01"  # and eax, 0x01               - we only want the lowest bit
     get_a_bit << "\x6b\x2f\x02"  # imul ebp, 2, [edi]          - load [edi], shifted left by 1, to ebp
@@ -81,49 +80,49 @@ class MetasploitModule < Msf::Encoder
     get_a_bit << "\x61"          # popa                        - restore previous ebx/eax
     get_a_bit << "\x83\xed\xff"  # sub ebp, 0xffffffff         - increment bits stored
 
-    inner_init = ""
-    inner_init << "\xb1\x08"      # mov cl, $0x8               - init loop counter
+    inner_init = ''
+    inner_init << "\xb1\x08" # mov cl, $0x8               - init loop counter
 
-    inner_loop = ""
+    inner_loop = ''
     # process_bits:
-    inner_loop << "\x80\xf9"     # cmp cl, <ignore_bit + 1>   - is this the one to ignore?
-    inner_loop << [(bit_num+1)].pack('C')
+    inner_loop << "\x80\xf9" # cmp cl, <ignore_bit + 1>   - is this the one to ignore?
+    inner_loop << [(bit_num + 1)].pack('C')
     len = get_a_bit.length + 3 + 2 + next_byte.length
-    inner_loop << "\x74" + [len].pack('C')                   # - je next_bit
+    inner_loop << "\x74" + [len].pack('C') # - je next_bit
     inner_loop << get_a_bit
-    inner_loop << "\x83\xfd\x08"  # cmp ebp, $0x8              - got 8 bits now?
-    inner_loop << "\x75" + [next_byte.length].pack('C')      # - jne to next_bit
+    inner_loop << "\x83\xfd\x08" # cmp ebp, $0x8              - got 8 bits now?
+    inner_loop << "\x75" + [next_byte.length].pack('C') # - jne to next_bit
     # next_dst_byte:
     inner_loop << next_byte
     # next_bit:
     # I really wish this silly padding wasn't necessary, however removing the bad characters in the
     # jump/call displacements has proven difficult otherwise.
-    inner_loop << "\x90" * 0x1a   # nops                       - for padding (so relative jumps don't have badchars)
-    len = -1 * (inner_loop.length+2)
-    inner_loop << "\xe2" + [len].pack('C')                   # - loop process_bits
+    inner_loop << "\x90" * 0x1a # nops                       - for padding (so relative jumps don't have badchars)
+    len = -1 * (inner_loop.length + 2)
+    inner_loop << "\xe2" + [len].pack('C') # - loop process_bits
 
     # prefixed by:                # jmp data_beg_call
-    outer_init = ""
+    outer_init = ''
     # get_data_beg:
     outer_init << "\x5e"          # pop esi                    - ptr to beginning of data
     outer_init << pre_init
     outer_init << "\x89\xf7"      # mov edi, esi               - decode in place, init dst ptr
 
-    outer_loop = ""
-    #outer_loop << "\x90" * (0xd+6)
+    outer_loop = ''
+    # outer_loop << "\x90" * (0xd+6)
     outer_loop << "\x83\xe0\x7f"  # and eax, 0x7f              - we only want the low byte
     outer_loop << "\xac"          # lods   al, [esi]           - load src byte
     outer_loop << inner_init << inner_loop
     outer_loop << "\x83\xeb\x01"  # sub ebx, 1                 - 1 byte down!
     outer_loop << "\x74\x07"      # jz +(2+5)                  - jump to data!
-    len = -1 * (outer_loop.length+2)
+    len = -1 * (outer_loop.length + 2)
     # next_byte:
-    outer_loop << "\xeb" + [len].pack('C')                   # - jmp process_byte
+    outer_loop << "\xeb" + [len].pack('C') # - jmp process_byte
     # data_beg_call:
 
     decoder = outer_init + outer_loop
     jmp = "\xeb" + [decoder.length].pack('C')
-    call = "\xe8" + [-1 * (decoder.length+5)].pack('V')
+    call = "\xe8" + [-1 * (decoder.length + 5)].pack('V')
     decoder = jmp + decoder + call
 
     # encoded sled
@@ -132,18 +131,17 @@ class MetasploitModule < Msf::Encoder
     return decoder
   end
 
-  def encode_block(state, block)
+  def encode_block(_state, block)
     bit_num = (datastore['BitNumber'] || 5).to_i
-    bit_num = (7-bit_num)
-    bit_val = (datastore['BitValue'] || true)
+    bit_num = (7 - bit_num)
+    bit_val = datastore['BitValue'] || true
 
     encoded = ''
     new_byte = 0
     nbits = 0
 
     block.unpack('C*').each do |ch|
-      7.step(0,-1) do |x|
-
+      7.step(0, -1) do |x|
         # is this the special bit?
         if (nbits == bit_num)
           new_byte <<= 1 if nbits > 0
@@ -176,7 +174,7 @@ class MetasploitModule < Msf::Encoder
     if nbits > 0
       while nbits < 8
         new_byte <<= 1
-        new_byte |= 1 if (nbits == bit_num) and bit_val
+        new_byte |= 1 if (nbits == bit_num) && bit_val
         nbits += 1
       end
       encoded << new_byte.chr
@@ -200,6 +198,7 @@ class MetasploitModule < Msf::Encoder
       enc_len_str = [state.encoded.length ^ xor_key].pack('v')
       next if has_badchars?(xor_key_str, state.badchars)
       next if has_badchars?(enc_len_str, state.badchars)
+
       break
     end
 

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -19,10 +19,9 @@ class MetasploitModule < Msf::Encoder::Alphanum
       'Arch' => ARCH_X86,
       'License' => BSD_LICENSE,
       'EncoderType' => Msf::Encoder::Type::AlphanumUnicodeMixed,
-      'Decoder' =>
-        {
-          'BlockSize' => 1
-        })
+      'Decoder' => {
+        'BlockSize' => 1
+      })
     register_options(
       [
         OptString.new('BufferRegister', [true, 'The register that points to the encoded payload', 'ECX'])

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -19,10 +19,9 @@ class MetasploitModule < Msf::Encoder::Alphanum
       'Arch' => ARCH_X86,
       'License' => BSD_LICENSE,
       'EncoderType' => Msf::Encoder::Type::AlphanumUnicodeUpper,
-      'Decoder' =>
-        {
-          'BlockSize' => 1
-        })
+      'Decoder' => {
+        'BlockSize' => 1
+      })
     register_options(
       [
         OptString.new('BufferRegister', [true, 'The register that points to the encoded payload', 'ECX'])

--- a/modules/encoders/x86/xor_dynamic.rb
+++ b/modules/encoders/x86/xor_dynamic.rb
@@ -7,11 +7,11 @@ class MetasploitModule < Msf::Encoder::XorDynamic
 
   def initialize
     super(
-      'Name'             => 'Dynamic key XOR Encoder',
-      'Description'      => 'An x86 XOR encoder with dynamic key size',
-      'Author'           => [ 'lupman', 'phra' ],
-      'Arch'             => ARCH_X86,
-      'License'          => MSF_LICENSE
+      'Name' => 'Dynamic Key XOR Encoder',
+      'Description' => 'An x86 XOR encoder with dynamic key size',
+      'Author' => [ 'lupman', 'phra' ],
+      'Arch' => ARCH_X86,
+      'License' => MSF_LICENSE
       )
   end
 
@@ -24,26 +24,26 @@ class MetasploitModule < Msf::Encoder::XorDynamic
   end
 
   def stub
-    "\xeb\x23" +             #        jmp    _call
-    "\x5b" +                 # _ret:  pop    ebx
-    "\x89\xdf" +             #        mov    edi, ebx
-    "\xb0\x41" +             #        mov    al, 'A'
-    "\xfc" +                 #        cld
-    "\xae" +                 # _lp1:  scas   al, BYTE PTR es:[edi]
-    "\x75\xfd" +             #        jne    _lp1
-    "\x89\xf9" +             #        mov    ecx, edi
-    "\x89\xde" +             # _lp2:  mov    esi, ebx
-    "\x8a\x06" +             # _lp3:  mov    al, BYTE PTR [esi]
-    "\x30\x07" +             #        xor    BYTE PTR [edi], al
-    "\x47" +                 #        inc    edi
-    "\x66\x81\x3f\x42\x42" + #        cmp    WORD PTR [edi], 'BB'
-    "\x74\x08" +             #        je     _jmp
-    "\x46" +                 #        inc    esi
-    "\x80\x3e\x41" +         #        cmp    BYTE PTR [esi], 'A'
-    "\x75\xee" +             #        jne    _lp3
-    "\xeb\xea" +             #        jmp    _lp2
-    "\xff\xe1" +             # _jmp:  jmp    ecx
-    "\xe8\xd8\xff\xff\xff"   # _call: call   _ret
+    "\xeb\x23" +               #        jmp    _call
+      "\x5b" +                 # _ret:  pop    ebx
+      "\x89\xdf" +             #        mov    edi, ebx
+      "\xb0\x41" +             #        mov    al, 'A'
+      "\xfc" +                 #        cld
+      "\xae" +                 # _lp1:  scas   al, BYTE PTR es:[edi]
+      "\x75\xfd" +             #        jne    _lp1
+      "\x89\xf9" +             #        mov    ecx, edi
+      "\x89\xde" +             # _lp2:  mov    esi, ebx
+      "\x8a\x06" +             # _lp3:  mov    al, BYTE PTR [esi]
+      "\x30\x07" +             #        xor    BYTE PTR [edi], al
+      "\x47" +                 #        inc    edi
+      "\x66\x81\x3f\x42\x42" + #        cmp    WORD PTR [edi], 'BB'
+      "\x74\x08" +             #        je     _jmp
+      "\x46" +                 #        inc    esi
+      "\x80\x3e\x41" +         #        cmp    BYTE PTR [esi], 'A'
+      "\x75\xee" +             #        jne    _lp3
+      "\xeb\xea" +             #        jmp    _lp2
+      "\xff\xe1" +             # _jmp:  jmp    ecx
+      "\xe8\xd8\xff\xff\xff"   # _call: call   _ret
   end
 
   def stub_key_term


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, with the exception of the following 107 offenses (the majority of which were resolved with `rubocop -A`):

<details>
<p>

```
modules/encoders/cmd/echo.rb:26:8: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    if state.badchars.length == 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/cmd/echo.rb:61:41: C: [Correctable] Style/AndOr: Use || instead of or.
        if state.badchars.include?('$') or state.badchars.include?('(')
                                        ^^
modules/encoders/cmd/generic_sh.rb:28:9: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    if (state.badchars.length == 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/cmd/generic_sh.rb:62:28: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    raise EncodingError if qot.length == 0
                           ^^^^^^^^^^^^^^^
modules/encoders/cmd/generic_sh.rb:114:42: C: [Correctable] Style/AndOr: Use || instead of or.
        if (state.badchars.include?('$') or state.badchars.include?('('))
                                         ^^
modules/encoders/cmd/perl.rb:26:8: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    if state.badchars.length == 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/cmd/perl.rb:111:28: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    raise EncodingError if qot.length == 0
                           ^^^^^^^^^^^^^^^
modules/encoders/cmd/powershell_base64.rb:5:1: C: Style/MixinUsage: include is used at the top level. Use inside class or module.
include Msf::Post::Windows
^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/cmd/powershell_base64.rb:25:8: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    if state.badchars.length == 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/cmd/printf_php_mq.rb:40:9: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    if (state.badchars.length == 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/cmd/printf_php_mq.rb:45:38: C: [Correctable] Style/AndOr: Use || instead of or.
    if state.badchars.include?('\\') or
                                     ^^
modules/encoders/cmd/printf_php_mq.rb:46:37: C: [Correctable] Style/AndOr: Use || instead of or.
       state.badchars.include?('|') or
                                    ^^
modules/encoders/cmd/printf_php_mq.rb:48:38: C: [Correctable] Style/AndOr: Use && instead of and.
       (state.badchars.include?('x') and state.badchars.include?('0'))
                                     ^^^
modules/encoders/mipsbe/byte_xori.rb:41:5: C: [Correctable] Style/RaiseArgs: Provide an exception class and message as arguments to raise.
    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/mipsbe/longxor.rb:20:7: F: Lint/Syntax: unexpected token tSTRING
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
      'Arch' => ARCH_MIPSBE,
      ^^^^^^
modules/encoders/mipsbe/longxor.rb:20:17: F: Lint/Syntax: dynamic constant assignment
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
      'Arch' => ARCH_MIPSBE,
                ^^^^^^^^^^^
modules/encoders/mipsbe/longxor.rb:21:20: F: Lint/Syntax: dynamic constant assignment
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
      'License' => MSF_LICENSE,
                   ^^^^^^^^^^^
modules/encoders/mipsbe/longxor.rb:27:10: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
        })
         ^
modules/encoders/mipsbe/longxor.rb:148:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
modules/encoders/mipsle/byte_xori.rb:41:5: C: [Correctable] Style/RaiseArgs: Provide an exception class and message as arguments to raise.
    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/mipsle/longxor.rb:20:7: F: Lint/Syntax: unexpected token tSTRING
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
      'Arch' => ARCH_MIPSLE,
      ^^^^^^
modules/encoders/mipsle/longxor.rb:20:17: F: Lint/Syntax: dynamic constant assignment
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
      'Arch' => ARCH_MIPSLE,
                ^^^^^^^^^^^
modules/encoders/mipsle/longxor.rb:21:20: F: Lint/Syntax: dynamic constant assignment
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
      'License' => MSF_LICENSE,
                   ^^^^^^^^^^^
modules/encoders/mipsle/longxor.rb:27:10: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
        })
         ^
modules/encoders/mipsle/longxor.rb:148:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
modules/encoders/x64/zutto_dekiru.rb:28:3: C: Style/ClassVars: Replace class var @@cpu64 with a class instance var.
  @@cpu64 = Metasm::X86_64.new
  ^^^^^^^
modules/encoders/x64/zutto_dekiru.rb:104:50: C: [Correctable] Style/SymbolProc: Pass &:to_a as an argument to map instead of a block.
    o = [('0'..'9'), ('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
                                                 ^^^^^^^^^^^^^^
modules/encoders/x64/zutto_dekiru.rb:115:28: C: Naming/MethodParameterName: Method parameter must be at least 2 characters long.
  def ordered_random_merge(a, b)
                           ^
modules/encoders/x64/zutto_dekiru.rb:115:31: C: Naming/MethodParameterName: Method parameter must be at least 2 characters long.
  def ordered_random_merge(a, b)
                              ^
modules/encoders/x86/add_sub.rb:71:9: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
    end while check_non_av_chars(c) == true
        ^^^^^
modules/encoders/x86/add_sub.rb:87:40: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of size > 0.
    buf << shellcode.pop(4).join while shellcode.size > 0
                                       ^^^^^^^^^^^^^^^^^^
modules/encoders/x86/add_sub.rb:99:7: W: Lint/UnreachableCode: Unreachable code detected.
      exit
      ^^^^
modules/encoders/x86/add_sub.rb:112:7: W: Lint/UnreachableCode: Unreachable code detected.
      exit
      ^^^^
modules/encoders/x86/add_sub.rb:124:9: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
    end while @z1 & @z2 != 0
        ^^^^^
modules/encoders/x86/alpha_mixed.rb:42:38: C: [Correctable] Style/AndOr: Use && instead of and.
      if (datastore['AllowWin32SEH'] and datastore['AllowWin32SEH'].to_s =~ /^(t|y|1)/i)
                                     ^^^
modules/encoders/x86/alpha_mixed.rb:74:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    if (modified_registers & saved_registers).length > 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/alpha_upper.rb:42:38: C: [Correctable] Style/AndOr: Use && instead of and.
      if (datastore['AllowWin32SEH'] and datastore['AllowWin32SEH'].to_s =~ /^(t|y|1)/i)
                                     ^^^
modules/encoders/x86/alpha_upper.rb:70:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    if (modified_registers & saved_registers).length > 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/avoid_underscore_tolower.rb:137:11: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
      end while (is_badchar(state, x) or is_badchar(state, y))
          ^^^^^
modules/encoders/x86/avoid_underscore_tolower.rb:137:39: C: [Correctable] Style/AndOr: Use || instead of or.
      end while (is_badchar(state, x) or is_badchar(state, y))
                                      ^^
modules/encoders/x86/avoid_underscore_tolower.rb:174:11: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
      end while (is_badchar(state, xv) or is_badchar(state, b - xv))
          ^^^^^
modules/encoders/x86/avoid_underscore_tolower.rb:174:40: C: [Correctable] Style/AndOr: Use || instead of or.
      end while (is_badchar(state, xv) or is_badchar(state, b - xv))
                                       ^^
modules/encoders/x86/avoid_utf8_tolower.rb:120:7: C: [Correctable] Style/RaiseArgs: Provide an exception class and message as arguments to raise.
      raise EncodingError.new("The payload being encoded is of an incompatible size (#{len} bytes)")
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/avoid_utf8_tolower.rb:173:32: C: [Correctable] Style/AndOr: Use || instead of or.
      return nil if (b == 0x80 or b == 0x81 or b == 0x7f)
                               ^^
modules/encoders/x86/avoid_utf8_tolower.rb:173:45: C: [Correctable] Style/AndOr: Use || instead of or.
      return nil if (b == 0x80 or b == 0x81 or b == 0x7f)
                                            ^^
modules/encoders/x86/avoid_utf8_tolower.rb:199:11: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
      end while (is_badchar(state, x) or is_badchar(state, y))
          ^^^^^
modules/encoders/x86/avoid_utf8_tolower.rb:199:39: C: [Correctable] Style/AndOr: Use || instead of or.
      end while (is_badchar(state, x) or is_badchar(state, y))
                                      ^^
modules/encoders/x86/avoid_utf8_tolower.rb:225:32: C: [Correctable] Style/AndOr: Use || instead of or.
      return nil if (b == 0xff or b == 0x01 or b == 0x00)
                               ^^
modules/encoders/x86/avoid_utf8_tolower.rb:225:45: C: [Correctable] Style/AndOr: Use || instead of or.
      return nil if (b == 0xff or b == 0x01 or b == 0x00)
                                            ^^
modules/encoders/x86/avoid_utf8_tolower.rb:236:11: W: [Correctable] Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
      end while (is_badchar(state, xv) or is_badchar(state, b - xv))
          ^^^^^
modules/encoders/x86/avoid_utf8_tolower.rb:236:40: C: [Correctable] Style/AndOr: Use || instead of or.
      end while (is_badchar(state, xv) or is_badchar(state, b - xv))
                                       ^^
modules/encoders/x86/bmp_polyglot.rb:80:15: C: [Correctable] Style/ZeroLengthPredicate: Use empty? instead of length == 0.
    return if possibles.length == 0
              ^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/bmp_polyglot.rb:152:22: C: [Correctable] Style/SlicingWithRange: Prefer [1..] over [1..-1].
      packed = packed[1..-1]
                     ^^^^^^^
modules/encoders/x86/bmp_polyglot.rb:282:17: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - b.
        proc { |b| "\xe8" + [0, 1].sample.chr + "\x00\x00\x00" + get_eip_nop.call(b) + (0x58 + b.regnum_of(src_addr_reg)).chr },
                ^
modules/encoders/x86/bmp_polyglot.rb:283:17: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - b.
        proc { |b| "\xe8\xff\xff\xff\xff" + (0xc0 + b.regnum_of([bit_reg, byte_reg, dst_addr_reg, src_addr_reg].sample)).chr + (0x58 + b.regnum_of(src_addr_reg)).chr },
                ^
modules/encoders/x86/call4_dword_xor.rb:27:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    if (modified_registers & saved_registers).length > 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/countdown.rb:29:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    if (modified_registers & saved_registers).length > 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/fnstenv_mov.rb:30:8: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    if (modified_registers & saved_registers).length > 0
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/opt_sub.rb:76:11: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    while sc.length > 0
          ^^^^^^^^^^^^^
modules/encoders/x86/service.rb:24:3: C: Style/ClassVars: Replace class var @@cpu32 with a class instance var.
  @@cpu32 = Metasm::Ia32.new
  ^^^^^^^
modules/encoders/x86/service.rb:54:11: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
    while str.length > 0
          ^^^^^^^^^^^^^^
modules/encoders/x86/service.rb:88:70: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xE8\x00\x00\x00\x00\x5F\xEB\x07\x58\x58\x58\x58\x31\xC0\xC3" +
                                                                     ^
modules/encoders/x86/service.rb:89:60: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "#{pushed_service_name}\x89\xE1\x8D\x47\x03\x6A\x00" +
                                                           ^
modules/encoders/x86/service.rb:90:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x50\x51\x68\x0B\xAA\x44\x52\xFF\xD5\x6A\x00\x6A\x00\x6A\x00\x6A" +
                                                                         ^
modules/encoders/x86/service.rb:91:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x00\x6A\x00\x6A\x00\x6A\x01\x6A\x10\x89\xE1\x6A\x00\x51\x50\x68" +
                                                                         ^
modules/encoders/x86/service.rb:99:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xFC\xE8\x89\x00\x00\x00\x60\x89\xE5\x31\xD2\x64\x8B\x52\x30\x8B" +
                                                                         ^
modules/encoders/x86/service.rb:100:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x52\x0C\x8B\x52\x14\x8B\x72\x28\x0F\xB7\x4A\x26\x31\xFF\x31\xC0" +
                                                                         ^
modules/encoders/x86/service.rb:101:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xAC\x3C\x61\x7C\x02\x2C\x20\xC1\xCF\x0D\x01\xC7\xE2\xF0\x52\x57" +
                                                                         ^
modules/encoders/x86/service.rb:102:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x8B\x52\x10\x8B\x42\x3C\x01\xD0\x8B\x40\x78\x85\xC0\x74\x4A\x01" +
                                                                         ^
modules/encoders/x86/service.rb:103:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xD0\x50\x8B\x48\x18\x8B\x58\x20\x01\xD3\xE3\x3C\x49\x8B\x34\x8B" +
                                                                         ^
modules/encoders/x86/service.rb:104:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x01\xD6\x31\xFF\x31\xC0\xAC\xC1\xCF\x0D\x01\xC7\x38\xE0\x75\xF4" +
                                                                         ^
modules/encoders/x86/service.rb:105:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x03\x7D\xF8\x3B\x7D\x24\x75\xE2\x58\x8B\x58\x24\x01\xD3\x66\x8B" +
                                                                         ^
modules/encoders/x86/service.rb:106:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x0C\x4B\x8B\x58\x1C\x01\xD3\x8B\x04\x8B\x01\xD0\x89\x44\x24\x24" +
                                                                         ^
modules/encoders/x86/service.rb:107:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x5B\x5B\x61\x59\x5A\x51\xFF\xE0\x58\x5F\x5A\x8B\x12\xEB\x86\x5D" +
                                                                         ^
modules/encoders/x86/service.rb:108:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x6A\x00\x68\x70\x69\x33\x32\x68\x61\x64\x76\x61\x54\x68\x4C\x77" +
                                                                         ^
modules/encoders/x86/service.rb:109:56: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x26\x07\xFF\xD5#{pushed_service_name}\x89\xE1" +
                                                       ^
modules/encoders/x86/service.rb:110:93: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x8D\x85#{[svcmain_code_offset].pack('I<')}\x6A\x00\x50\x51\x89\xE0\x6A\x00\x50\x68" +
                                                                                            ^
modules/encoders/x86/service.rb:111:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xFA\xF7\x72\xCB\xFF\xD5\x6A\x00\x68\xF0\xB5\xA2\x56\xFF\xD5\x58" +
                                                                         ^
modules/encoders/x86/service.rb:112:70: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x58\x58\x58\x31\xC0\xC3\xFC\xE8\x00\x00\x00\x00\x5D\x81\xED" +
                                                                     ^
modules/encoders/x86/service.rb:113:76: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "#{[hash_code_offset].pack('I<') + pushed_service_name}\x89\xE1\x8D" +
                                                                           ^
modules/encoders/x86/service.rb:114:100: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x85#{[svcctrlhandler_code_offset].pack('I<')}\x6A\x00\x50\x51\x68\x0B\xAA\x44\x52\xFF\xD5" +
                                                                                                   ^
modules/encoders/x86/service.rb:115:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x00\x6A\x04\x6A\x10" +
                                                                         ^
modules/encoders/x86/service.rb:116:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x89\xE1\x6A\x00\x51\x50\x68\xC6\x55\x37\x7D\xFF\xD5\x31\xFF\x6A" +
                                                                         ^
modules/encoders/x86/service.rb:117:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x04\x68\x00\x10\x00\x00\x6A\x54\x57\x68\x58\xA4\x53\xE5\xFF\xD5" +
                                                                         ^
modules/encoders/x86/service.rb:118:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xC7\x00\x44\x00\x00\x00\x8D\x70\x44\x57\x68\x2E\x65\x78\x65\x68" +
                                                                         ^
modules/encoders/x86/service.rb:119:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x6C\x6C\x33\x32\x68\x72\x75\x6E\x64\x89\xE1\x56\x50\x57\x57\x6A" +
                                                                         ^
modules/encoders/x86/service.rb:120:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x44\x57\x57\x57\x51\x57\x68\x79\xCC\x3F\x86\xFF\xD5\x8B\x0E\x6A" +
                                                                         ^
modules/encoders/x86/service.rb:121:86: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x40\x68\x00\x10\x00\x00\x68#{[block.length].pack('I<')}\x57\x51\x68\xAE\x87" +
                                                                                     ^
modules/encoders/x86/service.rb:122:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x92\x3F\xFF\xD5\xE8\x00\x00\x00\x00\x5A\x89\xC7\x8B\x0E\x81\xC2" +
                                                                         ^
modules/encoders/x86/service.rb:123:83: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "#{[shellcode_code_offset].pack('I<')}\x54\x68#{[block.length].pack('I<')}" +
                                                                                  ^
modules/encoders/x86/service.rb:124:46: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x52\x50\x51\x68\xC5\xD8\xBD\xE7\xFF" +
                                             ^
modules/encoders/x86/service.rb:125:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\xD5\x31\xC0\x8B\x0E\x50\x50\x50\x57\x50\x50\x51\x68\xC6\xAC\x9A" +
                                                                         ^
modules/encoders/x86/service.rb:126:74: C: [Correctable] Style/LineEndConcatenation: Use \ instead of + or << to concatenate those strings.
      "\x79\xFF\xD5\x8B\x0E\x51\x68\xC6\x96\x87\x52\xFF\xD5\x8B\x4E\x04" +
                                                                         ^
modules/encoders/x86/shikata_ga_nai.rb:41:10: C: [Correctable] Style/ZeroLengthPredicate: Use !empty? instead of length > 0.
      if (modified_registers & saved_registers).length > 0
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/shikata_ga_nai.rb:179:26: C: [Correctable] Style/AndOr: Use || instead of or.
      if ((offset < -255 or offset > 255) and state.badchars.include? "\x00")
                         ^^
modules/encoders/x86/shikata_ga_nai.rb:179:43: C: [Correctable] Style/AndOr: Use && instead of and.
      if ((offset < -255 or offset > 255) and state.badchars.include? "\x00")
                                          ^^^
modules/encoders/x86/shikata_ga_nai.rb:180:9: C: [Correctable] Style/RaiseArgs: Provide an exception class and message as arguments to raise.
        raise EncodingError.new("Can't generate NULL-free decoder with a BufferOffset bigger than one byte")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/encoders/x86/shikata_ga_nai.rb:195:22: C: [Correctable] Style/AndOr: Use && instead of and.
      if (offset > 0 and offset < 4)
                     ^^^
modules/encoders/x86/shikata_ga_nai.rb:197:25: C: [Correctable] Style/AndOr: Use && instead of and.
      elsif (offset < 0 and offset > -4)
                        ^^^
modules/encoders/x86/shikata_ga_nai.rb:206:27: C: [Correctable] Style/AndOr: Use || instead of or.
        if (offset < -255 or offset > 255)
                          ^^
modules/encoders/x86/shikata_ga_nai.rb:210:30: C: [Correctable] Style/AndOr: Use && instead of and.
        elsif (offset > -255 and offset != 0 and offset < 255)
                             ^^^
modules/encoders/x86/shikata_ga_nai.rb:210:46: C: [Correctable] Style/AndOr: Use && instead of and.
        elsif (offset > -255 and offset != 0 and offset < 255)
                                             ^^^
modules/encoders/x86/shikata_ga_nai.rb:293:27: C: [Correctable] Style/AndOr: Use || instead of or.
    return '' if imm.nil? or imm == 0
                          ^^
modules/encoders/x86/shikata_ga_nai.rb:295:18: C: [Correctable] Style/AndOr: Use || instead of or.
    if imm > 255 or imm < -255
                 ^^
modules/encoders/x86/shikata_ga_nai.rb:303:27: C: [Correctable] Style/AndOr: Use || instead of or.
    return '' if imm.nil? or imm == 0
                          ^^
modules/encoders/x86/shikata_ga_nai.rb:305:18: C: [Correctable] Style/AndOr: Use || instead of or.
    if imm > 255 or imm < -255
                 ^^
modules/encoders/x86/single_static_bit.rb:177:45: C: [Correctable] Style/AndOr: Use && instead of and.
        new_byte |= 1 if (nbits == bit_num) and bit_val
                                            ^^^
```
</p>
</details>

The two `exit` calls are suspicious. I've removed them. As far as I'm aware, Ruby will never execute any code immediately following a `raise`.

I've also removed `self.class` from the module init hash, as it was still present in a few modules and I believe this is no longer required.

Also fixes what was likely to have been an erroneous author attribution:

https://github.com/rapid7/metasploit-framework/blob/4c485cef325ac10a8f5c00b6fee392600d8b253d/modules/encoders/x64/xor_context.rb#L12


