### PR TITLE
Allow overwriting reported module name for report_vuln

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -303,7 +303,7 @@ module Auxiliary::Report
 
     timestamp  = opts[:timestamp]
     username   = opts[:username]
-    mname      = self.fullname # use module name when reporting attempt for correlation
+    mname      = opts[:module_fullname] || self.fullname # use module name when reporting attempt for correlation
 
     # report_vuln is only called in an identified case, consider setting value reported here
     attempt_info = {


### PR DESCRIPTION
This PR allows for overwriting the module name when reporting a vulnerability.
This is used in Pro during a discovery scan. As the discovery scan isa. module and reports vulnerabilities for other modules, this is needed to provide the correct module name that the user can click.

## Verification

- [ ] Start `msfconsole`
- [ ] Use an exploit/auxiliary that reports a vulnerability, e.g. `Apache Tomcat AJP File Read`
- [ ] `run` to ensure the existing functionality is not affected and defaults to the previous behaviour
- [ ] In Metasploit Pro, run a discovery scan against a Metasploitable2 VM
- [ ] Confirm that with this change, the `Disclosed Vulnerability` takes you to the correct page

## Scenario
Running a discovery scan, that reports vulnerabilities based on the check code returned from a module's `check` method.
An example against a Metasploitable2 VM:
![image](https://github.com/user-attachments/assets/e13b8433-238f-4c5f-9f5a-da5810e87415)

### Before
The hyperlink was pointing at the parent module, which was incorrect in this case
![image](https://github.com/user-attachments/assets/1d1c98cc-fcf9-461d-a668-4ee057c84733)

### After
The hyperlink points to the correct module
![image](https://github.com/user-attachments/assets/a13bfbc2-32ab-49b8-91d8-ac3b7335bed0)