### PR TITLE
exploit/windows/local/unquoted_service_path: Check if write_file fails

### DIFF
--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -170,7 +170,12 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("      Placing #{exe_path} for #{svc_name}")
       exe = @svc_exes[svc_name] ||= generate_payload_exe_service({ servicename: svc_name })
       print_status("      Attempting to write #{exe.length} bytes to #{exe_path}...")
-      write_file(exe_path, exe)
+
+      unless write_file(exe_path, exe)
+        print_error("#{exe_path} could not be written")
+        next
+      end
+
       print_good '      Successfully wrote payload'
       register_file_for_cleanup(exe_path)
 


### PR DESCRIPTION
The `exploit/windows/local/unquoted_service_path` module claims that file upload was successful regardless of whether file upload was successful.

https://github.com/rapid7/metasploit-framework/blob/4c485cef325ac10a8f5c00b6fee392600d8b253d/modules/exploits/windows/local/unquoted_service_path.rb#L166-L175

This leads to a poor user experience (#19029).

File write may fail for several reasons (including TOCTOU).

This may also result in deletion of an existing file by `register_file_for_cleanup` (although unlikely) during cleanup if Metasploit falsely believes that the file was created by Metasploit.

This PR addresses this issue by checking the return value of `write_file`.

---

A quick and easy method to test this behaviour is to create a harmless `C:\Program.exe` executable and run it prior to running the module, preventing the file from being overwritten by the module. Note that the module lies about successfully uploading the file.

Before:

```
msf6 exploit(windows/local/unquoted_service_path) > run
[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Finding a vulnerable service...
[+] Found potentially vulnerable service: TeamTalk Service - C:\Program Files\TeamTalk3\TeamTalkService.exe (LocalSystem)
[*]   Enumerating vulnerable paths
[+]     C:\ is writable
[*]       Placing C:\Program.exe for TeamTalk Service
[*]       Attempting to write 15872 bytes to C:\Program.exe...
[+]       Successfully wrote payload
[*] [TeamTalk Service] Restarting service
[-] Exploit failed [user-interrupt]: Rex::TimeoutError Send timed out
[-] Failed to delete C:\Program.exe: stdapi_fs_delete_file: Operation failed: Access is denied.
[-] run: Interrupted
```

After:

```
msf6 exploit(windows/local/unquoted_service_path) > rexploit 
[*] Reloading module...
[*] Started reverse TCP handler on 192.168.200.130:4444 
[*] Finding a vulnerable service...
[+] Found potentially vulnerable service: TeamTalk Service - C:\Program Files\TeamTalk3\TeamTalkService.exe (LocalSystem)
[*]   Enumerating vulnerable paths
[+]     C:\ is writable
[*]       Placing C:\Program.exe for TeamTalk Service
[*]       Attempting to write 15872 bytes to C:\Program.exe...
[-] C:\Program.exe could not be written
[*] Waiting 303 seconds for shell to arrive
```
