### PR TITLE
Fix defer module payload regression

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -438,8 +438,8 @@ class PayloadSet < ModuleSet
                                       end
 
     unless payload_type_cache[refname]
-      framework.configured_module_paths.each do |path|
-        framework.modules.try_load_module(path, "#{folder_name}/#{refname}", Msf::MODULE_PAYLOAD)
+      framework.configured_module_paths.each do |parent_path|
+        framework.modules.try_load_module(parent_path, Msf::MODULE_PAYLOAD, "#{folder_name}/#{refname}")
       end
     end
     payload_type_cache[refname]


### PR DESCRIPTION
Fix defer module payload regression introduced by changing the API arg order in https://github.com/rapid7/metasploit-framework/pull/20015 

## Verification

Steps:

```
bundle exec ruby ./msfconsole -q 
features set defer_module_loads true
save
exit

bundle exec ruby ./msfconsole -q 
use windows/local/cve_2024_35250_ks_driver
show options
```

Before - broken:

```
msf6 exploit(windows/local/cve_2024_35250_ks_driver) > options

Module options (exploit/windows/local/cve_2024_35250_ks_driver):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  -1               yes       The session to run this module on

[-] Invalid payload defined: windows/x64/meterpreter/reverse_tcp
```

After - working:

```
msf6 exploit(windows/local/cve_2024_35250_ks_driver) > options

Module options (exploit/windows/local/cve_2024_35250_ks_driver):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST                      yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows x64



View the full module info with the info, or info -d command.

msf6 exploit(windows/local/cve_2024_35250_ks_driver) > 
```