### PR TITLE
modules: examples: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/scanner/udp/example.rb
+++ b/modules/auxiliary/scanner/udp/example.rb
@@ -12,20 +12,26 @@ class MetasploitModule < Msf::Auxiliary
       update_info(
         info,
         # TODO: fill in all of this
-        'Name'           => 'UDP Scanner Example',
-        'Description'    => %q(
+        'Name' => 'UDP Scanner Example',
+        'Description' => %q{
           This module is an example of how to send probes to UDP services
           en-masse, analyze any responses, and then report on any discovered
           hosts, services, vulnerabilities or otherwise noteworthy things.
           Simply address any of the TODOs.
-        ),
-        'Author'         => 'Joe Contributor <joe_contributor[at]example.com>',
+        },
+        'Author' => 'Joe Contributor <joe_contributor[at]example.com>',
         'DisclosureDate' => '2014-03-15',
-        'License'        => MSF_LICENSE,
-        'References'     => [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '0000-0000' ], # remove or update if CVE exists
           [ 'URL', 'https://SomeURLinCyberspace.local' ]
-        ]
+        ],
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
 
@@ -44,20 +50,26 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
+  # rubocop:disable Lint/UselessMethodDefinition
   def setup
     super
     # TODO: do any sort of preliminary sanity checking, like perhaps validating some options
     # in the datastore, etc.
   end
+  # rubocop:enable Lint/UselessMethodDefinition
 
   # TODO: construct the appropriate probe here.
+  # rubocop:disable Naming/MemoizedInstanceVariableName
   def build_probe
     @probe ||= 'abracadabra!'
   end
+  # rubocop:enable Naming/MemoizedInstanceVariableName
 
-  # TODO: this is called before the scan block for each batch of hosts.  Do any
-  # per-batch setup here, otherwise remove it.
+  # TODO: this is called before the scan block for each batch of hosts.
+  # Do any per-batch setup here, otherwise remove it.
   def scanner_prescan(batch)
