### PR TITLE
modules/exploits/bsd: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -14,49 +14,60 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'              => 'Morris Worm fingerd Stack Buffer Overflow',
-      'Description'       => %q{
-        This module exploits a stack buffer overflow in fingerd on 4.3BSD.
+    super(
+      update_info(
+        info,
+        'Name' => 'Morris Worm fingerd Stack Buffer Overflow',
+        'Description' => %q{
+          This module exploits a stack buffer overflow in fingerd on 4.3BSD.
 
-        This vulnerability was exploited by the Morris worm in 1988-11-02.
-        Cliff Stoll reports on the worm in the epilogue of The Cuckoo's Egg.
+          This vulnerability was exploited by the Morris worm in 1988-11-02.
+          Cliff Stoll reports on the worm in the epilogue of The Cuckoo's Egg.
 
-        Currently, only bsd/vax/shell_reverse_tcp is supported.
-      },
-      'Author'            => [
-        'Robert Tappan Morris', # Discovery? Exploit and worm for sure
-        'Cliff Stoll',          # The Cuckoo's Egg epilogue and inspiration
-        'wvu'                   # Module, payload, and additional research
-      ],
-      'References'        => [
-        ['URL', 'https://en.wikipedia.org/wiki/Morris_worm'],         # History
-        ['URL', 'https://spaf.cerias.purdue.edu/tech-reps/823.pdf'],  # Analysis
-        ['URL', 'http://computerarcheology.com/Virus/MorrisWorm/'],   # Details
-        ['URL', 'https://github.com/arialdomartini/morris-worm'],     # Source
-        ['URL', 'http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH'] # Setup
-        # And credit to the innumerable VAX ISA docs on the Web
-      ],
-      'DisclosureDate'    => '1988-11-02',
-      'License'           => MSF_LICENSE,
-      'Platform'          => 'bsd',
-      'Arch'              => ARCH_VAX,
-      'Privileged'        => false, # Depends on inetd.conf, usually "nobody"
-      'Targets'           => [
-        # https://en.wikipedia.org/wiki/Source_Code_Control_System
-        ['@(#)fingerd.c   5.1 (Berkeley) 6/6/85',
-          'Ret'           => 0x7fffe9b0,
-          'Payload'       => {
-            'Space'       => 403,
-            'BadChars'    => "\n",
-            'Encoder'     => 'generic/none', # There is no spoon
-            'DisableNops' => true            # Hardcoded NOPs
-          }
-        ]
-      ],
-      'DefaultTarget'     => 0,
-      'DefaultOptions'    => {'PAYLOAD' => 'bsd/vax/shell_reverse_tcp'}
-    ))
+          Currently, only bsd/vax/shell_reverse_tcp is supported.
+        },
+        'Author' => [
+          'Robert Tappan Morris', # Discovery? Exploit and worm for sure
+          'Cliff Stoll',          # The Cuckoo's Egg epilogue and inspiration
+          'wvu'                   # Module, payload, and additional research
+        ],
+        'References' => [
+          ['URL', 'https://en.wikipedia.org/wiki/Morris_worm'],         # History
+          ['URL', 'https://spaf.cerias.purdue.edu/tech-reps/823.pdf'],  # Analysis
+          ['URL', 'http://computerarcheology.com/Virus/MorrisWorm/'],   # Details
+          ['URL', 'https://github.com/arialdomartini/morris-worm'],     # Source
+          ['URL', 'http://gunkies.org/wiki/Installing_4.3_BSD_on_SIMH'] # Setup
+          # And credit to the innumerable VAX ISA docs on the Web
+        ],
+        'DisclosureDate' => '1988-11-02',
+        'License' => MSF_LICENSE,
+        'Platform' => 'bsd',
+        'Arch' => ARCH_VAX,
+        'Privileged' => false, # Depends on inetd.conf, usually "nobody"
+        'Targets' => [
+          # https://en.wikipedia.org/wiki/Source_Code_Control_System
+          [
+            '@(#)fingerd.c   5.1 (Berkeley) 6/6/85',
+            {
+              'Ret' => 0x7fffe9b0,
+              'Payload' => {
+                'Space' => 403,
+                'BadChars' => "\n",
+                'Encoder' => 'generic/none', # There is no spoon
+                'DisableNops' => true # Hardcoded NOPs
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'PAYLOAD' => 'bsd/vax/shell_reverse_tcp' },
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_RESTARTS ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        }
+      )
+    )
 
     register_options([Opt::RPORT(79)])
   end


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, except missing notes.
