### PR TITLE
modules/exploits/irix: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/irix/lpd/tagprinter_exec.rb
+++ b/modules/exploits/irix/lpd/tagprinter_exec.rb
@@ -9,43 +9,47 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Irix LPD tagprinter Command Execution',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Irix LPD tagprinter Command Execution',
+        'Description' => %q{
           This module exploits an arbitrary command execution flaw in
-        the in.lpd service shipped with all versions of Irix.
-      },
-      'Author'         => [ 'optyx', 'hdm' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          the in.lpd service shipped with all versions of Irix.
+        },
+        'Author' => [ 'optyx', 'hdm' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2001-0800'],
           ['OSVDB', '8573']
         ],
-      'Privileged'     => false,
-      'Platform'       => %w{ irix unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'       => 512,
+        'Privileged' => false,
+        'Platform' => %w[irix unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 512,
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic telnet',
-            }
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic telnet'
+          }
         },
-      'Targets'        =>
-        [
-          [ 'Automatic Target', { }]
+        'Targets' => [
+          [ 'Automatic Target', {}]
         ],
-      'DisclosureDate' => '2001-09-01',
-      'DefaultTarget' => 0))
+        'DisclosureDate' => '2001-09-01',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
-    register_options(
-      [
-        Opt::RPORT(515)
-      ])
+    register_options([
+      Opt::RPORT(515)
+    ])
   end
 
   def check
@@ -54,11 +58,12 @@ class MetasploitModule < Msf::Exploit::Remote
     resp = sock.get_once
     disconnect
 
-    if (resp =~ /IRIX/)
+    if resp =~ /IRIX/
       vprint_status("Response: #{resp.strip}")
-      return Exploit::CheckCode::Vulnerable
+      return CheckCode::Vulnerable
     end
-    return Exploit::CheckCode::Safe
+
+    CheckCode::Safe
   end
 
   def exploit


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, except missing notes.
