### PR TITLE
Move exploit/dialup/multi/login/manyargs to exploit/solaris/dialup/

### DIFF
--- a/modules/exploits/solaris/dialup/manyargs.rb
+++ b/modules/exploits/solaris/dialup/manyargs.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
 
   include Msf::Exploit::Remote::Dialup
+  include Msf::Module::Deprecated
+
+  moved_from 'exploit/dialup/multi/login/manyargs'
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
This module is now categorized based on platform (`solaris`) not transport (`dialup`).