+    print_status("Sending requests to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
+
     super
   end
 
@@ -65,6 +77,8 @@ class MetasploitModule < Msf::Auxiliary
   # necessary probes.  If something different must be done for each IP, do it
   # here, otherwise remove it.
   def scan_host(ip)
+    vprint_status("#{ip}:#{rport} - Sending probe")
+
     super
   end
 
@@ -77,6 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     # not actually be the same as the original RPORT for some services if they
     # respond back from different ports
     return unless response.size >= 42
+
     @results[src_host] ||= []
 
     # TODO: store something about this response, perhaps the response itself,

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -171,17 +171,17 @@ class MetasploitModule < Msf::Exploit::Remote
     data = Rex::MIME::Message.new
     # https://github.com/rapid7/rex-mime/blob/master/lib/rex/mime/message.rb
     file_contents = payload.encoded
-    data.add_part(file_contents, 'application/octet-stream', 'binary', "form-data; name=\"file\"; filename=\"uploaded.bin\"")
-    data.add_part('example', nil, nil, "form-data; name=\"_wpnonce\"")
+    data.add_part(file_contents, 'application/octet-stream', 'binary', 'form-data; name="file"; filename="uploaded.bin"')
+    data.add_part('example', nil, nil, 'form-data; name="_wpnonce"')
 
     post_data = data.to_s
 
-    res = send_request_cgi(
-      'method'  => 'POST',
-      'uri'     => normalize_uri(target_uri.path, 'async-upload.php'),
-      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
-      'data'    => post_data,
-      'cookie'  => cookie
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'async-upload.php'),
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => post_data,
+      'cookie' => cookie
     )
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/windows/browser/example.rb
+++ b/modules/exploits/windows/browser/example.rb
@@ -20,49 +20,52 @@ class MetasploitModule < Msf::Exploit::Remote
   # :classid    => "{C3B92104-B5A7-11D0-A37F-00A0248F0AF1}",
   # :method     => "SetShapeNodeType",
   autopwn_info(
-    ua_name:    HttpClients::IE,
-    ua_minver:  "8.0",
-    ua_maxver:  "10.0",
+    ua_name: HttpClients::IE,
+    ua_minver: '8.0',
+    ua_maxver: '10.0',
     javascript: true,
-    os_name:    OperatingSystems::Match::WINDOWS,
-    rank:       NormalRanking
+    os_name: OperatingSystems::Match::WINDOWS,
+    rank: NormalRanking
   )
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'           => "Module Name",
-        'Description'    => %q(
+        'Name' => 'Module Name',
+        'Description' => %q{
           This template covers IE8/9/10, and uses the user-agent HTTP header to detect
           the browser version.  Please note IE8 and newer may emulate an older IE version
           in compatibility mode, in that case the module won't be able to detect the
           browser correctly.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         => [ 'sinn3r' ],
-        'References'     =>
-          [
-            [ 'URL', 'https://metasploit.com' ]
-          ],
-        'Platform'       => 'win',
-        'Targets'        =>
-          [
-            [ 'Automatic', {} ],
-            [ 'IE 8 on Windows XP SP3', { 'Rop' => :jre } ],
-            [ 'IE 8 on Windows Vista',  { 'Rop' => :jre } ],
-            [ 'IE 8 on Windows 7',      { 'Rop' => :jre } ],
-            [ 'IE 9 on Windows 7',      { 'Rop' => :jre } ],
-            [ 'IE 10 on Windows 8',     { 'Rop' => :jre } ]
-          ],
-        'Payload'        =>
-          {
-            'BadChars'        => "\x00", # js_property_spray
-            'StackAdjustment' => -3500
-          },
-        'Privileged'     => false,
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'sinn3r' ],
+        'References' => [
+          [ 'URL', 'https://metasploit.com' ]
+        ],
+        'Platform' => 'win',
+        'Targets' => [
+          [ 'Automatic', {} ],
+          [ 'IE 8 on Windows XP SP3', { 'Rop' => :jre } ],
+          [ 'IE 8 on Windows Vista', { 'Rop' => :jre } ],
+          [ 'IE 8 on Windows 7', { 'Rop' => :jre } ],
+          [ 'IE 9 on Windows 7', { 'Rop' => :jre } ],
+          [ 'IE 10 on Windows 8', { 'Rop' => :jre } ]
+        ],
+        'Payload' => {
+          'BadChars' => "\x00", # js_property_spray
+          'StackAdjustment' => -3500
+        },
+        'Privileged' => false,
         'DisclosureDate' => '2013-04-01',
-        'DefaultTarget'  => 0
+        'DefaultTarget' => 0,
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
     )
   end
@@ -97,25 +100,24 @@ class MetasploitModule < Msf::Exploit::Remote
     nil
   end
 
-  def get_payload(t)
+  def get_payload(tgt)
     stack_pivot = "\x41\x42\x43\x44"
-    code        = payload.encoded
+    code = payload.encoded
 
-    case t['Rop']
+    case tgt['Rop']
     when :msvcrt
-      print_status("Using msvcrt ROP")
+      print_status('Using msvcrt ROP')
       rop_payload = generate_rop_payload('msvcrt', code, 'pivot' => stack_pivot, 'target' => 'xp')
-
     else
-      print_status("Using JRE ROP")
+      print_status('Using JRE ROP')
       rop_payload = generate_rop_payload('java', code, 'pivot' => stack_pivot)
     end
 
     rop_payload
   end
 
-  def get_html(t)
-    js_p = ::Rex::Text.to_unescape(get_payload(t), ::Rex::Arch.endian(t.arch))
+  def get_html(tgt)
+    js_p = ::Rex::Text.to_unescape(get_payload(tgt), ::Rex::Arch.endian(tgt.arch))
     html = %|
       <script>
       #{js_property_spray}


### PR DESCRIPTION
Resolve RuboCop violations in several example modules:

* modules/exploits/windows/browser/example.rb
* modules/exploits/example_webapp.rb
* modules/auxiliary/scanner/udp/example.rb

Most violations were resolved with `rubocop -a`.

Two RuboCop rules needed to be explicitly disabled temporarily in the UDP scanner example module:

* rubocop:enable Lint/UselessMethodDefinition
* rubocop:disable Naming/MemoizedInstanceVariableName
