### PR TITLE
Fixes an issue were a step was using both `uses` and `run` in the same step

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -132,7 +132,6 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Setup Ruby
-        run: git config --system core.longpaths true
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -196,7 +196,6 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Setup Ruby
-        run: git config --system core.longpaths true
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
           # Required for macos13 pg gem compilation


### PR DESCRIPTION
Fixes some changes added as part of https://github.com/rapid7/metasploit-framework/pull/19736. Specifically adding the `run` key, as a step cannot have both the `uses` and `run` keys. Which was causing failures, see https://github.com/bcoles/metasploit-framework/actions/runs/14430191739/workflow.

This has been removed as it was also addressed as part of another PR - https://github.com/rapid7/metasploit-framework/pull/19959. By adding the following steps to both these workflows:
```
      # https://github.com/orgs/community/discussions/26952
      - name: Support longpaths
        if: runner.os == 'Windows'
        run: git config --system core.longpaths true
```

## Verification

- [ ] CI passes with no error/warnings
