### PR TITLE
Update att open proxy error handling

### DIFF
--- a/modules/auxiliary/scanner/wproxy/att_open_proxy.py
+++ b/modules/auxiliary/scanner/wproxy/att_open_proxy.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 
-from metasploit import module, probe_scanner
+import sys
+from metasploit import module
 
+dependencies_missing = False
+if sys.version_info >= (3, 8):
+    from metasploit import probe_scanner
+else:
+    dependencies_missing = True
 
 metadata = {
     'name': 'Open WAN-to-LAN proxy on AT&T routers',
@@ -41,7 +47,11 @@ def report_wproxy(target, response):
     module.report_vuln(target[0], 'wproxy', port=target[0])
 
 
-if __name__ == "__main__":
+def run():
+    if dependencies_missing:
+        module.log('Module dependencies missing, newer Python version 3.8 or above required', level='error')
+        return
+
     study = probe_scanner.make_scanner(
         # Payload and pattern are given and applied straight to the socket, so
         # they need to be bytes-like
@@ -50,3 +60,7 @@ if __name__ == "__main__":
         onmatch=report_wproxy
     )
     module.run(metadata, study)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Update Open WAN-to-LAN proxy on AT&T routers error handling when an older Python version is detected

## Verification

### Before

3.5

```
docker run -it -w $(pwd) -v $(pwd):$(pwd) python:3.5-slim /bin/bash
# PYTHONPATH=$(pwd)/lib/msf/core/modules/external/python ./modules/auxiliary/scanner/wproxy/att_open_proxy.py --help

Traceback (most recent call last):
  File "./modules/auxiliary/scanner/wproxy/att_open_proxy.py", line 3, in <module>
    from metasploit import module, probe_scanner
  File "/Users/user/Documents/code/metasploit-framework/lib/msf/core/modules/external/python/metasploit/probe_scanner.py", line 5, in <module>
    from async_timeout import timeout
  File "/Users/user/Documents/code/metasploit-framework/lib/msf/core/modules/external/python/async_timeout/__init__.py", line 141
    raise RuntimeError(f"invalid state {self._state.value}")
                                                          ^
SyntaxError: invalid syntax
```

3.6

```
docker run -it -w $(pwd) -v $(pwd):$(pwd) python:3.6-slim /bin/bash
# PYTHONPATH=$(pwd)/lib/msf/core/modules/external/python ./modules/auxiliary/scanner/wproxy/att_open_proxy.py
Traceback (most recent call last):
  File "./modules/auxiliary/scanner/wproxy/att_open_proxy.py", line 3, in <module>
    from metasploit import module, probe_scanner
  File "/Users/user/Documents/code/metasploit-framework/lib/msf/core/modules/external/python/metasploit/probe_scanner.py", line 5, in <module>
    from async_timeout import timeout
  File "/Users/user/Documents/code/metasploit-framework/lib/msf/core/modules/external/python/async_timeout/__init__.py", line 16, in <module>
    from typing_extensions import final
ModuleNotFoundError: No module named 'typing_extensions'
```

### After

Less than 3.8

```
docker run -it -w $(pwd) -v $(pwd):$(pwd) python:3.7-slim /bin/bash
# PYTHONPATH=$(pwd)/lib/msf/core/modules/external/python ./modules/auxiliary/scanner/wproxy/att_open_proxy.py --help
{"jsonrpc": "2.0", "method": "message", "params": {"level": "error", "message": "Module dependencies missing, newer Python version 3.8 or above required"}}
```

3.8

```
docker run -it -w $(pwd) -v $(pwd):$(pwd) python:3.8-slim /bin/bash
# PYTHONPATH=$(pwd)/lib/msf/core/modules/external/python ./modules/auxiliary/scanner/wproxy/att_open_proxy.py --help
usage: att_open_proxy.py [-h] --rhosts RHOSTS [--rport RPORT] [ACTION]

The Arris NVG589 and NVG599 routers configured with AT&T U-verse firmware 9.2.2h0d83 expose an un-authenticated proxy that allows connecting from WAN to LAN by MAC
address.

positional arguments:
  ACTION           The action to take (['run'])

optional arguments:
  -h, --help       show this help message and exit
  --rport RPORT    The target port, (default: 49152)

required arguments:
  --rhosts RHOSTS  The target address
```